### PR TITLE
Release v1.2.4 (unified: pip + MCP registry + plugin)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "ToolUniverse marketplace — 1000+ scientific research tools and 115 specialized skills for biology, chemistry, medicine, and data science.",
-    "version": "1.2.0"
+    "version": "1.2.4"
   },
   "plugins": [
     {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tooluniverse",
   "description": "1000+ scientific research tools for biology, chemistry, medicine, and data science. Access PubMed, UniProt, PubChem, TCGA, NHANES, GWAS Catalog, and hundreds more databases through a unified MCP interface. Includes 120+ specialized research skills for genomics, drug discovery, clinical analysis, protein variant interpretation, and more.",
-  "version": "1.2.1",
+  "version": "1.2.4",
   "author": {
     "name": "Shanghua Gao",
     "url": "https://shgao.site"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooluniverse"
-version = "1.2.3"
+version = "1.2.4"
 description = "A comprehensive collection of scientific tools for Agentic AI, offering integration with the ToolUniverse SDK and MCP Server to support advanced scientific workflows."
 authors = [
     { name = "Shanghua Gao", email = "shanghuagao@gmail.com" }

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mims-harvard/ToolUniverse",
     "source": "github"
   },
-  "version": "1.2.3",
+  "version": "1.2.4",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "tooluniverse",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Release v1.2.4 — unified bump across all distribution channels

Aligns every release channel at **1.2.4** and ships the backlog that accumulated on `main` since 1.2.3.

| File | Bump | Effect on merge |
|------|------|-----------------|
| `pyproject.toml` | 1.2.3 → 1.2.4 | `publish-pypi.yml` fires → **publishes PyPI 1.2.4**, shipping the src/ changes merged since 1.2.3 that never reached PyPI (#215 OxO retire, #217 Retry-After cap, #219 weekly-sweep fixes, #213 EpiGraphDB/MR, #222 proteins_api, #223 PubChem/MetaCyc) → then `publish-mcp-registry.yml` |
| `server.json` (top-level + `packages[]`) | 1.2.3 → 1.2.4 | MCP registry entry stays consistent with the pip package |
| `plugin/.claude-plugin/plugin.json` | 1.2.1 → 1.2.4 | Plugin auto-update (ships the literature-search multi-source rewrite #216, etc.) |
| `.claude-plugin/marketplace.json` | 1.2.0 → 1.2.4 | Marketplace metadata |

Why unified: PyPI releases are gated on a `pyproject.toml` bump, and nobody bumped it since 1.2.3 — so 6 merged code PRs were sitting unreleased. The plugin manifest had also drifted (1.2.1). This bump ships everything and re-aligns the four version lines at 1.2.4.

After merge: push `v1.2.4` tag → `release-plugin.yml` builds the GitHub Release.

⚠️ Merging this **publishes to PyPI** (all `pip`/`uvx` users get 1.2.4). All included commits are already reviewed + merged on main.

Recommend merging #224 (release-script fix) first.
