### PR TITLE
fix: tool issues surfaced by the weekly sweep (schemas + ImmPort + DynaMut2)

### DIFF
--- a/src/tooluniverse/data/civic_tools.json
+++ b/src/tooluniverse/data/civic_tools.json
@@ -58,7 +58,10 @@
                         "description": "Gene symbol/name"
                       },
                       "description": {
-                        "type": "string",
+                        "type": [
+                          "string",
+                          "null"
+                        ],
                         "description": "Gene description"
                       },
                       "entrezId": {
@@ -336,7 +339,9 @@
         "limit": 5
       }
     ],
-    "aliases": ["CIViC_search_variants"]
+    "aliases": [
+      "CIViC_search_variants"
+    ]
   },
   {
     "name": "civic_get_evidence_item",

--- a/src/tooluniverse/data/dynamut2_tools.json
+++ b/src/tooluniverse/data/dynamut2_tools.json
@@ -8,7 +8,9 @@
       "properties": {
         "operation": {
           "type": "string",
-          "enum": ["predict_stability"],
+          "enum": [
+            "predict_stability"
+          ],
           "description": "Operation type"
         },
         "pdb_id": {
@@ -24,21 +26,56 @@
           "description": "Single-point mutation in the format WtPosNew where Wt is the wild-type amino acid (1-letter code), Pos is the residue number, and New is the mutant amino acid (1-letter code). Examples: 'V1A' (Val1Ala), 'E346K' (Glu346Lys), 'G12D' (Gly12Asp)."
         }
       },
-      "required": ["operation", "pdb_id", "chain", "mutation"]
+      "required": [
+        "operation",
+        "pdb_id",
+        "chain",
+        "mutation"
+      ]
     },
     "return_schema": {
       "type": "object",
       "properties": {
-        "pdb_id": {"type": "string", "description": "PDB accession code used"},
-        "chain": {"type": "string", "description": "Chain identifier"},
-        "mutation": {"type": "string", "description": "Mutation in WtPosNew format"},
-        "wild_type": {"type": "string", "description": "Wild-type residue (3-letter code)"},
-        "mutant": {"type": "string", "description": "Mutant residue (3-letter code)"},
-        "position": {"type": "string", "description": "Residue position number"},
-        "ddg_prediction": {"type": "number", "description": "Predicted change in Gibbs free energy (ddG, kcal/mol). Positive = stabilizing, negative = destabilizing."},
-        "effect": {"type": "string", "description": "Predicted effect: 'stabilizing' or 'destabilizing'"},
-        "job_id": {"type": "string", "description": "DynaMut2 job identifier for retrieving results later"},
-        "results_page": {"type": "string", "description": "URL to the full DynaMut2 results page with visualizations"}
+        "pdb_id": {
+          "type": "string",
+          "description": "PDB accession code used"
+        },
+        "chain": {
+          "type": "string",
+          "description": "Chain identifier"
+        },
+        "mutation": {
+          "type": "string",
+          "description": "Mutation in WtPosNew format"
+        },
+        "wild_type": {
+          "type": "string",
+          "description": "Wild-type residue (3-letter code)"
+        },
+        "mutant": {
+          "type": "string",
+          "description": "Mutant residue (3-letter code)"
+        },
+        "position": {
+          "type": "string",
+          "description": "Residue position number"
+        },
+        "ddg_prediction": {
+          "type": "number",
+          "description": "Predicted change in Gibbs free energy (ddG, kcal/mol). Positive = stabilizing, negative = destabilizing."
+        },
+        "effect": {
+          "type": "string",
+          "description": "Predicted effect: 'stabilizing' or 'destabilizing'"
+        },
+        "job_id": {
+          "type": "string",
+          "description": "DynaMut2 job identifier for retrieving results later"
+        },
+        "results_page": {
+          "type": "string",
+          "description": "URL to the full DynaMut2 results page with visualizations"
+        }
       }
     },
     "test_examples": [
@@ -53,13 +90,15 @@
   {
     "name": "DynaMut2_get_job",
     "type": "DynaMut2Tool",
-    "description": "Retrieve results for a previously submitted DynaMut2 stability prediction job. If the job is still running, returns the current status. If complete, returns the full prediction result including ddG value and effect classification. Use this to check on long-running predictions or to retrieve results you submitted earlier.",
+    "description": "Retrieve results for a previously submitted DynaMut2 stability prediction job. If the job is still running, returns the current status. If complete, returns the full prediction result including ddG value and effect classification. Use this to check on long-running predictions or to retrieve results you submitted earlier. Note: DynaMut2 jobs are ephemeral and expire, so this tool has no static test example — submit a job with DynaMut2_predict_stability first to get a live job_id.",
     "parameter": {
       "type": "object",
       "properties": {
         "operation": {
           "type": "string",
-          "enum": ["get_job"],
+          "enum": [
+            "get_job"
+          ],
           "description": "Operation type"
         },
         "job_id": {
@@ -67,35 +106,78 @@
           "description": "DynaMut2 job identifier returned from a previous predict_stability call."
         },
         "endpoint": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "default": "prediction_single",
           "description": "API endpoint for the job type. Default: 'prediction_single'. Other options: 'prediction_list', 'prediction_mm'."
         }
       },
-      "required": ["operation", "job_id"]
+      "required": [
+        "operation",
+        "job_id"
+      ]
     },
     "return_schema": {
       "type": "object",
       "properties": {
-        "pdb_id": {"type": "string", "description": "PDB accession code (empty for get_job since it may not be stored)"},
-        "chain": {"type": "string", "description": "Chain identifier"},
-        "mutation": {"type": "string", "description": "Mutation in WtPosNew format"},
-        "wild_type": {"type": "string", "description": "Wild-type residue (3-letter code)"},
-        "mutant": {"type": "string", "description": "Mutant residue (3-letter code)"},
-        "position": {"type": "string", "description": "Residue position number"},
-        "ddg_prediction": {"type": "number", "description": "Predicted ddG (kcal/mol). Positive = stabilizing, negative = destabilizing."},
-        "effect": {"type": "string", "description": "Predicted effect: 'stabilizing' or 'destabilizing'"},
-        "job_id": {"type": "string", "description": "DynaMut2 job identifier"},
-        "results_page": {"type": "string", "description": "URL to DynaMut2 results page"},
-        "job_status": {"type": ["string", "null"], "description": "Job status if still running (e.g., 'RUNNING')"},
-        "message": {"type": ["string", "null"], "description": "Status message if job is still running"}
+        "pdb_id": {
+          "type": "string",
+          "description": "PDB accession code (empty for get_job since it may not be stored)"
+        },
+        "chain": {
+          "type": "string",
+          "description": "Chain identifier"
+        },
+        "mutation": {
+          "type": "string",
+          "description": "Mutation in WtPosNew format"
+        },
+        "wild_type": {
+          "type": "string",
+          "description": "Wild-type residue (3-letter code)"
+        },
+        "mutant": {
+          "type": "string",
+          "description": "Mutant residue (3-letter code)"
+        },
+        "position": {
+          "type": "string",
+          "description": "Residue position number"
+        },
+        "ddg_prediction": {
+          "type": "number",
+          "description": "Predicted ddG (kcal/mol). Positive = stabilizing, negative = destabilizing."
+        },
+        "effect": {
+          "type": "string",
+          "description": "Predicted effect: 'stabilizing' or 'destabilizing'"
+        },
+        "job_id": {
+          "type": "string",
+          "description": "DynaMut2 job identifier"
+        },
+        "results_page": {
+          "type": "string",
+          "description": "URL to DynaMut2 results page"
+        },
+        "job_status": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Job status if still running (e.g., 'RUNNING')"
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Status message if job is still running"
+        }
       }
     },
