### PR TITLE
ci: weekly health-check highlights NEW failures vs a known-failing baseline

### DIFF
--- a/.github/known_failing_categories.txt
+++ b/.github/known_failing_categories.txt
@@ -19,7 +19,6 @@ glygen
 gprofiler
 nci_thesaurus
 ols
-tool                 # not a real category — matches every *_tools.json (sweep artifact)
 
 # --- upstream down / erroring at sweep time (sites flaky or in maintenance) ---
 flymine

--- a/.github/known_failing_categories.txt
+++ b/.github/known_failing_categories.txt
@@ -1,0 +1,61 @@
+# Categories the weekly tool sweep is known to flag for NON-code reasons
+# (upstream API down/slow, rate-limited, env-only deps, or flaky-transient).
+#
+# Purpose: turn the weekly report from "37 categories failed" into the one
+# actionable line — "a category failed that is NOT listed here". Anything not
+# in this file is the signal to investigate; it usually means an upstream API
+# just changed.
+#
+# Maintainers:
+#   - Remove a line when an upstream recovers (so a future failure flags again).
+#   - Add a line when a new chronic/expected failure is accepted.
+#   - One bare category token per line; everything after '#' is a comment.
+#
+# Seeded from the 2026-06-02 full sweep (4282/4357 passed).
+
+# --- slow APIs: complete but exceed the per-category timeout under load ---
+clingen
+glygen
+gprofiler
+nci_thesaurus
+ols
+tool                 # not a real category — matches every *_tools.json (sweep artifact)
+
+# --- upstream down / erroring at sweep time (sites flaky or in maintenance) ---
+flymine
+openml
+rnacentral
+dfam                 # /families works; /annotations backend returns 405 Invalid Input
+dynamut2             # upstream HTTP 500
+immport              # upstream HTTP 400 on some terms
+fourdn               # TLS certificate periodically expires upstream
+oxo                  # EBI retired OxO (now in broken_apis/; OLS is the replacement)
+
+# --- env / key dependent ---
+esm                  # needs the optional `esm` ML package (heavy, not installed)
+semantic_scholar     # anonymous ~1 req/s limit; 429s under the parallel sweep
+semantic_scholar_ext
+metaboanalyst        # already documented in broken_apis/
+
+# --- transient / flaky (passed on re-run); listed to keep noise down ---
+arrayexpress
+arxiv
+ensembl_phenotype
+enrichr_ext
+interpro
+lncrna
+mibig
+mirna
+oncotree
+protacdb
+sabdab
+sasbdb
+umls
+url_fetch
+unified_guideline
+
+# --- schema-validation warnings only (not hard failures) ---
+civic
+dailymed
+disease_target_score
+finder

--- a/.github/workflows/weekly-tool-healthcheck.yml
+++ b/.github/workflows/weekly-tool-healthcheck.yml
@@ -138,14 +138,41 @@ jobs:
           # List failing categories (### ❌ / 🔥 <name>, single trailing token).
           fail_re = re.compile(r"^###\s+(❌|\U0001f525)\s+(\S+)\s*$", re.MULTILINE)
           cats = sorted({m.group(2) for m in fail_re.finditer(text)})
-          if cats:
-              print(f"## Failing categories ({len(cats)})\n")
-              print(", ".join(f"`{c}`" for c in cats))
+
+          # Diff against the known-failing baseline so the report highlights the
+          # one thing worth acting on: a category that failed but is NOT already
+          # a known/expected failure (usually an upstream API just changed).
+          baseline = set()
+          bl = pathlib.Path(".github/known_failing_categories.txt")
+          if bl.exists():
+              for line in bl.read_text().splitlines():
+                  tok = line.split("#", 1)[0].strip()
+                  if tok:
+                      baseline.add(tok)
+
+          new_fail = [c for c in cats if c not in baseline]
+          if new_fail:
+              print(f"## 🆕 NEW failing categories ({len(new_fail)}) — investigate\n")
+              print(", ".join(f"`{c}`" for c in new_fail))
               print(
-                  "\n> Note: API-key-gated and known-broken-upstream categories are "
-                  "expected here. Investigate new entries vs the previous week — a "
-                  "newly-failing category usually means an upstream API changed."
+                  "\n> These are not in `.github/known_failing_categories.txt`. A "
+                  "newly-failing category usually means an upstream API changed — "
+                  "reproduce, then fix or add it to the baseline."
               )
+          elif cats:
+              print("No new failures — every failing category is a known/expected one. ✅")
+
+          if cats:
+              print(f"\n<details><summary>All failing categories ({len(cats)})</summary>\n")
+              print(", ".join(f"`{c}`" for c in cats))
+              recovered = sorted(baseline - set(cats))
+              if recovered:
+                  print(
+                      f"\nBaseline entries that PASSED this week ({len(recovered)}, "
+                      "candidates to prune from the baseline): "
+                      + ", ".join(f"`{c}`" for c in recovered)
+                  )
+              print("\n</details>")
           else:
               print("All categories passed. ✅")
           PY

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -63,12 +63,15 @@ def extract_tool_patterns(config_files: List[Path]) -> Dict[str, List[Path]]:
         # Get base name without extension
         base_name = config_file.stem
         
-        # Extract pattern (typically prefix before _tools or first underscore)
+        # Extract pattern (typically the prefix before _tools).
         if '_tools' in base_name:
             pattern = base_name.replace('_tools', '')
-        elif '_' in base_name:
-            pattern = base_name.split('_')[0]
         else:
+            # Use the full stem for non-_tools files. Splitting on the first
+            # underscore produced over-broad patterns: e.g. tool_page_index.json
+            # and tool_discovery_agents.json both yielded "tool", and downstream
+            # test_new_tools.py globs *tool* — which matches every *_tools.json
+            # (500+ files) and times that "category" out on every run.
             pattern = base_name
         
         patterns[pattern].append(config_file)


### PR DESCRIPTION
## Summary

Two related improvements to the weekly tool-sweep canary (#214):

### 1. Highlight NEW failures vs a known-failing baseline

The sweep flags ~37 categories every run, but almost all fail for **non-code
reasons** (upstream down/slow, rate-limited, env-only, flaky). A flat list
buries the one thing worth acting on.

- `​.github/known_failing_categories.txt` — the known/expected failures, seeded
  from the 2026-06-02 full sweep, one reason per entry.
- The workflow summary now leads with **🆕 NEW failing categories** (not in the
  baseline) — the actionable signal that an upstream API just changed — and
  tucks the full list + baseline-entries-that-passed (prune candidates) into a
  collapsible block.

### 2. Fix over-broad sweep category patterns

`test_all_tools.py` grouped non-`_tools` config files by
`base_name.split("_")[0]`, so `tool_page_index.json` and
`tool_discovery_agents.json` both collapsed to the pattern `"tool"`. Downstream
`test_new_tools.py` globs `*tool*`, which matches **every** `*_tools.json`
(500+ files) and timed that synthetic "tool category" out (🔥 5 min) on every
run — the same over-broadening hit `api`, `mcp`, `drug`. Now each non-`_tools`
file maps to its full stem; no pattern resolves to >30 files. (The obsolete
`tool` baseline entry is dropped too.)

## Validation

- Baseline diff against the real 2026-06-02 report: 33 failing categories, all in
  the baseline → **0 NEW** (no false alarms); a simulated new failure is the only
  thing surfaced.
- Pattern fix: `extract_tool_patterns` no longer produces a `tool`/`api`/`mcp`
  mega-pattern; max files per pattern is now small.
- YAML + ruff clean.

Builds on #214.