### PR TITLE
Fix triaged ToolUniverse regressions

### DIFF
--- a/docs/expand_tooluniverse/contributing/local_tools.rst
+++ b/docs/expand_tooluniverse/contributing/local_tools.rst
@@ -82,6 +82,23 @@ Step 3: Register Tool
 
 The ``@register_tool('MyNewTool')`` decorator registers your tool class. Note that for contributions, we don't include the config in the decorator - that goes in a separate JSON file.
 
+.. important::
+
+   There are two different registration paths:
+
+   - **Contributing to ToolUniverse**: put the class under
+     ``src/tooluniverse/`` and put the JSON spec under
+     ``src/tooluniverse/data/``. The package discovery system can find the
+     decorated class from the ToolUniverse package tree.
+   - **Local experiment outside the package tree**: either import the Python
+     file before calling ``load_tools()``, or include the full config in
+     ``@register_tool(..., config={...})`` as shown in
+     :doc:`../local_tools/local_tools_tutorial`.
+
+   Passing only ``tool_config_files`` loads the JSON specification; it does not
+   import an arbitrary Python file from your current directory. If your class is
+   outside ``src/tooluniverse/``, import that module first so the decorator runs.
+
 Step 4: Create Configuration File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -269,9 +286,11 @@ Create ``examples/my_new_tool/my_new_tool_example.py``:
    if __name__ == "__main__":
        main()
 
-**Note**: A complete working example can be found in ``examples/my_new_tool/`` directory,
-which includes both the multi-file structure (for contributions) and a single-file
-example (for local development). See ``examples/my_new_tool/README.md`` for details.
+**Note**: A complete working example can be found in the
+``examples/my_new_tool/`` directory. That example imports the tool module before
+loading its JSON file because the example tool lives outside the installed
+``tooluniverse`` package tree. It also includes a single-file local-development
+example. See ``examples/my_new_tool/README.md`` for details.
 
 Step 10: Submit Pull Request
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guide/literature_search_web_ui_tutorial.rst
+++ b/docs/guide/literature_search_web_ui_tutorial.rst
@@ -1,6 +1,16 @@
 Wide Research Web UI Tutorial
 ==============================
 
+.. warning::
+
+   The Wide Research Web UI is not currently packaged in ToolUniverse. The
+   ``tooluniverse-wide-research`` console command is not installed by the
+   current ``pyproject.toml``, and the
+   ``tooluniverse.web_tools.literature_search_ui`` package is not present in
+   the source tree. Treat this page as legacy design documentation until the UI
+   package is restored. For packaged literature workflows, use the literature
+   tools through the CLI, Python API, or MCP server instead.
+
 This tutorial demonstrates how to use the ToolUniverse Wide Research Web UI, a powerful web-based interface that provides intelligent literature search and analysis capabilities across multiple academic databases.
 
 Overview
@@ -34,13 +44,17 @@ Quick Start
 Starting the Web UI
 ~~~~~~~~~~~~~~~~~~~
 
-The easiest way to start the Wide Research Web UI is using the command-line tool:
+When the UI package is restored, the intended command-line entry point is:
 
 .. code-block:: bash
 
     tooluniverse-wide-research
 
-This will start the web server and display:
+In current releases this command is not installed. If you need this workflow
+today, use ToolUniverse's packaged literature-search tools through ``tu run``,
+the Python API, or MCP.
+
+The restored command is expected to start the web server and display:
 
 .. code-block:: text
 

--- a/docs/help/troubleshooting.rst
+++ b/docs/help/troubleshooting.rst
@@ -565,6 +565,47 @@ Claude/AI assistant not finding tools
       tools = tu.return_all_loaded_tools()
       print(f"Registered {len(tools)} tools")
 
