### PR TITLE
Add molecular-cloning skill (Gibson + Golden Gate assembly design)

### DIFF
--- a/plugin/skills/tooluniverse-molecular-cloning/SKILL.md
+++ b/plugin/skills/tooluniverse-molecular-cloning/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: tooluniverse-molecular-cloning
+description: Molecular cloning assembly design — Gibson Assembly (overlap design for seamless multi-fragment joining) and Golden Gate Assembly (Type IIS / BsaI / BbsI design with unique 4-bp fusion overhangs). Use when you need to plan how to join DNA fragments into a construct, design assembly overlaps/overhangs, or decide between cloning methods. Covers the domestication (internal-site removal), overhang-uniqueness, and overlap-Tm rules. For PCR primers to generate the fragments, see tooluniverse-primer-design.
+disable-model-invocation: true
+---
+
+# Molecular Cloning Assembly Design (Gibson & Golden Gate)
+
+Plan how to join DNA fragments into a construct: design the **overlaps** (Gibson) or **Type IIS overhangs** (Golden Gate) and avoid the failures that come from internal sites and non-unique junctions.
+
+## Step 0 — Pick the method
+
+| Use **Gibson Assembly** when | Use **Golden Gate** when |
+|---|---|
+| A few fragments, **scarless/seamless** junctions anywhere you choose | Many parts, **standardized reusable** parts (MoClo/modular), one-pot |
+| You can add ~20–40 bp homology by PCR | You can remove internal BsaI/BbsI sites (domestication) |
+| One-off constructs | Combinatorial libraries / repeated assemblies |
+
+Both are sequence-independent (no scar at the junction for Gibson; a 4-bp fusion scar for Golden Gate). For 2–4 unique fragments, Gibson is usually simplest; for libraries or a parts toolkit, Golden Gate.
+
+## Step 1 — Gibson Assembly
+
+```bash
+tu run DNA_gibson_design '{"operation":"gibson_design",
+  "fragments":["ATGGCG...GAGGAC","GAGGAC...GGCAAG","GGGCAAG...ATCCT"],
+  "overlap_length":20}'
+```
+
+For each fragment it returns `left_overlap`, `right_overlap`, and `with_overlaps` (the fragment extended with the homology arms you'd add to your PCR primers — hand these to `tooluniverse-primer-design`).
+
+**Gibson design rules**
+- **Overlap length 15–40 bp** (20–25 typical); longer for GC-poor junctions.
+- **Overlap Tm ≈ 48–65 °C** and balanced between junctions.
+- **Fragment order matters** — list fragments in assembly order; the last fragment's 3′ overlaps the first only if you're making a circle (vector).
+- **Avoid repeats/secondary structure** at the junctions (hairpins, direct repeats) → misassembly.
+- **Unique junctions** — if two junctions share homology, fragments can swap; redesign so each overlap is unique.
+
+## Step 2 — Golden Gate Assembly
+
+```bash
+tu run DNA_golden_gate_design '{"operation":"golden_gate_design",
+  "parts":["ATGGCG...AAGAAC","CTGAGC...CTGATC","GAGGAG...GTGGTG"],
+  "enzyme":"BsaI"}'
+```
+
+Returns `parts_with_overhangs`: each part's unique 4-bp `left_overhang`/`right_overhang` and the `full_sequence` flanked by the Type IIS recognition sites (e.g. BsaI `GGTCTC(N1)` … cutting outside its site to leave the 4-bp fusion overhang).
+
+**Golden Gate design rules**
+- **Domestication is mandatory.** The chosen enzyme's site (BsaI `GGTCTC`, BbsI `GAAGAC`) must NOT occur **inside** any part, or it will be cut internally. Remove internal sites by silent mutation before assembly — check every part.
+- **Overhangs must be unique and non-palindromic.** Each 4-bp fusion site must differ from the others and not equal its own reverse complement, or junctions misligate. The tool assigns unique non-palindromic overhangs; keep them.
+- **Avoid high-GC or all-AT overhangs**; published high-fidelity overhang sets (e.g. Potapov 2018) ligate most cleanly.
+- **Order is encoded by the overhangs**, not by listing order — the 4-bp junctions define assembly.
+
+## Step 3 — QC before ordering
+
+`scripts/cloning_qc.py` screens parts for the problems above: internal BsaI/BbsI sites (Golden Gate), overhang uniqueness/palindromes, and Gibson overlap GC/length — and flags PASS/WARN.
+
+## Step 4 — Gotchas (state these)
+
+- **Internal Type IIS sites** (Golden Gate) — the #1 failure; domesticate every part.
+- **Non-unique Gibson overlaps** or shared homology → fragment swapping / misassembly.
+- **Repeats and strong secondary structure** at junctions reduce efficiency in both methods.
+- **Overlap Tm imbalance** (Gibson) → some junctions form, others don't.
+- **Generating the fragments** still needs primers with the overlaps/overhangs appended — design and QC those in `tooluniverse-primer-design` (and BLAST for specificity).
+
+## Honest limitations
+
+- These tools design the assembly junctions; they do not simulate the full ligation/exonuclease reaction or guarantee efficiency — validate by sequencing the assembled construct.
+- No vector-backbone or ORF-frame checking — confirm reading frame and backbone compatibility yourself.
+
+## Related skills
+- `tooluniverse-primer-design` — design the PCR primers (with homology arms / Type IIS tails) to make the fragments.
+- `tooluniverse-sequence-analysis` — handle the input sequences.

--- a/plugin/skills/tooluniverse-molecular-cloning/scripts/cloning_qc.py
+++ b/plugin/skills/tooluniverse-molecular-cloning/scripts/cloning_qc.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Cloning assembly QC for the tooluniverse-molecular-cloning skill.
+
+Screens DNA parts/fragments for the failures that wreck an assembly:
+- Golden Gate: internal Type IIS recognition sites (BsaI/BbsI) that must be
+  domesticated, plus uniqueness / palindrome checks on 4-bp overhangs.
+- Gibson: overlap length and GC of the supplied homology arms.
+
+Usage:
+  # Golden Gate: check parts for internal sites + given overhangs
+  python cloning_qc.py --golden-gate --enzyme BsaI --parts ATGGCG...,CTGAGC...
+  python cloning_qc.py --overhangs AAAC,AAAG,AAAT
+  # Gibson: check overlap arms
+  python cloning_qc.py --overlaps ATGGCGCCCAAGACGGGCTA,GAGGACGAGCTGCTGAAGCT
+"""
+
+import argparse
+
+_COMP = {"A": "T", "T": "A", "G": "C", "C": "G"}
+_SITES = {"BsaI": "GGTCTC", "BbsI": "GAAGAC"}
+
+
+def revcomp(s):
+    return "".join(_COMP.get(b, "N") for b in reversed(s.upper()))
+
+
+def gc(s):
+    return 100.0 * sum(b in "GC" for b in s.upper()) / len(s) if s else 0.0
+
+
+def check_internal_sites(parts, enzyme):
+    site = _SITES[enzyme]
+    rc = revcomp(site)
+    print(f"\nGolden Gate — internal {enzyme} sites ({site} / {rc}):")
+    ok = True
+    for i, p in enumerate(parts, 1):
+        p = p.upper()
+        n = p.count(site) + p.count(rc)
+        flag = "PASS" if n == 0 else "WARN"
+        if n:
+            ok = False
+        print(f"  [{flag}] Part_{i}: {n} internal site(s)" + ("" if n == 0 else " — DOMESTICATE (silent-mutate) before use"))
+    if ok:
+        print("  all parts free of internal sites.")
+
+
+def check_overhangs(ohs):
+    print("\nGolden Gate — 4-bp overhang QC:")
+    ohs = [o.upper() for o in ohs]
+    seen = {}
+    for i, o in enumerate(ohs, 1):
+        issues = []
+        if len(o) != 4:
+            issues.append(f"length {len(o)}!=4")
+        if o == revcomp(o):
+            issues.append("palindromic (self-complementary)")
+        if o in seen:
+            issues.append(f"duplicate of overhang #{seen[o]}")
+        if revcomp(o) in ohs:
+            issues.append("reverse-complement of another overhang")
+        seen.setdefault(o, i)
+        flag = "PASS" if not issues else "WARN"
+        print(f"  [{flag}] {o}" + ("" if not issues else "  — " + "; ".join(issues)))
+
+
+def check_overlaps(ovs):
+    print("\nGibson — overlap arm QC:")
+    for i, o in enumerate(ovs, 1):
+        o = o.upper()
+        issues = []
+        if not (15 <= len(o) <= 40):
+            issues.append(f"length {len(o)} (want 15-40 bp)")
+        if not (40 <= gc(o) <= 65):
+            issues.append(f"GC {gc(o):.0f}% (want 40-65%)")
+        flag = "PASS" if not issues else "WARN"
+        print(f"  [{flag}] overlap {i} ({len(o)} bp, GC {gc(o):.0f}%)" + ("" if not issues else "  — " + "; ".join(issues)))
+    # shared-homology check
+    for i in range(len(ovs)):
+        for j in range(i + 1, len(ovs)):
+            if ovs[i].upper() == ovs[j].upper():
+                print(f"  [WARN] overlaps {i + 1} and {j + 1} are identical — fragments can swap; make each unique.")
+
+
+def _split(s):
+    return [x.strip() for x in s.split(",") if x.strip()]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--golden-gate", action="store_true")
+    ap.add_argument("--enzyme", choices=list(_SITES), default="BsaI")
+    ap.add_argument("--parts", help="comma-separated part sequences")
+    ap.add_argument("--overhangs", help="comma-separated 4-bp overhangs")
+    ap.add_argument("--overlaps", help="comma-separated Gibson overlap arms")
+    args = ap.parse_args()
+
+    if (args.golden_gate or args.parts) and args.parts:
+        check_internal_sites(_split(args.parts), args.enzyme)
+    if args.overhangs:
+        check_overhangs(_split(args.overhangs))
+    if args.overlaps:
+        check_overlaps(_split(args.overlaps))
+    if not any((args.parts, args.overhangs, args.overlaps)):
+        ap.error("provide --parts, --overhangs, and/or --overlaps")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugin/skills/tooluniverse/SKILL.md
+++ b/plugin/skills/tooluniverse/SKILL.md
@@ -192,6 +192,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**clinical data integration**", "clinical phenotype", "EHR analysis", "clinical cohort" | `Skill(skill="tooluniverse-clinical-data-integration")` |
 | "**phylogenetics**", "phylogenetic tree", "sequence alignment", "evolutionary analysis", "treeness", "saturation", "parsimony", "PhyKIT", "DVMC", "long branch", "tree length", "MAFFT", "gap percentage" | `Skill(skill="tooluniverse-phylogenetics")` |
 | "**statistical modeling**", "regression analysis", "logistic regression", "survival analysis", "Cox", "ANOVA", "F-statistic", "chi-square", "spline", "odds ratio", "Cohen's d", "p-value", "clinical trial data", "**ordinal**", "**severity**", "**vaccination**", "SDTM", "DM.csv", "AE.csv", "adverse event severity" | `Skill(skill="tooluniverse-statistical-modeling")` |
+| "**molecular cloning**", "Gibson Assembly", "Golden Gate", "Type IIS", "BsaI", "BbsI", "assembly overlap", "fragment assembly", "construct design", "domestication" | `Skill(skill="tooluniverse-molecular-cloning")` |
 | "**metabolomics analysis**", "LC-MS analysis", "metabolite quantification", "metabolic flux" | `Skill(skill="tooluniverse-metabolomics-analysis")` |
 | "**functional genomics screen**", "CRISPR library", "shRNA screen", "barcode screen" | `Skill(skill="tooluniverse-functional-genomics-screens")` |
 | "**proteomics data**", "PRIDE", "MassIVE", "ProteomeXchange", "proteomics dataset" | `Skill(skill="tooluniverse-proteomics-data-retrieval")` |

--- a/skills/tooluniverse-molecular-cloning/SKILL.md
+++ b/skills/tooluniverse-molecular-cloning/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: tooluniverse-molecular-cloning
+description: Molecular cloning assembly design — Gibson Assembly (overlap design for seamless multi-fragment joining) and Golden Gate Assembly (Type IIS / BsaI / BbsI design with unique 4-bp fusion overhangs). Use when you need to plan how to join DNA fragments into a construct, design assembly overlaps/overhangs, or decide between cloning methods. Covers the domestication (internal-site removal), overhang-uniqueness, and overlap-Tm rules. For PCR primers to generate the fragments, see tooluniverse-primer-design.
+disable-model-invocation: true
+---
+
+# Molecular Cloning Assembly Design (Gibson & Golden Gate)
+
+Plan how to join DNA fragments into a construct: design the **overlaps** (Gibson) or **Type IIS overhangs** (Golden Gate) and avoid the failures that come from internal sites and non-unique junctions.
+
+## Step 0 — Pick the method
+
+| Use **Gibson Assembly** when | Use **Golden Gate** when |
+|---|---|
+| A few fragments, **scarless/seamless** junctions anywhere you choose | Many parts, **standardized reusable** parts (MoClo/modular), one-pot |
+| You can add ~20–40 bp homology by PCR | You can remove internal BsaI/BbsI sites (domestication) |
+| One-off constructs | Combinatorial libraries / repeated assemblies |
+
+Both are sequence-independent (no scar at the junction for Gibson; a 4-bp fusion scar for Golden Gate). For 2–4 unique fragments, Gibson is usually simplest; for libraries or a parts toolkit, Golden Gate.
+
+## Step 1 — Gibson Assembly
+
+```bash
+tu run DNA_gibson_design '{"operation":"gibson_design",
+  "fragments":["ATGGCG...GAGGAC","GAGGAC...GGCAAG","GGGCAAG...ATCCT"],
+  "overlap_length":20}'
+```
+
+For each fragment it returns `left_overlap`, `right_overlap`, and `with_overlaps` (the fragment extended with the homology arms you'd add to your PCR primers — hand these to `tooluniverse-primer-design`).
+
+**Gibson design rules**
+- **Overlap length 15–40 bp** (20–25 typical); longer for GC-poor junctions.
+- **Overlap Tm ≈ 48–65 °C** and balanced between junctions.
+- **Fragment order matters** — list fragments in assembly order; the last fragment's 3′ overlaps the first only if you're making a circle (vector).
+- **Avoid repeats/secondary structure** at the junctions (hairpins, direct repeats) → misassembly.
+- **Unique junctions** — if two junctions share homology, fragments can swap; redesign so each overlap is unique.
+
+## Step 2 — Golden Gate Assembly
+
+```bash
+tu run DNA_golden_gate_design '{"operation":"golden_gate_design",
+  "parts":["ATGGCG...AAGAAC","CTGAGC...CTGATC","GAGGAG...GTGGTG"],
+  "enzyme":"BsaI"}'
+```
+
+Returns `parts_with_overhangs`: each part's unique 4-bp `left_overhang`/`right_overhang` and the `full_sequence` flanked by the Type IIS recognition sites (e.g. BsaI `GGTCTC(N1)` … cutting outside its site to leave the 4-bp fusion overhang).
+
+**Golden Gate design rules**
+- **Domestication is mandatory.** The chosen enzyme's site (BsaI `GGTCTC`, BbsI `GAAGAC`) must NOT occur **inside** any part, or it will be cut internally. Remove internal sites by silent mutation before assembly — check every part.
+- **Overhangs must be unique and non-palindromic.** Each 4-bp fusion site must differ from the others and not equal its own reverse complement, or junctions misligate. The tool assigns unique non-palindromic overhangs; keep them.
+- **Avoid high-GC or all-AT overhangs**; published high-fidelity overhang sets (e.g. Potapov 2018) ligate most cleanly.
+- **Order is encoded by the overhangs**, not by listing order — the 4-bp junctions define assembly.
+
+## Step 3 — QC before ordering
+
+`scripts/cloning_qc.py` screens parts for the problems above: internal BsaI/BbsI sites (Golden Gate), overhang uniqueness/palindromes, and Gibson overlap GC/length — and flags PASS/WARN.
+
+## Step 4 — Gotchas (state these)
+
+- **Internal Type IIS sites** (Golden Gate) — the #1 failure; domesticate every part.
+- **Non-unique Gibson overlaps** or shared homology → fragment swapping / misassembly.
+- **Repeats and strong secondary structure** at junctions reduce efficiency in both methods.
+- **Overlap Tm imbalance** (Gibson) → some junctions form, others don't.
+- **Generating the fragments** still needs primers with the overlaps/overhangs appended — design and QC those in `tooluniverse-primer-design` (and BLAST for specificity).
+
+## Honest limitations
+
+- These tools design the assembly junctions; they do not simulate the full ligation/exonuclease reaction or guarantee efficiency — validate by sequencing the assembled construct.
+- No vector-backbone or ORF-frame checking — confirm reading frame and backbone compatibility yourself.
+
+## Related skills
+- `tooluniverse-primer-design` — design the PCR primers (with homology arms / Type IIS tails) to make the fragments.
+- `tooluniverse-sequence-analysis` — handle the input sequences.

--- a/skills/tooluniverse-molecular-cloning/scripts/cloning_qc.py
+++ b/skills/tooluniverse-molecular-cloning/scripts/cloning_qc.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Cloning assembly QC for the tooluniverse-molecular-cloning skill.
+
+Screens DNA parts/fragments for the failures that wreck an assembly:
+- Golden Gate: internal Type IIS recognition sites (BsaI/BbsI) that must be
+  domesticated, plus uniqueness / palindrome checks on 4-bp overhangs.
+- Gibson: overlap length and GC of the supplied homology arms.
+
+Usage:
+  # Golden Gate: check parts for internal sites + given overhangs
+  python cloning_qc.py --golden-gate --enzyme BsaI --parts ATGGCG...,CTGAGC...
+  python cloning_qc.py --overhangs AAAC,AAAG,AAAT
+  # Gibson: check overlap arms
+  python cloning_qc.py --overlaps ATGGCGCCCAAGACGGGCTA,GAGGACGAGCTGCTGAAGCT
+"""
+
+import argparse
+
+_COMP = {"A": "T", "T": "A", "G": "C", "C": "G"}
+_SITES = {"BsaI": "GGTCTC", "BbsI": "GAAGAC"}
+
+
+def revcomp(s):
+    return "".join(_COMP.get(b, "N") for b in reversed(s.upper()))
+
+
+def gc(s):
+    return 100.0 * sum(b in "GC" for b in s.upper()) / len(s) if s else 0.0
+
+
+def check_internal_sites(parts, enzyme):
+    site = _SITES[enzyme]
+    rc = revcomp(site)
+    print(f"\nGolden Gate — internal {enzyme} sites ({site} / {rc}):")
+    ok = True
+    for i, p in enumerate(parts, 1):
+        p = p.upper()
+        n = p.count(site) + p.count(rc)
+        flag = "PASS" if n == 0 else "WARN"
+        if n:
+            ok = False
+        print(f"  [{flag}] Part_{i}: {n} internal site(s)" + ("" if n == 0 else " — DOMESTICATE (silent-mutate) before use"))
+    if ok:
+        print("  all parts free of internal sites.")
+
+
+def check_overhangs(ohs):
+    print("\nGolden Gate — 4-bp overhang QC:")
+    ohs = [o.upper() for o in ohs]
+    seen = {}
+    for i, o in enumerate(ohs, 1):
+        issues = []
+        if len(o) != 4:
+            issues.append(f"length {len(o)}!=4")
+        if o == revcomp(o):
+            issues.append("palindromic (self-complementary)")
+        if o in seen:
+            issues.append(f"duplicate of overhang #{seen[o]}")
+        if revcomp(o) in ohs:
+            issues.append("reverse-complement of another overhang")
+        seen.setdefault(o, i)
+        flag = "PASS" if not issues else "WARN"
+        print(f"  [{flag}] {o}" + ("" if not issues else "  — " + "; ".join(issues)))
+
+
+def check_overlaps(ovs):
+    print("\nGibson — overlap arm QC:")
+    for i, o in enumerate(ovs, 1):
+        o = o.upper()
+        issues = []
+        if not (15 <= len(o) <= 40):
+            issues.append(f"length {len(o)} (want 15-40 bp)")
+        if not (40 <= gc(o) <= 65):
+            issues.append(f"GC {gc(o):.0f}% (want 40-65%)")
+        flag = "PASS" if not issues else "WARN"
+        print(f"  [{flag}] overlap {i} ({len(o)} bp, GC {gc(o):.0f}%)" + ("" if not issues else "  — " + "; ".join(issues)))
+    # shared-homology check
+    for i in range(len(ovs)):
+        for j in range(i + 1, len(ovs)):
+            if ovs[i].upper() == ovs[j].upper():
+                print(f"  [WARN] overlaps {i + 1} and {j + 1} are identical — fragments can swap; make each unique.")
+
+
+def _split(s):
+    return [x.strip() for x in s.split(",") if x.strip()]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--golden-gate", action="store_true")
+    ap.add_argument("--enzyme", choices=list(_SITES), default="BsaI")
+    ap.add_argument("--parts", help="comma-separated part sequences")
+    ap.add_argument("--overhangs", help="comma-separated 4-bp overhangs")
+    ap.add_argument("--overlaps", help="comma-separated Gibson overlap arms")
+    args = ap.parse_args()
+
+    if (args.golden_gate or args.parts) and args.parts:
+        check_internal_sites(_split(args.parts), args.enzyme)
+    if args.overhangs:
+        check_overhangs(_split(args.overhangs))
+    if args.overlaps:
+        check_overlaps(_split(args.overlaps))
+    if not any((args.parts, args.overhangs, args.overlaps)):
+        ap.error("provide --parts, --overhangs, and/or --overlaps")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tooluniverse-molecular-cloning/test_cloning_qc.py
+++ b/skills/tooluniverse-molecular-cloning/test_cloning_qc.py
@@ -1,0 +1,55 @@
+"""Tests for the molecular-cloning skill helper script (assembly QC)."""
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+SCRIPT = pathlib.Path(__file__).parent / "scripts" / "cloning_qc.py"
+sys.path.insert(0, str(SCRIPT.parent))
+import cloning_qc as cq  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_revcomp():
+    assert cq.revcomp("ATGC") == "GCAT"
+    assert cq.revcomp("GGTCTC") == "GAGACC"  # BsaI site / its reverse complement
+
+
+def test_gc():
+    assert cq.gc("GGCC") == pytest.approx(100.0)
+    assert cq.gc("ATGC") == pytest.approx(50.0)
+
+
+def test_internal_bsai_site_flagged():
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT), "--enzyme", "BsaI", "--parts", "ATGGCGGGTCTCAAAGCCC,CTGAGCGAGGAC"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "WARN" in out  # Part_1 has an internal GGTCTC
+    assert "DOMESTICATE" in out
+    assert "PASS" in out  # Part_2 is clean
+
+
+def test_palindromic_overhang_flagged():
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT), "--overhangs", "AAAC,AATT"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "palindromic" in out  # AATT is self-complementary
+
+
+def test_clean_overlaps_pass():
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT), "--overlaps", "ATGGCGCCCAAGACGGGCTA,GAGGACGAGCTGCTGAAGCT"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "WARN" not in out  # both 20 bp, good GC

