### PR TITLE
Add dose-response curve-fitting skill (IC50/EC50/potency)

### DIFF
--- a/plugin/skills/tooluniverse-dose-response/SKILL.md
+++ b/plugin/skills/tooluniverse-dose-response/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: tooluniverse-dose-response
+description: Dose-response / concentration-response curve fitting — IC50, EC50, Hill slope, Emax/Emin efficacy, and relative potency from paired concentration vs response data (enzyme/cell assays, drug screening, agonist/antagonist pharmacology). Fits the 4-parameter logistic (Hill sigmoidal) model. Use when you have concentrations + responses and need a potency value, to compare two compounds' potency, or to judge curve quality. NOT for image-derived dose-response (use tooluniverse-image-analysis) and NOT for survival/regression (use tooluniverse-statistical-modeling).
+disable-model-invocation: true
+---
+
+# Dose-Response / Concentration-Response Analysis
+
+Turn paired **concentration vs response** measurements into a potency (IC50/EC50), a Hill slope, an efficacy (Emax), and a quality judgment — and compare potency between compounds.
+
+## When to use this
+
+- Enzyme inhibition / activation assays, cell viability, reporter assays, radioligand binding, agonist/antagonist pharmacology.
+- You have a list of concentrations and the response at each, and want IC50/EC50 + Hill slope.
+- You want to say "compound A is N-fold more potent than B."
+
+The model is the 4-parameter logistic (4PL) / Hill sigmoidal:
+`f(x) = Emin + (Emax − Emin) / (1 + (EC50/x)^n)` — where `n` is the Hill slope.
+
+## Step 1 — Prepare the data (where results go wrong)
+
+| Issue | What to do |
+|---|---|
+| **Concentration units** | Pick ONE unit (µM, nM, M) and use it for every point. The IC50 comes back in that unit. Don't mix. |
+| **Log vs linear concentrations** | Pass concentrations on the **linear** scale (e.g. `0.01, 0.1, 1, 10`), not log10. The fitter logs internally. |
+| **Zero/control concentration** | Drop a literal `0` concentration (log(0) is undefined). Keep it only as the Emin/Emax reference if normalizing. |
+| **Direction** | Inhibition curves go high→low (IC50); activation curves go low→high (EC50). The tools handle both; just be consistent. |
+| **Normalization** | Convert raw signal to % of control if you want Emax/Emin near 100/0: `% = 100 × (raw − blank)/(control − blank)`. Raw values also fit, but plateaus are then in raw units. |
+| **Replicates** | Average technical replicates per concentration before fitting, or pass all points (the fit weights them equally). |
+
+**Coverage requirement:** you need **≥4 points** (the tools require it) and ideally **6–8 spanning both plateaus** — points clearly above and clearly below the inflection. A curve that never plateaus gives an unreliable, extrapolated IC50 (see Step 4).
+
+## Step 2 — Fit / get the potency
+
+Single curve → IC50 or EC50 (same math; "IC50" for inhibition, "EC50" for activation):
+
+```bash
+tu run DoseResponse_calculate_ic50 '{"operation":"calculate_ic50",
+  "concentrations":[0.001,0.01,0.1,1,10,100],
+  "responses":[98,95,80,45,12,3]}'
+```
+
+Returns `ic50`, `ic50_95_confidence_interval`, `hill_slope`, `emax`, `emin`, `r_squared`, `log_ic50`.
+
+Full 4PL parameters only → `DoseResponse_fit_curve` (same inputs). Two compounds → `DoseResponse_compare_potency` with `conc_a/resp_a/conc_b/resp_b` (returns each IC50 + `ic50_fold_shift_b_over_a` + `more_potent`).
+
+For non-standard needs (constrained plateaus, weighting, plotting), `scripts/fit_dose_response.py` runs a scipy 4PL fit from a CSV and matches the tool.
+
+## Step 3 — Interpret the four parameters
+
+| Parameter | Meaning | Sanity check |
+|---|---|---|
+| **IC50 / EC50** | Concentration giving half-maximal effect — the potency. Lower = more potent. | Should fall *within* your tested range; if it's at/beyond an endpoint, the curve is incomplete (Step 4). |
+| **Hill slope `n`** | Steepness / apparent cooperativity. ~1 = simple one-site. >1.5 = steep/positive cooperativity (or non-specific). <0.5 = shallow/multiple sites or heterogeneity. | A wildly large `|n|` (>4) usually means a bad fit or too few transition points, not real cooperativity. |
+| **Emax** | Maximal response (top plateau) = efficacy. | For % data, full agonist ≈100; a **partial agonist** plateaus well below 100 even at saturating dose. |
+| **Emin** | Bottom plateau (baseline/floor). | For % inhibition data, ≈0 for a complete inhibitor. |
+| **r²** | Fit quality. | ≥0.95 good; <0.90 → inspect for outliers, wrong model, or incomplete curve before trusting the IC50. |
+
+**Potency comparison:** report the **fold-shift** in IC50/EC50 (e.g. "A is 6.2× more potent than B"), and only call it meaningful if both fits are good (r²≥0.95) and the Hill slopes are comparable — a potency ratio between curves of very different slope is not a clean comparison.
+
+## Step 4 — Quality gotchas (state these, don't hide them)
+
+- **Incomplete curve / no plateau.** If responses don't flatten at both ends, Emax/Emin (and thus IC50) are extrapolated and unstable. Report the IC50 as "approximate / right-shifted of the tested range" and recommend wider concentrations.
+- **<4–5 points or none near the inflection.** The fit can converge to a nonsense IC50 with a high r². Check that points actually bracket the IC50.
+- **Biphasic / U-shaped data.** A single 4PL is wrong for hormesis or two-site behavior — the fit will look poor (low r²); flag it rather than forcing one IC50.
+- **IC50 vs Ki.** IC50 depends on assay conditions (substrate/ligand concentration). Don't report IC50 as an affinity (Ki) without a Cheng-Prusoff correction.
+- **Units.** The IC50 is only as correct as the concentration unit you fed in — always state the unit.
+
+## Honest limitations
+
+- 4PL assumes a monotonic sigmoid; it cannot describe biphasic, bell-shaped, or steep all-or-none responses.
+- A confident IC50 from a poor or incomplete curve is the most common error — let r² and curve coverage gate how you report it.
+- Potency (IC50/EC50) is not efficacy (Emax) — a more potent compound can be a weaker (partial) agonist; report both.
+
+## Related skills
+- `tooluniverse-image-analysis` — dose-response on image-derived measurements (.tif, colony, fluorescence).
+- `tooluniverse-gpcr-structural-pharmacology` / `tooluniverse-network-pharmacology` — receptor pharmacology context.
+- `tooluniverse-statistical-modeling` — general regression, EC50 via spline, power analysis.

