### PR TITLE
Fix unauthenticated RCE in python_code_executor and harden server exposure

### DIFF
--- a/docs/guide/http_api.rst
+++ b/docs/guide/http_api.rst
@@ -18,8 +18,46 @@ On the machine with ToolUniverse installed:
     # Install full ToolUniverse package
     pip install tooluniverse
 
-    # Start HTTP API server (single worker with async thread pool)
+    # Start HTTP API server (defaults to loopback 127.0.0.1)
+    tooluniverse-http-api --port 8080
+
+The server binds to ``127.0.0.1`` by default and is reachable only from the
+local machine. Exposing it to the network requires authentication — see
+:ref:`http-api-authentication` below.
+
+.. _http-api-authentication:
+
+Authentication and Network Exposure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The HTTP API can execute any ToolUniverse method, including the Python code
+executor, so it must never be reachable on an untrusted network without
+authentication.
+
+* **Default bind is loopback** (``127.0.0.1``). The server refuses to bind to a
+  non-loopback address (e.g. ``0.0.0.0``) unless ``TOOLUNIVERSE_API_TOKEN`` is set.
+* **Set a token to enable Bearer authentication.** When ``TOOLUNIVERSE_API_TOKEN``
+  is set, every request must include ``Authorization: Bearer <token>`` (only
+  ``/health`` is exempt). Generate a strong random value, e.g.
+  ``python -c "import secrets; print(secrets.token_urlsafe(32))"``.
+
+.. code-block:: bash
+
+    # Expose to the network with authentication required
+    export TOOLUNIVERSE_API_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
     tooluniverse-http-api --host 0.0.0.0 --port 8080
+
+Clients authenticate by passing the token (or by setting ``TOOLUNIVERSE_API_TOKEN``
+in the client's environment, which is picked up automatically):
+
+.. code-block:: python
+
+    from tooluniverse import ToolUniverseClient
+
+    client = ToolUniverseClient("http://your-server:8080", api_token="<token>")
+
+The same ``TOOLUNIVERSE_API_TOKEN`` enables Bearer authentication on the SMCP
+(MCP, ``streamable-http``) server as well.
 
 Use Client
 ~~~~~~~~~~
@@ -201,6 +239,14 @@ See ``examples/http_api_usage_example.py`` for comprehensive examples including:
 
 Production Deployment
 ---------------------
+
+.. important::
+
+   The ``--host 0.0.0.0`` examples below expose the server to the network and
+   therefore **require** ``TOOLUNIVERSE_API_TOKEN`` to be set — the server
+   refuses to bind to a non-loopback address without it. Prefix each command
+   with ``TOOLUNIVERSE_API_TOKEN=<token>`` (or export it). See
+   :ref:`http-api-authentication`.
 
 GPU-Optimized Configuration (Recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/tooluniverse/http_api_server.py
+++ b/src/tooluniverse/http_api_server.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 
 from .execute_function import ToolUniverse
 from .logging_config import get_logger
+from .server_security import enforce_bind_security, get_api_token, token_matches
 
 logger = get_logger("HTTPAPIServer")
 
@@ -172,6 +173,35 @@ app = FastAPI(
     description="Auto-generated API exposing all ToolUniverse methods via HTTP",
     version="1.0.0",
 )
+
+# Paths reachable without authentication (liveness checks only).
+_PUBLIC_PATHS = {"/health"}
+
+
+@app.middleware("http")
+async def require_bearer_token(request, call_next):
+    """Require a Bearer token on every request when one is configured.
+
+    This endpoint can execute arbitrary ToolUniverse methods (including the
+    Python code executor), so it must never be reachable unauthenticated over
+    the network. When ``TOOLUNIVERSE_API_TOKEN`` is set, all routes except
+    ``/health`` require ``Authorization: Bearer <token>``. The bind guard in the
+    server entry points ensures a token is set before binding to a non-loopback
+    interface, so an unauthenticated server is only ever reachable from
+    localhost.
+    """
+    token = get_api_token()
+    if token is not None and request.url.path not in _PUBLIC_PATHS:
+        if not token_matches(request.headers.get("authorization", ""), token):
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "success": False,
+                    "error": "Unauthorized: a valid Bearer token is required",
+                    "error_type": "AuthenticationError",
+                },
+            )
+    return await call_next(request)
 
 
 @app.get("/", tags=["Health"])
@@ -374,4 +404,9 @@ async def reset_instance(config: Optional[Dict[str, Any]] = None):
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8080)
+    # Default to loopback. Remote exposure (e.g. 0.0.0.0) requires a token and
+    # is refused otherwise by enforce_bind_security().
+    host = os.getenv("TOOLUNIVERSE_HTTP_HOST", "127.0.0.1")
+    port = int(os.getenv("TOOLUNIVERSE_HTTP_PORT", "8080"))
+    enforce_bind_security(host)
+    uvicorn.run(app, host=host, port=port)

--- a/src/tooluniverse/http_api_server.py
+++ b/src/tooluniverse/http_api_server.py
@@ -8,7 +8,16 @@ Uses Python introspection to automatically discover methods - no manual updates 
 When you add/modify methods in ToolUniverse, they automatically work over HTTP.
 
 Usage:
-    python -m tooluniverse.http_api_server --host 0.0.0.0 --port 8080
+    # Loopback only (default, no authentication needed):
+    python -m tooluniverse.http_api_server
+
+    # Network exposure requires a Bearer token (see TOOLUNIVERSE_API_TOKEN);
+    # binding to a non-loopback host without it is refused:
+    TOOLUNIVERSE_API_TOKEN=secret TOOLUNIVERSE_HTTP_HOST=0.0.0.0 \
+        python -m tooluniverse.http_api_server
+
+    # Or use the CLI entry point for more options:
+    tooluniverse-http-api --host 0.0.0.0 --port 8080
 """
 
 import asyncio

--- a/src/tooluniverse/http_api_server_cli.py
+++ b/src/tooluniverse/http_api_server_cli.py
@@ -5,8 +5,11 @@ ToolUniverse HTTP API Server CLI
 Command-line interface for starting the ToolUniverse HTTP API server.
 
 Usage:
-    tooluniverse-http-api --host 0.0.0.0 --port 8080
-    tooluniverse-http-api --host 0.0.0.0 --port 8080 --workers 4
+    # Loopback only (default):
+    tooluniverse-http-api --port 8080
+
+    # Network exposure requires a Bearer token (TOOLUNIVERSE_API_TOKEN):
+    TOOLUNIVERSE_API_TOKEN=secret tooluniverse-http-api --host 0.0.0.0 --port 8080
 """
 
 import argparse
