### PR TITLE
Release tooluniverse 1.3.1: OpenTargets migration follow-through + full-registry drift fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "ToolUniverse marketplace \u2014 1000+ scientific research tools and 115 specialized skills for biology, chemistry, medicine, and data science.",
-    "version": "1.2.18"
+    "version": "1.3.1"
   },
   "plugins": [
     {

--- a/.env.template
+++ b/.env.template
@@ -88,6 +88,9 @@ NCBI_API_KEY=
 # Without: Works at ~1 request/sec without it; the key raises rate limits.
 SEMANTIC_SCHOLAR_API_KEY=
 
+# OPENALEX_API_KEY (optional) — Search scholarly works via OpenAlex. Required for anonymous access since 2026-02-13. (https://openalex.org/settings/api)
+OPENALEX_API_KEY=
+
 # USPTO_API_KEY (required) — Search US patents and patent-application full text. (https://developer.uspto.gov/)
 # Without: USPTO patent tools are blocked without it.
 USPTO_API_KEY=

--- a/.env.template
+++ b/.env.template
@@ -84,12 +84,13 @@ HF_TOKEN=
 # Without: Works at 3 requests/sec without it; the key raises the limit to 10/sec.
 NCBI_API_KEY=
 
+# OPENALEX_API_KEY (optional) — Search scholarly works, authors, and sources via OpenAlex. (https://openalex.org/settings/api)
+# Without: OpenAlex requires a key since 2026-02-13; anonymous requests return HTTP 503.
+OPENALEX_API_KEY=
+
 # SEMANTIC_SCHOLAR_API_KEY (optional) — Search papers and traverse citation graphs via Semantic Scholar. (https://www.semanticscholar.org/product/api)
 # Without: Works at ~1 request/sec without it; the key raises rate limits.
 SEMANTIC_SCHOLAR_API_KEY=
-
-# OPENALEX_API_KEY (optional) — Search scholarly works via OpenAlex. Required for anonymous access since 2026-02-13. (https://openalex.org/settings/api)
-OPENALEX_API_KEY=
 
 # USPTO_API_KEY (required) — Search US patents and patent-application full text. (https://developer.uspto.gov/)
 # Without: USPTO patent tools are blocked without it.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.abspath("../src"))
 project = "ToolUniverse"
 copyright = "2025, Shanghua Gao"
 author = "Shanghua Gao"
-release = "1.0.0"
+release = "1.3.1"
 
 # -- General configuration ---------------------------------------------------
 extensions = [

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.4",
     "name": "tooluniverse",
     "display_name": "ToolUniverse",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "ToolUniverse: an ecosystem for democratizing AI scientists with 2000+ scientific tools.",
     "long_description": "ToolUniverse is an ecosystem for creating AI scientist systems from any large language model (LLM). It standardizes how LLMs interact with tools, integrating thousands of machine learning models, datasets, APIs, and scientific packages for data analysis, knowledge retrieval, and experimental design. This bundle exposes ToolUniverse capability via the Model Context Protocol (MCP), enabling AI assistants to perform complex scientific tasks.",
     "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooluniverse-mcpb-native"
-version = "1.3.0"
+version = "1.3.1"
 description = "ToolUniverse MCP Server (Native MCPB bundle)"
 requires-python = ">=3.10,<3.14"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tooluniverse",
   "description": "1000+ scientific research tools for biology, chemistry, medicine, and data science. Access PubMed, UniProt, PubChem, TCGA, NHANES, GWAS Catalog, and hundreds more databases through a unified MCP interface. Includes 120+ specialized research skills for genomics, drug discovery, clinical analysis, protein variant interpretation, and more.",
-  "version": "1.2.18",
+  "version": "1.3.1",
   "author": {
     "name": "Shanghua Gao",
     "url": "https://shgao.site"

--- a/plugins/tooluniverse/.codex-plugin/plugin.json
+++ b/plugins/tooluniverse/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tooluniverse",
   "description": "1000+ scientific research tools for biology, chemistry, medicine, and data science. Access PubMed, UniProt, PubChem, TCGA, NHANES, GWAS Catalog, and hundreds more databases through a unified MCP interface. Includes specialized research skills for genomics, drug discovery, clinical analysis, protein variant interpretation, and more.",
-  "version": "1.2.18",
+  "version": "1.3.1",
   "author": {
     "name": "Shanghua Gao",
     "url": "https://shgao.site"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "rcsb-api>=1.4.0",
     "fitz>=0.0.1.dev2",
     "pandas>=2.2.3",
+    "openpyxl>=3.1.0", # Read .xlsx bulk downloads (CellMarker, dataset tools)
     "setuptools>=70.0.0", # Fix pkg_resources deprecation warnings
     "pdfplumber>=0.11.0",
     "playwright>=1.55.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tooluniverse"
-version = "1.3.0"
+version = "1.3.1"
 description = "A comprehensive collection of scientific tools for Agentic AI, offering integration with the ToolUniverse SDK and MCP Server to support advanced scientific workflows."
 authors = [
     { name = "Shanghua Gao", email = "shanghuagao@gmail.com" }

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/mims-harvard/ToolUniverse",
     "source": "github"
   },
-  "version": "1.3.0",
+  "version": "1.3.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "tooluniverse",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/tooluniverse/cellmarker_tool.py
+++ b/src/tooluniverse/cellmarker_tool.py
@@ -6,8 +6,13 @@ cell type marker genes from single-cell RNA-seq and experimental studies.
 
 CellMarker 2.0 is a comprehensive database of cell type markers curated
 from >26,000 publications, covering >500 cell types across >400 tissue types
-for human and mouse. Data sources include single-cell sequencing, experiments,
-reviews, and commercial antibody panels.
+for human and mouse.
+
+The CellMarker 2.0 web site was restructured and no longer exposes the JSP
+search endpoints this tool previously scraped; the only public interface now is
+the bulk marker download. This tool therefore downloads the full marker table
+once (`Cell_marker_All.xlsx`), caches it on disk, and answers all queries
+locally from the cached table.
 
 Website: http://bio-bigdata.hrbmu.edu.cn/CellMarker/
 No authentication required.
@@ -15,87 +20,144 @@ No authentication required.
 Reference: Hu et al., Nucleic Acids Research, 2023 (PMID: 36300619)
 """
 
-import re
-import requests
+import os
+import tempfile
+import threading
 from typing import Dict, Any, List, Optional
+
+import requests
+
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
-CELLMARKER_BASE_URL = "http://bio-bigdata.hrbmu.edu.cn/CellMarker"
+# Bulk marker table. The primary domain sometimes 404s the download path; the
+# published IP mirror is used as a fallback.
+_DOWNLOAD_URLS = [
+    "http://bio-bigdata.hrbmu.edu.cn/CellMarker/CellMarker_download_files/file/Cell_marker_All.xlsx",
+    "http://117.50.127.228/CellMarker/CellMarker_download_files/file/Cell_marker_All.xlsx",
+]
+_CACHE_PATH = os.path.join(tempfile.gettempdir(), "tooluniverse_cellmarker_all.xlsx")
+_BROWSER_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+_DF = None  # cached pandas DataFrame (loaded once per process)
+_LOAD_LOCK = threading.Lock()
 
 
-def _parse_html_table_rows(html: str) -> List[Dict[str, str]]:
-    """Parse HTML table rows from CellMarker JSP response.
-
-    CellMarker returns data as HTML table rows with columns:
-    Species | Tissue Class | Tissue Type | Cancer/Normal | Cell Name | Cell Marker | Source | Supports
-    """
-    results = []
-    # Match all table rows with data
-    row_pattern = re.compile(r"<tr><td>(.*?)</tr>", re.DOTALL)
-    for match in row_pattern.finditer(html):
-        row_html = match.group(1)
-        # Extract cell contents - handle cells with nested HTML
-        cells = re.findall(r"<td>(.*?)</td>", "<td>" + row_html, re.DOTALL)
-        if len(cells) >= 6:
-            # Extract source from nested HTML (e.g., <p class='noplay'>Experiment</p><img...>)
-            source_raw = cells[6] if len(cells) > 6 else ""
-            source_match = re.search(r"class='noplay'>(.*?)</p>", source_raw)
-            source = source_match.group(1) if source_match else source_raw.strip()
-
-            # Extract support count
-            supports = cells[7].strip() if len(cells) > 7 else "0"
-
-            record = {
-                "species": cells[0].strip(),
-                "tissue_class": cells[1].strip(),
-                "tissue_type": cells[2].strip(),
-                "cell_type": cells[3].strip(),  # "Normal cell" or "Cancer cell"
-                "cell_name": cells[4].strip(),
-                "cell_marker": cells[5].strip(),
-                "source": source,
-                "supports": int(supports) if supports.isdigit() else 0,
-            }
-            results.append(record)
-    return results
+def _download_marker_table(timeout: int) -> None:
+    """Download the bulk marker table to the on-disk cache."""
+    last_err: Optional[Exception] = None
+    for url in _DOWNLOAD_URLS:
+        try:
+            resp = requests.get(
+                url, headers={"User-Agent": _BROWSER_UA}, timeout=timeout
+            )
+            resp.raise_for_status()
+            with open(_CACHE_PATH, "wb") as fh:
+                fh.write(resp.content)
+            return
+        except requests.RequestException as err:  # try the next mirror
+            last_err = err
+    raise RuntimeError(f"Could not download the CellMarker marker table: {last_err}")
 
 
-def _parse_cell_type_list(js_text: str) -> List[Dict[str, str]]:
-    """Parse the JavaScript cell type list from CONTROL endpoint.
+def _load_dataframe(timeout: int = 180):
+    """Load (and cache) the CellMarker marker table as a normalized DataFrame."""
+    global _DF
+    if _DF is not None:
+        return _DF
+    with _LOAD_LOCK:
+        if _DF is not None:
+            return _DF
+        import pandas as pd
 
-    CONTROL returns pseudo-JSON like:
-    [{id:0,tissuet:"none",tissuec:"X",pId:0,name:"Y",namein:"Z",...},...]
-    """
-    results = []
-    # Extract name values from the JS object array
-    name_pattern = re.compile(r'namein:"(.*?)"')
-    tissuec_pattern = re.compile(r'tissuec:"(.*?)"')
+        if not os.path.exists(_CACHE_PATH) or os.path.getsize(_CACHE_PATH) == 0:
+            _download_marker_table(timeout)
 
-    names = name_pattern.findall(js_text)
-    tissues = tissuec_pattern.findall(js_text)
+        df = pd.read_excel(
+            _CACHE_PATH,
+            usecols=[
+                "species",
+                "tissue_class",
+                "tissue_type",
+                "cancer_type",
+                "cell_type",
+                "cell_name",
+                "marker",
+                "Symbol",
+                "marker_source",
+            ],
+        )
+        # Marker gene symbol: prefer the curated Symbol, fall back to marker.
+        df["cell_marker"] = (
+            df["Symbol"].fillna(df["marker"]).fillna("").astype(str).str.strip()
+        )
+        df["source"] = df["marker_source"].fillna("").astype(str).str.strip()
+        for col in ("species", "tissue_class", "tissue_type", "cell_type", "cell_name"):
+            df[col] = df[col].fillna("").astype(str).str.strip()
+        # "supports" = number of curated records for the same marker/cell/tissue,
+        # i.e. how many studies back the marker–cell assignment.
+        df["supports"] = df.groupby(
+            ["species", "tissue_type", "cell_name", "cell_marker"]
+        )["cell_marker"].transform("size")
+        _DF = df
+        return _DF
 
-    for i, name in enumerate(names):
-        if name == "ALL":
-            continue
-        tissue = tissues[i] if i < len(tissues) else ""
-        results.append(
+
+_RECORD_COLUMNS = [
+    "species",
+    "tissue_class",
+    "tissue_type",
+    "cell_type",
+    "cell_name",
+    "cell_marker",
+    "source",
+    "supports",
+]
+
+
+def _records(df, limit: int = 200) -> List[Dict[str, Any]]:
+    """Convert a filtered DataFrame to the tool's record dict list."""
+    out = []
+    for _, row in df.head(limit).iterrows():
+        out.append(
             {
-                "cell_name": name,
-                "tissue_class": tissue,
+                "species": row["species"],
+                "tissue_class": row["tissue_class"],
+                "tissue_type": row["tissue_type"],
+                "cell_type": row["cell_type"],
+                "cell_name": row["cell_name"],
+                "cell_marker": row["cell_marker"],
+                "source": row["source"],
+                "supports": int(row["supports"]),
             }
         )
-    return results
+    return out
+
+
+def _apply_species(df, species: Optional[str]):
+    if species:
+        return df[df["species"].str.lower() == species.strip().lower()]
+    return df
+
+
+def _apply_tissue(df, tissue_type: Optional[str]):
+    if tissue_type:
+        t = tissue_type.strip().lower()
+        return df[
+            df["tissue_type"].str.lower().str.contains(t, regex=False)
+            | df["tissue_class"].str.lower().str.contains(t, regex=False)
+        ]
+    return df
 
 
 @register_tool("CellMarkerTool")
 class CellMarkerTool(BaseTool):
     """
     Tool for querying the CellMarker 2.0 cell type marker database.
-
-    CellMarker 2.0 provides curated marker genes for hundreds of cell types
-    across tissues in human and mouse, sourced from single-cell RNA-seq
-    studies, experiments, reviews, and commercial antibody panels.
 
     Supported operations:
     - search_by_gene: Find cell types that express a given marker gene
@@ -108,216 +170,113 @@ class CellMarkerTool(BaseTool):
         super().__init__(tool_config)
         self.parameter = tool_config.get("parameter", {})
         self.required = self.parameter.get("required", [])
-        self.session = requests.Session()
-        self.timeout = 30
+        self.timeout = 180
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        """Execute the CellMarker tool with given arguments."""
         operation = arguments.get("operation")
         if not operation:
             return {"status": "error", "error": "Missing required parameter: operation"}
 
-        operation_handlers = {
+        handlers = {
             "search_by_gene": self._search_by_gene,
             "search_by_cell_type": self._search_by_cell_type,
             "list_cell_types": self._list_cell_types,
             "search_cancer_markers": self._search_cancer_markers,
         }
-
-        handler = operation_handlers.get(operation)
+        handler = handlers.get(operation)
         if not handler:
             return {
                 "status": "error",
                 "error": "Unknown operation: {}".format(operation),
-                "available_operations": list(operation_handlers.keys()),
+                "available_operations": list(handlers.keys()),
             }
 
         try:
-            return handler(arguments)
-        except requests.exceptions.Timeout:
-            return {"status": "error", "error": "CellMarker request timed out"}
-        except requests.exceptions.ConnectionError:
-            return {
-                "status": "error",
-                "error": "Could not connect to CellMarker server",
-            }
-        except Exception as e:
+            df = _load_dataframe(self.timeout)
+            return handler(arguments, df)
+        except Exception as e:  # noqa: BLE001 - report any failure via the envelope
             return {"status": "error", "error": "CellMarker error: {}".format(str(e))}
 
-    def _search_by_gene(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        """Find cell types that express a given marker gene.
-
-        Uses Marker_table.jsp with POST: markerSpecies + markerMarker params.
-        Returns HTML table rows parsed into structured data.
-        """
+    def _search_by_gene(self, arguments, df) -> Dict[str, Any]:
         gene_symbol = arguments.get("gene_symbol")
         if not gene_symbol:
             return {
                 "status": "error",
                 "error": "Missing required parameter: gene_symbol",
             }
-
-        species = arguments.get("species", "")
+        species = arguments.get("species")
         tissue_type = arguments.get("tissue_type")
 
-        # Map species to API format
-        species_map = {
-            "Human": "human",
-            "Mouse": "mouse",
-            "human": "human",
-            "mouse": "mouse",
-        }
-        api_species = species_map.get(species, species.lower() if species else "")
+        sub = df[df["cell_marker"].str.lower() == gene_symbol.strip().lower()]
+        sub = _apply_species(sub, species)
+        sub = _apply_tissue(sub, tissue_type)
 
-        url = "{}/Marker_table.jsp".format(CELLMARKER_BASE_URL)
-        data = {
-            "markerSpecies": api_species,
-            "markerMarker": gene_symbol,
-        }
-
-        resp = self.session.post(url, data=data, timeout=self.timeout)
-        resp.raise_for_status()
-
-        records = _parse_html_table_rows(resp.text)
-
-        # Filter by tissue_type if specified
-        if tissue_type:
-            tissue_lower = tissue_type.lower()
-            records = [
-                r
-                for r in records
-                if tissue_lower in r["tissue_type"].lower()
-                or tissue_lower in r["tissue_class"].lower()
-            ]
-
-        # Deduplicate and summarize by cell type
         return {
             "status": "success",
             "data": {
                 "gene_symbol": gene_symbol,
                 "species": species if species else "all",
-                "total_records": len(records),
-                "records": records[:200],  # Limit to 200 records
+                "total_records": int(len(sub)),
+                "records": _records(sub),
             },
         }
 
-    def _search_by_cell_type(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        """Find marker genes for a specific cell type.
-
-        Uses Marker_table.jsp with quickkeyword + quick_v=yes for general search,
-        then filters results to match the target cell type.
-        """
+    def _search_by_cell_type(self, arguments, df) -> Dict[str, Any]:
         cell_name = arguments.get("cell_name")
         if not cell_name:
             return {"status": "error", "error": "Missing required parameter: cell_name"}
-
         species = arguments.get("species")
         tissue_type = arguments.get("tissue_type")
 
-        # Use quick search which searches across cell names, markers, and tissues
-        url = "{}/Marker_table.jsp".format(CELLMARKER_BASE_URL)
-        params = {
-            "quickkeyword": cell_name,
-            "quick_v": "yes",
-        }
+        sub = df[
+            df["cell_name"]
+            .str.lower()
+            .str.contains(cell_name.strip().lower(), regex=False)
+        ]
+        sub = _apply_species(sub, species)
+        sub = _apply_tissue(sub, tissue_type)
 
-        resp = self.session.get(url, params=params, timeout=self.timeout)
-        resp.raise_for_status()
-
-        records = _parse_html_table_rows(resp.text)
-
-        # Filter to records matching the cell name
-        cell_lower = cell_name.lower()
-        filtered = [r for r in records if cell_lower in r["cell_name"].lower()]
-
-        # Apply species filter
-        if species:
-            species_lower = species.lower()
-            filtered = [r for r in filtered if r["species"].lower() == species_lower]
-
-        # Apply tissue filter
-        if tissue_type:
-            tissue_lower = tissue_type.lower()
-            filtered = [
-                r
-                for r in filtered
-                if tissue_lower in r["tissue_type"].lower()
-                or tissue_lower in r["tissue_class"].lower()
-            ]
-
-        # Extract unique marker genes
-        marker_genes = sorted(set(r["cell_marker"] for r in filtered))
-
+        marker_genes = sorted(m for m in sub["cell_marker"].unique() if m)
         return {
             "status": "success",
             "data": {
                 "cell_name": cell_name,
                 "species": species if species else "all",
-                "total_records": len(filtered),
+                "total_records": int(len(sub)),
                 "unique_markers": len(marker_genes),
-                "marker_genes": marker_genes[:500],  # Limit list
-                "records": filtered[:200],
+                "marker_genes": marker_genes[:500],
+                "records": _records(sub),
             },
         }
 
-    def _list_cell_types(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        """List available cell types in a tissue.
-
-        Uses the CONTROL endpoint which returns a JavaScript array of cell types
-        for a given tissue and species combination.
-        """
-        tissue_type = arguments.get("tissue_type", "")
+    def _list_cell_types(self, arguments, df) -> Dict[str, Any]:
+        tissue_type = arguments.get("tissue_type")
         species = arguments.get("species", "Human")
         cell_class = arguments.get("cell_class")
 
-        # Map species to API format
-        species_map = {
-            "Human": "human",
-            "Mouse": "mouse",
-            "human": "human",
-            "mouse": "mouse",
-        }
-        api_species = species_map.get(species, species.lower() if species else "human")
+        sub = _apply_species(df, species)
+        sub = _apply_tissue(sub, tissue_type)
+        if cell_class and cell_class.strip().lower() == "cancer":
+            sub = sub[sub["cell_type"] == "Cancer cell"]
 
-        # Determine cancer type filter
-        cancer_type = "all"  # "all" for normal+cancer, "cancer" for cancer only
-        if cell_class and cell_class.lower() == "cancer":
-            cancer_type = "cancer"
-
-        url = "{}/CONTROL".format(CELLMARKER_BASE_URL)
-        params = {
-            "spcies": api_species,
-            "cancertype": cancer_type,
-            "tissuet": tissue_type,
-            "tissuec": tissue_type,
-        }
-
-        resp = self.session.get(url, params=params, timeout=self.timeout)
-        resp.raise_for_status()
-
-        cell_types = _parse_cell_type_list(resp.text)
+        seen = {}
+        for _, row in sub.iterrows():
+            name = row["cell_name"]
+            if name and name not in seen:
+                seen[name] = {"cell_name": name, "tissue_class": row["tissue_class"]}
+        cell_types = list(seen.values())
 
         return {
             "status": "success",
             "data": {
-                "species": species,
+                "species": species if species else "all",
                 "tissue_type": tissue_type if tissue_type else "all",
                 "total_cell_types": len(cell_types),
                 "cell_types": cell_types,
             },
         }
 
-    def _search_cancer_markers(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        """Search cancer-specific cell markers.
-
-        Searches for markers in cancer cell contexts. Can filter by:
-        - cancer_type (tissue where cancer occurs, e.g., "Breast", "Lung")
-        - gene_symbol (specific marker gene)
-        - cell_type (specific cancer cell type)
-
-        Uses Marker_table.jsp with markerSpecies/markerMarker for gene-based search,
-        or quickkeyword search for cell type / cancer type searches.
-        """
+    def _search_cancer_markers(self, arguments, df) -> Dict[str, Any]:
         cancer_type = arguments.get("cancer_type")
         gene_symbol = arguments.get("gene_symbol")
         cell_type = arguments.get("cell_type")
@@ -328,58 +287,18 @@ class CellMarkerTool(BaseTool):
                 "error": "At least one parameter required: cancer_type, gene_symbol, or cell_type",
             }
 
-        records = []
-
+        sub = df[df["cell_type"] == "Cancer cell"]
         if gene_symbol:
-            # Search by gene, then filter to cancer records
-            url = "{}/Marker_table.jsp".format(CELLMARKER_BASE_URL)
-            data = {
-                "markerSpecies": "human",
-                "markerMarker": gene_symbol,
-            }
-            resp = self.session.post(url, data=data, timeout=self.timeout)
-            resp.raise_for_status()
-            records = _parse_html_table_rows(resp.text)
-        elif cell_type:
-            # Search by cell type name
-            url = "{}/Marker_table.jsp".format(CELLMARKER_BASE_URL)
-            params = {"quickkeyword": cell_type, "quick_v": "yes"}
-            resp = self.session.get(url, params=params, timeout=self.timeout)
-            resp.raise_for_status()
-            records = _parse_html_table_rows(resp.text)
-        elif cancer_type:
-            # Search by cancer tissue type
-            url = "{}/Marker_table.jsp".format(CELLMARKER_BASE_URL)
-            params = {"quickkeyword": cancer_type, "quick_v": "yes"}
-            resp = self.session.get(url, params=params, timeout=self.timeout)
-            resp.raise_for_status()
-            records = _parse_html_table_rows(resp.text)
-
-        # Filter to cancer records only
-        cancer_records = [r for r in records if r["cell_type"] == "Cancer cell"]
-
-        # Apply additional filters
+            sub = sub[sub["cell_marker"].str.lower() == gene_symbol.strip().lower()]
         if cancer_type:
-            cancer_lower = cancer_type.lower()
-            cancer_records = [
-                r
-                for r in cancer_records
-                if cancer_lower in r["tissue_type"].lower()
-                or cancer_lower in r["tissue_class"].lower()
+            sub = _apply_tissue(sub, cancer_type)
+        if cell_type:
+            sub = sub[
+                sub["cell_name"]
+                .str.lower()
+                .str.contains(cell_type.strip().lower(), regex=False)
             ]
 
-        if cell_type and gene_symbol:
-            # If both provided, also filter by cell type name
-            cell_lower = cell_type.lower()
-            cancer_records = [
-                r for r in cancer_records if cell_lower in r["cell_name"].lower()
-            ]
-
-        if gene_symbol and cancer_type:
-            # Already filtered by gene, also filter by cancer tissue
-            pass  # cancer_type filter already applied above
-
-        # Build query summary, omitting None values
         query = {}
         if cancer_type:
             query["cancer_type"] = cancer_type
@@ -392,7 +311,7 @@ class CellMarkerTool(BaseTool):
             "status": "success",
             "data": {
                 "query": query,
-                "total_records": len(cancer_records),
-                "records": cancer_records[:200],
+                "total_records": int(len(sub)),
+                "records": _records(sub),
             },
         }

--- a/src/tooluniverse/cellmarker_tool.py
+++ b/src/tooluniverse/cellmarker_tool.py
@@ -107,18 +107,6 @@ def _load_dataframe(timeout: int = 180):
         return _DF
 
 
-_RECORD_COLUMNS = [
-    "species",
-    "tissue_class",
-    "tissue_type",
-    "cell_type",
-    "cell_name",
-    "cell_marker",
-    "source",
-    "supports",
-]
-
-
 def _records(df, limit: int = 200) -> List[Dict[str, Any]]:
     """Convert a filtered DataFrame to the tool's record dict list."""
     out = []

--- a/src/tooluniverse/data/alphafold_tools.json
+++ b/src/tooluniverse/data/alphafold_tools.json
@@ -592,7 +592,10 @@
                       "type": "string"
                     },
                     "unit": {
-                      "type": "string"
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   }
                 }

--- a/src/tooluniverse/data/api_keys_catalog.json
+++ b/src/tooluniverse/data/api_keys_catalog.json
@@ -403,6 +403,18 @@
     ]
   },
   {
+    "name": "OPENALEX_API_KEY",
+    "requirement": "optional",
+    "type": "secret",
+    "domain": "Literature & Patents",
+    "register_url": "https://openalex.org/settings/api",
+    "purpose": "Search scholarly works, authors, and sources via OpenAlex.",
+    "without": "OpenAlex requires a key since 2026-02-13; anonymous requests return HTTP 503.",
+    "used_by": [
+      "openalex_tools.json"
+    ]
+  },
+  {
     "name": "OPENGWAS_JWT",
     "requirement": "required",
     "type": "secret",

--- a/src/tooluniverse/data/clinical_tables_tools.json
+++ b/src/tooluniverse/data/clinical_tables_tools.json
@@ -86,10 +86,8 @@
     },
     "test_examples": [
       {
-        "arguments": {
-          "terms": "metformin",
-          "max_results": 5
-        }
+        "terms": "metformin",
+        "max_results": 5
       }
     ]
   },