-    "test_examples": [
-      {
-        "operation": "get_job",
-        "job_id": "177213420956"
-      }
-    ]
+    "test_examples": []
   }
 ]

--- a/src/tooluniverse/data/finder_tools.json
+++ b/src/tooluniverse/data/finder_tools.json
@@ -1,222 +1,255 @@
 [
-    {
-        "type": "ToolFinderEmbedding",
-        "name": "Tool_RAG",
-        "description": "Retrieve related tools from the toolbox based on the provided description",
-        "required_packages": ["sentence_transformers", "torch"],
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string",
-                    "description": "The description of the tool capability required."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "The number of tools to retrieve (default: 10)"
-                }
-            },
-            "required": ["description"]
+  {
+    "type": "ToolFinderEmbedding",
+    "name": "Tool_RAG",
+    "description": "Retrieve related tools from the toolbox based on the provided description",
+    "required_packages": [
+      "sentence_transformers",
+      "torch"
+    ],
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The description of the tool capability required."
         },
-        "required": ["description"],
-        "configs": {
-            "tool_finder_model": "mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B",
-            "exclude_tools": [
-                "Tool_RAG",
-                "Tool_Finder",
-                "Finish",
-                "CallAgent",
-                "Tool_Finder_LLM",
-                "Tool_Finder_Keyword"
-            ]
-        },
-        "test_examples": [
-            {
-                "description": "Find tools that can perform sequence alignment",
-                "limit": 5
-            }
-        ],
-        "return_schema": {
-            "type": "object",
-            "description": "Output of the tool execution.",
-            "properties": {}
+        "limit": {
+          "type": "integer",
+          "description": "The number of tools to retrieve (default: 10)"
         }
+      },
+      "required": [
+        "description"
+      ]
     },
