### PR TITLE
Update MCP server metadata to 2,500+ tools (fix stale count + typo)

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
     "name": "tooluniverse",
     "display_name": "ToolUniverse",
     "version": "1.3.1",
-    "description": "ToolUniverse: an ecosystem for democratizing AI scientists with 2000+ scientific tools.",
+    "description": "ToolUniverse: an ecosystem for democratizing AI scientists with 2,500+ scientific tools.",
     "long_description": "ToolUniverse is an ecosystem for creating AI scientist systems from any large language model (LLM). It standardizes how LLMs interact with tools, integrating thousands of machine learning models, datasets, APIs, and scientific packages for data analysis, knowledge retrieval, and experimental design. This bundle exposes ToolUniverse capability via the Model Context Protocol (MCP), enabling AI assistants to perform complex scientific tasks.",
     "author": {
         "name": "ToolUniverse Team",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mims-harvard/tooluniverse",
-  "description": "1000+ scientific tools for AI scientists: life science, reserach, literature, and more.",
+  "description": "2,500+ scientific tools for AI scientists: life science, research, literature, and more.",
   "websiteUrl": "https://aiscientist.tools",
   "repository": {
     "url": "https://github.com/mims-harvard/ToolUniverse",
@@ -26,7 +26,7 @@
         {
           "type": "positional",
           "value": "--compact-mode",
-          "description": "Compact mode enabled by default: only exposes 4 core tools (tool finder, tool executor, etc.) to prevent context window overflow. All 1000+ tools remain accessible via the execute_tool function."
+          "description": "Compact mode enabled by default: only exposes 4 core tools (tool finder, tool executor, etc.) to prevent context window overflow. All 2,500+ tools remain accessible via the execute_tool function."
         },
         {
           "type": "named",


### PR DESCRIPTION
## Why

The Claude connector / MCP-registry metadata still advertised an outdated tool count and had a typo. The package itself is current (1.3.1, 2,779 tools), but the descriptions people read were stale:

- \`server.json\` (published to the official MCP registry): "**1000+** scientific tools ... **reserach** ..." → the registry publish workflow only syncs the *version*, never the description, so this text has been frozen since February.
- \`mcpb/manifest.json\`: "**2000+** scientific tools".

## Changes
- \`server.json\` description → "2,500+ scientific tools ... **research** ..." (count + typo)
- \`server.json\` compact-mode argument text → "All **2,500+** tools remain accessible"
- \`mcpb/manifest.json\` description → "2,500+ scientific tools"

The corrected description auto-publishes to the MCP registry on the next version bump (the registry rejects re-publishing the same 1.3.1). No code or behavior change.