### PR TITLE
Round 006: tu run shows the real error instead of "unknown error"

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -143,3 +143,9 @@ TXAGENT_MCP_SERVER_HOST=
 # USPTO_MCP_SERVER_HOST (required) — URL of a self-hosted USPTO MCP server. (https://developer.uspto.gov/)
 # Without: Leave blank unless you run your own USPTO server.
 USPTO_MCP_SERVER_HOST=
+
+# === Other ===
+
+# WAQI_API_KEY (optional) — Fetch real per-city air quality data from the World Air Quality Index API. (https://aqicn.org/data-platform/token/)
+# Without: Falls back to the public 'demo' token, which returns a fixed sample station (Shanghai) for every city. The key is free.
+WAQI_API_KEY=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooluniverse"
-version = "1.2.2"
+version = "1.2.3"
 description = "A comprehensive collection of scientific tools for Agentic AI, offering integration with the ToolUniverse SDK and MCP Server to support advanced scientific workflows."
 authors = [
     { name = "Shanghua Gao", email = "shanghuagao@gmail.com" }

--- a/src/tooluniverse/alliance_genome_tool.py
+++ b/src/tooluniverse/alliance_genome_tool.py
@@ -161,36 +161,68 @@ class AllianceGenomeTool(BaseTool):
             url, headers={"Accept": "application/json"}, timeout=self.timeout
         )
         response.raise_for_status()
-        data = response.json()
+        payload = response.json()
 
-        species = data.get("species", {})
-        locations = data.get("genomeLocations", [])
+        # The Alliance API nests the gene record under a top-level "gene" key.
+        # Fall back to the payload itself for resilience against schema drift.
+        data = payload.get("gene") or payload
+
+        def _text(obj):
+            """Alliance wraps labels as {formatText, displayText}; unwrap them."""
+            if isinstance(obj, dict):
+                return obj.get("displayText") or obj.get("formatText")
+            return obj
+
+        taxon = data.get("taxon") or {}
+        taxon_species = taxon.get("species") or {}
+        # genomic location moved to geneGenomicLocationAssociations
+        locations = (
+            data.get("geneGenomicLocationAssociations")
+            or data.get("genomeLocations")
+            or []
+        )
         loc_info = locations[0] if locations else {}
-        xrefs = data.get("crossReferenceMap", {})
 