@@ -175,10 +173,8 @@
     },
     "test_examples": [
       {
-        "arguments": {
-          "terms": "diabetes",
-          "max_results": 5
-        }
+        "terms": "diabetes",
+        "max_results": 5
       }
     ]
   },
@@ -255,10 +251,8 @@
     },
     "test_examples": [
       {
-        "arguments": {
-          "terms": "cystic fibrosis",
-          "max_results": 5
-        }
+        "terms": "cystic fibrosis",
+        "max_results": 5
       }
     ]
   }

--- a/src/tooluniverse/data/crossref_tools.json
+++ b/src/tooluniverse/data/crossref_tools.json
@@ -394,54 +394,21 @@
       "method": "GET"
     },
     "return_schema": {
-      "oneOf": [
-        {
-          "type": "array",
-          "description": "Array of Crossref member (publisher) objects.",
-          "items": {
-            "type": "object",
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "type": "integer",
-                "description": "Numeric Crossref member id"
-              },
-              "primary-name": {
-                "type": "string"
-              },
-              "location": {
-                "type": "string"
-              },
-              "counts": {
-                "type": "object",
-                "description": "current-dois, backfile-dois, total-dois"
-              },
-              "breakdowns": {
-                "type": "object",
-                "description": "dois-by-issued-year"
-              },
-              "prefixes": {
-                "type": "array"
-              }
-            }
-          }
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string"
         },
