### PR TITLE
Add OpenAI-compatible provider for agentic tools

### DIFF
--- a/docs/guide/agentic_tools_tutorial.rst
+++ b/docs/guide/agentic_tools_tutorial.rst
@@ -54,7 +54,12 @@ Step 2: Choose Your LLM Provider
 
 ToolUniverse supports these AI providers:
 
-**OpenAI/Azure OpenAI**
+**OpenAI-Compatible**
+ - Models: GPT-5, GPT-4o, and compatible provider model IDs
+ - Configuration: Set ``OPENAI_API_KEY`` and optional ``OPENAI_BASE_URL``
+ - See :doc:`../guide/openai_compatible_support` for details
+
+**Azure OpenAI**
  - Models: GPT-4, GPT-4o, o1-mini, o1-preview
  - Configuration: Set ``AZURE_OPENAI_API_KEY`` and ``AZURE_OPENAI_ENDPOINT``
 
@@ -185,7 +190,7 @@ Set up AI model settings:
 
 **Configuration Options**:
 
-- ``api_type``: "CHATGPT", "GEMINI", "OPENROUTER", or "VLLM"
+- ``api_type``: "CHATGPT", "OPENAI", "GEMINI", "OPENROUTER", or "VLLM"
 - ``model_id``: Choose your model (see Step 2)
  - For vLLM: Must match the model name loaded on your vLLM server
  - Set ``VLLM_SERVER_URL`` environment variable when using vLLM

--- a/docs/guide/api_keys.rst
+++ b/docs/guide/api_keys.rst
@@ -393,7 +393,7 @@ Environment Variables
 
 .. code-block:: bash
 
-   # Default LLM provider (OPENAI, AZURE_OPENAI, GEMINI, VLLM)
+   # Default LLM provider (CHATGPT, OPENAI, OPENROUTER, GEMINI, VLLM)
    TOOLUNIVERSE_LLM_DEFAULT_PROVIDER=OPENAI
 
    # Model configuration per task
@@ -408,7 +408,7 @@ Environment Variables
    TOOLUNIVERSE_LLM_CONFIG_MODE=default
 
    # Custom fallback chain (JSON array of {api_type, model_id} objects)
-   AGENTIC_TOOL_FALLBACK_CHAIN='[{"api_type":"OPENAI","model_id":"gpt-4"},{"api_type":"GEMINI","model_id":"gemini-pro"}]'
+   AGENTIC_TOOL_FALLBACK_CHAIN='[{"api_type":"OPENAI","model_id":"gpt-4o-mini"},{"api_type":"GEMINI","model_id":"gemini-pro"}]'
 
 Configuration Modes
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -38,6 +38,7 @@ LLM Providers
 
 * **vLLM Support** → :doc:`vllm_support` - Use self-hosted LLM models with vLLM for high-performance inference
 * **OpenRouter Support** → :doc:`openrouter_support` - Access multiple LLM providers through OpenRouter API
+* **OpenAI-Compatible Support** -> :doc:`openai_compatible_support` - Use OpenAI and compatible chat-completions endpoints
 
 Advanced Features
 -----------------

