### PR TITLE
Sync MCPB bundle version to 1.2.3 + guard against drift

### DIFF
--- a/mcpb/build.sh
+++ b/mcpb/build.sh
@@ -28,6 +28,17 @@ rsync -a \
   --exclude='.DS_Store' \
   "$REPO_ROOT/src/tooluniverse/" "$BUILD_DIR/src/tooluniverse/"
 
+# Guard: the bundle version must track the package release version. Without this
+# the published bundle can silently lag the root pyproject.toml after a bump.
+ROOT_VER=$(grep -m1 '^version' "$REPO_ROOT/pyproject.toml" | sed -E 's/.*"([^"]+)".*/\1/')
+BUNDLE_VER=$(grep -m1 '^version' "$MCPB_SRC/pyproject.toml" | sed -E 's/.*"([^"]+)".*/\1/')
+MANIFEST_VER=$(python3 -c "import json; print(json.load(open('$MCPB_SRC/manifest.json'))['version'])")
+if [ "$ROOT_VER" != "$BUNDLE_VER" ] || [ "$ROOT_VER" != "$MANIFEST_VER" ]; then
+  echo "ERROR: version drift — root=$ROOT_VER mcpb/pyproject=$BUNDLE_VER mcpb/manifest=$MANIFEST_VER" >&2
+  echo "Bump mcpb/manifest.json and mcpb/pyproject.toml to match the root release." >&2
+  exit 1
+fi
+
 # Validate manifest against official schema.
 ( cd "$BUILD_DIR" && npx --yes @anthropic-ai/mcpb@latest validate manifest.json )
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "tooluniverse",
     "display_name": "ToolUniverse",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "ToolUniverse: an ecosystem for democratizing AI scientists with 2000+ scientific tools.",
     "long_description": "ToolUniverse is an ecosystem for creating AI scientist systems from any large language model (LLM). It standardizes how LLMs interact with tools, integrating thousands of machine learning models, datasets, APIs, and scientific packages for data analysis, knowledge retrieval, and experimental design. This bundle exposes ToolUniverse capability via the Model Context Protocol (MCP), enabling AI assistants to perform complex scientific tasks.",
     "author": {
@@ -42,11 +42,20 @@
     },
     "prompts_generated": true,
     "compatibility": {
-        "platforms": ["darwin", "win32", "linux"],
+        "platforms": [
+            "darwin",
+            "win32",
+            "linux"
+        ],
         "runtimes": {
             "python": ">=3.10,<3.14"
         }
     },
-    "keywords": ["science", "tooluniverse", "bioinformatics", "mcp"],
+    "keywords": [
+        "science",
+        "tooluniverse",
+        "bioinformatics",
+        "mcp"
+    ],
     "license": "MIT"
 }

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooluniverse-mcpb-native"
-version = "1.2.2"
+version = "1.2.3"
 description = "ToolUniverse MCP Server (Native MCPB bundle)"
 requires-python = ">=3.10,<3.14"
 

--- a/tests/unit/test_mcpb_bundle.py
+++ b/tests/unit/test_mcpb_bundle.py
@@ -25,18 +25,22 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 MCPB_DIR = REPO_ROOT / "mcpb"
 MANIFEST = MCPB_DIR / "manifest.json"
 BUNDLE_PYPROJECT = MCPB_DIR / "pyproject.toml"
+ROOT_PYPROJECT = REPO_ROOT / "pyproject.toml"
 
 # Per the MCPB manifest schema enforced by Claude Code's plugin loader.
 VALID_SERVER_TYPES = {"python", "node", "binary"}
 
 
-def _bundle_version_from_pyproject() -> str:
+def _version_from_pyproject(path: Path) -> str:
     import re
 
-    text = BUNDLE_PYPROJECT.read_text()
-    m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
-    assert m, "no version field in mcpb/pyproject.toml"
+    m = re.search(r'^version\s*=\s*"([^"]+)"', path.read_text(), re.MULTILINE)
+    assert m, f"no version field in {path}"
     return m.group(1)
+
+
+def _bundle_version_from_pyproject() -> str:
+    return _version_from_pyproject(BUNDLE_PYPROJECT)
 
 
 # ── Bug #1: manifest schema ──────────────────────────────────────────────────
@@ -69,6 +73,22 @@ def test_mcpb_manifest_version_matches_pyproject():
     assert manifest["version"] == _bundle_version_from_pyproject(), (
         "mcpb/manifest.json and mcpb/pyproject.toml versions drifted; "
         "bump both together when shipping a new bundle"
+    )
+
+
+def test_mcpb_version_tracks_root_pyproject():
+    """The bundle version must track the package release version.
+
+    The release bump touches the root pyproject.toml; without this guard the
+    mcpb/ files silently lag behind (as happened after the 1.2.3 bump), and the
+    published bundle ships an older version string than the package it carries.
+    """
+    bundle_version = _bundle_version_from_pyproject()
+    root_version = _version_from_pyproject(ROOT_PYPROJECT)
+    assert bundle_version == root_version, (
+        f"mcpb bundle version {bundle_version!r} != root package version "
+        f"{root_version!r}; bump mcpb/manifest.json and mcpb/pyproject.toml "
+        f"whenever the root release version changes"
     )
 
 


### PR DESCRIPTION
## Problem

The 1.2.3 release (`0867ee0f`) bumped `pyproject.toml` and `server.json` to `1.2.3`, but the `mcpb/` bundle files added in #207 stayed at `1.2.2`. The release version-bump process doesn't know about the new bundle manifest, so the published bundle would ship a `1.2.2` version string while carrying `1.2.3` package source.

The existing test only compared `mcpb/manifest.json` against `mcpb/pyproject.toml` (both `1.2.2` — passes), so it didn't catch the drift against the root release version.

## Changes

- Bump `mcpb/manifest.json` and `mcpb/pyproject.toml` to `1.2.3`.
- Add `test_mcpb_version_tracks_root_pyproject` — fails CI if the bundle version ever lags the root release version again.
- Add a version-drift guard to `mcpb/build.sh` that aborts the build (before validate + pack) when root and bundle versions disagree, with a message telling the maintainer which files to bump.

## Verification

```
tests/unit/test_mcpb_bundle.py  →  7 passed
bash mcpb/build.sh              →  builds at version 1.2.3, schema-valid
```

After merge the refreshed `1.2.3` bundle is uploaded to the `mcpb` release tag:

```bash
bash mcpb/build.sh
gh release upload mcpb dist/tooluniverse.mcpb --clobber --repo mims-harvard/ToolUniverse
```