### PR TITLE
Add RFdiffusion2 remote tool integration

### DIFF
--- a/docs/guide/api_keys.rst
+++ b/docs/guide/api_keys.rst
@@ -177,6 +177,14 @@ These settings configure connections to external Model Context Protocol (MCP) se
 :How to Setup: Deploy the Boltz MCP server
 :Tool Categories: ``mcp_auto_loader_boltz``
 
+**RFdiffusion2 Protein Design**
+
+:Server Command: ``RFDIFFUSION2_COMMAND`` on the RFdiffusion2 server
+:Host: ``RFDIFFUSION2_MCP_SERVER_HOST`` on the client
+:Required For: RFdiffusion2 backbone design via MCP
+:How to Setup: Deploy the RFdiffusion2 MCP server with RFdiffusion2 installed
+:Tool Categories: ``rfdiffusion2``, ``mcp_auto_loader_rfdiffusion2``
+
 **USPTO Patent Downloader**
 
 :Host: ``USPTO_MCP_SERVER_HOST``

--- a/docs/tools/remote/rfdiffusion2.md
+++ b/docs/tools/remote/rfdiffusion2.md
@@ -1,0 +1,50 @@
+# RFdiffusion2
+
+RFdiffusion2 is exposed through a ToolUniverse MCP server that wraps a
+server-side RFdiffusion2 command.
+
+## Server
+
+Configure the command on the RFdiffusion2 host:
+
+```bash
+export RFDIFFUSION2_COMMAND="python /opt/RFdiffusion2/scripts/run_inference.py"
+export RFDIFFUSION2_WORKDIR=/opt/RFdiffusion2
+python -m tooluniverse.remote.rfdiffusion2.rfdiffusion2_mcp_server
+```
+
+The server listens on port `8080` and exposes `rfdiffusion2_design`.
+
+## Client
+
+Set the host and load the MCP auto-loader category:
+
+```bash
+export RFDIFFUSION2_MCP_SERVER_HOST=your-server-host
+```
+
+```python
+from tooluniverse import ToolUniverse
+
+tu = ToolUniverse()
+tu.load_tools(tool_type=["mcp_auto_loader_rfdiffusion2"])
+```
+
+## Example
+
+```python
+result = tu.run(
+    {
+        "name": "rfdiffusion2_design",
+        "arguments": {
+            "contig_map": "150-150",
+            "num_designs": 1,
+            "output_prefix": "outputs/design",
+            "dry_run": True,
+        },
+    }
+)
+```
+
+Use `dry_run: true` to inspect the generated command before launching an
+RFdiffusion2 job.

--- a/docs/tools/remote_tools.rst
+++ b/docs/tools/remote_tools.rst
@@ -11,6 +11,7 @@ This section aggregates setup guides for all integrations under ``src/tooluniver
    remote/expert_feedback.md
    remote/immune_compass.md
    remote/pinnacle.md
+   remote/rfdiffusion2.md
    remote/transcriptformer.md
    remote/uspto_downloader.md
 

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -474,6 +474,7 @@ STATIC_LAZY_REGISTRY = {
     "RCSBTool": "rcsb_pdb_tool",
     "RDKitCheminfoTool": "rdkit_cheminfo_tool",
     "RESTfulTool": "restful_tool",
+    "RFDiffusion2Tool": "rfdiffusion2_tool",
     "RGDTool": "rgd_tool",
     "RNAcentralGetTool": "rnacentral_tool",
     "RNAcentralSearchTool": "rnacentral_tool",

--- a/src/tooluniverse/data/remote_tools/rfdiffusion2_tools.json
+++ b/src/tooluniverse/data/remote_tools/rfdiffusion2_tools.json
@@ -1,0 +1,57 @@
+[
+  {
+    "type": "RemoteTool",
+    "name": "rfdiffusion2_design",
+    "description": "Run RFdiffusion2 backbone design through a ToolUniverse MCP server.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "contig_map": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}, "minItems": 1}
+          ],
+          "description": "RFdiffusion contig specification."
+        },
+        "input_pdb": {"type": "string"},
+        "output_prefix": {"type": "string"},
+        "num_designs": {"type": "integer", "minimum": 1, "default": 1},
+        "inference_steps": {"type": "integer", "minimum": 1},
+        "hotspot_residues": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}, "minItems": 1}
+          ]
+        },
+        "extra_args": {"type": "array", "items": {"type": "string"}, "default": []},
+        "timeout_seconds": {"type": "integer", "minimum": 1, "default": 3600},
+        "dry_run": {"type": "boolean", "default": false}
+      },
+      "required": ["contig_map"]
+    },
+    "required_api_keys": ["RFDIFFUSION2_COMMAND"],
+    "return_schema": {
+      "type": "object",
+      "properties": {
+        "status": {"type": "string"},
+        "data": {"type": "object"},
+        "error": {"type": "string"}
+      }
+    },
+    "remote_info": {
+      "server_type": "MCP",
+      "transport": "http",
+      "original_type": "RFDiffusion2Tool",
+      "url": "https://zitniklab.hms.harvard.edu/ToolUniverse/expand_tooluniverse/remote/rfdiffusion2.html",
+      "code_url": "https://github.com/mims-harvard/ToolUniverse/tree/main/src/tooluniverse/remote/rfdiffusion2"
+    },
+    "test_examples": [
+      {
+        "contig_map": "150-150",
+        "num_designs": 1,
+        "output_prefix": "outputs/design",
+        "dry_run": true
+      }
+    ]
+  }
+]