--- a/skills/tooluniverse/SKILL.md
+++ b/skills/tooluniverse/SKILL.md
@@ -192,6 +192,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**clinical data integration**", "clinical phenotype", "EHR analysis", "clinical cohort" | `Skill(skill="tooluniverse-clinical-data-integration")` |
 | "**phylogenetics**", "phylogenetic tree", "sequence alignment", "evolutionary analysis", "treeness", "saturation", "parsimony", "PhyKIT", "DVMC", "long branch", "tree length", "MAFFT", "gap percentage" | `Skill(skill="tooluniverse-phylogenetics")` |
 | "**statistical modeling**", "regression analysis", "logistic regression", "survival analysis", "Cox", "ANOVA", "F-statistic", "chi-square", "spline", "odds ratio", "Cohen's d", "p-value", "clinical trial data", "**ordinal**", "**severity**", "**vaccination**", "SDTM", "DM.csv", "AE.csv", "adverse event severity" | `Skill(skill="tooluniverse-statistical-modeling")` |
+| "**molecular cloning**", "Gibson Assembly", "Golden Gate", "Type IIS", "BsaI", "BbsI", "assembly overlap", "fragment assembly", "construct design", "domestication" | `Skill(skill="tooluniverse-molecular-cloning")` |
 | "**metabolomics analysis**", "LC-MS analysis", "metabolite quantification", "metabolic flux" | `Skill(skill="tooluniverse-metabolomics-analysis")` |
 | "**functional genomics screen**", "CRISPR library", "shRNA screen", "barcode screen" | `Skill(skill="tooluniverse-functional-genomics-screens")` |
 | "**proteomics data**", "PRIDE", "MassIVE", "ProteomeXchange", "proteomics dataset" | `Skill(skill="tooluniverse-proteomics-data-retrieval")` |


