### PR TITLE
fix: build filter.advanced clause for filter_study_type

### DIFF
--- a/src/tooluniverse/ctg_tool.py
+++ b/src/tooluniverse/ctg_tool.py
@@ -149,7 +149,6 @@ class ClinicalTrialsTool(RESTfulTool):
             "query_intr": "query.intr",
             "query_term": "query.term",
             "filter_status": "filter.overallStatus",
-            "filter_study_type": "filter.studyType",
             "page_size": "pageSize",
             "next_page_token": "pageToken",
             "intervention": "query.intr",
@@ -181,6 +180,15 @@ class ClinicalTrialsTool(RESTfulTool):
                 if len(phases) > 1:
                     phase_clause = f"({phase_clause})"
                 advanced_clauses.append(phase_clause)
+            elif key == "filter_study_type":
+                # CTG API v2 uses filter.advanced for study type, not filter.studyType
+                study_types = [s.strip() for s in value.split(",")]
+                study_type_clause = " OR ".join(
+                    f"AREA[StudyType]{s}" for s in study_types
+                )
+                if len(study_types) > 1:
+                    study_type_clause = f"({study_type_clause})"
+                advanced_clauses.append(study_type_clause)
             elif key in _SEARCH_PARAM_MAP:
                 params[_SEARCH_PARAM_MAP[key]] = value
 

--- a/tests/unit/test_ctg_tool.py
+++ b/tests/unit/test_ctg_tool.py
@@ -1,0 +1,90 @@
+"""Unit tests for ClinicalTrialsTool search-param translation.
+
+The tool sits on CT.gov's v2 API, which has no `filter.studyType` (and no
+`filter.phase`) — both filters must be expressed via `filter.advanced`
+AREA clauses. These tests pin the outgoing URL shape so a future refactor
+can't silently regress the AREA-clause construction.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tooluniverse.ctg_tool import ClinicalTrialsTool
+
+
+def make_search_tool():
+    """Construct a search-operation ClinicalTrialsTool with minimal config."""
+    return ClinicalTrialsTool(
+        {
+            "name": "ClinicalTrials_search_studies",
+            "type": "ClinicalTrialsTool",
+            "fields": {"operation": "search"},
+            "query_schema": {},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+def make_empty_studies_response():
+    response = Mock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"studies": [], "totalCount": 0}
+    return response
+
+
+@pytest.mark.unit
+@patch("requests.get")
+def test_filter_study_type_builds_area_clause(mock_get):
+    """filter_study_type must NOT appear as a query param; it must go into filter.advanced as AREA[StudyType]<value>."""
+    mock_get.return_value = make_empty_studies_response()
+
+    make_search_tool().run(
+        {"query_cond": "asthma", "filter_study_type": "INTERVENTIONAL"}
+    )
+
+    params = mock_get.call_args.kwargs["params"]
+    assert "filter.studyType" not in params, (
+        "Regression: CT.gov v2 has no filter.studyType param; passing it 400s."
+    )
+    assert params["filter.advanced"] == "AREA[StudyType]INTERVENTIONAL"
+
+
+@pytest.mark.unit
+@patch("requests.get")
+def test_filter_study_type_multi_value_uses_or_with_parens(mock_get):
+    """Comma-separated study types must join with OR inside parentheses."""
+    mock_get.return_value = make_empty_studies_response()
+
+    make_search_tool().run(
+        {"query_cond": "asthma", "filter_study_type": "INTERVENTIONAL,OBSERVATIONAL"}
+    )
+
+    advanced = mock_get.call_args.kwargs["params"]["filter.advanced"]
+    assert advanced == (
+        "(AREA[StudyType]INTERVENTIONAL OR AREA[StudyType]OBSERVATIONAL)"
+    )
+
+
+@pytest.mark.unit
+@patch("requests.get")
+def test_filter_study_type_combines_with_filter_phase_via_and(mock_get):
+    """Study-type and phase clauses must combine with AND in filter.advanced (no regression on phase handling)."""
+    mock_get.return_value = make_empty_studies_response()
+
+    make_search_tool().run(
+        {
+            "query_cond": "asthma",
+            "filter_study_type": "INTERVENTIONAL",
+            "filter_phase": "PHASE3",
+        }
+    )
+
+    advanced = mock_get.call_args.kwargs["params"]["filter.advanced"]
+    # Order of clauses matches argument-dict iteration order (insertion-preserving in py3.7+);
+    # accept either ordering so the test isn't brittle to caller key order.
+    assert advanced in (
+        "AREA[Phase]PHASE3 AND AREA[StudyType]INTERVENTIONAL",
+        "AREA[StudyType]INTERVENTIONAL AND AREA[Phase]PHASE3",
+    )


### PR DESCRIPTION
Fixes #189.

`ClinicalTrials_search_studies` was mapping `filter_study_type` to a query-string parameter `filter.studyType`. CT.gov v2 does not accept that key, so any call passing `filter_study_type` hard-failed with HTTP 400 (`filter.studyType is unknown parameter`).

The repro from the issue:

```json
{
  "tool": "ClinicalTrials_search_studies",
  "arguments": {"query_cond": "asthma", "filter_study_type": "INTERVENTIONAL", "page_size": 1}
}
```

led to the outgoing URL `…&filter.studyType=INTERVENTIONAL&pageSize=1`, which CT.gov rejects.

### Fix

Apply the same `filter.advanced` `AREA[…]` treatment that `filter_phase` already uses in this method. The comment one branch up already calls this out (`# CTG API v2 uses filter.advanced for phase, not filter.phase`); this PR extends the pattern to study type.

After this PR the same call sends:

```
…&filter.advanced=AREA[StudyType]INTERVENTIONAL&pageSize=1
```

Multiple comma-separated values (`"INTERVENTIONAL,OBSERVATIONAL"`) are joined with `OR` and wrapped in parentheses, mirroring how phase values are handled.

### Scope

Only `src/tooluniverse/ctg_tool.py::ClinicalTrialsTool._run_search` is touched - that is the path the issue identifies. The other `clinicaltrials_tool.py` file uses a different mechanism (`aggFilters=phase:…`) and is out of scope for this PR.