### PR TITLE
Add tooluniverse-cs-setup — a Claude Science installer skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -85,6 +85,7 @@ npx skills add mims-harvard/ToolUniverse
 | Skill | Description |
 |-------|-------------|
 | `setup-tooluniverse` | Install and configure ToolUniverse (MCP, CLI, or SDK) |
+| `tooluniverse-cs-setup` | Install/update ToolUniverse in **Claude Science** (conda env + pip package + native skill; not MCP) |
 | `create-tooluniverse-skill` | Create new skills with test-driven methodology |
 | `devtu-auto-discover-apis` | Discover life science APIs and create tools automatically |
 | `devtu-create-tool` | Create new scientific tools with proper structure and testing |

--- a/skills/tooluniverse-cs-setup/SKILL.md
+++ b/skills/tooluniverse-cs-setup/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: tooluniverse-cs-setup
+description: Install or update ToolUniverse in Claude Science — create the conda env, install the tooluniverse pip package, and (re)build the tooluniverse-research skill by fetching the current workflow library from GitHub. Use for first-time setup, upgrading the ToolUniverse version, refreshing the bundled workflows after an upstream release, or reinstalling on a new machine.
+---
+
+# Set up ToolUniverse for Claude Science
+
+The upstream ToolUniverse ships a Claude **Code** plugin (MCP server + `uvx` + slash commands). Claude **Science** loads capabilities differently, so this skill installs the equivalent natively: the `tooluniverse` **pip package** supplies the 2500+ tools, and the workflow library is packaged into a single dynamically-loaded skill, `tooluniverse-research`. No `uv`, no MCP server, no plugin marketplace.
+
+Loading this skill defines `tu_build_research_bundle()` in the kernel (run cells in the **`tooluniverse`** conda env).
+
+## Full install / update — four steps
+
+**1. Create the conda env** (skip if it already exists):
+```
+manage_environments(mode="create", name="tooluniverse", python_version="3.11", packages=["pip"])
+```
+
+**2. Install (or upgrade) the tools** — the pip package is the tool layer:
+```
+manage_packages(mode="install", environment="tooluniverse", packages=["tooluniverse"], use_pip=True)
+```
+Pin a version for reproducibility with `["tooluniverse==1.3.0"]`.
+
+**3. Stage the workflow bundle** — fetch the current repo and rebuild the file tree (run in a `python` cell, env `tooluniverse`):
+```python
+res = tu_build_research_bundle(staging="./tu_staging")
+res  # {out_dir, n_workflows, n_files, dropped, files_head}
+```
+This downloads the repo tarball, parses every `tooluniverse-*` workflow (dropping the plugin/installer entries), and writes `./tu_staging/out/` = `SKILL.md`, `kernel.py`, `index.json`, `workflows/*.md`.
+
+**4. Publish the skill** — push the staged tree into the catalog (run in the **`repl`** tool; `host.skills.*` lives there, not in `python`):
+```python
+import os
+SKILL = "tooluniverse-research"
+out = os.path.abspath("./tu_staging/out")
+if any(s["name"] == SKILL for s in host.skills.list()):
+    host.skills.delete(SKILL)                       # clean rebuild
+for root, _d, fs in os.walk(out):
+    for f in fs:
+        p = os.path.join(root, f)
+        rel = os.path.relpath(p, out)
+        host.skills.edit(SKILL, rel, open(p, encoding="utf-8").read())
+print(host.skills.publish(SKILL, overwrite=True))
+```
+(`host.skills.publish` refuses if `kernel.py` fails the sidecar gate — the `edit` result carries the verdict.)
+
+## Verify
+
+```python
+skill("tooluniverse-research")                      # loads router + injects helpers
+tu = get_tu()
+tu.run({"name": "PubChem_get_CID_by_compound_name", "arguments": {"name": "metformin"}})
+# -> {'status': 'success', 'data': {'IdentifierList': {'CID': [4091]}}}
+```
+
+## Notes
+
+- **Sandbox cache**: ToolUniverse defaults its cache to `~/.tooluniverse`, which is read-only here; `get_tu()` redirects it to the workspace via `TOOLUNIVERSE_CACHE_DIR`. Nothing to configure.
+- **API keys** (optional): most tools work without them. For NCBI / OncoKB / NVIDIA etc., add keys under Customize → Credentials, then expose them in the `tooluniverse` env.
+- **What is NOT ported**: the plugin's slash commands (`/tooluniverse:research`) and MCP server — replaced by natural-language routing (`search_skills` → `find_tu_workflow`). The two `*-plugin` installer docs are dropped as non-research entries.
+- **Updating**: rerun steps 2–4. Step 2 upgrades the tools; steps 3–4 refresh the workflow library from the latest GitHub state.

