### PR TITLE
fix: add DisGeNET empty-result diagnostics

### DIFF
--- a/src/tooluniverse/disgenet_tool.py
+++ b/src/tooluniverse/disgenet_tool.py
@@ -4,8 +4,8 @@ DisGeNET API tool for ToolUniverse.
 DisGeNET is one of the largest public collections of genes and variants
 associated with human diseases, aggregating data from multiple sources.
 
-API Documentation: https://www.disgenet.org/api/
-Requires API key: Register at https://www.disgenet.org/
+API Documentation: https://api.disgenet.com/
+Requires API key: Register at https://www.disgenet.com/
 """
 
 import os
@@ -30,7 +30,7 @@ class DisGeNETTool(BaseTool):
     - Aggregated evidence scores
 
     Requires API key via DISGENET_API_KEY environment variable.
-    Register for free at https://www.disgenet.org/
+    Register for free at https://www.disgenet.com/
     """
 
     def __init__(self, tool_config: Dict[str, Any]):
@@ -54,7 +54,7 @@ class DisGeNETTool(BaseTool):
         if not self.api_key:
             return {
                 "status": "error",
-                "error": "DisGeNET API key required. Set DISGENET_API_KEY environment variable. Register at https://www.disgenet.org/",
+                "error": "DisGeNET API key required. Set DISGENET_API_KEY environment variable. Register at https://www.disgenet.com/",
             }
 
         operation = arguments.get("operation", "")
@@ -102,22 +102,28 @@ class DisGeNETTool(BaseTool):
             )
             response.raise_for_status()
             data = response.json()
+            associations = data if isinstance(data, list) else data.get("results", [])
+            count = len(data) if isinstance(data, list) else data.get("count", 0)
+            metadata = {
+                "source": "DisGeNET",
+                "gene": gene,
+                "api_url": DISGENET_API_URL,
+            }
+            if count == 0:
+                metadata["diagnostic"] = (
+                    "No DisGeNET associations were returned. Verify the gene "
+                    "identifier accepted by the current DisGeNET API and that "
+                    "the configured API plan has access to this endpoint/source."
+                )
 
             return {
                 "status": "success",
                 "data": {
                     "gene": gene,
-                    "associations": data
-                    if isinstance(data, list)
-                    else data.get("results", []),
-                    "count": len(data)
-                    if isinstance(data, list)
-                    else data.get("count", 0),
+                    "associations": associations,
+                    "count": count,
                 },
-                "metadata": {
-                    "source": "DisGeNET",
-                    "gene": gene,
-                },
+                "metadata": metadata,
             }
 
         except requests.exceptions.HTTPError as e:
@@ -165,22 +171,28 @@ class DisGeNETTool(BaseTool):
             )
             response.raise_for_status()
             data = response.json()
+            associations = data if isinstance(data, list) else data.get("results", [])
+            count = len(data) if isinstance(data, list) else data.get("count", 0)
+            metadata = {
+                "source": "DisGeNET",
+                "disease": disease,
+                "api_url": DISGENET_API_URL,
+            }
+            if count == 0:
+                metadata["diagnostic"] = (
+                    "No DisGeNET associations were returned. Verify the disease "
+                    "identifier accepted by the current DisGeNET API and that "
+                    "the configured API plan has access to this endpoint/source."
+                )
 
             return {
                 "status": "success",
                 "data": {
                     "disease": disease,
-                    "associations": data
-                    if isinstance(data, list)
-                    else data.get("results", []),
-                    "count": len(data)
-                    if isinstance(data, list)
-                    else data.get("count", 0),
+                    "associations": associations,
+                    "count": count,
                 },
-                "metadata": {
-                    "source": "DisGeNET",
-                    "disease": disease,
-                },
+                "metadata": metadata,
             }
 
         except requests.exceptions.HTTPError as e:

--- a/tests/tools/test_disgenet_tool.py
+++ b/tests/tools/test_disgenet_tool.py
@@ -27,7 +27,7 @@ class TestDisGeNETToolDirect:
 
     def test_missing_api_key(self, tool_config):
         """Test error when API key is missing."""
-        with patch.dict(os.environ, {"DISGENET_API_KEY": ""}, clear=True):
+        with patch.dict(os.environ, {"DISGENET_API_KEY": ""}, clear=False):
             from tooluniverse.disgenet_tool import DisGeNETTool
             tool = DisGeNETTool(tool_config)
             result = tool.run({"operation": "search_gene", "gene": "BRCA1"})

--- a/tests/tools/test_disgenet_tool.py
+++ b/tests/tools/test_disgenet_tool.py
@@ -60,6 +60,36 @@ class TestDisGeNETToolDirect:
         assert result["status"] == "success"
         assert len(result["data"]["associations"]) > 0
 
+    @patch("tooluniverse.disgenet_tool.requests.get")
+    def test_search_gene_empty_result_includes_diagnostic(self, mock_get, tool):
+        """Test empty gene search includes a troubleshooting diagnostic."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": [], "count": 0}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        result = tool.run({"operation": "search_gene", "gene": "UNKNOWN"})
+
+        assert result["status"] == "success"
+        assert result["data"]["count"] == 0
+        assert "diagnostic" in result["metadata"]
+        assert "api.disgenet.com" in result["metadata"]["api_url"]
+
+    @patch("tooluniverse.disgenet_tool.requests.get")
+    def test_search_disease_empty_result_includes_diagnostic(self, mock_get, tool):
+        """Test empty disease search includes a troubleshooting diagnostic."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": [], "count": 0}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        result = tool.run({"operation": "search_disease", "disease": "UNKNOWN"})
+
+        assert result["status"] == "success"
+        assert result["data"]["count"] == 0
+        assert "diagnostic" in result["metadata"]
+        assert "api.disgenet.com" in result["metadata"]["api_url"]
+
 
 class TestDisGeNETToolInterface:
     """Test DisGeNET tool via ToolUniverse interface (Level 2)."""


### PR DESCRIPTION
Summary
- update DisGeNET documentation and API-key guidance from old disgenet.org URLs to current disgenet.com and api.disgenet.com service references
- add endpoint-specific metadata for empty gene and disease search responses, including API URL and diagnostic guidance
- add regression tests for empty gene and disease search responses

Validation
- python -m pytest -q -p no:cacheprovider --no-cov tests/tools/test_disgenet_tool.py
- python -m compileall -q src/tooluniverse/disgenet_tool.py
- git diff --check

Notes
- Not a duplicate of #139; this PR addresses DisGeNET empty-success responses and current endpoint guidance, not generic non-JSON parsing.
- Related to #175.