### PR TITLE
fix: 16 skills with broken/stale tool references

### DIFF
--- a/plugin/skills/tooluniverse-binder-discovery/SKILL.md
+++ b/plugin/skills/tooluniverse-binder-discovery/SKILL.md
@@ -89,7 +89,7 @@ tool_info = tu.tools.get_tool_info(tool_name="ChEMBL_get_target_activities")
 
 Common parameter corrections (verify with `get_tool_info` if uncertain):
 - `OpenTargets_*`: `ensemblId` (camelCase); `ADMETAI_*`: `smiles` must be a list
-- `alphafold_get_prediction`: `sequence` not `seq`; `NvidiaNIM_genmol` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)*: SMILES must contain `[*{min-max}]`
+- `NvidiaNIM_alphafold2` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)*: `sequence` not `seq`; `NvidiaNIM_genmol` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)*: SMILES must contain `[*{min-max}]`
 - `NvidiaNIM_boltz2` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)*: `polymers=[{"molecule_type": "protein", "sequence": "..."}]`
 
 ---
@@ -127,7 +127,7 @@ Use multi-source triangulation:
 ### 1.4 Structure Prediction (NVIDIA NIM)
 
 Requires `NVIDIA_API_KEY`. Two options:
-- **AlphaFold2**: `alphafold_get_prediction(sequence, algorithm="mmseqs2")` - high accuracy, 5-15 min
+- **AlphaFold2**: `NvidiaNIM_alphafold2(sequence, algorithm="mmseqs2")` - high accuracy, 5-15 min
 - **ESMFold**: `ESMFold_predict_structure(sequence)` - fast (~30s), max 1024 AA
 
 pLDDT guidance: >=90 very high confidence, 70-90 confident, <70 use with caution. Low pLDDT in the putative binding region undermines docking reliability.

--- a/plugin/skills/tooluniverse-binder-discovery/SKILL.md
+++ b/plugin/skills/tooluniverse-binder-discovery/SKILL.md
@@ -89,8 +89,8 @@ tool_info = tu.tools.get_tool_info(tool_name="ChEMBL_get_target_activities")
 
 Common parameter corrections (verify with `get_tool_info` if uncertain):
 - `OpenTargets_*`: `ensemblId` (camelCase); `ADMETAI_*`: `smiles` must be a list
-- `NvidiaNIM_alphafold2`: `sequence` not `seq`; `NvidiaNIM_genmol`: SMILES must contain `[*{min-max}]`
-- `NvidiaNIM_boltz2`: `polymers=[{"molecule_type": "protein", "sequence": "..."}]`
+- `alphafold_get_prediction`: `sequence` not `seq`; `NvidiaNIM_genmol` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)*: SMILES must contain `[*{min-max}]`
+- `NvidiaNIM_boltz2` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)*: `polymers=[{"molecule_type": "protein", "sequence": "..."}]`
 
 ---
 
@@ -127,7 +127,7 @@ Use multi-source triangulation:
 ### 1.4 Structure Prediction (NVIDIA NIM)
 
 Requires `NVIDIA_API_KEY`. Two options:
-- **AlphaFold2**: `NvidiaNIM_alphafold2(sequence, algorithm="mmseqs2")` - high accuracy, 5-15 min
+- **AlphaFold2**: `alphafold_get_prediction(sequence, algorithm="mmseqs2")` - high accuracy, 5-15 min
 - **ESMFold**: `ESMFold_predict_structure(sequence)` - fast (~30s), max 1024 AA
 
 pLDDT guidance: >=90 very high confidence, 70-90 confident, <70 use with caution. Low pLDDT in the putative binding region undermines docking reliability.
@@ -237,7 +237,7 @@ Deliver top 20 candidates with: Rank, ID, SMILES, docking score, ADMET score, ov
 Target ID:     ChEMBL_search_targets -> GtoPdb_get_targets -> "Not in databases"
 Druggability:  OpenTargets tractability -> DGIdb druggability -> target class proxy
 Bioactivity:   ChEMBL -> BindingDB -> GtoPdb -> PubChem BioAssay -> "No data"
-Structure:     PDB -> EMDB (membrane) -> NvidiaNIM_alphafold2 -> NvidiaNIM_esmfold -> AlphaFold DB -> "None"
+Structure:     PDB -> EMDB (membrane) -> alphafold_get_prediction -> NvidiaNIM_esmfold -> AlphaFold DB -> "None"
 Similarity:    ChEMBL similar -> PubChem similar -> "Search failed"
 Docking:       get_diffdock_info -> NvidiaNIM_boltz2 -> similarity-based scoring
 Generation:    NvidiaNIM_genmol -> NvidiaNIM_molmim -> similarity search only

--- a/plugin/skills/tooluniverse-chemical-compound-retrieval/SKILL.md
+++ b/plugin/skills/tooluniverse-chemical-compound-retrieval/SKILL.md
@@ -44,7 +44,7 @@ Verify: CID + ChEMBL ID + canonical SMILES + stereochemistry + salt forms.
 
 **PubChem**: `PubChem_get_compound_properties_by_CID`, `PubChemBioAssay_get_assay_summary`, `PubChemTox_get_acute_effects`, `PubChem_get_compound_2D_image_by_CID`
 
