### PR TITLE
Add ESM-C as an MCP-native remote tool

### DIFF
--- a/src/tooluniverse/remote/esm/esm_remote.json
+++ b/src/tooluniverse/remote/esm/esm_remote.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "mcp_auto_loader_esm",
+    "description": "Auto-load ESM remote tools",
+    "type": "MCPAutoLoaderTool",
+    "tool_prefix": "",
+    "server_url": "http://localhost:8008/mcp",
+    "timeout": 30,
+    "required_api_keys": []
+  }
+]

--- a/src/tooluniverse/remote/esm/esm_remote_tool.py
+++ b/src/tooluniverse/remote/esm/esm_remote_tool.py
@@ -1,0 +1,81 @@
+"""
+ESM Remote MCP Tool (FastMCP-native)
+
+Exposes ESM-C protein sequence embeddings over MCP.
+"""
+
+from fastmcp import FastMCP
+
+from esm.models.esmc import ESMC
+from esm.sdk.api import ESMProtein, LogitsConfig
+
+# -----------------------------------------------------------------------------
+# MCP server
+# -----------------------------------------------------------------------------
+
+mcp = FastMCP("ESM Embedding MCP Server")
+
+# -----------------------------------------------------------------------------
+# Global model cache
+# -----------------------------------------------------------------------------
+
+_ESM_CLIENT = None
+
+
+def get_client():
+    global _ESM_CLIENT
+    if _ESM_CLIENT is None:
+        _ESM_CLIENT = ESMC.from_pretrained("esmc_300m")
+        _ESM_CLIENT.eval()
+    return _ESM_CLIENT
+
+
+# -----------------------------------------------------------------------------
+# CORE LOGIC (CALLABLE LOCALLY + BY MCP)
+# -----------------------------------------------------------------------------
+
+def compute_embedding(sequence: str):
+    """
+    Core embedding logic (pure Python, callable locally).
+    """
+    client = get_client()
+
+    protein = ESMProtein(sequence=sequence)
+    tensor = client.encode(protein)
+
+    output = client.logits(
+        tensor,
+        LogitsConfig(return_embeddings=True)
+    )
+
+    return output.embeddings[0].tolist()
+
+
+# -----------------------------------------------------------------------------
+# MCP TOOL
+# -----------------------------------------------------------------------------
+
+@mcp.tool(
+    name="esm_embed_sequence",
+    description="Generate protein sequence embeddings using ESM-C",
+)
+def esm_embed_sequence(sequence: str):
+    embedding = compute_embedding(sequence)
+    return {
+        "model": "esmc_300m",
+        "embedding_dim": len(embedding),
+        "embedding": embedding,
+    }
+
+
+# -----------------------------------------------------------------------------
+# MAIN
+# -----------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    # 🚀 START MCP SERVER
+    mcp.run(
+        transport="http",
+        host="0.0.0.0",
+        port=8008,
+    )


### PR DESCRIPTION
This PR adds **ESM-C (Evolutionary Scale Modeling)** as a **remote, MCP-native tool** in ToolUniverse, following the recommended *remote tool* onboarding pattern for models without an existing public API.

**Model**
ESM-C (from EvolutionaryScale / CZI Biohub)
GitHub: [https://github.com/evolutionaryscale/esm](https://github.com/evolutionaryscale/esm)

### What this PR does

* Implements a lightweight **FastMCP server** that wraps ESM-C inference and exposes a single MCP tool:

  * **`esm_embed_sequence`** — generates protein sequence embeddings using ESM-C.
* Adds an **`MCPAutoLoaderTool` configuration** (`esm_remote.json`) so ToolUniverse can automatically discover and invoke the tool via MCP.
* Keeps all model execution **fully remote**, with no ESM or GPU dependencies required on the ToolUniverse client side.

### Why this matters

* **Unblocks onboarding of Biohub / CZI models that do not yet have public APIs**, by providing a clean, agent-native interface layer.
* Enables **hosted deployment** (e.g., Biohub / CZI GPU infrastructure) as well as **local or private deployment** by external users.
* Establishes a **reusable template** for bringing current and future Biohub / Virtual Cell Platform models into ToolUniverse without requiring immediate REST API productization.

This aligns with the broader goal of making Biohub / CZI models directly usable inside ToolUniverse’s AI-scientist workflows while preserving flexibility around hosting, security, and future API evolution.