### PR TITLE
fix: avoid unicode logging errors on non-UTF streams

### DIFF
--- a/src/tooluniverse/logging_config.py
+++ b/src/tooluniverse/logging_config.py
@@ -53,9 +53,13 @@ class ToolUniverseFormatter(logging.Formatter):
         "CRITICAL": "🚨 ",
     }
 
+    def __init__(self, *args, use_emoji: bool = True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.use_emoji = use_emoji
+
     def format(self, record):
         # Add emoji prefix
-        emoji = self.EMOJI_PREFIX.get(record.levelname, "")
+        emoji = self.EMOJI_PREFIX.get(record.levelname, "") if self.use_emoji else ""
 
         # Add color if output is to terminal
         if hasattr(sys.stderr, "isatty") and sys.stderr.isatty():
@@ -66,6 +70,18 @@ class ToolUniverseFormatter(logging.Formatter):
         # Format the message
         formatted = super().format(record)
         return f"{emoji}{formatted}"
+
+
+def _stream_supports_unicode(stream) -> bool:
+    """Return whether a stream can encode ToolUniverse's log prefixes."""
+
+    encoding = getattr(stream, "encoding", None) or sys.getdefaultencoding()
+    try:
+        for prefix in ToolUniverseFormatter.EMOJI_PREFIX.values():
+            prefix.encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return False
+    return True
 
 
 class ToolUniverseLogger:
@@ -115,6 +131,7 @@ class ToolUniverseLogger:
         formatter = ToolUniverseFormatter(
             fmt="%(message)s",  # Simple format since we add emoji prefix
             datefmt="%H:%M:%S",
+            use_emoji=_stream_supports_unicode(output_stream),
         )
         handler.setFormatter(formatter)
 
@@ -138,6 +155,7 @@ class ToolUniverseLogger:
         formatter = ToolUniverseFormatter(
             fmt="%(message)s",
             datefmt="%H:%M:%S",
+            use_emoji=_stream_supports_unicode(sys.stderr),
         )
         handler.setFormatter(formatter)
 

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,100 @@
+"""Tests for ToolUniverse logging configuration."""
+
+import logging
+
+import pytest
+
+from tooluniverse.logging_config import ToolUniverseFormatter, _stream_supports_unicode
+
+
+class EncodingCheckingStream:
+    """Minimal stream that raises if written text cannot be encoded."""
+
+    def __init__(self, encoding):
+        self.encoding = encoding
+        self.values = []
+
+    def write(self, value):
+        value.encode(self.encoding)
+        self.values.append(value)
+
+    def flush(self):
+        pass
+
+    def getvalue(self):
+        return "".join(self.values)
+
+
+@pytest.mark.unit
+def test_stream_supports_unicode_detects_cp1252_limitations():
+    """Non-UTF Windows streams should not receive emoji log prefixes."""
+
+    stream = EncodingCheckingStream("cp1252")
+
+    assert _stream_supports_unicode(stream) is False
+
+
+@pytest.mark.unit
+def test_stream_supports_unicode_accepts_utf8_streams():
+    """UTF-8 streams should keep the existing emoji log prefixes."""
+
+    stream = EncodingCheckingStream("utf-8")
+
+    assert _stream_supports_unicode(stream) is True
+
+
+@pytest.mark.unit
+def test_formatter_does_not_emit_emoji_for_cp1252_stream():
+    """Formatter output should be encodable by non-UTF Windows consoles."""
+
+    stream = EncodingCheckingStream("cp1252")
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(
+        ToolUniverseFormatter(
+            fmt="%(message)s",
+            use_emoji=_stream_supports_unicode(stream),
+        )
+    )
+
+    record = logging.LogRecord(
+        name="tooluniverse.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="Loaded 1 tool",
+        args=(),
+        exc_info=None,
+    )
+
+    handler.emit(record)
+
+    assert stream.getvalue() == "Loaded 1 tool\n"
+
+
+@pytest.mark.unit
+def test_formatter_keeps_prefixes_for_utf8_stream():
+    """Formatter should preserve prefixed output when the stream supports it."""
+
+    stream = EncodingCheckingStream("utf-8")
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(
+        ToolUniverseFormatter(
+            fmt="%(message)s",
+            use_emoji=_stream_supports_unicode(stream),
+        )
+    )
+
+    record = logging.LogRecord(
+        name="tooluniverse.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="Loaded 1 tool",
+        args=(),
+        exc_info=None,
+    )
+
+    handler.emit(record)
+
+    assert "Loaded 1 tool" in stream.getvalue()
+    assert stream.getvalue() != "Loaded 1 tool\n"


### PR DESCRIPTION
## Summary
- detect whether the configured log stream can encode ToolUniverse log prefixes
- preserve emoji-prefixed logs on UTF-8 streams
- omit emoji prefixes on non-UTF streams such as Windows cp1252 consoles to avoid UnicodeEncodeError

## Validation
- PYTHONPATH=src pytest tests/unit/test_logging_config.py -q
- uvx --from ruff ruff check src/tooluniverse/logging_config.py tests/unit/test_logging_config.py
- uvx --from ruff ruff format --check src/tooluniverse/logging_config.py tests/unit/test_logging_config.py
- git diff --check
- manual cp1252 stream repro for logging emit