### PR TITLE
Add primer-design skill (PCR/qPCR primers + oligo QC)

### DIFF
--- a/plugin/skills/tooluniverse-primer-design/SKILL.md
+++ b/plugin/skills/tooluniverse-primer-design/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: tooluniverse-primer-design
+description: PCR / qPCR primer and oligo design — design forward/reverse primers for a target region (SantaLucia nearest-neighbor thermodynamics), compute melting temperature (Tm) and annealing temperature (Ta), check GC content, and screen an oligo for hairpins and primer-dimers. Use when you need primers for a sequence, want to QC an existing primer pair, or need the Tm of an oligo. Covers the primer-design rules (Tm matching, GC clamp, 3'-end, length) and the tools' constraint quirks.
+disable-model-invocation: true
+---
+
+# PCR / qPCR Primer & Oligo Design
+
+Design primers for a target DNA region, get their Tm/Ta, and QC them for the secondary-structure problems that make a PCR fail.
+
+## When to use this
+
+- Design a forward/reverse primer pair to amplify a region of a sequence.
+- Compute the Tm / annealing temperature of a primer.
+- QC an existing primer pair (GC clamp, 3'-end, hairpins, self/cross dimers, Tm match).
+
+## Step 1 — Design a primer pair
+
+```bash
+tu run DNA_primer_design '{"operation":"primer_design",
+  "sequence":"ATGGCG...AACGTG",
+  "target_start":40, "target_end":125,
+  "tm_target":60, "product_size_min":80, "product_size_max":140}'
+```
+
+Returns `forward_primer` / `reverse_primer` (sequence, tm, gc_content, length, position) and `product_size`.
+
+> **Constraint quirk — read this or it will error.** `target_start..target_end` is the region the **amplicon must cover**, and the design only succeeds when that span fits inside the product-size window AND good-Tm primers can be placed flanking it. So you need roughly: `product_size_min ≤ (target span) ≤ product ≤ product_size_max`, with enough flanking sequence on both sides. Common errors and the fix:
+> - *"Target region (N bp) is smaller than product_size_min"* → your target is narrower than `product_size_min`; lower `product_size_min` or widen the target.
+> - *"product does not cover the target / does not span"* → the target is too wide for `product_size_max`, or runs too close to a sequence end; widen `product_size_max` or give more flanking sequence.
+
+## Step 2 — Get Tm / annealing temperature for specific primers
+
+```bash
+tu run NEB_Tm_calculate '{"primer_sequence":"CTACCTGAAGAACCTGAG",
+  "primer_sequence_2":"CTTGATGTCCTCCAGCAT",
+  "polymerase":"Q5", "primer_concentration":500, "monovalent_salt_mm":50}'
+```
+
+NEB returns Tm for each primer and a recommended **annealing temperature (Ta)** for the chosen polymerase. `IDT_analyze_oligo` (sequence, salt/Mg/dNTP/oligo concentrations) adds GC%, molecular weight, and **hairpin / self-dimer** screening. `DNA_calculate_gc_content` is a quick GC check.
+
+> **Tm depends on method + conditions.** SantaLucia NN (the design tool), NEB, and IDT use different parameter sets, and Tm shifts with monovalent salt, Mg²⁺, and primer/dNTP concentration. Pick **one** calculator + condition set and use it for the whole experiment; don't compare a SantaLucia Tm to an IDT Tm. Always state the conditions.
+
+## Step 3 — Primer design rules (what "good" looks like)
+
+| Property | Target | Why |
+|---|---|---|
+| **Length** | 18–24 nt | long enough for specificity, short enough for efficient annealing |
+| **Tm** | 58–62 °C | works with standard cycling; keep the **pair within ~2–3 °C** of each other |
+| **ΔTm (forward vs reverse)** | < 3 °C (≤5 absolute max) | mismatched Tm → one primer anneals poorly |
+| **GC content** | 40–60 % | balanced stability |
+| **GC clamp** | 1–2 G/C in the last 3 nt of the 3′ end | stabilizes 3′ priming; >3 G/C risks mispriming |
+| **3′ end** | avoid 3′ complementarity within a pair and within a primer | prevents primer-dimers |
+| **Runs / repeats** | avoid ≥4 identical bases in a row and di-nucleotide repeats | reduce slippage / mispriming |
+| **Annealing temp (Ta)** | ~ Tm − 3 to −5 °C (use the polymerase's calculator) | specificity vs yield |
+| **Amplicon (qPCR)** | 70–150 bp | efficient amplification |
+
+`scripts/primer_qc.py` checks a primer pair against these rules (GC clamp, 3′ self/cross-complementarity, runs, GC%, length, Wallace/NN Tm, Tm match) and flags problems — use it to QC primers from any source.
+
+## Step 4 — Specificity (the tools do NOT do this)
+
+Tm and structure are necessary but **not sufficient**. A primer can be thermodynamically perfect and still amplify the wrong locus. These tools do **not** check genome specificity — always BLAST each primer (or use Primer-BLAST) against the target genome and confirm a single intended product before ordering. State this in any recommendation.
+
+## Step 5 — Common gotchas
+
+- **Forgetting specificity** (Step 4) — the #1 cause of a "well-designed" primer failing.
+- **Mismatched pair Tm** — design tries to match, but a hand-picked pair often isn't; check ΔTm.
+- **3′ primer-dimers** — 3′ complementarity between forward and reverse is the classic dimer; `IDT_analyze_oligo` / the QC script flag it.
+- **Tm method/condition mixing** (Step 2).
+- **Secondary structure in the template** (GC-rich/hairpin regions) can block priming even with good primers — consider additives or moving the target.
+
+## Honest limitations
+
+- Thermodynamic Tm/structure prediction ≠ empirical performance; validate by gradient PCR.
+- No genome-specificity check (Step 4) and no SNP-masking — handle those separately.
+
+## Related skills
+- `tooluniverse-sequence-analysis` — upstream sequence handling (FASTQ, alignment, coverage).
+- `tooluniverse-enzyme-kinetics` / `tooluniverse-dose-response` — other quantitative assay analyses.

--- a/plugin/skills/tooluniverse-primer-design/scripts/primer_qc.py
+++ b/plugin/skills/tooluniverse-primer-design/scripts/primer_qc.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Primer-pair QC for the tooluniverse-primer-design skill.
+
+Checks a forward/reverse primer against the standard design rules — length,
+GC%, GC clamp, 3'-end self/cross complementarity (dimer risk), mononucleotide
+runs, a salt-adjusted Tm estimate, and Tm match between the pair — and prints
+PASS/WARN per check. The rigorous nearest-neighbor Tm comes from the
+NEB_Tm_calculate / IDT_analyze_oligo tools; this is a fast, dependency-free
+screen for any primer pair.
+
+Usage:
+  python primer_qc.py --forward CTACCTGAAGAACCTGAG --reverse CTTGATGTCCTCCAGCAT
+"""
+
+import argparse
+
+_COMP = {"A": "T", "T": "A", "G": "C", "C": "G"}
+
+
+def gc(seq):
+    return 100.0 * sum(b in "GC" for b in seq) / len(seq)
+
+
+def tm_saltadj(seq, na_mm=50.0):
+    """Rough Tm: Wallace for <14 nt, else the 64.9+41*... formula (~50 mM Na+).
+
+    A fast screening estimate only — it runs lower than the nearest-neighbor
+    Tm from NEB_Tm_calculate / IDT_analyze_oligo, which are the values to cite.
+    """
+    import math
+
+    n = len(seq)
+    gc_n = sum(b in "GC" for b in seq)
+    if n < 14:
+        tm = 2 * (n - gc_n) + 4 * gc_n  # Wallace rule (assumes ~50 mM salt)
+    else:
+        tm = 64.9 + 41 * (gc_n - 16.4) / n  # baseline at ~50 mM Na+
+    # correction relative to the 50 mM reference the baseline assumes
+    return tm + 16.6 * math.log10(max(na_mm, 1) / 50.0)
+
+
+def longest_run(seq):
+    best = run = 1
+    for i in range(1, len(seq)):
+        run = run + 1 if seq[i] == seq[i - 1] else 1
+        best = max(best, run)
+    return best
+
+
+def three_prime_complement(a, b, window=5):
+    """Count complementary bases when a's 3' end pairs against b's 3' end.
+
+    High overlap at the 3' ends is the classic primer-dimer signature.
+    """
+    a3 = a[-window:]
+    b3 = b[-window:][::-1]  # align 3'-to-3'
+    return sum(_COMP.get(x) == y for x, y in zip(a3[::-1], b3))
+
+
+def check(seq, name):
+    seq = seq.upper().strip()
+    out = []
+    out.append(("length", 18 <= len(seq) <= 24, f"{len(seq)} nt (want 18-24)"))
+    out.append(("GC%", 40 <= gc(seq) <= 60, f"{gc(seq):.0f}% (want 40-60)"))
+    clamp = sum(b in "GC" for b in seq[-3:])
+    out.append(("3' GC clamp", 1 <= clamp <= 2, f"{clamp} G/C in last 3 (want 1-2)"))
+    run = longest_run(seq)
+    out.append(("no long runs", run < 4, f"longest run {run} (want <4)"))
+    selfd = three_prime_complement(seq, seq)
+    out.append(("3' self-dimer", selfd <= 2, f"{selfd}/5 3'-complementary (want <=2)"))
+    return seq, out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--forward", required=True)
+    ap.add_argument("--reverse", required=True)
+    ap.add_argument("--na-mm", type=float, default=50.0)
+    args = ap.parse_args()
+
+    fseq, fchecks = check(args.forward, "forward")
+    rseq, rchecks = check(args.reverse, "reverse")
+    tmf, tmr = tm_saltadj(fseq, args.na_mm), tm_saltadj(rseq, args.na_mm)
+
+    def show(name, seq, checks, tm):
+        print(f"\n{name}: {seq}  (Tm~{tm:.1f} C, salt-adjusted estimate)")
+        for label, ok, detail in checks:
+            print(f"  [{'PASS' if ok else 'WARN'}] {label:14} {detail}")
+
+    show("Forward", fseq, fchecks, tmf)
+    show("Reverse", rseq, rchecks, tmr)
+
+    print("\nPair:")
+    dtm = abs(tmf - tmr)
+    print(f"  [{'PASS' if dtm <= 3 else 'WARN'}] Tm match      dTm={dtm:.1f} C (want <3)")
+    cross = three_prime_complement(fseq, rseq)
+    print(f"  [{'PASS' if cross <= 2 else 'WARN'}] 3' cross-dimer {cross}/5 3'-complementary (want <=2)")
+    print(
+        "\nNote: this is a thermodynamic/structure screen only. It does NOT check genome "
+        "specificity — BLAST each primer (or Primer-BLAST) before ordering. Use NEB_Tm_calculate "
+        "for the polymerase-specific annealing temperature."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugin/skills/tooluniverse/SKILL.md
+++ b/plugin/skills/tooluniverse/SKILL.md
@@ -192,6 +192,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**clinical data integration**", "clinical phenotype", "EHR analysis", "clinical cohort" | `Skill(skill="tooluniverse-clinical-data-integration")` |
 | "**phylogenetics**", "phylogenetic tree", "sequence alignment", "evolutionary analysis", "treeness", "saturation", "parsimony", "PhyKIT", "DVMC", "long branch", "tree length", "MAFFT", "gap percentage" | `Skill(skill="tooluniverse-phylogenetics")` |
 | "**statistical modeling**", "regression analysis", "logistic regression", "survival analysis", "Cox", "ANOVA", "F-statistic", "chi-square", "spline", "odds ratio", "Cohen's d", "p-value", "clinical trial data", "**ordinal**", "**severity**", "**vaccination**", "SDTM", "DM.csv", "AE.csv", "adverse event severity" | `Skill(skill="tooluniverse-statistical-modeling")` |
+| "**primer design**", "PCR primers", "qPCR primer", "melting temperature", "Tm calculation", "annealing temperature", "GC clamp", "primer-dimer", "oligo analysis", "amplicon", "forward and reverse primer" | `Skill(skill="tooluniverse-primer-design")` |
 | "**metabolomics analysis**", "LC-MS analysis", "metabolite quantification", "metabolic flux" | `Skill(skill="tooluniverse-metabolomics-analysis")` |
 | "**functional genomics screen**", "CRISPR library", "shRNA screen", "barcode screen" | `Skill(skill="tooluniverse-functional-genomics-screens")` |
 | "**proteomics data**", "PRIDE", "MassIVE", "ProteomeXchange", "proteomics dataset" | `Skill(skill="tooluniverse-proteomics-data-retrieval")` |

--- a/skills/tooluniverse-primer-design/SKILL.md
+++ b/skills/tooluniverse-primer-design/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: tooluniverse-primer-design
+description: PCR / qPCR primer and oligo design — design forward/reverse primers for a target region (SantaLucia nearest-neighbor thermodynamics), compute melting temperature (Tm) and annealing temperature (Ta), check GC content, and screen an oligo for hairpins and primer-dimers. Use when you need primers for a sequence, want to QC an existing primer pair, or need the Tm of an oligo. Covers the primer-design rules (Tm matching, GC clamp, 3'-end, length) and the tools' constraint quirks.
+disable-model-invocation: true
+---
+
+# PCR / qPCR Primer & Oligo Design
+
+Design primers for a target DNA region, get their Tm/Ta, and QC them for the secondary-structure problems that make a PCR fail.
+
+## When to use this
+
+- Design a forward/reverse primer pair to amplify a region of a sequence.
+- Compute the Tm / annealing temperature of a primer.
+- QC an existing primer pair (GC clamp, 3'-end, hairpins, self/cross dimers, Tm match).
+
+## Step 1 — Design a primer pair
+
+```bash
+tu run DNA_primer_design '{"operation":"primer_design",
+  "sequence":"ATGGCG...AACGTG",
+  "target_start":40, "target_end":125,
+  "tm_target":60, "product_size_min":80, "product_size_max":140}'
+```
+
+Returns `forward_primer` / `reverse_primer` (sequence, tm, gc_content, length, position) and `product_size`.
+
+> **Constraint quirk — read this or it will error.** `target_start..target_end` is the region the **amplicon must cover**, and the design only succeeds when that span fits inside the product-size window AND good-Tm primers can be placed flanking it. So you need roughly: `product_size_min ≤ (target span) ≤ product ≤ product_size_max`, with enough flanking sequence on both sides. Common errors and the fix:
+> - *"Target region (N bp) is smaller than product_size_min"* → your target is narrower than `product_size_min`; lower `product_size_min` or widen the target.
+> - *"product does not cover the target / does not span"* → the target is too wide for `product_size_max`, or runs too close to a sequence end; widen `product_size_max` or give more flanking sequence.
+
+## Step 2 — Get Tm / annealing temperature for specific primers
+
+```bash
+tu run NEB_Tm_calculate '{"primer_sequence":"CTACCTGAAGAACCTGAG",
+  "primer_sequence_2":"CTTGATGTCCTCCAGCAT",
+  "polymerase":"Q5", "primer_concentration":500, "monovalent_salt_mm":50}'
+```
+
+NEB returns Tm for each primer and a recommended **annealing temperature (Ta)** for the chosen polymerase. `IDT_analyze_oligo` (sequence, salt/Mg/dNTP/oligo concentrations) adds GC%, molecular weight, and **hairpin / self-dimer** screening. `DNA_calculate_gc_content` is a quick GC check.
+
+> **Tm depends on method + conditions.** SantaLucia NN (the design tool), NEB, and IDT use different parameter sets, and Tm shifts with monovalent salt, Mg²⁺, and primer/dNTP concentration. Pick **one** calculator + condition set and use it for the whole experiment; don't compare a SantaLucia Tm to an IDT Tm. Always state the conditions.
+
+## Step 3 — Primer design rules (what "good" looks like)
+
+| Property | Target | Why |
+|---|---|---|
+| **Length** | 18–24 nt | long enough for specificity, short enough for efficient annealing |
+| **Tm** | 58–62 °C | works with standard cycling; keep the **pair within ~2–3 °C** of each other |
+| **ΔTm (forward vs reverse)** | < 3 °C (≤5 absolute max) | mismatched Tm → one primer anneals poorly |
+| **GC content** | 40–60 % | balanced stability |
+| **GC clamp** | 1–2 G/C in the last 3 nt of the 3′ end | stabilizes 3′ priming; >3 G/C risks mispriming |
+| **3′ end** | avoid 3′ complementarity within a pair and within a primer | prevents primer-dimers |
+| **Runs / repeats** | avoid ≥4 identical bases in a row and di-nucleotide repeats | reduce slippage / mispriming |
+| **Annealing temp (Ta)** | ~ Tm − 3 to −5 °C (use the polymerase's calculator) | specificity vs yield |
+| **Amplicon (qPCR)** | 70–150 bp | efficient amplification |
+
+`scripts/primer_qc.py` checks a primer pair against these rules (GC clamp, 3′ self/cross-complementarity, runs, GC%, length, Wallace/NN Tm, Tm match) and flags problems — use it to QC primers from any source.
+
+## Step 4 — Specificity (the tools do NOT do this)
+
+Tm and structure are necessary but **not sufficient**. A primer can be thermodynamically perfect and still amplify the wrong locus. These tools do **not** check genome specificity — always BLAST each primer (or use Primer-BLAST) against the target genome and confirm a single intended product before ordering. State this in any recommendation.
+
+## Step 5 — Common gotchas
+
+- **Forgetting specificity** (Step 4) — the #1 cause of a "well-designed" primer failing.
+- **Mismatched pair Tm** — design tries to match, but a hand-picked pair often isn't; check ΔTm.
+- **3′ primer-dimers** — 3′ complementarity between forward and reverse is the classic dimer; `IDT_analyze_oligo` / the QC script flag it.
+- **Tm method/condition mixing** (Step 2).
+- **Secondary structure in the template** (GC-rich/hairpin regions) can block priming even with good primers — consider additives or moving the target.
+
+## Honest limitations
+
+- Thermodynamic Tm/structure prediction ≠ empirical performance; validate by gradient PCR.
+- No genome-specificity check (Step 4) and no SNP-masking — handle those separately.
+
+## Related skills
+- `tooluniverse-sequence-analysis` — upstream sequence handling (FASTQ, alignment, coverage).
+- `tooluniverse-enzyme-kinetics` / `tooluniverse-dose-response` — other quantitative assay analyses.

--- a/skills/tooluniverse-primer-design/scripts/primer_qc.py
+++ b/skills/tooluniverse-primer-design/scripts/primer_qc.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Primer-pair QC for the tooluniverse-primer-design skill.
+
+Checks a forward/reverse primer against the standard design rules — length,
+GC%, GC clamp, 3'-end self/cross complementarity (dimer risk), mononucleotide
+runs, a salt-adjusted Tm estimate, and Tm match between the pair — and prints
+PASS/WARN per check. The rigorous nearest-neighbor Tm comes from the
+NEB_Tm_calculate / IDT_analyze_oligo tools; this is a fast, dependency-free
+screen for any primer pair.
+
+Usage:
+  python primer_qc.py --forward CTACCTGAAGAACCTGAG --reverse CTTGATGTCCTCCAGCAT
+"""
+
+import argparse
+
+_COMP = {"A": "T", "T": "A", "G": "C", "C": "G"}
+
+
+def gc(seq):
+    return 100.0 * sum(b in "GC" for b in seq) / len(seq)
+
+
+def tm_saltadj(seq, na_mm=50.0):
+    """Rough Tm: Wallace for <14 nt, else the 64.9+41*... formula (~50 mM Na+).
+
+    A fast screening estimate only — it runs lower than the nearest-neighbor
+    Tm from NEB_Tm_calculate / IDT_analyze_oligo, which are the values to cite.
+    """
+    import math
+
+    n = len(seq)
+    gc_n = sum(b in "GC" for b in seq)
+    if n < 14:
+        tm = 2 * (n - gc_n) + 4 * gc_n  # Wallace rule (assumes ~50 mM salt)
+    else:
+        tm = 64.9 + 41 * (gc_n - 16.4) / n  # baseline at ~50 mM Na+
+    # correction relative to the 50 mM reference the baseline assumes
+    return tm + 16.6 * math.log10(max(na_mm, 1) / 50.0)
+
+
+def longest_run(seq):
+    best = run = 1
+    for i in range(1, len(seq)):
+        run = run + 1 if seq[i] == seq[i - 1] else 1
+        best = max(best, run)
+    return best
+
+
+def three_prime_complement(a, b, window=5):
+    """Count complementary bases when a's 3' end pairs against b's 3' end.
+
+    High overlap at the 3' ends is the classic primer-dimer signature.
+    """
+    a3 = a[-window:]
+    b3 = b[-window:][::-1]  # align 3'-to-3'
+    return sum(_COMP.get(x) == y for x, y in zip(a3[::-1], b3))
+
+
+def check(seq, name):
+    seq = seq.upper().strip()
+    out = []
+    out.append(("length", 18 <= len(seq) <= 24, f"{len(seq)} nt (want 18-24)"))
+    out.append(("GC%", 40 <= gc(seq) <= 60, f"{gc(seq):.0f}% (want 40-60)"))
+    clamp = sum(b in "GC" for b in seq[-3:])
+    out.append(("3' GC clamp", 1 <= clamp <= 2, f"{clamp} G/C in last 3 (want 1-2)"))
+    run = longest_run(seq)
+    out.append(("no long runs", run < 4, f"longest run {run} (want <4)"))
+    selfd = three_prime_complement(seq, seq)
+    out.append(("3' self-dimer", selfd <= 2, f"{selfd}/5 3'-complementary (want <=2)"))
+    return seq, out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--forward", required=True)
+    ap.add_argument("--reverse", required=True)
+    ap.add_argument("--na-mm", type=float, default=50.0)
+    args = ap.parse_args()
+
+    fseq, fchecks = check(args.forward, "forward")
+    rseq, rchecks = check(args.reverse, "reverse")
+    tmf, tmr = tm_saltadj(fseq, args.na_mm), tm_saltadj(rseq, args.na_mm)
+
+    def show(name, seq, checks, tm):
+        print(f"\n{name}: {seq}  (Tm~{tm:.1f} C, salt-adjusted estimate)")
+        for label, ok, detail in checks:
+            print(f"  [{'PASS' if ok else 'WARN'}] {label:14} {detail}")
+
+    show("Forward", fseq, fchecks, tmf)
+    show("Reverse", rseq, rchecks, tmr)
+
+    print("\nPair:")
+    dtm = abs(tmf - tmr)
+    print(f"  [{'PASS' if dtm <= 3 else 'WARN'}] Tm match      dTm={dtm:.1f} C (want <3)")
+    cross = three_prime_complement(fseq, rseq)
+    print(f"  [{'PASS' if cross <= 2 else 'WARN'}] 3' cross-dimer {cross}/5 3'-complementary (want <=2)")
+    print(
+        "\nNote: this is a thermodynamic/structure screen only. It does NOT check genome "
+        "specificity — BLAST each primer (or Primer-BLAST) before ordering. Use NEB_Tm_calculate "
+        "for the polymerase-specific annealing temperature."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tooluniverse-primer-design/test_primer_qc.py
+++ b/skills/tooluniverse-primer-design/test_primer_qc.py
@@ -1,0 +1,41 @@
+"""Tests for the primer-design skill helper script (primer QC)."""
+
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent / "scripts"))
+import primer_qc as pq  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_gc_content():
+    assert pq.gc("GGCC") == pytest.approx(100.0)
+    assert pq.gc("ATGC") == pytest.approx(50.0)
+
+
+def test_longest_run():
+    assert pq.longest_run("ATGC") == 1
+    assert pq.longest_run("AAAACGT") == 4
+
+
+def test_tm_increases_with_gc():
+    at_rich = pq.tm_saltadj("ATATATATATATATATAT")
+    gc_rich = pq.tm_saltadj("GCGCGCGCGCGCGCGCGC")
+    assert gc_rich > at_rich
+
+
+def test_tm_reasonable_for_18mer():
+    # 18-mer, 50% GC should be ~48 C by the 64.9+41*... formula (a rough screen)
+    tm = pq.tm_saltadj("CTACCTGAAGAACCTGAG")
+    assert 40 < tm < 60
+
+
+def test_three_prime_complement_detects_dimer():
+    # 3'-to-3' geometry: a's 3' end (AAAGG) pairs with b's 3' end (TTTCC)
+    # -> fully complementary -> max dimer score.
+    assert pq.three_prime_complement("GGGGGAAAGG", "CCCCCTTTCC", window=5) == 5
+    # 3' ends that are NOT complementary score low.
+    assert pq.three_prime_complement("GGGGGAAAGG", "GGGGGAAAGG", window=5) < 5

--- a/skills/tooluniverse/SKILL.md
+++ b/skills/tooluniverse/SKILL.md
@@ -192,6 +192,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**clinical data integration**", "clinical phenotype", "EHR analysis", "clinical cohort" | `Skill(skill="tooluniverse-clinical-data-integration")` |
 | "**phylogenetics**", "phylogenetic tree", "sequence alignment", "evolutionary analysis", "treeness", "saturation", "parsimony", "PhyKIT", "DVMC", "long branch", "tree length", "MAFFT", "gap percentage" | `Skill(skill="tooluniverse-phylogenetics")` |
 | "**statistical modeling**", "regression analysis", "logistic regression", "survival analysis", "Cox", "ANOVA", "F-statistic", "chi-square", "spline", "odds ratio", "Cohen's d", "p-value", "clinical trial data", "**ordinal**", "**severity**", "**vaccination**", "SDTM", "DM.csv", "AE.csv", "adverse event severity" | `Skill(skill="tooluniverse-statistical-modeling")` |
+| "**primer design**", "PCR primers", "qPCR primer", "melting temperature", "Tm calculation", "annealing temperature", "GC clamp", "primer-dimer", "oligo analysis", "amplicon", "forward and reverse primer" | `Skill(skill="tooluniverse-primer-design")` |
 | "**metabolomics analysis**", "LC-MS analysis", "metabolite quantification", "metabolic flux" | `Skill(skill="tooluniverse-metabolomics-analysis")` |
 | "**functional genomics screen**", "CRISPR library", "shRNA screen", "barcode screen" | `Skill(skill="tooluniverse-functional-genomics-screens")` |
 | "**proteomics data**", "PRIDE", "MassIVE", "ProteomeXchange", "proteomics dataset" | `Skill(skill="tooluniverse-proteomics-data-retrieval")` |


### PR DESCRIPTION
Discovery harness — **task-gap** (Sub-loop B).

## Gap

Four primer/oligo tools exist — `DNA_primer_design` (SantaLucia NN), `NEB_Tm_calculate`, `IDT_analyze_oligo`, `DNA_calculate_gc_content` — but **no skill** for one of the most common molecular-biology tasks.

## Skill

`tooluniverse-primer-design`:

- **`DNA_primer_design` orchestration** + the **non-obvious constraint** I reverse-engineered: `product_size_min ≤ target span ≤ product ≤ product_size_max` — with the two common errors ("target smaller than product_size_min", "product does not span target") and their fixes.
- **`NEB_Tm_calculate`** (Tm + polymerase-specific annealing temp) and **`IDT_analyze_oligo`** (GC, MW, hairpin/dimer) usage + the *don't mix Tm methods/conditions* rule.
- **Design-rule table**: length 18–24, Tm 58–62, ΔTm<3, GC 40–60, GC clamp, 3′-end, runs, qPCR amplicon 70–150 bp.
- **Explicit specificity warning**: the tools do NOT check genome specificity — always BLAST / Primer-BLAST before ordering (the #1 cause of a 'good' primer failing).
- **`scripts/primer_qc.py`**: dependency-free QC of a primer pair (length, GC%, GC clamp, 3′ self/cross-dimer, runs, rough Tm + Tm match) → PASS/WARN.

## Validation

- `DNA_primer_design` verified live → forward/reverse primers (Tm, GC, position, product_size); documented its constraint quirk from the actual errors.
- QC script verified: a designed pair → all PASS (Tm match 0.0); a deliberately bad pair → flags long runs, GC%, GC clamp, ΔTm 19°C.
- Routing rows added (both `skills/` + `plugin/skills/` mirrors).