### PR TITLE
fix: add compact UniProt entry output

### DIFF
--- a/src/tooluniverse/data/uniprot_tools.json
+++ b/src/tooluniverse/data/uniprot_tools.json
@@ -8,6 +8,11 @@
         "accession": {
           "type": "string",
           "description": "UniProtKB entry accession, e.g., P05067."
+        },
+        "compact": {
+          "type": "boolean",
+          "description": "Return a bounded summary instead of the complete UniProtKB JSON entry. Use this when calling from an LLM context to avoid oversized outputs.",
+          "default": false
         }
       },
       "required": [

--- a/src/tooluniverse/uniprot_tool.py
+++ b/src/tooluniverse/uniprot_tool.py
@@ -34,6 +34,69 @@ class UniProtRESTTool(BaseTool):
             url = url.replace(f"{{{k}}}", str(v))
         return url
 
+    def _compact_entry(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a bounded summary of a UniProtKB entry for LLM contexts."""
+        protein_desc = data.get("proteinDescription", {})
+        recommended_name = (
+            protein_desc.get("recommendedName", {}).get("fullName", {}).get("value", "")
+        )
+        gene_names = []
+        for gene in data.get("genes", []):
+            gene_name = gene.get("geneName", {}).get("value")
+            if gene_name:
+                gene_names.append(gene_name)
+
+        comment_summaries = []
+        for comment in data.get("comments", []):
+            text_values = [
+                text["value"]
+                for text in comment.get("texts", [])
+                if isinstance(text, dict) and text.get("value")
+            ]
+            if text_values:
+                comment_summaries.append(
+                    {
+                        "commentType": comment.get("commentType", ""),
+                        "texts": text_values[:3],
+                    }
+                )
+
+        feature_summaries = []
+        for feature in data.get("features", [])[:100]:
+            feature_summaries.append(
+                {
+                    "type": feature.get("type", ""),
+                    "description": feature.get("description", ""),
+                    "location": feature.get("location", {}),
+                }
+            )
+
+        return {
+            "status": "success",
+            "data": {
+                "entryType": data.get("entryType", ""),
+                "primaryAccession": data.get("primaryAccession", ""),
+                "uniProtkbId": data.get("uniProtkbId", ""),
+                "protein_name": recommended_name,
+                "gene_names": gene_names,
+                "organism": data.get("organism", {}),
+                "sequence": data.get("sequence", {}),
+                "annotationScore": data.get("annotationScore"),
+                "proteinExistence": data.get("proteinExistence", ""),
+                "keywords": data.get("keywords", []),
+                "comments": comment_summaries[:25],
+                "features": feature_summaries,
+                "xref_count": len(data.get("uniProtKBCrossReferences", [])),
+            },
+            "metadata": {
+                "compact": True,
+                "comments_returned": min(len(comment_summaries), 25),
+                "features_returned": len(feature_summaries),
+                "total_comments": len(data.get("comments", [])),
+                "total_features": len(data.get("features", [])),
+            },
+        }
+
     def _extract_data(self, data: Dict, extract_path: str) -> Any:
         """Custom data extraction with support for filtering"""
 
@@ -506,7 +569,8 @@ class UniProtRESTTool(BaseTool):
             return self._handle_id_mapping(arguments)
 
         # Build URL for standard accession-based queries
-        url = self._build_url(arguments)
+        request_args = {k: v for k, v in arguments.items() if k != "compact"}
+        url = self._build_url(request_args)
         try:
             resp = requests.get(url, timeout=self.timeout)
             if resp.status_code != 200:
@@ -541,6 +605,9 @@ class UniProtRESTTool(BaseTool):
                 return result
 
             return result
+
+        if arguments.get("compact") is True:
+            return self._compact_entry(data)
 
         return data
 

--- a/tests/tools/test_uniprot_compact_entry.py
+++ b/tests/tools/test_uniprot_compact_entry.py
@@ -1,0 +1,67 @@
+from unittest.mock import Mock, patch
+
+from tooluniverse.uniprot_tool import UniProtRESTTool
+
+
+def _tool():
+    return UniProtRESTTool(
+        {
+            "fields": {
+                "endpoint": "https://rest.uniprot.org/uniprotkb/{accession}.json",
+            }
+        }
+    )
+
+
+def _response(payload):
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = payload
+    return response
+
+
+def test_compact_entry_returns_bounded_summary():
+    payload = {
+        "entryType": "UniProtKB reviewed (Swiss-Prot)",
+        "primaryAccession": "P05067",
+        "uniProtkbId": "A4_HUMAN",
+        "proteinDescription": {
+            "recommendedName": {"fullName": {"value": "Amyloid-beta precursor protein"}}
+        },
+        "genes": [{"geneName": {"value": "APP"}}],
+        "organism": {"scientificName": "Homo sapiens", "taxonId": 9606},
+        "sequence": {"value": "M" * 20, "length": 20},
+        "comments": [
+            {"commentType": "FUNCTION", "texts": [{"value": "Function text"}]},
+            {"commentType": "DISEASE", "texts": [{"value": "Disease text"}]},
+        ],
+        "features": [
+            {"type": "Chain", "description": "Processed chain"} for _ in range(105)
+        ],
+        "uniProtKBCrossReferences": [{"database": "PDB"} for _ in range(10)],
+    }
+
+    with patch(
+        "tooluniverse.uniprot_tool.requests.get", return_value=_response(payload)
+    ):
+        result = _tool().run({"accession": "P05067", "compact": True})
+
+    assert result["status"] == "success"
+    assert result["data"]["primaryAccession"] == "P05067"
+    assert result["data"]["protein_name"] == "Amyloid-beta precursor protein"
+    assert result["data"]["gene_names"] == ["APP"]
+    assert len(result["data"]["features"]) == 100
+    assert result["data"]["xref_count"] == 10
+    assert result["metadata"]["compact"] is True
+    assert result["metadata"]["total_features"] == 105
+
+
+def test_full_entry_remains_default_behavior():
+    payload = {"primaryAccession": "P05067", "large": {"nested": True}}
+
+    with patch(
+        "tooluniverse.uniprot_tool.requests.get", return_value=_response(payload)
+    ):
+        result = _tool().run({"accession": "P05067"})
+
+    assert result == payload


### PR DESCRIPTION
## Summary
- Adds an optional compact: true mode to UniProt_get_entry_by_accession for bounded LLM-friendly output
- Keeps default behavior unchanged, returning the complete UniProtKB JSON entry unless compact mode is requested
- Documents the new parameter in uniprot_tools.json

## Validation
- PYTHONPATH=src pytest tests/tools/test_uniprot_compact_entry.py -q -> 2 passed
- uvx --from ruff ruff check src/tooluniverse/uniprot_tool.py tests/tools/test_uniprot_compact_entry.py -> passed
- uvx --from ruff ruff format --check src/tooluniverse/uniprot_tool.py tests/tools/test_uniprot_compact_entry.py -> passed
- python -m json.tool src/tooluniverse/data/uniprot_tools.json -> passed
- git diff --check -> passed

Addresses the oversized-output concern in #56 without changing existing callers.