### PR TITLE
Release 1.2.1 + fix self-healing PyPI publish workflow gate

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,8 +5,13 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'pyproject.toml'
+    # NOTE: deliberately no `paths:` filter. GitHub Actions has occasionally
+    # missed firing this workflow on large squash-merges that did modify
+    # pyproject.toml (observed for PR #161 merge: 727 files changed, the
+    # path filter did not trigger publish-pypi.yml even though pyproject.toml
+    # was in the diff). The version-check step below is cheap (~10s) and
+    # short-circuits on every push that doesn't actually bump the version,
+    # so always-fire is the safer default.
 
 jobs:
   check-version-change:
@@ -20,38 +25,66 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Check if version changed
+      - name: Check if version is newer than what's on PyPI
         id: check_version
         run: |
-          # Get current version using Python (portable, no grep -P dependency)
+          # Compare current pyproject.toml version against PyPI's published latest.
+          #
+          # This used to compare HEAD vs HEAD~1, which had two failure modes:
+          #   1. Large squash-merges sometimes don't fire the path filter on
+          #      pyproject.toml — the workflow never runs, and the version
+          #      bump is silently missed. There is no recovery on the next
+          #      push because HEAD~1 will then equal HEAD.
+          #   2. workflow_dispatch reruns hit the same gate (HEAD~1==HEAD),
+          #      so manual recovery was impossible without surgery.
+          #
+          # Comparing against PyPI directly makes the gate self-healing: any
+          # push to main with a pyproject version newer than PyPI's latest
+          # will publish, regardless of how it got into this state.
+
           CURRENT_VERSION=$(python3 -c "
           import re
           with open('pyproject.toml') as f:
               m = re.search(r'version\s*=\s*\"([^\"]+)\"', f.read())
               print(m.group(1) if m else '')
           ")
-          echo "Current version: $CURRENT_VERSION"
+          echo "Current pyproject.toml version: $CURRENT_VERSION"
 
-          # Get previous commit version
-          git checkout HEAD~1 -- pyproject.toml 2>/dev/null || true
-          PREVIOUS_VERSION=$(python3 -c "
-          import re
-          with open('pyproject.toml') as f:
-              m = re.search(r'version\s*=\s*\"([^\"]+)\"', f.read())
-              print(m.group(1) if m else 'none')
-          " 2>/dev/null || echo "none")
-          echo "Previous version: $PREVIOUS_VERSION"
+          # Query PyPI for the published latest. Tolerate transient outages
+          # by treating any failure as "publish allowed" — the publish step
+          # itself will reject duplicate uploads via twine, so a false
+          # positive here just makes that step fail loudly instead of
+          # silently skipping a real release.
+          PYPI_VERSION=$(curl -fsSL "https://pypi.org/pypi/tooluniverse/json" 2>/dev/null \
+              | python3 -c "import json, sys; print(json.load(sys.stdin)['info']['version'])" 2>/dev/null \
+              || echo "")
+          echo "PyPI latest version: ${PYPI_VERSION:-<unavailable>}"
 
-          # Restore current version
-          git checkout HEAD -- pyproject.toml
+          # Use packaging.Version for PEP 440-aware comparison (handles
+          # 1.10.0 > 1.9.0, pre-releases, etc.). packaging ships with pip.
+          python3 -m pip install --quiet packaging || true
 
-          # Check if version has changed
-          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
-            echo "Version changed from $PREVIOUS_VERSION to $CURRENT_VERSION"
+          NEWER=$(python3 - <<PYEOF
+          from packaging.version import Version, InvalidVersion
+          cur, pypi = "$CURRENT_VERSION", "$PYPI_VERSION"
+          if not pypi:
+              # PyPI unavailable: allow publish, let twine arbitrate.
+              print("true")
+          else:
+              try:
+                  print("true" if Version(cur) > Version(pypi) else "false")
+              except InvalidVersion:
+                  # Unparseable version in pyproject — fail safely (don't publish).
+                  print("false")
+          PYEOF
+          )
+
+          if [ "$NEWER" = "true" ]; then
+            echo "Version $CURRENT_VERSION > PyPI latest ($PYPI_VERSION) — will publish"
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           else
-            echo "Version not changed"
+            echo "Version $CURRENT_VERSION not newer than PyPI ($PYPI_VERSION) — skipping publish"
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooluniverse"
-version = "1.2.0"
+version = "1.2.1"
 description = "A comprehensive collection of scientific tools for Agentic AI, offering integration with the ToolUniverse SDK and MCP Server to support advanced scientific workflows."
 authors = [
     { name = "Shanghua Gao", email = "shanghuagao@gmail.com" }


### PR DESCRIPTION
## Background

PyPI shows tooluniverse **1.1.11** (released 2026-03-29). `main` has been at
**1.2.0** since 2026-05-21 (PR #161). The auto-publish workflow silently
missed that bump. Today's PR #190 merge also did not publish — gate
short-circuited in 9 seconds.

Two compounding root causes were verified source-level:

### Root cause A — path filter missed the squash-merge

`publish-pypi.yml` had `on.push.paths: ['pyproject.toml']`. PR #161 was a
727-file / 154k-insert squash-merge; the squashed diff DID include
`pyproject.toml | 2 +-` (verified via `git show --stat 16af425c`), yet
`gh api repos/.../actions/runs?head_sha=16af425c` confirms only 3 workflows
ran for that commit — and **publish-pypi was not one of them**. Known
GitHub Actions flakiness under large squash-merges. Rather than debug the
specific GH cause, this PR removes the path filter and lets every main
push fire the check-version step (~10s, short-circuits when no bump).

### Root cause B — gate had no recovery path

The check-version step compared HEAD vs HEAD~1 pyproject versions. If A
ever fires (workflow misses a bump), the next push sees `HEAD == HEAD~1`
and reports "Version not changed" — the version is **permanently stuck**.
This was reproduced today: PR #190 merge at 235f4ba3, workflow fired
correctly, but the gate compared `HEAD(1.2.0) == HEAD~1(1.2.0)`, declared
"not changed", exited in 9 seconds — even though PyPI was still on 1.1.11.

## Changes

### `pyproject.toml`
- Bump `1.2.0` → `1.2.1` so this push will publish (carries forward all
  PR #161 + PR #190 fixes).

### `.github/workflows/publish-pypi.yml`
- **Remove** `on.push.paths` filter (Root Cause A fix). The check job
  now runs on every main push.
- **Replace** the HEAD~1 comparison with a PyPI-vs-current comparison
  (Root Cause B fix). Self-heals: any push where pyproject version >
  PyPI latest will publish, regardless of how it got into that state.
- Use `packaging.Version` for PEP 440 comparison (so `1.10.0 > 1.9.0`,
  pre-releases handled correctly).
- PyPI fetch failures → treat as "allow publish" (twine arbitrates
  duplicates loudly, beats silent skip).
- Unparseable version strings → "don't publish" (fail safe).

## Test plan

Unit-tested the new gate logic locally against 7 scenarios — all pass:

| Case | current | pypi | expected | got |
|---|---|---|---|---|
| Real scenario | `1.2.1` | `1.1.11` | publish | ✓ publish |
| No bump | `1.2.0` | `1.2.0` | skip | ✓ skip |
| pyproject behind PyPI | `1.1.5` | `1.1.11` | skip | ✓ skip |
| PyPI unavailable | `1.2.1` | (empty) | publish | ✓ publish |
| Broken version | `garbage` | `1.1.11` | skip | ✓ skip |
| Major jump | `2.0.0` | `1.1.11` | publish | ✓ publish |
| PEP 440 pre-release | `1.2.1a1` | `1.2.0` | publish | ✓ publish |

Workflow YAML validated: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-pypi.yml'))"` passes.

## Expected outcome after merge

Merging this PR pushes a new commit to `main` with `pyproject=1.2.1`:
1. `publish-pypi.yml` fires (no path filter, always-fire)
2. Gate compares `1.2.1` > `1.1.11` (PyPI latest) → `version_changed=true`
3. Publish job runs → `tooluniverse 1.2.1` lands on PyPI
4. 1.2.1 carries everything from PR #161 (plugin) + PR #190 (Gemini /
   setuptools / protobuf fixes)
5. Downstream users (e.g. the user behind PR #190) can drop both
   `override-dependencies` entries (`setuptools>=82.0.1`, `protobuf>=6.33.6`)

Going forward: any future bump (e.g. 1.2.2) will publish even if the
workflow misses a single trigger, because the gate self-heals on the next
push.