--- a/docs/guide/openai_compatible_support.rst
+++ b/docs/guide/openai_compatible_support.rst
@@ -1,0 +1,66 @@
+OpenAI-Compatible Provider Support
+==================================
+
+ToolUniverse agentic tools support a generic ``OPENAI`` provider backed by the
+OpenAI Python SDK. Use it for OpenAI directly or for OpenAI-compatible hosted
+endpoints.
+
+Configuration
+-------------
+
+Set an API key:
+
+.. code-block:: bash
+
+   export OPENAI_API_KEY=your_key_here
+
+For OpenAI-compatible endpoints, also set a base URL:
+
+.. code-block:: bash
+
+   export OPENAI_BASE_URL=https://your-provider.example/v1
+
+Then configure an agentic tool with ``api_type: "OPENAI"``:
+
+.. code-block:: json
+
+   {
+     "name": "openai_compatible_reasoning_tool",
+     "type": "AgenticTool",
+     "prompt": "Answer this question: {question}",
+     "input_arguments": ["question"],
+     "api_type": "OPENAI",
+     "model_id": "gpt-4o-mini",
+     "parameter": {
+       "type": "object",
+       "properties": {
+         "question": {"type": "string"}
+       },
+       "required": ["question"]
+     }
+   }
+
+Environment Variables
+---------------------
+
+``OPENAI_API_KEY``
+   Required API key for the selected endpoint.
+
+``OPENAI_BASE_URL``
+   Optional OpenAI-compatible API base URL. If unset, the OpenAI SDK default is
+   used.
+
+``OPENAI_MAX_TOKENS_BY_MODEL``
+   Optional JSON mapping of model ID or model prefix to default max output
+   tokens. Example: ``{"gpt-4o": 4096}``.
+
+``OPENAI_DEFAULT_MODEL_LIMITS``
+   Optional JSON mapping that extends or overrides ToolUniverse's built-in
+   model-family defaults.
+
+Provider Notes
+--------------
+
+Use ``OPENAI`` for OpenAI-compatible chat completions endpoints. Use
+``OPENROUTER`` when you want OpenRouter-specific headers and model naming, and
+use ``VLLM`` for self-hosted vLLM servers.

--- a/docs/reference/environment_variables.rst
+++ b/docs/reference/environment_variables.rst
@@ -157,7 +157,7 @@ Configure Large Language Model providers for agentic tools and LLM-powered featu
      - Description
    * - ``TOOLUNIVERSE_LLM_DEFAULT_PROVIDER``
      - (none)
-     - Default LLM provider: ``openai``, ``azure``, ``gemini``, ``anthropic``
+     - Default LLM provider: ``CHATGPT``, ``OPENAI``, ``OPENROUTER``, ``GEMINI``, ``VLLM``
    * - ``TOOLUNIVERSE_LLM_CONFIG_MODE``
      - ``default``
      - LLM configuration mode. Use ``default`` or custom profiles.
@@ -174,7 +174,7 @@ Configure Large Language Model providers for agentic tools and LLM-powered featu
 **Examples**::
 
    # Use OpenAI for all LLM tasks
-   export TOOLUNIVERSE_LLM_DEFAULT_PROVIDER=openai
+   export TOOLUNIVERSE_LLM_DEFAULT_PROVIDER=OPENAI
    export TOOLUNIVERSE_LLM_MODEL_DEFAULT=gpt-4o-mini
    
    # Task-specific models
@@ -191,6 +191,28 @@ Configure Large Language Model providers for agentic tools and LLM-powered featu
 - **Custom Tools**: Your own tools that leverage LLM capabilities
 
 **See also**: Provider-specific API keys in :doc:`../guide/api_keys`.
+
+OpenAI-compatible variables:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Variable
+     - Default
+     - Description
+   * - ``OPENAI_API_KEY``
+     - (none)
+     - API key for OpenAI or an OpenAI-compatible endpoint.
+   * - ``OPENAI_BASE_URL``
+     - SDK default
+     - Optional OpenAI-compatible API base URL.
+   * - ``OPENAI_MAX_TOKENS_BY_MODEL``
+     - (none)
+     - JSON mapping of model IDs or prefixes to default max output tokens.
+   * - ``OPENAI_DEFAULT_MODEL_LIMITS``
+     - built-in
+     - JSON mapping that extends or overrides built-in model-family defaults.
 
 Performance & System
 --------------------
@@ -553,6 +575,15 @@ Complete Variable List
      - LLM
    * - ``TOOLUNIVERSE_LLM_MODEL_{TASK}``
      - (none)
+     - LLM
+   * - ``OPENAI_BASE_URL``
+     - SDK default
+     - LLM
+   * - ``OPENAI_MAX_TOKENS_BY_MODEL``
+     - (none)
+     - LLM
+   * - ``OPENAI_DEFAULT_MODEL_LIMITS``
+     - built-in
      - LLM
    * - ``TOOLUNIVERSE_THREAD_POOL_SIZE``
      - 20