-        {
-          "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
-          "properties": {
-            "status": {
-              "const": "error"
-            },
-            "error": {
-              "type": "string"
-            }
-          }
+        "data": {
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "error": {
+          "type": "string"
         }
-      ]
+      }
     },
     "test_examples": [
       {

--- a/src/tooluniverse/data/dailymed_tools.json
+++ b/src/tooluniverse/data/dailymed_tools.json
@@ -131,101 +131,17 @@
     "return_schema": {
       "type": "object",
       "properties": {
+        "status": {
+          "type": "string"
+        },
+        "xml": {
+          "type": "string"
+        },
         "error": {
           "type": "string"
         },
         "error_details": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "retriable": {
-              "type": "boolean"
-            },
-            "next_steps": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "details": {
-              "type": "object",
-              "properties": {
-                "validation_error": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "properties": {
-                      "type": "object",
-                      "properties": {
-                        "setid": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "format": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "format": {
-                          "type": "object",
-                          "properties": {
-                            "type": {
-                              "type": "string"
-                            },
-                            "enum": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "default": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "required": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "parameter": {
-                  "type": "string"
-                },
-                "expected": {
-                  "type": "string"
-                }
-              }
-            }
-          }
+          "type": "object"
         }
       }
     }

--- a/src/tooluniverse/data/dbaasp_tools.json
+++ b/src/tooluniverse/data/dbaasp_tools.json
@@ -29,10 +29,10 @@
                 "name": {"type": "string"},
                 "sequence": {"type": "string"},
                 "sequenceLength": {"type": "integer"},
-                "nTerminus": {"type": ["string", "null"]},
-                "cTerminus": {"type": ["string", "null"]},
-                "synthesisType": {"type": ["string", "null"]},
-                "complexity": {"type": ["string", "null"]},
+                "nTerminus": {"type": ["string", "object", "null"]},
+                "cTerminus": {"type": ["string", "object", "null"]},
+                "synthesisType": {"type": ["string", "object", "null"]},
+                "complexity": {"type": ["string", "object", "null"]},
                 "pdbs": {"type": "array"},
                 "structureModel": {"type": ["object", "null"]},
                 "targetGroups": {"type": "array"},
@@ -41,7 +41,7 @@
                 "antibiofilmActivities": {"type": "array"},
                 "uniprots": {"type": "array"},
                 "sourceGenes": {"type": "array"},
-                "smiles": {"type": ["string", "null"]},
+                "smiles": {"type": ["string", "array", "null"]},
                 "articles": {"type": "array"}
               }
             },
@@ -160,10 +160,10 @@
                   "name": {"type": ["string", "null"]},
                   "sequence": {"type": ["string", "null"]},
                   "sequenceLength": {"type": ["integer", "null"]},
-                  "nTerminus": {"type": ["string", "null"]},
-                  "cTerminus": {"type": ["string", "null"]},
-                  "complexity": {"type": ["string", "null"]},
-                  "synthesisType": {"type": ["string", "null"]},
+                  "nTerminus": {"type": ["string", "object", "null"]},
+                  "cTerminus": {"type": ["string", "object", "null"]},
+                  "complexity": {"type": ["string", "object", "null"]},
+                  "synthesisType": {"type": ["string", "object", "null"]},
                   "pdb": {"type": ["string", "null"]},
                   "pubchemCid": {"type": ["integer", "string", "null"]}
                 }

--- a/src/tooluniverse/data/depmap_tools.json
+++ b/src/tooluniverse/data/depmap_tools.json
@@ -82,12 +82,12 @@
                 "data": {
                     "type": "object",
                     "properties": {
-                        "model_id": {"type": "string"},
-                        "model_name": {"type": "string"},
-                        "tissue": {"type": "string"},
-                        "cancer_type": {"type": "string"},
-                        "msi_status": {"type": "string"},
-                        "ploidy": {"type": "number"}
+                        "model_id": {"type": ["string", "null"]},
+                        "model_name": {"type": ["string", "null"]},
+                        "tissue": {"type": ["string", "null"]},
+                        "cancer_type": {"type": ["string", "null"]},
+                        "msi_status": {"type": ["string", "null"]},
+                        "ploidy": {"type": ["number", "null"]}
                     }
                 },
                 "error": {"type": "string"}

--- a/src/tooluniverse/data/efo_tools.json
+++ b/src/tooluniverse/data/efo_tools.json
@@ -195,44 +195,21 @@
       {"obo_id": "EFO:0001444", "size": 5}
     ],
     "return_schema": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "const": "success"},
