### PR TITLE
Add PGS Catalog tools (published polygenic scores, EMBL-EBI)

### DIFF
--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -452,6 +452,7 @@ STATIC_LAZY_REGISTRY = {
     "PagedResponse": "ols_tool",
     "PaleobiologyRESTTool": "paleobiology_tool",
     "PathwayCommonsTool": "pathwaycommons_tool",
+    "PGSCatalogTool": "pgs_catalog_tool",
     "PfamTool": "pfam_tool",
     "PharmGKBTool": "pharmgkb_tool",
     "PharmacoDBTool": "pharmacodb_tool",

--- a/src/tooluniverse/data/pgs_catalog_tools.json
+++ b/src/tooluniverse/data/pgs_catalog_tools.json
@@ -1,0 +1,154 @@
+[
+  {
+    "type": "PGSCatalogTool",
+    "name": "PGSCatalog_search_traits",
+    "description": "Search the PGS Catalog (pgscatalog.org, EMBL-EBI — the open database of published polygenic scores) for traits/phenotypes matching a term. Returns each matching trait's id (EFO/MONDO, e.g. 'MONDO_0004989'), label, description, and the number of polygenic scores published for it. Use this first to find the trait_id, then PGSCatalog_get_scores_by_trait to list its scores. No API key.",
+    "fields": {"operation": "search_traits"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Trait or phenotype term, e.g. 'coronary artery disease', 'type 2 diabetes', 'breast cancer'."
+        }
+      },
+      "required": ["query"]
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "status": {"type": "string", "enum": ["success"]},
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "trait_id": {"type": "string"},
+                  "label": {"type": "string"},
+                  "description": {"type": "string"},
+                  "n_scores": {"type": "integer"}
+                }
+              }
+            },
+            "metadata": {"type": "object"}
+          },
+          "required": ["status", "data"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {"type": "string", "enum": ["error"]},
+            "error": {"type": "string"}
+          },
+          "required": ["status", "error"]
+        }
+      ]
+    },
+    "test_examples": [{"query": "coronary artery disease"}]
+  },
+  {
+    "type": "PGSCatalogTool",
+    "name": "PGSCatalog_get_scores_by_trait",
+    "description": "List the published polygenic scores (PGS) for a trait in the PGS Catalog, given its EFO/MONDO trait id (find one with PGSCatalog_search_traits). Each score summary includes the PGS id, name, reported trait, number of variants, development method, genome build, and publication (author/journal/year/PMID/DOI) plus the scoring-file URL. Use PGSCatalog_get_score for the full record of one score. No API key.",
+    "fields": {"operation": "get_scores_by_trait"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "trait_id": {
+          "type": "string",
+          "description": "EFO or MONDO trait id, e.g. 'MONDO_0004989' (breast carcinoma) or 'EFO_0001645' (coronary artery disease)."
+        }
+      },
+      "required": ["trait_id"]
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "status": {"type": "string", "enum": ["success"]},
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pgs_id": {"type": "string"},
+                  "trait_reported": {"type": "string"},
+                  "variants_number": {"type": "integer"},
+                  "method_name": {"type": "string"},
+                  "publication": {"type": "object"},
+                  "scoring_file": {"type": "string"}
+                }
+              }
+            },
+            "metadata": {"type": "object"}
+          },
+          "required": ["status", "data"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {"type": "string", "enum": ["error"]},
+            "error": {"type": "string"}
+          },
+          "required": ["status", "error"]
+        }
+      ]
+    },
+    "test_examples": [{"trait_id": "MONDO_0004989"}]
+  },
+  {
+    "type": "PGSCatalogTool",
+    "name": "PGSCatalog_get_score",
+    "description": "Retrieve the full metadata for a specific polygenic score from the PGS Catalog by its PGS id (e.g. 'PGS000001'): reported and EFO/MONDO traits, number of variants, development method, genome build, weight type, publication, training samples, ancestry distribution, and the downloadable scoring-file URL. Find PGS ids with PGSCatalog_get_scores_by_trait. No API key.",
+    "fields": {"operation": "get_score"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "pgs_id": {
+          "type": "string",
+          "description": "PGS Catalog score id, e.g. 'PGS000001'."
+        }
+      },
+      "required": ["pgs_id"]
+    },
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "status": {"type": "string", "enum": ["success"]},
+            "data": {
+              "type": "object",
+              "properties": {
+                "pgs_id": {"type": "string"},
+                "name": {"type": "string"},
+                "trait_reported": {"type": "string"},
+                "trait_efo": {"type": "array"},
+                "variants_number": {"type": "integer"},
+                "method_name": {"type": "string"},
+                "genome_build": {"type": "string"},
+                "publication": {"type": "object"},
+                "ancestry_distribution": {"type": "object"},
+                "scoring_file": {"type": "string"}
+              }
+            },
+            "metadata": {"type": "object"}
+          },
+          "required": ["status", "data"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {"type": "string", "enum": ["error"]},
+            "error": {"type": "string"}
+          },
+          "required": ["status", "error"]
+        }
+      ]
+    },
+    "test_examples": [{"pgs_id": "PGS000001"}]
+  }
+]

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -257,6 +257,8 @@ default_tool_files = {
     ),
     "embedding": os.path.join(current_dir, "data", "embedding_tools.json"),
     "gwas": os.path.join(current_dir, "data", "gwas_tools.json"),
