### PR TITLE
[codex] validate AgenticTool env config

### DIFF
--- a/src/tooluniverse/agentic_tool.py
+++ b/src/tooluniverse/agentic_tool.py
@@ -34,6 +34,28 @@ class AgenticTool(BaseTool):
     STREAM_FLAG_KEY = "_tooluniverse_stream"
 
     @staticmethod
+    def _parse_bool_env(value: Optional[str]) -> Optional[bool]:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        raise ValueError(f"Expected boolean environment value, got: {value!r}")
+
+    @staticmethod
+    def _parse_float_env(value: Optional[str]) -> Optional[float]:
+        if value is None or value == "":
+            return None
+        try:
+            return float(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"Expected numeric TOOLUNIVERSE_LLM_TEMPERATURE, got: {value!r}"
+            ) from exc
+
+    @staticmethod
     def has_any_api_keys() -> bool:
         """
         Check if any API keys are available across all supported API types.
@@ -89,8 +111,13 @@ class AgenticTool(BaseTool):
                     "TOOLUNIVERSE_LLM_MODEL_DEFAULT"
                 )
             elif key == "temperature":
-                temp_str = os.getenv("TOOLUNIVERSE_LLM_TEMPERATURE")
-                env_value = float(temp_str) if temp_str else None
+                env_value = self._parse_float_env(
+                    os.getenv("TOOLUNIVERSE_LLM_TEMPERATURE")
+                )
+            elif key == "return_json":
+                env_value = self._parse_bool_env(
+                    os.getenv("TOOLUNIVERSE_LLM_RETURN_JSON")
+                )
 
             mode = os.getenv("TOOLUNIVERSE_LLM_CONFIG_MODE", "default")
 

--- a/tests/unit/test_agentic_tool_env_vars.py
+++ b/tests/unit/test_agentic_tool_env_vars.py
@@ -26,6 +26,7 @@ class TestAgenticToolEnvironmentVariables:
             "TOOLUNIVERSE_LLM_DEFAULT_PROVIDER",
             "TOOLUNIVERSE_LLM_MODEL_DEFAULT",
             "TOOLUNIVERSE_LLM_TEMPERATURE",
+            "TOOLUNIVERSE_LLM_RETURN_JSON",
             "TOOLUNIVERSE_LLM_MAX_TOKENS",
             "TOOLUNIVERSE_LLM_CONFIG_MODE",
             "GEMINI_MODEL_ID",
@@ -363,6 +364,47 @@ class TestAgenticToolEnvironmentVariables:
             # In fallback mode with no tool config, should use built-in defaults
             assert tool._api_type == "CHATGPT"  # Built-in default
             assert tool._temperature == 1.0     # Built-in default
+
+    def test_return_json_env_override(self):
+        """Test that TOOLUNIVERSE_LLM_RETURN_JSON can override tool config."""
+        os.environ["TOOLUNIVERSE_LLM_CONFIG_MODE"] = "env_override"
+        os.environ["TOOLUNIVERSE_LLM_RETURN_JSON"] = "true"
+
+        tool_config = {
+            "name": "test_tool",
+            "prompt": "Test prompt: {input}",
+            "input_arguments": ["input"],
+            "parameter": {
+                "type": "object",
+                "properties": {"input": {"type": "string"}},
+                "required": ["input"],
+            },
+            "return_json": False,
+        }
+
+        with patch.object(AgenticTool, '_try_initialize_api'):
+            tool = AgenticTool(tool_config)
+
+            assert tool._return_json is True
+
+    def test_invalid_temperature_env_var_fails_fast(self):
+        """Invalid temperature env values should fail with a clear error."""
+        os.environ["TOOLUNIVERSE_LLM_TEMPERATURE"] = "not-a-number"
+
+        tool_config = {
+            "name": "test_tool",
+            "prompt": "Test prompt: {input}",
+            "input_arguments": ["input"],
+            "parameter": {
+                "type": "object",
+                "properties": {"input": {"type": "string"}},
+                "required": ["input"],
+            },
+        }
+
+        with patch.object(AgenticTool, '_try_initialize_api'):
+            with pytest.raises(ValueError, match="TOOLUNIVERSE_LLM_TEMPERATURE"):
+                AgenticTool(tool_config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
﻿## Summary
- Add `TOOLUNIVERSE_LLM_RETURN_JSON` environment override support
- Fail fast with a clear error for invalid `TOOLUNIVERSE_LLM_TEMPERATURE` values
- Add regression tests for the new env parsing behavior

## Validation
- `python -m py_compile src\tooluniverse\agentic_tool.py tests\unit\test_agentic_tool_env_vars.py`
- `python -m pytest tests\unit\test_agentic_tool_env_vars.py -q -k "return_json_env_override or invalid_temperature_env_var"`