--- a/src/tooluniverse/data/rfdiffusion2_mcp_loader_tools.json
+++ b/src/tooluniverse/data/rfdiffusion2_mcp_loader_tools.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "mcp_auto_loader_rfdiffusion2",
+    "description": "Discover RFdiffusion2 protein design tools exposed by a ToolUniverse MCP server",
+    "type": "MCPAutoLoaderTool",
+    "server_url": "http://${RFDIFFUSION2_MCP_SERVER_HOST}:8080/mcp",
+    "required_api_keys": ["RFDIFFUSION2_MCP_SERVER_HOST"],
+    "test_examples": [{}],
+    "return_schema": {
+      "type": "object",
+      "description": "Output of the tool discovery operation.",
+      "properties": {}
+    }
+  }
+]

--- a/src/tooluniverse/data/rfdiffusion2_tools.json
+++ b/src/tooluniverse/data/rfdiffusion2_tools.json
@@ -1,0 +1,90 @@
+[
+  {
+    "type": "RFDiffusion2Tool",
+    "name": "rfdiffusion2_design",
+    "description": "Run RFdiffusion2 backbone design through a configured server-side command.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "contig_map": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}, "minItems": 1}
+          ],
+          "description": "RFdiffusion contig specification, for example '150-150' or ['A1-100/0 50-100']."
+        },
+        "input_pdb": {
+          "type": "string",
+          "description": "Optional input PDB path available on the RFdiffusion2 server."
+        },
+        "output_prefix": {
+          "type": "string",
+          "description": "Optional output prefix for generated designs."
+        },
+        "num_designs": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1,
+          "description": "Number of designs to generate."
+        },
+        "inference_steps": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Optional diffusion step count passed as diffuser.T."
+        },
+        "hotspot_residues": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}, "minItems": 1}
+          ],
+          "description": "Optional hotspot residues for binder design, for example ['A30', 'A33']."
+        },
+        "extra_args": {
+          "type": "array",
+          "items": {"type": "string"},
+          "default": [],
+          "description": "Additional RFdiffusion2/Hydra arguments appended verbatim."
+        },
+        "timeout_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 3600,
+          "description": "Maximum command runtime in seconds."
+        },
+        "dry_run": {
+          "type": "boolean",
+          "default": false,
+          "description": "Return the command that would be executed without running RFdiffusion2."
+        }
+      },
+      "required": ["contig_map"]
+    },
+    "return_schema": {
+      "type": "object",
+      "properties": {
+        "status": {"type": "string", "enum": ["success", "error"]},
+        "data": {
+          "type": "object",
+          "description": "Command, working directory, stdout/stderr, return code, and output prefix."
+        },
+        "error": {"type": "string"}
+      }
+    },
+    "required_api_keys": ["RFDIFFUSION2_COMMAND"],
+    "test_examples": [
+      {
+        "contig_map": "150-150",
+        "num_designs": 1,
+        "output_prefix": "outputs/design",
+        "dry_run": true
+      },
+      {
+        "contig_map": ["A1-100/0 50-100"],
+        "input_pdb": "inputs/target.pdb",
+        "hotspot_residues": ["A30", "A33"],
+        "dry_run": true
+      }
+    ],
+    "label": ["protein-design", "structure-generation", "rfdiffusion", "remote"]
+  }
+]

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -203,6 +203,9 @@ default_tool_files = {
     "mcp_auto_loader_boltz": os.path.join(
         current_dir, "data", "boltz_mcp_loader_tools.json"
     ),
+    "mcp_auto_loader_rfdiffusion2": os.path.join(
+        current_dir, "data", "rfdiffusion2_mcp_loader_tools.json"
+    ),
     "mcp_auto_loader_esm": os.path.join(
         current_dir, "data", "mcp_auto_loader_esm.json"
     ),
@@ -319,6 +322,8 @@ default_tool_files = {
     "biogrid": os.path.join(current_dir, "data", "biogrid_tools.json"),
     # NVIDIA NIM Healthcare APIs - Structure prediction, molecular docking, genomics
     "nvidia_nim": os.path.join(current_dir, "data", "nvidia_nim_tools.json"),
+    # RFdiffusion2 command-backed protein design
+    "rfdiffusion2": os.path.join(current_dir, "data", "rfdiffusion2_tools.json"),
     # COSMIC - Catalogue of Somatic Mutations in Cancer
     "cosmic": os.path.join(current_dir, "data", "cosmic_tools.json"),
     # OncoKB - Precision Oncology Knowledge Base

--- a/src/tooluniverse/remote/rfdiffusion2/README.md
+++ b/src/tooluniverse/remote/rfdiffusion2/README.md
@@ -1,0 +1,24 @@
+# RFdiffusion2 Remote Tool
+
+This directory exposes RFdiffusion2 as a ToolUniverse MCP server.
+
+## Server setup
+
+Install RFdiffusion2 in the runtime environment, then point
+`RFDIFFUSION2_COMMAND` at the RFdiffusion2 inference entry point:
+
+```bash
+export RFDIFFUSION2_COMMAND="python /opt/RFdiffusion2/scripts/run_inference.py"
+export RFDIFFUSION2_WORKDIR=/opt/RFdiffusion2
+python -m tooluniverse.remote.rfdiffusion2.rfdiffusion2_mcp_server
+```
+
+The MCP server listens on port `8080` and exposes `rfdiffusion2_design`.
+
+## Client setup
+
+Set `RFDIFFUSION2_MCP_SERVER_HOST` to the host running this server and load the
+`mcp_auto_loader_rfdiffusion2` tool category.
+
+Use `dry_run: true` to inspect the generated RFdiffusion2 command without
+starting an inference job.

--- a/src/tooluniverse/remote/rfdiffusion2/rfdiffusion2_client_tools.json
+++ b/src/tooluniverse/remote/rfdiffusion2/rfdiffusion2_client_tools.json
@@ -1,0 +1,42 @@
+[
+  {
+    "type": "RFDiffusion2Tool",
+    "name": "rfdiffusion2_design",
+    "description": "Run RFdiffusion2 backbone design through a configured server-side command.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "contig_map": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}, "minItems": 1}
+          ],
+          "description": "RFdiffusion contig specification."
+        },
+        "input_pdb": {"type": "string"},
+        "output_prefix": {"type": "string"},
+        "num_designs": {"type": "integer", "minimum": 1, "default": 1},
+        "inference_steps": {"type": "integer", "minimum": 1},
+        "hotspot_residues": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}, "minItems": 1}
+          ]
+        },
+        "extra_args": {"type": "array", "items": {"type": "string"}, "default": []},
+        "timeout_seconds": {"type": "integer", "minimum": 1, "default": 3600},
+        "dry_run": {"type": "boolean", "default": false}
+      },
+      "required": ["contig_map"]
+    },
+    "required_api_keys": ["RFDIFFUSION2_COMMAND"],
+    "return_schema": {
+      "type": "object",
+      "properties": {
+        "status": {"type": "string"},
+        "data": {"type": "object"},
+        "error": {"type": "string"}
+      }
+    }
+  }
+]