-        # Extract cross-references
-        other_xrefs = xrefs.get("other", [])
-        xref_list = [
-            {"name": x.get("name"), "url": x.get("crossRefCompleteUrl")}
-            for x in other_xrefs[:10]
+        synonyms = [
+            _text(s) for s in (data.get("geneSynonyms") or data.get("synonyms") or [])
         ]
+
+        # cross-references: new schema is a flat list of {referencedCurie, displayName}
+        cross_refs = data.get("crossReferences")
+        if cross_refs is None:
+            cross_refs = (data.get("crossReferenceMap") or {}).get("other", [])
+        xref_list = [
+            {
+                "name": x.get("displayName") or x.get("name"),
+                "curie": x.get("referencedCurie"),
+                "url": x.get("crossRefCompleteUrl"),
+            }
+            for x in cross_refs[:10]
+        ]
+
+        gene_type = data.get("geneType") or data.get("soTerm") or {}
 
         return {
             "status": "success",
             "data": {
-                "id": data.get("id"),
-                "symbol": data.get("symbol"),
-                "name": data.get("name"),
+                "id": data.get("primaryExternalId") or data.get("id"),
+                "symbol": _text(data.get("geneSymbol")) or data.get("symbol"),
+                "name": _text(data.get("geneFullName")) or data.get("name"),
                 "species": {
-                    "name": species.get("name"),
-                    "short_name": species.get("shortName"),
-                    "taxon_id": species.get("taxonId"),
-                    "data_provider": species.get("dataProviderShortName"),
+                    "name": taxon.get("name") or taxon_species.get("fullName"),
+                    "short_name": taxon_species.get("displayName")
+                    or taxon_species.get("abbreviation"),
+                    "taxon_id": taxon.get("curie") or taxon.get("taxonId"),
+                    "data_provider": (data.get("dataProvider") or {}).get(
+                        "abbreviation"
+                    )
+                    if isinstance(data.get("dataProvider"), dict)
+                    else data.get("dataProvider"),
                 },
                 "gene_synopsis": data.get("geneSynopsis"),
                 "automated_gene_synopsis": data.get("automatedGeneSynopsis"),
-                "synonyms": data.get("synonyms", []),
-                "so_term": data.get("soTerm", {}).get("name"),
+                "synonyms": synonyms,
+                "so_term": gene_type.get("name"),
                 "genomic_location": {
                     "chromosome": loc_info.get("chromosome"),
                     "start": loc_info.get("start"),
@@ -202,7 +234,6 @@ class AllianceGenomeTool(BaseTool):
             },
             "metadata": {
                 "query_gene_id": gene_id,
-                "data_provider": data.get("dataProvider"),
                 "source": "Alliance of Genome Resources",
             },
         }

--- a/src/tooluniverse/alliance_genome_tool.py
+++ b/src/tooluniverse/alliance_genome_tool.py
@@ -252,13 +252,13 @@ class AllianceGenomeTool(BaseTool):
         limit = int(arguments.get("limit", 10))
         # When filtering by species, fetch more candidates so client-side filtering
         # still returns enough results (Alliance has no server-side species filter).
+        # The autocomplete endpoint no longer honours a `category=gene` query
+        # param (it returns zero results) and mixes gene/disease/dataset hits,
+        # so fetch a buffer unfiltered and keep gene hits client-side. The gene
+        # id is now in `curie` (was `primaryKey`).
         _SPECIES_FETCH_MULTIPLIER = 5
-        fetch_limit = (
-            min(limit * _SPECIES_FETCH_MULTIPLIER, 100)
-            if species_prefix
-            else min(limit, 50)
-        )
-        params = {"q": query, "category": "gene", "limit": fetch_limit}
+        fetch_limit = min(max(limit * _SPECIES_FETCH_MULTIPLIER, 25), 100)
+        params = {"q": query, "limit": fetch_limit}
 
         response = requests.get(
             f"{ALLIANCE_BASE}/search_autocomplete",
@@ -269,17 +269,20 @@ class AllianceGenomeTool(BaseTool):
         response.raise_for_status()
         results = response.json().get("results", [])
 
+        # Keep only gene hits (autocomplete also returns diseases, datasets, …).
+        results = [r for r in results if r.get("category") == "gene_search_result"]
+
         if species_prefix:
             results = [
-                r for r in results if r.get("primaryKey", "").startswith(species_prefix)
+                r for r in results if str(r.get("curie", "")).startswith(species_prefix)
             ]
 
         genes = [
             {
                 "symbol": r.get("symbol"),
                 "name": r.get("name"),
-                "gene_id": r.get("primaryKey"),
-                "category": r.get("category"),
+                "gene_id": r.get("curie"),
+                "category": "gene",
             }
             for r in results[:limit]
         ]
@@ -326,9 +329,17 @@ class AllianceGenomeTool(BaseTool):
         phenotypes = []
         for r in results:
             subject = r.get("subject", {})
+            # subject.geneSymbol is now a {formatText, displayText} object, not
+            # a plain `symbol` string — unwrap it (was returning null).
+            gene_symbol_obj = subject.get("geneSymbol")
+            gene_symbol = (
+                gene_symbol_obj.get("displayText") or gene_symbol_obj.get("formatText")
+                if isinstance(gene_symbol_obj, dict)
+                else subject.get("symbol")
+            )
             phenotypes.append(
                 {
-                    "gene_symbol": subject.get("symbol"),
+                    "gene_symbol": gene_symbol,
                     "gene_id": subject.get("primaryExternalId"),
                     "phenotype_statement": r.get("phenotypeStatement"),
                 }

--- a/src/tooluniverse/base_rest_tool.py
+++ b/src/tooluniverse/base_rest_tool.py
@@ -138,6 +138,16 @@ class BaseRESTTool(BaseTool):
             if "default" in prop and prop["default"] is not None:
                 params[param_mapping.get(key, key)] = prop["default"]
 
+        # Inject an API token from an environment variable into a query param
+        # when configured. Config: {"env_var": "WAQI_API_KEY", "param": "token"}.
+        # If the env var is unset the config default (e.g. a public "demo"
+        # token) is left in place, so this is a non-breaking opt-in.
+        auth_param_cfg = self.tool_config.get("fields", {}).get("auth_param")
+        if auth_param_cfg:
+            env_value = os.environ.get(auth_param_cfg.get("env_var", ""), "")
+            if env_value:
+                params[auth_param_cfg.get("param", "token")] = env_value
+
         return params
 
     def _process_response(
@@ -221,6 +231,20 @@ class BaseRESTTool(BaseTool):
         """
         url = None
         try:
+            # Normalize case-sensitive params before building the request.
+            # Some backends (e.g. CPIC's PostgREST `name=eq.{name}` filter) only
+            # match lowercase values, so a capitalized input silently returns an
+            # empty success. `fields.lowercase_params` lists params to downcase.
+            lowercase_params = (
+                self.tool_config.get("fields", {}).get("lowercase_params") or []
+            )
+            if lowercase_params:
+                arguments = dict(arguments)
+                for key in lowercase_params:
+                    value = arguments.get(key)
+                    if isinstance(value, str):
+                        arguments[key] = value.lower()
+
             url = self._build_url(arguments)
             params = self._build_params(arguments)
 

--- a/src/tooluniverse/base_rest_tool.py
+++ b/src/tooluniverse/base_rest_tool.py
@@ -44,10 +44,13 @@ class BaseRESTTool(BaseTool):
         """
         Get parameter name mappings from argument names to API parameter names.
 
-        Override this in subclasses to provide custom mappings.
+        Reads ``fields.param_mapping`` from the tool config so pure config-driven
+        BaseRESTTool entries can rename query params without a Python subclass
+        (e.g. OData APIs needing {"filter": "$filter", "top": "$top"}).
+        Subclasses may still override to provide mappings in code.
         Example: {"limit": "rows", "query": "q"}
         """
-        return {}
+        return self.tool_config.get("fields", {}).get("param_mapping", {})
 
     def _build_url(self, args: Dict[str, Any]) -> str:
         """

--- a/src/tooluniverse/chebi_tool.py
+++ b/src/tooluniverse/chebi_tool.py
@@ -20,6 +20,16 @@ from .tool_registry import register_tool
 
 CHEBI_BASE_URL = "https://www.ebi.ac.uk/chebi/backend/api/public"
 
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_html(text):
+    """Remove search-highlight markup (e.g. <em>...</em>) ChEBI embeds in
+    name/synonym fields. Non-string values pass through unchanged."""
+    if isinstance(text, str):
+        return _HTML_TAG_RE.sub("", text)
+    return text
+
 
 @register_tool("ChEBITool")
 class ChEBITool(BaseTool):
@@ -111,7 +121,7 @@ class ChEBITool(BaseTool):
             if isinstance(name_list, list):
                 for entry in name_list[:10]:
                     if isinstance(entry, dict):
-                        syn = entry.get("name", "")
+                        syn = _strip_html(entry.get("name", ""))
                         if syn and syn not in synonyms:
                             synonyms.append(syn)
 
@@ -143,8 +153,8 @@ class ChEBITool(BaseTool):
         result = {
             "chebi_id": raw.get("id", chebi_id),
             "chebi_accession": raw.get("chebi_accession", f"CHEBI:{chebi_id}"),
-            "name": raw.get("name", ""),
-            "definition": raw.get("definition", None),
+            "name": _strip_html(raw.get("name", "")),
+            "definition": _strip_html(raw.get("definition", None)),
             "stars": raw.get("stars", 0),
             "formula": chem_data.get("formula", None),
             "mass": mass_val,

--- a/src/tooluniverse/chebi_tool.py
+++ b/src/tooluniverse/chebi_tool.py
@@ -87,6 +87,14 @@ class ChEBITool(BaseTool):
                 "error": "chebi_id parameter is required (e.g., 15365 for aspirin)",
             }
 
+        # Accept the "CHEBI:27732" CURIE form that ChEBI_search returns as
+        # chebi_accession, not just the bare integer — so the two tools chain
+        # without the caller having to strip the prefix.
+        if isinstance(chebi_id, str):
+            chebi_id = chebi_id.strip()
+            if chebi_id.upper().startswith("CHEBI:"):
+                chebi_id = chebi_id.split(":", 1)[1].strip()
+
         url = f"{CHEBI_BASE_URL}/compound/{chebi_id}/"
         response = requests.get(
             url,

--- a/src/tooluniverse/cli.py
+++ b/src/tooluniverse/cli.py
@@ -464,8 +464,16 @@ def _render_run(d: dict) -> str:
         return str(d)
     if d.get("status") != "error" and "error" not in d:
         return json.dumps(d, indent=2, ensure_ascii=False)
-    # Short, actionable error summary
-    short_err = d.get("error", "unknown error")
+    # Short, actionable error summary. The project's standard envelope nests
+    # the error message under d["data"]["error"]; older tools put it at the
+    # top level. Check both so the CLI never falls back to "unknown error"
+    # when the message is actually present.
+    nested = d.get("data") or {}
+    short_err = (
+        d.get("error")
+        or (nested.get("error") if isinstance(nested, dict) else None)
+        or "unknown error"
+    )
     lines = [f"Error: {short_err}"]
     details = d.get("error_details") or {}
 

--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -122,7 +122,26 @@ class ClinVarRESTTool(BaseTool):
         variant_data = data.get("result", {}).get(variant_id)
 
         if not variant_data:
-            return {"error_result": result}
+            # NCBI returns HTTP 200 with an empty uids list and an inline
+            # "Invalid uid ..." message when the id is not a numeric ClinVar
+            # Variation ID (e.g. a dbSNP rsID was passed). Surface this as a
+            # real error instead of forwarding the raw success envelope.
+            ncbi_err = data.get("error") or data.get("result", {}).get("error")
+            msg = f"No ClinVar record found for variant_id '{variant_id}'."
+            if isinstance(variant_id, str) and variant_id.lower().startswith("rs"):
+                msg += (
+                    " Pass a numeric ClinVar Variation ID (e.g. 12345), not a"
+                    " dbSNP rsID."
+                )
+            if ncbi_err:
+                msg += f" NCBI: {ncbi_err}"
+            return {
+                "error_result": {
+                    "status": "error",
+                    "error": msg,
+                    "url": result.get("url"),
+                }
+            }
 
         # Check for NCBI inline error (HTTP 200 but variant not found)
         if variant_data.get("error"):

--- a/src/tooluniverse/data/api_keys_catalog.json
+++ b/src/tooluniverse/data/api_keys_catalog.json
@@ -388,5 +388,17 @@
     "used_by": [
       "uspto_downloader_tools.json"
     ]
+  },
+  {
+    "name": "WAQI_API_KEY",
+    "requirement": "optional",
+    "type": "secret",
+    "domain": "Other",
+    "register_url": "https://aqicn.org/data-platform/token/",
+    "purpose": "Fetch real per-city air quality data from the World Air Quality Index API.",
+    "without": "Falls back to the public 'demo' token, which returns a fixed sample station (Shanghai) for every city. The key is free.",
+    "used_by": [
+      "waqi_tools.json"
+    ]
   }
 ]

--- a/src/tooluniverse/data/chebi_tools.json
+++ b/src/tooluniverse/data/chebi_tools.json
@@ -6,8 +6,11 @@
       "type": "object",
       "properties": {
         "chebi_id": {
-          "type": "integer",
-          "description": "ChEBI numeric identifier (without the 'CHEBI:' prefix). Examples: 15365 (aspirin), 17234 (glucose), 16236 (ethanol), 15377 (water), 17790 (methanol)."
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "ChEBI identifier as a bare integer (e.g. 15365) or the 'CHEBI:15365' CURIE form returned by ChEBI_search. Examples: 15365 (aspirin), 17234 (glucose)."
         }
       },
       "required": [

--- a/src/tooluniverse/data/cpic_tools.json
+++ b/src/tooluniverse/data/cpic_tools.json
@@ -290,7 +290,8 @@
       ]
     },
     "fields": {
-      "endpoint": "https://api.cpicpgx.org/v1/drug?name=eq.{name}"
+      "endpoint": "https://api.cpicpgx.org/v1/drug?name=eq.{name}",
+      "lowercase_params": ["name"]
     },
     "type": "BaseRESTTool",
     "test_examples": [

--- a/src/tooluniverse/data/interpro_entry_tools.json
+++ b/src/tooluniverse/data/interpro_entry_tools.json
@@ -60,9 +60,6 @@
                       "name": {
                         "type": "string"
                       },
-                      "short_name": {
-                        "type": "string"
-                      },
                       "type": {
                         "type": "string"
                       },
@@ -173,9 +170,6 @@
                         "type": "string"
                       },
                       "name": {
-                        "type": "string"
-                      },
-                      "short_name": {
                         "type": "string"
                       },
                       "type": {

--- a/src/tooluniverse/data/openneuro_tools.json
+++ b/src/tooluniverse/data/openneuro_tools.json
@@ -182,7 +182,7 @@
   },
   {
     "name": "OpenNeuro_get_dataset_snapshots",
-    "description": "Get all version snapshots of a specific dataset on OpenNeuro. Returns snapshot tags, creation dates, and summary information for all published versions of the dataset.",
+    "description": "Get all version snapshots of a specific dataset on OpenNeuro. Returns the snapshot id, tag, and creation date for every published version of the dataset. For per-snapshot summary statistics (modalities, subjects, file counts), use OpenNeuro_get_dataset, which returns the latest snapshot's summary.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -195,7 +195,7 @@
         "datasetId"
       ]
     },
-    "query_schema": "query GetSnapshots($datasetId: ID!) {\n  dataset(id: $datasetId) {\n    id\n    name\n    snapshots {\n      id\n      tag\n      created\n      size\n      summary { modalities subjects totalFiles size }\n      description { Name BIDSVersion Authors }\n    }\n  }\n}",
+    "query_schema": "query GetSnapshots($datasetId: ID!) {\n  dataset(id: $datasetId) {\n    id\n    name\n    snapshots {\n      id\n      tag\n      created\n    }\n  }\n}",
     "fields": {},
     "type": "OpenNeuroTool",
     "test_examples": [
@@ -234,9 +234,6 @@
                           },
                           "created": {
                             "type": ["string", "null"]
-                          },
-                          "summary": {
-                            "type": ["object", "null"]
                           }
                         }
                       }

