### PR TITLE
Fix Round 009: openFDA adverse-event tools silently empty on unknown param

### DIFF
--- a/src/tooluniverse/openfda_adv_tool.py
+++ b/src/tooluniverse/openfda_adv_tool.py
@@ -158,9 +158,13 @@ class FDADrugAdverseEventTool(BaseTool):
     def _search(self, arguments):
         search_parts = []
         for param_name, value in arguments.items():
-            fda_fields = self.search_fields.get(
-                param_name, [param_name]
-            )  # Map param -> FDA field
+            # Only forward parameters defined in the search-field map; an
+            # unrecognized argument (e.g. a stray 'limit') must NOT become a
+            # bogus FDA filter like 'limit:2', which matches nothing and yields
+            # a silent empty result.
+            fda_fields = self.search_fields.get(param_name)
+            if not fda_fields:
+                continue
             # Use the first field name for value mapping
             fda_field = fda_fields[0] if fda_fields else param_name
 
@@ -302,8 +306,11 @@ class FDACountAdditiveReactionsTool(FDADrugAdverseEventTool):
         # Combine additional filters
         filters = []
         for k, v in arguments.items():
-            # Get FDA field name(s) from search_fields mapping
-            fda_fields = self.search_fields.get(k, [k])
+            # Get FDA field name(s) from the search-field map; skip unrecognized
+            # filters rather than forwarding them as bogus FDA constraints.
+            fda_fields = self.search_fields.get(k)
+            if not fda_fields:
+                continue
             # Use the first field name for value mapping
             fda_field = fda_fields[0] if fda_fields else k
 
@@ -418,9 +425,13 @@ class FDADrugAdverseEventDetailTool(BaseTool):
         # Build search query
         search_parts = []
         for param_name, value in arguments.items():
-            fda_fields = self.search_fields.get(
-                param_name, [param_name]
-            )  # Map param -> FDA field
+            # Only forward parameters defined in the search-field map; an
+            # unrecognized argument (e.g. a stray 'limit') must NOT become a
+            # bogus FDA filter like 'limit:2', which matches nothing and yields
+            # a silent empty result.
+            fda_fields = self.search_fields.get(param_name)
+            if not fda_fields:
+                continue
             # Use the first field name for value mapping
             fda_field = fda_fields[0] if fda_fields else param_name
 
@@ -771,9 +782,11 @@ class FDADrugInteractionDetailTool(BaseTool):
         # Build additional filters
         filter_parts = []
         for param_name, value in arguments.items():
-            fda_fields = self.search_fields.get(
-                param_name, [param_name]
-            )  # Map param -> FDA field
+            # Skip unrecognized arguments rather than forwarding them as bogus
+            # FDA filters (which silently match nothing).
+            fda_fields = self.search_fields.get(param_name)
+            if not fda_fields:
+                continue
             # Use the first field name for value mapping
             fda_field = fda_fields[0] if fda_fields else param_name
 

--- a/tests/unit/test_faers_unknown_param.py
+++ b/tests/unit/test_faers_unknown_param.py
@@ -1,0 +1,57 @@
+"""FAERS / openFDA adverse-event tools: unrecognized params must not corrupt the query.
+
+Regression for a silent-failure bug: an unknown argument (e.g. a stray 'limit')
+was forwarded into the openFDA search query as a bogus filter ('limit:2'),
+which matches nothing and returns a silent empty result. The tool must now
+ignore params not in its search-field map.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool():
+    from tooluniverse.openfda_adv_tool import FDADrugAdverseEventTool
+
+    return FDADrugAdverseEventTool(
+        {
+            "name": "FAERS_count_reactions_by_drug_event",
+            "type": "FDADrugAdverseEventTool",
+            "count_field": "patient.reaction.reactionmeddrapt.exact",
+            "fields": {
+                "search_fields": {"medicinalproduct": ["patient.drug.medicinalproduct"]},
+            },
+        }
+    )
+
+
+class TestUnknownParam(unittest.TestCase):
+    def _run_and_capture_url(self, arguments):
+        tool = _make_tool()
+        with patch("tooluniverse.openfda_adv_tool.requests.get") as get:
+            resp = MagicMock()
+            resp.json.return_value = {"results": [{"term": "FATIGUE", "count": 100}]}
+            resp.status_code = 200
+            get.return_value = resp
+            tool.run(arguments)
+            return get.call_args.args[0] if get.call_args.args else get.call_args.kwargs.get("url", "")
+
+    def test_known_param_is_in_query(self):
+        url = self._run_and_capture_url({"medicinalproduct": "SIMVASTATIN"})
+        self.assertIn("patient.drug.medicinalproduct", url)
+        self.assertIn("SIMVASTATIN", url)
+
+    def test_unknown_param_is_ignored_not_forwarded(self):
+        # 'limit' is not in search_fields -> must NOT appear as a bogus filter
+        url = self._run_and_capture_url({"medicinalproduct": "SIMVASTATIN", "limit": 2})
+        self.assertIn("patient.drug.medicinalproduct", url)  # the real query survives
+        self.assertNotIn("limit:2", url)  # the stray param is dropped
+        self.assertNotIn("limit", url.split("count=")[0])  # not in the search clause
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found via the CLI role-play test harness (a clinical-pharmacology persona querying simvastatin adverse events).

## Bug

`FAERS_count_reactions_by_drug_event` — and the three sibling FDA adverse-event/interaction tools — forwarded **any** argument into the openFDA search query. An unrecognized parameter (e.g. a stray `limit`) became a bogus filter `limit:2` that matches nothing, producing a **silent empty** `{result: []}` with no error.

Reproduce (before): `FAERS_count_reactions_by_drug_event {"medicinalproduct":"SIMVASTATIN","limit":2}` → `{result: []}` (0 reactions). Without `limit` it returns the real top reactions.

## Root cause

The four `FDADrugAdverseEvent*` classes in `openfda_adv_tool.py` built the query with `self.search_fields.get(param, [param])` — the `[param]` fallback turned any unknown arg into an FDA search filter.

## Fix

All four query-building loops now **skip params not in the search-field map** (`fda_fields = self.search_fields.get(param); if not fda_fields: continue`), so stray arguments are ignored instead of corrupting the query.

## Validation

- After fix: `{"medicinalproduct":"SIMVASTATIN","limit":2}` → real reactions (FATIGUE 11855, NAUSEA 10904, …); normal calls unchanged.
- `test_new_tools.py faers` → 6/6 still pass (no regression).
- `tests/unit/test_faers_unknown_param.py` → 2 mocked regression tests (known param survives; `limit` dropped from the search clause).

Other harness findings this round were CLI-verified as false positives (e.g. STRING `identifiers` is correctly typed `string` — passing a list was a caller error).