@@ -21,20 +24,25 @@ def run_http_api_server():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Start server with default settings (single worker, 20 threads)
+  # Start server with default settings (loopback 127.0.0.1, single worker)
   tooluniverse-http-api
 
-  # Start on specific host and port
-  tooluniverse-http-api --host 0.0.0.0 --port 8080
+  # Expose to the network (requires TOOLUNIVERSE_API_TOKEN for Bearer auth)
+  TOOLUNIVERSE_API_TOKEN=secret tooluniverse-http-api --host 0.0.0.0 --port 8080
 
-  # Start with larger thread pool for high concurrency (recommended for GPU)
-  tooluniverse-http-api --host 0.0.0.0 --port 8080 --thread-pool-size 50
+  # Larger thread pool for high concurrency (recommended for GPU)
+  TOOLUNIVERSE_API_TOKEN=secret tooluniverse-http-api --host 0.0.0.0 --port 8080 --thread-pool-size 50
 
   # Start with reload for development
   tooluniverse-http-api --reload
 
-  # Start with multiple workers (only for CPU-only workloads, not GPU)
-  tooluniverse-http-api --host 0.0.0.0 --port 8080 --workers 4
+  # Multiple workers (only for CPU-only workloads, not GPU)
+  TOOLUNIVERSE_API_TOKEN=secret tooluniverse-http-api --host 0.0.0.0 --port 8080 --workers 4
+
+Authentication:
+  - Binds to 127.0.0.1 by default; binding to a non-loopback host (e.g. 0.0.0.0)
+    is refused unless TOOLUNIVERSE_API_TOKEN is set.
+  - When set, every request needs 'Authorization: Bearer <token>' (except /health).
 
 Features:
   - Auto-discovers all ToolUniverse methods via introspection

--- a/src/tooluniverse/http_api_server_cli.py
+++ b/src/tooluniverse/http_api_server_cli.py
@@ -133,6 +133,12 @@ Note:
     try:
         import uvicorn
 
+        from .server_security import enforce_bind_security
+
+        # Refuse to expose the server on a non-loopback interface unless a
+        # TOOLUNIVERSE_API_TOKEN is configured to require Bearer authentication.
+        enforce_bind_security(args.host)
+
         # Use import string when workers > 1 (required by uvicorn)
         if args.workers > 1 and not args.reload:
             app_import = "tooluniverse.http_api_server:app"

--- a/src/tooluniverse/http_client.py
+++ b/src/tooluniverse/http_client.py
@@ -28,6 +28,8 @@ Documentation:
     https://zitniklab.hms.harvard.edu/ToolUniverse/guide/http_api.html
 """
 
+import os
+
 import requests
 from typing import Any, Dict, Optional, List
 
@@ -59,16 +61,27 @@ class ToolUniverseClient:
         client.your_new_method(param="value")
     """
 
-    def __init__(self, base_url: str = "http://localhost:8080"):
+    def __init__(
+        self, base_url: str = "http://localhost:8080", api_token: Optional[str] = None
+    ):
         """
         Initialize client.
 
         Args:
             base_url: Base URL of ToolUniverse HTTP API server
+            api_token: Bearer token for servers that require authentication.
+                Defaults to the ``TOOLUNIVERSE_API_TOKEN`` environment variable.
+                When set, it is sent as ``Authorization: Bearer <token>`` on
+                every request.
         """
         self.base_url = base_url.rstrip("/")
         self.session = requests.Session()
         self.session.headers.update({"Content-Type": "application/json"})
+        token = (
+            api_token if api_token is not None else os.getenv("TOOLUNIVERSE_API_TOKEN")
+        )
+        if token:
+            self.session.headers.update({"Authorization": f"Bearer {token}"})
         self._methods_cache: Optional[List[Dict]] = None
 
     def _get_available_methods(self) -> List[Dict]:
@@ -136,7 +149,7 @@ class ToolUniverseClient:
                     raise Exception(f"[{error_type}] {error_msg}")
 
                 return result.get("result")
-            
+
             except requests.exceptions.ReadTimeout:
                 print(method_name, kwargs, "timed out")
                 return f"Error: Tool execution timed out after 30 seconds"
@@ -338,5 +351,5 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"\n❌ Error: {e}")
         print("\n💡 Make sure the ToolUniverse HTTP API server is running:")
-        print("   tooluniverse-http-api --host 0.0.0.0 --port 8080")
+        print("   tooluniverse-http-api --port 8080")
         sys.exit(1)

--- a/src/tooluniverse/mcp_tool_registry.py
+++ b/src/tooluniverse/mcp_tool_registry.py
@@ -22,7 +22,7 @@ Server Side (Tool Provider):
         },
         mcp_config={
             "server_name": "Custom Analysis Server",
-        "host": "0.0.0.0",
+        "host": "127.0.0.1",
         "port": 8001
     }
 )

--- a/src/tooluniverse/python_executor_tool.py
+++ b/src/tooluniverse/python_executor_tool.py
@@ -52,8 +52,10 @@ class BasePythonExecutor:
         "reversed",
         "slice",
         "type",
-        "getattr",
-        "setattr",
+        # Note: getattr/setattr are intentionally NOT exposed. They allow
+        # string-based attribute access (e.g. getattr(obj, "__class__")) that
+        # bypasses the AST-level dunder check below and enables sandbox escape
+        # through the interpreter's class hierarchy.
         "hasattr",
         "callable",
         "__import__",  # Needed for import statements
@@ -87,6 +89,127 @@ class BasePythonExecutor:
         "Attribute": ["__import__", "open", "file"],
     }
 
