### PR TITLE
Add diagnostic-test-evaluation skill (2x2 + ROC/AUC + Bayes)

### DIFF
--- a/plugin/skills/tooluniverse-diagnostic-test-evaluation/SKILL.md
+++ b/plugin/skills/tooluniverse-diagnostic-test-evaluation/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: tooluniverse-diagnostic-test-evaluation
+description: Diagnostic test / biomarker accuracy — sensitivity, specificity, PPV, NPV, likelihood ratios, accuracy from a 2x2 table; ROC curve, AUC, and the optimal cutoff (Youden) for a continuous biomarker; and post-test probability via Bayes. Use when you have test results vs a gold standard (binary 2x2, or a continuous score + true labels) and need to judge how good the test is, pick a threshold, or compute the probability of disease given a result. Emphasizes the prevalence-dependence of PPV/NPV.
+disable-model-invocation: true
+---
+
+# Diagnostic Test / Biomarker Accuracy Evaluation
+
+Judge how well a test or biomarker discriminates disease — at a fixed cutoff (2×2) or across all cutoffs (ROC) — and turn a result into a probability of disease.
+
+## Which case are you in?
+
+| You have… | Go to |
+|---|---|
+| A 2×2 table (TP/FP/TN/FN) at a fixed cutoff | **Step 1** (`Epidemiology_diagnostic`) |
+| A **continuous** biomarker score + true labels | **Step 2** (ROC / AUC / Youden, Python) |
+| A test's sens/spec + a patient's pre-test probability | **Step 3** (`Epidemiology_bayesian`) |
+
+## Step 1 — Fixed-cutoff metrics from a 2×2 table
+
+```bash
+tu run Epidemiology_diagnostic '{"operation":"diagnostic","tp":90,"fp":10,"tn":180,"fn":20}'
+```
+
+Returns `sensitivity`, `specificity`, `PPV`, `NPV`, `accuracy`, `LR_pos`, `LR_neg`, and the sample `prevalence`.
+
+| Metric | Question it answers | Depends on prevalence? |
+|---|---|---|
+| **Sensitivity** = TP/(TP+FN) | Of those WITH disease, what fraction test positive? | No |
+| **Specificity** = TN/(TN+FP) | Of those WITHOUT disease, what fraction test negative? | No |
+| **PPV** = TP/(TP+FP) | If positive, what's the chance of disease? | **Yes — strongly** |
+| **NPV** = TN/(TN+FN) | If negative, what's the chance of being disease-free? | **Yes** |
+| **LR+** = sens/(1−spec) | How much a positive raises the odds of disease | No |
+| **LR−** = (1−sens)/spec | How much a negative lowers the odds | No |
+
+> **The PPV/NPV trap.** Sensitivity and specificity are properties of the *test*; **PPV and NPV depend on the disease prevalence in the tested population.** A test with great sens/spec has poor PPV in a low-prevalence (screening) setting. Never quote PPV/NPV from a case-control design (its 50/50 prevalence is artificial) — compute them for the real-world prevalence with `Epidemiology_bayesian` (Step 3). Report **sensitivity, specificity, and likelihood ratios** as the prevalence-independent summary.
+
+## Step 2 — ROC / AUC / optimal cutoff for a continuous biomarker
+
+When the test is a continuous score, evaluate across **all** thresholds:
+
+```bash
+python skills/tooluniverse-diagnostic-test-evaluation/scripts/roc_analysis.py --input scores.csv
+# scores.csv columns: label (1=disease, 0=healthy), score (continuous biomarker)
+```
+
+It reports AUC (with a bootstrap 95% CI), the **Youden-optimal cutoff** (max sensitivity+specificity−1) and its sens/spec, and a text ROC curve.
+
+| AUC | Discrimination |
+|---|---|
+| 0.5 | no better than chance |
+| 0.7–0.8 | acceptable |
+| 0.8–0.9 | excellent |
+| >0.9 | outstanding |
+
+- The **Youden** cutoff weights sensitivity and specificity equally; if false negatives and false positives have different costs, pick the threshold from the clinical tradeoff, not Youden.
+- Once you choose a cutoff, build its 2×2 and run Step 1 for the fixed-cutoff metrics at that operating point.
+
+## Step 3 — Post-test probability (Bayes)
+
+Turn a result into the probability of disease for a given pre-test probability/prevalence:
+
+```bash
+tu run Epidemiology_bayesian '{"operation":"bayesian","prevalence":0.10,
+  "sensitivity":0.90,"specificity":0.95,"test_result":"positive"}'
+```
+
+Returns `pre_test_odds`, the `LR`, and `post_test_probability`. This is how you get the *real-world* PPV: plug the true prevalence in. (Example: a 90%/95% test at 10% prevalence gives a post-positive probability of only ~67%, not 95%.)
+
+## Gotchas (state these)
+
+- **PPV/NPV without a stated prevalence are meaningless** — always give the prevalence they assume.
+- **AUC ignores the operating point.** A high AUC doesn't tell you the test is useful at the threshold you'll actually use — report sens/spec at the chosen cutoff too.
+- **Class imbalance.** With very few positives, ROC/AUC can look good while PPV is poor; consider a precision-recall curve and always report PPV at the real prevalence.
+- **Spectrum bias.** Sens/spec measured on clearly-sick vs clearly-healthy subjects overestimate real-world performance on borderline cases.
+- **Single cutoff chosen on the same data** it's evaluated on is optimistic — validate the threshold on a held-out set.
+
+## Honest limitations
+
+- These are discrimination/accuracy metrics, not calibration — a well-discriminating model can still output poorly-calibrated probabilities.
+- A single AUC compares nothing; to compare two tests on the same patients, use a paired AUC test (DeLong) — beyond the basic script here.
+
+## Related skills
+- `tooluniverse-statistical-modeling` — logistic regression that produces the score, ORs.
+- `tooluniverse-epidemiological-analysis` — population-level risk, screening program metrics.
+- `tooluniverse-meta-analysis` — pool diagnostic accuracy across studies.