-            "url": {"type": "string"},
-            "count": {"type": "integer"},
-            "total": {"type": ["integer", "null"]},
-            "descendants": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "iri": {"type": ["string", "null"]},
-                  "obo_id": {"type": ["string", "null"]},
-                  "short_form": {"type": ["string", "null"]},
-                  "label": {"type": ["string", "null"]}
-                },
-                "additionalProperties": true
-              }
-            }
-          },
-          "required": ["status", "descendants"],
-          "additionalProperties": true
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string"
         },
-        {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "const": "error"},
-            "url": {"type": "string"},
-            "error": {"type": "string"},
-            "detail": {},
-            "status_code": {"type": "integer"}
-          },
-          "required": ["status", "error"],
-          "additionalProperties": true
+        "data": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "error": {
+          "type": "string"
         }
-      ]
+      }
     },
     "fields": {"kind": "descendants", "ontology_id": "efo"}
   },

--- a/src/tooluniverse/data/flybase_tools.json
+++ b/src/tooluniverse/data/flybase_tools.json
@@ -534,11 +534,8 @@
     "type": "AllianceGenomeTool",
     "test_examples": [
       {
-        "description": "Expression annotations for dpp (decapentaplegic)",
-        "arguments": {
-          "gene_id": "FB:FBgn0000490",
-          "limit": 5
-        }
+        "gene_id": "FB:FBgn0000490",
+        "limit": 5
       }
     ],
     "return_schema": {

--- a/src/tooluniverse/data/lncrna_tools.json
+++ b/src/tooluniverse/data/lncrna_tools.json
@@ -213,7 +213,11 @@
                   "type": "boolean"
                 },
                 "distinct_databases": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "array",
