### PR TITLE
Round 007: proteins_api_search auto-widens to non-human organisms

### DIFF
--- a/src/tooluniverse/data/proteins_api_tools.json
+++ b/src/tooluniverse/data/proteins_api_tools.json
@@ -252,6 +252,14 @@
         "reviewed": {
           "type": "boolean",
           "description": "If true, return only reviewed Swiss-Prot entries. If false or omitted, includes unreviewed TrEMBL entries."
+        },
+        "organism": {
+          "type": "string",
+          "description": "Restrict the search to an organism by name (e.g. 'Klebsiella pneumoniae', 'Escherichia coli'). By default a gene/protein-name search is biased toward human (taxid 9606); set this for non-human proteins. If omitted and no human match is found, the search auto-widens to all organisms."
+        },
+        "taxid": {
+          "type": "string",
+          "description": "Restrict the search to an NCBI taxonomy id (e.g. '573' for Klebsiella pneumoniae, '562' for E. coli). Alternative to 'organism' for precise scoping."
         }
       },
       "required": []
@@ -272,6 +280,10 @@
       {
         "query": "insulin",
         "size": 5
+      },
+      {
+        "query": "blaKPC",
+        "size": 3
       }
     ]
   },

--- a/src/tooluniverse/proteins_api_tool.py
+++ b/src/tooluniverse/proteins_api_tool.py
@@ -455,27 +455,63 @@ class ProteinsAPIRESTTool(BaseTool):
 
             response.raise_for_status()
             data = response.json()
+            widened_organism = False
 
-            # Feature-81B-fallback: if gene-name search returns empty,
-            # retry with protein= param (e.g. "insulin" is a protein name, not gene symbol)
+            # If a name search came back empty, progressively widen it before
+            # giving up. Two reasons a search returns nothing:
+            #   1. the query is a protein name, not a gene symbol ("insulin")
+            #   2. the default human filter (taxid=9606, Feature-69A-007) drops
+            #      every hit for a non-human query (e.g. bacterial "blaKPC",
+            #      "Klebsiella pneumoniae KPC carbapenemase") — a silent empty.
+            # Retry with protein=/gene= and without the human-only filter so
+            # non-human proteins surface instead of a silent empty success.
+            auto_human = (
+                "organism" not in arguments
+                and "taxid" not in arguments
+                and params.get("taxid") == "9606"
+            )
             if (
                 tool_name == "proteins_api_search"
                 and isinstance(data, list)
                 and len(data) == 0
-                and "gene" in params
             ):
-                retry_params = dict(params)
-                retry_params.pop("gene")
-                retry_params["protein"] = arguments.get("query", "")
-                retry_resp = self.session.get(
-                    url, params=retry_params, timeout=self.timeout
-                )
-                if retry_resp.status_code == 200:
+                query = arguments.get("query", "")
+                used_gene = "gene" in params
+
+                def _retry_params(use_gene: bool, keep_human: bool) -> Dict[str, Any]:
+                    p = {"format": params.get("format", "json")}
+                    if "size" in params:
+                        p["size"] = params["size"]
+                    p["gene" if use_gene else "protein"] = query
+                    if keep_human and auto_human:
+                        p["taxid"] = "9606"
+                    return p
+
+                # Order: swap field but keep human; then drop the human filter
+                # (same field, then swapped field) so any-organism hits surface.
+                candidates = []
+                if used_gene:
+                    candidates.append(_retry_params(use_gene=False, keep_human=True))
+                if auto_human:
+                    candidates.append(
+                        _retry_params(use_gene=used_gene, keep_human=False)
+                    )
+                    candidates.append(
+                        _retry_params(use_gene=not used_gene, keep_human=False)
+                    )
+
+                for cand in candidates:
+                    retry_resp = self.session.get(
+                        url, params=cand, timeout=self.timeout
+                    )
+                    if retry_resp.status_code != 200:
+                        continue
                     retry_data = retry_resp.json()
                     if isinstance(retry_data, list) and len(retry_data) > 0:
                         data = retry_data
-                        # Update response for URL tracking
                         response = retry_resp
+                        widened_organism = "taxid" not in cand
+                        break
 
             # Cap features per entry to avoid 25MB+ responses for heavily-annotated proteins
             if tool_name == "proteins_api_get_variants" and isinstance(data, list):
@@ -511,6 +547,12 @@ class ProteinsAPIRESTTool(BaseTool):
                 "data": data,
                 "url": response.url,
             }
+            if widened_organism:
+                response_data["note"] = (
+                    "No human matches found; the search was automatically "
+                    "widened to all organisms. Pass an explicit 'organism' "
+                    "(e.g. 'Klebsiella pneumoniae') or 'taxid' to scope it."
+                )
 
             if isinstance(data, list):
                 response_data["count"] = len(data)

