### PR TITLE
fix: add CTD non-JSON response diagnostics

### DIFF
--- a/src/tooluniverse/ctd_tool.py
+++ b/src/tooluniverse/ctd_tool.py
@@ -16,6 +16,10 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 CTD_BASE_URL = "https://ctdbase.org/tools/batchQuery.go"
+CTD_REQUEST_HEADERS = {
+    "Accept": "application/json",
+    "User-Agent": "ToolUniverse CTDTool",
+}
 
 
 @register_tool("CTDTool")
@@ -93,44 +97,15 @@ class CTDTool(BaseTool):
             "format": "json",
         }
 
-        response = requests.get(CTD_BASE_URL, params=params, timeout=self.timeout)
+        response = requests.get(
+            CTD_BASE_URL,
+            params=params,
+            headers=CTD_REQUEST_HEADERS,
+            timeout=self.timeout,
+        )
         response.raise_for_status()
 
         raw_text = response.text.strip()
-
-        if not raw_text or raw_text == "[]":
-            return {
-                "status": "success",
-                "data": [],
-                "metadata": {
-                    "total_results": 0,
-                    "input_type": input_type,
-                    "report_type": report_type,
-                    "query": input_terms,
-                },
-            }
-
-        content_type = response.headers.get("content-type", "")
-        try:
-            data = response.json()
-        except ValueError:
-            snippet = raw_text[:200]
-            is_html = "text/html" in content_type or raw_text.lstrip().startswith("<")
-            return {
-                "status": "error",
-                "error": "CTD API returned non-JSON response",
-                "content_type": content_type,
-                "response_snippet": snippet,
-                "retryable": is_html,
-                "suggestion": (
-                    "CTD may be under maintenance or rate-limiting. "
-                    "Check https://ctdbase.org for status. "
-                    "Retry in a few minutes."
-                    if is_html
-                    else "Response was truncated or malformed. Retry the request."
-                ),
-            }
-
         metadata = {
             "input_type": input_type,
             "report_type": report_type,
@@ -142,6 +117,38 @@ class CTDTool(BaseTool):
                 f"CTD uses '{normalized_terms}' instead of '{input_terms}' "
                 "for mitochondrial genes."
             )
+
+        if not raw_text or raw_text == "[]":
+            return {
+                "status": "success",
+                "data": [],
+                "metadata": {**metadata, "total_results": 0},
+            }
+
+        content_type = response.headers.get("content-type", "")
+        try:
+            data = response.json()
+        except ValueError:
+            snippet = raw_text[:200]
+            is_html = "text/html" in content_type or raw_text.lstrip().startswith("<")
+            return {
+                "status": "error",
+                "error": "CTD API returned non-JSON response",
+                "status_code": response.status_code,
+                "content_type": content_type,
+                "request_url": response.url,
+                "response_snippet": snippet,
+                "metadata": metadata,
+                "retryable": is_html,
+                "suggestion": (
+                    "CTD may be under maintenance or rate-limiting. "
+                    "Check https://ctdbase.org for status and retry. "
+                    "If this persists, include request_url and response_snippet "
+                    "when reporting the issue."
+                    if is_html
+                    else "Response was truncated or malformed. Retry the request."
+                ),
+            }
 
         if isinstance(data, (list, dict)):
             metadata["total_results"] = len(data) if isinstance(data, list) else 1

