### PR TITLE
Fix: sync mcpb bundle version to 1.2.4 (main CI is red)

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "tooluniverse",
     "display_name": "ToolUniverse",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "description": "ToolUniverse: an ecosystem for democratizing AI scientists with 2000+ scientific tools.",
     "long_description": "ToolUniverse is an ecosystem for creating AI scientist systems from any large language model (LLM). It standardizes how LLMs interact with tools, integrating thousands of machine learning models, datasets, APIs, and scientific packages for data analysis, knowledge retrieval, and experimental design. This bundle exposes ToolUniverse capability via the Model Context Protocol (MCP), enabling AI assistants to perform complex scientific tasks.",
     "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooluniverse-mcpb-native"
-version = "1.2.3"
+version = "1.2.4"
 description = "ToolUniverse MCP Server (Native MCPB bundle)"
 requires-python = ">=3.10,<3.14"
 


### PR DESCRIPTION
## Unblock CI on main

`tests/unit/test_mcpb_bundle.py::test_mcpb_version_tracks_root_pyproject` is failing on `main`: the v1.2.4 unified release (#220) bumped root `pyproject.toml`, `server.json`, and the plugin manifests but missed the MCPB bundle, leaving `mcpb/manifest.json` and `mcpb/pyproject.toml` at 1.2.3. The test enforces parity, so **every PR branched from main inherits the failure** (that's why #230 and #232 both show 'test failed').

Bumps both mcpb files to 1.2.4. Verified locally: `pytest tests/unit/test_mcpb_bundle.py` → 7 passed.

Merge this first; then #230/#232 just need a rebase to go green. Note for future releases: whatever bumps root `pyproject.toml` must also bump `mcpb/manifest.json` + `mcpb/pyproject.toml` (this test guards it).