### PR TITLE
Fix warning suppression

### DIFF
--- a/src/tooluniverse/__init__.py
+++ b/src/tooluniverse/__init__.py
@@ -197,86 +197,85 @@ PaleobiologyRESTTool: Any
 OLSTool: Any
 if not _LIGHT_IMPORT and not LAZY_LOADING_ENABLED:
     # Import all tool classes immediately (old behavior) with warning suppression  # noqa: E501
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
-        warnings.filterwarnings("ignore", category=RuntimeWarning)
-        warnings.filterwarnings("ignore", category=UserWarning)
-        warnings.filterwarnings("ignore", category=FutureWarning)
-        # Suppress specific third-party warnings
-        warnings.filterwarnings(
-            "ignore", category=DeprecationWarning, module="pkg_resources"
-        )
-        warnings.filterwarnings(
-            "ignore", category=RuntimeWarning, module="importlib._bootstrap"
-        )
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    warnings.filterwarnings("ignore", category=RuntimeWarning)
+    warnings.filterwarnings("ignore", category=UserWarning)
+    warnings.filterwarnings("ignore", category=FutureWarning)
+    # Suppress specific third-party warnings
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, module="pkg_resources"
+    )
+    warnings.filterwarnings(
+        "ignore", category=RuntimeWarning, module="importlib._bootstrap"
+    )
 