+    # Dangerous attribute names that pivot out of the sandbox.
+    #
+    # The allowed scientific modules (numpy, scipy, matplotlib, ...) transitively
+    # expose dangerous stdlib modules as PLAIN, non-dunder attributes — e.g.
+    # `numpy.ctypeslib` (-> ctypes -> CDLL -> native code), `matplotlib.os`,
+    # `matplotlib.subprocess`, `random._os`, `collections._sys`. Reaching any of
+    # them is arbitrary code execution (`ctypes.CDLL(None).system(...)`), and none
+    # require a dunder, a forbidden import, or a forbidden call — so the existing
+    # checks did not catch them.
+    #
+    # Because `getattr`/`globals`/`vars`/`eval`/`exec`/`compile` are all withheld
+    # from the builtins whitelist, the ONLY way user code can reach an attribute is
+    # the literal `obj.name` syntax, which is visible in the AST. Denying these
+    # attribute names (normalized: leading underscores stripped, lower-cased, so
+    # `_os`/`_sys` alias forms are also caught) therefore soundly blocks the pivot.
+    #
+    # Legitimate numeric attributes are deliberately NOT listed: numpy.random,
+    # scipy.signal, scipy.fft, numpy.linalg, numpy.trace, re.compile, etc.
+    DANGEROUS_ATTRIBUTE_NAMES = frozenset(
+        {
+            # OS / process / system modules
+            "os",
+            "sys",
+            "subprocess",
+            "posix",
+            "nt",
+            "socket",
+            "platform",
+            "shutil",
+            "pathlib",
+            "pty",
+            "multiprocessing",
+            "mmap",
+            "fcntl",
+            "resource",
+            "termios",
+            "tty",
+            # import / introspection -> builtins, frames, code objects
+            "importlib",
+            "imp",
+            "builtins",
+            "runpy",
+            "gc",
+            "inspect",
+            "types",
+            "ctypes",
+            "ctypeslib",
+            "cffi",
+            "pickle",
+            "marshal",
+            "pdb",
+            "sysconfig",
+            "distutils",
+            "f2py",
+            # FFI loaders (defense in depth; normally reached only via ctypes)
+            "cdll",
+            "windll",
+            "oledll",
+            "pydll",
+            "libraryloader",
+            "loadlibrary",
+            "dlopen",
+            # process-exec primitives (defense in depth)
+            "system",
+            "popen",
+            "fork",
+            "forkpty",
+            "kill",
+            "killpg",
+            "execl",
+            "execle",
+            "execlp",
+            "execlpe",
+            "execv",
+            "execve",
+            "execvp",
+            "execvpe",
+            "spawnl",
+            "spawnle",
+            "spawnlp",
+            "spawnlpe",
+            "spawnv",
+            "spawnve",
+            "spawnvp",
+            "spawnvpe",
+            "getoutput",
+            "getstatusoutput",
+            "check_output",
+            "check_call",
+            # code-generation pivot that exec()s generated source
+            "lambdify",
+            # builtins module + its aliases (e.g. the enum module exposes it as
+            # `bltns`): reaching it hands back getattr/eval/exec and re-enables
+            # the class-hierarchy escape.
+            "builtin",
+            "bltns",
+            # introspection builtins that re-enable string-based dunder traversal
+            # or frame walking if reached through any module attribute.
+            "getattr",
+            "setattr",
+            "delattr",
+            "vars",
+            "globals",
+            "locals",
+            "memoryview",
+            "breakpoint",
+            "currentframe",
+        }
+    )
+
+    @classmethod
+    def _is_dangerous_attribute(cls, name: Any) -> bool:
+        """True for attribute names that pivot to native code / os / subprocess.
+
+        Normalizes leading underscores and case so alias forms like ``_os`` and
+        ``CDLL`` are caught the same as ``os`` / ``cdll``.
+        """
+        if not isinstance(name, str):
+            return False
+        return name.lstrip("_").lower() in cls.DANGEROUS_ATTRIBUTE_NAMES
+
     def __init__(self, tool_config: Dict[str, Any]):
         """Initialize the executor with tool configuration."""
         self.tool_config = tool_config
@@ -95,6 +218,21 @@ class BasePythonExecutor:
         # Add custom allowed modules if specified
         if "allowed_imports" in tool_config:
             self.allowed_modules.update(tool_config["allowed_imports"])
+
+    @staticmethod
+    def _is_dunder(name: Any) -> bool:
+        """Return True for double-underscore names like ``__class__``.
+
+        These names are the entry points used to walk out of the sandbox via the
+        interpreter's class hierarchy (``__class__`` -> ``__bases__`` ->
+        ``__subclasses__`` -> ``__init__`` -> ``__globals__`` -> ``__builtins__``).
+        """
+        return (
+            isinstance(name, str)
+            and len(name) > 4
+            and name.startswith("__")
+            and name.endswith("__")
+        )
 
     def _check_ast_safety(self, code: str) -> tuple[bool, List[str]]:
         """
@@ -130,10 +268,34 @@ class BasePythonExecutor:
                     if node.func.attr in self.FORBIDDEN_AST_NODES["Call"]:
                         warnings.append(f"Forbidden method call: {node.func.attr}")
 
-            # Check for forbidden attribute access
+            # Block ALL dunder attribute access (e.g. obj.__class__). A name-based
+            # denylist of specific dangerous attributes is not sound; any dunder
+            # can be chained to reach a live os/subprocess reference, so deny the
+            # whole class of attribute access rather than enumerate it.
             elif isinstance(node, ast.Attribute):
-                if node.attr in self.FORBIDDEN_AST_NODES["Attribute"]:
+                if self._is_dunder(node.attr):
+                    warnings.append(f"Forbidden dunder attribute access: {node.attr}")
+                elif node.attr in self.FORBIDDEN_AST_NODES["Attribute"]:
                     warnings.append(f"Forbidden attribute access: {node.attr}")
+                elif self._is_dangerous_attribute(node.attr):
+                    # Blocks module-pivot / FFI escapes such as numpy.ctypeslib,
+                    # matplotlib.subprocess, random._os, ...CDLL, os.system.
+                    warnings.append(
+                        f"Forbidden attribute access (sandbox escape): {node.attr}"
+                    )
+
+            # Block bare dunder names (e.g. __builtins__, __import__) so they
+            # cannot be read directly out of the execution namespace.
+            elif isinstance(node, ast.Name):
+                if self._is_dunder(node.id):
+                    warnings.append(f"Forbidden dunder name: {node.id}")
+
+            # Block dunder string literals. With getattr removed this is defense
+            # in depth: it stops string-based traversal such as
+            # globals()["__builtins__"] or vars(obj)["__class__"].
+            elif isinstance(node, ast.Constant):
+                if self._is_dunder(node.value):
+                    warnings.append(f"Forbidden dunder string literal: {node.value}")
 
         return len(warnings) == 0, warnings
 
@@ -531,9 +693,10 @@ class PythonCodeExecutor(BasePythonExecutor, BaseTool):
             return_variable = arguments.get("return_variable", "result")
             additional_vars = arguments.get("arguments", {})
 
-            # Update allowed modules if specified
-            if "allowed_imports" in arguments:
-                self.allowed_modules.update(arguments["allowed_imports"])
+            # SECURITY: The set of importable modules is a server-side trust
+            # boundary configured via tool_config["allowed_imports"]. It must
+            # NOT be widened by caller-supplied arguments, or a caller could
+            # allowlist os/subprocess and disable the sandbox before it runs.
 
             # Check AST safety
             is_safe, ast_warnings = self._check_ast_safety(code)

--- a/src/tooluniverse/remote/depmap_24q2/depmap_24q2_mcp_tool.py
+++ b/src/tooluniverse/remote/depmap_24q2/depmap_24q2_mcp_tool.py
@@ -19,8 +19,28 @@ import uuid
 from typing import Dict, Optional
 from fastmcp import FastMCP
 
+
+def _optional_token_auth():
+    """Require a Bearer token only when TOOLUNIVERSE_API_TOKEN is set.
+
+    Returns None (no authentication, unchanged behavior) when the variable is
+    not set, so existing deployments are unaffected.
+    """
+    token = os.getenv("TOOLUNIVERSE_API_TOKEN")
+    if not token:
+        return None
+    try:
+        from fastmcp.server.auth import StaticTokenVerifier
+
+        return StaticTokenVerifier(
+            tokens={token: {"client_id": "tooluniverse", "scopes": []}}
+        )
+    except Exception:
+        return None
+
+
 # Initialize MCP Server for DepMap gene correlation analysis
-server = FastMCP("DepMap Gene Correlation SMCP Server")
+server = FastMCP("DepMap Gene Correlation SMCP Server", auth=_optional_token_auth())
 
 
 class DepmapCorrelationTool:

--- a/src/tooluniverse/remote/esm/esm_tool.py
+++ b/src/tooluniverse/remote/esm/esm_tool.py
@@ -84,7 +84,9 @@ def compute_embedding(sequence: str):
     },
     mcp_config={
         "server_name": "ESM Embedding MCP Server",
-        "host": "0.0.0.0",
+        # Loopback by default; remote exposure requires TOOLUNIVERSE_API_TOKEN
+        # (enforced by the SMCP bind guard at server start).
+        "host": "127.0.0.1",
         "port": 8008,
         "transport": "http",
     },

--- a/src/tooluniverse/remote/expert_feedback/human_expert_mcp_tools.py
+++ b/src/tooluniverse/remote/expert_feedback/human_expert_mcp_tools.py
@@ -18,6 +18,7 @@ Usage:
     # Tools are automatically registered and available on startup
 """
 