+                    "null"
+                  ]
                 }
               }
             },

--- a/src/tooluniverse/data/mirna_tools.json
+++ b/src/tooluniverse/data/mirna_tools.json
@@ -213,7 +213,11 @@
                   "type": "boolean"
                 },
                 "distinct_databases": {
-                  "type": "string"
+                  "type": [
+                    "string",
+                    "array",
+                    "null"
+                  ]
                 }
               }
             },

--- a/src/tooluniverse/data/ols_tools.json
+++ b/src/tooluniverse/data/ols_tools.json
@@ -325,32 +325,20 @@
     "return_schema": {
       "type": "object",
       "properties": {
+        "status": {
+          "type": "string"
+        },
+        "results": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
         "error": {
           "type": "string"
         },
         "error_details": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "retriable": {
-              "type": "boolean"
-            },
-            "next_steps": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "details": {
-              "type": "object",
-              "properties": {}
-            }
-          }
+          "type": "object"
         }
       }
     }
@@ -698,42 +686,37 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "terms": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "iri": {
-                "type": "string"
-              },
-              "ontologyName": {
-                "type": "string"
-              },
-              "shortForm": {
-                "type": "string"
-              },
-              "label": {
-                "type": "string"
-              },
-              "oboId": {
-                "type": "null"
-              },
-              "isObsolete": {
-                "type": "boolean"
-              }
-            }
-          }
-        },
-        "total_items": {
-          "type": "integer"
-        },
-        "showing": {
-          "type": "integer"
+        "status": {
+          "type": "string"
         },
         "term_iri": {
           "type": "string"
         },
+        "source_label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "ontology": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "similar_terms": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "total": {
+          "type": "integer"
+        },
+        "note": {
+          "type": "string"
+        },
+        "error": {
           "type": "string"
         }
       }

--- a/src/tooluniverse/data/oma_tools.json
+++ b/src/tooluniverse/data/oma_tools.json
@@ -673,6 +673,7 @@
                     "type": [
                       "integer",
                       "number",
+                      "string",
                       "null"
                     ]
                   }