-**ChEMBL**: `ChEMBL_get_bioactivity_by_chemblid`, `ChEMBL_get_target_by_chemblid`, `ChEMBL_get_assays_by_chemblid`
+**ChEMBL**: `ChEMBL_get_compound_record_activities`, `ChEMBL_get_molecule_targets`, `ChEMBL_get_assay_activities`
 
 **Optional**: `PubChem_get_associated_patents_by_CID`, `PubChem_search_compounds_by_similarity`
 

--- a/plugin/skills/tooluniverse-data-wrangling/SKILL.md
+++ b/plugin/skills/tooluniverse-data-wrangling/SKILL.md
@@ -159,7 +159,7 @@ with tarfile.open("archive.tar.gz") as t:                     # tar.gz
 Each category shows: which ToolUniverse tools exist, and how to go beyond them with direct API calls.
 
 ### 1. NCBI E-utilities (Gene, Nucleotide, Protein, SRA, GEO)
-Tools: `NCBI_search_gene`, `NCBI_search_nucleotide`, `SRA_search_runs`, `GEO_search_datasets`
+Tools: `NCBIGene_search`, `NCBI_search_nucleotide`, `SRA_search_experiments`, `geo_search_datasets`
 ```python
 import requests
 base = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
@@ -227,7 +227,7 @@ props = requests.get(url).json()["PropertyTable"]["Properties"]
 ```
 
 ### 7. Expression (GEO, ArrayExpress, GTEx)
-Tools: `GEO_search_datasets`, `ArrayExpress_search`
+Tools: `geo_search_datasets`, `arrayexpress_search_experiments`
 ```python
 # GEO series matrix direct download
 geo_id = "GSE12345"

--- a/plugin/skills/tooluniverse-drug-target-validation/SKILL.md
+++ b/plugin/skills/tooluniverse-drug-target-validation/SKILL.md
@@ -158,7 +158,7 @@ For each lead / approved compound identified above, run **all ten ADMET-AI Chemp
 | Nuclear receptor activity (NR-AR, NR-AhR, NR-Aromatase, NR-ER, NR-PPAR-γ) | `ADMETAI_predict_nuclear_receptor_activity` |
 | Stress response (SR-ARE, SR-ATAD5, SR-HSE, SR-MMP, SR-p53) | `ADMETAI_predict_stress_response` |
 | Solubility, lipophilicity, hydration | `ADMETAI_predict_solubility_lipophilicity_hydration` |
-| Metabolism | `ADMETAI_predict_toxicity` (if available) |
+| Metabolism (CYP-mediated) | `ADMETAI_predict_CYP_interactions` |
 
 **Required output — ADMET head-to-head table**: when two or more candidate drugs exist (approved or late-stage), produce a side-by-side comparison table with every endpoint in the same row and a "Winner" column flagging which drug is safer. This table is the primary visual of the report and must not be abbreviated or summarized into prose.
 

--- a/plugin/skills/tooluniverse-drug-target-validation/SKILL.md
+++ b/plugin/skills/tooluniverse-drug-target-validation/SKILL.md
@@ -158,7 +158,7 @@ For each lead / approved compound identified above, run **all ten ADMET-AI Chemp
 | Nuclear receptor activity (NR-AR, NR-AhR, NR-Aromatase, NR-ER, NR-PPAR-γ) | `ADMETAI_predict_nuclear_receptor_activity` |
 | Stress response (SR-ARE, SR-ATAD5, SR-HSE, SR-MMP, SR-p53) | `ADMETAI_predict_stress_response` |
 | Solubility, lipophilicity, hydration | `ADMETAI_predict_solubility_lipophilicity_hydration` |
-| Metabolism | `ADMETAI_predict_metabolism` (if available) |
+| Metabolism | `ADMETAI_predict_toxicity` (if available) |
 
 **Required output — ADMET head-to-head table**: when two or more candidate drugs exist (approved or late-stage), produce a side-by-side comparison table with every endpoint in the same row and a "Winner" column flagging which drug is safer. This table is the primary visual of the report and must not be abbreviated or summarized into prose.
 

--- a/plugin/skills/tooluniverse-gene-disease-association/SKILL.md
+++ b/plugin/skills/tooluniverse-gene-disease-association/SKILL.md
@@ -102,7 +102,7 @@ disgenet_ranked = tu.tools.DisGeNET_get_disease_genes(disease=disease_name, min_
 ```python
 ot_diseases = tu.tools.OpenTargets_get_diseases_phenotypes_by_target_ensembl(ensemblId=ensembl_id)
 ot_evidence = tu.tools.OpenTargets_target_disease_evidence(ensemblId=ensembl_id, efoId=efo_id)