-        from .restful_tool import MonarchTool, MonarchDiseasesForMultiplePhenoTool
-        from .ctg_tool import ClinicalTrialsSearchTool, ClinicalTrialsDetailsTool
-        from .graphql_tool import (
-            OpentargetTool,
-            OpentargetGeneticsTool,
-            OpentargetToolDrugNameMatch,
-            DiseaseTargetScoreTool,
-        )
-        from .openfda_tool import (
-            FDADrugLabelTool,
-            FDADrugLabelSearchTool,
-            FDADrugLabelSearchIDTool,
-            FDADrugLabelGetDrugGenericNameTool,
-        )
-        from .openfda_adv_tool import (
-            FDADrugAdverseEventTool,
-            FDACountAdditiveReactionsTool,
-        )
-        from .chem_tool import ChEMBLTool
-        from .compose_tool import ComposeTool
-        from .python_executor_tool import (
-            PythonCodeExecutor,
-            PythonScriptRunner,
-        )
-        from .europe_pmc_tool import EuropePMCTool
-        from .semantic_scholar_tool import SemanticScholarTool
-        from .pubtator_tool import PubTatorTool
-        from .efo_tool import EFOTool
-        from .agentic_tool import AgenticTool
-        from .dataset_tool import DatasetTool
-        from .dailymed_tool import SearchSPLTool, GetSPLBySetIDTool
-        from .hpa_tool import HPAGetGeneJSONTool, HPAGetGeneXMLTool
-        from .reactome_tool import ReactomeRESTTool
-        from .pubchem_tool import PubChemRESTTool
-        from .url_tool import URLHTMLTagTool, URLToPDFTextTool
-        from .medlineplus_tool import MedlinePlusRESTTool
-        from .uniprot_tool import UniProtRESTTool
-        from .package_tool import PackageTool
-        from .uspto_tool import USPTOOpenDataPortalTool
-        from .xml_tool import XMLDatasetTool
-        from .tool_finder_embedding import ToolFinderEmbedding
-        from .tool_finder_keyword import ToolFinderKeyword
-        from .tool_finder_llm import ToolFinderLLM
-        from .embedding_database import EmbeddingDatabase
-        from .embedding_sync import EmbeddingSync
-        from .rcsb_pdb_tool import RCSBTool
-        from .rcsb_search_tool import RCSBSearchTool
-        from .web_search_tool import (
-            WebSearchTool,
-            WebAPIDocumentationSearchTool,
-        )
-        from .package_discovery_tool import DynamicPackageDiscovery
-        from .pypi_package_inspector_tool import PyPIPackageInspector
-        from .gwas_tool import (
-            GWASAssociationSearch,
-            GWASStudySearch,
-            GWASSNPSearch,
-            GWASAssociationByID,
-            GWASStudyByID,
-            GWASSNPByID,
-            GWASVariantsForTrait,
-            GWASAssociationsForTrait,
-            GWASAssociationsForSNP,
-            GWASStudiesForTrait,
-            GWASSNPsForGene,
-            GWASAssociationsForStudy,
-        )
+    from .restful_tool import MonarchTool, MonarchDiseasesForMultiplePhenoTool
+    from .ctg_tool import ClinicalTrialsSearchTool, ClinicalTrialsDetailsTool
+    from .graphql_tool import (
+        OpentargetTool,
+        OpentargetGeneticsTool,
+        OpentargetToolDrugNameMatch,
+        DiseaseTargetScoreTool,
+    )
+    from .openfda_tool import (
+        FDADrugLabelTool,
+        FDADrugLabelSearchTool,
+        FDADrugLabelSearchIDTool,
+        FDADrugLabelGetDrugGenericNameTool,
+    )
+    from .openfda_adv_tool import (
+        FDADrugAdverseEventTool,
+        FDACountAdditiveReactionsTool,
+    )
+    from .chem_tool import ChEMBLTool
+    from .compose_tool import ComposeTool
+    from .python_executor_tool import (
+        PythonCodeExecutor,
+        PythonScriptRunner,
+    )
+    from .europe_pmc_tool import EuropePMCTool
+    from .semantic_scholar_tool import SemanticScholarTool
+    from .pubtator_tool import PubTatorTool
+    from .efo_tool import EFOTool
+    from .agentic_tool import AgenticTool
+    from .dataset_tool import DatasetTool
+    from .dailymed_tool import SearchSPLTool, GetSPLBySetIDTool
+    from .hpa_tool import HPAGetGeneJSONTool, HPAGetGeneXMLTool
+    from .reactome_tool import ReactomeRESTTool
+    from .pubchem_tool import PubChemRESTTool
+    from .url_tool import URLHTMLTagTool, URLToPDFTextTool
+    from .medlineplus_tool import MedlinePlusRESTTool
+    from .uniprot_tool import UniProtRESTTool
+    from .package_tool import PackageTool
+    from .uspto_tool import USPTOOpenDataPortalTool
+    from .xml_tool import XMLDatasetTool
+    from .tool_finder_embedding import ToolFinderEmbedding
+    from .tool_finder_keyword import ToolFinderKeyword
+    from .tool_finder_llm import ToolFinderLLM
+    from .embedding_database import EmbeddingDatabase
+    from .embedding_sync import EmbeddingSync
+    from .rcsb_pdb_tool import RCSBTool
+    from .rcsb_search_tool import RCSBSearchTool
+    from .web_search_tool import (
+        WebSearchTool,
+        WebAPIDocumentationSearchTool,
+    )
+    from .package_discovery_tool import DynamicPackageDiscovery
+    from .pypi_package_inspector_tool import PyPIPackageInspector
+    from .gwas_tool import (
+        GWASAssociationSearch,
+        GWASStudySearch,
+        GWASSNPSearch,
+        GWASAssociationByID,
+        GWASStudyByID,
+        GWASSNPByID,
+        GWASVariantsForTrait,
+        GWASAssociationsForTrait,
+        GWASAssociationsForSNP,
+        GWASStudiesForTrait,
+        GWASSNPsForGene,
+        GWASAssociationsForStudy,
+    )
 
     from .mcp_client_tool import MCPClientTool, MCPAutoLoaderTool
     from .admetai_tool import ADMETAITool


### PR DESCRIPTION
Warning messages are not suppressed correctly and still show up when executing `tooluniverse-smcp` on the commandline.

This occurs because the warnings are not getting caught by the `warnings.catch_warnings()` context manager as they occur outside of that context. This PR fixes the problem by removing the context manager.