### PR TITLE
Rename variant-predictor-dms-benchmarking → variant-predictor-dms-validation

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -31,7 +31,7 @@ covering single-variant mechanistic interpretation through whole-protein DMS ana
   AlphaMissense + AlphaFold + UniProt + DynaMut2) with 6-category decision rule.
 - `tooluniverse-protein-structural-annotation-pdb` — wraps Structure_annotate_per_residue.
 - `MaveDB_get_effect_matrix` — orchestrates `MaveDB_*` tools + HGVS parsing.
-- `tooluniverse-variant-predictor-dms-benchmarking` — validate ANY
+- `tooluniverse-variant-predictor-dms-validation` — validate ANY
   per-variant predictor (AlphaMissense / SAE / ESM logits / EVE / conservation
   / DynaMut2 / custom) against DMS data via Mann-Whitney U + robustness sweep.
   SAE is shown as the worked example; the methodology is predictor-agnostic.

--- a/plugin/skills/tooluniverse-residue-functional-mechanism-interpretation/SKILL.md
+++ b/plugin/skills/tooluniverse-residue-functional-mechanism-interpretation/SKILL.md
@@ -39,7 +39,7 @@ they came from:
 
 **Not for**:
 - Validating a *predictor* against DMS — use
-  `tooluniverse-variant-predictor-dms-benchmarking`
+  `tooluniverse-variant-predictor-dms-validation`
 - Single-variant **SAE feature decomposition** when you want to see which
   ESMC features changed — use `tooluniverse-protein-sae-variant-interpretation`
 - Single-variant **LoF mechanism synthesis** for one variant in isolation
@@ -234,7 +234,7 @@ top_features = [f["feature_id"] for f in region["data"]["top_features"]]
 ```
 This is the right default — 1 Forge call vs 20 × cluster-size for the DMS-tensor path. For non-contiguous clusters, run once per contiguous sub-range and union the top-K.
 
-**Path B — you already have a precomputed SAE tensor** from a DMS sweep (e.g. the variant-predictor-dms-benchmarking pipeline left one on disk): compute drops directly without re-calling Forge.
+**Path B — you already have a precomputed SAE tensor** from a DMS sweep (e.g. the variant-predictor-dms-validation pipeline left one on disk): compute drops directly without re-calling Forge.
 ```python
 def cluster_sae_features(sae_tensor, wt_vec, cluster_positions, top_n=5):
     """Returns top SAE features by mean drop at cluster, ready for labeling."""
@@ -499,7 +499,7 @@ own sequence — see `tooluniverse-protein-structural-annotation-pdb` pitfalls).
 | `ESM_get_region_sae_features` | Step 4 Path A — aggregate SAE features over a contiguous cluster in 1 Forge call (preferred) |
 | `ESM_get_sae_features` | Step 4 Path B — only if you already have a precomputed full DMS SAE tensor |
 | `ESM_describe_sae_feature` | Label SAE features in Step 4 |
-| `tooluniverse-variant-predictor-dms-benchmarking` | Sibling skill: validate a predictor before trusting its scores |
+| `tooluniverse-variant-predictor-dms-validation` | Sibling skill: validate a predictor before trusting its scores |
 | (heatmap visualization is now Step 7 of this skill) | annotated DMS panel with per-hotspot callouts |
 | `alphafold_get_prediction` | pLDDT context if no experimental PDB available |
 

--- a/plugin/skills/tooluniverse-variant-predictor-dms-validation/SKILL.md
+++ b/plugin/skills/tooluniverse-variant-predictor-dms-validation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tooluniverse-variant-predictor-dms-benchmarking
+name: tooluniverse-variant-predictor-dms-validation
 description: "Validate a variant-effect predictor (AlphaMissense, ESM-C SAE, ESM logits, EVE, conservation scores, or any per-variant numeric score) against experimental deep mutational scanning (DMS) data. Computes per-variant predictor scores, splits variants into neutral vs disruptive groups by DMS effect, runs a Mann-Whitney U test on the predictor scores, and sweeps the stratification thresholds for robustness. Use when you need to know whether a predictor's scores track real functional disruption on a specific protein."
 disable-model-invocation: true
 ---

--- a/tests/tools/test_alphamissense_tool.py
+++ b/tests/tools/test_alphamissense_tool.py
@@ -40,7 +40,7 @@ class TestAlphaMissenseToolDirect:
 
         Pins the iter-3 fix: previously the tool returned only sample_residue +
         sample_data (one position); now it returns the full scores list. Skill