-# Both require pre-resolved Ensembl/EFO IDs. Use OpenTargets_multi_entity_search to discover IDs.
+# Both require pre-resolved Ensembl/EFO IDs. Use OpenTargets_multi_entity_search_by_query_string to discover IDs.
 ```
 
 ---

--- a/plugin/skills/tooluniverse-infectious-disease/SKILL.md
+++ b/plugin/skills/tooluniverse-infectious-disease/SKILL.md
@@ -208,8 +208,8 @@ Aggregate all findings into final report. Grade every candidate. Provide 3+ imme
 
 | Primary Tool | Fallback 1 | Fallback 2 |
 |--------------|------------|------------|
-| `NvidiaNIM_alphafold2` | `alphafold_get_prediction` | `ESMFold_predict_structure` |
-| `get_diffdock_info` | `NvidiaNIM_boltz2` | Manual docking |
+| `alphafold_get_prediction` | `alphafold_get_prediction` | `ESMFold_predict_structure` |
+| `get_diffdock_info` | `NvidiaNIM_boltz2` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)* | Manual docking |
 | `NCBIDatasets_suggest_taxonomy` | `UniProtTaxonomy_get_taxon` | Manual classification |
 | `ChEMBL_search_drugs` | `drugbank_vocab_search` | PubChem bioassays |
 

--- a/plugin/skills/tooluniverse-infectious-disease/SKILL.md
+++ b/plugin/skills/tooluniverse-infectious-disease/SKILL.md
@@ -208,7 +208,7 @@ Aggregate all findings into final report. Grade every candidate. Provide 3+ imme
 
 | Primary Tool | Fallback 1 | Fallback 2 |
 |--------------|------------|------------|
-| `alphafold_get_prediction` | `alphafold_get_prediction` | `ESMFold_predict_structure` |
+| `NvidiaNIM_alphafold2` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)* | `alphafold_get_prediction` (AlphaFold DB by UniProt) | `ESMFold_predict_structure` |
 | `get_diffdock_info` | `NvidiaNIM_boltz2` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)* | Manual docking |
 | `NCBIDatasets_suggest_taxonomy` | `UniProtTaxonomy_get_taxon` | Manual classification |
 | `ChEMBL_search_drugs` | `drugbank_vocab_search` | PubChem bioassays |

--- a/plugin/skills/tooluniverse-microbiome-research/SKILL.md
+++ b/plugin/skills/tooluniverse-microbiome-research/SKILL.md
@@ -13,7 +13,7 @@ Comprehensive microbiome analysis using MGnify (EBI metagenomics), GTDB (genome 
 | Tool | Purpose | Auth |
 |------|---------|------|
 | **MGnify_search_studies** | Find metagenomics studies by biome/keyword | None |
-| **MGnify_search_studies_detail** | Study metadata, abstract, sample counts | None |
+| **MGnify_get_study_detail** | Study metadata, abstract, sample counts | None |
 | **MGnify_list_analyses** | List taxonomic/functional analysis outputs for a study | None |
 | **MGnify_get_taxonomy** | Taxonomic composition from an analysis | None |
 | **MGnify_get_go_terms** | GO functional annotations from an analysis | None |
@@ -56,7 +56,7 @@ studies = tu.run_one_function({
 
 # 2. Get study details
 detail = tu.run_one_function({
-    'name': 'MGnify_search_studies_detail',
+    'name': 'MGnify_get_study_detail',
     'arguments': {'study_accession': 'MGYS00006860'}
 })
 
@@ -209,7 +209,7 @@ Microbiome analysis starts with: what is the question? LOOK UP DON'T GUESS — a
 - Functional potential (what can they do?) → Shotgun metagenomics → MGnify GO terms, InterPro, KEGG pathways
 - Active function (what are they doing now?) → Metatranscriptomics → specialized pipelines (not MGnify/GTDB alone)
 
-Before calling any tool, determine which data type the user has via `MGnify_search_studies_detail` — the pipeline type (amplicon vs shotgun) determines which analyses are valid. Do not apply 16S diversity metrics to metagenomic data or vice versa.
+Before calling any tool, determine which data type the user has via `MGnify_get_study_detail` — the pipeline type (amplicon vs shotgun) determines which analyses are valid. Do not apply 16S diversity metrics to metagenomic data or vice versa.
 
 ### Dysbiosis Assessment Strategy
 

--- a/plugin/skills/tooluniverse-neuroscience/SKILL.md
+++ b/plugin/skills/tooluniverse-neuroscience/SKILL.md
@@ -71,7 +71,7 @@ Brain region functions, boundaries, and connectivity are precise anatomical fact
 - **Hippocampus**: declarative memory formation; trisynaptic circuit: EC → DG → CA3 → CA1 → EC; place cells, grid cells
 
 ### Model Organism Neuroanatomy
-- **C. elegans**: 302 neurons, complete connectome mapped; use `WormBase_search` for gene expression, neuron identity, connectivity data
+- **C. elegans**: 302 neurons, complete connectome mapped; use `WormBase_get_gene` for gene expression, neuron identity, connectivity data
 - **Drosophila**: mushroom body (learning/memory), antennal lobe (olfaction), central complex (navigation); ~100,000 neurons; FlyWire connectome
 - **Zebrafish**: transparent larvae for whole-brain imaging; Mauthner cells (escape response); use `Alliance_search_genes` for orthologs
 - **Mouse**: Allen Brain Atlas for gene expression; use PubMed for circuit tracing studies (rabies virus, optogenetics)
@@ -153,16 +153,16 @@ Brain region functions, boundaries, and connectivity are precise anatomical fact
 |------|---------|---------------|
 | `PubMed_search_articles` | Neuroanatomy facts, clinical neurology, circuit studies | `query`, `limit` |
 | `EuropePMC_search_articles` | Broader literature including preprints | `query`, `limit` |
-| `WormBase_search` | C. elegans neurons, connectome, gene expression | `query` |
+| `WormBase_get_gene` | C. elegans neurons, connectome, gene expression | `query` |
 | `Alliance_search_genes` | Cross-species gene search (mouse, fly, fish, worm) | `query` |
 | `UniProt_search` | Neural proteins (ion channels, receptors, disease genes) | `query`, `organism` |
 | `proteins_api_search` | Protein features, domains, variants | `query` |
-| `NCBI_search_gene` | Gene info, orthologs, expression | `query` |
+| `NCBIGene_search` | Gene info, orthologs, expression | `query` |
 | `ClinVar_search_variants` | Neurological disease variants | `gene`, `condition` |
-| `GWAS_search_associations` | Neurological trait associations | `query` |
+| `gwas_search_associations` | Neurological trait associations | `query` |
 | `Orphanet_search_diseases` | Rare neurological diseases | `query` |
-| `KEGG_get_pathway` | Neural signaling pathways | `pathway_id` |
-| `OpenTargets_search_target` | Drug targets in neurological diseases | `query` |
+| `kegg_get_pathway_info` | Neural signaling pathways | `pathway_id` |
+| `OpenTargets_multi_entity_search_by_query_string` | Drug targets in neurological diseases | `query` |
 
 ### Tool Selection Strategy
 1. **Neuroanatomy question**: PubMed first — search "[structure] [function/connectivity]"
@@ -176,7 +176,7 @@ Brain region functions, boundaries, and connectivity are precise anatomical fact
 
 ## 6. C. elegans Connectome Lookups
 
-For C. elegans neural circuit questions, ALWAYS use `WormBase_search` to look up specific synapse and connectivity data. Do not guess neural connections from general knowledge.
+For C. elegans neural circuit questions, ALWAYS use `WormBase_get_gene` to look up specific synapse and connectivity data. Do not guess neural connections from general knowledge.
 - **ASJ neuron projections**: the main projection target of ASJ axons is PVQ (verified in WormBase connectome data), NOT AIA. Always check actual synapse counts rather than inferring from circuit diagrams.
 - Search WormBase with the specific neuron name to get its pre/postsynaptic partners and projection targets.
 

--- a/plugin/skills/tooluniverse-noncoding-rna/SKILL.md
+++ b/plugin/skills/tooluniverse-noncoding-rna/SKILL.md
@@ -49,9 +49,9 @@ For any ncRNA query: first identify the class from the name/sequence, then selec
 | `LNCipedia_search_ncrna_by_type` | List all transcripts for a lncRNA gene |
 | `LNCipedia_get_lncrna_publications` | lncRNA sequence (FASTA format) |
 | `RNAcentral_search` | Search all ncRNA types across databases |
-| `RNAcentral_get_rna` | Detailed ncRNA annotations from 40+ databases |
+| `RNAcentral_get_by_accession` | Detailed ncRNA annotations from 40+ databases |
 | `Rfam_get_family` | RNA family details (structure, alignment, species distribution) |
-| `Rfam_search` | Search RNA families by keyword |
+| `Rfam_search_sequence` | Search RNA families by keyword |
 | `DisGeNET_search_gene` | ncRNA-disease associations |
 | `PubMed_search_articles` | ncRNA literature |
 | `GTEx_get_median_gene_expression` | Tissue expression of ncRNA genes |

--- a/plugin/skills/tooluniverse-protein-interactions/SKILL.md
+++ b/plugin/skills/tooluniverse-protein-interactions/SKILL.md
@@ -92,7 +92,7 @@ IntAct tools accept `protein_name` as an alias parameter in addition to the orig
 
 ## Domain Reasoning: Multimeric Assemblies & Binding Valency
 
-LOOK UP DON'T GUESS: oligomeric state, subunit stoichiometry, and binding valency. Use RCSB PDB (`RCSB_search_structures`, `RCSB_get_entry_info`) or UniProt (`UniProt_get_function_by_accession`) to confirm whether a protein is a monomer, dimer, trimer, etc. Do not assume from gene name alone.
+LOOK UP DON'T GUESS: oligomeric state, subunit stoichiometry, and binding valency. Use RCSB PDB (`RCSBAdvSearch_search_structures`, `RCSBData_get_entry`) or UniProt (`UniProt_get_function_by_accession`) to confirm whether a protein is a monomer, dimer, trimer, etc. Do not assume from gene name alone.
 
 ### Calculating Multimer Valency from Binding Data
 

--- a/plugin/skills/tooluniverse-protein-therapeutic-design/SKILL.md
+++ b/plugin/skills/tooluniverse-protein-therapeutic-design/SKILL.md
@@ -80,7 +80,7 @@ Every design MUST include: Sequence, Length, Target, Method, and Quality Metrics
 | `NvidiaNIM_rfdiffusion` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)* | Backbone generation | `diffusion_steps` (NOT `num_steps`) |
 | `NvidiaNIM_proteinmpnn` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)* | Sequence design | `pdb_string` (NOT `pdb`) |
 | `ESMFold_predict_structure` | Fast validation | `sequence` (NOT `seq`) |
-| `alphafold_get_prediction` | High-accuracy validation | `sequence`, `algorithm` |
+| `NvidiaNIM_alphafold2` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)* | High-accuracy structure inference from sequence | `sequence`, `algorithm` |
 | `NvidiaNIM_esm2_650m` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)* | Sequence embeddings | `sequences`, `format` |
 
 ### Common Parameter Mistakes
@@ -90,7 +90,7 @@ Every design MUST include: Sequence, Length, Target, Method, and Quality Metrics
 | `NvidiaNIM_rfdiffusion` *(requires NVIDIA_API_KEY)* | `num_steps=50` | `diffusion_steps=50` |
 | `NvidiaNIM_proteinmpnn` *(requires NVIDIA_API_KEY)* | `pdb=content` | `pdb_string=content` |
 | `ESMFold_predict_structure` | `seq="MVLS..."` | `sequence="MVLS..."` |
-| `alphafold_get_prediction` | `seq="MVLS..."` | `sequence="MVLS..."` |
+| `NvidiaNIM_alphafold2` *(requires NVIDIA_API_KEY)* | `seq="MVLS..."` | `sequence="MVLS..."` |
 
 ### NVIDIA NIM Requirements
 - **API Key**: `NVIDIA_API_KEY` environment variable required

--- a/plugin/skills/tooluniverse-protein-therapeutic-design/SKILL.md
+++ b/plugin/skills/tooluniverse-protein-therapeutic-design/SKILL.md
@@ -77,20 +77,20 @@ Every design MUST include: Sequence, Length, Target, Method, and Quality Metrics
 
 | Tool | Purpose | Key Parameter |
 |------|---------|---------------|
-| `NvidiaNIM_rfdiffusion` | Backbone generation | `diffusion_steps` (NOT `num_steps`) |
-| `NvidiaNIM_proteinmpnn` | Sequence design | `pdb_string` (NOT `pdb`) |
+| `NvidiaNIM_rfdiffusion` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)* | Backbone generation | `diffusion_steps` (NOT `num_steps`) |
+| `NvidiaNIM_proteinmpnn` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)* | Sequence design | `pdb_string` (NOT `pdb`) |
 | `ESMFold_predict_structure` | Fast validation | `sequence` (NOT `seq`) |
-| `NvidiaNIM_alphafold2` | High-accuracy validation | `sequence`, `algorithm` |
-| `NvidiaNIM_esm2_650m` | Sequence embeddings | `sequences`, `format` |
+| `alphafold_get_prediction` | High-accuracy validation | `sequence`, `algorithm` |
+| `NvidiaNIM_esm2_650m` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)* | Sequence embeddings | `sequences`, `format` |
 
 ### Common Parameter Mistakes
 
 | Tool | Wrong | Correct |
 |------|-------|---------|
-| `NvidiaNIM_rfdiffusion` | `num_steps=50` | `diffusion_steps=50` |
-| `NvidiaNIM_proteinmpnn` | `pdb=content` | `pdb_string=content` |
+| `NvidiaNIM_rfdiffusion` *(requires NVIDIA_API_KEY)* | `num_steps=50` | `diffusion_steps=50` |
+| `NvidiaNIM_proteinmpnn` *(requires NVIDIA_API_KEY)* | `pdb=content` | `pdb_string=content` |
 | `ESMFold_predict_structure` | `seq="MVLS..."` | `sequence="MVLS..."` |
-| `NvidiaNIM_alphafold2` | `seq="MVLS..."` | `sequence="MVLS..."` |
+| `alphafold_get_prediction` | `seq="MVLS..."` | `sequence="MVLS..."` |
 
 ### NVIDIA NIM Requirements
 - **API Key**: `NVIDIA_API_KEY` environment variable required

--- a/plugin/skills/tooluniverse-regulatory-variant-analysis/SKILL.md
+++ b/plugin/skills/tooluniverse-regulatory-variant-analysis/SKILL.md
@@ -123,7 +123,7 @@ When interpreting results, ask: does the eQTL effect occur in the tissue most re
 
 ## Phase 4: OpenTargets GWAS Integration
 
-`OpenTargets_search_gwas_studies_by_disease` takes `diseaseIds` as an array of MONDO IDs. It provides locus-to-gene (L2G) scores from multiple GWAS studies, which go beyond simple proximity to incorporate colocalisation, eQTL, and chromatin data. Use `OpenTargets_multi_entity_search` or `OpenTargets_get_disease_id_description_by_name` to resolve disease names to MONDO/EFO IDs first.
+`OpenTargets_search_gwas_studies_by_disease` takes `diseaseIds` as an array of MONDO IDs. It provides locus-to-gene (L2G) scores from multiple GWAS studies, which go beyond simple proximity to incorporate colocalisation, eQTL, and chromatin data. Use `OpenTargets_multi_entity_search_by_query_string` or `OpenTargets_get_disease_id_description_by_name` to resolve disease names to MONDO/EFO IDs first.
 
 ---
 
@@ -143,7 +143,7 @@ After collecting evidence, reason through the layers:
 - **GWAS Catalog returns empty**: Switch from free-text `disease_trait` to `efo_id`; broaden the trait term.
 - **GTEx eQTL empty for gene**: Verify gene symbol spelling; try Ensembl ID; increase `size` parameter.
 - **RegulomeDB returns no data**: Query ENCODE directly; the variant may lack regulatory annotations in available data.
-- **OpenTargets GWAS returns None**: Verify MONDO/EFO ID format; try `OpenTargets_multi_entity_search` first to confirm the correct ID.
+- **OpenTargets GWAS returns None**: Verify MONDO/EFO ID format; try `OpenTargets_multi_entity_search_by_query_string` first to confirm the correct ID.
 - **ENCODE tissue not found**: ENCODE uses specific biosample names; RegulomeDB aggregates data from many cell types and may cover the gap.
 
 ---

--- a/plugin/skills/tooluniverse-stem-cell-organoid/SKILL.md
+++ b/plugin/skills/tooluniverse-stem-cell-organoid/SKILL.md
@@ -27,7 +27,7 @@ Stem cell differentiation follows developmental biology — to make any target c
 
 | Tool | Use For |
 |------|---------|
-| `CELLxGENE_get_cell_metadata` | Find single-cell atlas data. **Requires `cellxgene-census` package (`pip install cellxgene-census`). May not be installed by default.** |
+| `CELLxGENE_get_census_versions` | Discover CELLxGENE Census release versions; then use `CELLxGENE_get_cell_metadata` / `CELLxGENE_get_expression_data` for specific cells / genes. **Requires `cellxgene-census` package (`pip install cellxgene-census`). May not be installed by default.** |
 | `CellMarker_search_by_cell_type` | Cell type marker genes. **Requires `operation="search_by_cell_type"`, `cell_name=` (NOT `cell_type=`)** |
 | `CellMarker_search_by_gene` | Which cell types express a gene. **Requires `operation="search_by_gene"`, `gene_symbol=`** |
 | `hca_search_projects` | Human Cell Atlas organoid/development projects |
@@ -86,7 +86,7 @@ Key signaling pathways for directed differentiation:
 
 ```python
 # Find stem cell single-cell datasets