+    # PGS Catalog - published polygenic scores (EMBL-EBI)
+    "pgs_catalog": os.path.join(current_dir, "data", "pgs_catalog_tools.json"),
     # GWAS Summary Statistics - full variant-level summary stats from deposited studies
     "gwas_sumstats": os.path.join(current_dir, "data", "gwas_sumstats_tools.json"),
     "admetai": os.path.join(current_dir, "data", "admetai_tools.json"),

--- a/src/tooluniverse/pgs_catalog_tool.py
+++ b/src/tooluniverse/pgs_catalog_tool.py
@@ -1,0 +1,192 @@
+"""
+PGS Catalog tool for ToolUniverse.
+
+The PGS Catalog (pgscatalog.org, hosted by EMBL-EBI) is the open database of
+published polygenic scores (PGS) — for each score it records the trait, the
+number of variants, the development method, the publication, the training and
+evaluation sample ancestries, and links to the downloadable scoring file.
+
+This tool lets an agent (a) find the trait id for a phenotype, (b) list the
+polygenic scores published for that trait, and (c) retrieve the full metadata
+for a specific score. It complements the polygenic-risk-score skill, which
+previously had no way to query published scores.
+
+API: https://www.pgscatalog.org/rest (public, no key).
+"""
+
+from typing import Any, Dict, List
+
+import requests
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+
+PGS_API = "https://www.pgscatalog.org/rest"
+PGS_SOURCE = "PGS Catalog (pgscatalog.org, EMBL-EBI)"
+
+
+def _score_summary(s: Dict[str, Any]) -> Dict[str, Any]:
+    """Trim a raw PGS score record to the useful summary fields."""
+    pub = s.get("publication") or {}
+    return {
+        "pgs_id": s.get("id"),
+        "name": s.get("name"),
+        "trait_reported": s.get("trait_reported"),
+        "variants_number": s.get("variants_number"),
+        "method_name": s.get("method_name"),
+        "genome_build": s.get("variants_genomebuild"),
+        "weight_type": s.get("weight_type"),
+        "publication": {
+            "first_author": pub.get("firstauthor"),
+            "journal": pub.get("journal"),
+            "year": pub.get("date_publication", "")[:4]
+            if pub.get("date_publication")
+            else None,
+            "pmid": pub.get("PMID"),
+            "doi": pub.get("doi"),
+        },
+        "scoring_file": s.get("ftp_scoring_file"),
+    }
+
+
+@register_tool("PGSCatalogTool")
+class PGSCatalogTool(BaseTool):
+    """Query the PGS Catalog (EBI) for published polygenic scores."""
+
+    def __init__(self, tool_config: Dict[str, Any]):
+        super().__init__(tool_config)
+        self.timeout: int = tool_config.get("timeout", 30)
+        self.operation: str = tool_config.get("fields", {}).get("operation", "")
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        operation = arguments.get("operation") or self.operation
+        if operation == "search_traits":
+            return self._search_traits(arguments)
+        if operation == "get_scores_by_trait":
+            return self._get_scores_by_trait(arguments)
+        if operation == "get_score":
+            return self._get_score(arguments)
+        return {
+            "status": "error",
+            "error": f"Unknown operation: {operation}. Supported: "
+            "search_traits, get_scores_by_trait, get_score.",
+        }
+
+    def _request(self, path: str, params: Dict[str, Any] | None = None):
+        try:
+            resp = requests.get(
+                f"{PGS_API}/{path}",
+                params=params or {},
+                headers={"Accept": "application/json"},
+                timeout=self.timeout,
+            )
+        except requests.Timeout:
+            return None, {
+                "status": "error",
+                "error": f"PGS Catalog request timed out after {self.timeout}s.",
+            }
+        except requests.exceptions.RequestException as e:
+            return None, {
+                "status": "error",
+                "error": f"Failed to reach PGS Catalog: {str(e)}",
+            }
+        if resp.status_code == 404:
+            return None, {"status": "error", "error": "Not found in the PGS Catalog."}
+        if resp.status_code != 200:
+            return None, {
+                "status": "error",
+                "error": f"PGS Catalog returned HTTP {resp.status_code}",
+            }
+        try:
+            return resp.json(), None
+        except ValueError:
+            return None, {
+                "status": "error",
+                "error": "PGS Catalog returned a non-JSON response.",
+            }
+
+    def _search_traits(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        term = arguments.get("query") or arguments.get("term")
+        if not term or not str(term).strip():
+            return {
+                "status": "error",
+                "error": "Parameter 'query' is required (a trait/phenotype term, e.g. 'coronary artery disease').",
+            }
+        body, err = self._request("trait/search", {"term": str(term)})
+        if err:
+            return err
+        results: List[Dict[str, Any]] = (
+            body.get("results", []) if isinstance(body, dict) else []
+        )
+        traits = [
+            {
+                "trait_id": t.get("id"),
+                "label": t.get("label"),
+                "description": t.get("description"),
+                "n_scores": len(t.get("associated_pgs_ids", [])),
+            }
+            for t in results
+        ]
+        return {
+            "status": "success",
+            "data": traits,
+            "metadata": {
+                "source": PGS_SOURCE,
+                "query": str(term),
+                "returned": len(traits),
+            },
+        }
+
+    def _get_scores_by_trait(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        trait_id = arguments.get("trait_id") or arguments.get("efo_id")
+        if not trait_id or not str(trait_id).strip():
+            return {
+                "status": "error",
+                "error": "Parameter 'trait_id' is required (an EFO/MONDO id, e.g. "
+                "'MONDO_0004989'; find one with operation 'search_traits').",
+            }
+        body, err = self._request("score/search", {"trait_id": str(trait_id).strip()})
+        if err:
+            return err
+        results = body.get("results", []) if isinstance(body, dict) else []
+        return {
+            "status": "success",
+            "data": [_score_summary(s) for s in results],
+            "metadata": {
+                "source": PGS_SOURCE,
+                "trait_id": str(trait_id).strip(),
+                "total": body.get("count") if isinstance(body, dict) else len(results),
+                "returned": len(results),
+            },
+        }
+
+    def _get_score(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        pgs_id = arguments.get("pgs_id") or arguments.get("score_id")
+        if not pgs_id or not str(pgs_id).strip():
+            return {
+                "status": "error",
+                "error": "Parameter 'pgs_id' is required (e.g. 'PGS000001').",
+            }
+        pgs_id = str(pgs_id).strip().upper()
+        body, err = self._request(f"score/{pgs_id}")
+        if err:
+            return err
+        if not isinstance(body, dict) or not body.get("id"):
+            return {
+                "status": "error",
+                "error": f"No PGS Catalog score found for '{pgs_id}'.",
+            }
+
+        summary = _score_summary(body)
+        # add the richer fields available on the single-score endpoint
+        summary["trait_efo"] = [
+            {"id": t.get("id"), "label": t.get("label")}
+            for t in (body.get("trait_efo") or [])
+        ]
+        summary["ancestry_distribution"] = body.get("ancestry_distribution")
+        summary["samples_training"] = body.get("samples_training")
+        return {
+            "status": "success",
+            "data": summary,
+            "metadata": {"source": PGS_SOURCE},
+        }

--- a/tests/unit/test_pgs_catalog_tool.py
+++ b/tests/unit/test_pgs_catalog_tool.py
@@ -1,0 +1,109 @@
+"""PGS Catalog tool (published polygenic scores, EMBL-EBI).
+
+Mocked unit tests for the three operations + normalization + error paths
+(no live pgscatalog.org calls).
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool(operation):
+    from tooluniverse.pgs_catalog_tool import PGSCatalogTool
+
+    return PGSCatalogTool(
+        {"name": f"PGSCatalog_{operation}", "type": "PGSCatalogTool", "fields": {"operation": operation}}
+    )
+
+
+def _resp(status_code, body):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = body
+    return r
+
+
+_SCORE = {
+    "id": "PGS000001",
+    "name": "PGS000001",
+    "trait_reported": "Breast cancer",
+    "variants_number": 77,
+    "method_name": "SNPs passing genome-wide significance",
+    "variants_genomebuild": "GRCh37",
+    "trait_efo": [{"id": "MONDO_0004989", "label": "breast carcinoma"}],
+    "publication": {"firstauthor": "Mavaddat N", "journal": "AJHG", "date_publication": "2019-01-01", "PMID": 30554720},
+    "ftp_scoring_file": "https://ftp/PGS000001.txt.gz",
+}
+
+
+class TestSearchTraits(unittest.TestCase):
+    def test_missing_query_rejected(self):
+        result = _make_tool("search_traits").run({})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("query", result["error"])
+
+    def test_trait_search_counts_scores(self):
+        tool = _make_tool("search_traits")
+        body = {"results": [{"id": "MONDO_0004989", "label": "breast carcinoma", "associated_pgs_ids": ["PGS1", "PGS2"]}]}
+        with patch("tooluniverse.pgs_catalog_tool.requests.get") as get:
+            get.return_value = _resp(200, body)
+            result = tool.run({"query": "breast cancer"})
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"][0]["trait_id"], "MONDO_0004989")
+        self.assertEqual(result["data"][0]["n_scores"], 2)
+        self.assertEqual(get.call_args.kwargs["params"]["term"], "breast cancer")
+
+
+class TestScoresByTrait(unittest.TestCase):
+    def test_missing_trait_id_rejected(self):
+        result = _make_tool("get_scores_by_trait").run({})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("trait_id", result["error"])
+
+    def test_scores_summarized(self):
+        tool = _make_tool("get_scores_by_trait")
+        with patch("tooluniverse.pgs_catalog_tool.requests.get") as get:
+            get.return_value = _resp(200, {"count": 1, "results": [_SCORE]})
+            result = tool.run({"trait_id": "MONDO_0004989"})
+        s = result["data"][0]
+        self.assertEqual(s["pgs_id"], "PGS000001")
+        self.assertEqual(s["variants_number"], 77)
+        self.assertEqual(s["publication"]["first_author"], "Mavaddat N")
+        self.assertEqual(s["publication"]["year"], "2019")  # parsed from date
+        self.assertEqual(result["metadata"]["total"], 1)
+
+
+class TestGetScore(unittest.TestCase):
+    def test_get_score_adds_efo_and_ancestry(self):
+        tool = _make_tool("get_score")
+        with patch("tooluniverse.pgs_catalog_tool.requests.get") as get:
+            get.return_value = _resp(200, _SCORE)
+            result = tool.run({"pgs_id": "pgs000001"})  # lowercased -> normalized
+        d = result["data"]
+        self.assertEqual(d["pgs_id"], "PGS000001")
+        self.assertEqual(d["trait_efo"][0]["label"], "breast carcinoma")
+        self.assertTrue(get.call_args.args[0].endswith("/score/PGS000001"))  # upper-cased
+
+    def test_404_is_clear_error(self):
+        tool = _make_tool("get_score")
+        with patch("tooluniverse.pgs_catalog_tool.requests.get") as get:
+            get.return_value = _resp(404, {})
+            result = tool.run({"pgs_id": "PGS999999"})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Not found", result["error"])
+
+    def test_unknown_operation(self):
+        from tooluniverse.pgs_catalog_tool import PGSCatalogTool
+
+        tool = PGSCatalogTool({"name": "x", "type": "PGSCatalogTool", "fields": {}})
+        result = tool.run({"operation": "bogus"})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Unknown operation", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Discovery harness — **net-new resource**.

## Gap
No tool queried the **PGS Catalog** (pgscatalog.org, EMBL-EBI) — the authoritative open DB of **published polygenic scores** (~5000+) — though a `polygenic-risk-score` skill exists. Found via fresh resource sweep (`pgscatalog.org/rest` → 200 JSON, not in TU). Public REST, no key.

## Tools
- **`PGSCatalog_search_traits`** — phenotype term → trait ids (EFO/MONDO) + labels + score counts.
- **`PGSCatalog_get_scores_by_trait`** — trait id → published scores (PGS id, trait, variant count, method, build, publication, scoring-file URL).
- **`PGSCatalog_get_score`** — PGS id → full metadata (traits, EFO, method, ancestry distribution, training samples, scoring file).

Aliases (query/term, trait_id/efo_id, pgs_id/score_id); pgs_id upper-cased; 404→clear not-found; never raises; oneOf schemas.

## Validation
- Live: T2D → MONDO_0005148 (219 scores); breast carcinoma → 144 scores incl. PGS000001 (77 variants, Mavaddat N); get_score full metadata.
- Sweep 3/3 passed; 7 mocked unit tests passed.