### PR TITLE
Fix coding-API stub generator: nullable types and injected-param collisions

### DIFF
--- a/src/tooluniverse/generate_tools.py
+++ b/src/tooluniverse/generate_tools.py
@@ -10,14 +10,26 @@ from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
 
 
+# Keyword-only parameters the generator injects into every wrapper signature.
+# A tool whose own parameter sanitizes to one of these would otherwise emit a
+# duplicate argument (e.g. "duplicate argument 'use_cache'") — a hard
+# SyntaxError that breaks importing the entire tools package.
+_INJECTED_PARAM_NAMES = frozenset({"stream_callback", "use_cache", "validate"})
+
+
 def sanitize_param_name(name: str) -> str:
     """Convert an API parameter name to a valid Python identifier.
 
     Handles dots (query.cond -> query_cond), hyphens (from-date -> from_date),
-    and Python reserved keywords (for -> for_, in -> in_).
+    Python reserved keywords (for -> for_, in -> in_), and collisions with the
+    generator's injected keyword-only params (use_cache -> use_cache_).
     """
     sanitized = re.sub(r"[.\-]", "_", name)
-    if keyword.iskeyword(sanitized) or keyword.issoftkeyword(sanitized):
+    if (
+        keyword.iskeyword(sanitized)
+        or keyword.issoftkeyword(sanitized)
+        or sanitized in _INJECTED_PARAM_NAMES
+    ):
         sanitized = sanitized + "_"
     return sanitized
 
@@ -108,21 +120,25 @@ def prop_to_python_type(prop: Dict[str, Any]) -> str:
     Returns:
         Python type annotation as string (e.g., "str", "str | list[str]")
     """
-    # Handle oneOf schemas (e.g., string or array)
+    # Handle oneOf schemas (e.g., string or array). Drop "null" entries: a
+    # nullable field's optionality is already conveyed by the Optional[...]
+    # wrapper, so keeping "null" only yielded noise like Optional[str | Any].
     if "oneOf" in prop:
         types = [
             _resolve_single_type(item.get("type", ""), item)
             for item in prop["oneOf"]
-            if item.get("type")
+            if item.get("type") and item.get("type") != "null"
         ]
         return _deduplicate_types(types)
 
     # Fall back to regular type handling
     json_type = prop.get("type", "string")
 
-    # Handle when type is a list (e.g., ["string", "array"])
+    # Handle when type is a list (e.g., ["string", "array"], ["string", "null"]).
+    # Exclude "null" for the same reason as above — ["string", "null"] is a
+    # nullable string and should annotate as str, not "str | Any".
     if isinstance(json_type, list):
-        types = [_resolve_single_type(t, prop) for t in json_type if t]
+        types = [_resolve_single_type(t, prop) for t in json_type if t and t != "null"]
         return _deduplicate_types(types)
 
     if json_type == "array":
@@ -593,7 +609,9 @@ def main(
     tu = ToolUniverse()
     tu.load_tools()
 
-    output = Path(output_dir) if output_dir is not None else Path(__file__).parent / "tools"
+    output = (
+        Path(output_dir) if output_dir is not None else Path(__file__).parent / "tools"
+    )
     output.mkdir(parents=True, exist_ok=True)
     print(f"   Output → {output}")
 

--- a/tests/unit/test_generate_tools_types.py
+++ b/tests/unit/test_generate_tools_types.py
@@ -1,0 +1,97 @@
+"""Unit tests for the coding-API stub generator's type-annotation logic.
+
+Guards a regression where a nullable JSON type such as ``["string", "null"]``
+was annotated as ``Optional[str | Any]`` instead of ``Optional[str]``: the
+``"null"`` member must be dropped, since a field's optionality is expressed by
+the surrounding ``Optional[...]`` wrapper, not by a ``| Any`` union.
+"""
+
+import pytest
+
+from tooluniverse.generate_tools import (
+    json_type_to_python,
+    prop_to_python_type,
+    sanitize_param_name,
+)
+
+
+@pytest.mark.unit
+class TestPropToPythonType:
+    def test_nullable_string_drops_null(self):
+        """["string", "null"] is a nullable string -> str (not "str | Any")."""
+        assert prop_to_python_type({"type": ["string", "null"]}) == "str"
+
+    def test_nullable_integer_drops_null(self):
+        """["integer", "null"] -> int, with the null member dropped."""
+        assert prop_to_python_type({"type": ["integer", "null"]}) == "int"
+
+    def test_single_element_list_unchanged(self):
+        """A single-element type list resolves to that one type."""
+        assert prop_to_python_type({"type": ["string"]}) == "str"
+
+    def test_plain_string_type(self):
+        """A plain (non-list) string type maps to str."""
+        assert prop_to_python_type({"type": "string"}) == "str"
+
+    def test_legitimate_union_preserved(self):
+        """A real multi-type union must still be reported (null is the only drop)."""
+        assert prop_to_python_type({"type": ["string", "array"]}) == "str | list[Any]"
+
+    def test_oneof_with_null_drops_null(self):
+        """oneOf containing a null branch collapses to the non-null type."""
+        prop = {"oneOf": [{"type": "string"}, {"type": "null"}]}
+        assert prop_to_python_type(prop) == "str"
+
+    def test_oneof_union_preserved(self):
+        """oneOf with two real types keeps the union annotation."""
+        prop = {"oneOf": [{"type": "string"}, {"type": "array"}]}
+        assert prop_to_python_type(prop) == "str | list[Any]"
+
+    def test_array_of_strings(self):
+        """An array with string items annotates as list[str]."""
+        prop = {"type": "array", "items": {"type": "string"}}
+        assert prop_to_python_type(prop) == "list[str]"
+
+    def test_only_null_falls_back_to_any(self):
+        """A degenerate null-only schema falls back to Any (no crash, no '| Any')."""
+        assert prop_to_python_type({"type": ["null"]}) == "Any"
+
+
+@pytest.mark.unit
+class TestSanitizeParamName:
+    """A tool param must never collide with the generator's injected kw-only args."""
+
+    @pytest.mark.parametrize("reserved", ["use_cache", "validate", "stream_callback"])
+    def test_injected_name_collision_suffixed(self, reserved):
+        """A param named like an injected arg gets a trailing underscore."""
+        assert sanitize_param_name(reserved) == reserved + "_"
+
+    def test_python_keyword_suffixed(self):
+        """A Python keyword param is suffixed (pre-existing behavior preserved)."""
+        assert sanitize_param_name("for") == "for_"
+
+    def test_ordinary_name_unchanged(self):
+        """An ordinary param name passes through untouched."""
+        assert sanitize_param_name("query") == "query"
+
+    def test_dots_and_hyphens_normalized(self):
+        """Dots and hyphens become underscores."""
+        assert sanitize_param_name("query.cond") == "query_cond"
+        assert sanitize_param_name("from-date") == "from_date"
+
+
+@pytest.mark.unit
+class TestJsonTypeToPython:
+    """The simpler helper already filtered null; pin that behavior too."""
+
+    def test_nullable_string(self):
+        """A nullable string list yields Optional[str] from the simple helper."""
+        assert json_type_to_python(["string", "null"]) == "Optional[str]"
+
+    def test_plain_integer(self):
+        """A plain integer type maps to int."""
+        assert json_type_to_python("integer") == "int"
+
+    def test_unknown_type_is_any(self):
+        """An unrecognized type name falls back to Any."""
+        assert json_type_to_python("widget") == "Any"


