### PR TITLE
fix: cap honoured Retry-After in request_with_retry (prevent retry-hang)

### DIFF
--- a/src/tooluniverse/http_utils.py
+++ b/src/tooluniverse/http_utils.py
@@ -37,6 +37,7 @@ def request_with_retry(
     retry_statuses: RetryStatuses = (408, 429, 500, 502, 503, 504),
     max_attempts: int = 3,
     backoff_seconds: float = 0.5,
+    max_retry_after_seconds: float = 30.0,
 ) -> requests.Response:
     """
     Make an HTTP request with small exponential backoff on transient failures.
@@ -45,8 +46,12 @@ def request_with_retry(
     - Timeouts and connection errors
     - HTTP status codes listed in *retry_statuses*
 
+    A ``Retry-After`` response header is honoured but capped at
+    *max_retry_after_seconds* — that wait happens outside the per-request
+    timeout, so an oversized value must not be allowed to hang the caller.
+
     Does NOT call ``raise_for_status()``; callers decide how to handle non-2xx.
-    Defaults: 3 attempts, 0.5 s initial backoff.
+    Defaults: 3 attempts, 0.5 s initial backoff, Retry-After capped at 30 s.
     """
     m = (method or "GET").upper()
     attempts = max(1, int(max_attempts))
@@ -72,6 +77,13 @@ def request_with_retry(
                         sleep_s = max(0.0, float(retry_after_header))
                     except (TypeError, ValueError):
                         sleep_s = backoff_seconds * (2**attempt)
+                    # Cap the honoured Retry-After: this sleep happens outside
+                    # the per-request timeout, so an oversized value (e.g. a
+                    # server returning "Retry-After: 3600") would otherwise make
+                    # the tool block far past its own timeout. If the server
+                    # wants a long wait it isn't a "transient" retry — fail fast
+                    # and let the caller retry later.
+                    sleep_s = min(sleep_s, max_retry_after_seconds)
                     sleep_s += random.uniform(0.0, backoff_seconds * 0.25)
                     time.sleep(sleep_s)
                 else:

--- a/tests/unit/test_http_retry_after_cap.py
+++ b/tests/unit/test_http_retry_after_cap.py
@@ -1,0 +1,58 @@
+"""Unit test for request_with_retry's Retry-After cap.
+
+A 429/503 Retry-After header is honoured, but the wait happens outside the
+per-request timeout — so an oversized value (e.g. "Retry-After: 3600")
+must be capped, otherwise the tool blocks far past its own timeout.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+import tooluniverse.http_utils as hu
+
+
+class _FakeSession:
+    """Returns 429+Retry-After on the first call, then 200."""
+
+    def __init__(self, retry_after):
+        self.calls = 0
+        self.retry_after = retry_after
+
+    def request(self, *args, **kwargs):
+        self.calls += 1
+        resp = MagicMock()
+        if self.calls == 1:
+            resp.status_code = 429
+            resp.headers = {"Retry-After": self.retry_after}
+        else:
+            resp.status_code = 200
+            resp.headers = {}
+        return resp
+
+
+@pytest.mark.unit
+def test_oversized_retry_after_is_capped(monkeypatch):
+    slept = []
+    monkeypatch.setattr(hu.time, "sleep", lambda s: slept.append(s))
+
+    resp = hu.request_with_retry(
+        _FakeSession("3600"), "GET", "http://example", max_retry_after_seconds=30.0
+    )
+
+    assert resp.status_code == 200
+    assert slept, "should have slept once before the retry"
+    # 30 + a small jitter, never the raw 3600.
+    assert slept[0] <= 31.0
+
+
+@pytest.mark.unit
+def test_small_retry_after_is_honoured_unchanged(monkeypatch):
+    slept = []
+    monkeypatch.setattr(hu.time, "sleep", lambda s: slept.append(s))
+
+    hu.request_with_retry(
+        _FakeSession("2"), "GET", "http://example", max_retry_after_seconds=30.0
+    )
+
+    # ~2s honoured (plus tiny jitter), well under the cap.
+    assert 2.0 <= slept[0] <= 2.5


### PR DESCRIPTION
## Summary

`request_with_retry` (the shared retry helper used by `BaseRESTTool` and the
literature tools) honours a `429`/`503` **`Retry-After`** header by sleeping for
the indicated number of seconds. That sleep happens **outside** the per-request
timeout, so an oversized value — e.g. a server returning `Retry-After: 3600` —
would block the calling tool for an hour, far past its own configured timeout,
turning a "transient" retry into a hang.

## Context

This surfaced while triaging the weekly tool-sweep's `semantic_scholar` failures.
Those particular failures turned out to be a **sweep-concurrency false positive**
(the parallel sweep hammers Semantic Scholar's anonymous ~1 req/s limit; single
real-world calls succeed, and the 429 retry + Retry-After handling already work).
But the investigation exposed the genuine latent issue above in the shared
helper.

## Fix

Add a `max_retry_after_seconds` parameter (default **30s**) and cap the honoured
`Retry-After` to it. If a server asks for a longer wait it isn't really a
transient retry — fail fast and let the caller retry later. Behaviour for normal
small `Retry-After` values is unchanged.

## Validation

`tests/unit/test_http_retry_after_cap.py`:
- `Retry-After: 3600` → capped to ≤31s (not 3600)
- `Retry-After: 2` → honoured unchanged (~2s)

Existing http_utils-dependent tests still pass.