### PR TITLE
Fix release-plugin.sh: drift-resilient versioning + tolerate absent manifests

### DIFF
--- a/scripts/release-plugin.sh
+++ b/scripts/release-plugin.sh
@@ -61,8 +61,24 @@ for arg in "$@"; do
     esac
 done
 
-CURRENT=$(python3 -c "import json; print(json.load(open('plugin/.claude-plugin/plugin.json'))['version'])")
-echo "Current version: $CURRENT"
+# Baseline = the highest of the manifest version and any existing vX.Y.Z git tag.
+# The plugin manifest can drift BEHIND the released tag line (e.g. PyPI-driven
+# releases bump pyproject/tags but not plugin.json). Computing a patch/minor
+# bump from a stale manifest would produce a version that collides with an
+# existing tag and make `git tag` fail, breaking the auto-release chain. Taking
+# the max keeps relative bumps monotonic regardless of manifest drift.
+CURRENT=$(python3 -c "
+import json, re, subprocess
+def parse(v):
+    m = re.match(r'^(\d+)\.(\d+)\.(\d+)$', v)
+    return tuple(int(x) for x in m.groups()) if m else (0, 0, 0)
+versions = [json.load(open('plugin/.claude-plugin/plugin.json'))['version']]
+tags = subprocess.run(['git', 'tag', '--list', 'v*'],
+                      capture_output=True, text=True).stdout.split()
+versions += [t[1:] for t in tags if re.match(r'^v\d+\.\d+\.\d+$', t)]
+print(max(versions, key=parse))
+")
+echo "Current version: $CURRENT  (max of plugin.json and existing v* tags)"
 
 case "$LEVEL" in
     patch|minor|major)
@@ -94,6 +110,11 @@ if [ "$NEW" = "$CURRENT" ]; then
     exit 1
 fi
 
+if git rev-parse -q --verify "refs/tags/v$NEW" >/dev/null; then
+    echo "Error: tag v$NEW already exists. Choose a higher version." >&2
+    exit 1
+fi
+
 echo "New version:     $NEW"
 echo "Tag will be:     v$NEW"
 echo
@@ -109,10 +130,12 @@ fi
 
 if [ "$DRY_RUN" -eq 1 ]; then
     echo
-    echo "(--dry-run) Would change:"
-    echo "  plugin/.claude-plugin/plugin.json         version: $CURRENT → $NEW"
-    echo "  plugin/.claude-plugin/marketplace.json    metadata.version: $CURRENT → $NEW"
-    echo "  .claude-plugin/marketplace.json           metadata.version: $CURRENT → $NEW"
+    echo "(--dry-run) Would change (absent manifests are skipped):"
+    for f in plugin/.claude-plugin/plugin.json \
+             plugin/.claude-plugin/marketplace.json \
+             .claude-plugin/marketplace.json; do
+        [ -f "$f" ] && echo "  $f   $CURRENT → $NEW" || echo "  $f   (absent, skipped)"
+    done
     echo "  Then commit \"Release v$NEW\", tag v$NEW, push to origin/$BRANCH"
     exit 0
 fi
@@ -127,6 +150,10 @@ files = [
 ]
 for path, field in files:
     p = pathlib.Path(path)
+    if not p.exists():
+        # Not all manifests exist in every layout; skip rather than crash.
+        print(f"  skip (absent) {path}")
+        continue
     data = json.loads(p.read_text())
     if field == "version":
         data["version"] = new
@@ -137,9 +164,11 @@ for path, field in files:
 EOF
 
 echo
-git add plugin/.claude-plugin/plugin.json \
-        plugin/.claude-plugin/marketplace.json \
-        .claude-plugin/marketplace.json
+for f in plugin/.claude-plugin/plugin.json \
+         plugin/.claude-plugin/marketplace.json \
+         .claude-plugin/marketplace.json; do
+    [ -f "$f" ] && git add "$f"
+done
 git commit -m "Release v$NEW"
 git tag -a "v$NEW" -m "v$NEW"
 echo


### PR DESCRIPTION
## Fix the auto-release chain (currently broken)

`scripts/release-plugin.sh` — invoked by `auto-release.yml` on `[release:*]` marker commits — cannot succeed in the current repo state, for two independent reasons:

1. **Tag collision from manifest drift.** Next version was computed only from `plugin/.claude-plugin/plugin.json`, which has drifted to `1.2.1` while tags/Releases are at `v1.2.3`. A `patch` bump would produce `1.2.2`, and `git tag v1.2.2` fails because that tag already exists.
2. **Crash on an absent manifest.** The script reads and `git add`s `plugin/.claude-plugin/marketplace.json`, which does not exist in the current layout → `FileNotFoundError` / pathspec error.

### Changes
- Baseline version = `max(plugin.json version, highest existing vX.Y.Z tag)`, so relative bumps stay monotonic regardless of manifest drift.
- Skip manifest files that don't exist (both in the bump step and `git add`) instead of crashing.
- Add an explicit "tag vX already exists" guard.
- `--dry-run` output now reflects which manifests are actually present.

### Verified
- `bash -n` clean.
- Baseline logic: manifest `1.2.1` + tags → correctly takes the max.
- `release-plugin.sh patch --dry-run` runs cleanly, marks the absent manifest as skipped, and computes a non-colliding next version.

No behavior change for a normal in-sync release; this only makes the script resilient to the drift/missing-file conditions that currently block it.