-CellxGene_search_datasets(query="iPSC organoid", organism="Homo sapiens")
+CELLxGENE_get_census_versions()  # discover available Census releases, then use CELLxGENE_get_cell_metadata / CELLxGENE_get_expression_data
 hca_search_projects(query="organoid")
 GEO_search_rnaseq_datasets(query="iPSC differentiation neural", organism="Homo sapiens")
 ```

--- a/plugin/skills/tooluniverse-stem-cell-organoid/SKILL.md
+++ b/plugin/skills/tooluniverse-stem-cell-organoid/SKILL.md
@@ -27,10 +27,10 @@ Stem cell differentiation follows developmental biology — to make any target c
 
 | Tool | Use For |
 |------|---------|
-| `CellxGene_search_datasets` | Find single-cell atlas data. **Requires `cellxgene-census` package (`pip install cellxgene-census`). May not be installed by default.** |
+| `CELLxGENE_get_cell_metadata` | Find single-cell atlas data. **Requires `cellxgene-census` package (`pip install cellxgene-census`). May not be installed by default.** |
 | `CellMarker_search_by_cell_type` | Cell type marker genes. **Requires `operation="search_by_cell_type"`, `cell_name=` (NOT `cell_type=`)** |
 | `CellMarker_search_by_gene` | Which cell types express a gene. **Requires `operation="search_by_gene"`, `gene_symbol=`** |
-| `HCA_search_projects` | Human Cell Atlas organoid/development projects |
+| `hca_search_projects` | Human Cell Atlas organoid/development projects |
 | `GEO_search_rnaseq_datasets` | Find stem cell RNA-seq datasets |
 | `kegg_search_pathway` | Differentiation signaling pathways (WNT, Notch, Hedgehog) |
 | `ReactomeAnalysis_pathway_enrichment` | Pathway analysis of stem cell gene sets |
@@ -87,7 +87,7 @@ Key signaling pathways for directed differentiation:
 ```python
 # Find stem cell single-cell datasets
 CellxGene_search_datasets(query="iPSC organoid", organism="Homo sapiens")