### PR DESCRIPTION
Discovery harness — **task-gap** (Sub-loop B).

## Gap

`DNA_gibson_design` and `DNA_golden_gate_design` exist but **no skill** — molecular cloning assembly design had no workflow. Complements the new `tooluniverse-primer-design`.

## Skill

`tooluniverse-molecular-cloning`:

- **Method-selection table**: Gibson (scarless, few fragments) vs Golden Gate (Type IIS, modular/library).
- **Gibson**: overlap design rules (15–40 bp, Tm balance, fragment order, unique junctions, avoid repeats); the tool returns the homology arms to append to primers.
- **Golden Gate**: Type IIS (BsaI/BbsI) with the **mandatory domestication rule** (no internal enzyme sites — the #1 failure) + unique **non-palindromic 4-bp overhangs**.
- **Gotchas**: internal Type IIS sites, non-unique overlaps → fragment swapping, junction repeats, overlap-Tm imbalance; fragments still need primers (→ `tooluniverse-primer-design`) + specificity BLAST.
- **`scripts/cloning_qc.py`**: screens parts for internal BsaI/BbsI sites, overhang uniqueness/palindromes, and Gibson overlap length/GC.

## Validation

- Both tools verified live (Gibson → per-fragment overlaps + `with_overlaps`; Golden Gate → unique 4-bp overhangs + BsaI-flanked `full_sequence`).
- QC script verified: catches an internal BsaI site (→ domesticate), a palindromic/duplicate overhang, and passes clean 20-bp overlaps.
- Routing rows added (both `skills/` + `plugin/skills/` mirrors).