+import os
 import threading
 import time
 import uuid
@@ -1781,11 +1782,20 @@ class ExpertInterface:
 # =============================================================================
 
 
-def start_http_api_server(port=9877):
-    """Start the HTTP API server for expert system communication"""
+def start_http_api_server(port=9877, host=None):
+    """Start the HTTP API server for expert system communication.
+
+    Defaults to loopback. Set TOOLUNIVERSE_EXPERT_HOST (or pass ``host``) to
+    bind elsewhere; a non-loopback bind requires TOOLUNIVERSE_API_TOKEN.
+    """
     if not FLASK_AVAILABLE:
         print("⚠️  Cannot start HTTP API server: Flask not installed")
         return
+
+    from tooluniverse.server_security import enforce_bind_security
+
+    host = host or os.getenv("TOOLUNIVERSE_EXPERT_HOST", "127.0.0.1")
+    enforce_bind_security(host)
 
     api_app = create_http_api_server()
     if api_app is None:
@@ -1796,9 +1806,9 @@ def start_http_api_server(port=9877):
 
     def run_api_server():
         print(f"🌐 Starting HTTP API server on port {port}")
-        print(f"📡 API endpoints available at http://0.0.0.0:{port}/api/")
+        print(f"📡 API endpoints available at http://{host}:{port}/api/")
         try:
-            api_app.run(host="0.0.0.0", port=port, debug=False, use_reloader=False)
+            api_app.run(host=host, port=port, debug=False, use_reloader=False)
         except Exception as e:
             print(f"❌ HTTP API server failed: {e}")
 
@@ -1814,17 +1824,26 @@ def start_http_api_server(port=9877):
     return api_thread
 
 
-def start_web_server():
-    """Start the Flask web server for expert interface"""
+def start_web_server(host=None, port=8090):
+    """Start the Flask web server for expert interface.
+
+    Defaults to loopback. Set TOOLUNIVERSE_EXPERT_HOST (or pass ``host``) to
+    bind elsewhere; a non-loopback bind requires TOOLUNIVERSE_API_TOKEN.
+    """
     if not FLASK_AVAILABLE:
         print("❌ Cannot start web interface: Flask not installed")
         print("   Install with: pip install flask")
         return
 
+    from tooluniverse.server_security import enforce_bind_security
+
+    host = host or os.getenv("TOOLUNIVERSE_EXPERT_HOST", "127.0.0.1")
+    enforce_bind_security(host)
+
     app = create_web_app()
     if app:
-        print("🌐 Starting web interface on http://localhost:8090")
-        app.run(host="0.0.0.0", port=8090, debug=False, use_reloader=False)
+        print(f"🌐 Starting web interface on http://{host}:{port}")
+        app.run(host=host, port=port, debug=False, use_reloader=False)
 
 
 def run_expert_interface():

--- a/src/tooluniverse/remote/expert_feedback/human_expert_mcp_tools.py
+++ b/src/tooluniverse/remote/expert_feedback/human_expert_mcp_tools.py
@@ -207,7 +207,9 @@ executor = ThreadPoolExecutor(max_workers=4)
     },
     mcp_config={
         "server_name": "Human Expert Consultation Server",
-        "host": "0.0.0.0",
+        # Loopback by default; remote exposure requires TOOLUNIVERSE_API_TOKEN
+        # (enforced by the SMCP bind guard at server start).
+        "host": "127.0.0.1",
         "port": 9876,
     },
 )

--- a/src/tooluniverse/remote/immune_compass/compass_tool.py
+++ b/src/tooluniverse/remote/immune_compass/compass_tool.py
@@ -22,8 +22,28 @@ sys.path.insert(0, f"{os.getenv('COMPASS_MODEL_PATH')}/immune-compass/COMPASS") 
 
 from compass import loadcompass  # noqa: E402
 
+
+def _optional_token_auth():
+    """Require a Bearer token only when TOOLUNIVERSE_API_TOKEN is set.
+
+    Returns None (no authentication, unchanged behavior) when the variable is
+    not set, so existing deployments are unaffected.
+    """
+    token = os.getenv("TOOLUNIVERSE_API_TOKEN")
+    if not token:
+        return None
+    try:
+        from fastmcp.server.auth import StaticTokenVerifier
+
+        return StaticTokenVerifier(
+            tokens={token: {"client_id": "tooluniverse", "scopes": []}}
+        )
+    except Exception:
+        return None
+
+
 # Initialize MCP Server for COMPASS predictions
-server = FastMCP("COMPASS Prediction SMCP Server")
+server = FastMCP("COMPASS Prediction SMCP Server", auth=_optional_token_auth())
 
 
 class CompassTool:

--- a/src/tooluniverse/remote/pinnacle/pinnacle_tool.py
+++ b/src/tooluniverse/remote/pinnacle/pinnacle_tool.py
@@ -22,8 +22,27 @@ import uuid
 from typing import Dict, Tuple, Optional, Any
 
 
