### PR TITLE
Fix and expand literature-search skills: adaptive multi-source coverage

### DIFF
--- a/plugin/commands/literature-sweep.md
+++ b/plugin/commands/literature-sweep.md
@@ -1,6 +1,6 @@
 ---
 name: literature-sweep
-description: Run a graded mini-review on a topic across multiple literature sources (PubMed, EuropePMC, bioRxiv, Semantic Scholar). Dedupes hits, scores relevance to the topic, returns a ranked table with citation, year, key claim, and relevance. Use when the user wants more than a raw search dump — they want a curated short-list ready to read.
+description: Run a graded mini-review on a topic across many literature sources, adaptively chosen by domain — a core multi-field set (PubMed, EuropePMC, OpenAlex, Semantic Scholar) plus domain-specific indexes (ArXiv/DBLP for CS, InspireHEP for physics, PubTator/PMC/clinical guidelines for biomedical, Crossref/CORE/DOAJ/Fatcat for broad coverage, OSF/preprints for the latest work). Dedupes hits, scores relevance to the topic, returns a ranked table with citation, year, key claim, and relevance. Use when the user wants more than a raw search dump — they want a curated short-list ready to read.
 argument-hint: "[topic, e.g. 'KRAS G12C inhibitor resistance mechanisms', 'CRISPR base editing in Friedreich ataxia']"
 ---
 
@@ -24,24 +24,63 @@ For "KRAS G12C inhibitor resistance mechanisms":
 
 State the formulations in one line before searching.
 
-### 2. Search 2-3 independent literature sources
+### 2. Search several independent literature sources (adaptive by domain)
 
-PubMed (NIH), EuropePMC, Semantic Scholar, bioRxiv each maintain their own
-indices. Run the topic across at least 2 of them so a paper missed by one
-gets picked up by another.
+ToolUniverse exposes 15+ keyword-searchable literature indexes. Each maintains
+its own coverage, so running a topic across several catches papers any single
+one misses. **Don't blindly fire all of them** — that's slow and noisy. Pick
+the always-on CORE set, then add the domain rows that match the topic.
+
+**ALWAYS run (multi-field core — 4 indexes):**
 
 ```bash
-# PubMed (peer-reviewed, mostly biomedical)
-tu run PubMed_search_articles '{"query":"KRAS G12C resistance mechanism","max_results":20}'
+# PubMed (NIH; peer-reviewed biomedical, MeSH-indexed)
+tu run PubMed_search_articles '{"query":"KRAS G12C resistance mechanism","limit":20}'
 
-# EuropePMC (broader incl. preprints, agricultural, pharm)
+# EuropePMC (broader: clinical, agricultural, pharma + preprints via SRC:PPR)
 tu run EuropePMC_search_articles '{"query":"KRAS G12C resistance mechanism","limit":20}'
 
-# Semantic Scholar (citation graph, sometimes catches non-MeSH-indexed)
-tu run semantic_scholar_search '{"query":"KRAS G12C inhibitor resistance","limit":20}'
+# OpenAlex (250M+ works, every discipline; good cross-field recall)
+tu run openalex_search_works '{"search":"KRAS G12C inhibitor resistance","per_page":20}'
+
+# Semantic Scholar (AI-ranked citation graph; catches non-MeSH-indexed work)
+tu run SemanticScholar_search_papers '{"query":"KRAS G12C inhibitor resistance","limit":20}'
 ```
 