--- a/tests/unit/test_ctd_tool.py
+++ b/tests/unit/test_ctd_tool.py
@@ -1,0 +1,120 @@
+"""Unit tests for the CTD tool."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tooluniverse.ctd_tool import CTD_REQUEST_HEADERS, CTDTool
+
+
+def make_ctd_tool(input_type="gene", report_type="diseases_curated"):
+    """Create a CTD tool with a small deterministic config."""
+
+    return CTDTool(
+        {
+            "name": "CTD_get_gene_diseases",
+            "type": "CTDTool",
+            "fields": {
+                "input_type": input_type,
+                "report_type": report_type,
+            },
+        }
+    )
+
+
+def make_response(text, json_value=None, content_type="application/json"):
+    """Create a mock requests response."""
+
+    response = Mock()
+    response.status_code = 200
+    response.url = "https://ctdbase.org/tools/batchQuery.go?inputTerms=TP53"
+    response.text = text
+    response.headers = {"content-type": content_type}
+    response.raise_for_status.return_value = None
+    if json_value is None:
+        response.json.side_effect = ValueError("not json")
+    else:
+        response.json.return_value = json_value
+    return response
+
+
+@pytest.mark.unit
+@patch("tooluniverse.ctd_tool.requests.get")
+def test_ctd_non_json_response_includes_diagnostics(mock_get):
+    """HTML responses should include enough context to debug API failures."""
+
+    mock_get.return_value = make_response(
+        "<!DOCTYPE html><html><head><title>CTD</title></head></html>",
+        content_type="text/html;charset=UTF-8",
+    )
+    tool = make_ctd_tool()
+
+    result = tool.run({"input_terms": "TP53"})
+
+    assert result["status"] == "error"
+    assert result["error"] == "CTD API returned non-JSON response"
+    assert result["status_code"] == 200
+    assert result["content_type"] == "text/html;charset=UTF-8"
+    assert result["request_url"].startswith("https://ctdbase.org/tools/batchQuery.go")
+    assert result["response_snippet"].startswith("<!DOCTYPE html>")
+    assert result["metadata"] == {
+        "input_type": "gene",
+        "report_type": "diseases_curated",
+        "query": "TP53",
+    }
+    assert result["retryable"] is True
+    assert "request_url" in result["suggestion"]
+
+
+@pytest.mark.unit
+@patch("tooluniverse.ctd_tool.requests.get")
+def test_ctd_request_asks_for_json(mock_get):
+    """CTD requests should ask the API for JSON explicitly."""
+
+    mock_get.return_value = make_response("[]", json_value=[])
+    tool = make_ctd_tool()
+
+    tool.run({"input_terms": "TP53"})
+
+    assert mock_get.call_args.kwargs["headers"] == CTD_REQUEST_HEADERS
+
+
+@pytest.mark.unit
+@patch("tooluniverse.ctd_tool.requests.get")
+def test_ctd_empty_response_reuses_metadata(mock_get):
+    """Empty CTD responses should include query metadata."""
+
+    mock_get.return_value = make_response("[]", json_value=[])
+    tool = make_ctd_tool()
+
+    result = tool.run({"input_terms": "BRCA1"})
+
+    assert result == {
+        "status": "success",
+        "data": [],
+        "metadata": {
+            "input_type": "gene",
+            "report_type": "diseases_curated",
+            "query": "BRCA1",
+            "total_results": 0,
+        },
+    }
+
+
+@pytest.mark.unit
+@patch("tooluniverse.ctd_tool.requests.get")
+def test_ctd_non_json_response_keeps_normalized_query_metadata(mock_get):
+    """Error metadata should preserve mitochondrial gene normalization details."""
+
+    mock_get.return_value = make_response(
+        "<html>temporary CTD page</html>",
+        content_type="text/html;charset=UTF-8",
+    )
+    tool = make_ctd_tool()
+
+    result = tool.run({"input_terms": "MT-ND5"})
+
+    assert result["metadata"]["query"] == "MT-ND5"
+    assert result["metadata"]["normalized_query"] == "ND5"
+    assert "mitochondrial genes" in result["metadata"]["note"]
+    assert mock_get.call_args.kwargs["params"]["inputTerms"] == "ND5"


### PR DESCRIPTION
## Summary
- request JSON explicitly from the CTD batch API
- include status code, request URL, response snippet, and query metadata when CTD returns non-JSON content
- preserve mitochondrial gene normalization metadata in both success and error paths
- add mocked unit tests for CTD HTML responses, headers, empty responses, and normalized query metadata

## Validation
- PYTHONPATH=src pytest tests/unit/test_ctd_tool.py -q
- uvx --from ruff ruff check src/tooluniverse/ctd_tool.py tests/unit/test_ctd_tool.py
- uvx --from ruff ruff format --check src/tooluniverse/ctd_tool.py tests/unit/test_ctd_tool.py
- git diff --check
- live CTD TP53 call confirms non-JSON diagnostic fields are returned