### PR DESCRIPTION
## Summary

`generate_tools.py` (the `tu build` coding-API stub generator) emitted two kinds of invalid/incorrect output when regenerating the per-tool wrapper stubs under `src/tooluniverse/tools/`. Both are fixed here with unit tests; the existing coding-API integration suite goes back to green.

## Fixes

1. **Nullable type → noisy `| Any`.** A nullable JSON type such as `{"type": ["string", "null"]}` was annotated as `Optional[str | Any]` instead of `Optional[str]`. `prop_to_python_type` did not drop the `"null"` member (unlike `json_type_to_python`, which already does), so nullability — already conveyed by the `Optional[...]` wrapper — leaked a redundant `| Any`. Now `"null"` is filtered out of both the `oneOf` and type-list branches. Legitimate unions (e.g. `["string", "array"]` → `str | list[Any]`) are preserved.

2. **Injected-param-name collision → hard `SyntaxError`.** A tool whose own parameter is named like one of the generator's injected keyword-only args (`use_cache`, `validate`, `stream_callback`) produced a duplicate argument — e.g. `SyntaxError: duplicate argument 'use_cache' in function definition` — which broke importing the **entire** `tooluniverse.tools` package (hit in practice by `ESM_describe_sae_feature`, whose config has a `use_cache` param). `sanitize_param_name` now suffixes such names (`use_cache` → `use_cache_`), mirroring its existing Python-keyword handling; the original name is still used as the API key in the kwargs dict.

## Tests

- New `tests/unit/test_generate_tools_types.py` (18 cases) covering nullable/oneOf/union type resolution and injected-name/keyword collision handling.
- `tests/integration/test_coding_api_integration.py::TestSDKIntegration::test_sdk_import_integration` was failing on the pre-existing `use_cache` collision (reproduced on a clean `origin/main`); it now passes — full file 11/11 green.

## Scope

Generator code + tests only. Does **not** regenerate/commit the stub files themselves; a clean full stub re-sync via `tu build` is now unblocked and can follow as a separate PR.