--- a/src/tooluniverse/remote/rfdiffusion2/rfdiffusion2_mcp_server.py
+++ b/src/tooluniverse/remote/rfdiffusion2/rfdiffusion2_mcp_server.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from fastmcp import FastMCP
+
+from tooluniverse.rfdiffusion2_tool import RFDiffusion2Tool
+
+try:
+    with open(
+        os.path.join(os.path.dirname(__file__), "rfdiffusion2_client_tools.json"),
+        "r",
+        encoding="utf-8",
+    ) as f:
+        rfdiffusion2_tools = json.load(f)
+except FileNotFoundError as e:
+    print(f"Error: {e}")
+    print(f"Is rfdiffusion2_client_tools.json next to {__file__}?")
+    sys.exit(1)
+
+server = FastMCP("RFdiffusion2 MCP Server")
+agents = {
+    tool_config["name"]: RFDiffusion2Tool(tool_config=tool_config)
+    for tool_config in rfdiffusion2_tools
+}
+
+
+@server.tool()
+def run_rfdiffusion2(query: dict):
+    """Run RFdiffusion2 protein backbone design.
+
+    Args:
+        query: RFdiffusion2 arguments such as contig_map, input_pdb,
+            output_prefix, num_designs, hotspot_residues, extra_args, and dry_run.
+
+    Returns:
+        A ToolUniverse-style result dictionary with status, data, and error.
+    """
+    return agents["rfdiffusion2_design"].run(query)
+
+
+if __name__ == "__main__":
+    server.run(
+        transport="streamable-http", host="0.0.0.0", port=8080, stateless_http=True
+    )