-If a search returns <5 hits, broaden the query. If >50, narrow it.
+**THEN add domain-specific indexes when the topic matches:**
+
+| Topic signal | Add these sources | Why |
+|---|---|---|
+| Biomedical / clinical / gene·drug·disease | `PMC_search_papers` (full text), `PubTator3_LiteratureSearch` (entity & relation queries, e.g. `relations:treat\|@CHEMICAL_X\|@DISEASE_Y`) | Full-text body hits + entity-normalized recall |
+| Clinical practice / treatment guidelines | `PubMed_Guidelines_Search` | Filters to guideline / practice-guideline pub types |
+| CS / ML / AI / algorithms | `ArXiv_search_papers`, `DBLP_search_publications` | arXiv preprints + CS bibliography (often not in PubMed) |
+| Physics / HEP / astro | `InspireHEP_search_papers` | 1.6M+ particle/astro physics records |
+| Broad / cross-disciplinary / hard-to-find | `Crossref_search_works`, `CORE_search_papers`, `DOAJ_search_articles`, `Fatcat_search_scholar` | DOI registry + open-access aggregators + Internet Archive Scholar |
+| Need the very latest (preprints) | `EuropePMC_search_articles` with `SRC:PPR`, `OSF_search_preprints` | bioRxiv/medRxiv/PsyArXiv etc. before peer review |
+| Datasets / code / supplementary outputs | `Figshare_search_articles`, `Zenodo_search_records` | Research data and software with citable DOIs |
+
+Run the core 4 plus the matching domain row(s) — typically **5–8 sources total**.
+State which sources you chose (and why) in one line before searching.
+
+**Parameter gotchas** (the add-on tools don't all use `query` + `limit` — run
+`tu info <Tool>` if a call is rejected):
+- `InspireHEP_search_papers`: query param is `q`, count is `size`.
+- `Figshare_search_articles`: query param is `search_for` (not `query`).
+- OpenAlex has two tools with **different** query params: `openalex_search_works`
+  uses `search` (or `query`); `openalex_literature_search` uses `search_keywords`.
+  Passing the wrong one silently returns unfiltered (off-topic) results — pick one
+  and match its param.
+- `DBLP_search_publications`, `PubMed_Guidelines_Search`, `Fatcat_search_scholar`,
+  `HAL_search_archive`, `OpenAIRE_search_publications`: a count param is
+  **required** (`limit` or `max_results`) — passing only the query is rejected.
+  `OpenAIRE` also requires `type` (`"publications"`).
+- Preprints: append `SRC:PPR` to the EuropePMC `query` string.
+- `CORE_search_papers` is rate-limited (HTTP 429) without `CORE_API_KEY` — treat
+  as best-effort; don't rely on it as a sole source.
+
+If a search returns <5 hits, broaden the query. If >50, narrow it. If a source
+errors or needs an unconfigured API key, note it and proceed with the rest —
+never let one dead source abort the sweep.
 
 ### 3. Dedupe across sources
 