--- a/plugin/skills/tooluniverse-dose-response/scripts/fit_dose_response.py
+++ b/plugin/skills/tooluniverse-dose-response/scripts/fit_dose_response.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""4-parameter logistic (Hill) dose-response fit for the
+tooluniverse-dose-response skill.
+
+Reads a CSV of concentration,response[,replicate columns], fits the 4PL model
+  f(x) = Emin + (Emax - Emin) / (1 + (EC50/x)^n)
+and reports IC50/EC50, Hill slope, Emax, Emin, r^2, and a 95% CI on the IC50.
+Matches DoseResponse_calculate_ic50; use this when you need normalization,
+replicate averaging, or a text curve that the tool doesn't provide.
+
+CSV columns: concentration, response   (one row per measurement; replicates at
+the same concentration are averaged). Optionally --normalize with a control and
+blank to convert raw signal to % response.
+
+Usage:
+  python fit_dose_response.py --input data.csv
+  python fit_dose_response.py --input raw.csv --normalize --control 12000 --blank 200
+"""
+
+import argparse
+import csv
+import math
+
+import numpy as np
+from scipy.optimize import curve_fit
+
+
+def hill_4pl(x, emin, emax, ec50, n):
+    return emin + (emax - emin) / (1 + (ec50 / x) ** n)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True, help="CSV: concentration,response")
+    ap.add_argument("--normalize", action="store_true", help="convert raw signal to % of control")
+    ap.add_argument("--control", type=float, help="raw signal of the 100% control (with --normalize)")
+    ap.add_argument("--blank", type=float, default=0.0, help="raw blank/background (with --normalize)")
+    args = ap.parse_args()
+
+    pairs = {}
+    with open(args.input, newline="") as fh:
+        for row in csv.DictReader(fh):
+            try:
+                c = float(row["concentration"])
+                r = float(row["response"])
+            except (KeyError, ValueError):
+                continue
+            if c <= 0:  # log(0) undefined; drop zero-concentration rows
+                continue
+            pairs.setdefault(c, []).append(r)
+
+    if len(pairs) < 4:
+        raise SystemExit("Need >=4 distinct positive concentrations to fit a 4PL curve.")
+
+    conc = np.array(sorted(pairs))
+    resp = np.array([float(np.mean(pairs[c])) for c in conc])
+    if args.normalize:
+        if args.control is None:
+            raise SystemExit("--normalize requires --control (raw 100% signal).")
+        resp = 100.0 * (resp - args.blank) / (args.control - args.blank)
+
+    # Initial guesses: plateaus from the data, EC50 at the geometric midpoint.
+    p0 = [float(resp.min()), float(resp.max()), float(np.exp(np.mean(np.log(conc)))), 1.0]
+    popt, pcov = curve_fit(hill_4pl, conc, resp, p0=p0, maxfev=20000)
+    emin, emax, ec50, n = popt
+    perr = np.sqrt(np.diag(pcov))
+    ci = (ec50 - 1.96 * perr[2], ec50 + 1.96 * perr[2])
+
+    pred = hill_4pl(conc, *popt)
+    ss_res = float(np.sum((resp - pred) ** 2))
+    ss_tot = float(np.sum((resp - resp.mean()) ** 2))
+    r2 = 1 - ss_res / ss_tot if ss_tot else float("nan")
+
+    print(f"\n4PL dose-response fit ({len(conc)} concentrations)\n")
+    print(f"{'Conc':>12}{'Response':>12}{'Fitted':>12}")
+    for c, ro, pr in zip(conc, resp, pred):
+        print(f"{c:>12g}{ro:>12.2f}{pr:>12.2f}")
+    print("-" * 36)
+    # Report plateaus by position (top/bottom) so labels are unambiguous for
+    # both inhibition (high->low) and activation (low->high) curves.
+    top, bottom = max(emin, emax), min(emin, emax)
+    print(f"IC50/EC50 = {ec50:.4g}   95% CI [{ci[0]:.4g}, {ci[1]:.4g}]  (concentration units of the input)")
+    print(f"Hill slope |n| = {abs(n):.3f}   top plateau = {top:.2f}   bottom plateau = {bottom:.2f}   r^2 = {r2:.4f}")
+
+    # Quality gates the skill asks us to surface.
+    if not (conc.min() <= ec50 <= conc.max()):
+        print("  ! IC50 falls OUTSIDE the tested range — curve is incomplete; widen concentrations.")
+    if r2 < 0.90:
+        print("  ! r^2 < 0.90 — poor fit; check for outliers, biphasic data, or wrong model.")
+    if abs(n) > 4:
+        print(f"  ! |Hill slope|={abs(n):.1f} is very steep — usually too few transition points, not real cooperativity.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugin/skills/tooluniverse/SKILL.md
+++ b/plugin/skills/tooluniverse/SKILL.md
@@ -192,6 +192,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**clinical data integration**", "clinical phenotype", "EHR analysis", "clinical cohort" | `Skill(skill="tooluniverse-clinical-data-integration")` |
 | "**phylogenetics**", "phylogenetic tree", "sequence alignment", "evolutionary analysis", "treeness", "saturation", "parsimony", "PhyKIT", "DVMC", "long branch", "tree length", "MAFFT", "gap percentage" | `Skill(skill="tooluniverse-phylogenetics")` |
 | "**statistical modeling**", "regression analysis", "logistic regression", "survival analysis", "Cox", "ANOVA", "F-statistic", "chi-square", "spline", "odds ratio", "Cohen's d", "p-value", "clinical trial data", "**ordinal**", "**severity**", "**vaccination**", "SDTM", "DM.csv", "AE.csv", "adverse event severity" | `Skill(skill="tooluniverse-statistical-modeling")` |
+| "**dose-response**", "concentration-response", "IC50", "EC50", "Hill slope", "potency", "4-parameter logistic", "4PL", "sigmoidal fit", "Emax", "relative potency", "fold-shift", "drug screening curve" | `Skill(skill="tooluniverse-dose-response")` |
 | "**metabolomics analysis**", "LC-MS analysis", "metabolite quantification", "metabolic flux" | `Skill(skill="tooluniverse-metabolomics-analysis")` |
 | "**functional genomics screen**", "CRISPR library", "shRNA screen", "barcode screen" | `Skill(skill="tooluniverse-functional-genomics-screens")` |
 | "**proteomics data**", "PRIDE", "MassIVE", "ProteomeXchange", "proteomics dataset" | `Skill(skill="tooluniverse-proteomics-data-retrieval")` |

--- a/skills/tooluniverse-dose-response/SKILL.md
+++ b/skills/tooluniverse-dose-response/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: tooluniverse-dose-response
+description: Dose-response / concentration-response curve fitting — IC50, EC50, Hill slope, Emax/Emin efficacy, and relative potency from paired concentration vs response data (enzyme/cell assays, drug screening, agonist/antagonist pharmacology). Fits the 4-parameter logistic (Hill sigmoidal) model. Use when you have concentrations + responses and need a potency value, to compare two compounds' potency, or to judge curve quality. NOT for image-derived dose-response (use tooluniverse-image-analysis) and NOT for survival/regression (use tooluniverse-statistical-modeling).
+disable-model-invocation: true
+---
+
+# Dose-Response / Concentration-Response Analysis
+
+Turn paired **concentration vs response** measurements into a potency (IC50/EC50), a Hill slope, an efficacy (Emax), and a quality judgment — and compare potency between compounds.
+
+## When to use this
+
+- Enzyme inhibition / activation assays, cell viability, reporter assays, radioligand binding, agonist/antagonist pharmacology.
+- You have a list of concentrations and the response at each, and want IC50/EC50 + Hill slope.
+- You want to say "compound A is N-fold more potent than B."
+
+The model is the 4-parameter logistic (4PL) / Hill sigmoidal:
+`f(x) = Emin + (Emax − Emin) / (1 + (EC50/x)^n)` — where `n` is the Hill slope.
+
+## Step 1 — Prepare the data (where results go wrong)
+
+| Issue | What to do |
+|---|---|
+| **Concentration units** | Pick ONE unit (µM, nM, M) and use it for every point. The IC50 comes back in that unit. Don't mix. |
+| **Log vs linear concentrations** | Pass concentrations on the **linear** scale (e.g. `0.01, 0.1, 1, 10`), not log10. The fitter logs internally. |
+| **Zero/control concentration** | Drop a literal `0` concentration (log(0) is undefined). Keep it only as the Emin/Emax reference if normalizing. |
+| **Direction** | Inhibition curves go high→low (IC50); activation curves go low→high (EC50). The tools handle both; just be consistent. |
+| **Normalization** | Convert raw signal to % of control if you want Emax/Emin near 100/0: `% = 100 × (raw − blank)/(control − blank)`. Raw values also fit, but plateaus are then in raw units. |
+| **Replicates** | Average technical replicates per concentration before fitting, or pass all points (the fit weights them equally). |
+
+**Coverage requirement:** you need **≥4 points** (the tools require it) and ideally **6–8 spanning both plateaus** — points clearly above and clearly below the inflection. A curve that never plateaus gives an unreliable, extrapolated IC50 (see Step 4).
+
+## Step 2 — Fit / get the potency
+
+Single curve → IC50 or EC50 (same math; "IC50" for inhibition, "EC50" for activation):
+
+```bash
+tu run DoseResponse_calculate_ic50 '{"operation":"calculate_ic50",
+  "concentrations":[0.001,0.01,0.1,1,10,100],
+  "responses":[98,95,80,45,12,3]}'
+```
+
+Returns `ic50`, `ic50_95_confidence_interval`, `hill_slope`, `emax`, `emin`, `r_squared`, `log_ic50`.
+
+Full 4PL parameters only → `DoseResponse_fit_curve` (same inputs). Two compounds → `DoseResponse_compare_potency` with `conc_a/resp_a/conc_b/resp_b` (returns each IC50 + `ic50_fold_shift_b_over_a` + `more_potent`).
+
+For non-standard needs (constrained plateaus, weighting, plotting), `scripts/fit_dose_response.py` runs a scipy 4PL fit from a CSV and matches the tool.
+
+## Step 3 — Interpret the four parameters
+
+| Parameter | Meaning | Sanity check |
+|---|---|---|
+| **IC50 / EC50** | Concentration giving half-maximal effect — the potency. Lower = more potent. | Should fall *within* your tested range; if it's at/beyond an endpoint, the curve is incomplete (Step 4). |
+| **Hill slope `n`** | Steepness / apparent cooperativity. ~1 = simple one-site. >1.5 = steep/positive cooperativity (or non-specific). <0.5 = shallow/multiple sites or heterogeneity. | A wildly large `|n|` (>4) usually means a bad fit or too few transition points, not real cooperativity. |
+| **Emax** | Maximal response (top plateau) = efficacy. | For % data, full agonist ≈100; a **partial agonist** plateaus well below 100 even at saturating dose. |
+| **Emin** | Bottom plateau (baseline/floor). | For % inhibition data, ≈0 for a complete inhibitor. |
+| **r²** | Fit quality. | ≥0.95 good; <0.90 → inspect for outliers, wrong model, or incomplete curve before trusting the IC50. |
+
+**Potency comparison:** report the **fold-shift** in IC50/EC50 (e.g. "A is 6.2× more potent than B"), and only call it meaningful if both fits are good (r²≥0.95) and the Hill slopes are comparable — a potency ratio between curves of very different slope is not a clean comparison.
+
+## Step 4 — Quality gotchas (state these, don't hide them)
+
+- **Incomplete curve / no plateau.** If responses don't flatten at both ends, Emax/Emin (and thus IC50) are extrapolated and unstable. Report the IC50 as "approximate / right-shifted of the tested range" and recommend wider concentrations.
+- **<4–5 points or none near the inflection.** The fit can converge to a nonsense IC50 with a high r². Check that points actually bracket the IC50.
+- **Biphasic / U-shaped data.** A single 4PL is wrong for hormesis or two-site behavior — the fit will look poor (low r²); flag it rather than forcing one IC50.
+- **IC50 vs Ki.** IC50 depends on assay conditions (substrate/ligand concentration). Don't report IC50 as an affinity (Ki) without a Cheng-Prusoff correction.
+- **Units.** The IC50 is only as correct as the concentration unit you fed in — always state the unit.
+
+## Honest limitations
+
+- 4PL assumes a monotonic sigmoid; it cannot describe biphasic, bell-shaped, or steep all-or-none responses.
+- A confident IC50 from a poor or incomplete curve is the most common error — let r² and curve coverage gate how you report it.
+- Potency (IC50/EC50) is not efficacy (Emax) — a more potent compound can be a weaker (partial) agonist; report both.
+
+## Related skills
+- `tooluniverse-image-analysis` — dose-response on image-derived measurements (.tif, colony, fluorescence).
+- `tooluniverse-gpcr-structural-pharmacology` / `tooluniverse-network-pharmacology` — receptor pharmacology context.
+- `tooluniverse-statistical-modeling` — general regression, EC50 via spline, power analysis.

--- a/skills/tooluniverse-dose-response/scripts/fit_dose_response.py
+++ b/skills/tooluniverse-dose-response/scripts/fit_dose_response.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""4-parameter logistic (Hill) dose-response fit for the
+tooluniverse-dose-response skill.
+
+Reads a CSV of concentration,response[,replicate columns], fits the 4PL model
+  f(x) = Emin + (Emax - Emin) / (1 + (EC50/x)^n)
+and reports IC50/EC50, Hill slope, Emax, Emin, r^2, and a 95% CI on the IC50.
+Matches DoseResponse_calculate_ic50; use this when you need normalization,
+replicate averaging, or a text curve that the tool doesn't provide.
+
+CSV columns: concentration, response   (one row per measurement; replicates at
+the same concentration are averaged). Optionally --normalize with a control and
+blank to convert raw signal to % response.
+
+Usage:
+  python fit_dose_response.py --input data.csv
+  python fit_dose_response.py --input raw.csv --normalize --control 12000 --blank 200
+"""
+
+import argparse
+import csv
+import math
+
+import numpy as np
+from scipy.optimize import curve_fit
+
+
+def hill_4pl(x, emin, emax, ec50, n):
+    return emin + (emax - emin) / (1 + (ec50 / x) ** n)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True, help="CSV: concentration,response")
+    ap.add_argument("--normalize", action="store_true", help="convert raw signal to % of control")
+    ap.add_argument("--control", type=float, help="raw signal of the 100% control (with --normalize)")
+    ap.add_argument("--blank", type=float, default=0.0, help="raw blank/background (with --normalize)")
+    args = ap.parse_args()
+
+    pairs = {}
+    with open(args.input, newline="") as fh:
+        for row in csv.DictReader(fh):
+            try:
+                c = float(row["concentration"])
+                r = float(row["response"])
+            except (KeyError, ValueError):
+                continue
+            if c <= 0:  # log(0) undefined; drop zero-concentration rows
+                continue
+            pairs.setdefault(c, []).append(r)
+
+    if len(pairs) < 4:
+        raise SystemExit("Need >=4 distinct positive concentrations to fit a 4PL curve.")
+
+    conc = np.array(sorted(pairs))
+    resp = np.array([float(np.mean(pairs[c])) for c in conc])
+    if args.normalize:
+        if args.control is None:
+            raise SystemExit("--normalize requires --control (raw 100% signal).")
+        resp = 100.0 * (resp - args.blank) / (args.control - args.blank)
+
+    # Initial guesses: plateaus from the data, EC50 at the geometric midpoint.
+    p0 = [float(resp.min()), float(resp.max()), float(np.exp(np.mean(np.log(conc)))), 1.0]
+    popt, pcov = curve_fit(hill_4pl, conc, resp, p0=p0, maxfev=20000)
+    emin, emax, ec50, n = popt
+    perr = np.sqrt(np.diag(pcov))
+    ci = (ec50 - 1.96 * perr[2], ec50 + 1.96 * perr[2])
+
+    pred = hill_4pl(conc, *popt)
+    ss_res = float(np.sum((resp - pred) ** 2))
+    ss_tot = float(np.sum((resp - resp.mean()) ** 2))
+    r2 = 1 - ss_res / ss_tot if ss_tot else float("nan")
+
+    print(f"\n4PL dose-response fit ({len(conc)} concentrations)\n")
+    print(f"{'Conc':>12}{'Response':>12}{'Fitted':>12}")
+    for c, ro, pr in zip(conc, resp, pred):
+        print(f"{c:>12g}{ro:>12.2f}{pr:>12.2f}")
+    print("-" * 36)
+    # Report plateaus by position (top/bottom) so labels are unambiguous for
+    # both inhibition (high->low) and activation (low->high) curves.
+    top, bottom = max(emin, emax), min(emin, emax)
+    print(f"IC50/EC50 = {ec50:.4g}   95% CI [{ci[0]:.4g}, {ci[1]:.4g}]  (concentration units of the input)")
+    print(f"Hill slope |n| = {abs(n):.3f}   top plateau = {top:.2f}   bottom plateau = {bottom:.2f}   r^2 = {r2:.4f}")
+
+    # Quality gates the skill asks us to surface.
+    if not (conc.min() <= ec50 <= conc.max()):
+        print("  ! IC50 falls OUTSIDE the tested range — curve is incomplete; widen concentrations.")
+    if r2 < 0.90:
+        print("  ! r^2 < 0.90 — poor fit; check for outliers, biphasic data, or wrong model.")
+    if abs(n) > 4:
+        print(f"  ! |Hill slope|={abs(n):.1f} is very steep — usually too few transition points, not real cooperativity.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tooluniverse-dose-response/test_fit_dose_response.py
+++ b/skills/tooluniverse-dose-response/test_fit_dose_response.py
@@ -1,0 +1,34 @@
+"""Tests for the dose-response skill helper script (4PL Hill fit)."""
+
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent / "scripts"))
+import fit_dose_response as dr  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_hill_4pl_endpoints():
+    # f(x) = emin + (emax-emin)/(1+(ec50/x)^n); x->0 -> emin, x->inf -> emax
+    assert dr.hill_4pl(1e-9, 0.0, 100.0, 1.0, 1.0) == pytest.approx(0.0, abs=1e-3)
+    assert dr.hill_4pl(1e9, 0.0, 100.0, 1.0, 1.0) == pytest.approx(100.0, abs=1e-3)
+
+
+def test_hill_4pl_at_ec50_is_midpoint():
+    # at x = ec50, response is halfway between emin and emax
+    assert dr.hill_4pl(5.0, 0.0, 100.0, 5.0, 1.5) == pytest.approx(50.0, rel=1e-6)
+
+
+def test_fit_recovers_known_ic50(tmp_path):
+    # generate a clean inhibition curve with EC50=1, then fit it back
+    from scipy.optimize import curve_fit
+
+    conc = np.array([0.01, 0.1, 1, 10, 100], dtype=float)
+    true = (5.0, 95.0, 1.0, 1.0)  # emin, emax, ec50, n
+    resp = dr.hill_4pl(conc, *true)
+    popt, _ = curve_fit(dr.hill_4pl, conc, resp, p0=[0, 100, 0.5, 1], maxfev=20000)
+    assert popt[2] == pytest.approx(1.0, rel=1e-3)  # EC50 recovered

