### PR TITLE
Release tooluniverse 1.3.1

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "tooluniverse",
     "display_name": "ToolUniverse",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "ToolUniverse: an ecosystem for democratizing AI scientists with 2000+ scientific tools.",
     "long_description": "ToolUniverse is an ecosystem for creating AI scientist systems from any large language model (LLM). It standardizes how LLMs interact with tools, integrating thousands of machine learning models, datasets, APIs, and scientific packages for data analysis, knowledge retrieval, and experimental design. This bundle exposes ToolUniverse capability via the Model Context Protocol (MCP), enabling AI assistants to perform complex scientific tasks.",
     "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooluniverse-mcpb-native"
-version = "1.3.0"
+version = "1.3.1"
 description = "ToolUniverse MCP Server (Native MCPB bundle)"
 requires-python = ">=3.10,<3.14"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooluniverse"
-version = "1.3.0"
+version = "1.3.1"
 description = "A comprehensive collection of scientific tools for Agentic AI, offering integration with the ToolUniverse SDK and MCP Server to support advanced scientific workflows."
 authors = [
     { name = "Shanghua Gao", email = "shanghuagao@gmail.com" }

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mims-harvard/ToolUniverse",
     "source": "github"
   },
-  "version": "1.3.0",
+  "version": "1.3.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "tooluniverse",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Release 1.3.1

Patch release. Bumps the version consistently across all 5 package declarations (`pyproject.toml`, `mcpb/pyproject.toml`, `mcpb/manifest.json`, `server.json` ×2). `src/tooluniverse/__init__.py` reads the version dynamically, so it needs no edit.

## What ships in 1.3.1
- **#266** (merged): OpenTargets EFO→MONDO migration fix + GraphQL not-found hardening (fixes #264).
- **#268**: `ThreeDBeacons_get_annotations` — treat "no annotations of this type" (404) as an empty result, not an error.

## ⚠️ Merge order
Merge **#268 first**, then this PR. `publish-pypi.yml` auto-publishes to PyPI (and tags `v1.3.1` + creates the GitHub Release) the moment a version newer than PyPI's latest lands on `main`, so this must be the **last** thing merged.