--- a/skills/tooluniverse-cs-setup/kernel.py
+++ b/skills/tooluniverse-cs-setup/kernel.py
@@ -1,0 +1,113 @@
+"""Setup helper for ToolUniverse on Claude Science (auto-loaded with the skill).
+
+Pure-Python builder: fetch the ToolUniverse repo, parse its SKILL.md
+workflow tree, and stage a rebuilt `tooluniverse-research` skill on disk.
+The control-plane publish step runs separately in the `repl` tool.
+Run in the `tooluniverse` conda environment.
+"""
+import os
+import re
+import sys
+import json
+import tarfile
+import shutil
+import urllib.request
+
+REPO_TARBALL = "https://codeload.github.com/mims-harvard/ToolUniverse/tar.gz/refs/heads/"
+DROP_WORKFLOWS = ("tooluniverse-install-skills",
+                  "tooluniverse-claude-code-plugin",
+                  "tooluniverse-codex-plugin")
+AUX_ORDER = ("TOOLS_REFERENCE.md", "REPORT_TEMPLATE.md", "REPORT_GUIDELINES.md",
+             "CHECKLIST.md", "EXAMPLES.md")
+
+
+def tu_split_frontmatter(text):
+    """Return (frontmatter_dict, body) for a SKILL.md string."""
+    m = re.match(r"^---\s*\n(.*?)\n---\s*\n(.*)$", text, re.DOTALL)
+    fm = {}
+    if not m:
+        return fm, text
+    for line in m.group(1).splitlines():
+        mm = re.match(r"^(\w[\w-]*):\s*(.*)$", line)
+        if mm:
+            fm[mm.group(1)] = mm.group(2).strip()
+    return fm, m.group(2)
+
+
+def tu_build_research_bundle(staging="./tu_staging", ref="main"):
+    """Fetch ToolUniverse and stage a rebuilt tooluniverse-research skill.
+
+    Downloads the repo tarball, parses every tooluniverse-* workflow (dropping
+    plugin/installer entries), and writes a ready-to-publish file tree under
+    <staging>/out : SKILL.md, kernel.py, index.json, workflows/*.md.
+
+    Returns a manifest dict: {out_dir, n_workflows, files, dropped}.
+    """
+    here = os.path.dirname(sys._getframe().f_code.co_filename) or "."
+    staging = os.path.abspath(staging)
+    if os.path.isdir(staging):
+        shutil.rmtree(staging)
+    os.makedirs(staging)
+
+    # 1. download
+    tgz = os.path.join(staging, "repo.tar.gz")
+    urllib.request.urlretrieve(REPO_TARBALL + ref, tgz)
+
+    # 2. extract only skills/**/*.md (avoids protected .mcp.json members)
+    ex = os.path.join(staging, "extract")
+    os.makedirs(ex)
+    with tarfile.open(tgz) as tf:
+        members = [m for m in tf.getmembers()
+                   if "/skills/" in m.name and m.name.endswith(".md")]
+        tf.extractall(ex, members=members)
+    roots = [d for d in os.listdir(ex) if d.startswith("ToolUniverse")]
+    if not roots:
+        raise RuntimeError("skills tree not found in tarball")
+    skills_dir = os.path.join(ex, roots[0], "skills")
+
+    # 3. parse workflows
+    out = os.path.join(staging, "out")
+    os.makedirs(os.path.join(out, "workflows"))
+    index = []
+    dropped = []
+    for sd in sorted(os.listdir(skills_dir)):
+        if not sd.startswith("tooluniverse-"):
+            continue
+        smd = os.path.join(skills_dir, sd, "SKILL.md")
+        if not os.path.isfile(smd):
+            continue
+        fm, body = tu_split_frontmatter(
+            open(smd, encoding="utf-8", errors="replace").read())
+        name = fm.get("name", sd)
+        if name in DROP_WORKFLOWS:
+            dropped.append(name)
+            continue
+        parts = [body.strip()]
+        for aux in AUX_ORDER:
+            ap = os.path.join(skills_dir, sd, aux)
+            if os.path.isfile(ap):
+                parts.append("\n\n---\n\n# Appendix: " + aux + "\n\n"
+                             + open(ap, encoding="utf-8", errors="replace").read().strip())
+        open(os.path.join(out, "workflows", name + ".md"), "w",
+             encoding="utf-8").write("\n".join(parts))
+        index.append({"name": name, "description": fm.get("description", "")})
+
+    # 4. index + templated router / research-kernel
+    json.dump(index, open(os.path.join(out, "index.json"), "w",
+                          encoding="utf-8"), ensure_ascii=False, indent=0)
+    tdir = os.path.join(here, "templates")
+    router = open(os.path.join(tdir, "router_SKILL.md"), encoding="utf-8").read()
+    n = str(len(index))
+    # normalize any "<digits> ... workflows" count to the real number
+    router = re.sub(r"\b\d+(?=(?:\s+\w+){0,2}\s+workflows\b)", n, router)
+    open(os.path.join(out, "SKILL.md"), "w", encoding="utf-8").write(router)
+    shutil.copy(os.path.join(tdir, "research_kernel.py"),
+                os.path.join(out, "kernel.py"))
+
+    files = []
+    for r, _d, fs in os.walk(out):
+        for f in fs:
+            files.append(os.path.relpath(os.path.join(r, f), out))
+    return {"out_dir": out, "n_workflows": len(index),
+            "n_files": len(files), "dropped": dropped,
+            "files_head": sorted(files)[:6]}