--- a/src/tooluniverse/data/pubchem_tools.json
+++ b/src/tooluniverse/data/pubchem_tools.json
@@ -191,6 +191,17 @@
         "cid": {
           "type": "integer",
           "description": "PubChem compound ID to query, e.g., 2244 (Aspirin)."
+        },
+        "properties": {
+          "type": [
+            "array",
+            "string",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional list of PubChem property names to retrieve (e.g. ['MolecularFormula','InChIKey','XLogP','IUPACName','MolecularWeight']). If omitted, returns a default set (MolecularWeight, IUPACName, SMILES). See PubChem PUG-REST property tables for valid names. Accepts a list or a comma-separated string."
         }
       },
       "required": [
@@ -416,7 +427,7 @@
     "fields": {
       "endpoint": "/compound/fastsimilarity_2d/smiles/{smiles}/cids/JSON",
       "use_pugview": false,
-      "input_description": "Input is:\n- smiles: SMILES for similarity comparison;\n- threshold: specify similarity threshold, PubChem will return all CIDs with similarity \u2265 threshold.",
+      "input_description": "Input is:\n- smiles: SMILES for similarity comparison;\n- threshold: specify similarity threshold, PubChem will return all CIDs with similarity ≥ threshold.",
       "output_description": "Returns a JSON object with structure example:\n{\n  \"IdentifierList\": {\n    \"CID\": [2244, 2245, ...]\n  }\n}\n\nWhere: CID array contains compound IDs with similarity above specified threshold to target molecule. LLM can use this for chemical similarity analysis.",
       "property_list": []
     },

--- a/src/tooluniverse/data/unified_guideline_tools.json
+++ b/src/tooluniverse/data/unified_guideline_tools.json
@@ -17,8 +17,7 @@
         }
       },
       "required": [
-        "query",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -75,8 +74,7 @@
         }
       },
       "required": [
-        "query",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -127,8 +125,7 @@
         }
       },
       "required": [
-        "query",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -184,7 +181,6 @@
       },
       "required": [
         "query",
-        "limit",
         "search_type"
       ]
     },
@@ -236,8 +232,7 @@
         }
       },
       "required": [
-        "query",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -301,8 +296,7 @@
         }
       },
       "required": [
-        "query",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -563,8 +557,7 @@
         }
       },
       "required": [
-        "query",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -614,8 +607,7 @@
         }
       },
       "required": [
-        "query",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {

--- a/src/tooluniverse/data/unified_guideline_tools.json
+++ b/src/tooluniverse/data/unified_guideline_tools.json
@@ -45,7 +45,7 @@
     },
     "test_examples": [
       {
-        "query": "machine learning optimization",
+        "query": "asthma",
         "limit": 1
       }
     ]

--- a/src/tooluniverse/data/waqi_tools.json
+++ b/src/tooluniverse/data/waqi_tools.json
@@ -154,6 +154,15 @@
     },
     "optional_api_keys": [
       "WAQI_API_KEY"
-    ]
+    ],
+    "api_key_info": {
+      "WAQI_API_KEY": {
+        "domain": "Other",
+        "type": "secret",
+        "register_url": "https://aqicn.org/data-platform/token/",
+        "purpose": "Fetch real per-city air quality data from the World Air Quality Index API.",
+        "without": "Falls back to the public 'demo' token, which returns a fixed sample station (Shanghai) for every city. The key is free."
+      }
+    }
   }
 ]

--- a/src/tooluniverse/data/waqi_tools.json
+++ b/src/tooluniverse/data/waqi_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "WAQI_get_air_quality",
-    "description": "Get real-time Air Quality Index (AQI) data for a city or monitoring station using the World Air Quality Index API with the public demo token. Returns AQI values, dominant pollutant, and individual pollutant readings (PM2.5, PM10, NO2, O3, SO2, CO). No personal API key required (uses demo token with limited quota). Useful for environmental research, health risk assessment, and air quality monitoring.",
+    "description": "Get real-time Air Quality Index (AQI) data for a city or monitoring station using the World Air Quality Index API. Returns AQI values, dominant pollutant, and individual pollutant readings (PM2.5, PM10, NO2, O3, SO2, CO). IMPORTANT: without a personal token the public 'demo' token is used, which returns a fixed sample station (Shanghai) regardless of the requested city — do NOT treat demo results as the requested city's air quality. Set the free WAQI_API_KEY environment variable (register at https://aqicn.org/data-platform/token/) to get real per-city data.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -18,18 +18,16 @@
       "endpoint": "https://api.waqi.info/feed/{city}/",
       "params": {
         "token": "demo"
+      },
+      "auth_param": {
+        "env_var": "WAQI_API_KEY",
+        "param": "token"
       }
     },
     "type": "BaseRESTTool",
     "test_examples": [
       {
-        "city": "beijing"
-      },
-      {
-        "city": "london"
-      },
-      {
-        "city": "los-angeles"
+        "city": "shanghai"
       }
     ],
     "return_schema": {
@@ -153,6 +151,9 @@
           ]
         }
       ]
-    }
+    },
+    "optional_api_keys": [
+      "WAQI_API_KEY"
+    ]
   }
 ]

--- a/src/tooluniverse/data/who_gho_tools.json
+++ b/src/tooluniverse/data/who_gho_tools.json
@@ -6,11 +6,17 @@
       "type": "object",
       "properties": {
         "filter": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "OData filter string for indicator names. Examples: \"contains(IndicatorName,'malaria')\", \"contains(IndicatorName,'HIV')\", \"contains(IndicatorName,'mortality')\", \"contains(IndicatorName,'obesity')\""
         },
         "top": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum number of results to return. Default: 10, max: 100"
         }
       },
@@ -18,13 +24,28 @@
     },
     "fields": {
       "endpoint": "https://ghoapi.azureedge.net/api/Indicator",
-      "params": {"$top": 10}
+      "params": {
+        "$top": 10
+      },
+      "param_mapping": {
+        "filter": "$filter",
+        "top": "$top"
+      }
     },
     "type": "BaseRESTTool",
     "test_examples": [
-      {"filter": "contains(IndicatorName,'malaria')", "top": 5},
-      {"filter": "contains(IndicatorName,'HIV')", "top": 5},
-      {"filter": "contains(IndicatorName,'life expectancy')", "top": 5}
+      {
+        "filter": "contains(IndicatorName,'malaria')",
+        "top": 5
+      },
+      {
+        "filter": "contains(IndicatorName,'HIV')",
+        "top": 5
+      },
+      {
+        "filter": "contains(IndicatorName,'life expectancy')",
+        "top": 5
+      }
     ],
     "return_schema": {
       "oneOf": [
@@ -38,8 +59,14 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "IndicatorCode": {"type": "string", "description": "Unique indicator code (use in WHOGHO_get_indicator_data)"},
-                  "IndicatorName": {"type": "string", "description": "Full indicator name/description"}
+                  "IndicatorCode": {
+                    "type": "string",
+                    "description": "Unique indicator code (use in WHOGHO_get_indicator_data)"
+                  },
+                  "IndicatorName": {
+                    "type": "string",
+                    "description": "Full indicator name/description"
+                  }
                 }
               }
             }
@@ -47,8 +74,14 @@
         },
         {
           "type": "object",
-          "properties": {"error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -64,25 +97,46 @@
           "description": "WHO GHO indicator code. Examples: 'WHOSIS_000001' (life expectancy), 'MALARIA002' (malaria cases), 'MDG_0000000026' (HIV prevalence), 'NCD_BMI_30C' (obesity), 'SDGPM25' (air pollution PM2.5), 'WHS4_100' (hospital beds)"
         },
         "filter": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "OData filter for data rows. Examples: \"SpatialDim eq 'USA'\", \"TimeDim eq 2022\", \"Dim1 eq 'SEX_FMLE' and TimeDim ge 2015\""
         },
         "top": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum number of data rows to return. Default: 20"
         }
       },
