### PR TITLE
docs: redirect /tutorials/ → /guide/ for paper-cited URLs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,22 @@ extensions = [
     # "sphinx_tabs.tabs",  # Temporarily disabled due to Sphinx 9.x compatibility issue
     "sphinx_design",
     # "notfound.extension",  # Temporarily disabled due to theme compatibility issue
+    "sphinx_reredirects",
 ]
+
+# HTML redirects for paths that moved during a docs reshuffle.
+# Old path → new path. The ToolUniverse paper and external blog posts cite
+# /tutorials/<name>.html URLs from before the docs were reorganised under
+# /guide/. Without these redirects, every cited URL 404s.
+redirects = {
+    "tutorials/tooluniverse_case_study": "../guide/tooluniverse_case_study.html",
+    "tutorials/agentic_tools_tutorial": "../guide/agentic_tools_tutorial.html",
+    "tutorials/literature_search_tools_tutorial": "../guide/literature_search_tools_tutorial.html",
+    "tutorials/literature_search_web_ui_tutorial": "../guide/literature_search_web_ui_tutorial.html",
+    "tutorials/visualization_tutorial": "../guide/visualization_tutorial.html",
+    "tutorials/expert_feedback": "../guide/expert_feedback.html",
+    "tutorials/finding_tools": "../guide/finding_tools.html",
+}
 
 templates_path = ["_templates"]
 exclude_patterns = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ docs = [
     "sphinx-design>=0.3.0",
     "sphinx-notfound-page>=0.8",
     "sphinx-autodoc-typehints>=1.12.0",
+    "sphinx-reredirects>=0.1.5",
 ]
 embedding = [
     "sentence-transformers>=5.1.0",


### PR DESCRIPTION
## Summary

The ToolUniverse paper cites
`https://zitniklab.hms.harvard.edu/ToolUniverse/tutorials/tooluniverse_case_study.html`
but a docs reshuffle moved that page under `/guide/`, so the old URL 404s.

A reader (and the paper) hit this. This PR fixes it via sphinx-reredirects.

## Audit

I scanned every old `/tutorials/<name>.html` referenced in `docs/locale/zh_CN/LC_MESSAGES/tutorials/*.po` (which is the leftover translation tree from before the reshuffle) and probed both URLs on the live site:

| Path | `/tutorials/` | `/guide/` | Status |
|---|---|---|---|
| `tooluniverse_case_study` ← cited by paper | 404 | 200 | ✅ redirect added |
| `agentic_tools_tutorial` | 404 | 200 | ✅ redirect added |
| `literature_search_tools_tutorial` | 404 | 200 | ✅ redirect added |
| `literature_search_web_ui_tutorial` | 404 | 200 | ✅ redirect added |
| `visualization_tutorial` | 404 | 200 | ✅ redirect added |
| `expert_feedback` | 404 | 200 | ✅ redirect added |
| `finding_tools` | 404 | 200 | ✅ redirect added |
| `remote_tools` | 404 | 404 | ⚠️ not redirectable, page genuinely missing |
| `mcp_integration` | 404 | 404 | ⚠️ same |
| `skills` | 404 | 404 | ⚠️ same |
| `tool_finder` | 404 | 404 | ⚠️ same |
| `overview` | 404 | 404 | ⚠️ same |

The bottom 5 are 404 in *both* locations — either deleted or renamed elsewhere. Not safe to silently redirect without knowing intent; leaving for a separate follow-up.

## Changes

- `docs/conf.py` — register `sphinx_reredirects` extension + `redirects` dict
- `pyproject.toml` — add `sphinx-reredirects>=0.1.5` to the `docs` extras

## Verification

```
sphinx-build -b html docs /tmp/out -q -W --keep-going
ls /tmp/out/tutorials/
# tooluniverse_case_study.html  agentic_tools_tutorial.html  ... (7 stubs)
```

Each stub is ~250 bytes: meta-refresh + JS `window.location.replace` preserving fragments. No new toctree warnings introduced.

After this PR deploys: the paper's URL will redirect to `/guide/tooluniverse_case_study.html` in <1 second.