### PR TITLE
Release tooluniverse 1.3.0 (PyPI)

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "tooluniverse",
     "display_name": "ToolUniverse",
-    "version": "1.2.6",
+    "version": "1.3.0",
     "description": "ToolUniverse: an ecosystem for democratizing AI scientists with 2000+ scientific tools.",
     "long_description": "ToolUniverse is an ecosystem for creating AI scientist systems from any large language model (LLM). It standardizes how LLMs interact with tools, integrating thousands of machine learning models, datasets, APIs, and scientific packages for data analysis, knowledge retrieval, and experimental design. This bundle exposes ToolUniverse capability via the Model Context Protocol (MCP), enabling AI assistants to perform complex scientific tasks.",
     "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooluniverse-mcpb-native"
-version = "1.2.6"
+version = "1.3.0"
 description = "ToolUniverse MCP Server (Native MCPB bundle)"
 requires-python = ">=3.10,<3.14"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooluniverse"
-version = "1.2.6"
+version = "1.3.0"
 description = "A comprehensive collection of scientific tools for Agentic AI, offering integration with the ToolUniverse SDK and MCP Server to support advanced scientific workflows."
 authors = [
     { name = "Shanghua Gao", email = "shanghuagao@gmail.com" }

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mims-harvard/ToolUniverse",
     "source": "github"
   },
-  "version": "1.2.6",
+  "version": "1.3.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "tooluniverse",
-      "version": "1.2.6",
+      "version": "1.3.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Bumps the PyPI package version **1.2.6 → 1.3.0** to ship everything merged to `main` since the last release (`v1.2.6`, 2026-06-06). The package was never re-released, so `uvx`/`pip` users are still on the 1.2.6 tool set — and **missing the security fix**.

Only `pyproject.toml` changes; `__version__` tracks it via `importlib.metadata`.

## What ships in 1.3.0 (since v1.2.6)

- **+302 tools** (2176 → 2478) across **36 new databases** — cross-biobank PheWAS, de-novo MSA & phylogeny, clinical risk calculators, peptide-resource databases, and more (#248, #254, #255)
- 🔒 **Unauthenticated RCE fix** + server-exposure hardening in `python_code_executor` (#251)
- Coding-API stub generator fix — nullable types + injected-param collisions (#256)

## How it publishes

`publish-pypi.yml` fires on every push to `main` and compares `pyproject.toml`'s version to PyPI's latest — so **merging this PR auto-publishes 1.3.0** (no manual tag push needed). A `v1.3.0` git tag is optional, for marking the release point.

## Note on plugin versions

This is the **package** line only. The Claude + Codex plugins (1.2.18) are independent; once the package is 1.3.0, the plugins resync to `1.3.x` on their next plugin release (per the package-tracked scheme in #249).