### PR TITLE
Add direct OpenAI support via a separate LLM client

### DIFF
--- a/src/tooluniverse/.env.template
+++ b/src/tooluniverse/.env.template
@@ -1,7 +1,9 @@
 # API Keys for ToolUniverse
 # Copy this file to .env and fill in your actual API keys
 
-At least one of: OPENAI_API_KEY, AZURE_OPENAI_API_KEY=your_api_key_here
+# LLM Provider API Keys (at least one recommended for agentic tools)
+OPENAI_API_KEY=your_api_key_here
+AZURE_OPENAI_API_KEY=your_api_key_here
 
 BOLTZ_MCP_SERVER_HOST=your_api_key_here
 

--- a/src/tooluniverse/agentic_tool.py
+++ b/src/tooluniverse/agentic_tool.py
@@ -8,19 +8,21 @@ from typing import Any, Callable, Dict, List, Optional
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 from .logging_config import get_logger
-from .llm_clients import AzureOpenAIClient, GeminiClient, OpenRouterClient, VLLMClient
+from .llm_clients import AzureOpenAIClient, GeminiClient, OpenAIClient, OpenRouterClient, VLLMClient
 
 
 # Global default fallback configuration
 DEFAULT_FALLBACK_CHAIN = [
     {"api_type": "CHATGPT", "model_id": "gpt-4o-1120"},
     {"api_type": "OPENROUTER", "model_id": "openai/gpt-4o"},
+    {"api_type": "OPENAI", "model_id": "gpt-4o"},
     {"api_type": "GEMINI", "model_id": "gemini-2.0-flash"},
 ]
 
 # API key environment variable mapping
 API_KEY_ENV_VARS = {
     "CHATGPT": ["AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"],
+    "OPENAI": ["OPENAI_API_KEY"],
     "OPENROUTER": ["OPENROUTER_API_KEY"],
     "GEMINI": ["GEMINI_API_KEY"],
     "VLLM": ["VLLM_SERVER_URL"],
@@ -272,6 +274,8 @@ class AgenticTool(BaseTool):
         try:
             if api_type == "CHATGPT":
                 self._llm_client = AzureOpenAIClient(model_id, None, self.logger)
+            elif api_type == "OPENAI":
+                self._llm_client = OpenAIClient(model_id, self.logger)
             elif api_type == "OPENROUTER":
                 self._llm_client = OpenRouterClient(model_id, self.logger)
             elif api_type == "GEMINI":
@@ -602,6 +606,8 @@ class AgenticTool(BaseTool):
         try:
             if self._api_type == "CHATGPT":
                 self._llm_client = AzureOpenAIClient(self._model_id, None, self.logger)
+            elif self._api_type == "OPENAI":
+                self._llm_client = OpenAIClient(self._model_id, self.logger)
             elif self._api_type == "OPENROUTER":
                 self._llm_client = OpenRouterClient(self._model_id, self.logger)
             elif self._api_type == "GEMINI":

--- a/src/tooluniverse/agentic_tool.py
+++ b/src/tooluniverse/agentic_tool.py
@@ -319,7 +319,7 @@ class AgenticTool(BaseTool):
 
     # ------------------------------------------------------------------ LLM utilities -----------
     def _validate_model_config(self):
-        supported_api_types = ["CHATGPT", "OPENROUTER", "GEMINI", "VLLM"]
+        supported_api_types = ["CHATGPT", "OPENAI", "OPENROUTER", "GEMINI", "VLLM"]
         if self._api_type not in supported_api_types:
             raise ValueError(
                 f"Unsupported API type: {self._api_type}. Supported types: {supported_api_types}"

--- a/src/tooluniverse/llm_clients.py
+++ b/src/tooluniverse/llm_clients.py
@@ -398,6 +398,335 @@ class AzureOpenAIClient(BaseLLMClient):
         )
 
 
+class OpenAIClient(BaseLLMClient):
+    # Built-in defaults for model families (can be overridden by env)
+    DEFAULT_MODEL_LIMITS: Dict[str, Dict[str, int]] = {
+        # GPT-4.1 series
+        "gpt-4.1": {"max_output": 32768, "context_window": 1_047_576},
+        "gpt-4.1-mini": {"max_output": 32768, "context_window": 1_047_576},
+        "gpt-4.1-nano": {"max_output": 32768, "context_window": 1_047_576},
+        # GPT-4o series
+        "gpt-4o-1120": {"max_output": 16384, "context_window": 128_000},
+        "gpt-4o-0806": {"max_output": 16384, "context_window": 128_000},
+        "gpt-4o-mini-0718": {"max_output": 16384, "context_window": 128_000},
+        "gpt-4o": {"max_output": 16384, "context_window": 128_000},  # general prefix
+        # O-series
+        "o4-mini-0416": {"max_output": 100_000, "context_window": 200_000},
+        "o3-mini-0131": {"max_output": 100_000, "context_window": 200_000},
+        "o4-mini": {"max_output": 100_000, "context_window": 200_000},
+        "o3-mini": {"max_output": 100_000, "context_window": 200_000},
+        # Embeddings (for completeness)
+        "embedding-ada": {"max_output": 8192, "context_window": 8192},
+        "text-embedding-3-small": {"max_output": 8192, "context_window": 8192},
+        "text-embedding-3-large": {"max_output": 8192, "context_window": 8192},
+    }
+
+    def __init__(self, model_id: str, logger):
+        try:
+            from openai import OpenAI as _OpenAI  # type: ignore
+            import openai as _openai  # type: ignore
+        except Exception as e:  # pragma: no cover
+            raise RuntimeError("openai OpenAI client is not available") from e
+        self._OpenAI = _OpenAI
+        self._openai = _openai
+
+        self.model_name = model_id
+        self.logger = logger
+
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY not set")
+        self.client = self._OpenAI(api_key=api_key)
+
+        # Load env overrides for model limits (JSON dict of {prefix: {max_output, context_window}})
+        env_limits_raw = os.getenv("OPENAI_DEFAULT_MODEL_LIMITS")
+        self._default_limits: Dict[str, Dict[str, int]] = (
+            self.DEFAULT_MODEL_LIMITS.copy()
+        )
+        if env_limits_raw:
+            try:
+                env_limits = _json.loads(env_limits_raw)
+                # shallow merge by keys
+                for k, v in env_limits.items():
+                    if isinstance(v, dict):
+                        base = self._default_limits.get(k, {}).copy()
+                        base.update(
+                            {
+                                kk: int(vv)
+                                for kk, vv in v.items()
+                                if isinstance(vv, (int, float, str))
+                            }
+                        )
+                        self._default_limits[k] = base
+            except Exception:
+                # ignore bad env format
+                pass
+
+    # --------- helpers ---------
+    def _resolve_default_max_tokens(self, model_id: str) -> Optional[int]:
+        # Highest priority: explicit env per-model tokens mapping
+        mapping_raw = os.getenv("OPENAI_MAX_TOKENS_BY_MODEL")
+        mapping: Dict[str, Any] = {}
+        if mapping_raw:
+            try:
+                mapping = _json.loads(mapping_raw)
+            except Exception:
+                mapping = {}
+        if model_id in mapping:
+            try:
+                return int(mapping[model_id])
+            except Exception:
+                pass
+        for k, v in mapping.items():
+            try:
+                if model_id.startswith(k):
+                    return int(v)
+            except Exception:
+                continue
+        # Next: built-in/default-limits map (with env merged)
+        if model_id in self._default_limits:
+            return int(self._default_limits[model_id].get("max_output", 0)) or None
+        for k, v in self._default_limits.items():
+            try:
+                if model_id.startswith(k):
+                    return int(v.get("max_output", 0)) or None
+            except Exception:
+                continue
+        return None
+
+    def _normalize_temperature(
+        self, model_id: str, temperature: Optional[float]
+    ) -> Optional[float]:
+        if isinstance(model_id, str) and (
+            model_id.startswith("o3-mini") or model_id.startswith("o4-mini")
+        ):
+            if temperature is not None:
+                self.logger.warning(
+                    f"Model {model_id} does not support 'temperature'; ignoring provided value."
+                )
+            return None
+        return temperature
+
+    def _extract_text_from_chunk(self, chunk) -> Optional[str]:
+        """Extract text from a streaming chunk."""
+        if hasattr(chunk, "choices") and chunk.choices:
+            delta = chunk.choices[0].delta
+            if hasattr(delta, "content") and delta.content:
+                return delta.content
+        return None
+
+    # --------- public API ---------
+    def test_api(self) -> None:
+        test_messages = [{"role": "user", "content": "ping"}]
+        token_attempts = [1, 4, 16, 32]
+        last_error: Optional[Exception] = None
+        for tok in token_attempts:
+            try:
+                try:
+                    self.client.chat.completions.create(
+                        model=self.model_name,
+                        messages=test_messages,
+                        max_tokens=tok,
+                        temperature=0,
+                    )
+                    return
+                except self._openai.BadRequestError:  # type: ignore[attr-defined]
+                    self.client.chat.completions.create(
+                        model=self.model_name,
+                        messages=test_messages,
+                        max_completion_tokens=tok,
+                    )
+                    return
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                msg = str(e).lower()
+                if (
+                    "max_tokens" in msg
+                    or "model output limit" in msg
+                    or "finish the message" in msg
+                ) and tok != token_attempts[-1]:
+                    continue
+                break
+        if last_error:
+            raise ValueError(f"OpenAI API test failed: {last_error}")
+        raise ValueError("OpenAI API test failed: unknown error")
+
+    def infer(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float],
+        max_tokens: Optional[int],
+        return_json: bool,
+        custom_format: Any = None,
+        max_retries: int = 5,
+        retry_delay: int = 5,
+    ) -> Optional[str]:
+        retries = 0
+        call_fn = (
+            self.client.chat.completions.parse
+            if custom_format is not None
+            else self.client.chat.completions.create
+        )
+        response_format = (
+            custom_format
+            if custom_format is not None
+            else ({"type": "json_object"} if return_json else None)
+        )
+        eff_temp = self._normalize_temperature(self.model_name, temperature)
+        eff_max = (
+            max_tokens
+            if max_tokens is not None
+            else self._resolve_default_max_tokens(self.model_name)
+        )
+        while retries < max_retries:
+            try:
+                kwargs: Dict[str, Any] = {
+                    "model": self.model_name,
+                    "messages": messages,
+                }
+                if response_format is not None:
+                    kwargs["response_format"] = response_format
+                if eff_temp is not None:
+                    kwargs["temperature"] = eff_temp
+                try:
+                    if eff_max is not None:
+                        resp = call_fn(max_tokens=eff_max, **kwargs)
+                    else:
+                        resp = call_fn(**kwargs)
+                except self._openai.BadRequestError as be:  # type: ignore[attr-defined]
+                    if eff_max is not None:
+                        resp = call_fn(max_completion_tokens=eff_max, **kwargs)
+                    else:
+                        be_msg = str(be).lower()
+                        fallback_limits = [
+                            8192,
+                            4096,
+                            2048,
+                            1024,
+                            512,
+                            256,
+                            128,
+                            64,
+                            32,
+                        ]
+                        if any(
+                            k in be_msg
+                            for k in [
+                                "max_tokens",
+                                "output limit",
+                                "finish the message",
+                                "max_completion_tokens",
+                            ]
+                        ):
+                            last_exc: Optional[Exception] = be
+                            for lim in fallback_limits:
+                                try:
+                                    try:
+                                        resp = call_fn(
+                                            max_completion_tokens=lim, **kwargs
+                                        )
+                                        last_exc = None
+                                        break
+                                    except Exception as inner_e:  # noqa: BLE001
+                                        last_exc = inner_e
+                                        resp = call_fn(max_tokens=lim, **kwargs)
+                                        last_exc = None
+                                        break
+                                except Exception as inner2:  # noqa: BLE001
+                                    last_exc = inner2
+                                    continue
+                            if last_exc is not None:
+                                raise last_exc
+                        else:
+                            raise be
+                if custom_format is not None:
+                    return resp.choices[0].message.parsed.model_dump()
+                return resp.choices[0].message.content
+            except self._openai.RateLimitError:  # type: ignore[attr-defined]
+                self.logger.warning(
+                    f"Rate limit exceeded. Retrying in {retry_delay} seconds..."
+                )
+                retries += 1
+                time.sleep(retry_delay * retries)
+            except Exception as e:  # noqa: BLE001
+                self.logger.error(f"An error occurred: {e}")
+                import traceback
+
+                traceback.print_exc()
+                break
+        self.logger.error("Max retries exceeded. Unable to complete the request.")
+        return None
+
+    def infer_stream(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float],
+        max_tokens: Optional[int],
+        return_json: bool,
+        custom_format: Any = None,
+        max_retries: int = 5,
+        retry_delay: int = 5,
+    ):
+        if return_json or custom_format is not None:
+            yield from super().infer_stream(
+                messages,
+                temperature,
+                max_tokens,
+                return_json,
+                custom_format,
+                max_retries,
+                retry_delay,
+            )
+            return
+
+        retries = 0
+        eff_temp = self._normalize_temperature(self.model_name, temperature)
+        eff_max = (
+            max_tokens
+            if max_tokens is not None
+            else self._resolve_default_max_tokens(self.model_name)
+        )
+
+        while retries < max_retries:
+            try:
+                kwargs: Dict[str, Any] = {
+                    "model": self.model_name,
+                    "messages": messages,
+                    "stream": True,
+                }
+                if eff_temp is not None:
+                    kwargs["temperature"] = eff_temp
+                if eff_max is not None:
+                    kwargs["max_tokens"] = eff_max
+
+                stream = self.client.chat.completions.create(**kwargs)
+                for chunk in stream:
+                    text = self._extract_text_from_chunk(chunk)
+                    if text:
+                        yield text
+                return
+            except self._openai.RateLimitError:  # type: ignore[attr-defined]
+                self.logger.warning(
+                    f"Rate limit exceeded. Retrying in {retry_delay} seconds (streaming)..."
+                )
+                retries += 1
+                time.sleep(retry_delay * retries)
+            except Exception as e:  # noqa: BLE001
+                self.logger.error(f"Streaming error: {e}")
+                break
+
+        # Fallback to non-streaming if streaming fails
+        yield from super().infer_stream(
+            messages,
+            temperature,
+            max_tokens,
+            return_json,
+            custom_format,
+            max_retries,
+            retry_delay,
+        )
+
+
 class GeminiClient(BaseLLMClient):
     def __init__(self, model_name: str, logger):
         try:


### PR DESCRIPTION
In relation to https://github.com/mims-harvard/ToolUniverse/issues/8 This PR adds support for OpenAI (without needing Azure) via the `OpenAIClient` using `OPENAI_API_KEY` and `api_type=OPENAI`.