-      "required": ["indicator_code"]
+      "required": [
+        "indicator_code"
+      ]
     },
     "fields": {
       "endpoint": "https://ghoapi.azureedge.net/api/{indicator_code}",
-      "params": {"$top": 20}
+      "params": {
+        "$top": 20
+      }
     },
     "type": "BaseRESTTool",
     "test_examples": [
-      {"indicator_code": "WHOSIS_000001", "filter": "TimeDim eq 2020", "top": 10},
-      {"indicator_code": "MALARIA002", "top": 10},
-      {"indicator_code": "NCD_BMI_30C", "filter": "SpatialDim eq 'USA'", "top": 10}
+      {
+        "indicator_code": "WHOSIS_000001",
+        "filter": "TimeDim eq 2020",
+        "top": 10
+      },
+      {
+        "indicator_code": "MALARIA002",
+        "top": 10
+      },
+      {
+        "indicator_code": "NCD_BMI_30C",
+        "filter": "SpatialDim eq 'USA'",
+        "top": 10
+      }
     ],
     "return_schema": {
       "oneOf": [
@@ -96,14 +150,61 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "IndicatorCode": {"type": ["string", "null"]},
-                  "SpatialDim": {"type": ["string", "null"], "description": "Country/region ISO code"},
-                  "TimeDim": {"type": ["integer", "null"], "description": "Year"},
-                  "Dim1": {"type": ["string", "null"], "description": "Dimension 1 (e.g., SEX_BTSX, SEX_MLE, SEX_FMLE)"},
-                  "NumericValue": {"type": ["number", "null"], "description": "Numeric data value"},
-                  "Value": {"type": ["string", "null"], "description": "Formatted value with confidence intervals"},
-                  "Low": {"type": ["number", "null"], "description": "Lower confidence interval"},
-                  "High": {"type": ["number", "null"], "description": "Upper confidence interval"}
+                  "IndicatorCode": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "SpatialDim": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Country/region ISO code"
+                  },
+                  "TimeDim": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "description": "Year"
+                  },
+                  "Dim1": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Dimension 1 (e.g., SEX_BTSX, SEX_MLE, SEX_FMLE)"
+                  },
+                  "NumericValue": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Numeric data value"
+                  },
+                  "Value": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Formatted value with confidence intervals"
+                  },
+                  "Low": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Lower confidence interval"
+                  },
+                  "High": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Upper confidence interval"
+                  }
                 }
               }
             }