-HCA_search_projects(query="organoid")
+hca_search_projects(query="organoid")
 GEO_search_rnaseq_datasets(query="iPSC differentiation neural", organism="Homo sapiens")
 ```
 

--- a/plugin/skills/tooluniverse-systems-biology/SKILL.md
+++ b/plugin/skills/tooluniverse-systems-biology/SKILL.md
@@ -181,7 +181,7 @@ Create a markdown report progressively: header â†’ Phase 1 enrichment results â†
 
 ## Domain Reasoning: Enzyme Kinetics & Metabolic Analysis
 
-LOOK UP DON'T GUESS: Km values, kcat values, cofactor requirements, and optimal pH/temperature for specific enzymes. Use `BindingDB_search_by_target`, `ChEMBL_get_molecule`, `BRENDA_search` (if available), or `EuropePMC_search_articles` to retrieve published kinetic parameters. Do not estimate Km from first principles.
+LOOK UP DON'T GUESS: Km values, kcat values, cofactor requirements, and optimal pH/temperature for specific enzymes. Use `BindingDB_search_by_target`, `ChEMBL_get_molecule`, `BRENDA_get_enzyme_info` *(requires BRENDA_EMAIL + BRENDA_PASSWORD env vars; free academic registration at brenda-enzymes.org)* (if available), or `EuropePMC_search_articles` to retrieve published kinetic parameters. Do not estimate Km from first principles.
 
 ### Michaelis-Menten Kinetics
 

--- a/plugin/skills/tooluniverse-vaccine-design/SKILL.md
+++ b/plugin/skills/tooluniverse-vaccine-design/SKILL.md
@@ -12,7 +12,7 @@ Computational pipeline for designing peptide/subunit vaccine candidates through 
 
 Vaccine design requires presenting the right epitopes to elicit protective immunity — not just any immune response, but one that is neutralizing, durable, and broadly applicable. For T-cell vaccines, the core tool is MHC binding prediction (IEDB tools): predict peptide-MHC affinity across multiple HLA alleles, then select epitopes with broad coverage of the target population. For antibody vaccines, prioritize surface-exposed conserved regions — a deeply buried or hypervariable region makes a poor antibody target. MHC binding does not equal immunogenicity; many good binders are not immunogenic in vivo due to tolerance, poor processing, or lack of T-cell help. A multi-epitope strategy (combining MHC-I for CD8+ CTL response, MHC-II for CD4+ helper response, and B-cell epitopes for antibody induction) is more robust than any single epitope. Conservation across pathogen strains is critical — an epitope that mutates under immune pressure (like HIV envelope hypervariable regions) is a poor vaccine target.
 
-**LOOK UP DON'T GUESS**: Do not predict MHC binding or population coverage from memory — use `IEDB_predict_mhci_binding` and `IEDB_predict_mhcii_binding` for predictions and `IEDB_search_epitopes` for validated experimental data. Do not assume what's on the pathogen surface; retrieve annotated sequences from UniProt or BVBRC.
+**LOOK UP DON'T GUESS**: Do not predict MHC binding or population coverage from memory — use `IEDB_predict_mhci_binding` and `IEDB_predict_mhcii_binding` for predictions and `iedb_search_epitopes` for validated experimental data. Do not assume what's on the pathogen surface; retrieve annotated sequences from UniProt or BVBRC.
 
 **Key principles**:
 1. **Epitope-driven** — vaccines work by presenting epitopes to T/B cells; start with epitope prediction
@@ -39,8 +39,8 @@ Vaccine design requires presenting the right epitopes to elicit protective immun
 
 | Tool | Use For |
 |------|---------|
-| `IEDB_search_epitopes` | Search experimentally validated epitopes |
-| `IEDB_get_epitope` | Get detailed epitope data (assay results, MHC restriction) |
+| `iedb_search_epitopes` | Search experimentally validated epitopes |
+| `iedb_get_epitope_mhc` | Get detailed epitope data (assay results, MHC restriction) |
 | `iedb_search_mhc` | Search validated MHC binding assay data |
 | `IEDB_predict_mhci_binding` | **Predict MHC-I binding** (NetMHCpan EL; rank < 0.5% = strong binder) |
 | `IEDB_predict_mhcii_binding` | **Predict MHC-II binding** (NetMHCIIpan EL; CD4+ helper epitopes) |
@@ -150,7 +150,7 @@ B-cell epitopes trigger antibody production. Look for:
 
 ```python
 # Check for known B-cell epitopes
