### PR TITLE
docs: add OpenCode manual MCP setup

### DIFF
--- a/docs/guide/building_ai_scientists/opencode.rst
+++ b/docs/guide/building_ai_scientists/opencode.rst
@@ -9,3 +9,23 @@ To set up ToolUniverse, open OpenCode and run:
 .. code-block:: text
 
    Read https://aiscientist.tools/setup.md and set up ToolUniverse for me.
+
+Manual MCP configuration
+------------------------
+
+If you prefer to configure the MCP server manually, add ToolUniverse as a stdio
+server that runs the ``tooluniverse`` command through ``uvx``:
+
+.. code-block:: json
+
+   {
+     "mcp": {
+       "tooluniverse": {
+         "type": "local",
+         "command": ["uvx", "--refresh", "tooluniverse"]
+       }
+     }
+   }
+
+After saving the configuration, restart OpenCode and ask it to list available
+ToolUniverse tools.


### PR DESCRIPTION
Summary
- add a direct OpenCode MCP configuration example for ToolUniverse
- show the uvx --refresh tooluniverse stdio command in opencode.json format
- add a quick verification step after restart

Validation
- git diff --check
- python -m compileall -q src/tooluniverse/cli.py

Related to mims-harvard/ToolUniverse#63