-        5 (variant-predictor-dms-benchmarking) iterates `data['scores']` keyed
+        5 (variant-predictor-dms-validation) iterates `data['scores']` keyed
         by `resi`, so this shape contract is load-bearing.
         """
         from tooluniverse.alphamissense_tool import AlphaMissenseTool

--- a/tests/tools/test_dms_skill_snippets.py
+++ b/tests/tools/test_dms_skill_snippets.py
@@ -4,7 +4,7 @@ After the Phase D refactor (skills reframed around user goals not methodology;
 DMS retrieval lifted into the MaveDB_get_effect_matrix tool), the 3 remaining
 DMS-analysis SKILL.md files are:
   - tooluniverse-protein-structural-annotation-pdb
-  - tooluniverse-variant-predictor-dms-benchmarking
+  - tooluniverse-variant-predictor-dms-validation
   - tooluniverse-residue-functional-mechanism-interpretation
     (Step 7 subsumes what used to be a standalone annotated-dms-heatmap skill;
      entry generalized to accept user-provided residues, not just DMS hotspots)
@@ -182,7 +182,7 @@ def test_skill8_landmark_check(kras_short_sequence):
 
 # ---------------------------------------------------------------------------
 # Per-variant feature matrix prerequisites (formerly sae-mutant-tensor-build,
-# now folded into variant-predictor-dms-benchmarking + residue-functional-mechanism-interpretation)
+# now folded into variant-predictor-dms-validation + residue-functional-mechanism-interpretation)
 # — pooling + cache + WT-diagonal logic
 # ---------------------------------------------------------------------------
 
@@ -251,7 +251,7 @@ def test_skill9_cache_function(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# tooluniverse-variant-predictor-dms-benchmarking — drop, topk, categorize, MWU
+# tooluniverse-variant-predictor-dms-validation — drop, topk, categorize, MWU
 # ---------------------------------------------------------------------------
 
 def topk_drop(drops, K):
@@ -482,7 +482,7 @@ def test_skill12_full_render(tmp_path, synthetic_dms_matrix, kras_short_sequence
 # ---------------------------------------------------------------------------
 
 def test_variant_predictor_alphamissense_bin_parsing():
-    """Verbatim from variant-predictor-dms-benchmarking Step 2 option B.
+    """Verbatim from variant-predictor-dms-validation Step 2 option B.
 
     AM hegelab proxy returns categorical bins like 'pathogenic_all':
     '19:A,C,D,E,...,Y'; the skill maps each alt_aa to a bin-midpoint to
@@ -530,7 +530,7 @@ def test_variant_predictor_alphamissense_bin_parsing():
 
 
 def test_variant_predictor_nan_sanity_gate():
-    """Verbatim from variant-predictor-dms-benchmarking new Step 3.5.
+    """Verbatim from variant-predictor-dms-validation new Step 3.5.
 
     Catches the silent-NaN failure mode that hit iter-1 eval-1 (SAE matrix
     all NaN → MWU still ran → "AM wins by default" false-positive).


### PR DESCRIPTION
## Summary

- Renames the skill `tooluniverse-variant-predictor-dms-benchmarking` → `tooluniverse-variant-predictor-dms-validation`.
- The skill's job is to check whether a variant-effect predictor's scores correspond to measured functional effects on a specific protein — i.e. validate the predictor on its target. "Benchmarking" implied cross-method comparison on a standard set, which is not what the skill does and reads as engineering jargon to bio/AI users.

## Scope

- Directory rename: `plugin/skills/tooluniverse-variant-predictor-dms-benchmarking/` → `tooluniverse-variant-predictor-dms-validation/`
- `SKILL.md` frontmatter `name:` field
- 3 cross-references in `tooluniverse-residue-functional-mechanism-interpretation/SKILL.md`
- 1 entry in `plugin/CHANGELOG.md`
- 6 mentions across `tests/tools/test_alphamissense_tool.py` + `tests/tools/test_dms_skill_snippets.py`

11 references rewritten, 0 stale. 62 affected tests pass; ruff clean.

## Base branch

Targeted at `feature/sae-inference-and-interpretation` (PR #192) since the skill only exists there. Once #192 merges, retarget this PR's base to `main` via the GitHub UI.

## Test plan

- [x] `pytest tests/tools/test_dms_skill_snippets.py tests/tools/test_alphamissense_tool.py tests/tools/test_esm_sae_tool.py` — 62 passed
- [x] `ruff check .` — all checks passed
- [x] `grep -r "variant-predictor-dms-benchmarking" plugin/ tests/` — no remaining matches