--- a/plugin/skills/tooluniverse-diagnostic-test-evaluation/scripts/roc_analysis.py
+++ b/plugin/skills/tooluniverse-diagnostic-test-evaluation/scripts/roc_analysis.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""ROC / AUC / optimal-cutoff analysis for the
+tooluniverse-diagnostic-test-evaluation skill.
+
+Reads a CSV of (label, score), computes the ROC AUC with a bootstrap 95% CI,
+finds the Youden-optimal cutoff and its sensitivity/specificity, and prints a
+text ROC curve. For the fixed-cutoff 2x2 metrics use Epidemiology_diagnostic;
+for post-test probability use Epidemiology_bayesian.
+
+CSV columns: label (1=disease/positive, 0=healthy/negative), score (continuous).
+
+Usage:
+  python roc_analysis.py --input scores.csv
+"""
+
+import argparse
+import csv
+
+import numpy as np
+from sklearn.metrics import roc_auc_score, roc_curve
+
+
+def bootstrap_auc_ci(y, s, n=2000, seed=0):
+    rng = np.random.default_rng(seed)
+    idx = np.arange(len(y))
+    aucs = []
+    for _ in range(n):
+        b = rng.choice(idx, size=len(idx), replace=True)
+        if len(np.unique(y[b])) < 2:
+            continue
+        aucs.append(roc_auc_score(y[b], s[b]))
+    if not aucs:
+        return (float("nan"), float("nan"))
+    return tuple(np.percentile(aucs, [2.5, 97.5]))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True, help="CSV: label,score")
+    args = ap.parse_args()
+
+    ys, ss = [], []
+    with open(args.input, newline="") as fh:
+        for row in csv.DictReader(fh):
+            try:
+                ys.append(int(float(row["label"])))
+                ss.append(float(row["score"]))
+            except (KeyError, ValueError):
+                continue
+    y, s = np.array(ys), np.array(ss)
+    if len(np.unique(y)) < 2:
+        raise SystemExit("Need both positive (1) and negative (0) labels.")
+
+    auc = roc_auc_score(y, s)
+    lo, hi = bootstrap_auc_ci(y, s)
+    fpr, tpr, thr = roc_curve(y, s)
+    youden = tpr - fpr
+    j = int(np.argmax(youden))
+    cutoff, sens, spec = thr[j], tpr[j], 1 - fpr[j]
+
+    band = (
+        "outstanding" if auc > 0.9 else
+        "excellent" if auc > 0.8 else
+        "acceptable" if auc > 0.7 else
+        "poor/near-chance"
+    )
+    print(f"\nROC analysis: {len(y)} samples ({int(y.sum())} positive, {int((1 - y).sum())} negative)\n")
+    print(f"AUC = {auc:.3f}  95% CI [{lo:.3f}, {hi:.3f}]  ({band})")
+    print(f"Youden-optimal cutoff: score >= {cutoff:.4g}  ->  sensitivity {sens:.3f}, specificity {spec:.3f}")
+
+    # text ROC curve
+    print("\nROC (TPR vs FPR):")
+    grid = np.linspace(0, 1, 11)
+    tpr_at = np.interp(grid, fpr, tpr)
+    for g, t in zip(grid[::-1], tpr_at[::-1]):
+        bar = "#" * int(round(t * 40))
+        print(f"  FPR={g:.1f} | {bar:<40} TPR={t:.2f}")
+    if auc < 0.7:
+        print("\n  ! AUC < 0.7 — weak discrimination.")
+    if y.mean() < 0.1 or y.mean() > 0.9:
+        print("  ! strong class imbalance — also report PPV at the real prevalence (precision-recall is informative).")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugin/skills/tooluniverse/SKILL.md
+++ b/plugin/skills/tooluniverse/SKILL.md
@@ -192,6 +192,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**clinical data integration**", "clinical phenotype", "EHR analysis", "clinical cohort" | `Skill(skill="tooluniverse-clinical-data-integration")` |
 | "**phylogenetics**", "phylogenetic tree", "sequence alignment", "evolutionary analysis", "treeness", "saturation", "parsimony", "PhyKIT", "DVMC", "long branch", "tree length", "MAFFT", "gap percentage" | `Skill(skill="tooluniverse-phylogenetics")` |
 | "**statistical modeling**", "regression analysis", "logistic regression", "survival analysis", "Cox", "ANOVA", "F-statistic", "chi-square", "spline", "odds ratio", "Cohen's d", "p-value", "clinical trial data", "**ordinal**", "**severity**", "**vaccination**", "SDTM", "DM.csv", "AE.csv", "adverse event severity" | `Skill(skill="tooluniverse-statistical-modeling")` |
+| "**diagnostic test**", "sensitivity specificity", "ROC curve", "AUC", "PPV", "NPV", "likelihood ratio", "Youden", "optimal cutoff", "post-test probability", "biomarker accuracy", "confusion matrix" | `Skill(skill="tooluniverse-diagnostic-test-evaluation")` |
 | "**metabolomics analysis**", "LC-MS analysis", "metabolite quantification", "metabolic flux" | `Skill(skill="tooluniverse-metabolomics-analysis")` |
 | "**functional genomics screen**", "CRISPR library", "shRNA screen", "barcode screen" | `Skill(skill="tooluniverse-functional-genomics-screens")` |
 | "**proteomics data**", "PRIDE", "MassIVE", "ProteomeXchange", "proteomics dataset" | `Skill(skill="tooluniverse-proteomics-data-retrieval")` |

--- a/skills/tooluniverse-diagnostic-test-evaluation/SKILL.md
+++ b/skills/tooluniverse-diagnostic-test-evaluation/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: tooluniverse-diagnostic-test-evaluation
+description: Diagnostic test / biomarker accuracy — sensitivity, specificity, PPV, NPV, likelihood ratios, accuracy from a 2x2 table; ROC curve, AUC, and the optimal cutoff (Youden) for a continuous biomarker; and post-test probability via Bayes. Use when you have test results vs a gold standard (binary 2x2, or a continuous score + true labels) and need to judge how good the test is, pick a threshold, or compute the probability of disease given a result. Emphasizes the prevalence-dependence of PPV/NPV.
+disable-model-invocation: true
+---
+
+# Diagnostic Test / Biomarker Accuracy Evaluation
+
+Judge how well a test or biomarker discriminates disease — at a fixed cutoff (2×2) or across all cutoffs (ROC) — and turn a result into a probability of disease.
+
+## Which case are you in?
+
+| You have… | Go to |
+|---|---|
+| A 2×2 table (TP/FP/TN/FN) at a fixed cutoff | **Step 1** (`Epidemiology_diagnostic`) |
+| A **continuous** biomarker score + true labels | **Step 2** (ROC / AUC / Youden, Python) |
+| A test's sens/spec + a patient's pre-test probability | **Step 3** (`Epidemiology_bayesian`) |
+
+## Step 1 — Fixed-cutoff metrics from a 2×2 table
+
+```bash
+tu run Epidemiology_diagnostic '{"operation":"diagnostic","tp":90,"fp":10,"tn":180,"fn":20}'
+```
+
+Returns `sensitivity`, `specificity`, `PPV`, `NPV`, `accuracy`, `LR_pos`, `LR_neg`, and the sample `prevalence`.
+
+| Metric | Question it answers | Depends on prevalence? |
+|---|---|---|
+| **Sensitivity** = TP/(TP+FN) | Of those WITH disease, what fraction test positive? | No |
+| **Specificity** = TN/(TN+FP) | Of those WITHOUT disease, what fraction test negative? | No |
+| **PPV** = TP/(TP+FP) | If positive, what's the chance of disease? | **Yes — strongly** |
+| **NPV** = TN/(TN+FN) | If negative, what's the chance of being disease-free? | **Yes** |
+| **LR+** = sens/(1−spec) | How much a positive raises the odds of disease | No |
+| **LR−** = (1−sens)/spec | How much a negative lowers the odds | No |
+
+> **The PPV/NPV trap.** Sensitivity and specificity are properties of the *test*; **PPV and NPV depend on the disease prevalence in the tested population.** A test with great sens/spec has poor PPV in a low-prevalence (screening) setting. Never quote PPV/NPV from a case-control design (its 50/50 prevalence is artificial) — compute them for the real-world prevalence with `Epidemiology_bayesian` (Step 3). Report **sensitivity, specificity, and likelihood ratios** as the prevalence-independent summary.
+
+## Step 2 — ROC / AUC / optimal cutoff for a continuous biomarker
+
+When the test is a continuous score, evaluate across **all** thresholds:
+
+```bash
+python skills/tooluniverse-diagnostic-test-evaluation/scripts/roc_analysis.py --input scores.csv
+# scores.csv columns: label (1=disease, 0=healthy), score (continuous biomarker)
+```
+
+It reports AUC (with a bootstrap 95% CI), the **Youden-optimal cutoff** (max sensitivity+specificity−1) and its sens/spec, and a text ROC curve.
+
+| AUC | Discrimination |
+|---|---|
+| 0.5 | no better than chance |
+| 0.7–0.8 | acceptable |
+| 0.8–0.9 | excellent |
+| >0.9 | outstanding |
+
+- The **Youden** cutoff weights sensitivity and specificity equally; if false negatives and false positives have different costs, pick the threshold from the clinical tradeoff, not Youden.
+- Once you choose a cutoff, build its 2×2 and run Step 1 for the fixed-cutoff metrics at that operating point.
+
+## Step 3 — Post-test probability (Bayes)
+
+Turn a result into the probability of disease for a given pre-test probability/prevalence:
+
+```bash
+tu run Epidemiology_bayesian '{"operation":"bayesian","prevalence":0.10,
+  "sensitivity":0.90,"specificity":0.95,"test_result":"positive"}'
+```
+
+Returns `pre_test_odds`, the `LR`, and `post_test_probability`. This is how you get the *real-world* PPV: plug the true prevalence in. (Example: a 90%/95% test at 10% prevalence gives a post-positive probability of only ~67%, not 95%.)
+
+## Gotchas (state these)
+
+- **PPV/NPV without a stated prevalence are meaningless** — always give the prevalence they assume.
+- **AUC ignores the operating point.** A high AUC doesn't tell you the test is useful at the threshold you'll actually use — report sens/spec at the chosen cutoff too.
+- **Class imbalance.** With very few positives, ROC/AUC can look good while PPV is poor; consider a precision-recall curve and always report PPV at the real prevalence.
+- **Spectrum bias.** Sens/spec measured on clearly-sick vs clearly-healthy subjects overestimate real-world performance on borderline cases.
+- **Single cutoff chosen on the same data** it's evaluated on is optimistic — validate the threshold on a held-out set.
+
+## Honest limitations
+
+- These are discrimination/accuracy metrics, not calibration — a well-discriminating model can still output poorly-calibrated probabilities.
+- A single AUC compares nothing; to compare two tests on the same patients, use a paired AUC test (DeLong) — beyond the basic script here.
+
+## Related skills
+- `tooluniverse-statistical-modeling` — logistic regression that produces the score, ORs.
+- `tooluniverse-epidemiological-analysis` — population-level risk, screening program metrics.
+- `tooluniverse-meta-analysis` — pool diagnostic accuracy across studies.

--- a/skills/tooluniverse-diagnostic-test-evaluation/scripts/roc_analysis.py
+++ b/skills/tooluniverse-diagnostic-test-evaluation/scripts/roc_analysis.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""ROC / AUC / optimal-cutoff analysis for the
+tooluniverse-diagnostic-test-evaluation skill.
+
+Reads a CSV of (label, score), computes the ROC AUC with a bootstrap 95% CI,
+finds the Youden-optimal cutoff and its sensitivity/specificity, and prints a
+text ROC curve. For the fixed-cutoff 2x2 metrics use Epidemiology_diagnostic;
+for post-test probability use Epidemiology_bayesian.
+
+CSV columns: label (1=disease/positive, 0=healthy/negative), score (continuous).
+
+Usage:
+  python roc_analysis.py --input scores.csv
+"""
+
+import argparse
+import csv
+
+import numpy as np
+from sklearn.metrics import roc_auc_score, roc_curve
+
+
+def bootstrap_auc_ci(y, s, n=2000, seed=0):
+    rng = np.random.default_rng(seed)
+    idx = np.arange(len(y))
+    aucs = []
+    for _ in range(n):
+        b = rng.choice(idx, size=len(idx), replace=True)
+        if len(np.unique(y[b])) < 2:
+            continue
+        aucs.append(roc_auc_score(y[b], s[b]))
+    if not aucs:
+        return (float("nan"), float("nan"))
+    return tuple(np.percentile(aucs, [2.5, 97.5]))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True, help="CSV: label,score")
+    args = ap.parse_args()
+
+    ys, ss = [], []
+    with open(args.input, newline="") as fh:
+        for row in csv.DictReader(fh):
+            try:
+                ys.append(int(float(row["label"])))
+                ss.append(float(row["score"]))
+            except (KeyError, ValueError):
+                continue
+    y, s = np.array(ys), np.array(ss)
+    if len(np.unique(y)) < 2:
+        raise SystemExit("Need both positive (1) and negative (0) labels.")
+
+    auc = roc_auc_score(y, s)
+    lo, hi = bootstrap_auc_ci(y, s)
+    fpr, tpr, thr = roc_curve(y, s)
+    youden = tpr - fpr
+    j = int(np.argmax(youden))
+    cutoff, sens, spec = thr[j], tpr[j], 1 - fpr[j]
+
+    band = (
+        "outstanding" if auc > 0.9 else
+        "excellent" if auc > 0.8 else
+        "acceptable" if auc > 0.7 else
+        "poor/near-chance"
+    )
+    print(f"\nROC analysis: {len(y)} samples ({int(y.sum())} positive, {int((1 - y).sum())} negative)\n")
+    print(f"AUC = {auc:.3f}  95% CI [{lo:.3f}, {hi:.3f}]  ({band})")
+    print(f"Youden-optimal cutoff: score >= {cutoff:.4g}  ->  sensitivity {sens:.3f}, specificity {spec:.3f}")
+
+    # text ROC curve
+    print("\nROC (TPR vs FPR):")
+    grid = np.linspace(0, 1, 11)
+    tpr_at = np.interp(grid, fpr, tpr)
+    for g, t in zip(grid[::-1], tpr_at[::-1]):
+        bar = "#" * int(round(t * 40))
+        print(f"  FPR={g:.1f} | {bar:<40} TPR={t:.2f}")
+    if auc < 0.7:
+        print("\n  ! AUC < 0.7 — weak discrimination.")
+    if y.mean() < 0.1 or y.mean() > 0.9:
+        print("  ! strong class imbalance — also report PPV at the real prevalence (precision-recall is informative).")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tooluniverse-diagnostic-test-evaluation/test_roc_analysis.py
+++ b/skills/tooluniverse-diagnostic-test-evaluation/test_roc_analysis.py
@@ -1,0 +1,40 @@
+"""Tests for the diagnostic-test-evaluation skill helper script (ROC)."""
+
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent / "scripts"))
+import roc_analysis as roc  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_perfect_separation_auc_one():
+    y = np.array([0, 0, 0, 1, 1, 1])
+    s = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])  # positives strictly higher
+    lo, hi = roc.bootstrap_auc_ci(y, s, n=200, seed=0)
+    assert lo == pytest.approx(1.0)
+    assert hi == pytest.approx(1.0)
+
+
+def test_bootstrap_ci_brackets_point_auc():
+    from sklearn.metrics import roc_auc_score
+
+    rng = np.random.default_rng(0)
+    y = np.array([0] * 100 + [1] * 100)
+    s = np.concatenate([rng.normal(0, 1, 100), rng.normal(1.5, 1, 100)])
+    point = roc_auc_score(y, s)
+    lo, hi = roc.bootstrap_auc_ci(y, s, n=500, seed=1)
+    assert lo <= point <= hi
+    assert 0.5 < lo < hi <= 1.0
+
+
+def test_ci_handles_degenerate_resample():
+    # tiny imbalanced set: some bootstrap resamples have one class -> skipped, no crash
+    y = np.array([0, 0, 1])
+    s = np.array([0.1, 0.2, 0.9])
+    lo, hi = roc.bootstrap_auc_ci(y, s, n=100, seed=2)
+    assert not (lo != lo)  # not NaN (at least some valid resamples)