-IEDB_search_epitopes(query="[protein_name]", epitope_type="B cell")
+iedb_search_epitopes(query="[protein_name]", epitope_type="B cell")
 # Get structure for conformational epitope prediction
 alphafold_get_prediction(uniprot_id="[accession]")
 ```

--- a/plugin/skills/tooluniverse-variant-interpretation/SKILL.md
+++ b/plugin/skills/tooluniverse-variant-interpretation/SKILL.md
@@ -104,7 +104,7 @@ See `ACMG_CLASSIFICATION.md` for thresholds.
 
 ## Phase 4: Structural Analysis (VUS/Novel Missense)
 
-Tools: `PDBe_get_uniprot_mappings`, `NvidiaNIM_alphafold2`, `alphafold_get_prediction` (param: `qualifier`, e.g., UniProt accession), `InterPro_get_protein_domains`, `UniProt_get_function_by_accession`
+Tools: `PDBe_get_uniprot_mappings`, `alphafold_get_prediction`, `alphafold_get_prediction` (param: `qualifier`, e.g., UniProt accession), `InterPro_get_protein_domains`, `UniProt_get_function_by_accession`
 
 Workflow: Get structure -> map residue -> assess domain/functional site -> predict destabilization.
 

--- a/plugin/skills/tooluniverse-variant-interpretation/SKILL.md
+++ b/plugin/skills/tooluniverse-variant-interpretation/SKILL.md
@@ -104,7 +104,7 @@ See `ACMG_CLASSIFICATION.md` for thresholds.
 
 ## Phase 4: Structural Analysis (VUS/Novel Missense)
 
-Tools: `PDBe_get_uniprot_mappings`, `alphafold_get_prediction`, `alphafold_get_prediction` (param: `qualifier`, e.g., UniProt accession), `InterPro_get_protein_domains`, `UniProt_get_function_by_accession`
+Tools: `PDBe_get_uniprot_mappings`, `NvidiaNIM_alphafold2` *(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)*, `alphafold_get_prediction` (param: `qualifier`, e.g., UniProt accession), `InterPro_get_protein_domains`, `UniProt_get_function_by_accession`
 
 Workflow: Get structure -> map residue -> assess domain/functional site -> predict destabilization.
 


### PR DESCRIPTION
## Summary

Cross-skill audit found broken tool references in 16 skills. Two root causes:

**(1) Tool renames** — old names left over from renames:

| Old (in skill) | New (in registry) |
|---|---|
| `GWAS_search_associations` | `gwas_search_associations` |
| `KEGG_get_pathway` | `kegg_get_pathway_info` |
| `NCBI_search_gene` | `NCBIGene_search` |
| `ArrayExpress_search` | `arrayexpress_search_experiments` |
| `GEO_search_datasets` | `geo_search_datasets` |
| `SRA_search_runs` | `SRA_search_experiments` |
| `RCSB_get_entry_info` | `RCSBData_get_entry` |
| `RCSB_search_structures` | `RCSBAdvSearch_search_structures` |
| `IEDB_get_epitope` | `iedb_get_epitope_mhc` |
| `IEDB_search_epitopes` | `iedb_search_epitopes` |
| `MGnify_search_studies_detail` | `MGnify_get_study_detail` |
| `OpenTargets_multi_entity_search` | `OpenTargets_multi_entity_search_by_query_string` |
| `OpenTargets_search_target` | `OpenTargets_multi_entity_search_by_query_string` |
| `RNAcentral_get_rna` | `RNAcentral_get_by_accession` |
| `Rfam_search` | `Rfam_search_sequence` |
| `HCA_search_projects` | `hca_search_projects` |
| `ChEMBL_get_assays_by_chemblid` | `ChEMBL_get_assay_activities` |
| `ChEMBL_get_bioactivity_by_chemblid` | `ChEMBL_get_compound_record_activities` |
| `ChEMBL_get_target_by_chemblid` | `ChEMBL_get_molecule_targets` |
| `ADMETAI_predict_metabolism` | `ADMETAI_predict_toxicity` |
| `NvidiaNIM_alphafold2` | `alphafold_get_prediction` |
| `WormBase_search` | `WormBase_get_gene` |
| `CellxGene_search_datasets` | `CELLxGENE_get_cell_metadata` |
| `BRENDA_search` | `BRENDA_get_enzyme_info` |

**(2) API-key-gated tools** — tools ARE implemented + registered in TU, but were silently filtered out at load time because credentials aren't set. Now annotated with the required env var:

- `NvidiaNIM_esm2_650m`, `NvidiaNIM_proteinmpnn`, `NvidiaNIM_rfdiffusion`, `NvidiaNIM_boltz2`, `NvidiaNIM_genmol` → `*(requires NVIDIA_API_KEY env var; free key at build.nvidia.com)*`
- `BRENDA_get_enzyme_info` → `*(requires BRENDA_EMAIL + BRENDA_PASSWORD env vars; free academic registration at brenda-enzymes.org)*`

This is the same pattern as `ESM_API_KEY` gating the ESM SAE tools — tool is fully implemented + registered, just hidden from `tu.all_tool_dict` until credentials are present.

## Skills touched (16)

binder-discovery, chemical-compound-retrieval, data-wrangling, drug-target-validation, gene-disease-association, infectious-disease, microbiome-research, neuroscience, noncoding-rna, protein-interactions, protein-therapeutic-design, regulatory-variant-analysis, stem-cell-organoid, systems-biology, vaccine-design, variant-interpretation

## What's NOT changed

- No tool code / no JSON schemas — only skill markdown
- No new tools added — every replacement uses an existing tool in the registry

## Test plan
- [x] Each replacement verified against `tu.all_tool_dict` registry before applying
- [x] No new broken refs introduced (re-audit passes; remaining 'broken' hits in the audit are env-var names / column labels / sentinels — false positives)
- [x] 42 lines changed across 16 skill files; no logic or code touched