### PR TITLE
Make MCP server configurable

### DIFF
--- a/src/tooluniverse/generate_mcp_tools.py
+++ b/src/tooluniverse/generate_mcp_tools.py
@@ -97,8 +97,8 @@ def main():
         )
         f.write("\n".join(all_functions))
         f.write(
-            "\n\ndef run_server():\n"
-            "    mcp.run(transport='streamable-http', host='127.0.0.1', port=8000)\n\n"
+            "\n\ndef run_server(transport: str = 'streamable-http', host: str = '127.0.0.1', port: int = 8000):\n"
+            "    mcp.run(mcp.run(transport=transport, host=host, port=port))\n\n"
             "def run_claude_desktop():\n"
             "    print(\"Starting ToolUniverse MCP server...\")\n"
             "    mcp.run(transport='stdio')\n"

--- a/src/tooluniverse/mcp_server.py
+++ b/src/tooluniverse/mcp_server.py
@@ -3331,9 +3331,8 @@ def OpenTargets_get_target_id_description_by_name(
         }
     })
 
-
-def run_server():
-    mcp.run(transport='streamable-http', host='127.0.0.1', port=8000)
+def run_server(transport: str = 'streamable-http', host: str = '127.0.0.1', port: int = 8000):
+    mcp.run(transport=transport, host=host, port=port)
 
 def run_claude_desktop():
     print("Starting ToolUniverse MCP server...")


### PR DESCRIPTION
Trivial changes to allow users to configure the preferred host, port and transport method for the MCP server.
Also patched the generator to reflect the change there.