### PR TITLE
Add Dockerfile for Docker MCP Registry integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install build dependencies and runtime libraries for packages that need them
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  gcc \
+  g++ \
+  libxrender1 \
+  libxext6 \
+  libsm6 \
+  libx11-6 \
+  libexpat1 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install tooluniverse from PyPI
+RUN pip install --no-cache-dir tooluniverse
+
+# Remove build dependencies to reduce image size (keep runtime libraries)
+RUN apt-get purge -y gcc g++ && apt-get autoremove -y
+
+# Set environment variable to reduce verbosity (optional)
+ENV TOOLUNIVERSE_LOG_LEVEL=WARNING
+
+# Run the MCP server with stdio transport
+# TOOLUNIVERSE_STDIO_MODE=1 is automatically set by tooluniverse-smcp-stdio
+CMD ["tooluniverse-smcp-stdio"]
+


### PR DESCRIPTION
# Add Dockerfile for Docker MCP Registry Integration

Related to #44

This PR is **Step 1** of the Docker MCP Registry integration. After this is merged, Step 2 will be submitting the `server.yaml` configuration to the [docker/mcp-registry](https://github.com/docker/mcp-registry) repository.

This PR adds a Dockerfile to enable ToolUniverse integration with the [Docker MCP Registry](https://hub.docker.com/mcp/explore), making ToolUniverse discoverable and easily deployable through Docker Desktop's MCP Toolkit.

## Overview

The Dockerfile creates a containerized ToolUniverse MCP server that:

- Uses Python 3.12-slim as the base image
- Installs build dependencies (gcc, g++) for packages that require compilation (like `traits`)
- Installs runtime libraries (libxrender1, libxext6, libsm6, libx11-6, libexpat1) needed by RDKit
- Installs `tooluniverse` from PyPI (all dependencies are automatically handled via `pyproject.toml`)
- Removes build dependencies after installation to keep the image size small
- Sets `TOOLUNIVERSE_LOG_LEVEL=WARNING` to reduce verbosity
- Runs `tooluniverse-smcp-stdio` as the entrypoint for stdio transport (required by Docker MCP)

## Dockerfile

```dockerfile
FROM python:3.12-slim

WORKDIR /app

# Install build dependencies and runtime libraries for packages that need them
RUN apt-get update && apt-get install -y --no-install-recommends \
  gcc \
  g++ \
  libxrender1 \
  libxext6 \
  libsm6 \
  libx11-6 \
  libexpat1 \
  && rm -rf /var/lib/apt/lists/*

# Install tooluniverse from PyPI
RUN pip install --no-cache-dir tooluniverse

# Remove build dependencies to reduce image size (keep runtime libraries)
RUN apt-get purge -y gcc g++ && apt-get autoremove -y

# Set environment variable to reduce verbosity (optional)
ENV TOOLUNIVERSE_LOG_LEVEL=WARNING

# Run the MCP server with stdio transport
# TOOLUNIVERSE_STDIO_MODE=1 is automatically set by tooluniverse-smcp-stdio
CMD ["tooluniverse-smcp-stdio"]
```

## Testing

I've tested the Dockerfile locally and confirmed:

- The image builds successfully
- The MCP server starts correctly with `tooluniverse-smcp-stdio`
- The server is ready to accept MCP protocol messages via stdio transport

## Next Steps

After this PR is merged, the following `server.yaml` configuration will be submitted to the [docker/mcp-registry](https://github.com/docker/mcp-registry) repository:

```yaml
name: tooluniverse
image: mcp/tooluniverse
type: server
meta:
  category: science
  tags:
    - science
    - research
    - ai-scientists
    - scientific-tools
    - mcp
    - bioinformatics
    - cheminformatics
about:
  title: ToolUniverse
  description: |
    Comprehensive ecosystem for creating AI scientist systems with 600+ scientific tools. 
    Integrates machine learning models, datasets, APIs, and scientific packages for data 
    analysis, knowledge retrieval, and experimental design. Supports protein analysis, 
    drug discovery, literature search, genomics, and more.
  icon: https://zitniklab.hms.harvard.edu/ToolUniverse/en/_static/logo.png
source:
  project: https://github.com/mims-harvard/ToolUniverse
  commit: TBD  # Will be updated after this PR is merged
  dockerfile: Dockerfile
run:
  command:
    - tooluniverse-smcp-stdio
config:
  description: Configure optional API keys for enhanced functionality. ToolUniverse works without these keys but with reduced functionality.
  secrets:
    - name: tooluniverse.openai_api_key
      env: OPENAI_API_KEY
      example: <OPENAI_API_KEY>
      description: OpenAI API key (at least one of OPENAI_API_KEY or AZURE_OPENAI_API_KEY is recommended)
    - name: tooluniverse.azure_openai_api_key
      env: AZURE_OPENAI_API_KEY
      example: <AZURE_OPENAI_API_KEY>
      description: Azure OpenAI API key (at least one of OPENAI_API_KEY or AZURE_OPENAI_API_KEY is recommended)
    - name: tooluniverse.opentargets_api_key
      env: OPENTARGETS_API_KEY
      example: <OPENTARGETS_API_KEY>
      description: OpenTargets API key for enhanced OpenTargets features
    - name: tooluniverse.ncbi_api_key
      env: NCBI_API_KEY
      example: <NCBI_API_KEY>
      description: NCBI API key for enhanced NCBI features
    - name: tooluniverse.hf_token
      env: HF_TOKEN
      example: <HF_TOKEN>
      description: Hugging Face token for accessing Hugging Face models
    - name: tooluniverse.uspto_api_key
      env: USPTO_API_KEY
      example: <USPTO_API_KEY>
      description: USPTO API key for USPTO patent search features
    - name: tooluniverse.boltz_mcp_server_host
      env: BOLTZ_MCP_SERVER_HOST
      example: <BOLTZ_MCP_SERVER_HOST>
      description: Boltz MCP server host URL
    - name: tooluniverse.expert_feedback_mcp_server_url
      env: EXPERT_FEEDBACK_MCP_SERVER_URL
      example: <EXPERT_FEEDBACK_MCP_SERVER_URL>
      description: Expert Feedback MCP server URL
    - name: tooluniverse.txagent_mcp_server_host
      env: TXAGENT_MCP_SERVER_HOST
      example: <TXAGENT_MCP_SERVER_HOST>
      description: TXAgent MCP server host URL
    - name: tooluniverse.uspto_mcp_server_host
      env: USPTO_MCP_SERVER_HOST
      example: <USPTO_MCP_SERVER_HOST>
      description: USPTO MCP server host URL
```

## Notes

- The Dockerfile installs and then removes build dependencies to minimize image size while ensuring all packages compile correctly
- The server uses stdio transport as required by Docker MCP for local servers
- This Dockerfile uses `pip install tooluniverse` directly from PyPI, which automatically handles all dependencies via `pyproject.toml` (the documentation example showing `requirements.txt` is outdated I believe on https://zitniklab.hms.harvard.edu/ToolUniverse/en/installation.html under the "Container Installation" section)