--- a/skills/tooluniverse/SKILL.md
+++ b/skills/tooluniverse/SKILL.md
@@ -192,6 +192,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**clinical data integration**", "clinical phenotype", "EHR analysis", "clinical cohort" | `Skill(skill="tooluniverse-clinical-data-integration")` |
 | "**phylogenetics**", "phylogenetic tree", "sequence alignment", "evolutionary analysis", "treeness", "saturation", "parsimony", "PhyKIT", "DVMC", "long branch", "tree length", "MAFFT", "gap percentage" | `Skill(skill="tooluniverse-phylogenetics")` |
 | "**statistical modeling**", "regression analysis", "logistic regression", "survival analysis", "Cox", "ANOVA", "F-statistic", "chi-square", "spline", "odds ratio", "Cohen's d", "p-value", "clinical trial data", "**ordinal**", "**severity**", "**vaccination**", "SDTM", "DM.csv", "AE.csv", "adverse event severity" | `Skill(skill="tooluniverse-statistical-modeling")` |
+| "**dose-response**", "concentration-response", "IC50", "EC50", "Hill slope", "potency", "4-parameter logistic", "4PL", "sigmoidal fit", "Emax", "relative potency", "fold-shift", "drug screening curve" | `Skill(skill="tooluniverse-dose-response")` |
 | "**metabolomics analysis**", "LC-MS analysis", "metabolite quantification", "metabolic flux" | `Skill(skill="tooluniverse-metabolomics-analysis")` |
 | "**functional genomics screen**", "CRISPR library", "shRNA screen", "barcode screen" | `Skill(skill="tooluniverse-functional-genomics-screens")` |
 | "**proteomics data**", "PRIDE", "MassIVE", "ProteomeXchange", "proteomics dataset" | `Skill(skill="tooluniverse-proteomics-data-retrieval")` |