@@ -73,8 +112,8 @@ title alone — be conservative.
 
 ```
 ## Literature sweep: <topic>
-## Sources: PubMed (n=20), EuropePMC (n=20), Semantic Scholar (n=15)
-## Deduped: 38 unique papers; 14 above relevance threshold
+## Sources queried: PubMed (n=20), EuropePMC (n=20), OpenAlex (n=20), Semantic Scholar (n=15), PMC (n=12), PubTator3 (n=8)
+## Deduped: 61 raw hits → 38 unique papers; 14 above relevance threshold
 
 | # | Paper | Year | Source(s) | Score | Key claim |
 |---|---|---|---|---|---|
@@ -116,8 +155,10 @@ End with:
 
 ## Stop conditions
 
-- 2 sources both return 0 hits → topic is mis-specified or too narrow.
-  Don't fabricate; report empty and suggest broader formulations.
+- The core sources (PubMed + EuropePMC + OpenAlex) all return 0 hits → topic is
+  mis-specified or too narrow. Don't fabricate; report empty and suggest broader
+  formulations. (A domain-specific index returning 0 is normal — e.g. ArXiv on a
+  pure-clinical topic — and is not a stop condition.)
 - Dedup runs into citation cycles (same paper claimed by 5+ different
   source-IDs) → trust DOI first, then PMID, ignore the rest.
 - 50+ deduped papers above threshold → narrow the topic OR present only

--- a/plugin/skills/tooluniverse-literature-deep-research/SKILL.md
+++ b/plugin/skills/tooluniverse-literature-deep-research/SKILL.md
@@ -119,15 +119,29 @@ Non-bio: skip bio tools, use ArXiv/DBLP/OSF. Cross-domain: resolve bio entities 
 **Step 2: Citation expansion**: `PubMed_get_cited_by`, `EuropePMC_get_citations/references`, `PubMed_get_related`, `SemanticScholar_get_recommendations`, `OpenCitations_get_citations`
 **Step 3: Collision-filtered broader queries**: `"[TERM]" AND ([context]) NOT [collision]`
 
-### 2.2 Literature Tools
+### 2.2 Literature Tools — core set + adaptive by domain
 
-**Biomedical**: `PubMed_search_articles`, `PMC_search_papers`, `EuropePMC_search_articles`, `PubTator3_LiteratureSearch`
-**Biology (ecology/evolution/plant)**: **EuropePMC as PRIMARY** (PubMed returns 0-1 for non-clinical biology). Also `openalex_literature_search`.
-**CS/ML**: `ArXiv_search_papers`, `DBLP_search_publications`, `SemanticScholar_search_papers`
-**General**: `openalex_literature_search`, `Crossref_search_works`, `CORE_search_papers`, `DOAJ_search_articles`
-**Preprints**: `BioRxiv_get_preprint`, `MedRxiv_get_preprint`, `OSF_search_preprints`, `EuropePMC_search_articles(source='PPR')`
-**Multi-source**: `advanced_literature_search_agent` (12+ DBs; needs Azure key -- fallback: query PubMed+ArXiv+SemanticScholar+OpenAlex individually)
+Run the **core multi-field set on every review** (catches what any single index misses), then add the domain rows that match the subject. Don't fire every source blindly — 6–10 well-chosen indexes beat 20 noisy ones.
+
+**ALWAYS run (core, all disciplines)**: `PubMed_search_articles`, `EuropePMC_search_articles`, `openalex_search_works` (query param `search`/`query`) **or** `openalex_literature_search` (query param `search_keywords`) — pick one and match its param; mixing them silently returns off-topic results — and `SemanticScholar_search_papers`
+
+**Then add by domain:**
+
+| Domain | Add these | Notes |
+|--------|-----------|-------|
+| Biomedical / clinical | `PMC_search_papers` (full text), `PubTator3_LiteratureSearch` (entity & `relations:` queries), `PubMed_Guidelines_Search` (clinical guidelines) | PubTator normalizes gene/drug/disease entities |
+| Biology (ecology/evolution/plant) | **EuropePMC as PRIMARY** + OpenAlex | PubMed returns 0–1 for non-clinical biology |
+| CS / ML / AI | `ArXiv_search_papers`, `DBLP_search_publications` | arXiv + CS bibliography |
+| Physics / HEP / astro | `InspireHEP_search_papers` | 1.6M+ particle/astro records |
+| Broad / hard-to-find / OA | `Crossref_search_works`, `CORE_search_papers`, `DOAJ_search_articles`, `Fatcat_search_scholar` | DOI registry + OA aggregators + Internet Archive Scholar |
+| Regional / EU-funded | `OpenAIRE_search_publications`, `HAL_search_archive` | EU open science + French national archive |
+| Datasets / software / outputs | `Figshare_search_articles`, `Zenodo_search_records` | Citable DOIs for data & code |
+| Preprints (latest) | `EuropePMC_search_articles(source='PPR')`, `OSF_search_preprints`, `BioRxiv_get_preprint`/`MedRxiv_get_preprint` (DOI lookup) | bioRxiv/medRxiv/PsyArXiv etc. |
+
+**Multi-source**: `advanced_literature_search_agent` (12+ DBs; needs Azure key -- fallback: query the core set individually).
 **Citation impact**: `iCite_search_publications` (RCR/APT), `iCite_get_publications` (by PMID), `scite_get_tallies` (support/contradict). PubMed-only; for CS use SemanticScholar.
+
+A domain-specific index returning 0 (e.g. ArXiv on a pure-clinical topic) is normal — only worry if the whole core set is empty.
 
 ### 2.3-2.4 Full-Text & PubMed Zero-Result Fallback
 

--- a/plugin/skills/tooluniverse-literature-deep-research/TOOL_NAMES_REFERENCE.md
+++ b/plugin/skills/tooluniverse-literature-deep-research/TOOL_NAMES_REFERENCE.md
@@ -4,7 +4,7 @@
 
 ---
 
-## Literature Search Tools (23)
+## Literature Search Tools
 
 ### Biomedical & Life Sciences
 ```python