@@ -111,8 +212,14 @@
         },
         {
           "type": "object",
-          "properties": {"error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/dgidb_tool.py
+++ b/src/tooluniverse/dgidb_tool.py
@@ -35,6 +35,26 @@ class DGIdbTool(BaseTool):
         self.timeout = tool_config.get("timeout", 30)
         self.operation = tool_config.get("fields", {}).get("operation", "interactions")
 
+    @staticmethod
+    def _envelope(payload: Dict[str, Any], collection: str) -> Dict[str, Any]:
+        """Unwrap the GraphQL ``data`` key into the standard envelope.
+
+        DGIdb's GraphQL responses are shaped ``{"data": {<collection>:
+        {"nodes": [...]}}, "errors": [...]}``. Forwarding that verbatim under
+        another ``data`` key produced an awkward ``data.data.<collection>``
+        shape with no metadata. Unwrap one level so ``data`` holds the payload
+        directly and attach a ``metadata.total`` node count.
+        """
+        if payload.get("errors"):
+            return {"status": "error", "error": payload["errors"]}
+        inner = payload.get("data", {}) or {}
+        nodes = (inner.get(collection) or {}).get("nodes", []) or []
+        return {
+            "status": "success",
+            "data": inner,
+            "metadata": {"total": len(nodes)},
+        }
+
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute the DGIdb API call."""
         operation = self.operation
@@ -137,8 +157,7 @@ class DGIdbTool(BaseTool):
                         filtered.append(interaction)
                     node["interactions"] = filtered
 
-            # Feature-68A-002: wrap in status envelope consistent with other ToolUniverse tools
-            return {"status": "success", "data": data}
+            return self._envelope(data, "genes")
         except requests.RequestException as e:
             return {"status": "error", "error": f"DGIdb API request failed: {str(e)}"}
 
@@ -181,8 +200,7 @@ class DGIdbTool(BaseTool):
                 timeout=self.timeout,
             )
             response.raise_for_status()
-            # Feature-68A-002: wrap in status envelope
-            return {"status": "success", "data": response.json()}
+            return self._envelope(response.json(), "genes")
         except requests.RequestException as e:
             return {"status": "error", "error": f"DGIdb API request failed: {str(e)}"}
 
@@ -218,8 +236,7 @@ class DGIdbTool(BaseTool):
                 timeout=self.timeout,
             )
             response.raise_for_status()
-            # Feature-68A-002: wrap in status envelope
-            return {"status": "success", "data": response.json()}
+            return self._envelope(response.json(), "drugs")
         except requests.RequestException as e:
             return {"status": "error", "error": f"DGIdb API request failed: {str(e)}"}
 
@@ -262,7 +279,6 @@ class DGIdbTool(BaseTool):
                 timeout=self.timeout,
             )
             response.raise_for_status()
-            # Feature-68A-002: wrap in status envelope
-            return {"status": "success", "data": response.json()}
+            return self._envelope(response.json(), "genes")
         except requests.RequestException as e:
             return {"status": "error", "error": f"DGIdb API request failed: {str(e)}"}

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -5,6 +5,13 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 import requests
 import copy
+import time
+
+# Upper bound on how long DiseaseTargetScoreTool will paginate through
+# OpenTargets associatedTargets before returning what it has so far. A
+# disease can have >10,000 associated targets; without a bound the loop
+# issues hundreds of sequential requests and can run for many minutes.
+_DISEASE_TARGET_SCORE_TIME_BUDGET_S = 25.0
 
 
 def validate_query(query_str, schema_str):
@@ -311,8 +318,17 @@ class DiseaseTargetScoreTool(GraphQLTool):
         total_fetched = 0
         total_count = None
         disease_info = None
+        truncated = False
+
+        deadline = time.monotonic() + _DISEASE_TARGET_SCORE_TIME_BUDGET_S
 
         while True:
+            # Bound total wall-clock time. A disease can have >10,000
+            # associated targets; without this the loop can run for minutes.
+            if time.monotonic() >= deadline:
+                truncated = True
+                break
+
             variables = {"efoId": efo_id, "index": page_index, "size": page_size}
 
             response_data = execute_query(
@@ -357,12 +373,18 @@ class DiseaseTargetScoreTool(GraphQLTool):
                 break
             page_index += 1
 
-        return {
-            "status": "success",
-            "data": {
-                "disease_info": disease_info,
-                "datasource": datasource_id,
-                "total_targets_with_scores": len(results),
-                "target_scores": results,
-            },
+        data = {
+            "disease_info": disease_info,
+            "datasource": datasource_id,
+            "total_targets_with_scores": len(results),
+            "target_scores": results,
         }
+        if truncated:
+            data["truncated"] = True
+            data["note"] = (
+                f"Stopped after {_DISEASE_TARGET_SCORE_TIME_BUDGET_S:.0f}s; "
+                f"scanned {total_fetched} of {total_count} associated targets. "
+                "Increase pageSize to scan more targets per request, or query a "
+                "more specific disease."
+            )
+        return {"status": "success", "data": data}

--- a/src/tooluniverse/interpro_entry_tool.py
+++ b/src/tooluniverse/interpro_entry_tool.py
@@ -93,19 +93,19 @@ class InterProEntryTool(BaseTool):
         entries = []
         for r in results:
             meta = r.get("metadata", {})
-            name_obj = meta.get("name", {})
-            if isinstance(name_obj, dict):
-                name = name_obj.get("name", "")
-                short_name = name_obj.get("short", "")
-            else:
-                name = str(name_obj) if name_obj else ""
-                short_name = ""
+            # The InterPro protein-entries endpoint returns metadata.name as a
+            # plain string; keep the dict guard in case the API shape changes.
+            name_obj = meta.get("name", "")
+            name = (
+                name_obj.get("name", "")
+                if isinstance(name_obj, dict)
+                else (str(name_obj) if name_obj else "")
+            )
 
             entries.append(
                 {
                     "accession": meta.get("accession"),
                     "name": name,
-                    "short_name": short_name,
                     "type": meta.get("type"),
                     "source_database": meta.get("source_database"),
                 }
@@ -157,20 +157,19 @@ class InterProEntryTool(BaseTool):
         entries = []
         for r in results:
             meta = r.get("metadata", {})
-            name_obj = meta.get("name", {})
-            if isinstance(name_obj, dict):
-                name = name_obj.get("name", "")
-                short_name = name_obj.get("short", "")
-            else:
-                name = str(name_obj) if name_obj else ""
-                short_name = ""
+            # metadata.name is a plain string here; keep the dict guard for safety.
+            name_obj = meta.get("name", "")
+            name = (
+                name_obj.get("name", "")
+                if isinstance(name_obj, dict)
+                else (str(name_obj) if name_obj else "")
+            )
 
             counters = meta.get("counters", {})
             entries.append(
                 {
                     "accession": meta.get("accession"),
                     "name": name,
-                    "short_name": short_name,
                     "type": meta.get("type"),
                     "protein_count": counters.get("proteins"),
                     "structure_count": counters.get("structures"),

--- a/src/tooluniverse/metabolite_tool.py
+++ b/src/tooluniverse/metabolite_tool.py
@@ -19,10 +19,16 @@ PUBCHEM_API = "https://pubchem.ncbi.nlm.nih.gov/rest/pug"
 CTD_API = "https://ctdbase.org/tools/batchQuery.go"
 
 # Regex to strip common stereochemistry prefixes so CTD can match the parent compound.
-# Example: "Beta-D-Glucose" → "Glucose", "L-Alanine" → "Alanine"
+# Example: "Beta-D-Glucose" → "Glucose", "L-Alanine" → "Alanine", "L-Lactic Acid" → "Lactic Acid"
+#
+# Each stereo descriptor must be followed by its own separator ([-\s]+). This
+# prevents over-stripping when the compound name itself starts with a stereo
+# letter: "L-Lactic Acid" must strip only "L-" (→ "Lactic Acid"), NOT "L-L"
+# (→ "actic Acid"). The trailing optional group only matches a *second*
+# descriptor that is itself separator-terminated (e.g. the "D-" in "Beta-D-").
+_STEREO_DESC = r"(?:alpha|beta|D|L|R|S|cis|trans|endo|exo)"
 _STEREO_PREFIX = re.compile(
-    r"^(alpha|beta|Alpha|Beta|D|L|R|S|cis|trans|endo|exo)[-\s]+"
-    r"(alpha|beta|Alpha|Beta|D|L|R|S|cis|trans|endo|exo)?[-\s]*",
+    rf"^{_STEREO_DESC}[-\s]+(?:{_STEREO_DESC}[-\s]+)?",
     re.IGNORECASE,
 )
 

--- a/src/tooluniverse/pubchem_tool.py
+++ b/src/tooluniverse/pubchem_tool.py
@@ -43,10 +43,25 @@ class PubChemRESTTool(BaseTool):
         """
         url_path = self.endpoint_template
 
-        # First replace property_list (if exists and endpoint_template contains this placeholder)
-        if self.property_list and "{property_list}" in url_path:
-            prop_str = ",".join(self.property_list)
-            url_path = url_path.replace("{property_list}", prop_str)
+        # Replace {property_list}. Prefer a caller-supplied `properties`
+        # argument over the fixed config default so the caller can choose
+        # which properties to fetch — the tool is "get_compound_properties"
+        # but previously ignored the requested set and always returned the
+        # three configured defaults.
+        if "{property_list}" in url_path:
+            user_props = arguments.get("properties")
+            if user_props:
+                prop_list = (
+                    user_props
+                    if isinstance(user_props, list)
+                    else [p.strip() for p in str(user_props).split(",") if p.strip()]
+                )
+            else:
+                prop_list = self.property_list or []
+            if prop_list:
+                url_path = url_path.replace(
+                    "{property_list}", ",".join(map(str, prop_list))
+                )
 
         # Find all placeholders {xxx} in template
         placeholders = re.findall(r"\{([^{}]+)\}", url_path)

--- a/src/tooluniverse/pubmed_tool.py
+++ b/src/tooluniverse/pubmed_tool.py
@@ -508,8 +508,25 @@ class PubMedRESTTool(BaseRESTTool):
                     id_list = esearch_result.get("idlist", [])
 
                     # If this is a search request (has 'query' in arguments),
-                    # fetch article summaries and return as list
-                    if "query" in arguments and id_list:
+                    # fetch article summaries and return the standard envelope.
+                    if "query" in arguments:
+                        # A search that matched nothing must still return the
+                        # same {status, data, metadata} envelope as a search
+                        # that matched — otherwise zero-hit queries fall through
+                        # to the bare-id-list path below and consumers that read
+                        # result["status"] hit a KeyError.
+                        if not id_list:
+                            return {
+                                "status": "success",
+                                "data": [],
+                                "metadata": {
+                                    "count": 0,
+                                    "total": int(esearch_result.get("count", 0)),
+                                    "query": arguments.get("query"),
+                                    "source": "PubMed",
+                                },
+                            }
+
                         summary_result = self._fetch_summaries(id_list)
 
                         if summary_result["status"] == "error":

--- a/tests/tools/test_paper_search_fixes.py
+++ b/tests/tools/test_paper_search_fixes.py
@@ -110,6 +110,54 @@ class TestPubMedPMCID(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Feature-007F-04: a zero-hit search returns the standard envelope
+# ---------------------------------------------------------------------------
+class TestPubMedZeroHitEnvelope(unittest.TestCase):
+    """A search that matches nothing must return {status,data,metadata},
+    not a bare id list (which the framework wraps as {"result": []})."""
+
+    def _make_tool(self):
+        from tooluniverse.pubmed_tool import PubMedRESTTool
+
+        return PubMedRESTTool(
+            {
+                "name": "PubMed_search_articles",
+                "type": "PubMedRESTTool",
+                "fields": {
+                    "endpoint": "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+                    "method": "GET",
+                    "db": "pubmed",
+                    "retmode": "json",
+                },
+                "parameter": {"type": "object", "properties": {}, "required": []},
+            }
+        )
+
+    def test_zero_hit_search_returns_envelope(self):
+        tool = self._make_tool()
+
+        # esearch response with an empty idlist (no matches)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.url = "https://eutils.ncbi.nlm.nih.gov/...esearch..."
+        mock_resp.json.return_value = {
+            "esearchresult": {"idlist": [], "count": "0"}
+        }
+
+        with patch.object(tool, "_enforce_rate_limit"):
+            with patch(
+                "tooluniverse.pubmed_tool.request_with_retry", return_value=mock_resp
+            ):
+                result = tool.run({"query": "zzz_no_such_term_zzz", "limit": 2})
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"], [])
+        self.assertEqual(result["metadata"]["count"], 0)
+        self.assertEqual(result["metadata"]["total"], 0)
+
+
+# ---------------------------------------------------------------------------
 # Feature-81B-002: PubMed limit=0 honoured
 # ---------------------------------------------------------------------------
 class TestPubMedLimit(unittest.TestCase):

--- a/tests/tools/test_paper_search_fixes.py
+++ b/tests/tools/test_paper_search_fixes.py
@@ -427,14 +427,17 @@ class TestSemanticScholarLimitZero(unittest.TestCase):
     def test_limit_zero(self):
         tool = self._make_tool()
         result = tool.run({"query": "cancer", "limit": 0})
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 0)
+        # Tool returns the standard {status, data, metadata} envelope.
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"], [])
+        self.assertEqual(result["metadata"]["total"], 0)
 
     def test_limit_negative(self):
         tool = self._make_tool()
         result = tool.run({"query": "cancer", "limit": -1})
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 0)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"], [])
+        self.assertEqual(result["metadata"]["total"], 0)
 
 
 # ---------------------------------------------------------------------------
@@ -1445,7 +1448,7 @@ class TestGTExGeneSymbolResolution(unittest.TestCase):
             mock_resolve.assert_called_once_with(
                 "FBN1", "https://gtexportal.org/api/v2", 30
             )
-            self.assertTrue(result["success"])
+            self.assertEqual(result["status"], "success")
 
     def test_eqtl_tool_uses_gene_symbol(self):
         from tooluniverse.gtex_tool import GTExEQTLTool
@@ -1467,7 +1470,7 @@ class TestGTExGeneSymbolResolution(unittest.TestCase):
             mock_resolve.assert_called_once_with(
                 "TP53", "https://gtexportal.org/api/v2", 30
             )
-            self.assertTrue(result["success"])
+            self.assertEqual(result["status"], "success")
 
 
 # ---------------------------------------------------------------------------
@@ -1503,7 +1506,8 @@ class TestClinVarConditionQuoting(unittest.TestCase):
         }
         tool = self._make_tool()
         tool.run({"gene": "FBN1", "condition": "Marfan syndrome"})
-        call_args = mock_request.call_args
+        # First call is the esearch; a later esummary call has no "term".
+        call_args = mock_request.call_args_list[0]
         term = call_args[0][1]["term"]
         self.assertIn('"Marfan syndrome"', term)
 
@@ -1521,7 +1525,7 @@ class TestClinVarConditionQuoting(unittest.TestCase):
         }
         tool = self._make_tool()
         tool.run({"gene": "BRCA1", "condition": "cancer"})
-        call_args = mock_request.call_args
+        call_args = mock_request.call_args_list[0]
         term = call_args[0][1]["term"]
         self.assertIn("cancer", term)
         self.assertNotIn('"cancer"', term)
@@ -1540,7 +1544,7 @@ class TestClinVarConditionQuoting(unittest.TestCase):
         }
         tool = self._make_tool()
         tool.run({"condition": '"Marfan syndrome"'})
-        call_args = mock_request.call_args
+        call_args = mock_request.call_args_list[0]
         term = call_args[0][1]["term"]
         # Should not be double-quoted
         self.assertNotIn('""Marfan syndrome""', term)

