### PR TITLE
fix(plugin): correct install skill — skill count, .mcp.json args, version pin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "tooluniverse",
       "source": "./plugin",
-      "description": "1000+ scientific tools (PubMed, UniProt, PubChem, TCGA, FAERS, ClinicalTrials.gov, etc.) + 115 research skills + MCP server + research slash commands.",
+      "description": "1000+ scientific tools (PubMed, UniProt, PubChem, TCGA, FAERS, ClinicalTrials.gov, etc.) + 120+ research skills + MCP server + research slash commands.",
       "category": "science",
       "strict": false
     }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tooluniverse",
-  "description": "1000+ scientific research tools for biology, chemistry, medicine, and data science. Access PubMed, UniProt, PubChem, TCGA, NHANES, GWAS Catalog, and hundreds more databases through a unified MCP interface. Includes 118 specialized research skills for genomics, drug discovery, clinical analysis, protein variant interpretation, and more.",
+  "description": "1000+ scientific research tools for biology, chemistry, medicine, and data science. Access PubMed, UniProt, PubChem, TCGA, NHANES, GWAS Catalog, and hundreds more databases through a unified MCP interface. Includes 120+ specialized research skills for genomics, drug discovery, clinical analysis, protein variant interpretation, and more.",
   "version": "1.2.1",
   "author": {
     "name": "Shanghua Gao",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -27,7 +27,7 @@ claude plugin install tooluniverse@tooluniverse
 ## What's Included
 
 - **MCP Server**: Auto-configured via `.mcp.json`. Provides `find_tools`, `list_tools`, `get_tool_info`, `execute_tool` — accessing 1000+ scientific APIs.
-- **115 Research Skills**: Specialized workflows for genomics, drug discovery, clinical analysis, statistical modeling, data wrangling, and more.
+- **120+ Research Skills**: Specialized workflows for genomics, drug discovery, clinical analysis, statistical modeling, data wrangling, and more.
 - **Slash Commands** (each enforces a discipline the agent won't apply on its own):
   - `/tooluniverse:research` — drive a multi-database investigation inline in this chat (you see every step)
   - `/tooluniverse:translate-id` — resolve an ID across all relevant namespaces

--- a/plugin/skills/tooluniverse-claude-code-plugin/SKILL.md
+++ b/plugin/skills/tooluniverse-claude-code-plugin/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: tooluniverse-claude-code-plugin
-description: Install the ToolUniverse Claude Code plugin in one step — provides MCP server with 1000+ scientific tools, 115 research skills, slash commands, hooks, and the research agent. Use for first-time plugin install, troubleshooting plugin not loading, verifying MCP server connection, listing API key requirements, or configuring auto-update.
+description: Install the ToolUniverse Claude Code plugin in one step — provides MCP server with 1000+ scientific tools, 120+ research skills, slash commands, hooks, and the research agent. Use for first-time plugin install, troubleshooting plugin not loading, verifying MCP server connection, listing API key requirements, or configuring auto-update.
 disable-model-invocation: true
 ---
 
 # Install the ToolUniverse Plugin for Claude Code
 
-One-step install of the ToolUniverse plugin: MCP server with 1000+ tools, 115 research skills, slash commands, and the research agent — all auto-configured.
+One-step install of the ToolUniverse plugin: MCP server with 1000+ tools, 120+ research skills, slash commands, and the research agent — all auto-configured.
 
 ## Prerequisites (check once)
 
@@ -41,14 +41,15 @@ rm -rf ~/.claude/skills/create-tooluniverse-skill
 rm -rf ~/.claude/skills/setup-tooluniverse
 ```
 
-### Pin to a version (optional)
+### Pin the tool version (optional, for reproducibility)
 
-```bash
-claude plugin marketplace add mims-harvard/ToolUniverse#v1.2.0
-claude plugin install tooluniverse@tooluniverse
+The MCP server runs the `tooluniverse` PyPI package via `uvx`. To lock tool behavior for a long-running analysis, pin the package version in the plugin's `.mcp.json` — change the args to:
+
+```json
+"args": ["tooluniverse@1.2.0"]
 ```
 
-Replace `v1.2.0` with any released tag from https://github.com/mims-harvard/ToolUniverse/releases.
+Replace `1.2.0` with any released version from https://pypi.org/project/tooluniverse/. Restart Claude Code to apply. (`.mcp.json` location is shown under "API keys" below.)
 
 ## Verify it worked
 
@@ -76,7 +77,7 @@ The router skill auto-dispatches to the right specialized skill — no command p
 | **`/tooluniverse:compare`** | N-way side-by-side comparison with domain-appropriate columns | Slash command |
 | **`/tooluniverse:literature-sweep`** | Graded mini-review across PubMed + EuropePMC + Semantic Scholar | Slash command |
 | **`/tooluniverse:researcher`** | Same investigation as `research`, delegated to a forked subagent | Slash command |
-| **115 skills** | Structured workflows (drug research, variant interpretation, pharmacovigilance, CRISPR screens, statistical modeling, etc.) | Auto-activate on matching questions |
+| **120+ skills** | Structured workflows (drug research, variant interpretation, pharmacovigilance, CRISPR screens, statistical modeling, etc.) | Auto-activate on matching questions |
 
 ## API keys (optional, but recommended)
 
@@ -98,7 +99,7 @@ find ~/.claude/plugins -name '.mcp.json' -path '*tooluniverse*'
   "mcpServers": {
     "tooluniverse": {
       "command": "uvx",
-      "args": ["--refresh", "tooluniverse"],
+      "args": ["tooluniverse"],
       "env": {
         "PYTHONIOENCODING": "utf-8",
         "NCBI_API_KEY": "your_key",

--- a/plugin/skills/tooluniverse-claude-code-plugin/SKILL.md
+++ b/plugin/skills/tooluniverse-claude-code-plugin/SKILL.md
@@ -46,10 +46,10 @@ rm -rf ~/.claude/skills/setup-tooluniverse
 The MCP server runs the `tooluniverse` PyPI package via `uvx`. To lock tool behavior for a long-running analysis, pin the package version in the plugin's `.mcp.json` — change the args to:
 
 ```json
-"args": ["tooluniverse@1.2.0"]
+"args": ["tooluniverse@1.2.2"]
 ```
 
-Replace `1.2.0` with any released version from https://pypi.org/project/tooluniverse/. Restart Claude Code to apply. (`.mcp.json` location is shown under "API keys" below.)
+Replace `1.2.2` with any released version from https://pypi.org/project/tooluniverse/. Restart Claude Code to apply. (`.mcp.json` location is shown under "API keys" below.)
 
 ## Verify it worked
 

--- a/skills/tooluniverse-claude-code-plugin/SKILL.md
+++ b/skills/tooluniverse-claude-code-plugin/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: tooluniverse-claude-code-plugin
-description: Install the ToolUniverse Claude Code plugin in one step — provides MCP server with 1000+ scientific tools, 115 research skills, slash commands, hooks, and the research agent. Use for first-time plugin install, troubleshooting plugin not loading, verifying MCP server connection, listing API key requirements, or configuring auto-update.
+description: Install the ToolUniverse Claude Code plugin in one step — provides MCP server with 1000+ scientific tools, 120+ research skills, slash commands, hooks, and the research agent. Use for first-time plugin install, troubleshooting plugin not loading, verifying MCP server connection, listing API key requirements, or configuring auto-update.
 disable-model-invocation: true
 ---
 
 # Install the ToolUniverse Plugin for Claude Code
 
-One-step install of the ToolUniverse plugin: MCP server with 1000+ tools, 115 research skills, slash commands, and the research agent — all auto-configured.
+One-step install of the ToolUniverse plugin: MCP server with 1000+ tools, 120+ research skills, slash commands, and the research agent — all auto-configured.
 
 ## Prerequisites (check once)
 
@@ -41,14 +41,15 @@ rm -rf ~/.claude/skills/create-tooluniverse-skill
 rm -rf ~/.claude/skills/setup-tooluniverse
 ```
 
-### Pin to a version (optional)
+### Pin the tool version (optional, for reproducibility)
 
-```bash
-claude plugin marketplace add mims-harvard/ToolUniverse#v1.2.0
-claude plugin install tooluniverse@tooluniverse
+The MCP server runs the `tooluniverse` PyPI package via `uvx`. To lock tool behavior for a long-running analysis, pin the package version in the plugin's `.mcp.json` — change the args to:
+
+```json
+"args": ["tooluniverse@1.2.0"]
 ```
 
-Replace `v1.2.0` with any released tag from https://github.com/mims-harvard/ToolUniverse/releases.
+Replace `1.2.0` with any released version from https://pypi.org/project/tooluniverse/. Restart Claude Code to apply. (`.mcp.json` location is shown under "API keys" below.)
 
 ## Verify it worked
 
@@ -76,7 +77,7 @@ The router skill auto-dispatches to the right specialized skill — no command p
 | **`/tooluniverse:compare`** | N-way side-by-side comparison with domain-appropriate columns | Slash command |
 | **`/tooluniverse:literature-sweep`** | Graded mini-review across PubMed + EuropePMC + Semantic Scholar | Slash command |
 | **`/tooluniverse:researcher`** | Same investigation as `research`, delegated to a forked subagent | Slash command |
-| **115 skills** | Structured workflows (drug research, variant interpretation, pharmacovigilance, CRISPR screens, statistical modeling, etc.) | Auto-activate on matching questions |
+| **120+ skills** | Structured workflows (drug research, variant interpretation, pharmacovigilance, CRISPR screens, statistical modeling, etc.) | Auto-activate on matching questions |
 
 ## API keys (optional, but recommended)
 
@@ -98,7 +99,7 @@ find ~/.claude/plugins -name '.mcp.json' -path '*tooluniverse*'
   "mcpServers": {
     "tooluniverse": {
       "command": "uvx",
-      "args": ["--refresh", "tooluniverse"],
+      "args": ["tooluniverse"],
       "env": {
         "PYTHONIOENCODING": "utf-8",
         "NCBI_API_KEY": "your_key",

--- a/skills/tooluniverse-claude-code-plugin/SKILL.md
+++ b/skills/tooluniverse-claude-code-plugin/SKILL.md
@@ -46,10 +46,10 @@ rm -rf ~/.claude/skills/setup-tooluniverse
 The MCP server runs the `tooluniverse` PyPI package via `uvx`. To lock tool behavior for a long-running analysis, pin the package version in the plugin's `.mcp.json` — change the args to:
 
 ```json
-"args": ["tooluniverse@1.2.0"]
+"args": ["tooluniverse@1.2.2"]
 ```
 
-Replace `1.2.0` with any released version from https://pypi.org/project/tooluniverse/. Restart Claude Code to apply. (`.mcp.json` location is shown under "API keys" below.)
+Replace `1.2.2` with any released version from https://pypi.org/project/tooluniverse/. Restart Claude Code to apply. (`.mcp.json` location is shown under "API keys" below.)
 
 ## Verify it worked
 


### PR DESCRIPTION
## Summary

Corrects three wrong/misleading items in the `tooluniverse-claude-code-plugin` install skill (and aligns the skill-count claim across `marketplace.json`, `plugin.json`, and `plugin/README.md`).

- **Skill count was stale.** `115` (and `118` in `plugin.json`) were hardcoded and out of date. Replaced with a drift-tolerant `120+` across all user-facing surfaces (matches the existing `1000+ tools` lower-bound style). The plugin currently bundles 120 user-facing skills.
- **`.mcp.json` example used `--refresh`.** The example showed `"args": ["--refresh", "tooluniverse"]`, but the real installed config is `"args": ["tooluniverse"]`. `--refresh` forces a package re-resolve on every launch (slower cold start). Aligned the example with the actual config.
- **Version-pin example referenced a non-existent release.** The skill told users to pin `tooluniverse@1.2.0`, but `1.2.0` does not exist on PyPI (only `1.2.1` / `1.2.2`) — `uvx` would fail to resolve it. Also switched the pin mechanism from an unsupported `claude plugin marketplace add ...#v1.2.0` (the `#tag` syntax is not in `marketplace add`) to the verified `.mcp.json` PyPI pin. Example now uses `tooluniverse@1.2.2`.

## Verification

All install commands were run against the live `claude` CLI (2.1.156), `uv`, PyPI, and the MCP server:

- `claude plugin validate .` and `claude plugin validate ./plugin` — both pass
- `uvx tooluniverse` and `uvx tooluniverse@1.2.2` — MCP server boots, responds to the `initialize` handshake
- `tools/list` exposes the documented meta-tools (`find_tools`, `get_tool_info`, `execute_tool`, plus `list_tools`, `grep_tools`)
- `find_tools(query=...)` end-to-end returns real tool results
- `mims-harvard/ToolUniverse` marketplace.json is reachable and well-formed (name `tooluniverse`, source `./plugin`)
- PyPI release list confirmed: `1.2.0` absent, `1.2.2` present

## Test plan

- [ ] Re-run `claude plugin validate ./plugin`
- [ ] Confirm the version-pin example resolves: `uvx tooluniverse@1.2.2 --help` (or MCP boot)