### PR TITLE
fix: add BioModels non-JSON diagnostics

### DIFF
--- a/src/tooluniverse/biomodels_tool.py
+++ b/src/tooluniverse/biomodels_tool.py
@@ -45,16 +45,18 @@ class BioModelsRESTTool(BaseRESTTool):
         except ValueError:
             text = response.text or ""
             content_type = response.headers.get("Content-Type", "")
+            retryable = "text/html" in content_type.lower() or text.lstrip().startswith("<")
             return {
                 "status": "error",
-                "error": (
-                    "BioModels returned a non-JSON response. The endpoint may "
-                    "have moved, be temporarily unavailable, or require a "
-                    "different request format."
-                ),
+                "error": "BioModels returned a non-JSON response",
                 "url": url,
                 "content_type": content_type,
-                "detail": text[:500],
+                "response_snippet": text[:200],
+                "retryable": retryable,
+                "suggestion": (
+                    "BioModels may have returned an HTML maintenance or redirect page. "
+                    "Check the endpoint URL, request parameters, and service availability."
+                ),
             }
 
         # Build result

--- a/src/tooluniverse/biomodels_tool.py
+++ b/src/tooluniverse/biomodels_tool.py
@@ -40,7 +40,22 @@ class BioModelsRESTTool(BaseRESTTool):
         self, response: requests.Response, url: str
     ) -> Dict[str, Any]:
         """Process BioModels API response."""
-        data = response.json()
+        try:
+            data = response.json()
+        except ValueError:
+            text = response.text or ""
+            content_type = response.headers.get("Content-Type", "")
+            return {
+                "status": "error",
+                "error": (
+                    "BioModels returned a non-JSON response. The endpoint may "
+                    "have moved, be temporarily unavailable, or require a "
+                    "different request format."
+                ),
+                "url": url,
+                "content_type": content_type,
+                "detail": text[:500],
+            }
 
         # Build result
         result = {

--- a/tests/tools/test_biomodels_tool.py
+++ b/tests/tools/test_biomodels_tool.py
@@ -25,4 +25,6 @@ def test_biomodels_non_json_response_returns_diagnostic():
     assert result["status"] == "error"
     assert "non-JSON" in result["error"]
     assert result["content_type"] == "text/html"
-    assert result["detail"] == "<html>Moved</html>"
+    assert result["response_snippet"] == "<html>Moved</html>"
+    assert result["retryable"] is True
+    assert "BioModels" in result["suggestion"]

--- a/tests/tools/test_biomodels_tool.py
+++ b/tests/tools/test_biomodels_tool.py
@@ -1,0 +1,28 @@
+"""Unit tests for BioModels REST response handling."""
+
+from unittest.mock import MagicMock
+
+from tooluniverse.biomodels_tool import BioModelsRESTTool
+
+
+def _tool():
+    return BioModelsRESTTool(
+        {
+            "name": "biomodels_search",
+            "fields": {"endpoint": "https://www.ebi.ac.uk/biomodels/search"},
+        }
+    )
+
+
+def test_biomodels_non_json_response_returns_diagnostic():
+    response = MagicMock()
+    response.json.side_effect = ValueError("not json")
+    response.text = "<html>Moved</html>"
+    response.headers = {"Content-Type": "text/html"}
+
+    result = _tool()._process_response(response, "https://example.test")
+
+    assert result["status"] == "error"
+    assert "non-JSON" in result["error"]
+    assert result["content_type"] == "text/html"
+    assert result["detail"] == "<html>Moved</html>"


### PR DESCRIPTION
Summary
- fill the BioModels-specific non-JSON gap that was not covered by #139
- align BioModels parse-failure diagnostics with the existing ToolUniverse pattern: content_type, response_snippet, retryable, suggestion
- keep URL context and regression coverage for HTML or redirect responses

Validation
- python -m pytest -q -p no:cacheprovider --no-cov tests/tools/test_biomodels_tool.py
- python -m compileall -q src/tooluniverse/biomodels_tool.py
- git diff --check

Notes
- Complements #139; #139 did not touch BioModels.
- Related to #174.