### PR TITLE
fix: stabilize task manager listing

### DIFF
--- a/src/tooluniverse/task_manager.py
+++ b/src/tooluniverse/task_manager.py
@@ -40,6 +40,7 @@ class Task:
     progress: Optional[TaskProgress] = None
     auth_context: Optional[str] = None
     _task_handle: Optional[asyncio.Task] = None
+    _sequence: int = 0
 
     def is_expired(self) -> bool:
         """Check if task has exceeded its TTL."""
@@ -61,6 +62,7 @@ class TaskManager:
         self.lock = asyncio.Lock()
         self.tool_universe = tool_universe
         self._cleanup_task: Optional[asyncio.Task] = None
+        self._task_sequence = 0
 
     # -- Lifecycle --------------------------------------------------------
 
@@ -148,8 +150,11 @@ class TaskManager:
 
         Async tools are awaited directly; sync tools run in a thread pool.
         """
-        sig = inspect.signature(tool.run)
-        kwargs = {"progress": progress} if "progress" in sig.parameters else {}
+        try:
+            sig = inspect.signature(tool.run)
+            kwargs = {"progress": progress} if "progress" in sig.parameters else {}
+        except (TypeError, ValueError):
+            kwargs = {}
         is_async = inspect.iscoroutinefunction(tool.run)
 
         if is_async:
@@ -167,19 +172,20 @@ class TaskManager:
     ) -> str:
         """Create a new task and start background execution. Returns the task ID."""
         task_id = str(uuid.uuid4())
-        task = Task(
-            task_id=task_id,
-            tool_name=tool_name,
-            arguments=arguments,
-            status="working",
-            status_message=f"Task submitted: {tool_name}",
-            created_at=datetime.now(),
-            ttl=ttl,
-            auth_context=auth_context,
-        )
-        task.progress = TaskProgress(task, lock=self.lock)
-
         async with self.lock:
+            self._task_sequence += 1
+            task = Task(
+                task_id=task_id,
+                tool_name=tool_name,
+                arguments=arguments,
+                status="working",
+                status_message=f"Task submitted: {tool_name}",
+                created_at=datetime.now(),
+                ttl=ttl,
+                auth_context=auth_context,
+                _sequence=self._task_sequence,
+            )
+            task.progress = TaskProgress(task, lock=self.lock)
             self.tasks[task_id] = task
 
         task._task_handle = asyncio.create_task(self._execute_task(task))
@@ -273,7 +279,7 @@ class TaskManager:
                 for task in self.tasks.values()
                 if not auth_context or task.auth_context == auth_context
             ]
-            tasks_list.sort(key=lambda t: t.created_at, reverse=True)
+            tasks_list.sort(key=lambda t: (t.created_at, t._sequence), reverse=True)
 
             return {
                 "tasks": [

--- a/tests/unit/test_task_manager.py
+++ b/tests/unit/test_task_manager.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import sys
+from datetime import datetime
 
 import pytest
 import pytest_asyncio
@@ -10,6 +11,7 @@ from unittest.mock import Mock, AsyncMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
+import tooluniverse.task_manager as task_manager_module
 from tooluniverse.task_manager import TaskManager, Task
 from tooluniverse.task_progress import TaskProgress
 
@@ -422,6 +424,41 @@ async def test_list_tasks_sorted_by_creation_time(task_manager):
     assert result["tasks"][0]["taskId"] == task_id3
     assert result["tasks"][1]["taskId"] == task_id2
     assert result["tasks"][2]["taskId"] == task_id1
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_uses_sequence_when_creation_times_match(task_manager):
+    """Tasks created in the same clock tick should still sort newest first."""
+    task_id1 = await task_manager.create_task("TestTool", {"arg": "1"}, 3600000)
+    task_id2 = await task_manager.create_task("TestTool", {"arg": "2"}, 3600000)
+    task_id3 = await task_manager.create_task("TestTool", {"arg": "3"}, 3600000)
+
+    same_time = datetime.now()
+    async with task_manager.lock:
+        for task_id in (task_id1, task_id2, task_id3):
+            task_manager.tasks[task_id].created_at = same_time
+
+    result = await task_manager.list_tasks()
+
+    assert [task["taskId"] for task in result["tasks"][:3]] == [task_id3, task_id2, task_id1]
+
+
+@pytest.mark.asyncio
+async def test_run_tool_handles_uninspectable_run_signature(task_manager, monkeypatch):
+    """Some callable implementations do not expose a Python signature."""
+    tool = Mock()
+    tool.run = Mock(return_value={"data": {"result": "success"}})
+    progress = TaskProgress(Task("task", "TestTool", {}, "working", "working", datetime.now()))
+
+    def raise_uninspectable(_callable):
+        raise ValueError("no signature available")
+
+    monkeypatch.setattr(task_manager_module.inspect, "signature", raise_uninspectable)
+
+    result = await task_manager._run_tool(tool, {"arg": "value"}, progress)
+
+    assert result == {"data": {"result": "success"}}
+    tool.run.assert_called_once_with({"arg": "value"})
 
 
 # ============================================================================


### PR DESCRIPTION
Summary
- preserve task creation order with an internal sequence number so tied timestamps still list newest tasks first
- avoid failing task execution when a tool's run callable cannot be inspected for a progress argument
- add TaskManager regression coverage for tied timestamps and uninspectable run signatures

Validation
- python -m pytest -q tests/unit/test_task_manager.py
- python -m compileall -q src/tooluniverse/task_manager.py