--- a/tests/tools/test_tu_cli.py
+++ b/tests/tools/test_tu_cli.py
@@ -1834,6 +1834,34 @@ class TestRenderFunctions:
         assert len(result) == 20
         assert result.endswith("…")
 
+    @pytest.mark.unit
+    def test_render_run_envelope_error_unwraps_data_error(self):
+        """Standard envelope {status:error, data:{error:..}} renders the inner error."""
+        from tooluniverse.cli import _render_run
+
+        out = _render_run(
+            {"status": "error", "data": {"error": "SSL certificate verify failed"}}
+        )
+        assert "SSL certificate verify failed" in out
+        assert "unknown error" not in out
+
+    @pytest.mark.unit
+    def test_render_run_top_level_error_still_works(self):
+        """Top-level {error: ...} (legacy shape) still renders the message."""
+        from tooluniverse.cli import _render_run
+
+        out = _render_run({"status": "error", "error": "top-level msg"})
+        assert "top-level msg" in out
+        assert "unknown error" not in out
+
+    @pytest.mark.unit
+    def test_render_run_truly_empty_error_falls_back(self):
+        """When no error message is present in either location, fall back."""
+        from tooluniverse.cli import _render_run
+
+        out = _render_run({"status": "error", "data": {}})
+        assert "unknown error" in out
+
 
 class TestResolveCategories:
     """Tests for _resolve_categories — case-insensitive category name mapping.

--- a/tests/unit/test_alliance_gene_schema.py
+++ b/tests/unit/test_alliance_gene_schema.py
@@ -72,3 +72,82 @@ def test_get_gene_detail_parses_nested_schema():
     assert "LFS1" in data["synonyms"]
     assert data["genomic_location"]["start"] == 7661779
     assert data["cross_references"][0]["name"] == "RGD"
+
+
+def _make_search_tool():
+    return AllianceGenomeTool(
+        {
+            "name": "Alliance_search_genes",
+            "type": "AllianceGenomeTool",
+            "fields": {"endpoint_type": "search_genes"},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+@pytest.mark.unit
+def test_search_genes_filters_category_and_uses_curie():
+    """Feature-008: autocomplete no longer honours category=gene and ids moved
+    to `curie`; keep gene hits client-side and read the curie."""
+    tool = _make_search_tool()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        "results": [
+            {"symbol": "TP53", "name": "TP53", "curie": "HGNC:11998",
+             "category": "gene_search_result"},
+            {"symbol": "should-drop", "curie": "DOID:1", "name": "x",
+             "category": "disease_search_result"},
+            {"symbol": "tp53", "name": "tp53", "curie": "ZFIN:ZDB-GENE-1",
+             "category": "gene_search_result"},
+        ]
+    }
+    with patch(
+        "tooluniverse.alliance_genome_tool.requests.get", return_value=resp
+    ) as mock_get:
+        result = tool.run({"query": "TP53"})
+
+    # category=gene must NOT be sent (it now returns zero results upstream)
+    assert "category" not in mock_get.call_args.kwargs.get("params", {})
+    data = result["data"]
+    assert len(data) == 2  # disease hit filtered out
+    assert data[0]["symbol"] == "TP53"
+    assert data[0]["gene_id"] == "HGNC:11998"
+
+
+@pytest.mark.unit
+def test_gene_phenotypes_unwraps_gene_symbol():
+    """Feature-008: phenotype subject.geneSymbol is now a {displayText} object."""
+    tool = AllianceGenomeTool(
+        {
+            "name": "Alliance_get_gene_phenotypes",
+            "type": "AllianceGenomeTool",
+            "fields": {"endpoint_type": "gene_phenotypes"},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        "total": 1,
+        "results": [
+            {
+                "phenotypeStatement": "Abnormal bleeding",
+                "subject": {
+                    "primaryExternalId": "HGNC:11998",
+                    "geneSymbol": {"formatText": "TP53", "displayText": "TP53"},
+                },
+            }
+        ],
+    }
+    with patch(
+        "tooluniverse.alliance_genome_tool.requests.get", return_value=resp
+    ):
+        result = tool.run({"gene_id": "HGNC:11998"})
+
+    pheno = result["data"][0]
+    assert pheno["gene_symbol"] == "TP53"
+    assert pheno["gene_id"] == "HGNC:11998"
+    assert pheno["phenotype_statement"] == "Abnormal bleeding"

--- a/tests/unit/test_alliance_gene_schema.py
+++ b/tests/unit/test_alliance_gene_schema.py
@@ -1,0 +1,74 @@
+"""Unit test for Alliance_get_gene's nested-schema parsing.
+
+Regression for Feature-007L-01: the Alliance of Genome Resources API
+moved the gene record under a top-level "gene" key and wrapped labels as
+{formatText, displayText}. The tool parsed the old flat schema, so every
+field came back null while still reporting status="success" (a silent
+failure that makes a real gene look nonexistent).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.alliance_genome_tool import AllianceGenomeTool
+
+
+def _make_tool():
+    return AllianceGenomeTool(
+        {
+            "name": "Alliance_get_gene",
+            "type": "AllianceGenomeTool",
+            "fields": {"endpoint_type": "gene_detail"},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+# Minimal stand-in for the current Alliance /gene/{id} response shape.
+_NESTED_RESPONSE = {
+    "category": "gene",
+    "gene": {
+        "primaryExternalId": "HGNC:11998",
+        "geneSymbol": {"formatText": "TP53", "displayText": "TP53"},
+        "geneFullName": {"formatText": "tumor protein p53", "displayText": "tumor protein p53"},
+        "taxon": {
+            "curie": "NCBITaxon:9606",
+            "name": "Homo sapiens",
+            "species": {"displayName": "HUMAN", "abbreviation": "Hsa"},
+        },
+        "geneType": {"name": "protein_coding_gene"},
+        "geneSynonyms": [
+            {"displayText": "LFS1"},
+            {"displayText": "TRP53"},
+        ],
+        "geneGenomicLocationAssociations": [{"start": 7661779, "end": 7687550}],
+        "crossReferences": [
+            {"referencedCurie": "RGD:70502", "displayName": "RGD"},
+        ],
+    },
+}
+
+
+@pytest.mark.unit
+def test_get_gene_detail_parses_nested_schema():
+    tool = _make_tool()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = _NESTED_RESPONSE
+
+    with patch(
+        "tooluniverse.alliance_genome_tool.requests.get", return_value=resp
+    ):
+        result = tool.run({"gene_id": "HGNC:11998"})
+
+    assert result["status"] == "success"
+    data = result["data"]
+    assert data["symbol"] == "TP53"
+    assert data["name"] == "tumor protein p53"
+    assert data["species"]["name"] == "Homo sapiens"
+    assert data["species"]["taxon_id"] == "NCBITaxon:9606"
+    assert data["so_term"] == "protein_coding_gene"
+    assert "LFS1" in data["synonyms"]
+    assert data["genomic_location"]["start"] == 7661779
+    assert data["cross_references"][0]["name"] == "RGD"

--- a/tests/unit/test_base_rest_param_mapping.py
+++ b/tests/unit/test_base_rest_param_mapping.py
@@ -1,0 +1,56 @@
+"""Unit tests for config-driven BaseRESTTool query-param mapping.
+
+Regression for Feature-007I-01/02: WHOGHO_search_indicators is a
+config-only BaseRESTTool whose documented params are `filter` and `top`,
+but the WHO OData API needs `$filter` and `$top`. Before this, the params
+were passed through unmapped, so the filter was silently ignored (every
+search returned the same unfiltered indicator page) and `top` had no
+effect. A `fields.param_mapping` entry now renames them.
+"""
+import pytest
+
+from tooluniverse.base_rest_tool import BaseRESTTool
+
+
+def _make_tool(fields):
+    return BaseRESTTool(
+        {
+            "name": "T",
+            "type": "BaseRESTTool",
+            "fields": {"endpoint": "https://example.org/api", **fields},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+@pytest.mark.unit
+def test_param_mapping_renames_query_params():
+    tool = _make_tool(
+        {"param_mapping": {"filter": "$filter", "top": "$top"}}
+    )
+    assert tool._get_param_mapping() == {"filter": "$filter", "top": "$top"}
+    params = tool._build_params({"filter": "contains(IndicatorName,'malaria')", "top": 5})
+    assert params["$filter"] == "contains(IndicatorName,'malaria')"
+    assert params["$top"] == 5
+    # Unmapped raw names must NOT leak through.
+    assert "filter" not in params
+    assert "top" not in params
+
+
+@pytest.mark.unit
+def test_mapped_value_overrides_default_param():
+    # fields.params provides a default $top; the caller's mapped top wins.
+    tool = _make_tool(
+        {"params": {"$top": 10}, "param_mapping": {"top": "$top"}}
+    )
+    params = tool._build_params({"top": 3})
+    assert params["$top"] == 3
+
+
+@pytest.mark.unit
+def test_no_param_mapping_is_unchanged():
+    # Tools without a param_mapping field keep the previous behaviour.
+    tool = _make_tool({})
+    assert tool._get_param_mapping() == {}
+    params = tool._build_params({"foo": "bar"})
+    assert params["foo"] == "bar"

--- a/tests/unit/test_base_rest_param_mapping.py
+++ b/tests/unit/test_base_rest_param_mapping.py
@@ -54,3 +54,30 @@ def test_no_param_mapping_is_unchanged():
     assert tool._get_param_mapping() == {}
     params = tool._build_params({"foo": "bar"})
     assert params["foo"] == "bar"
+
+
+@pytest.mark.unit
+def test_auth_param_overrides_default_token_when_env_set(monkeypatch):
+    # Feature-007K-01: a real env token replaces the public demo token.
+    tool = _make_tool(
+        {
+            "params": {"token": "demo"},
+            "auth_param": {"env_var": "WAQI_API_KEY", "param": "token"},
+        }
+    )
+    monkeypatch.setenv("WAQI_API_KEY", "REALKEY123")
+    params = tool._build_params({"city": "Boston"})
+    assert params["token"] == "REALKEY123"
+
+
+@pytest.mark.unit
+def test_auth_param_keeps_default_token_when_env_unset(monkeypatch):
+    tool = _make_tool(
+        {
+            "params": {"token": "demo"},
+            "auth_param": {"env_var": "WAQI_API_KEY", "param": "token"},
+        }
+    )
+    monkeypatch.delenv("WAQI_API_KEY", raising=False)
+    params = tool._build_params({"city": "Boston"})
+    assert params["token"] == "demo"

--- a/tests/unit/test_chebi_id_normalization.py
+++ b/tests/unit/test_chebi_id_normalization.py
@@ -1,0 +1,42 @@
+"""Unit test for ChEBI_get_compound accepting the CURIE id form.
+
+Regression for Feature-008B-02 / 007F-01: ChEBI_search returns ids as
+chebi_accession="CHEBI:27732", but ChEBI_get_compound required a bare
+integer and rejected the string, breaking the natural search->get chain.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.chebi_tool import ChEBITool
+
+
+def _make_tool():
+    return ChEBITool(
+        {
+            "name": "ChEBI_get_compound",
+            "type": "ChEBITool",
+            "fields": {"endpoint_type": "get_compound"},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("chebi_id", [27732, "27732", "CHEBI:27732", "chebi:27732"])
+def test_get_compound_accepts_int_and_curie_forms(chebi_id):
+    tool = _make_tool()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"id": 27732, "name": "caffeine", "chebi_accession": "CHEBI:27732"}
+
+    with patch(
+        "tooluniverse.chebi_tool.requests.get", return_value=resp
+    ) as mock_get:
+        result = tool.run({"chebi_id": chebi_id})
+
+    # The request URL must always use the bare integer, regardless of input form.
+    called_url = mock_get.call_args[0][0]
+    assert called_url.endswith("/compound/27732/")
+    assert result["status"] == "success"

--- a/tests/unit/test_chebi_id_normalization.py
+++ b/tests/unit/test_chebi_id_normalization.py
@@ -8,7 +8,23 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tooluniverse.chebi_tool import ChEBITool
+from tooluniverse.chebi_tool import ChEBITool, _strip_html
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("1<em>H</em>-purin", "1H-purin"),
+        ("plain text", "plain text"),
+        ("<b>bold</b> and <i>italic</i>", "bold and italic"),
+        (None, None),
+        (42, 42),
+    ],
+)
+def test_strip_html(raw, expected):
+    # Feature-008B-03: ChEBI embeds <em> highlight tags in name/synonym fields.
+    assert _strip_html(raw) == expected
 
 
 def _make_tool():

--- a/tests/unit/test_disease_target_score_pagination.py
+++ b/tests/unit/test_disease_target_score_pagination.py
@@ -1,0 +1,90 @@
+"""Unit tests for DiseaseTargetScoreTool's bounded pagination.
+
+OpenTargets diseases can have >10,000 associated targets. The tool
+paginates client-side over all of them; without a wall-clock bound the
+loop issues hundreds of sequential requests and can run for minutes.
+These tests pin the time-budget guard without touching the live API.
+"""
+from unittest.mock import patch
+
+import pytest
+
+import tooluniverse.graphql_tool as gqt
+from tooluniverse.graphql_tool import DiseaseTargetScoreTool
+
+
+def make_tool():
+    return DiseaseTargetScoreTool(
+        {
+            "name": "disease_target_score",
+            "type": "DiseaseTargetScoreTool",
+            "query_schema": "query { disease { id } }",
+            "parameter": {"type": "object", "properties": {}},
+            "datasource_id": "chembl",
+        }
+    )
+
+
+def _page(index, page_size, total, datasource="chembl"):
+    """Build one associatedTargets page that always reports a huge total."""
+    rows = [
+        {
+            "target": {"approvedSymbol": f"GENE{index}_{i}", "id": f"ENSG{index}_{i}"},
+            "datasourceScores": [{"id": datasource, "score": 0.5}],
+        }
+        for i in range(page_size)
+    ]
+    return {
+        "data": {
+            "disease": {
+                "id": "EFO_0000339",
+                "name": "test disease",
+                "associatedTargets": {"count": total, "rows": rows},
+            }
+        }
+    }
+
+
+@pytest.mark.unit
+def test_pagination_stops_at_time_budget(monkeypatch):
+    """A never-ending result set must terminate via the wall-clock budget."""
+    # Force the budget to elapse after the 3rd page regardless of real time.
+    fake_now = iter([0.0] + [i * 10.0 for i in range(1, 50)])
+    monkeypatch.setattr(gqt.time, "monotonic", lambda: next(fake_now))
+
+    calls = {"n": 0}
+
+    def fake_execute(endpoint, query, variables):
+        calls["n"] += 1
+        # total far exceeds anything we will fetch → loop relies on the budget
+        return _page(variables["index"], variables["size"], total=1_000_000)
+
+    with patch.object(gqt, "execute_query", side_effect=fake_execute):
+        result = make_tool().run(
+            {"efoId": "EFO_0000339", "datasourceId": "chembl", "pageSize": 5}
+        )
+
+    assert result["status"] == "success"
+    assert result["data"]["truncated"] is True
+    assert "note" in result["data"]
+    # Budget (25s) is crossed within a handful of pages, not hundreds.
+    assert calls["n"] < 10
+
+
+@pytest.mark.unit
+def test_pagination_completes_without_truncation(monkeypatch):
+    """When the result set is small, it finishes and is not marked truncated."""
+    monkeypatch.setattr(gqt.time, "monotonic", lambda: 0.0)
+
+    def fake_execute(endpoint, query, variables):
+        # total == page_size → exactly one page, loop exits naturally
+        return _page(variables["index"], variables["size"], total=variables["size"])
+
+    with patch.object(gqt, "execute_query", side_effect=fake_execute):
+        result = make_tool().run(
+            {"efoId": "EFO_0000339", "datasourceId": "chembl", "pageSize": 5}
+        )
+
+    assert result["status"] == "success"
+    assert "truncated" not in result["data"]
+    assert result["data"]["total_targets_with_scores"] == 5

--- a/tests/unit/test_metabolite_strip_stereo.py
+++ b/tests/unit/test_metabolite_strip_stereo.py
@@ -1,0 +1,38 @@
+"""Unit tests for metabolite stereochemistry-prefix stripping.
+
+Regression for Feature-007F-03: `_strip_stereo("L-Lactic Acid")` used to
+return "actic Acid" (it over-stripped "L-L"), so CTD never matched the
+parent compound and Metabolite_get_diseases silently returned 0 diseases
+for L-lactate and other stereoisomers whose name starts with a stereo
+letter.
+"""
+import pytest
+
+from tooluniverse.metabolite_tool import _strip_stereo
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        # First letter of the compound is itself a stereo letter — must NOT be eaten.
+        ("L-Lactic Acid", "Lactic Acid"),
+        ("D-Lactic acid", "Lactic acid"),
+        ("L-Leucine", "Leucine"),
+        ("D-Ribose", "Ribose"),
+        # Two genuine stereo descriptors are both stripped.
+        ("Beta-D-Glucose", "Glucose"),
+        ("cis-trans-Retinal", "Retinal"),
+        # Single descriptor where the compound does not start with a stereo letter.
+        ("L-Alanine", "Alanine"),
+    ],
+)
+def test_strip_stereo_does_not_over_strip(name, expected):
+    assert _strip_stereo(name) == expected
+
+
+@pytest.mark.unit
+def test_strip_stereo_returns_empty_when_no_prefix():
+    # No leading stereo descriptor → returns "" (signals "no parent variant").
+    assert _strip_stereo("Glucose") == ""
+    assert _strip_stereo("Lactic Acid") == ""

--- a/tests/unit/test_pubchem_properties_override.py
+++ b/tests/unit/test_pubchem_properties_override.py
@@ -1,0 +1,45 @@
+"""Unit tests for PubChem property-selection.
+
+Regression for Feature-008B-01 / 007K-02: PubChem_get_compound_properties_by_CID
+hardcoded its property set and silently ignored a caller-supplied
+`properties` argument, so a user could not retrieve MolecularFormula /
+InChIKey / XLogP despite the tool being named "...properties...".
+"""
+import pytest
+
+from tooluniverse.pubchem_tool import PubChemRESTTool
+
+
+def _make_tool():
+    return PubChemRESTTool(
+        {
+            "name": "PubChem_get_compound_properties_by_CID",
+            "type": "PubChemRESTTool",
+            "fields": {
+                "endpoint": "/compound/cid/{cid}/property/{property_list}/JSON",
+                "property_list": ["MolecularWeight", "IUPACName", "CanonicalSMILES"],
+            },
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+@pytest.mark.unit
+def test_user_properties_list_overrides_default():
+    url = _make_tool()._build_url(
+        {"cid": 2519, "properties": ["MolecularFormula", "InChIKey", "XLogP"]}
+    )
+    assert "/property/MolecularFormula,InChIKey,XLogP/JSON" in url
+    assert "MolecularWeight" not in url  # default set not used
+
+
+@pytest.mark.unit
+def test_user_properties_comma_string_overrides_default():
+    url = _make_tool()._build_url({"cid": 2519, "properties": "MolecularFormula,TPSA"})
+    assert "/property/MolecularFormula,TPSA/JSON" in url
+
+
+@pytest.mark.unit
+def test_default_property_list_used_when_not_supplied():
+    url = _make_tool()._build_url({"cid": 2519})
+    assert "/property/MolecularWeight,IUPACName,CanonicalSMILES/JSON" in url

--- a/tests/unit/test_round007_fixes.py
+++ b/tests/unit/test_round007_fixes.py
@@ -1,0 +1,144 @@
+"""Round 007 fixes — verified from researcher-persona findings.
+
+Covers three fixes:
+- ClinVar silent-failure on a dbSNP rsID (Feature-007-001)
+- DGIdb double-nested ``data.data`` envelope (Feature-007-002)
+- BaseRESTTool ``lowercase_params`` for case-sensitive backends (Feature-007-003)
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Feature-007-001: ClinVar rsID returns a real error, not silent success
+# ---------------------------------------------------------------------------
+class TestClinVarRsidSilentFailure(unittest.TestCase):
+    """An rsID passed to a numeric-UID endpoint must not yield status:success."""
+
+    def _make_tool(self):
+        from tooluniverse.clinvar_tool import ClinVarGetClinicalSignificance
+
+        config = {
+            "name": "ClinVar_get_clinical_significance",
+            "type": "ClinVarGetClinicalSignificance",
+            "fields": {
+                "endpoint": "https://eutils.ncbi.nlm.nih.gov/entrez/eutils",
+                "format": "json",
+            },
+        }
+        return ClinVarGetClinicalSignificance(config)
+
+    def test_rsid_returns_actionable_error(self):
+        tool = self._make_tool()
+        # NCBI esummary: HTTP 200 success envelope, empty uids, inline error.
+        with patch.object(tool, "_make_request") as mock_request:
+            mock_request.return_value = {
+                "status": "success",
+                "data": {
+                    "error": "Invalid uid rs4244285 at position= 0",
+                    "result": {"uids": []},
+                },
+                "url": "https://eutils.ncbi.nlm.nih.gov/...",
+            }
+            result = tool.run({"variant_id": "rs4244285"})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("rs4244285", result["error"])
+        self.assertIn("numeric ClinVar Variation ID", result["error"])
+        # The raw NCBI message is surfaced too.
+        self.assertIn("Invalid uid", result["error"])
+
+    def test_missing_numeric_record_is_error_not_success(self):
+        tool = self._make_tool()
+        with patch.object(tool, "_make_request") as mock_request:
+            mock_request.return_value = {
+                "status": "success",
+                "data": {"result": {"uids": []}},
+            }
+            result = tool.run({"variant_id": "99999999"})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("99999999", result["error"])
+
+
+# ---------------------------------------------------------------------------
+# Feature-007-002: DGIdb envelope unwraps GraphQL data + adds metadata
+# ---------------------------------------------------------------------------
+class TestDGIdbEnvelope(unittest.TestCase):
+    def test_unwraps_graphql_data_and_counts_nodes(self):
+        """data holds the GraphQL payload directly with a node count."""
+        from tooluniverse.dgidb_tool import DGIdbTool
+
+        payload = {"data": {"genes": {"nodes": [{"name": "KRAS"}, {"name": "TP53"}]}}}
+        env = DGIdbTool._envelope(payload, "genes")
+        self.assertEqual(env["status"], "success")
+        # No more data.data nesting: data holds the GraphQL payload directly.
+        self.assertEqual(env["data"], {"genes": {"nodes": [{"name": "KRAS"}, {"name": "TP53"}]}})
+        self.assertEqual(env["metadata"]["total"], 2)
+
+    def test_graphql_errors_become_error_status(self):
+        """A GraphQL errors block maps to status:error."""
+        from tooluniverse.dgidb_tool import DGIdbTool
+
+        env = DGIdbTool._envelope({"errors": [{"message": "boom"}]}, "genes")
+        self.assertEqual(env["status"], "error")
+        self.assertIn("boom", str(env["error"]))
+
+    def test_empty_collection_total_zero(self):
+        from tooluniverse.dgidb_tool import DGIdbTool
+
+        env = DGIdbTool._envelope({"data": {"drugs": {"nodes": []}}}, "drugs")
+        self.assertEqual(env["status"], "success")
+        self.assertEqual(env["metadata"]["total"], 0)
+
+
+# ---------------------------------------------------------------------------
+# Feature-007-003: BaseRESTTool lowercase_params downcases before request
+# ---------------------------------------------------------------------------
+class TestBaseRESTLowercaseParams(unittest.TestCase):
+    def _make_tool(self):
+        from tooluniverse.base_rest_tool import BaseRESTTool
+
+        config = {
+            "name": "CPIC_get_drug_info",
+            "type": "BaseRESTTool",
+            "parameter": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+            "fields": {
+                "endpoint": "https://api.cpicpgx.org/v1/drug?name=eq.{name}",
+                "lowercase_params": ["name"],
+            },
+        }
+        return BaseRESTTool(config)
+
+    def test_capitalized_name_is_lowercased_in_url(self):
+        """A capitalized name is downcased before the request URL is built."""
+        tool = self._make_tool()
+        captured = {}
+
+        def fake_request(session, method, url, **kwargs):
+            captured["url"] = url
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = []
+            resp.headers = {"content-type": "application/json"}
+            resp.text = "[]"
+            return resp
+
+        with patch(
+            "tooluniverse.base_rest_tool.request_with_retry", side_effect=fake_request
+        ):
+            tool.run({"name": "Clopidogrel"})
+
+        self.assertIn("name=eq.clopidogrel", captured["url"])
+        self.assertNotIn("Clopidogrel", captured["url"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`tu run` displayed `Error: unknown error` whenever a tool returned the project's standard error envelope `{status: "error", data: {error: "<message>"}}`. The actual error message was buried in `data.error`, but the renderer only checked `d["error"]` at the top level.

This affects every `BaseTool` subclass whose `except Exception` handler returns the standard envelope — i.e. most of them. The user-facing message had been wrong for any network failure, SSL issue, or upstream 500 surfaced through that path.

## Root cause

`src/tooluniverse/cli.py:_render_run`:

```python
# before
short_err = d.get("error", "unknown error")
```

For `d = {"status":"error", "data":{"error":"..."}}` that returns the literal default.

## Fix

Check both locations before falling back:

```python
nested = d.get("data") or {}
short_err = (
    d.get("error")
    or (nested.get("error") if isinstance(nested, dict) else None)
    or "unknown error"
)
```

Legacy top-level error shape (`{"status":"error","error":"..."}`) still works.

## Reproduction (before)

```
$ tu run FourDN_search_data '{"operation":"search","query":"Hi-C","item_type":"File","limit":10}'
Error: unknown error
```

## Validation (after)

```
$ tu run FourDN_search_data '{"operation":"search","query":"Hi-C","item_type":"File","limit":10}'
Error: HTTPSConnectionPool(host='data.4dnucleome.org', port=443): Max retries exceeded with url:
/search/?type=File&q=Hi-C&limit=10&format=json (Caused by SSLError(SSLCertVerificationError(1,
'[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired')))
```

The CLI now surfaces the actual upstream failure (4DN's TLS cert has expired — separate upstream issue, not addressed here).

## Test coverage

Three new tests in `TestRenderFunctions`:
- `test_render_run_envelope_error_unwraps_data_error` — standard envelope
- `test_render_run_top_level_error_still_works` — legacy shape (regression guard)
- `test_render_run_truly_empty_error_falls_back` — fallback still fires when nothing is present

```
$ pytest tests/tools/test_tu_cli.py -k "render_run" -v
test_render_run_envelope_error_unwraps_data_error  PASSED
test_render_run_top_level_error_still_works        PASSED
test_render_run_truly_empty_error_falls_back       PASSED
```