--- a/skills/tooluniverse/SKILL.md
+++ b/skills/tooluniverse/SKILL.md
@@ -192,6 +192,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**clinical data integration**", "clinical phenotype", "EHR analysis", "clinical cohort" | `Skill(skill="tooluniverse-clinical-data-integration")` |
 | "**phylogenetics**", "phylogenetic tree", "sequence alignment", "evolutionary analysis", "treeness", "saturation", "parsimony", "PhyKIT", "DVMC", "long branch", "tree length", "MAFFT", "gap percentage" | `Skill(skill="tooluniverse-phylogenetics")` |
 | "**statistical modeling**", "regression analysis", "logistic regression", "survival analysis", "Cox", "ANOVA", "F-statistic", "chi-square", "spline", "odds ratio", "Cohen's d", "p-value", "clinical trial data", "**ordinal**", "**severity**", "**vaccination**", "SDTM", "DM.csv", "AE.csv", "adverse event severity" | `Skill(skill="tooluniverse-statistical-modeling")` |
+| "**diagnostic test**", "sensitivity specificity", "ROC curve", "AUC", "PPV", "NPV", "likelihood ratio", "Youden", "optimal cutoff", "post-test probability", "biomarker accuracy", "confusion matrix" | `Skill(skill="tooluniverse-diagnostic-test-evaluation")` |
 | "**metabolomics analysis**", "LC-MS analysis", "metabolite quantification", "metabolic flux" | `Skill(skill="tooluniverse-metabolomics-analysis")` |
 | "**functional genomics screen**", "CRISPR library", "shRNA screen", "barcode screen" | `Skill(skill="tooluniverse-functional-genomics-screens")` |
 | "**proteomics data**", "PRIDE", "MassIVE", "ProteomeXchange", "proteomics dataset" | `Skill(skill="tooluniverse-proteomics-data-retrieval")` |