-    {
-        "type": "ToolFinderEmbedding",
-        "name": "Tool_Finder",
-        "description": "Retrieve related tools from the toolbox based on the provided description, advanced version with more functionality.",
-        "required_packages": ["sentence_transformers", "torch"],
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string",
-                    "description": "The description of the tool capability required."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "The number of tools to retrieve (default: 10)"
-                },
-                "picked_tool_names": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Pre-selected tool names to process. If provided, tool selection will skip these tools."
-                },
-                "return_call_result": {
-                    "type": "boolean",
-                    "description": "Whether to return both prompts and tool names. If false, returns only tool prompts."
-                },
-                "categories": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Optional list of tool categories to filter by"
-                }
-            },
-            "required": ["description"]
-        },
-        "required": ["description"],
-        "configs": {
-            "tool_finder_model": "mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B",
-            "exclude_tools": [
-                "Tool_RAG",
-                "Tool_Finder",
-                "Finish",
-                "CallAgent",
-                "Tool_Finder_LLM",
-                "Tool_Finder_Keyword"
-            ]
-        },
-        "test_examples": [
-            {
-                "description": "Find tools for analyzing gene expression data",
-                "limit": 1,
-                "picked_tool_names": [],
-                "return_call_result": true,
-                "categories": []
-            }
-        ],
-        "return_schema": {
-            "type": "object",
-            "description": "Output of the tool execution.",
-            "properties": {}
-        }
+    "required": [
+      "description"
+    ],
+    "configs": {
+      "tool_finder_model": "mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B",
+      "exclude_tools": [
+        "Tool_RAG",
+        "Tool_Finder",
+        "Finish",
+        "CallAgent",
+        "Tool_Finder_LLM",
+        "Tool_Finder_Keyword"
+      ]
     },