--- a/skills/tooluniverse-cs-setup/templates/research_kernel.py
+++ b/skills/tooluniverse-cs-setup/templates/research_kernel.py
@@ -1,0 +1,80 @@
+"""ToolUniverse research helpers (auto-loaded with the skill).
+
+Run cells in the `tooluniverse` conda environment.
+"""
+import os
+import sys
+import json
+import re
+
+DEFAULT_CACHE = "./tooluniverse_cache"
+
+
+def get_tu(cache_dir=None):
+    """Return a loaded ToolUniverse instance.
+
+    The host home (~/.tooluniverse) is not writable in this sandbox, so the
+    result cache is redirected to the workspace via TOOLUNIVERSE_CACHE_DIR.
+    """
+    if cache_dir is None:
+        cache_dir = DEFAULT_CACHE
+    os.environ.setdefault("TOOLUNIVERSE_CACHE_DIR", os.path.abspath(cache_dir))
+    os.makedirs(os.environ["TOOLUNIVERSE_CACHE_DIR"], exist_ok=True)
+    from tooluniverse import ToolUniverse
+    tu = ToolUniverse()
+    tu.load_tools()
+    return tu
+
+
+def tu_workflows():
+    """List every bundled workflow: [{'name', 'description'}, ...]."""
+    here = os.path.dirname(sys._getframe().f_code.co_filename) or "."
+    return json.load(open(os.path.join(here, "index.json"), encoding="utf-8"))
+
+
+def find_tu_workflow(query, top=5):
+    """Rank bundled workflows by relevance to `query`.
+
+    Name-token matches are weighted heavily; the score also rewards covering
+    distinct query terms rather than one term repeated many times.
+    """
+    here = os.path.dirname(sys._getframe().f_code.co_filename) or "."
+    idx = json.load(open(os.path.join(here, "index.json"), encoding="utf-8"))
+    terms = sorted({t for t in re.split(r"\W+", query.lower()) if len(t) > 2})
+    scored = []
+    for e in idx:
+        name = e["name"].replace("tooluniverse-", "").replace("-", " ").lower()
+        desc = e.get("description", "").lower()
+        score = 0.0
+        covered = 0
+        for t in terms:
+            n_hits = name.count(t)
+            d_hits = desc.count(t)
+            if n_hits or d_hits:
+                covered += 1
+            score += 5.0 * n_hits + min(d_hits, 3)
+        score += 2.0 * covered
+        if score:
+            scored.append((score, e["name"], e.get("description", "")))
+    scored.sort(reverse=True)
+    return [{"name": n, "description": d, "score": round(s, 1)}
+            for s, n, d in scored[:top]]
+
+
+def tu_workflow(name):
+    """Return the full step-by-step procedure for one workflow."""
+    here = os.path.dirname(sys._getframe().f_code.co_filename) or "."
+    if not name.startswith("tooluniverse-"):
+        name = "tooluniverse-" + name
+    path = os.path.join(here, "workflows", name + ".md")
+    if not os.path.isfile(path):
+        raise FileNotFoundError("No such workflow: " + name)
+    return open(path, encoding="utf-8").read()
+
+
+def tu_tool_info(tu, name):
+    """Return the JSON spec (incl. argument schema) for a tool by name."""
+    for t in getattr(tu, "all_tools", []) or []:
+        if t.get("name") == name:
+            return t
+    return None