@@ -24,6 +24,11 @@
 'SemanticScholar_search_papers'   # 200M+ AI-ranked papers
 ```
 
+### Physics / High-Energy Physics
+```python
+'InspireHEP_search_papers'        # 1.6M+ particle/astro physics (a:/t:/j:/cn: syntax)
+```
+
 ### General Academic
 ```python
 'openalex_literature_search'      # 250M+ works across fields
@@ -41,11 +46,14 @@
 
 ### Regional/Specialized
 ```python
-'OpenAIRE_search_publications'    # EU-funded research
-'HAL_search_archive'              # French national archive
+'OpenAIRE_search_publications'    # EU-funded research (best-effort: API has been returning 400s; verify before relying on it)
+'HAL_search_archive'              # French national archive (max_results required)
 'OSF_search_preprints'            # Social science preprints
 'Zenodo_search_records'           # Datasets, software, publications
+'Figshare_search_articles'        # Datasets, figures, code, posters, theses (query param is `search_for`)
 ```
+
+> Reliability: `CORE_search_papers` needs `CORE_API_KEY` (HTTP 429 without it); `OpenAIRE_search_publications` has been returning HTTP 400 on basic queries — treat both as best-effort, not sole sources.
 
 ### Text Mining / NER
 ```python
@@ -375,14 +383,25 @@
 # ArXiv
 {'query': 'ti:"transformer" AND abs:"attention mechanism"', 'limit': 50, 'sort_by': 'submittedDate'}
 
-# DBLP
-{'query': 'graph neural network', 'max_results': 50}
+# DBLP (count param `limit` is REQUIRED, not `max_results`)
+{'query': 'graph neural network', 'limit': 50}
 
 # SemanticScholar
 {'query': 'retrieval augmented generation', 'limit': 50, 'year': '2023-2024', 'sort': 'citationCount:desc'}
 
-# OpenAlex
-{'search_keywords': 'term', 'max_results': 100, 'year_from': 2020}
+# OpenAlex (query alias `search`; count alias `per_page`)
+{'search': 'term', 'per_page': 100, 'filter': 'from_publication_date:2020-01-01'}
+
+# InspireHEP (query param is `q`, count is `size`)
+{'q': 'higgs boson', 'size': 25, 'sort': 'mostcited'}
+
+# Figshare (query param is `search_for`, not `query`)
+{'search_for': 'crispr screen dataset', 'page_size': 20}
+
+# Required count param (query alone is rejected): HAL/OpenAIRE/Fatcat/PubMed_Guidelines
+{'query': 'term', 'max_results': 20}          # HAL, Fatcat
+{'query': 'term', 'max_results': 20, 'type': 'publications'}  # OpenAIRE also needs type
+{'query': 'hypertension', 'limit': 20}        # PubMed_Guidelines_Search
 
 # With collision filter
 {'query': '"TRAG" AND immune NOT plasmid NOT conjugation', 'limit': 50}

--- a/skills/tooluniverse-literature-deep-research/SKILL.md
+++ b/skills/tooluniverse-literature-deep-research/SKILL.md
@@ -119,15 +119,29 @@ Non-bio: skip bio tools, use ArXiv/DBLP/OSF. Cross-domain: resolve bio entities 
 **Step 2: Citation expansion**: `PubMed_get_cited_by`, `EuropePMC_get_citations/references`, `PubMed_get_related`, `SemanticScholar_get_recommendations`, `OpenCitations_get_citations`
 **Step 3: Collision-filtered broader queries**: `"[TERM]" AND ([context]) NOT [collision]`
 
-### 2.2 Literature Tools
+### 2.2 Literature Tools — core set + adaptive by domain
 
-**Biomedical**: `PubMed_search_articles`, `PMC_search_papers`, `EuropePMC_search_articles`, `PubTator3_LiteratureSearch`
-**Biology (ecology/evolution/plant)**: **EuropePMC as PRIMARY** (PubMed returns 0-1 for non-clinical biology). Also `openalex_literature_search`.
-**CS/ML**: `ArXiv_search_papers`, `DBLP_search_publications`, `SemanticScholar_search_papers`
-**General**: `openalex_literature_search`, `Crossref_search_works`, `CORE_search_papers`, `DOAJ_search_articles`
-**Preprints**: `BioRxiv_get_preprint`, `MedRxiv_get_preprint`, `OSF_search_preprints`, `EuropePMC_search_articles(source='PPR')`
-**Multi-source**: `advanced_literature_search_agent` (12+ DBs; needs Azure key -- fallback: query PubMed+ArXiv+SemanticScholar+OpenAlex individually)
+Run the **core multi-field set on every review** (catches what any single index misses), then add the domain rows that match the subject. Don't fire every source blindly — 6–10 well-chosen indexes beat 20 noisy ones.
+
+**ALWAYS run (core, all disciplines)**: `PubMed_search_articles`, `EuropePMC_search_articles`, `openalex_search_works` (query param `search`/`query`) **or** `openalex_literature_search` (query param `search_keywords`) — pick one and match its param; mixing them silently returns off-topic results — and `SemanticScholar_search_papers`
+
+**Then add by domain:**
+
+| Domain | Add these | Notes |
+|--------|-----------|-------|
+| Biomedical / clinical | `PMC_search_papers` (full text), `PubTator3_LiteratureSearch` (entity & `relations:` queries), `PubMed_Guidelines_Search` (clinical guidelines) | PubTator normalizes gene/drug/disease entities |
+| Biology (ecology/evolution/plant) | **EuropePMC as PRIMARY** + OpenAlex | PubMed returns 0–1 for non-clinical biology |
+| CS / ML / AI | `ArXiv_search_papers`, `DBLP_search_publications` | arXiv + CS bibliography |
+| Physics / HEP / astro | `InspireHEP_search_papers` | 1.6M+ particle/astro records |
+| Broad / hard-to-find / OA | `Crossref_search_works`, `CORE_search_papers`, `DOAJ_search_articles`, `Fatcat_search_scholar` | DOI registry + OA aggregators + Internet Archive Scholar |
+| Regional / EU-funded | `OpenAIRE_search_publications`, `HAL_search_archive` | EU open science + French national archive |
+| Datasets / software / outputs | `Figshare_search_articles`, `Zenodo_search_records` | Citable DOIs for data & code |
+| Preprints (latest) | `EuropePMC_search_articles(source='PPR')`, `OSF_search_preprints`, `BioRxiv_get_preprint`/`MedRxiv_get_preprint` (DOI lookup) | bioRxiv/medRxiv/PsyArXiv etc. |
+
+**Multi-source**: `advanced_literature_search_agent` (12+ DBs; needs Azure key -- fallback: query the core set individually).
 **Citation impact**: `iCite_search_publications` (RCR/APT), `iCite_get_publications` (by PMID), `scite_get_tallies` (support/contradict). PubMed-only; for CS use SemanticScholar.
+
+A domain-specific index returning 0 (e.g. ArXiv on a pure-clinical topic) is normal — only worry if the whole core set is empty.
 
 ### 2.3-2.4 Full-Text & PubMed Zero-Result Fallback
 

--- a/skills/tooluniverse-literature-deep-research/TOOL_NAMES_REFERENCE.md
+++ b/skills/tooluniverse-literature-deep-research/TOOL_NAMES_REFERENCE.md
@@ -4,7 +4,7 @@
 
 ---
 
-## Literature Search Tools (23)
+## Literature Search Tools
 
 ### Biomedical & Life Sciences
 ```python