### PR DESCRIPTION
Discovery harness — **task-gap** (Sub-loop B).

## Gap

Three `DoseResponse_*` tools exist (`fit_curve`, `calculate_ic50`, `compare_potency` — 4-parameter logistic / Hill model) but **no skill** taught the workflow. "IC50" appeared only inside domain skills (computational-biophysics, gpcr-structural-pharmacology), and `image-analysis` covers only image-**derived** dose-response — assay concentration-response had no home.

## Skill

`tooluniverse-dose-response` focuses on what people get wrong:

- **Data-prep table**: consistent concentration units, **linear** (not log) input, dropping zero-concentration rows, curve direction, raw→% normalization, replicate handling, and the **≥4–6 points spanning both plateaus** coverage requirement.
- **Tool orchestration**: `calculate_ic50` / `fit_curve` / `compare_potency`.
- **Interpretation table** for the four 4PL parameters (IC50/EC50, Hill slope = cooperativity, Emax = efficacy incl. partial agonism, r²) with sanity checks.
- **Quality gotchas**: incomplete/no-plateau curves, too few transition points, biphasic/hormetic data, IC50≠Ki (Cheng-Prusoff), units.
- **`scripts/fit_dose_response.py`**: scipy 4PL fit from a CSV with optional normalization + replicate averaging; reports plateaus by position and flags out-of-range IC50 / low r² / implausibly steep slopes.

## Validation

- The script **cross-validates exactly** against `DoseResponse_calculate_ic50`: IC50 **0.7624**, Hill slope 0.736, r²=0.9998 on a shared 6-point inhibition curve.
- `compare_potency` verified (6.23× fold-shift, correct more-potent verdict).
- Routing rows added to the router (both `skills/` + `plugin/skills/` mirrors), scoped to concentration-response/IC50/potency so they don't collide with image-analysis's image-derived dose-response.