### PR TITLE
Add enzyme-kinetics (Michaelis-Menten) skill

### DIFF
--- a/plugin/skills/tooluniverse-enzyme-kinetics/SKILL.md
+++ b/plugin/skills/tooluniverse-enzyme-kinetics/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: tooluniverse-enzyme-kinetics
+description: Enzyme kinetics — Michaelis-Menten Km, Vmax, kcat (turnover), and kcat/Km (catalytic efficiency / specificity constant) from substrate-velocity data, plus inhibition-mechanism analysis (competitive / uncompetitive / non-competitive, Ki). Fits the MM equation by nonlinear regression (and reports Lineweaver-Burk for reference). Use when you have substrate concentrations and initial reaction velocities and need kinetic parameters or to classify an inhibitor. NOT for BRENDA database lookups of published constants (use the BRENDA tools).
+disable-model-invocation: true
+---
+
+# Enzyme Kinetics (Michaelis-Menten)
+
+Turn **substrate concentration vs initial velocity** data into Km, Vmax, kcat, and catalytic efficiency — and classify an inhibitor's mechanism.
+
+The Michaelis-Menten model: `v = Vmax·[S] / (Km + [S])`.
+
+## When to use this
+
+- You measured initial reaction rates at several substrate concentrations.
+- You need Km (substrate affinity), Vmax, kcat (turnover number), or kcat/Km.
+- You have ±inhibitor velocity data and want to classify the inhibition mode + Ki.
+
+For *published* kinetic constants (someone else's Km/kcat), use the BRENDA tools instead — this skill is for analyzing **your own measured** data.
+
+## Step 1 — Prepare the data
+
+| Issue | What to do |
+|---|---|
+| **Initial velocities, not endpoints** | `v` must be the *initial* rate (linear phase, <10% substrate consumed). Endpoint or plateaued rates give a wrong Km/Vmax. |
+| **Substrate range must span Km** | Include `[S]` both well below and well above Km (ideally ~0.2×Km to ~5×Km). Points only above Km can't define Km; only below can't define Vmax. |
+| **Units — be consistent** | One `[S]` unit (mM, µM) → Km comes back in that unit. One velocity unit. Keep them fixed. |
+| **For kcat you need [E]** | kcat = Vmax / [E]total. The tool's "catalytic_efficiency" is Vmax/Km on the velocity scale; to get true kcat (per-second turnover) and kcat/Km, divide Vmax by the molar enzyme concentration yourself. |
+| **≥5–7 points** | Few points → unstable fit. Spread them across the range, not clustered. |
+
+## Step 2 — Fit Michaelis-Menten
+
+```bash
+tu run EnzymeKinetics_calculate '{"operation":"michaelis_menten",
+  "substrate_concs":[0.1,0.25,0.5,1,2,5,10],
+  "velocities":[8.5,18,32,52,72,90,98]}'
+```
+
+Returns a `nonlinear_fit` block (`Vmax`, `Km`, `R2`, `SSE`) **— use these as the answer**, a `lineweaver_burk` block (for reference only), `catalytic_efficiency` (Vmax/Km), and `predicted_velocities` + `residuals`.
+
+> **Prefer the nonlinear fit, not Lineweaver-Burk.** The double-reciprocal (Lineweaver-Burk) linearization distorts error (it over-weights low-`[S]` points) and is only for visualization/sanity — never report its Km/Vmax as the final values. The tool gives both; cite `nonlinear_fit`.
+
+`scripts/fit_michaelis_menten.py` does the same nonlinear fit from a CSV and converts Vmax→kcat→kcat/Km when you supply the enzyme concentration.
+
+## Step 3 — Interpret
+
+| Parameter | Meaning | Notes |
+|---|---|---|
+| **Km** | Substrate concentration at ½Vmax — *apparent affinity* (lower Km = tighter binding / higher affinity). | In the same units as `[S]`. Must lie inside your tested range to be trustworthy. |
+| **Vmax** | Maximum velocity at saturating substrate. | Depends on [E]; not an intrinsic enzyme property. |
+| **kcat** | Turnover number = Vmax/[E] (per second). | Requires the molar enzyme concentration; intrinsic to the enzyme. |
+| **kcat/Km** | Catalytic efficiency / specificity constant. | The best single metric to compare enzymes or substrates; near ~10⁸–10⁹ M⁻¹s⁻¹ is diffusion-limited ("catalytically perfect"). |
+| **R² / SSE** | Fit quality. | R²≥0.98 good; check `residuals` for systematic curvature (a pattern, not random scatter, means MM is the wrong model). |
+
+## Step 4 — Inhibition mechanism
+
+Provide velocities ±inhibitor to classify the mode:
+
+```bash
+tu run EnzymeKinetics_calculate '{"operation":"inhibition",
+  "substrate_concs":[...],
+  "velocities_no_inhibitor":[...],
+  "velocities_with_inhibitor":[...],
+  "inhibitor_conc":5, "inhibition_type":"competitive"}'
+```
+
+| Mechanism | Effect on apparent Km | Effect on Vmax | Signature |
+|---|---|---|---|
+| **Competitive** | ↑ (increases) | unchanged | inhibitor competes at the active site; beatable by more substrate |
+| **Uncompetitive** | ↓ (decreases) | ↓ | inhibitor binds only the ES complex |
+| **Non-competitive (mixed)** | ~unchanged (pure) / changes (mixed) | ↓ | binds enzyme and ES; not relieved by substrate |
+
+Ki is the inhibition constant (lower = more potent inhibitor). Decide the mechanism from how Km and Vmax shift, not from a single Lineweaver-Burk eyeball.
+
+## Step 5 — Gotchas (state these)
+
+- **Substrate inhibition** (velocity rises then *falls* at high `[S]`) breaks MM — the fit will show systematic residuals; flag it instead of forcing one Km.
+- **Km outside the tested range** → unreliable; widen `[S]`.
+- **kcat without [E]** is impossible — don't report a turnover number if you only fit velocities.
+- **Lineweaver-Burk for final numbers** is the classic error — it's for a quick plot, not the reported Km/Vmax.
+
+## Honest limitations
+
+- MM assumes a single substrate, initial-rate, steady-state, one active site. Allosteric (sigmoidal) enzymes need the Hill equation; multi-substrate enzymes need their own formalism.
+- Parameters are only as good as the substrate range and the initial-rate measurement.
+
+## Related skills
+- `tooluniverse-dose-response` — IC50/EC50 (the Hill/4PL sibling for concentration-response).
+- `tooluniverse-statistical-modeling` — general nonlinear regression and model comparison.
+- BRENDA tools — look up *published* enzyme kinetic constants.

--- a/plugin/skills/tooluniverse-enzyme-kinetics/scripts/fit_michaelis_menten.py
+++ b/plugin/skills/tooluniverse-enzyme-kinetics/scripts/fit_michaelis_menten.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Michaelis-Menten nonlinear fit for the tooluniverse-enzyme-kinetics skill.
+
+Reads a substrate-velocity CSV, fits v = Vmax*[S]/(Km+[S]) by nonlinear
+regression (matching EnzymeKinetics_calculate's nonlinear_fit), and — when an
+enzyme concentration is given — converts Vmax to kcat and kcat/Km. Prefer this
+over the Lineweaver-Burk linearization for reported values.
+
+CSV columns: substrate, velocity   (one row per measurement; replicates at the
+same [S] are averaged).
+
+Usage:
+  python fit_michaelis_menten.py --input kinetics.csv
+  python fit_michaelis_menten.py --input kinetics.csv --enzyme-conc 5e-9   # molar, for kcat
+"""
+
+import argparse
+import csv
+
+import numpy as np
+from scipy.optimize import curve_fit
+
+
+def mm(s, vmax, km):
+    return vmax * s / (km + s)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True, help="CSV: substrate,velocity")
+    ap.add_argument(
+        "--enzyme-conc",
+        type=float,
+        default=None,
+        help="total enzyme concentration (molar) to convert Vmax->kcat",
+    )
+    args = ap.parse_args()
+
+    pairs = {}
+    with open(args.input, newline="") as fh:
+        for row in csv.DictReader(fh):
+            try:
+                s = float(row["substrate"])
+                v = float(row["velocity"])
+            except (KeyError, ValueError):
+                continue
+            if s < 0:
+                continue
+            pairs.setdefault(s, []).append(v)
+
+    if len(pairs) < 4:
+        raise SystemExit("Need >=4 distinct substrate concentrations.")
+
+    s = np.array(sorted(pairs))
+    v = np.array([float(np.mean(pairs[x])) for x in s])
+
+    p0 = [float(v.max()) * 1.2, float(np.median(s))]
+    popt, _ = curve_fit(mm, s, v, p0=p0, maxfev=20000, bounds=(0, np.inf))
+    vmax, km = popt
+    pred = mm(s, *popt)
+    ss_res = float(np.sum((v - pred) ** 2))
+    ss_tot = float(np.sum((v - v.mean()) ** 2))
+    r2 = 1 - ss_res / ss_tot if ss_tot else float("nan")
+
+    print(f"\nMichaelis-Menten nonlinear fit ({len(s)} points)\n")
+    print(f"{'[S]':>12}{'v':>12}{'fitted':>12}{'resid':>10}")
+    for si, vi, pi in zip(s, v, pred):
+        print(f"{si:>12g}{vi:>12.3f}{pi:>12.3f}{vi - pi:>10.3f}")
+    print("-" * 46)
+    print(f"Vmax = {vmax:.4g}   Km = {km:.4g} (same units as [S])   R^2 = {r2:.4f}")
+    print(f"catalytic efficiency (Vmax/Km) = {vmax / km:.4g}")
+
+    if args.enzyme_conc:
+        kcat = vmax / args.enzyme_conc
+        print(f"kcat = Vmax/[E] = {kcat:.4g} s^-1   kcat/Km = {kcat / km:.4g} (per [S]-unit)·s^-1")
+
+    if not (s.min() <= km <= s.max()):
+        print("  ! Km falls OUTSIDE the tested [S] range — widen substrate concentrations.")
+    if r2 < 0.98:
+        print("  ! R^2 < 0.98 — check residuals for curvature (substrate inhibition / wrong model).")
+    # systematic residual sign pattern hints at a non-MM shape (e.g. substrate inhibition)
+    signs = np.sign(v - pred)
+    if len(signs) >= 6 and np.sum(signs[: len(signs) // 2]) * np.sum(signs[len(signs) // 2 :]) < -1:
+        print("  ! residuals change sign systematically across [S] — MM may be the wrong model.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugin/skills/tooluniverse/SKILL.md
+++ b/plugin/skills/tooluniverse/SKILL.md
@@ -192,6 +192,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**clinical data integration**", "clinical phenotype", "EHR analysis", "clinical cohort" | `Skill(skill="tooluniverse-clinical-data-integration")` |
 | "**phylogenetics**", "phylogenetic tree", "sequence alignment", "evolutionary analysis", "treeness", "saturation", "parsimony", "PhyKIT", "DVMC", "long branch", "tree length", "MAFFT", "gap percentage" | `Skill(skill="tooluniverse-phylogenetics")` |
 | "**statistical modeling**", "regression analysis", "logistic regression", "survival analysis", "Cox", "ANOVA", "F-statistic", "chi-square", "spline", "odds ratio", "Cohen's d", "p-value", "clinical trial data", "**ordinal**", "**severity**", "**vaccination**", "SDTM", "DM.csv", "AE.csv", "adverse event severity" | `Skill(skill="tooluniverse-statistical-modeling")` |
+| "**enzyme kinetics**", "Michaelis-Menten", "Km", "Vmax", "kcat", "turnover number", "catalytic efficiency", "specificity constant", "Lineweaver-Burk", "enzyme inhibition", "Ki", "competitive inhibitor" | `Skill(skill="tooluniverse-enzyme-kinetics")` |
 | "**metabolomics analysis**", "LC-MS analysis", "metabolite quantification", "metabolic flux" | `Skill(skill="tooluniverse-metabolomics-analysis")` |
 | "**functional genomics screen**", "CRISPR library", "shRNA screen", "barcode screen" | `Skill(skill="tooluniverse-functional-genomics-screens")` |
 | "**proteomics data**", "PRIDE", "MassIVE", "ProteomeXchange", "proteomics dataset" | `Skill(skill="tooluniverse-proteomics-data-retrieval")` |

--- a/skills/tooluniverse-enzyme-kinetics/SKILL.md
+++ b/skills/tooluniverse-enzyme-kinetics/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: tooluniverse-enzyme-kinetics
+description: Enzyme kinetics — Michaelis-Menten Km, Vmax, kcat (turnover), and kcat/Km (catalytic efficiency / specificity constant) from substrate-velocity data, plus inhibition-mechanism analysis (competitive / uncompetitive / non-competitive, Ki). Fits the MM equation by nonlinear regression (and reports Lineweaver-Burk for reference). Use when you have substrate concentrations and initial reaction velocities and need kinetic parameters or to classify an inhibitor. NOT for BRENDA database lookups of published constants (use the BRENDA tools).
+disable-model-invocation: true
+---
+
+# Enzyme Kinetics (Michaelis-Menten)
+
+Turn **substrate concentration vs initial velocity** data into Km, Vmax, kcat, and catalytic efficiency — and classify an inhibitor's mechanism.
+
+The Michaelis-Menten model: `v = Vmax·[S] / (Km + [S])`.
+
+## When to use this
+
+- You measured initial reaction rates at several substrate concentrations.
+- You need Km (substrate affinity), Vmax, kcat (turnover number), or kcat/Km.
+- You have ±inhibitor velocity data and want to classify the inhibition mode + Ki.
+
+For *published* kinetic constants (someone else's Km/kcat), use the BRENDA tools instead — this skill is for analyzing **your own measured** data.
+
+## Step 1 — Prepare the data
+
+| Issue | What to do |
+|---|---|
+| **Initial velocities, not endpoints** | `v` must be the *initial* rate (linear phase, <10% substrate consumed). Endpoint or plateaued rates give a wrong Km/Vmax. |
+| **Substrate range must span Km** | Include `[S]` both well below and well above Km (ideally ~0.2×Km to ~5×Km). Points only above Km can't define Km; only below can't define Vmax. |
+| **Units — be consistent** | One `[S]` unit (mM, µM) → Km comes back in that unit. One velocity unit. Keep them fixed. |
+| **For kcat you need [E]** | kcat = Vmax / [E]total. The tool's "catalytic_efficiency" is Vmax/Km on the velocity scale; to get true kcat (per-second turnover) and kcat/Km, divide Vmax by the molar enzyme concentration yourself. |
+| **≥5–7 points** | Few points → unstable fit. Spread them across the range, not clustered. |
+
+## Step 2 — Fit Michaelis-Menten
+
+```bash
+tu run EnzymeKinetics_calculate '{"operation":"michaelis_menten",
+  "substrate_concs":[0.1,0.25,0.5,1,2,5,10],
+  "velocities":[8.5,18,32,52,72,90,98]}'
+```
+
+Returns a `nonlinear_fit` block (`Vmax`, `Km`, `R2`, `SSE`) **— use these as the answer**, a `lineweaver_burk` block (for reference only), `catalytic_efficiency` (Vmax/Km), and `predicted_velocities` + `residuals`.
+
+> **Prefer the nonlinear fit, not Lineweaver-Burk.** The double-reciprocal (Lineweaver-Burk) linearization distorts error (it over-weights low-`[S]` points) and is only for visualization/sanity — never report its Km/Vmax as the final values. The tool gives both; cite `nonlinear_fit`.
+
+`scripts/fit_michaelis_menten.py` does the same nonlinear fit from a CSV and converts Vmax→kcat→kcat/Km when you supply the enzyme concentration.
+
+## Step 3 — Interpret
+
+| Parameter | Meaning | Notes |
+|---|---|---|
+| **Km** | Substrate concentration at ½Vmax — *apparent affinity* (lower Km = tighter binding / higher affinity). | In the same units as `[S]`. Must lie inside your tested range to be trustworthy. |
+| **Vmax** | Maximum velocity at saturating substrate. | Depends on [E]; not an intrinsic enzyme property. |
+| **kcat** | Turnover number = Vmax/[E] (per second). | Requires the molar enzyme concentration; intrinsic to the enzyme. |
+| **kcat/Km** | Catalytic efficiency / specificity constant. | The best single metric to compare enzymes or substrates; near ~10⁸–10⁹ M⁻¹s⁻¹ is diffusion-limited ("catalytically perfect"). |
+| **R² / SSE** | Fit quality. | R²≥0.98 good; check `residuals` for systematic curvature (a pattern, not random scatter, means MM is the wrong model). |
+
+## Step 4 — Inhibition mechanism
+
+Provide velocities ±inhibitor to classify the mode:
+
+```bash
+tu run EnzymeKinetics_calculate '{"operation":"inhibition",
+  "substrate_concs":[...],
+  "velocities_no_inhibitor":[...],
+  "velocities_with_inhibitor":[...],
+  "inhibitor_conc":5, "inhibition_type":"competitive"}'
+```
+
+| Mechanism | Effect on apparent Km | Effect on Vmax | Signature |
+|---|---|---|---|
+| **Competitive** | ↑ (increases) | unchanged | inhibitor competes at the active site; beatable by more substrate |
+| **Uncompetitive** | ↓ (decreases) | ↓ | inhibitor binds only the ES complex |
+| **Non-competitive (mixed)** | ~unchanged (pure) / changes (mixed) | ↓ | binds enzyme and ES; not relieved by substrate |
+
+Ki is the inhibition constant (lower = more potent inhibitor). Decide the mechanism from how Km and Vmax shift, not from a single Lineweaver-Burk eyeball.
+
+## Step 5 — Gotchas (state these)
+
+- **Substrate inhibition** (velocity rises then *falls* at high `[S]`) breaks MM — the fit will show systematic residuals; flag it instead of forcing one Km.
+- **Km outside the tested range** → unreliable; widen `[S]`.
+- **kcat without [E]** is impossible — don't report a turnover number if you only fit velocities.
+- **Lineweaver-Burk for final numbers** is the classic error — it's for a quick plot, not the reported Km/Vmax.
+
+## Honest limitations
+
+- MM assumes a single substrate, initial-rate, steady-state, one active site. Allosteric (sigmoidal) enzymes need the Hill equation; multi-substrate enzymes need their own formalism.
+- Parameters are only as good as the substrate range and the initial-rate measurement.
+
+## Related skills
+- `tooluniverse-dose-response` — IC50/EC50 (the Hill/4PL sibling for concentration-response).
+- `tooluniverse-statistical-modeling` — general nonlinear regression and model comparison.
+- BRENDA tools — look up *published* enzyme kinetic constants.

--- a/skills/tooluniverse-enzyme-kinetics/scripts/fit_michaelis_menten.py
+++ b/skills/tooluniverse-enzyme-kinetics/scripts/fit_michaelis_menten.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Michaelis-Menten nonlinear fit for the tooluniverse-enzyme-kinetics skill.
+
+Reads a substrate-velocity CSV, fits v = Vmax*[S]/(Km+[S]) by nonlinear
+regression (matching EnzymeKinetics_calculate's nonlinear_fit), and — when an
+enzyme concentration is given — converts Vmax to kcat and kcat/Km. Prefer this
+over the Lineweaver-Burk linearization for reported values.
+
+CSV columns: substrate, velocity   (one row per measurement; replicates at the
+same [S] are averaged).
+
+Usage:
+  python fit_michaelis_menten.py --input kinetics.csv
+  python fit_michaelis_menten.py --input kinetics.csv --enzyme-conc 5e-9   # molar, for kcat
+"""
+
+import argparse
+import csv
+
+import numpy as np
+from scipy.optimize import curve_fit
+
+
+def mm(s, vmax, km):
+    return vmax * s / (km + s)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True, help="CSV: substrate,velocity")
+    ap.add_argument(
+        "--enzyme-conc",
+        type=float,
+        default=None,
+        help="total enzyme concentration (molar) to convert Vmax->kcat",
+    )
+    args = ap.parse_args()
+
+    pairs = {}
+    with open(args.input, newline="") as fh:
+        for row in csv.DictReader(fh):
+            try:
+                s = float(row["substrate"])
+                v = float(row["velocity"])
+            except (KeyError, ValueError):
+                continue
+            if s < 0:
+                continue
+            pairs.setdefault(s, []).append(v)
+
+    if len(pairs) < 4:
+        raise SystemExit("Need >=4 distinct substrate concentrations.")
+
+    s = np.array(sorted(pairs))
+    v = np.array([float(np.mean(pairs[x])) for x in s])
+
+    p0 = [float(v.max()) * 1.2, float(np.median(s))]
+    popt, _ = curve_fit(mm, s, v, p0=p0, maxfev=20000, bounds=(0, np.inf))
+    vmax, km = popt
+    pred = mm(s, *popt)
+    ss_res = float(np.sum((v - pred) ** 2))
+    ss_tot = float(np.sum((v - v.mean()) ** 2))
+    r2 = 1 - ss_res / ss_tot if ss_tot else float("nan")
+
+    print(f"\nMichaelis-Menten nonlinear fit ({len(s)} points)\n")
+    print(f"{'[S]':>12}{'v':>12}{'fitted':>12}{'resid':>10}")
+    for si, vi, pi in zip(s, v, pred):
+        print(f"{si:>12g}{vi:>12.3f}{pi:>12.3f}{vi - pi:>10.3f}")
+    print("-" * 46)
+    print(f"Vmax = {vmax:.4g}   Km = {km:.4g} (same units as [S])   R^2 = {r2:.4f}")
+    print(f"catalytic efficiency (Vmax/Km) = {vmax / km:.4g}")
+
+    if args.enzyme_conc:
+        kcat = vmax / args.enzyme_conc
+        print(f"kcat = Vmax/[E] = {kcat:.4g} s^-1   kcat/Km = {kcat / km:.4g} (per [S]-unit)·s^-1")
+
+    if not (s.min() <= km <= s.max()):
+        print("  ! Km falls OUTSIDE the tested [S] range — widen substrate concentrations.")
+    if r2 < 0.98:
+        print("  ! R^2 < 0.98 — check residuals for curvature (substrate inhibition / wrong model).")
+    # systematic residual sign pattern hints at a non-MM shape (e.g. substrate inhibition)
+    signs = np.sign(v - pred)
+    if len(signs) >= 6 and np.sum(signs[: len(signs) // 2]) * np.sum(signs[len(signs) // 2 :]) < -1:
+        print("  ! residuals change sign systematically across [S] — MM may be the wrong model.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tooluniverse-enzyme-kinetics/test_fit_michaelis_menten.py
+++ b/skills/tooluniverse-enzyme-kinetics/test_fit_michaelis_menten.py
@@ -1,0 +1,31 @@
+"""Tests for the enzyme-kinetics skill helper script (Michaelis-Menten fit)."""
+
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent / "scripts"))
+import fit_michaelis_menten as ek  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_mm_at_km_is_half_vmax():
+    # v = Vmax*[S]/(Km+[S]); at [S]=Km, v = Vmax/2
+    assert ek.mm(5.0, 100.0, 5.0) == pytest.approx(50.0, rel=1e-9)
+
+
+def test_mm_saturates_to_vmax():
+    assert ek.mm(1e9, 100.0, 5.0) == pytest.approx(100.0, rel=1e-6)
+
+
+def test_fit_recovers_km_vmax():
+    from scipy.optimize import curve_fit
+
+    s = np.array([0.1, 0.25, 0.5, 1, 2, 5, 10], dtype=float)
+    v = ek.mm(s, 120.0, 1.5)  # true Vmax=120, Km=1.5
+    popt, _ = curve_fit(ek.mm, s, v, p0=[100, 1], maxfev=20000, bounds=(0, np.inf))
+    assert popt[0] == pytest.approx(120.0, rel=1e-3)  # Vmax
+    assert popt[1] == pytest.approx(1.5, rel=1e-3)  # Km

--- a/skills/tooluniverse/SKILL.md
+++ b/skills/tooluniverse/SKILL.md
@@ -192,6 +192,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**clinical data integration**", "clinical phenotype", "EHR analysis", "clinical cohort" | `Skill(skill="tooluniverse-clinical-data-integration")` |
 | "**phylogenetics**", "phylogenetic tree", "sequence alignment", "evolutionary analysis", "treeness", "saturation", "parsimony", "PhyKIT", "DVMC", "long branch", "tree length", "MAFFT", "gap percentage" | `Skill(skill="tooluniverse-phylogenetics")` |
 | "**statistical modeling**", "regression analysis", "logistic regression", "survival analysis", "Cox", "ANOVA", "F-statistic", "chi-square", "spline", "odds ratio", "Cohen's d", "p-value", "clinical trial data", "**ordinal**", "**severity**", "**vaccination**", "SDTM", "DM.csv", "AE.csv", "adverse event severity" | `Skill(skill="tooluniverse-statistical-modeling")` |
+| "**enzyme kinetics**", "Michaelis-Menten", "Km", "Vmax", "kcat", "turnover number", "catalytic efficiency", "specificity constant", "Lineweaver-Burk", "enzyme inhibition", "Ki", "competitive inhibitor" | `Skill(skill="tooluniverse-enzyme-kinetics")` |
 | "**metabolomics analysis**", "LC-MS analysis", "metabolite quantification", "metabolic flux" | `Skill(skill="tooluniverse-metabolomics-analysis")` |
 | "**functional genomics screen**", "CRISPR library", "shRNA screen", "barcode screen" | `Skill(skill="tooluniverse-functional-genomics-screens")` |
 | "**proteomics data**", "PRIDE", "MassIVE", "ProteomeXchange", "proteomics dataset" | `Skill(skill="tooluniverse-proteomics-data-retrieval")` |


### PR DESCRIPTION
Discovery harness — **task-gap** (Sub-loop B).

## Gap

`EnzymeKinetics_calculate` exists (Michaelis-Menten Km/Vmax via nonlinear fit + Lineweaver-Burk, catalytic efficiency, and inhibition-mode analysis) but **no skill** — enzyme kinetics appeared only as passing mentions in domain skills.

## Skill

`tooluniverse-enzyme-kinetics`:

- **Data prep**: initial velocities (not endpoints), substrate range must span Km, unit consistency, and the **[E] requirement for kcat**.
- **Tool**: `michaelis_menten` + `inhibition` operations.
- **Key guidance**: *prefer the nonlinear fit over Lineweaver-Burk* — the double-reciprocal linearization distorts error and is for visualization only, never final Km/Vmax.
- **Interpretation table**: Km (affinity), Vmax, kcat (turnover), **kcat/Km** (specificity constant, incl. the ~10⁸–10⁹ diffusion limit), R²/residuals.
- **Inhibition table**: competitive (Km↑, Vmax=), uncompetitive (both↓), non-competitive (Vmax↓); Ki.
- **Gotchas**: substrate inhibition (biphasic), Km out of range, no kcat without [E].
- **`scripts/fit_michaelis_menten.py`**: nonlinear MM fit from CSV + Vmax→kcat→kcat/Km via `--enzyme-conc`; flags out-of-range Km and curved residuals.

## Validation

- Tool verified live (nonlinear Vmax 107.8, Km 1.1, R² 0.998 + Lineweaver-Burk reference + catalytic efficiency + residuals).
- Script cross-checks within optimizer variance (Vmax 110.6 / Km 1.156, R²≈0.998).
- Routing rows added (both `skills/` + `plugin/skills/` mirrors).