--- a/src/tooluniverse/agentic_tool.py
+++ b/src/tooluniverse/agentic_tool.py
@@ -8,7 +8,13 @@ from typing import Any, Callable, Dict, List, Optional
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 from .logging_config import get_logger
-from .llm_clients import AzureOpenAIClient, GeminiClient, OpenRouterClient, VLLMClient
+from .llm_clients import (
+    AzureOpenAIClient,
+    GeminiClient,
+    OpenAICompatibleClient,
+    OpenRouterClient,
+    VLLMClient,
+)
 
 
 # Global default fallback configuration
@@ -21,6 +27,7 @@ DEFAULT_FALLBACK_CHAIN = [
 # API key environment variable mapping
 API_KEY_ENV_VARS = {
     "CHATGPT": ["AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"],
+    "OPENAI": ["OPENAI_API_KEY"],
     "OPENROUTER": ["OPENROUTER_API_KEY"],
     "GEMINI": ["GEMINI_API_KEY"],
     "VLLM": ["VLLM_SERVER_URL"],
@@ -272,6 +279,8 @@ class AgenticTool(BaseTool):
         try:
             if api_type == "CHATGPT":
                 self._llm_client = AzureOpenAIClient(model_id, None, self.logger)
+            elif api_type == "OPENAI":
+                self._llm_client = OpenAICompatibleClient(model_id, self.logger)
             elif api_type == "OPENROUTER":
                 self._llm_client = OpenRouterClient(model_id, self.logger)
             elif api_type == "GEMINI":
@@ -315,7 +324,7 @@ class AgenticTool(BaseTool):
 
     # ------------------------------------------------------------------ LLM utilities -----------
     def _validate_model_config(self):
-        supported_api_types = ["CHATGPT", "OPENROUTER", "GEMINI", "VLLM"]
+        supported_api_types = ["CHATGPT", "OPENAI", "OPENROUTER", "GEMINI", "VLLM"]
         if self._api_type not in supported_api_types:
             raise ValueError(
                 f"Unsupported API type: {self._api_type}. Supported types: {supported_api_types}"
@@ -602,6 +611,8 @@ class AgenticTool(BaseTool):
         try:
             if self._api_type == "CHATGPT":
                 self._llm_client = AzureOpenAIClient(self._model_id, None, self.logger)
+            elif self._api_type == "OPENAI":
+                self._llm_client = OpenAICompatibleClient(self._model_id, self.logger)
             elif self._api_type == "OPENROUTER":
                 self._llm_client = OpenRouterClient(self._model_id, self.logger)
             elif self._api_type == "GEMINI":

--- a/src/tooluniverse/llm_clients.py
+++ b/src/tooluniverse/llm_clients.py
@@ -551,6 +551,186 @@ class GeminiClient(BaseLLMClient):
         )
 
 
+class OpenAICompatibleClient(BaseLLMClient):
+    """
+    Generic OpenAI-compatible chat completions client.
+
+    Supports OpenAI directly and compatible endpoints configured with
+    OPENAI_BASE_URL.
+    """
+
+    DEFAULT_MODEL_LIMITS: Dict[str, Dict[str, int]] = {
+        "gpt-5": {"max_output": 128_000, "context_window": 400_000},
+        "gpt-4.1": {"max_output": 32768, "context_window": 1_047_576},
+        "gpt-4o": {"max_output": 16384, "context_window": 128_000},
+        "o4-mini": {"max_output": 100_000, "context_window": 200_000},
+        "o3-mini": {"max_output": 100_000, "context_window": 200_000},
+    }
+
+    def __init__(self, model_id: str, logger):
+        try:
+            from openai import OpenAI as _OpenAI  # type: ignore
+            import openai as _openai  # type: ignore
+        except Exception as e:  # pragma: no cover
+            raise RuntimeError("openai client is not available") from e
+
+        self._OpenAI = _OpenAI
+        self._openai = _openai
+        self.model_name = model_id
+        self.logger = logger
+
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY not set")
+
+        base_url = os.getenv("OPENAI_BASE_URL")
+        client_kwargs: Dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self.client = self._OpenAI(**client_kwargs)
+
+        env_limits_raw = os.getenv("OPENAI_DEFAULT_MODEL_LIMITS")
+        self._default_limits: Dict[str, Dict[str, int]] = (
+            self.DEFAULT_MODEL_LIMITS.copy()
+        )
+        if env_limits_raw:
+            try:
+                env_limits = _json.loads(env_limits_raw)
+                for k, v in env_limits.items():
+                    if isinstance(v, dict):
+                        base = self._default_limits.get(k, {}).copy()
+                        base.update(
+                            {
+                                kk: int(vv)
+                                for kk, vv in v.items()
+                                if isinstance(vv, (int, float, str))
+                            }
+                        )
+                        self._default_limits[k] = base
+            except Exception:
+                pass
+
+    def _resolve_default_max_tokens(self, model_id: str) -> Optional[int]:
+        mapping_raw = os.getenv("OPENAI_MAX_TOKENS_BY_MODEL")
+        mapping: Dict[str, Any] = {}
+        if mapping_raw:
+            try:
+                mapping = _json.loads(mapping_raw)
+            except Exception:
+                mapping = {}
+
+        if model_id in mapping:
+            try:
+                return int(mapping[model_id])
+            except Exception:
+                pass
+
+        for k, v in mapping.items():
+            try:
+                if model_id.startswith(k):
+                    return int(v)
+            except Exception:
+                continue
+
+        if model_id in self._default_limits:
+            return int(self._default_limits[model_id].get("max_output", 0)) or None
+
+        for k, v in self._default_limits.items():
+            try:
+                if model_id.startswith(k):
+                    return int(v.get("max_output", 0)) or None
+            except Exception:
+                continue
+
+        return None
+
+    def test_api(self) -> None:
+        test_messages = [{"role": "user", "content": "ping"}]
+        token_attempts = [1, 4, 16, 32]
+        last_error: Optional[Exception] = None
+
+        for tok in token_attempts:
+            try:
+                self.client.chat.completions.create(
+                    model=self.model_name,
+                    messages=test_messages,
+                    max_tokens=tok,
+                    temperature=0,
+                )
+                return
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                msg = str(e).lower()
+                if (
+                    "max_tokens" in msg
+                    or "model output limit" in msg
+                    or "finish the message" in msg
+                ) and tok != token_attempts[-1]:
+                    continue
+                break
+
+        if last_error:
+            raise ValueError(f"OpenAI-compatible API test failed: {last_error}")
+        raise ValueError("OpenAI-compatible API test failed: unknown error")
+
+    def infer(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float],
+        max_tokens: Optional[int],
+        return_json: bool,
+        custom_format: Any = None,
+        max_retries: int = 5,
+        retry_delay: int = 5,
+    ) -> Optional[str]:
+        retries = 0
+        call_fn = (
+            self.client.chat.completions.parse
+            if custom_format is not None
+            else self.client.chat.completions.create
+        )
+        response_format = (
+            custom_format
+            if custom_format is not None
+            else ({"type": "json_object"} if return_json else None)
+        )
+        eff_max = (
+            max_tokens
+            if max_tokens is not None
+            else self._resolve_default_max_tokens(self.model_name)
+        )
+
+        while retries < max_retries:
+            try:
+                kwargs: Dict[str, Any] = {
+                    "model": self.model_name,
+                    "messages": messages,
+                }
+                if response_format is not None:
+                    kwargs["response_format"] = response_format
+                if temperature is not None:
+                    kwargs["temperature"] = temperature
+                if eff_max is not None:
+                    kwargs["max_tokens"] = eff_max
+
+                resp = call_fn(**kwargs)
+                if custom_format is not None:
+                    return resp.choices[0].message.parsed.model_dump()
+                return resp.choices[0].message.content
+            except self._openai.RateLimitError:  # type: ignore[attr-defined]
+                self.logger.warning(
+                    f"Rate limit exceeded. Retrying in {retry_delay} seconds..."
+                )
+                retries += 1
+                time.sleep(retry_delay * retries)
+            except Exception as e:  # noqa: BLE001
+                self.logger.error(f"OpenAI-compatible error: {e}")
+                break
+
+        self.logger.error("Max retries exceeded for OpenAI-compatible request")
+        return None
+
+
 class OpenRouterClient(BaseLLMClient):
     """
     OpenRouter client using OpenAI SDK with custom base URL.

--- a/tests/unit/test_agentic_tool_env_vars.py
+++ b/tests/unit/test_agentic_tool_env_vars.py
@@ -31,6 +31,8 @@ class TestAgenticToolEnvironmentVariables:
             "GEMINI_MODEL_ID",
             "AGENTIC_TOOL_FALLBACK_CHAIN",
             "VLLM_SERVER_URL",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
         ]
         for var in env_vars_to_clear:
             if var in os.environ:
@@ -287,6 +289,29 @@ class TestAgenticToolEnvironmentVariables:
             # Verify the VLLM server URL was correctly read
             # This is tested indirectly through the VLLM client initialization
             assert os.getenv("VLLM_SERVER_URL") == "http://localhost:8000"
+
+    def test_openai_provider_is_supported(self):
+        """Test that OpenAI-compatible provider config is accepted."""
+        os.environ["OPENAI_API_KEY"] = "test-key"
+
+        tool_config = {
+            "name": "test_tool",
+            "prompt": "Test prompt: {input}",
+            "input_arguments": ["input"],
+            "parameter": {
+                "type": "object",
+                "properties": {"input": {"type": "string"}},
+                "required": ["input"],
+            },
+            "api_type": "OPENAI",
+            "model_id": "gpt-4o-mini",
+        }
+
+        with patch.object(AgenticTool, "_try_initialize_api"):
+            tool = AgenticTool(tool_config)
+
+            assert tool._api_type == "OPENAI"
+            assert AgenticTool.has_any_api_keys() is True
 
     def test_task_specific_model_env_var(self):
         """Test that task-specific model environment variables work."""

--- a/tests/unit/test_openai_compatible_client.py
+++ b/tests/unit/test_openai_compatible_client.py
@@ -1,0 +1,91 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from tooluniverse.llm_clients import OpenAICompatibleClient
+
+
+class FakeRateLimitError(Exception):
+    pass
+
+
+class FakeCompletions:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+
+class FakeOpenAIClient:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.completions = FakeCompletions()
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(
+                create=self.completions.create,
+                parse=self.completions.create,
+            )
+        )
+        FakeOpenAIClient.instances.append(self)
+
+
+@pytest.fixture(autouse=True)
+def fake_openai(monkeypatch):
+    FakeOpenAIClient.instances = []
+    monkeypatch.setitem(
+        sys.modules,
+        "openai",
+        SimpleNamespace(OpenAI=FakeOpenAIClient, RateLimitError=FakeRateLimitError),
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+
+def test_openai_compatible_client_uses_base_url(monkeypatch):
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.test/v1")
+
+    client = OpenAICompatibleClient(
+        "provider/model",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+
+    assert FakeOpenAIClient.instances[0].kwargs == {
+        "api_key": "test-key",
+        "base_url": "https://example.test/v1",
+    }
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=0,
+        max_tokens=16,
+        return_json=True,
+        max_retries=1,
+        retry_delay=0,
+    )
+    assert result == "ok"
+
+
+def test_openai_compatible_default_max_tokens_from_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_MAX_TOKENS_BY_MODEL", '{"gpt-4o": 123}')
+    client = OpenAICompatibleClient(
+        "gpt-4o-mini",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=None,
+        max_tokens=None,
+        return_json=False,
+        max_retries=1,
+        retry_delay=0,
+    )
+
+    assert result == "ok"
+    assert FakeOpenAIClient.instances[0].completions.calls[0]["max_tokens"] == 123


### PR DESCRIPTION
## Summary
- add `OPENAI` as a first-class AgenticTool provider backed by the OpenAI SDK
- support OpenAI-compatible endpoints via `OPENAI_BASE_URL`, plus model-token override env vars
- document provider selection and add unit coverage for client initialization/inference config

Closes #8.

## Tests
- `python -m pytest -q --no-cov tests\unit\test_openai_compatible_client.py tests\unit\test_agentic_tool_env_vars.py`
- `python -m compileall -q src\tooluniverse tests\unit\test_openai_compatible_client.py`
- `python -m json.tool src\tooluniverse\data\agentic_tools.json > $null`
- `git diff --check`

## Notes
- Ruff is configured in the project, but `python -m ruff` is not available in this local environment.