--- a/skills/tooluniverse-cs-setup/templates/router_SKILL.md
+++ b/skills/tooluniverse-cs-setup/templates/router_SKILL.md
@@ -1,0 +1,41 @@
+---
+name: tooluniverse-research
+description: Biomedical and scientific research via ToolUniverse's 2500+ tools across 133 structured workflows — drug research, disease research, gene and variant interpretation, cancer genomics, clinical trials, ADMET prediction, pharmacovigilance and adverse events, CRISPR screens, protein and structure analysis, epidemiology, and graded literature reviews. Use for "tell me about drug/gene/disease/variant X", multi-database investigations, cross-validating biomedical claims, ID translation, or any structured scientific lookup spanning FDA, ChEMBL, PubChem, ClinicalTrials.gov, UniProt, Ensembl, PubMed, and 200+ other databases.
+---
+
+# ToolUniverse Research
+
+Brings ToolUniverse's 2500+ scientific tools and 133 structured research workflows into Claude Science. The `tooluniverse` PyPI package supplies the tools; this skill bundles the workflows and a kernel sidecar that wires them up.
+
+## Setup
+
+Run all cells in the **`tooluniverse`** conda environment. Loading this skill auto-defines these helpers in the kernel:
+
+- `get_tu()` → a loaded `ToolUniverse` instance (cache redirected to the workspace, since `~/.tooluniverse` is read-only here).
+- `tu_workflows()` → list all 133 workflows (`name` + `description`).
+- `find_tu_workflow(query)` → rank workflows by relevance to a question.
+- `tu_workflow(name)` → the full step-by-step procedure for one workflow.
+- `tu_tool_info(tu, name)` → a tool's JSON spec, including its argument schema.
+
+## Answering a research question
+
+1. **Route** to a workflow: `find_tu_workflow("tell me about metformin")` returns ranked names. (Or browse `tu_workflows()`.)
+2. **Load** its procedure: `print(tu_workflow("tooluniverse-drug-research"))` and follow the steps.
+3. **Execute** the tools the workflow names. Every `ToolName(args)` reference maps to:
+   ```python
+   tu = get_tu()
+   tu.run({"name": "PubChem_get_CID_by_compound_name",
+           "arguments": {"name": "metformin"}})
+   ```
+4. **Confirm argument names** before a call if unsure — `tu_tool_info(tu, "PubChem_get_CID_by_compound_name")` shows the exact schema. Workflow prose abbreviates arguments; the schema is authoritative.
+5. **Discover tools** at runtime when no workflow fits:
+   ```python
+   tu.run({"name": "Tool_Finder_Keyword",
+           "arguments": {"description": "drug adverse events", "limit": 10}})
+   ```
+
+## Notes
+
+- Most tools work without API keys. A few (NCBI, OncoKB, NVIDIA, …) unlock enhanced access when keys are set in the env — add under Customize → Credentials, then expose them in the `tooluniverse` env.
+- Workflows are self-contained: report templates, checklists, and tool references are appended to each as appendices.
+- These workflows emphasize *looking things up* over recalling them — when a workflow says query a database, run the tool rather than answering from memory.


### PR DESCRIPTION
## What this adds

A new **Developer Skill**, `tooluniverse-cs-setup`, that installs ToolUniverse into **Claude Science** (Anthropic's scientific-computing agent).

Claude Science does not use the MCP-plugin delivery path that the existing `setup-tooluniverse` skill targets (MCP server via `uvx`, `.mcp.json`, slash commands). Instead it loads a **pip package** plus **native skills**. This installer bridges that gap:

1. Creates a `tooluniverse` conda environment.
2. `pip install tooluniverse` (the 2500+ tools).
3. Fetches the current `skills/` workflow library from this repo and rebuilds it into a single dynamically-loaded `tooluniverse-research` skill.
4. Publishes `tooluniverse-research` into the user's Claude Science catalog.

## Why a separate skill (not a change to `setup-tooluniverse`)

The existing `setup-tooluniverse` is **platform-general** (MCP / CLI / SDK). This one is **Claude-Science-specific** — it uses Claude Science host APIs (`manage_environments`, `manage_packages`, native skill publishing) that don't exist on other platforms. Keeping it as a distinct, clearly-named skill avoids overloading the general installer with platform-specific logic. The name uses `cs` (Claude Science) because the skill-name field disallows the reserved word in full.

## Design notes

- **No workflow duplication.** The installer rebuilds the research skill from this repo's own `skills/tooluniverse-*` tree at install time, so it always tracks the latest workflows and adds no copies to maintain.
- **Self-contained.** A `kernel.py` sidecar (`tu_build_research_bundle()`) does the fetch/parse/stage; the four documented steps do env + publish.
- Plugin/installer entries (`*-plugin`, `install-skills`) are excluded from the rebuilt research bundle as non-research.

## Files

- `skills/tooluniverse-cs-setup/SKILL.md` — the four-step install/update procedure
- `skills/tooluniverse-cs-setup/kernel.py` — builder sidecar
- `skills/tooluniverse-cs-setup/templates/` — router SKILL.md + research kernel used to rebuild `tooluniverse-research`
- `skills/README.md` — one row added to the Developer Skills table

## Testing

Built and verified end-to-end in Claude Science: env creation, `pip install tooluniverse` (v1.3.0), `tu_build_research_bundle()` fetched and rebuilt 133 workflows from this repo, published `tooluniverse-research`, and a live tool call (`PubChem_get_CID_by_compound_name("metformin") -> CID 4091`) returned data.