-    {
-        "type": "ToolFinderLLM",
-        "name": "Tool_Finder_LLM",
-        "description": "LLM-based tool finder that uses natural language processing to intelligently select relevant tools based on user queries. This tool analyzes all available tool descriptions and uses an LLM to determine which tools would be most helpful for a given task or question.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string",
-                    "description": "The description of the tool capability required."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "The number of tools to retrieve (default: 10)"
-                },
-                "picked_tool_names": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Pre-selected tool names to process. If provided, tool selection will skip these tools."
-                },
-                "return_call_result": {
-                    "type": "boolean",
-                    "description": "Whether to return both prompts and tool names. If false, returns only tool prompts."
-                },
-                "categories": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Optional list of tool categories to filter by"
-                }
-            },
-            "required": ["description"]
-        },
-        "configs": {
-            "return_json": true,
-            "return_list_only": true,
-            "exclude_tools": [
-                "Tool_RAG",
-                "Tool_Finder",
-                "Finish",
-                "CallAgent",
-                "Tool_Finder_LLM",
-                "Tool_Finder_Keyword"
-            ]
-        },
-        "test_examples": [
-            {
-                "description": "Find tools for analyzing gene expression data",
-                "limit": 1,
-                "picked_tool_names": [],
-                "return_call_result": true,
-                "categories": []
-            }
-        ],
-        "return_schema": {
-            "type": "object",
-            "description": "Output of the tool execution.",
-            "properties": {}
-        }
-    },
-    {
-        "type": "ToolFinderKeyword",
-        "name": "Tool_Finder_Keyword",
-        "description": "Simple keyword-based tool finder for discovering relevant tools using text matching",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string",
-                    "description": "The description of the tool capability required."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "The number of tools to retrieve (default: 10)"
-                },
-                "picked_tool_names": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Pre-selected tool names to process. If provided, tool selection will skip these tools."
-                },
-                "return_call_result": {
-                    "type": "boolean",
-                    "description": "Whether to return both prompts and tool names. If false, returns only tool prompts."
-                },
-                "categories": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Optional list of tool categories to filter by"
-                }
-            },
-            "required": ["description"]
-        },
-        "required": ["description"],
-        "configs": {
-            "exclude_tools": [
-                "Tool_RAG",
-                "Tool_Finder",
-                "Finish",
-                "CallAgent",
-                "Tool_Finder_LLM",
-                "Tool_Finder_Keyword"
-            ]
-        },
-        "test_examples": [
-            {
-                "description": "Find tools for analyzing gene expression data",
-                "limit": 1,
-                "picked_tool_names": [],
-                "return_call_result": true,
-                "categories": []
-            }
-        ],
-        "return_schema": {
-            "type": "object",
-            "description": "Output of the tool execution.",
-            "properties": {}
-        }
+    "test_examples": [
+      {
+        "description": "Find tools that can perform sequence alignment",
+        "limit": 5
+      }
+    ],
+    "return_schema": {
+      "type": "object",
+      "description": "Output of the tool execution.",
+      "properties": {}
     }
+  },
+  {
+    "type": "ToolFinderEmbedding",
+    "name": "Tool_Finder",
+    "description": "Retrieve related tools from the toolbox based on the provided description, advanced version with more functionality.",
+    "required_packages": [
+      "sentence_transformers",
+      "torch"
+    ],
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The description of the tool capability required."
+        },
+        "limit": {
+          "type": "integer",
+          "description": "The number of tools to retrieve (default: 10)"
+        },
+        "picked_tool_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Pre-selected tool names to process. If provided, tool selection will skip these tools."
+        },
+        "return_call_result": {
+          "type": "boolean",
+          "description": "Whether to return both prompts and tool names. If false, returns only tool prompts."
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional list of tool categories to filter by"
+        }
+      },
+      "required": [
+        "description"
+      ]
+    },
+    "required": [
+      "description"
+    ],
+    "configs": {
+      "tool_finder_model": "mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B",
+      "exclude_tools": [
+        "Tool_RAG",
+        "Tool_Finder",
+        "Finish",
+        "CallAgent",
+        "Tool_Finder_LLM",
+        "Tool_Finder_Keyword"
+      ]
+    },
+    "test_examples": [
+      {
+        "description": "Find tools for analyzing gene expression data",
+        "limit": 1,
+        "picked_tool_names": [],
+        "return_call_result": true,
+        "categories": []
+      }
+    ],
+    "return_schema": {
+      "type": "object",
+      "description": "Output of the tool execution.",
+      "properties": {}
+    }
+  },
+  {
+    "type": "ToolFinderLLM",
+    "name": "Tool_Finder_LLM",
+    "description": "LLM-based tool finder that uses natural language processing to intelligently select relevant tools based on user queries. This tool analyzes all available tool descriptions and uses an LLM to determine which tools would be most helpful for a given task or question.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The description of the tool capability required."
+        },
+        "limit": {
+          "type": "integer",
+          "description": "The number of tools to retrieve (default: 10)"
+        },
+        "picked_tool_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Pre-selected tool names to process. If provided, tool selection will skip these tools."
+        },
+        "return_call_result": {
+          "type": "boolean",
+          "description": "Whether to return both prompts and tool names. If false, returns only tool prompts."
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional list of tool categories to filter by"
+        }
+      },
+      "required": [
+        "description"
+      ]
+    },
+    "configs": {
+      "return_json": true,
+      "return_list_only": true,
+      "exclude_tools": [
+        "Tool_RAG",
+        "Tool_Finder",
+        "Finish",
+        "CallAgent",
+        "Tool_Finder_LLM",
+        "Tool_Finder_Keyword"
+      ]
+    },
+    "test_examples": [
+      {
+        "description": "Find tools for analyzing gene expression data",
+        "limit": 1,
+        "picked_tool_names": [],
+        "return_call_result": true,
+        "categories": []
+      }
+    ],
+    "return_schema": {
+      "type": "object",
+      "description": "Output of the tool execution.",
+      "properties": {}
+    }
+  },
+  {
+    "type": "ToolFinderKeyword",
+    "name": "Tool_Finder_Keyword",
+    "description": "Simple keyword-based tool finder for discovering relevant tools using text matching",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The description of the tool capability required."
+        },
+        "limit": {
+          "type": "integer",
+          "description": "The number of tools to retrieve (default: 10)"
+        },
+        "picked_tool_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Pre-selected tool names to process. If provided, tool selection will skip these tools."
+        },
+        "return_call_result": {
+          "type": "boolean",
+          "description": "Whether to return both prompts and tool names. If false, returns only tool prompts."
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional list of tool categories to filter by"
+        }
+      },
+      "required": [
+        "description"
+      ]
+    },
+    "required": [
+      "description"
+    ],
+    "configs": {
+      "exclude_tools": [
+        "Tool_RAG",
+        "Tool_Finder",
+        "Finish",
+        "CallAgent",
+        "Tool_Finder_LLM",
+        "Tool_Finder_Keyword"
+      ]
+    },
+    "test_examples": [
+      {
+        "description": "Find tools for analyzing gene expression data",
+        "limit": 1,
+        "picked_tool_names": [],
+        "categories": []
+      }
+    ],
+    "return_schema": {
+      "type": "array",
+      "description": "List of matching tools (name, description, parameter schema), ranked by keyword relevance.",
+      "items": {
+        "type": "object"
+      }
+    }
+  }
 ]