+Claude Desktop reports ``spawn uv ENOENT`` or ``spawn uvx ENOENT``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Diagnosis:**
+
+Claude Desktop starts MCP servers from a GUI process and may not inherit the
+same ``PATH`` as your terminal. A config that works in a shell can still fail in
+Claude Desktop if ``uv`` or ``uvx`` is not available by absolute path.
+
+**Solutions:**
+
+1. **Verify the command in a normal terminal:**
+
+   .. code-block:: bash
+
+      uvx --version
+      uvx tooluniverse --help
+
+2. **Find the absolute path to ``uvx``:**
+
+   .. code-block:: bash
+
+      which uvx      # macOS/Linux
+      where uvx      # Windows
+
+3. **Use that absolute path in Claude Desktop config.** For example:
+
+   .. code-block:: json
+
+      {
+        "mcpServers": {
+          "tooluniverse": {
+            "command": "/Users/yourname/.local/bin/uvx",
+            "args": ["--refresh", "tooluniverse"]
+          }
+        }
+      }
+
+4. **Restart Claude Desktop completely** after saving the config. First startup
+   can take longer while ``uvx`` resolves and installs the package.
+
 Advanced Debugging
 ------------------
 

--- a/src/tooluniverse/ctd_tool.py
+++ b/src/tooluniverse/ctd_tool.py
@@ -130,23 +130,44 @@ class CTDTool(BaseTool):
             data = response.json()
         except ValueError:
             snippet = raw_text[:200]
+            lower_text = raw_text.lower()
             is_html = "text/html" in content_type or raw_text.lstrip().startswith("<")
+            is_human_verification = any(
+                phrase in lower_text
+                for phrase in (
+                    "verify you are a human",
+                    "human verification",
+                    "captcha",
+                    "checking your browser",
+                )
+            )
             return {
                 "status": "error",
-                "error": "CTD API returned non-JSON response",
+                "error": (
+                    "CTD API blocked programmatic access with human verification"
+                    if is_human_verification
+                    else "CTD API returned non-JSON response"
+                ),
                 "status_code": response.status_code,
                 "content_type": content_type,
                 "request_url": response.url,
                 "response_snippet": snippet,
                 "metadata": metadata,
-                "retryable": is_html,
+                "retryable": is_html and not is_human_verification,
                 "suggestion": (
-                    "CTD may be under maintenance or rate-limiting. "
-                    "Check https://ctdbase.org for status and retry. "
-                    "If this persists, include request_url and response_snippet "
-                    "when reporting the issue."
-                    if is_html
-                    else "Response was truncated or malformed. Retry the request."
+                    "CTD returned a CAPTCHA or human-verification page instead of JSON. "
+                    "This cannot be resolved by retrying from ToolUniverse. Use CTD's "
+                    "website directly, or consider OpenTargets for gene-disease "
+                    "associations and FAERS/OpenFDA tools for chemical safety questions."
+                    if is_human_verification
+                    else (
+                        "CTD may be under maintenance or rate-limiting. "
+                        "Check https://ctdbase.org for status and retry. "
+                        "If this persists, include request_url and response_snippet "
+                        "when reporting the issue."
+                        if is_html
+                        else "Response was truncated or malformed. Retry the request."
+                    )
                 ),
             }
 