--- a/src/tooluniverse/data/openalex_tools.json
+++ b/src/tooluniverse/data/openalex_tools.json
@@ -1,6 +1,9 @@
 [
   {
     "type": "OpenAlexTool",
+    "optional_api_keys": [
+      "OPENALEX_API_KEY"
+    ],
     "name": "openalex_literature_search",
     "description": "Search for academic literature using OpenAlex. Supports optional full-text-index filtering (has_fulltext + fulltext.search) when you need body-only term discovery, but note: OpenAlex full-text indexing is incomplete, and a work can be open-access elsewhere (e.g., PMC) while still having has_fulltext=false in OpenAlex. Returns paper metadata and (when available) OA links/content URLs.",
     "parameter": {
@@ -185,6 +188,9 @@
   },
   {
     "type": "OpenAlexRESTTool",
+    "optional_api_keys": [
+      "OPENALEX_API_KEY"
+    ],
     "name": "openalex_search_works",
     "description": "Search OpenAlex works (papers) via the /works endpoint. Supports both general search and optional full-text-index filtering: set require_has_fulltext=true and/or pass fulltext_terms to add OpenAlex filters (has_fulltext:true and fulltext.search:<term>). Important: has_fulltext/fulltext.search only match works where OpenAlex has indexed full text; this can miss papers whose full text is available elsewhere (e.g., PMC) but not indexed by OpenAlex. Use this to discover Work IDs (W...) and DOIs, then follow up with openalex_get_work/openalex_get_work_by_doi to retrieve OA links and (sometimes) content_urls.",
     "parameter": {
@@ -282,6 +288,9 @@
   },
   {
     "type": "OpenAlexRESTTool",
+    "optional_api_keys": [
+      "OPENALEX_API_KEY"
+    ],
     "name": "openalex_get_work",
     "description": "Get a single OpenAlex work (paper) by OpenAlex Work ID (W...). You can pass either the short ID (e.g., \"W2626778328\") or the full URL (e.g., \"https://openalex.org/W2626778328\").",
     "parameter": {
@@ -319,6 +328,9 @@
   },
   {
     "type": "OpenAlexRESTTool",
+    "optional_api_keys": [
+      "OPENALEX_API_KEY"
+    ],
     "name": "openalex_get_work_by_doi",
     "description": "Get a single OpenAlex work (paper) by DOI. Provide a DOI string like \"10.65215/2q58a426\" (you can also pass a DOI URL like \"https://doi.org/10.65215/2q58a426\").",
     "parameter": {
@@ -350,6 +362,9 @@
   },
   {
     "type": "OpenAlexRESTTool",
+    "optional_api_keys": [
+      "OPENALEX_API_KEY"
+    ],
     "name": "openalex_search_authors",
     "description": "Search OpenAlex authors via the /authors endpoint. Use this to discover Author IDs (A...) and then fetch details with openalex_get_author.",
     "parameter": {
@@ -395,6 +410,9 @@
   },
   {
     "type": "OpenAlexRESTTool",
+    "optional_api_keys": [
+      "OPENALEX_API_KEY"
+    ],
     "name": "openalex_get_author",
     "description": "Get a single OpenAlex author by Author ID (A...). You can pass either the short ID (e.g., \"A5001226970\") or the full URL (e.g., \"https://openalex.org/A5001226970\").",
     "parameter": {
@@ -426,6 +444,9 @@
   },
   {
     "type": "OpenAlexRESTTool",
+    "optional_api_keys": [
+      "OPENALEX_API_KEY"
+    ],
     "name": "openalex_search_institutions",
     "description": "Search OpenAlex institutions via the /institutions endpoint. Use this to discover Institution IDs (I...) and then fetch details with openalex_get_institution.",
     "parameter": {
@@ -471,6 +492,9 @@
   },
   {
     "type": "OpenAlexRESTTool",
+    "optional_api_keys": [
+      "OPENALEX_API_KEY"
+    ],
     "name": "openalex_get_institution",
     "description": "Get a single OpenAlex institution by Institution ID (I...). You can pass either the short ID (e.g., \"I136199984\") or the full URL (e.g., \"https://openalex.org/I136199984\").",
     "parameter": {
@@ -502,6 +526,9 @@
   },
   {
     "type": "OpenAlexRESTTool",
+    "optional_api_keys": [
+      "OPENALEX_API_KEY"
+    ],
     "name": "openalex_search_sources",
     "description": "Search OpenAlex sources (journals, conferences, repositories) by name or ISSN and return JOURNAL-LEVEL BIBLIOMETRIC IMPACT METRICS for each match: the Source ID (S...), display name, ISSN-L and ISSNs, host organization (publisher), works_count, cited_by_count, open-access status (is_oa), and summary_stats containing h_index, i10_index, and 2yr_mean_citedness (an impact-factor-like 2-year mean citedness). Use this to look up the impact/standing of a journal by name (e.g. 'nature', 'lancet') or to resolve an ISSN to its OpenAlex Source ID, then optionally fetch the full record with openalex_get_source. Results are returned newest/most-relevant first; pass relevance_score sorting via OpenAlex defaults.",
     "parameter": {
@@ -550,6 +577,9 @@
   },
   {
     "type": "OpenAlexRESTTool",
+    "optional_api_keys": [
+      "OPENALEX_API_KEY"
+    ],
     "name": "openalex_get_source",
     "description": "Fetch the full OpenAlex source (journal) record by Source ID (S...) or by ISSN, returning journal-level bibliometric impact metrics: display name, ISSN-L and ISSNs, host organization (publisher), works_count, cited_by_count, is_oa / is_in_doaj open-access status, apc (article processing charges), and summary_stats with h_index, i10_index, and 2yr_mean_citedness (an impact-factor-like 2-year mean citedness). Resolve a journal name to its Source ID first using openalex_search_sources. You may also pass an ISSN directly as the source_id (OpenAlex accepts issn:0028-0836).",
     "parameter": {

--- a/src/tooluniverse/data/openalex_tools.json
+++ b/src/tooluniverse/data/openalex_tools.json
@@ -4,6 +4,15 @@
     "optional_api_keys": [
       "OPENALEX_API_KEY"
     ],
+    "api_key_info": {
+      "OPENALEX_API_KEY": {
+        "domain": "Literature & Patents",
+        "type": "secret",
+        "register_url": "https://openalex.org/settings/api",
+        "purpose": "Search scholarly works, authors, and sources via OpenAlex.",
+        "without": "OpenAlex requires a key since 2026-02-13; anonymous requests return HTTP 503."
+      }
+    },
     "name": "openalex_literature_search",
     "description": "Search for academic literature using OpenAlex. Supports optional full-text-index filtering (has_fulltext + fulltext.search) when you need body-only term discovery, but note: OpenAlex full-text indexing is incomplete, and a work can be open-access elsewhere (e.g., PMC) while still having has_fulltext=false in OpenAlex. Returns paper metadata and (when available) OA links/content URLs.",
     "parameter": {

--- a/src/tooluniverse/data/openfda_tools.json
+++ b/src/tooluniverse/data/openfda_tools.json
@@ -1057,7 +1057,11 @@
                                         "description": "Product presentation/strength"
                                     },
                                     "therapeutic_category": {
-                                        "type": "string",
+                                        "type": [
+                                            "array",
+                                            "string",
+                                            "null"
+                                        ],
                                         "description": "Therapeutic category"
                                     },
                                     "company_name": {
@@ -1394,7 +1398,10 @@
                                         "description": "Report creation date"
                                     },
                                     "date_started": {
-                                        "type": "string",
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
                                         "description": "Reaction onset date"
                                     },
                                     "outcomes": {

--- a/src/tooluniverse/data/pharmgkb_tools.json
+++ b/src/tooluniverse/data/pharmgkb_tools.json
@@ -731,7 +731,11 @@
                     "type": "string"
                   },
                   "significance": {
-                    "type": "string"
+                    "type": [
+                      "object",
+                      "string",
+                      "null"
+                    ]
                   },
                   "sentence": {
                     "type": "string"

--- a/src/tooluniverse/data/pharos_tools.json
+++ b/src/tooluniverse/data/pharos_tools.json
@@ -252,7 +252,7 @@
                             "properties": {
                                 "sym": {"type": "string"},
                                 "tdl": {"type": "string"},
-                                "fam": {"type": "string"},
+                                "fam": {"type": ["string", "null"]},
                                 "ligandCounts": {
                                     "type": "array",
                                     "items": {
@@ -352,7 +352,7 @@
                                                 "properties": {
                                                     "sym": {"type": "string"},
                                                     "tdl": {"type": "string"},
-                                                    "fam": {"type": "string"}
+                                                    "fam": {"type": ["string", "null"]}
                                                 }
                                             },
                                             "type": {"type": ["string", "null"]},

--- a/src/tooluniverse/data/variant_validator_tools.json
+++ b/src/tooluniverse/data/variant_validator_tools.json
@@ -214,11 +214,29 @@
           "description": "VariantFormatter result. The top-level key is the submitted genomic variant; under it a nested key (the normalized g.HGVS) holds 'hgvs_t_and_p' (per-transcript projections keyed by RefSeq transcript accession), 'p_vcf', and 'selected_build'. A 'metadata' key carries VariantFormatter/VariantValidator versions.",
           "properties": {
             "metadata": {
-              "type": ["object", "null"],
+              "type": [
+                "object",
+                "null"
+              ],
               "properties": {
-                "variantformatter_version": {"type": ["string", "null"]},
-                "variantvalidator_version": {"type": ["string", "null"]},
-                "vvdb_version": {"type": ["string", "null"]}
+                "variantformatter_version": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "variantvalidator_version": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "vvdb_version": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
               }
             }
           },
@@ -226,36 +244,115 @@
             "type": "object",
             "description": "Per-variant block. Inner key is the normalized g.HGVS.",
             "additionalProperties": {
-              "type": "object",
+              "type": [
+                "object",
+                "array",
+                "string",
+                "null"
+              ],
               "properties": {
-                "g_hgvs": {"type": ["string", "null"], "description": "Normalized genomic HGVS"},
-                "p_vcf": {"type": ["string", "null"], "description": "Pseudo-VCF chrom:pos:ref:alt"},
-                "selected_build": {"type": ["string", "null"]},
-                "genomic_variant_error": {"type": ["string", "null"]},
+                "g_hgvs": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Normalized genomic HGVS"
+                },
+                "p_vcf": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Pseudo-VCF chrom:pos:ref:alt"
+                },
+                "selected_build": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "genomic_variant_error": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
                 "hgvs_t_and_p": {
-                  "type": ["object", "null"],
+                  "type": [
+                    "object",
+                    "null"
+                  ],
                   "description": "Per-transcript projections keyed by RefSeq transcript accession (e.g. NM_000088.4)",
                   "additionalProperties": {
                     "type": "object",
                     "properties": {
-                      "t_hgvs": {"type": ["string", "null"], "description": "Transcript coding HGVS (c.)"},
-                      "p_hgvs_tlc": {"type": ["string", "null"], "description": "Protein HGVS, three-letter code"},
-                      "p_hgvs_slc": {"type": ["string", "null"], "description": "Protein HGVS, single-letter code"},
+                      "t_hgvs": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Transcript coding HGVS (c.)"
+                      },
+                      "p_hgvs_tlc": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Protein HGVS, three-letter code"
+                      },
+                      "p_hgvs_slc": {
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "Protein HGVS, single-letter code"
+                      },
                       "gene_info": {
-                        "type": ["object", "null"],
+                        "type": [
+                          "object",
+                          "null"
+                        ],
                         "properties": {
-                          "hgnc_id": {"type": ["string", "null"]},
-                          "symbol": {"type": ["string", "null"]}
+                          "hgnc_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "symbol": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
                         }
                       },
                       "select_status": {
-                        "type": ["object", "null"],
+                        "type": [
+                          "object",
+                          "null"
+                        ],
                         "properties": {
-                          "mane_select": {"type": ["boolean", "null"]},
-                          "refseq_select": {"type": ["boolean", "null"]}
+                          "mane_select": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          },
+                          "refseq_select": {
+                            "type": [
+                              "boolean",
+                              "null"
+                            ]
+                          }
                         }
                       },
-                      "transcript_variant_error": {"type": ["string", "null"]}
+                      "transcript_variant_error": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
                     }
                   }
                 }
@@ -266,9 +363,13 @@
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/zfin_tools.json
+++ b/src/tooluniverse/data/zfin_tools.json
@@ -641,11 +641,8 @@
     "type": "AllianceGenomeTool",
     "test_examples": [
       {
-        "description": "Expression annotations for shha (sonic hedgehog a)",
-        "arguments": {
-          "gene_id": "ZFIN:ZDB-GENE-980526-166",
-          "limit": 5
-        }
+        "gene_id": "ZFIN:ZDB-GENE-980526-166",
+        "limit": 5
       }
     ],
     "return_schema": {

--- a/src/tooluniverse/mirna_tool.py
+++ b/src/tooluniverse/mirna_tool.py
@@ -206,29 +206,56 @@ class miRNAGetTool(BaseTool):
         rnacentral_id = arguments.get("rnacentral_id", "")
         taxid = arguments.get("taxid")
 
-        # Build URL: /api/v1/rna/{URS}/{taxid} or /api/v1/rna/{URS}
-        if taxid:
-            url = f"{RNACENTRAL_BASE}/rna/{rnacentral_id}/{taxid}?format=json"
-        else:
-            url = f"{RNACENTRAL_BASE}/rna/{rnacentral_id}?format=json"
-
+        # The /rna/{URS}/{taxid} path now serves an HTML species view rather
+        # than JSON, so fetch the JSON record (sequence, length, ...) and derive
+        # the species-specific fields (rna_type, species, description) from the
+        # xrefs endpoint, filtered by taxid when provided.
+        url = f"{RNACENTRAL_BASE}/rna/{rnacentral_id}/?format=json"
         resp = requests.get(url, timeout=self.timeout)
         resp.raise_for_status()
         result = resp.json()
 
+        rna_type = species = description = ""
+        try:
+            xr = requests.get(
+                f"{RNACENTRAL_BASE}/rna/{rnacentral_id}/xrefs/?format=json&page_size=100",
+                timeout=self.timeout,
+            )
+            if xr.ok:
+                xrefs = xr.json().get("results", [])
+                match = None
+                if taxid:
+                    match = next(
+                        (x for x in xrefs if str(x.get("taxid")) == str(taxid)), None
+                    )
+                match = match or (xrefs[0] if xrefs else None)
+                # Species-specific annotation lives under the xref's accession.
+                acc = (match or {}).get("accession") or {}
+                rna_type = acc.get("rna_type") or ""
+                species = acc.get("species") or ""
+                description = acc.get("description") or ""
+        except (requests.RequestException, ValueError):
+            pass
+
         return {
             "status": "success",
             "data": {
-                "rnacentral_id": result.get("rnacentral_id", ""),
-                "description": result.get("description", ""),
+                "rnacentral_id": result.get("rnacentral_id", rnacentral_id),
+                "description": description,
                 "short_description": result.get("short_description", ""),
                 "sequence": result.get("sequence", ""),
                 "length": result.get("length", 0),
-                "rna_type": result.get("rna_type", ""),
-                "species": result.get("species", ""),
-                "taxid": result.get("taxid"),
+                "rna_type": rna_type,
+                "species": species,
+                "taxid": taxid,
                 "genes": result.get("genes", []),
-                "publications_count": result.get("publications", 0),
+                # The record's "publications" field is a URL, not a count; only
+                # keep it when the API returns an integer count.
+                "publications_count": (
+                    result.get("publications")
+                    if isinstance(result.get("publications"), int)
+                    else 0
+                ),
                 "is_active": result.get("is_active", True),
                 "distinct_databases": result.get("distinct_databases", ""),
             },

--- a/src/tooluniverse/openalex_tool.py
+++ b/src/tooluniverse/openalex_tool.py
@@ -1,8 +1,24 @@
+import os
 import requests
 from typing import Any, Dict, Optional
 from .base_tool import BaseTool
 from .http_utils import request_with_retry
 from .tool_registry import register_tool
+
+
+def _with_api_key(params):
+    """Add the OpenAlex API key when configured.
+
+    OpenAlex requires an API key as of 2026-02-13 (the polite-pool `mailto`
+    parameter was discontinued); anonymous requests now return HTTP 503. The
+    key is a query parameter named `api_key` (free at openalex.org/settings/api)
+    and is read from the OPENALEX_API_KEY environment variable.
+    """
+    key = os.environ.get("OPENALEX_API_KEY")
+    if key:
+        params = dict(params or {})
+        params["api_key"] = key
+    return params
 
 
 @register_tool("OpenAlexTool")
@@ -109,7 +125,7 @@ class OpenAlexTool(BaseTool):
             params["filter"] = ",".join(filters)
 
         try:
-            response = requests.get(self.base_url, params=params)
+            response = requests.get(self.base_url, params=_with_api_key(params))
             response.raise_for_status()
             data = response.json()
 
@@ -255,7 +271,7 @@ class OpenAlexTool(BaseTool):
             url = f"https://api.openalex.org/works/https://doi.org/{doi}"
             params = {"mailto": "support@openalex.org"}
 
-            response = requests.get(url, params=params)
+            response = requests.get(url, params=_with_api_key(params))
             response.raise_for_status()
             work = response.json()
 
@@ -284,7 +300,7 @@ class OpenAlexTool(BaseTool):
                 "mailto": "support@openalex.org",
             }
 
-            response = requests.get(self.base_url, params=params)
+            response = requests.get(self.base_url, params=_with_api_key(params))
             response.raise_for_status()
             data = response.json()
 
@@ -449,7 +465,7 @@ class OpenAlexRESTTool(BaseTool):
                 self.session,
                 "GET",
                 url,
-                params=params,
+                params=_with_api_key(params),
                 timeout=self.timeout,
                 max_attempts=3,
             )

--- a/src/tooluniverse/three_d_beacons_tool.py
+++ b/src/tooluniverse/three_d_beacons_tool.py
@@ -249,6 +249,31 @@ class ThreeDBeaconsTool(BaseTool):
             params["provider"] = provider
 
         response = requests.get(url, params=params, timeout=self.timeout)
+        # The annotations endpoint returns 404 when the protein has no
+        # annotations of the requested type (e.g. P04637 has DOMAIN but no
+        # BINDING). That is a valid empty result, not an error — distinguish it
+        # from a genuine failure rather than reporting "no structures found".
+        if response.status_code == 404:
+            return {
+                "status": "success",
+                "data": {
+                    "accession": accession,
+                    "type_filter": annotation_type,
+                    "annotation_count": 0,
+                    "annotations": [],
+                    "note": (
+                        f"No {annotation_type or 'matching'} annotations for "
+                        f"{accession} in 3D Beacons (the accession may also be "
+                        "absent from the annotations index)."
+                    ),
+                },
+                "metadata": {
+                    "source": "3D Beacons Hub API",
+                    "accession": accession,
+                    "type_filter": annotation_type,
+                    "provider_filter": provider,
+                },
+            }
         response.raise_for_status()
         data = response.json()
 

--- a/tests/tools/test_three_d_beacons_annotations.py
+++ b/tests/tools/test_three_d_beacons_annotations.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for ThreeDBeaconsTool annotations 404 handling.
+
+The 3D Beacons annotations endpoint returns HTTP 404 when a valid protein
+simply has no annotations of the requested type (e.g. P04637 has DOMAIN
+annotations but no BINDING annotations). That is an empty result, not a
+failure — the tool must report it as a success with zero annotations rather
+than the misleading "No structures found" error.
+"""
+
+import json
+from unittest.mock import patch, MagicMock
+
+
+def _tool():
+    from tooluniverse.three_d_beacons_tool import ThreeDBeaconsTool
+
+    cfg = next(
+        t
+        for t in json.load(open("src/tooluniverse/data/three_d_beacons_tools.json"))
+        if t["name"] == "ThreeDBeacons_get_annotations"
+    )
+    return ThreeDBeaconsTool(cfg)
+
+
+class TestAnnotations404:
+    def test_404_is_empty_success_not_error(self):
+        resp = MagicMock()
+        resp.status_code = 404
+        with patch(
+            "tooluniverse.three_d_beacons_tool.requests.get", return_value=resp
+        ):
+            result = _tool().run({"accession": "P04637", "type": "BINDING"})
+        assert result["status"] == "success"
+        assert result["data"]["annotation_count"] == 0
+        assert result["data"]["annotations"] == []
+        # message must not claim "structures" for an annotations query
+        assert "structure" not in result["data"]["note"].lower()
+
+    def test_200_returns_annotations(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "accession": "P38398",
+            "id": "P38398",
+            "sequence": "MDL",
+            "annotation": [
+                {"type": "DOMAIN", "description": "BRCT", "residues": [1, 2, 3]}
+            ],
+        }
+        resp.raise_for_status = MagicMock()
+        with patch(
+            "tooluniverse.three_d_beacons_tool.requests.get", return_value=resp
+        ):
+            result = _tool().run({"accession": "P38398", "type": "DOMAIN"})
+        assert result["status"] == "success"
+        assert result["data"]["annotation_count"] == 1
+        assert result["data"]["annotations"][0]["type"] == "DOMAIN"
+
+    def test_non_404_http_error_still_errors(self):
+        import requests
+
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            response=resp
+        )
+        with patch(
+            "tooluniverse.three_d_beacons_tool.requests.get", return_value=resp
+        ):
+            result = _tool().run({"accession": "P38398", "type": "DOMAIN"})
+        assert result["status"] == "error"


### PR DESCRIPTION
## Summary

This is the **1.3.1 release** PR. It bumps the version (last commit) **and** carries every tool fix surfaced while validating the release, so merging it ships 1.3.1 with all fixes atomically. (Supersedes #267, now closed. The OpenTargets EFO→MONDO fix from #264 shipped separately in #266, already on main.)

`publish-pypi.yml` auto-publishes to PyPI + tags `v1.3.1` + creates the GitHub Release once this lands on `main`.

## Version bump (final commit)
`pyproject.toml`, `mcpb/pyproject.toml`, `mcpb/manifest.json`, `server.json` (×2) → 1.3.1. `src/tooluniverse/__init__.py` reads the version dynamically.

## Tool fixes (~26 tools)

**Functional / endpoint**
- `ThreeDBeacons_get_annotations` — treat a "no annotations of this type" 404 as an empty result, not an error.
- `miRBase_get_mirna` — RNAcentral's `/rna/{id}/{taxid}` path now serves HTML; switched to the JSON record + `/xrefs` endpoints (species metadata from `accession`).
- `OpenAlex` (10 tools) — OpenAlex requires an API key since 2026-02-13; added `OPENALEX_API_KEY` support (`api_key` query param) + `optional_api_keys` + `.env.template`.
- **CellMarker (4 tools) — rewritten**: the CellMarker 2.0 site removed its JSP search API; the tool now downloads the bulk marker table once (`Cell_marker_All.xlsx`, ~10 MB / 96k rows), caches it, and answers all four operations locally.

**Stale `return_schema` / examples** (tools returned data fine; the contract or example was stale)
- `PharmGKB_get_variant_annotations`, `OpenFDA_search_drug_shortages`, `OpenFDA_search_food_adverse_events`, `OMA_get_genome_pair_orthologs`, `ols_search_ontologies`, `ols_find_similar_terms`, `DailyMed_get_spl_by_setid`, `ols_get_efo_term_descendants`, `Crossref_search_members`, `DepMap_get_cell_line`, `Pharos_get_ligand_targets`, `alphafold_get_annotations`, `DBAASP_get_peptide`, `VariantValidator_format_genomic_to_transcripts`.
- Malformed `{arguments: {...}}` test_examples flattened: `ZFIN`, `FlyBase`, `RxTerms_search_drugs`, `HealthConditions_search`, `DiseaseNames_search`.

## Validation
Every fixed tool passes `scripts/test_new_tools.py` with **0 schema-invalid**. The full 2779-tool scan's remaining failures are upstream outages (SCREEN, OmicsDI, KEGG list/organism, EOL), transient blips (WormBase self-healed), or key/dep-gated (NvidiaNIM, AlphaGenome) — documented, not client-fixable.

## Method note
Surfaced by a resumable full-registry scan (`scripts/test_new_tools.py` + a parallel scanner). ADMETAI's 8 scan "failures" were false positives from the parallel scanner hitting thread-unsafe torch — verified working single-threaded, not changed.