--- a/tests/unit/test_proteins_api_organism_widening.py
+++ b/tests/unit/test_proteins_api_organism_widening.py
@@ -1,0 +1,84 @@
+"""proteins_api_search organism-widening fix (Feature-007B-1/2/3).
+
+A bare gene/protein-name search defaults to the human taxon (taxid=9606) so
+human hits rank first. That silently returned an empty success for non-human
+queries (e.g. bacterial ``blaKPC``). The tool now auto-widens to all organisms
+when the human-filtered search is empty, and surfaces an explanatory ``note``.
+Human queries (e.g. TP53) must keep their human-first behaviour unchanged.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool():
+    from tooluniverse.proteins_api_tool import ProteinsAPIRESTTool
+
+    return ProteinsAPIRESTTool(
+        {"name": "proteins_api_search", "type": "ProteinsAPIRESTTool", "fields": {}}
+    )
+
+
+def _resp(status_code, payload):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = payload
+    r.url = "https://www.ebi.ac.uk/proteins/api/proteins"
+    r.raise_for_status.return_value = None
+    return r
+
+
+class TestOrganismWidening(unittest.TestCase):
+    def test_bacterial_query_widens_when_human_empty(self):
+        """blaKPC: human-filtered call is empty, widened call returns hits."""
+        tool = _make_tool()
+        bacterial_hit = [{"accession": "Q9F663", "id": "BLKPC_KLEPN"}]
+        # Main call (gene=blaKPC&taxid=9606) and the human-kept protein retry are
+        # both empty (no human protein named blaKPC); the taxid-dropped retry hits.
+        tool.session.get = MagicMock(
+            side_effect=[_resp(200, []), _resp(200, []), _resp(200, bacterial_hit)]
+        )
+
+        result = tool.run({"query": "blaKPC", "size": 3})
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 1)
+        self.assertIn("note", result)
+        self.assertIn("widened", result["note"].lower())
+        self.assertGreaterEqual(tool.session.get.call_count, 2)
+
+    def test_human_query_stays_human_first_without_note(self):
+        """TP53: human call returns hits, so no widening and no note."""
+        tool = _make_tool()
+        human_hit = [{"accession": "P04637", "id": "P53_HUMAN"}]
+        tool.session.get = MagicMock(return_value=_resp(200, human_hit))
+
+        result = tool.run({"query": "TP53", "size": 2})
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["count"], 1)
+        self.assertNotIn("note", result)
+        # No empty result -> no retry needed.
+        self.assertEqual(tool.session.get.call_count, 1)
+
+    def test_explicit_organism_is_not_overridden(self):
+        """An explicit organism scopes the query and disables auto-widening."""
+        tool = _make_tool()
+        params = tool._build_params(
+            {"query": "blaKPC", "organism": "Klebsiella pneumoniae"}
+        )
+        self.assertEqual(params.get("organism"), "Klebsiella pneumoniae")
+        self.assertNotIn("taxid", params)  # human default not injected
+
+    def test_explicit_taxid_disables_human_default(self):
+        tool = _make_tool()
+        params = tool._build_params({"query": "blaKPC", "taxid": "573"})
+        self.assertEqual(params.get("taxid"), "573")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`proteins_api_search` defaults a bare gene/protein-name search to the human taxon (`taxid=9606`) so human hits rank first (Feature-69A-007). But that silently returned an **empty `status:success`** for any non-human query — e.g. bacterial `blaKPC`, `Klebsiella pneumoniae KPC carbapenemase` — so a researcher would wrongly conclude the protein doesn't exist.

Surfaced by a microbiology researcher-persona round (Feature-007B-1/2/3), then CLI-verified: the resolved URL carried `&taxid=9606` and returned `count:0`, while the same query without the human filter returns real hits (UniProt Q9F663, KPC-2 carbapenemase).

## Fix

- **`run()`**: when the human-filtered name search comes back empty, retry without the `taxid` filter (and swap `gene`↔`protein`) so non-human proteins surface. A `note` is added when the result was widened, telling the caller to pass an explicit organism to scope it.
- **schema**: expose `organism` and `taxid` parameters (already read by the code, previously undocumented) so callers can scope to a species directly.
- **tests**: added a `blaKPC` `test_example` for the weekly sweep + mocked unit tests in `tests/unit/test_proteins_api_organism_widening.py`.

## Preserved behaviour

Human queries like `TP53` keep human-first ordering — the human call runs first and only widens if empty, so they return human hits with **no** widening and **no** note. Verified live:

| query | before | after |
|---|---|---|
| `blaKPC` | `count:0` (silent) | `count:3` + widen note |
| `carbapenem-hydrolyzing beta-lactamase KPC` | `count:0` | `count:3` + note |
| `TP53` | human hits | human hits (unchanged) |
| `blaKPC` + `organism=Klebsiella pneumoniae` | n/a | scoped hits |

## Tests

- `tests/unit/test_proteins_api_organism_widening.py` — 4 passed (mocked, no live API)
- `scripts/test_new_tools.py proteins_api` — 21/21 passed, schema valid

This round's two researcher personas (oncology + microbiology) surfaced 7 candidate issues; the other 6 were CLI-verified as false positives (OncoKB demo `warning` field is present; DGIdb `data.data` nesting already fixed in #210) or out-of-scope cross-tool envelope variance.