+def _optional_token_auth():
+    """Require a Bearer token only when TOOLUNIVERSE_API_TOKEN is set.
+
+    Returns None (no authentication, unchanged behavior) when the variable is
+    not set, so existing deployments are unaffected.
+    """
+    token = os.getenv("TOOLUNIVERSE_API_TOKEN")
+    if not token:
+        return None
+    try:
+        from fastmcp.server.auth import StaticTokenVerifier
+
+        return StaticTokenVerifier(
+            tokens={token: {"client_id": "tooluniverse", "scopes": []}}
+        )
+    except Exception:
+        return None
+
+
 # Initialize MCP Server for PINNACLE PPI embedding retrieval
-server = FastMCP("PINNACLE PPI SMCP Server")
+server = FastMCP("PINNACLE PPI SMCP Server", auth=_optional_token_auth())
 
 
 class PinnaclePPITool:

--- a/src/tooluniverse/remote/uspto_downloader/uspto_downloader_mcp_server.py
+++ b/src/tooluniverse/remote/uspto_downloader/uspto_downloader_mcp_server.py
@@ -18,7 +18,27 @@ except FileNotFoundError as e:
     )
     sys.exit(1)
 
-server = FastMCP("Your MCP Server")
+
+def _optional_token_auth():
+    """Require a Bearer token only when TOOLUNIVERSE_API_TOKEN is set.
+
+    Returns None (no authentication, unchanged behavior) when the variable is
+    not set, so existing deployments are unaffected.
+    """
+    token = os.getenv("TOOLUNIVERSE_API_TOKEN")
+    if not token:
+        return None
+    try:
+        from fastmcp.server.auth import StaticTokenVerifier
+
+        return StaticTokenVerifier(
+            tokens={token: {"client_id": "tooluniverse", "scopes": []}}
+        )
+    except Exception:
+        return None
+
+
+server = FastMCP("Your MCP Server", auth=_optional_token_auth())
 agents = {}
 for tool_config in uspto_downloader_tools:
     agents[tool_config["name"]] = USPTOPatentDocumentDownloader(tool_config=tool_config)

--- a/src/tooluniverse/scripts/visualize_tool_graph.py
+++ b/src/tooluniverse/scripts/visualize_tool_graph.py
@@ -809,12 +809,21 @@ def main():
 
             threading.Thread(target=open_browser, daemon=True).start()
 
-        # Run the server
+        # Run the server. Refuse to expose a non-loopback bind without a token,
+        # and never run the Werkzeug debugger (debug/reloader) off-loopback —
+        # it allows arbitrary code execution.
+        from tooluniverse.server_security import (
+            enforce_bind_security,
+            is_loopback_host,
+        )
+
+        enforce_bind_security(args.host)
+        debug = (not args.no_auto_reload) and is_loopback_host(args.host)
         app.run(
             host=args.host,
             port=args.port,
-            debug=not args.no_auto_reload,
-            use_reloader=not args.no_auto_reload,
+            debug=debug,
+            use_reloader=debug,
         )
 
     except KeyboardInterrupt:

--- a/src/tooluniverse/server_security.py
+++ b/src/tooluniverse/server_security.py
@@ -1,0 +1,85 @@
+"""Shared authentication helpers for ToolUniverse network servers.
+
+ToolUniverse can expose tool execution (including the Python code executor) over
+HTTP via several entry points: the FastAPI app (``http_api_server``) and the
+FastMCP-based SMCP server (``smcp``). None of these should be reachable over the
+network without authentication.
+
+This module centralizes two controls used by every server entry point:
+
+1. A Bearer token, read from the ``TOOLUNIVERSE_API_TOKEN`` environment variable.
+   When set, callers must present ``Authorization: Bearer <token>`` on every
+   request. The token is a server-side trust boundary and is never accepted from
+   request bodies or tool arguments.
+
+2. A bind guard (:func:`enforce_bind_security`) that refuses to expose a server
+   on a non-loopback interface unless a token is configured. The shipped default
+   bind address is loopback (``127.0.0.1``); operators must opt in to remote
+   exposure *and* set a token to do so.
+"""
+
+import hmac
+import ipaddress
+import os
+
+API_TOKEN_ENV = "TOOLUNIVERSE_API_TOKEN"
+
+# Hostnames that resolve to the local machine only.
+_LOOPBACK_HOSTNAMES = {"localhost", ""}
+
+
+def get_api_token():
+    """Return the configured API token, or ``None`` if authentication is disabled.
+
+    Whitespace is stripped; an empty value is treated as "no token".
+    """
+    token = os.getenv(API_TOKEN_ENV, "").strip()
+    return token or None
+
+
+def is_loopback_host(host):
+    """Return ``True`` if ``host`` only accepts connections from the local machine."""
+    if host is None:
+        return True
+    candidate = host.strip().lower()
+    if candidate in _LOOPBACK_HOSTNAMES:
+        return True
+    try:
+        return ipaddress.ip_address(candidate).is_loopback
+    except ValueError:
+        # A non-literal hostname other than "localhost": treat as remotely
+        # reachable so we fail closed rather than open.
+        return False
+
+
+def token_matches(provided_header, expected_token):
+    """Constant-time check of an ``Authorization`` header against the token.
+
+    ``provided_header`` is the raw header value (e.g. ``"Bearer abc"``).
+    Returns ``False`` for any malformed or missing header.
+    """
+    if not expected_token or not provided_header:
+        return False
+    parts = provided_header.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return False
+    return hmac.compare_digest(parts[1].strip(), expected_token)
+
+
+def enforce_bind_security(host):
+    """Refuse to expose the server on a non-loopback host without a token.
+
+    Returns the configured token (or ``None`` for loopback-only runs) so callers
+    can decide whether to install request authentication.
+
+    Raises:
+        RuntimeError: if ``host`` is remotely reachable and no token is set.
+    """
+    token = get_api_token()
+    if not is_loopback_host(host) and token is None:
+        raise RuntimeError(
+            f"Refusing to bind to non-loopback host {host!r} without authentication. "
+            f"Set the {API_TOKEN_ENV} environment variable to require a Bearer token "
+            f"on every request, or bind to 127.0.0.1 for local-only access."
+        )
+    return token

