### PR TITLE
Fix: drop deprecated google-generativeai, loosen setuptools cap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "openai>=1.107.0",
     "pyyaml>=6.0.0",
     "google-genai>=1.36.0",
-    "google-generativeai>=0.7.2",
     "mcp[cli]>=1.9.3",
     "fastmcp>=2.12.3,<4.0.0",
     "xmltodict>=1.0.0",
@@ -32,7 +31,7 @@ dependencies = [
     "rcsb-api>=1.4.0",
     "fitz>=0.0.1.dev2",
     "pandas>=2.2.3",
-    "setuptools>=70.0.0,<81.0.0", # Fix pkg_resources deprecation warnings
+    "setuptools>=70.0.0", # Fix pkg_resources deprecation warnings
     "pdfplumber>=0.11.0",
     "playwright>=1.55.0",
     "faiss-cpu==1.12.0",

--- a/src/tooluniverse/llm_clients.py
+++ b/src/tooluniverse/llm_clients.py
@@ -401,28 +401,31 @@ class AzureOpenAIClient(BaseLLMClient):
 class GeminiClient(BaseLLMClient):
     def __init__(self, model_name: str, logger):
         try:
-            import google.generativeai as genai  # type: ignore
+            from google import genai  # type: ignore
+            from google.genai import types as genai_types  # type: ignore
         except Exception as e:  # pragma: no cover
-            raise RuntimeError("google.generativeai not available") from e
+            raise RuntimeError("google-genai not available") from e
         api_key = os.getenv("GEMINI_API_KEY")
         if not api_key:
             raise ValueError("GEMINI_API_KEY not found")
-        self._genai = genai
-        self._genai.configure(api_key=api_key)
+        self._client = genai.Client(api_key=api_key)
+        self._types = genai_types
         self.model_name = model_name
         self.logger = logger
 
-    def _build_model(self):
-        return self._genai.GenerativeModel(self.model_name)
+    def _build_config(self, temperature: Optional[float], max_tokens: Optional[int]):
+        kwargs: Dict[str, Any] = {
+            "temperature": (temperature if temperature is not None else 0)
+        }
+        if max_tokens is not None:
+            kwargs["max_output_tokens"] = max_tokens
+        return self._types.GenerateContentConfig(**kwargs)
 
     def test_api(self) -> None:
-        model = self._build_model()
-        model.generate_content(
-            "ping",
-            generation_config={
-                "max_output_tokens": 8,
-                "temperature": 0,
-            },
+        self._client.models.generate_content(
+            model=self.model_name,
+            contents="ping",
+            config=self._build_config(temperature=0, max_tokens=8),
         )
 
     def infer(
@@ -444,13 +447,11 @@ class GeminiClient(BaseLLMClient):
         retries = 0
         while retries < max_retries:
             try:
-                gen_cfg: Dict[str, Any] = {
-                    "temperature": (temperature if temperature is not None else 0)
-                }
-                if max_tokens is not None:
-                    gen_cfg["max_output_tokens"] = max_tokens
-                model = self._build_model()
-                resp = model.generate_content(contents, generation_config=gen_cfg)
+                resp = self._client.models.generate_content(
+                    model=self.model_name,
+                    contents=contents,
+                    config=self._build_config(temperature, max_tokens),
+                )
                 return getattr(resp, "text", None) or getattr(resp, "candidates", [{}])[
                     0
                 ].get("content")
@@ -520,15 +521,10 @@ class GeminiClient(BaseLLMClient):
         retries = 0
         while retries < max_retries:
             try:
-                gen_cfg: Dict[str, Any] = {
-                    "temperature": (temperature if temperature is not None else 0)
-                }
-                if max_tokens is not None:
-                    gen_cfg["max_output_tokens"] = max_tokens
-
-                model = self._build_model()
-                stream = model.generate_content(
-                    contents, generation_config=gen_cfg, stream=True
+                stream = self._client.models.generate_content_stream(
+                    model=self.model_name,
+                    contents=contents,
+                    config=self._build_config(temperature, max_tokens),
                 )
                 for chunk in stream:
                     text = self._extract_text_from_stream_chunk(chunk)

--- a/tests/unit/test_gemini_client.py
+++ b/tests/unit/test_gemini_client.py
@@ -1,0 +1,54 @@
+"""Unit tests for the migrated GeminiClient (google-generativeai → google-genai)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from unittest import mock
+
+import pytest
+
+from tooluniverse.llm_clients import GeminiClient
+
+
+def test_missing_api_key_raises_value_error(monkeypatch):
+    """Constructor must raise ValueError (not ImportError) when key is absent."""
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="GEMINI_API_KEY not found"):
+        GeminiClient("gemini-2.5-flash", logging.getLogger("test"))
+
+
+def test_constructs_with_api_key(monkeypatch):
+    """With key present, constructor should produce a google.genai.Client."""
+    monkeypatch.setenv("GEMINI_API_KEY", "fake-key-not-validated-at-construction")
+    client = GeminiClient("gemini-2.5-flash", logging.getLogger("test"))
+    # google.genai.Client is the documented type for the new SDK
+    assert type(client._client).__name__ == "Client"
+    assert client.model_name == "gemini-2.5-flash"
+
+
+def test_build_config_passes_temperature_and_max_tokens(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
+    client = GeminiClient("gemini-2.5-flash", logging.getLogger("test"))
+    cfg = client._build_config(temperature=0.7, max_tokens=128)
+    assert cfg.temperature == 0.7
+    assert cfg.max_output_tokens == 128
+
+
+def test_build_config_omits_max_tokens_when_none(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
+    client = GeminiClient("gemini-2.5-flash", logging.getLogger("test"))
+    cfg = client._build_config(temperature=0.0, max_tokens=None)
+    assert cfg.temperature == 0.0
+    assert cfg.max_output_tokens is None
+
+
+def test_no_dependency_on_deprecated_google_generativeai():
+    """Regression guard: the migration removes google.generativeai. If a
+    future edit re-introduces it, this test should catch the import sneaking back."""
+    import tooluniverse.llm_clients as mod
+    src = open(mod.__file__).read()
+    assert "google.generativeai" not in src, (
+        "google.generativeai was reintroduced into llm_clients.py — "
+        "the deprecated package should remain absent; use google.genai (the new SDK)."
+    )


### PR DESCRIPTION
## Summary

Two dependency-related issues reported by an external user via email (GitHub
issue access blocked on their work account). After 1.1.11, downstream users
must add the following overrides to their own `pyproject.toml` to install
tooluniverse — this PR makes both unnecessary:

```toml
# Previously required (both can be removed after this merges + 1.2.1 ships):
override-dependencies = [
    "protobuf>=6.33.6",
    "setuptools>=82.0.1",
]
```

## Root cause

**setuptools cap (`>=70.0.0,<81.0.0`)**: added to suppress a `pkg_resources`
deprecation warning. That warning has settled in modern setuptools, the cap
is no longer needed.

**protobuf transitive pin to `<6.0.0`**: comes from
`google-generativeai 0.8.6` → `google-ai-generativelanguage` →
`protobuf!=4.21.0,!=...,<6.0.0dev,>=3.20.2`. The replacement SDK
`google-genai` (already declared above in the same `pyproject.toml`) does NOT
constrain protobuf in its core install (only in the optional `local-tokenizer`
extra). Removing `google-generativeai` breaks the constraint chain.

## Changes

### `pyproject.toml`
- Remove `google-generativeai>=0.7.2` (deprecated upstream; replacement
  `google-genai` already declared)
- Remove `,<81.0.0` upper bound on setuptools; keep `>=70.0.0` and the
  comment about pkg_resources

### `src/tooluniverse/llm_clients.py` — `GeminiClient` migration
- `import google.generativeai as genai` → `from google import genai`,
  `from google.genai import types`
- `genai.configure(api_key=...)` + `genai.GenerativeModel(name)` →
  `genai.Client(api_key=...)` + `client.models.generate_content(...)`
- `generation_config={dict}` → `types.GenerateContentConfig(...)` instance
- Streaming: `model.generate_content(..., stream=True)` →
  `client.models.generate_content_stream(...)`
- `_build_model()` helper → `_build_config()` helper (client is persistent;
  config is per-call)
- Public API surface (`__init__`, `infer`, `infer_stream`, `test_api`,
  `_extract_text_from_stream_chunk`) unchanged — only internals

API mapping verified against the official `google-genai` docs at
https://googleapis.github.io/python-genai/

### `tests/unit/test_gemini_client.py` (new, 5 tests)
1. Missing `GEMINI_API_KEY` → `ValueError` (not `ImportError`, confirming the
   new SDK is present)
2. With key → constructs a `google.genai.Client` successfully
3. `_build_config(0.7, 128)` → temperature=0.7, max_output_tokens=128
4. `_build_config(0.0, None)` → max_output_tokens omitted (not coerced to 0)
5. Regression guard: `google.generativeai` string absent from
   `llm_clients.py` source

## Test plan

- [x] All 5 new unit tests pass locally (no API key required for any of them)
- [x] `tests/unit/test_agentic_tool_env_vars.py` continues to pass (no
      regression — 13/13)
- [x] `import tooluniverse` still works
- [x] `ruff check src/tooluniverse/llm_clients.py` passes
- [x] No remaining `google.generativeai` import in `src/`
- [ ] (Not in this PR) Real API call to Gemini with a live key — out of scope
      for the migration; existing test_api smoke would catch a regression
      on next deploy

## Release plan

Once merged, bump version to 1.2.1 in `pyproject.toml` and tag `v1.2.1` to
trigger `publish-pypi.yml`. After PyPI publish, downstream users can drop
both override-dependencies entries.