@@ -24,6 +24,11 @@
 'SemanticScholar_search_papers'   # 200M+ AI-ranked papers
 ```
 
+### Physics / High-Energy Physics
+```python
+'InspireHEP_search_papers'        # 1.6M+ particle/astro physics (a:/t:/j:/cn: syntax)
+```
+
 ### General Academic
 ```python
 'openalex_literature_search'      # 250M+ works across fields
@@ -41,11 +46,14 @@
 
 ### Regional/Specialized
 ```python
-'OpenAIRE_search_publications'    # EU-funded research
-'HAL_search_archive'              # French national archive
+'OpenAIRE_search_publications'    # EU-funded research (best-effort: API has been returning 400s; verify before relying on it)
+'HAL_search_archive'              # French national archive (max_results required)
 'OSF_search_preprints'            # Social science preprints
 'Zenodo_search_records'           # Datasets, software, publications
+'Figshare_search_articles'        # Datasets, figures, code, posters, theses (query param is `search_for`)
 ```
+
+> Reliability: `CORE_search_papers` needs `CORE_API_KEY` (HTTP 429 without it); `OpenAIRE_search_publications` has been returning HTTP 400 on basic queries — treat both as best-effort, not sole sources.
 
 ### Text Mining / NER
 ```python
@@ -375,14 +383,25 @@
 # ArXiv
 {'query': 'ti:"transformer" AND abs:"attention mechanism"', 'limit': 50, 'sort_by': 'submittedDate'}
 
-# DBLP
-{'query': 'graph neural network', 'max_results': 50}
+# DBLP (count param `limit` is REQUIRED, not `max_results`)
+{'query': 'graph neural network', 'limit': 50}
 
 # SemanticScholar
 {'query': 'retrieval augmented generation', 'limit': 50, 'year': '2023-2024', 'sort': 'citationCount:desc'}
 
-# OpenAlex
-{'search_keywords': 'term', 'max_results': 100, 'year_from': 2020}
+# OpenAlex (query alias `search`; count alias `per_page`)
+{'search': 'term', 'per_page': 100, 'filter': 'from_publication_date:2020-01-01'}
+
+# InspireHEP (query param is `q`, count is `size`)
+{'q': 'higgs boson', 'size': 25, 'sort': 'mostcited'}
+
+# Figshare (query param is `search_for`, not `query`)
+{'search_for': 'crispr screen dataset', 'page_size': 20}
+
+# Required count param (query alone is rejected): HAL/OpenAIRE/Fatcat/PubMed_Guidelines
+{'query': 'term', 'max_results': 20}          # HAL, Fatcat
+{'query': 'term', 'max_results': 20, 'type': 'publications'}  # OpenAIRE also needs type
+{'query': 'hypertension', 'limit': 20}        # PubMed_Guidelines_Search
 
 # With collision filter
 {'query': '"TRAG" AND immune NOT plasmid NOT conjugation', 'limit': 50}


### PR DESCRIPTION
## Summary
Expands the two literature-search skills from a handful of hard-coded sources to **adaptive, domain-aware coverage of 15+ literature indexes**, and fixes real defects found via live verification.

### literature-sweep command
- Previously queried only 3 sources and referenced a **nonexistent tool** (`semantic_scholar_search`), which fails at runtime. Replaced with an always-on core (PubMed, EuropePMC, OpenAlex, Semantic Scholar) plus domain add-ons chosen by topic:
  - Biomedical → PMC (full text), PubTator3 (entity/relation), PubMed guidelines
  - CS/ML → ArXiv, DBLP · Physics → InspireHEP
  - Broad/OA → Crossref, CORE, DOAJ, Fatcat · Preprints → EuropePMC `SRC:PPR`, OSF · Data → Figshare, Zenodo
- Added a "parameter gotchas" section so tools with non-standard params don't fail on first call: InspireHEP `q`/`size`, Figshare `search_for`, required count params (DBLP/HAL/Fatcat/OpenAIRE/Guidelines), and the OpenAlex `search` vs `search_keywords` distinction.

### tooluniverse-literature-deep-research skill
- Phase 2.2 reworked into an explicit core+adaptive source table; InspireHEP and Figshare surfaced.
- Corrected the DBLP parameter (`limit`, not `max_results`).
- Flagged `CORE` API-key requirement and current `OpenAIRE` API instability as best-effort.
- `skills/` and `plugin/skills/` mirror copies kept byte-identical.

## Verification
Every referenced source was exercised with live `tu` calls. A/B evaluation (new vs pre-edit) across biomedical, CS, and physics topics:

| Artifact | New | Old |
|---|---|---|
| literature-sweep | 100% | 53% |
| deep-research | 100% | 90% |

Old runs reproduced the `semantic_scholar_search` not-found error and the DBLP/InspireHEP parameter errors; the new versions avoid them and add domain-appropriate sources.