--- a/src/tooluniverse/smcp.py
+++ b/src/tooluniverse/smcp.py
@@ -25,7 +25,7 @@ server = SMCP(
 )
 server.run_simple(
     transport="http",
-    host="0.0.0.0",
+    host="127.0.0.1",
     port=7000
 )
 ```
@@ -414,6 +414,28 @@ class SMCP(FastMCP):
         # Filter out SMCP-specific kwargs before passing to FastMCP
         fastmcp_kwargs = kwargs.copy()
         fastmcp_kwargs.pop("tooluniverse", None)  # Remove if accidentally passed
+
+        # Require Bearer-token authentication on HTTP transports when a token is
+        # configured. This server can execute arbitrary tools (including the
+        # Python code executor), so it must not be reachable unauthenticated over
+        # the network. The bind guard in run()/run_simple() refuses to expose the
+        # server on a non-loopback host unless this token is set.
+        from .server_security import get_api_token
+
+        _api_token = get_api_token()
+        if _api_token and "auth" not in fastmcp_kwargs:
+            try:
+                from fastmcp.server.auth import StaticTokenVerifier
+
+                fastmcp_kwargs["auth"] = StaticTokenVerifier(
+                    tokens={_api_token: {"client_id": "tooluniverse", "scopes": []}}
+                )
+            except Exception as exc:  # pragma: no cover - depends on fastmcp version
+                raise RuntimeError(
+                    "TOOLUNIVERSE_API_TOKEN is set but Bearer-token authentication "
+                    "could not be configured on this FastMCP version. Refusing to "
+                    f"start an unauthenticated server. Original error: {exc}"
+                )
 
         # Initialize FastMCP with default settings optimized for scientific use
         super().__init__(name=name or "SMCP Server", **fastmcp_kwargs)
@@ -1407,10 +1429,17 @@ class SMCP(FastMCP):
         """
         # Save transport information for banner display
         transport = kwargs.get("transport", args[0] if args else "unknown")
-        host = kwargs.get("host", "0.0.0.0")
+        host = kwargs.get("host", "127.0.0.1")
         port = kwargs.get("port", 7000)
 
         self._transport_type = transport
+
+        # Refuse to expose an HTTP/SSE server on a non-loopback interface unless
+        # a TOOLUNIVERSE_API_TOKEN is set (which also enables Bearer auth above).
+        if transport in ("streamable-http", "http", "sse"):
+            from .server_security import enforce_bind_security
+
+            enforce_bind_security(host)
 
         # Build server URL based on transport
         if transport == "streamable-http" or transport == "http":
@@ -1441,7 +1470,7 @@ class SMCP(FastMCP):
     def run_simple(
         self,
         transport: Literal["stdio", "http", "sse"] = "http",
-        host: str = "0.0.0.0",
+        host: str = "127.0.0.1",
         port: int = 7000,
         **kwargs,
     ):

--- a/src/tooluniverse/smcp_server.py
+++ b/src/tooluniverse/smcp_server.py
@@ -762,8 +762,10 @@ Examples:
     )
     parser.add_argument(
         "--host",
-        default="0.0.0.0",
-        help="Host to bind to for HTTP/SSE transport (default: 0.0.0.0)",
+        default="127.0.0.1",
+        help="Host to bind to for HTTP/SSE transport (default: 127.0.0.1). "
+        "Binding to a non-loopback address (e.g. 0.0.0.0) requires setting "
+        "TOOLUNIVERSE_API_TOKEN to enable Bearer-token authentication.",
     )
     parser.add_argument(
         "--port",

--- a/src/tooluniverse/tool_graph_web_ui.py
+++ b/src/tooluniverse/tool_graph_web_ui.py
@@ -237,8 +237,22 @@ class ToolGraphWebUI:
 
         return {"incoming": incoming, "outgoing": outgoing}
 
-    def run(self, host: str = "0.0.0.0", port: int = 5000, debug: bool = True):
-        """Run the web application."""
+    def run(self, host: str = "127.0.0.1", port: int = 5000, debug: bool = False):
+        """Run the web application.
+
+        Defaults to loopback with the debugger off. Flask's ``debug=True`` exposes
+        the Werkzeug interactive debugger (arbitrary code execution), so it must
+        never be enabled on a network-reachable bind. Binding to a non-loopback
+        host without TOOLUNIVERSE_API_TOKEN is refused.
+        """
+        from .server_security import enforce_bind_security, is_loopback_host
+
+        enforce_bind_security(host)
+        if debug and not is_loopback_host(host):
+            raise RuntimeError(
+                "Refusing to run the Flask debugger (debug=True) on a non-loopback "
+                f"host {host!r}: the Werkzeug debugger allows arbitrary code execution."
+            )
         print(f"Starting Tool Graph Web UI on http://{host}:{port}")
         self.app.run(host=host, port=port, debug=debug)
 

--- a/tests/unit/test_security_advisory_fixes.py
+++ b/tests/unit/test_security_advisory_fixes.py
@@ -1,0 +1,189 @@
+"""Regression tests for the RCE / unauthenticated-exposure security advisory.
+
+Covers three independent fixes:
+
+1. The Python code executor no longer lets a caller widen the import allowlist
+   via tool arguments (Path 1 of the advisory).
+2. The executor's AST check blocks dunder-traversal sandbox escapes, in every
+   form (attribute access, getattr, and string-literal/subscript), while still
+   allowing legitimate scientific code (Path 2 of the advisory).
+3. The network servers default to loopback and refuse to bind to a non-loopback
+   interface without a Bearer token; the FastAPI app enforces that token on all
+   routes except /health.
+"""
+
+import os
+
+import pytest
+
+from tooluniverse import server_security as ss
+from tooluniverse.python_executor_tool import (
+    BasePythonExecutor,
+    PythonCodeExecutor,
+)
+
+
+def _executor():
+    return PythonCodeExecutor({"name": "python_code_executor"})
+
+
+def _run(code, **extra):
+    return _executor().run({"code": code, **extra})
+
+
+# --------------------------------------------------------------------------- #
+# Path 1: caller-supplied allowlist override must be ignored
+# --------------------------------------------------------------------------- #
+
+
+def test_caller_cannot_widen_import_allowlist():
+    """`allowed_imports` in call arguments must not enable `import os`."""
+    result = _run("import os\nprint(os.getuid())", allowed_imports=["os", "subprocess"])
+    assert result["status"] == "error"
+    assert "Forbidden import: os" in result["data"]["error"]
+
+
+def test_server_config_allowlist_still_respected():
+    """Server-side tool_config allowlist remains the trust boundary."""
+    ex = PythonCodeExecutor({"name": "python_code_executor", "allowed_imports": ["os"]})
+    # os is allowlisted server-side, but reaching anything dangerous still
+    # requires dunder traversal, which is independently blocked. A plain
+    # allowlisted import is permitted.
+    result = ex.run({"code": "import math\nprint(math.sqrt(9))"})
+    assert result["status"] == "success"
+
+
+# --------------------------------------------------------------------------- #
+# Path 2: dunder-traversal sandbox escape must be blocked in all forms
+# --------------------------------------------------------------------------- #
+
+
+DUNDER_ESCAPES = [
+    # getattr-based traversal (the advisory's exact payload shape)
+    'getattr(getattr((), "__class__"), "__bases__")',
+    # literal attribute traversal
+    "().__class__.__bases__[0].__subclasses__()",
+    # string-literal / subscript traversal
+    'globals()["__builtins__"]',
+    # bare dunder name read
+    "print(__builtins__)",
+]
+
+
+@pytest.mark.parametrize("code", DUNDER_ESCAPES)
+def test_dunder_traversal_blocked(code):
+    result = _run(code)
+    assert result["status"] == "error", f"escape not blocked: {code!r}"
+    assert "Forbidden dunder" in result["data"]["error"]
+
+
+def test_getattr_setattr_not_exposed():
+    """getattr/setattr enable string-based dunder access and must be removed."""
+    assert "getattr" not in BasePythonExecutor.SAFE_BUILTINS
+    assert "setattr" not in BasePythonExecutor.SAFE_BUILTINS
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        (
+            "import math, numpy as np\nresult = np.array([1, 2, 3]).sum() + math.sqrt(16)",
+            10.0,
+        ),
+        ("result = sum(x * x for x in range(5))", 30),
+    ],
+)
+def test_legitimate_code_still_runs(code, expected):
+    result = _run(code)
+    assert result["status"] == "success", result["data"].get("error")
+    assert result["data"]["result"] == expected
+
+
+# --------------------------------------------------------------------------- #
+# server_security helpers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _clear_token(monkeypatch):
+    monkeypatch.delenv(ss.API_TOKEN_ENV, raising=False)
+    yield
+
+
+@pytest.mark.parametrize(
+    "host,loopback",
+    [
+        ("127.0.0.1", True),
+        ("localhost", True),
+        ("::1", True),
+        ("0.0.0.0", False),
+        ("1.2.3.4", False),
+    ],
+)
+def test_is_loopback_host(host, loopback):
+    assert ss.is_loopback_host(host) is loopback
+
+
+def test_bind_guard_allows_loopback_without_token():
+    assert ss.enforce_bind_security("127.0.0.1") is None
+
+
+def test_bind_guard_refuses_remote_without_token():
+    with pytest.raises(RuntimeError):
+        ss.enforce_bind_security("0.0.0.0")
+
+
+def test_bind_guard_allows_remote_with_token(monkeypatch):
+    monkeypatch.setenv(ss.API_TOKEN_ENV, "secret123")
+    assert ss.enforce_bind_security("0.0.0.0") == "secret123"
+
+
+@pytest.mark.parametrize(
+    "header,token,ok",
+    [
+        ("Bearer secret123", "secret123", True),
+        ("bearer secret123", "secret123", True),  # scheme is case-insensitive
+        ("Bearer wrong", "secret123", False),
+        ("secret123", "secret123", False),  # missing scheme
+        ("", "secret123", False),
+        ("Bearer secret123", "", False),  # no token configured
+    ],
+)
+def test_token_matches(header, token, ok):
+    assert ss.token_matches(header, token) is ok
+
+
+# --------------------------------------------------------------------------- #
+# FastAPI middleware enforcement (auth-rejection path needs no ToolUniverse)
+# --------------------------------------------------------------------------- #
+
+
+def test_http_api_requires_token_when_configured(monkeypatch):
+    monkeypatch.setenv(ss.API_TOKEN_ENV, "tok-123")
+    fastapi_testclient = pytest.importorskip("fastapi.testclient")
+    from tooluniverse import http_api_server
+
+    client = fastapi_testclient.TestClient(http_api_server.app)
+
+    # /health stays public for liveness probes.
+    assert client.get("/health").status_code == 200
+
+    # Protected route without a token is rejected before any tool runs.
+    resp = client.get("/api/methods")
+    assert resp.status_code == 401
+    assert resp.json()["error_type"] == "AuthenticationError"
+
+    # Wrong token is rejected too.
+    resp = client.get("/api/methods", headers={"Authorization": "Bearer nope"})
+    assert resp.status_code == 401
+
+
+def test_http_api_open_when_no_token(monkeypatch):
+    """With no token configured (loopback-only dev mode), routes are reachable."""
+    monkeypatch.delenv(ss.API_TOKEN_ENV, raising=False)
+    fastapi_testclient = pytest.importorskip("fastapi.testclient")
+    from tooluniverse import http_api_server
+
+    client = fastapi_testclient.TestClient(http_api_server.app)
+    # No 401 — the middleware is a no-op without a configured token.
+    assert client.get("/health").status_code == 200

--- a/tests/unit/test_security_advisory_fixes.py
+++ b/tests/unit/test_security_advisory_fixes.py
@@ -250,3 +250,71 @@ def test_http_api_open_when_no_token(monkeypatch):
     client = fastapi_testclient.TestClient(http_api_server.app)
     # No 401 — the middleware is a no-op without a configured token.
     assert client.get("/health").status_code == 200
+
+
+# --------------------------------------------------------------------------- #
+# Client can authenticate against a token-protected server
+# --------------------------------------------------------------------------- #
+
+
+def test_client_sends_bearer_token_from_arg():
+    from tooluniverse.http_client import ToolUniverseClient
+
+    client = ToolUniverseClient("http://x:8080", api_token="abc")
+    assert client.session.headers.get("Authorization") == "Bearer abc"
+
+
+def test_client_reads_token_from_env(monkeypatch):
+    monkeypatch.setenv(ss.API_TOKEN_ENV, "envtok")
+    from tooluniverse.http_client import ToolUniverseClient
+
+    client = ToolUniverseClient("http://x:8080")
+    assert client.session.headers.get("Authorization") == "Bearer envtok"
+
+
+def test_client_no_auth_header_without_token(monkeypatch):
+    monkeypatch.delenv(ss.API_TOKEN_ENV, raising=False)
+    from tooluniverse.http_client import ToolUniverseClient
+
+    client = ToolUniverseClient("http://x:8080")
+    assert "Authorization" not in client.session.headers
+
+
+# --------------------------------------------------------------------------- #
+# Tool Graph Web UI: loopback + debugger guards
+# --------------------------------------------------------------------------- #
+
+
+def _graph_ui(tmp_path):
+    pytest.importorskip("flask")
+    from tooluniverse.tool_graph_web_ui import ToolGraphWebUI
+
+    graph_file = tmp_path / "graph.json"
+    graph_file.write_text('{"nodes": [], "edges": []}')
+    return ToolGraphWebUI(str(graph_file))
+
+
+def test_graph_ui_refuses_remote_bind_without_token(tmp_path, monkeypatch):
+    monkeypatch.delenv(ss.API_TOKEN_ENV, raising=False)
+    ui = _graph_ui(tmp_path)
+    monkeypatch.setattr(ui.app, "run", lambda **kw: None)  # must not be reached
+    with pytest.raises(RuntimeError):
+        ui.run(host="0.0.0.0")
+
+
+def test_graph_ui_refuses_remote_debugger_even_with_token(tmp_path, monkeypatch):
+    monkeypatch.setenv(ss.API_TOKEN_ENV, "tok")
+    ui = _graph_ui(tmp_path)
+    monkeypatch.setattr(ui.app, "run", lambda **kw: None)
+    with pytest.raises(RuntimeError):
+        ui.run(host="0.0.0.0", debug=True)
+
+
+def test_graph_ui_loopback_default_runs(tmp_path, monkeypatch):
+    monkeypatch.delenv(ss.API_TOKEN_ENV, raising=False)
+    ui = _graph_ui(tmp_path)
+    called = {}
+    monkeypatch.setattr(ui.app, "run", lambda **kw: called.update(kw))
+    ui.run()  # defaults: host=127.0.0.1, debug=False
+    assert called["host"] == "127.0.0.1"
+    assert called["debug"] is False

--- a/tests/unit/test_security_advisory_fixes.py
+++ b/tests/unit/test_security_advisory_fixes.py
@@ -100,6 +100,69 @@ def test_legitimate_code_still_runs(code, expected):
 
 
 # --------------------------------------------------------------------------- #
+# Path 4: module-pivot / FFI sandbox escape must be blocked
+#
+# The allowed scientific modules transitively expose dangerous stdlib modules as
+# plain, non-dunder attributes (numpy.ctypeslib -> ctypes -> CDLL -> native code,
+# matplotlib.os / .subprocess, random._os, collections._sys, enum's `bltns` alias
+# of builtins -> getattr). None require a dunder, a forbidden import, or a
+# forbidden call, so they bypassed the earlier checks. They are now blocked by the
+# DANGEROUS_ATTRIBUTE_NAMES denylist (normalized: leading underscores stripped,
+# lower-cased), which is sound because getattr/globals/vars/eval/exec are withheld
+# so attribute access is only ever the literal obj.name the AST can see.
+# --------------------------------------------------------------------------- #
+
+
+MODULE_PIVOT_ESCAPES = [
+    # ctypes -> native code execution (the confirmed RCE)
+    "libc = numpy.ctypeslib.ctypes.CDLL(None)\nresult = libc.getpid()",
+    # os / subprocess reached straight off matplotlib
+    "result = matplotlib.os.system('id')",
+    "result = matplotlib.subprocess.check_output(['id'])",
+    # os reached via random's private alias (underscore-normalized to 'os')
+    "result = random._os.system('id')",
+    # sys reached via collections' private alias
+    "result = collections._sys.modules",
+    # builtins reached via the enum module's `bltns` alias, then getattr back
+    "result = re.enum.bltns.getattr([], 'append')",
+]
+
+
+@pytest.mark.parametrize("code", MODULE_PIVOT_ESCAPES)
+def test_module_pivot_escape_blocked(code):
+    result = _run(code)
+    assert result["status"] == "error", f"escape not blocked: {code!r}"
+    assert "Forbidden" in result["data"]["error"]
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        # legit numeric attrs that resemble nothing dangerous keep working
+        ("import numpy as np\nresult = int(np.random.RandomState(0).randint(5, 6))", 5),
+        ("import numpy as np\nresult = float(np.trace(np.eye(3)))", 3.0),
+        ("import numpy as np\nresult = float(np.trace(np.linalg.inv(np.eye(2))))", 2.0),
+    ],
+)
+def test_numeric_attributes_not_false_positived(code, expected):
+    result = _run(code)
+    assert result["status"] == "success", result["data"].get("error")
+    assert result["data"]["result"] == expected
+
+
+def test_dangerous_attribute_normalization():
+    """Underscore/case-alias forms normalize to the same denied name; legit
+    numeric attribute names are not flagged."""
+    is_bad = BasePythonExecutor._is_dangerous_attribute
+    assert is_bad("os") and is_bad("_os") and is_bad("__os")  # noqa: PT018
+    assert is_bad("CDLL") and is_bad("ctypeslib") and is_bad("bltns")  # noqa: PT018
+    assert not is_bad("random")  # numpy.random
+    assert not is_bad("signal")  # scipy.signal
+    assert not is_bad("trace")  # numpy.trace
+    assert not is_bad("compile")  # re.compile (handled separately as a call)
+
+
+# --------------------------------------------------------------------------- #
 # server_security helpers
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## Summary

Closes a critical, fully-reproduced **unauthenticated remote code execution** path reported via GitHub Security Advisory. The `python_code_executor` tool executed attacker-controlled code, and its AST sandbox was defeated by two independent techniques; the HTTP/MCP servers exposed it on `0.0.0.0` with no authentication.

All issues were CLI-reproduced against the current code before fixing, and the fixes verified to block every variant while preserving legitimate scientific code.

## Executor sandbox (`python_executor_tool.py`)

- **Path 1 — allowlist override:** removed the per-call `allowed_imports` handling so a caller can no longer widen the server-side import allowlist before the AST check runs. The allowlist is now a server-side trust boundary (`tool_config`) only.
- **Path 2 — dunder traversal:** the previous denylist did not block `getattr`/`__subclasses__`/dunder access. Now:
  - `getattr`/`setattr` removed from safe builtins (they enabled string-based attribute access).
  - All dunder attribute access, bare dunder names, and dunder string literals are blocked — defeating `().__class__.__bases__[0].__subclasses__()` and its `getattr`/subscript variants.
- **Module-pivot escape (defense added):** allowed scientific modules transitively expose stdlib as *plain* attributes (e.g. `matplotlib.os`, `numpy.ctypeslib`, `random._os`). These are now blocked via a normalized dangerous-attribute denylist, while legitimate attributes (`numpy.random`, `numpy.linalg`, `scipy.signal`, ...) remain available.

## Server authentication (`server_security.py`, `http_api_server*`, `smcp*`)

- Default all binds to `127.0.0.1`.
- Refuse to bind to a non-loopback interface unless `TOOLUNIVERSE_API_TOKEN` is set (fail-closed bind guard).
- Enforce `Authorization: Bearer <token>` on all FastAPI routes except `/health`, and on the FastMCP HTTP transport via `StaticTokenVerifier`, whenever a token is configured.

## Tests

`tests/unit/test_security_advisory_fixes.py` — 25 tests covering both bypass paths (all forms), the module-pivot escapes, legitimate code, the bind guard, token matching, and FastAPI auth enforcement. All pass.

## Notes

- Backward compatible: with no token set, loopback-only runs work unauthenticated as before (local dev). Remote exposure now requires an explicit token.
- Pre-existing, orthogonal: method calls named `compile`/`eval`/`exec`/`open` (e.g. `re.compile`) were already blocked by the original denylist; left unchanged to keep this PR scoped to the advisory.