### PR TITLE
Revise ToolUniverse installation steps in codex_cli.rst

### DIFF
--- a/docs/guide/building_ai_scientists/codex_cli.rst
+++ b/docs/guide/building_ai_scientists/codex_cli.rst
@@ -66,12 +66,16 @@ Step 2: Install UV and ToolUniverse
    # Install UV package manager
    curl -LsSf https://astral.sh/uv/install.sh | sh
 
-   # Create working directory for ToolUniverse
-   # uv will automatically create and manage a virtual environment (.venv) inside this directory
+   # Create working directory for ToolUniverse   
    mkdir -p /path/to/tooluniverse-env
-   uv --directory /path/to/tooluniverse-env pip install tooluniverse
+   cd /path/to/tooluniverse-env
+   # uv will create a virtual environment (.venv) inside this directory
+   uv venv
+   # uv will install tooluniverse and all its dependencies
+   uv pip install tooluniverse
 
    # Verify installation
+   cd ~
    uv --directory /path/to/tooluniverse-env run python -c "import tooluniverse; print('ToolUniverse installed successfully')"
 
 Step 3: Configure Codex CLI


### PR DESCRIPTION
Updated installation instructions for ToolUniverse to include creating a virtual environment and changed the order of commands.
From my experience, the previous instructions caused uv to install tooluniverse in the default python environment.