--- a/src/tooluniverse/rfdiffusion2_tool.py
+++ b/src/tooluniverse/rfdiffusion2_tool.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from typing import Any, Dict, List, Optional
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+
+@register_tool("RFDiffusion2Tool")
+class RFDiffusion2Tool(BaseTool):
+    """Command-backed RFdiffusion2 protein backbone design tool."""
+
+    DEFAULT_COMMAND = "run_inference.py"
+
+    def run(self, arguments: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        arguments = arguments or {}
+        validation_error = self.validate_parameters(arguments)
+        if validation_error:
+            return {"status": "error", "error": str(validation_error)}
+
+        try:
+            command_args = self._build_command(arguments)
+        except ValueError as exc:
+            return {"status": "error", "error": str(exc)}
+
+        dry_run = bool(arguments.get("dry_run", False))
+        if dry_run:
+            return {
+                "status": "success",
+                "data": {
+                    "dry_run": True,
+                    "command": command_args,
+                    "cwd": self._resolve_workdir(),
+                },
+            }
+
+        configured_command = self._resolve_command()
+        if not configured_command:
+            return {
+                "status": "error",
+                "error": (
+                    "RFDIFFUSION2_COMMAND is not set. Configure it on the "
+                    "RFdiffusion2 server or call with dry_run=true."
+                ),
+            }
+
+        timeout = int(arguments.get("timeout_seconds", 3600))
+        try:
+            completed = subprocess.run(
+                command_args,
+                cwd=self._resolve_workdir(),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return {
+                "status": "error",
+                "error": f"RFdiffusion2 timed out after {timeout} seconds",
+                "stdout": exc.stdout,
+                "stderr": exc.stderr,
+            }
+        except OSError as exc:
+            return {"status": "error", "error": f"Failed to run RFdiffusion2: {exc}"}
+
+        status = "success" if completed.returncode == 0 else "error"
+        data = {
+            "returncode": completed.returncode,
+            "command": command_args,
+            "cwd": self._resolve_workdir(),
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+            "output_prefix": arguments.get("output_prefix"),
+        }
+        if status == "error":
+            return {
+                "status": "error",
+                "error": "RFdiffusion2 command failed",
+                "data": data,
+            }
+        return {"status": "success", "data": data}
+
+    def _resolve_command(self) -> Optional[str]:
+        return self.tool_config.get("command") or os.getenv("RFDIFFUSION2_COMMAND")
+
+    def _resolve_workdir(self) -> Optional[str]:
+        return self.tool_config.get("workdir") or os.getenv("RFDIFFUSION2_WORKDIR")
+
+    def _base_command(self, dry_run: bool) -> List[str]:
+        command = self._resolve_command()
+        if not command and dry_run:
+            command = self.DEFAULT_COMMAND
+        if not command:
+            return []
+        return shlex.split(command)
+
+    def _build_command(self, arguments: Dict[str, Any]) -> List[str]:
+        command_args = self._base_command(bool(arguments.get("dry_run", False)))
+        if not command_args:
+            return []
+
+        contig_map = arguments.get("contig_map")
+        if isinstance(contig_map, list):
+            if not all(isinstance(item, str) and item for item in contig_map):
+                raise ValueError("contig_map list entries must be non-empty strings")
+            contig_value = ",".join(contig_map)
+        elif isinstance(contig_map, str) and contig_map:
+            contig_value = contig_map
+        else:
+            raise ValueError("contig_map is required")
+
+        command_args.append(f"contigmap.contigs=[{contig_value}]")
+
+        mappings = {
+            "input_pdb": "inference.input_pdb",
+            "output_prefix": "inference.output_prefix",
+            "num_designs": "inference.num_designs",
+            "inference_steps": "diffuser.T",
+        }
+        for argument_name, hydra_name in mappings.items():
+            if arguments.get(argument_name) is not None:
+                command_args.append(f"{hydra_name}={arguments[argument_name]}")
+
+        hotspot_residues = arguments.get("hotspot_residues")
+        if hotspot_residues:
+            if isinstance(hotspot_residues, str):
+                hotspot_value = hotspot_residues
+            elif isinstance(hotspot_residues, list) and all(
+                isinstance(item, str) and item for item in hotspot_residues
+            ):
+                hotspot_value = ",".join(hotspot_residues)
+            else:
+                raise ValueError(
+                    "hotspot_residues must be a string or list of non-empty strings"
+                )
+            command_args.append(f"ppi.hotspot_res=[{hotspot_value}]")
+
+        extra_args = arguments.get("extra_args", [])
+        if extra_args:
+            if not isinstance(extra_args, list) or not all(
+                isinstance(item, str) and item for item in extra_args
+            ):
+                raise ValueError("extra_args must be a list of non-empty strings")
+            command_args.extend(extra_args)
+
+        return command_args

--- a/tests/tools/test_rfdiffusion2_tool.py
+++ b/tests/tools/test_rfdiffusion2_tool.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from tooluniverse import ToolUniverse
+from tooluniverse.rfdiffusion2_tool import RFDiffusion2Tool
+
+
+CONFIG_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "tooluniverse"
+    / "data"
+    / "rfdiffusion2_tools.json"
+)
+
+
+def load_config():
+    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))[0]
+
+
+def test_dry_run_builds_rfdiffusion2_command(monkeypatch):
+    monkeypatch.delenv("RFDIFFUSION2_COMMAND", raising=False)
+    tool = RFDiffusion2Tool(load_config())
+
+    result = tool.run(
+        {
+            "contig_map": ["A1-100/0 50-100"],
+            "input_pdb": "inputs/target.pdb",
+            "output_prefix": "outputs/design",
+            "num_designs": 2,
+            "inference_steps": 50,
+            "hotspot_residues": ["A30", "A33"],
+            "extra_args": ["potentials.guiding_potentials=[]"],
+            "dry_run": True,
+        }
+    )
+
+    assert result["status"] == "success"
+    command = result["data"]["command"]
+    assert command[0] == "run_inference.py"
+    assert "contigmap.contigs=[A1-100/0 50-100]" in command
+    assert "inference.input_pdb=inputs/target.pdb" in command
+    assert "inference.output_prefix=outputs/design" in command
+    assert "inference.num_designs=2" in command
+    assert "diffuser.T=50" in command
+    assert "ppi.hotspot_res=[A30,A33]" in command
+    assert "potentials.guiding_potentials=[]" in command
+
+
+def test_non_dry_run_requires_configured_command(monkeypatch):
+    monkeypatch.delenv("RFDIFFUSION2_COMMAND", raising=False)
+    tool = RFDiffusion2Tool(load_config())
+
+    result = tool.run({"contig_map": "150-150"})
+
+    assert result["status"] == "error"
+    assert "RFDIFFUSION2_COMMAND is not set" in result["error"]
+
+
+def test_runs_configured_command(monkeypatch):
+    monkeypatch.setenv("RFDIFFUSION2_COMMAND", "python run_inference.py")
+    tool = RFDiffusion2Tool(load_config())
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append({"args": args, **kwargs})
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("tooluniverse.rfdiffusion2_tool.subprocess.run", fake_run)
+
+    result = tool.run({"contig_map": "150-150", "timeout_seconds": 5})
+
+    assert result["status"] == "success"
+    assert calls[0]["timeout"] == 5
+    assert calls[0]["args"][0:2] == ["python", "run_inference.py"]
+    assert "contigmap.contigs=[150-150]" in calls[0]["args"]
+
+
+def test_tooluniverse_loads_rfdiffusion2_config(monkeypatch):
+    monkeypatch.setenv("RFDIFFUSION2_COMMAND", "python run_inference.py")
+    tu = ToolUniverse()
+    tu.load_tools(tool_type=["rfdiffusion2"])
+
+    assert "rfdiffusion2_design" in tu.all_tool_dict
+    assert tu.all_tool_dict["rfdiffusion2_design"]["type"] == "RFDiffusion2Tool"


### PR DESCRIPTION
## Summary
- add `RFDiffusion2Tool`, a command-backed RFdiffusion2 wrapper with dry-run support and subprocess execution
- add local tool config, MCP auto-loader config, remote metadata, and a FastMCP server wrapper
- document server/client setup and register the tool in the lazy registry/default config

Closes #14.

## Tests
- `$env:PYTHONPATH=(Resolve-Path .\src).Path; python -m pytest -q --no-cov tests\tools\test_rfdiffusion2_tool.py tests\integration\test_remote_tools.py`
- `$env:PYTHONPATH=(Resolve-Path .\src).Path; python -m compileall -q src\tooluniverse\rfdiffusion2_tool.py src\tooluniverse\remote\rfdiffusion2 tests\tools\test_rfdiffusion2_tool.py`
- `python -m json.tool` on the new RFdiffusion2 JSON configs
- `git diff --check`