### PR TITLE
Add uv preflight check + document uv prerequisite (foolproof onboarding)

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -2,6 +2,17 @@
 
 1000+ scientific research tools for biology, chemistry, medicine, and data science.
 
+## Prerequisite: `uv`
+
+The MCP server is launched with `uvx`, so **[uv](https://docs.astral.sh/uv/) must be installed**. If it isn't, the `tooluniverse` MCP server cannot start and its tools won't appear (the plugin prints a one-line reminder on startup).
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh   # macOS/Linux
+# Windows: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+Then restart Claude Code. (No separate `tooluniverse` install needed — `uvx` fetches it on first use.)
+
 ## Install
 
 ```bash

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -6,6 +6,10 @@
           {
             "type": "command",
             "command": "if [ ! -f ~/.claude/.tooluniverse-plugin-cleanup-done ] && ls ~/.claude/skills/tooluniverse-* 1>/dev/null 2>&1; then rm -rf ~/.claude/skills/tooluniverse-* ~/.claude/skills/create-tooluniverse-skill ~/.claude/skills/setup-tooluniverse 2>/dev/null; touch ~/.claude/.tooluniverse-plugin-cleanup-done; echo 'ToolUniverse plugin: cleaned up legacy global skills (one-time, replaced by plugin)'; fi"
+          },
+          {
+            "type": "command",
+            "command": "command -v uvx >/dev/null 2>&1 || echo 'ToolUniverse: uv/uvx was not found, so the tooluniverse MCP server cannot start and its tools will be unavailable. Install uv with:  curl -LsSf https://astral.sh/uv/install.sh | sh   then restart Claude Code. Docs: https://docs.astral.sh/uv/getting-started/installation/'"
           }
         ]
       }


### PR DESCRIPTION
## Make the uv prerequisite foolproof

The bundled `.mcp.json` launches the MCP server with `uvx tooluniverse`. If a user installs the plugin but doesn't have **uv** on their machine, `uvx` is not found → the `tooluniverse` MCP server silently fails to start → none of the tools appear, with no hint about the cause. There was no preflight and the README didn't flag uv as a prerequisite.

### Changes
- **SessionStart hook**: `command -v uvx >/dev/null 2>&1 || echo '<install hint>'`. Prints a one-line install instruction **only when uvx is missing**. When uv is present it produces no output and makes no network call; it always exits 0 (failure-silent, never blocks the session).
- **README**: a `Prerequisite: uv` section with the install command (macOS/Linux + Windows).

### Tested
- `hooks.json` valid JSON (2 SessionStart hooks).
- uv present → hook silent, exit 0.
- uv absent (simulated via stripped PATH) → prints the install hint, exit 0.

Targets the most likely naive-user failure; does not touch versioning/`.mcp.json` resolution (uvx already auto-resolves to the latest published tooluniverse for normal users).
