### PR TITLE
Pin MCP server to released version so plugin upgrades also upgrade tooluniverse

### DIFF
--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "tooluniverse": {
       "command": "uvx",
-      "args": ["tooluniverse"],
+      "args": ["tooluniverse@1.2.4"],
       "env": {
         "PYTHONIOENCODING": "utf-8",
         "PYTORCH_MPS_HIGH_WATERMARK_RATIO": "0.0",

--- a/scripts/release-plugin.sh
+++ b/scripts/release-plugin.sh
@@ -136,6 +136,7 @@ if [ "$DRY_RUN" -eq 1 ]; then
              .claude-plugin/marketplace.json; do
         [ -f "$f" ] && echo "  $f   $CURRENT → $NEW" || echo "  $f   (absent, skipped)"
     done
+    [ -f plugin/.mcp.json ] && echo "  plugin/.mcp.json   pin tooluniverse@$NEW"
     echo "  Then commit \"Release v$NEW\", tag v$NEW, push to origin/$BRANCH"
     exit 0
 fi
@@ -161,12 +162,32 @@ for path, field in files:
         data.setdefault("metadata", {})["version"] = new
     p.write_text(json.dumps(data, indent=2) + "\n")
     print(f"  bumped {path}")
+
+# Pin the bundled MCP server to the released pip version. .mcp.json launches
+# 'uvx tooluniverse'; without a version pin uvx reuses a cached/older env, so a
+# plugin auto-update would NOT pull the matching tooluniverse from PyPI. Writing
+# the version here keeps plugin and pip package in lockstep on every release.
+mcp = pathlib.Path("plugin/.mcp.json")
+if mcp.exists():
+    m = json.loads(mcp.read_text())
+    args = m.get("mcpServers", {}).get("tooluniverse", {}).get("args", [])
+    pinned = False
+    for i, a in enumerate(args):
+        if isinstance(a, str) and a.split("@", 1)[0] == "tooluniverse":
+            args[i] = f"tooluniverse@{new}"
+            pinned = True
+    if pinned:
+        mcp.write_text(json.dumps(m, indent=2) + "\n")
+        print(f"  pinned plugin/.mcp.json -> tooluniverse@{new}")
+    else:
+        print("  warn: no 'tooluniverse' arg found in plugin/.mcp.json to pin")
 EOF
 
 echo
 for f in plugin/.claude-plugin/plugin.json \
          plugin/.claude-plugin/marketplace.json \
-         .claude-plugin/marketplace.json; do
+         .claude-plugin/marketplace.json \
+         plugin/.mcp.json; do
     [ -f "$f" ] && git add "$f"
 done
 git commit -m "Release v$NEW"


### PR DESCRIPTION
## Make a plugin upgrade also upgrade the `tooluniverse` pip package

### Problem
`plugin/.mcp.json` launches the MCP server with `uvx tooluniverse` — no version, no `--refresh`. `uvx` reuses its cached resolved environment, so it never picks up newer PyPI releases (it kept running an old 1.1.2 locally). The file is also byte-identical across plugin versions, so bumping the plugin (e.g. 1.2.1 → 1.2.4) does nothing to the MCP launch command. Result: the Claude Code plugin and the `tooluniverse` pip package were fully decoupled — a plugin auto-update did **not** upgrade tooluniverse. (No hook did it either; the only SessionStart hook just cleans up legacy skills.)

### Fix
- **Pin** `plugin/.mcp.json` to the released version: `uvx tooluniverse@1.2.4`. uvx fetches that exact version, so when the plugin auto-updates to a new version that ships a new pin, uvx pulls the matching tooluniverse.
- **Keep it in lockstep**: `scripts/release-plugin.sh` now rewrites the `tooluniverse@X.Y.Z` pin in `.mcp.json` on every bump (alongside the manifests) and stages it. So every release keeps plugin ↔ pip in sync automatically.

### Tested
- `bash -n` clean; `.mcp.json` valid JSON with `args: ["tooluniverse@1.2.4"]`.
- End-to-end: `release-plugin.sh 1.2.5 --no-push` bumped `plugin.json`, `marketplace.json`, **and** pinned `.mcp.json → tooluniverse@1.2.5` in one shot (then reverted).
- Runtime: a version-pinned `uvx` resolves to the pinned version (vs. bare `uvx tooluniverse` reusing the stale cache).