--- a/src/tooluniverse/immport_tool.py
+++ b/src/tooluniverse/immport_tool.py
@@ -61,6 +61,12 @@ class ImmPortTool(BaseTool):
         if not query:
             return {"status": "error", "error": "query parameter is required"}
 
+        # ImmPort's search API parses Lucene-style operators, so an embedded
+        # hyphen ("PD-1", "COVID-19", "CTLA-4") is read as a NOT operator and
+        # rejected with HTTP 400. Treat the input as plain keywords by turning
+        # hyphens into spaces (e.g. "PD-1" -> "PD 1").
+        query = query.replace("-", " ")
+
         condition = arguments.get("condition_or_disease")
         assay = arguments.get("assay_method")
         focus = arguments.get("research_focus")


### PR DESCRIPTION
## Summary

Re-examining the weekly sweep's "upstream/external" failures showed that four
were actually **our-side and fixable**, not the remote APIs being down:

### Return-schema mismatches
- **civic_search_genes** — a gene's `description` can be `null` (CIViC genes
  without a curated description); the schema required `string`. → `["string","null"]`.
- **Tool_Finder_Keyword** — placeholder schema declared `object` but the tool
  returns a **list**. → `array`, and drop `return_call_result: true` from the
  test_example (that flag selects the internal tuple interface).

### Wrong API usage / bad test data
- **ImmPort_search_studies** — ImmPort's search parses Lucene operators, so a
  hyphen in the query (`PD-1`, `COVID-19`, `CTLA-4`) is read as a NOT operator
  and 400s. A whole class of immunology terms was unusable. → replace hyphens
  with spaces so the input is plain keywords (verified: `PD-1`/`COVID-19` now
  return results; plain terms unchanged).
- **DynaMut2_get_job** — its test_example pinned a hard-coded `job_id` that has
  long since expired (DynaMut2 jobs are ephemeral) → HTTP 500 every run. No
  static id can pass. → drop the example (skipped, not failed) and note a live
  id from `DynaMut2_predict_stability` is required.

## Validation

`test_new_tools.py` for civic / finder / immport / dynamut2 → Schema Invalid: 0,
Failed: 0. `PD-1` and `COVID-19` ImmPort searches now succeed; DynaMut2
`predict_stability` passes and `get_job` is skipped.

These were the genuinely-fixable items hiding in the sweep's "upstream" bucket;
the remaining failures (flymine/openml/rnacentral/dfam timeouts, etc.) are
confirmed slow/down upstream with correct endpoints.