### PR DESCRIPTION
Discovery harness — **task-gap** (Sub-loop B).

## Gap

`Epidemiology_diagnostic` (2×2 → sens/spec/PPV/NPV/LR) and `Epidemiology_bayesian` (post-test probability) exist, but **no skill**, and **ROC-curve analysis** for a continuous biomarker (AUC, optimal cutoff) had no home.

## Skill

`tooluniverse-diagnostic-test-evaluation` (hybrid: tools for 2×2/Bayes + Python for ROC):

- **Case routing**: 2×2 table → `Epidemiology_diagnostic`; continuous score → ROC; pre-test probability → `Epidemiology_bayesian`.
- **2×2 metrics table** + the central **PPV/NPV prevalence-dependence trap** — report sens/spec/LR as the prevalence-independent summary; get real-world PPV from Bayes (a 90/95 test at 10% prevalence → post-positive prob only ~67%, not 95%).
- **ROC interpretation** (AUC bands), **Youden** optimal cutoff + the cost-asymmetry caveat.
- **Gotchas**: AUC ignores the operating point, class imbalance → PR curve, spectrum bias, threshold chosen+evaluated on the same data.
- **`scripts/roc_analysis.py`**: sklearn ROC AUC + **bootstrap 95% CI** + Youden cutoff (sens/spec) + text ROC curve.

## Validation

- Both tools verified live (`Epidemiology_diagnostic` → sens 0.82/spec 0.95/PPV/NPV/LR; `Epidemiology_bayesian` → post-test 0.667).
- ROC script verified on a 200-sample synthetic set: AUC 0.878 [0.825, 0.927], Youden cutoff with sens/spec.
- Routing rows added (both `skills/` + `plugin/skills/` mirrors).