--- a/src/tooluniverse/data/uniprot_tools.json
+++ b/src/tooluniverse/data/uniprot_tools.json
@@ -11,8 +11,8 @@
         },
         "compact": {
           "type": "boolean",
-          "description": "Return a bounded summary instead of the complete UniProtKB JSON entry. Use this when calling from an LLM context to avoid oversized outputs.",
-          "default": false
+          "description": "Return a bounded summary instead of the complete UniProtKB JSON entry. Defaults to true to avoid oversized LLM outputs. Set compact=false only when you explicitly need the raw UniProtKB JSON.",
+          "default": true
         }
       },
       "required": [
@@ -22,7 +22,7 @@
     "fields": {
       "endpoint": "https://rest.uniprot.org/uniprotkb/{accession}.json",
       "input_description": "Input UniProtKB accession, e.g., P05067.",
-      "output_description": "Returns the complete UniProtKB entry JSON for that accession. WARNING: Output can be extremely large (40,000+ lines) and may exceed LLM context limits. Consider using specific extraction tools instead."
+      "output_description": "Returns a compact bounded summary for that accession by default. Set compact=false to return the complete UniProtKB entry JSON. WARNING: raw output can be extremely large (40,000+ lines) and may exceed LLM context limits."
     },
     "type": "UniProtRESTTool",
     "test_examples": [

--- a/src/tooluniverse/ols_tool.py
+++ b/src/tooluniverse/ols_tool.py
@@ -187,10 +187,7 @@ class OLSTool(BaseTool):
 
         handler = getattr(self, handler_name)
         try:
-            result = handler(arguments)
-            if isinstance(result, dict) and "status" not in result:
-                return {"status": "success", **result}
-            return result
+            return handler(arguments)
         except requests.RequestException as exc:
             return {"status": "error", "error": str(exc)}
         except ValidationError as exc:
@@ -433,7 +430,26 @@ class OLSTool(BaseTool):
             term_data = self._get_json(
                 f"/api/v2/ontologies/{ontology}/classes/{encoded}"
             )
+            if isinstance(term_data, dict) and not term_data.get("label"):
+                legacy_terms = self._format_term_collection(term_data, size)
+                if "terms" in legacy_terms:
+                    legacy_terms["term_iri"] = term_iri
+                    legacy_terms["ontology"] = ontology
+                    legacy_terms["note"] = (
+                        "Returned terms from an OLS collection response; "
+                        "source term label was not available."
+                    )
+                    return legacy_terms
             label = term_data.get("label", "")
+            if isinstance(label, list):
+                label = next(
+                    (
+                        value
+                        for value in label
+                        if isinstance(value, str) and value.strip()
+                    ),
+                    "",
+                )
         except Exception:
             pass
 

--- a/src/tooluniverse/tools/UniProt_get_entry_by_accession.py
+++ b/src/tooluniverse/tools/UniProt_get_entry_by_accession.py
@@ -10,6 +10,7 @@ from ._shared_client import get_shared_client
 
 def UniProt_get_entry_by_accession(
     accession: str,
+    compact: Optional[bool] = None,
     *,
     stream_callback: Optional[Callable[[str], None]] = None,
     use_cache: bool = False,
@@ -22,6 +23,8 @@ def UniProt_get_entry_by_accession(
     ----------
     accession : str
         UniProtKB entry accession, e.g., P05067.
+    compact : bool, optional
+        Return a bounded summary instead of the complete UniProtKB JSON entry. Defaults to true in the tool configuration.
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False
@@ -36,7 +39,11 @@ def UniProt_get_entry_by_accession(
     # Handle mutable defaults to avoid B006 linting error
 
     # Strip None values so optional parameters don't trigger schema validation errors
-    _args = {k: v for k, v in {"accession": accession}.items() if v is not None}
+    _args = {
+        k: v
+        for k, v in {"accession": accession, "compact": compact}.items()
+        if v is not None
+    }
     return get_shared_client().run_one_function(
         {
             "name": "UniProt_get_entry_by_accession",

--- a/src/tooluniverse/uniprot_tool.py
+++ b/src/tooluniverse/uniprot_tool.py
@@ -606,7 +606,13 @@ class UniProtRESTTool(BaseTool):
 
             return result
 
-        if arguments.get("compact") is True:
+        compact_default = (
+            self.tool_config.get("parameter", {})
+            .get("properties", {})
+            .get("compact", {})
+            .get("default", False)
+        )
+        if arguments.get("compact", compact_default) is True:
             return self._compact_entry(data)
 
         return data

--- a/tests/tools/test_uniprot_compact_entry.py
+++ b/tests/tools/test_uniprot_compact_entry.py
@@ -6,6 +6,13 @@ from tooluniverse.uniprot_tool import UniProtRESTTool
 def _tool():
     return UniProtRESTTool(
         {
+            "parameter": {
+                "properties": {
+                    "compact": {
+                        "default": True,
+                    }
+                }
+            },
             "fields": {
                 "endpoint": "https://rest.uniprot.org/uniprotkb/{accession}.json",
             }
@@ -56,12 +63,30 @@ def test_compact_entry_returns_bounded_summary():
     assert result["metadata"]["total_features"] == 105
 
 
-def test_full_entry_remains_default_behavior():
-    payload = {"primaryAccession": "P05067", "large": {"nested": True}}
+def test_compact_entry_is_default_behavior():
+    payload = {
+        "primaryAccession": "P05067",
+        "proteinDescription": {
+            "recommendedName": {"fullName": {"value": "Amyloid-beta precursor protein"}}
+        },
+    }
 
     with patch(
         "tooluniverse.uniprot_tool.requests.get", return_value=_response(payload)
     ):
         result = _tool().run({"accession": "P05067"})
+
+    assert result["status"] == "success"
+    assert result["metadata"]["compact"] is True
+    assert result["data"]["primaryAccession"] == "P05067"
+
+
+def test_full_entry_remains_available_with_compact_false():
+    payload = {"primaryAccession": "P05067", "large": {"nested": True}}
+
+    with patch(
+        "tooluniverse.uniprot_tool.requests.get", return_value=_response(payload)
+    ):
+        result = _tool().run({"accession": "P05067", "compact": False})
 
     assert result == payload

--- a/tests/unit/test_ctd_tool.py
+++ b/tests/unit/test_ctd_tool.py
@@ -68,6 +68,28 @@ def test_ctd_non_json_response_includes_diagnostics(mock_get):
 
 @pytest.mark.unit
 @patch("tooluniverse.ctd_tool.requests.get")
+def test_ctd_human_verification_response_is_non_retryable(mock_get):
+    """CAPTCHA pages should be reported as a blocked access state."""
+
+    mock_get.return_value = make_response(
+        "<html><title>Verify you are a human</title><body>captcha</body></html>",
+        content_type="text/html;charset=UTF-8",
+    )
+    tool = make_ctd_tool()
+
+    result = tool.run({"input_terms": "TP53"})
+
+    assert result["status"] == "error"
+    assert result["error"] == (
+        "CTD API blocked programmatic access with human verification"
+    )
+    assert result["retryable"] is False
+    assert "OpenTargets" in result["suggestion"]
+    assert "FAERS" in result["suggestion"]
+
+
+@pytest.mark.unit
+@patch("tooluniverse.ctd_tool.requests.get")
 def test_ctd_request_asks_for_json(mock_get):
     """CTD requests should ask the API for JSON explicitly."""
 


### PR DESCRIPTION
## Summary
- restore OLS handler return compatibility and tolerate legacy OLS collection responses in similar-term lookup
- make UniProt_get_entry_by_accession compact by default while keeping compact=false for raw full entries
- detect CTD CAPTCHA/human-verification responses as non-retryable with alternate data-source guidance
- clarify stale Wide Research UI docs, Claude Desktop uvx path troubleshooting, and custom local-tool registration guidance

## Issues
- Addresses #24
- Addresses #36
- Addresses #48
- Addresses #56
- Addresses #137

## Verification
- python -m pytest -q --no-cov tests/tools/test_ols_tool.py tests/integration/test_smcp_stream_callback_fix.py tests/tools/test_uniprot_compact_entry.py tests/unit/test_ctd_tool.py
- python -m compileall -q src\tooluniverse\ols_tool.py src\tooluniverse\uniprot_tool.py src\tooluniverse\ctd_tool.py src\tooluniverse\tools\UniProt_get_entry_by_accession.py
- python -m json.tool src\tooluniverse\data\uniprot_tools.json > $null
- git diff --check

Note: python -m black was not run because Black is not installed in this environment.