### PR TITLE
Fix DisGeNET tools to use the DisGeNET v1 summary API

### DIFF
--- a/src/tooluniverse/disgenet_tool.py
+++ b/src/tooluniverse/disgenet_tool.py
@@ -6,16 +6,26 @@ associated with human diseases, aggregating data from multiple sources.
 
 API Documentation: https://api.disgenet.com/
 Requires API key: Register at https://www.disgenet.com/
+
+Note: the DisGeNET v1 API exposes gene/variant-disease associations through the
+`/gda/summary` and `/vda/summary` endpoints using QUERY parameters
+(`gene_symbol`, `gene_ncbi_id`, `disease`, `variant`), authenticated with an
+`Authorization: <api_key>` header (no "Bearer " prefix). Academic API keys can
+only access CURATED sources (CLINGEN, CLINVAR, ORPHANET, GENCC, UNIPROT, ...).
 """
 
 import os
+import re
 import requests
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, List
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 # Base URL for DisGeNET API
 DISGENET_API_URL = "https://api.disgenet.com/api/v1"
+
+# A disease passed as a bare UMLS CUI looks like "C0006142".
+_CUI_RE = re.compile(r"^C\d+$")
 
 
 @register_tool("DisGeNETTool")
@@ -23,11 +33,10 @@ class DisGeNETTool(BaseTool):
     """
     Tool for querying DisGeNET gene-disease association database.
 
-    DisGeNET provides:
+    Supports:
     - Gene-disease associations (GDAs)
     - Variant-disease associations (VDAs)
-    - Disease-disease associations
-    - Aggregated evidence scores
+    - Disease -> associated genes
 
     Requires API key via DISGENET_API_KEY environment variable.
     Register for free at https://www.disgenet.com/
@@ -40,14 +49,94 @@ class DisGeNETTool(BaseTool):
         self.api_key = os.environ.get("DISGENET_API_KEY", "")
 
     def _get_headers(self) -> Dict[str, str]:
-        """Get request headers with authentication."""
+        """Get request headers with authentication.
+
+        The DisGeNET v1 API expects the raw key in the Authorization header
+        (NOT an OAuth "Bearer <key>" form).
+        """
         headers = {
             "Accept": "application/json",
             "User-Agent": "ToolUniverse/DisGeNET",
         }
         if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
+            headers["Authorization"] = self.api_key
         return headers
+
+    # ------------------------------------------------------------------ helpers
+
+    @staticmethod
+    def _normalize_disease(disease: str):
+        """Return a DisGeNET-acceptable disease code, or None if the input is a
+        free-text name (which the summary endpoint does not accept)."""
+        d = (disease or "").strip()
+        if not d:
+            return None
+        if d.upper().startswith("UMLS_"):
+            return "UMLS_" + d[5:]
+        if _CUI_RE.match(d):
+            return "UMLS_" + d
+        # Already a vocabulary-prefixed code (e.g. MONDO_..., DO_..., HPO_...)
+        if "_" in d and d.split("_", 1)[0].isupper():
+            return d
+        return None
+
+    def _query_summary(self, kind: str, query: Dict[str, Any]):
+        """Call /{gda,vda}/summary with query params. Returns (payload, warnings).
+        Raises requests exceptions on HTTP error (handled by callers)."""
+        params = {"page_number": 0}
+        params.update({k: v for k, v in query.items() if v not in (None, "")})
+        response = requests.get(
+            f"{DISGENET_API_URL}/{kind}/summary",
+            params=params,
+            headers=self._get_headers(),
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        body = response.json()
+        payload = body.get("payload") or []
+        warnings = body.get("warnings") or []
+        return payload, warnings
+
+    @staticmethod
+    def _fmt_gda(row: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "gene_symbol": row.get("symbolOfGene"),
+            "gene_ncbi_id": row.get("geneNcbiID"),
+            "disease_name": row.get("diseaseName"),
+            "disease_umls_cui": row.get("diseaseUMLSCUI"),
+            "score": row.get("score"),
+            "n_pmids": row.get("numPMIDs"),
+            "ei": row.get("ei"),
+        }
+
+    @staticmethod
+    def _fmt_vda(row: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "variant": row.get("variantStrID"),
+            "gene_symbol": row.get("symbolOfGene"),
+            "disease_name": row.get("diseaseName"),
+            "disease_umls_cui": row.get("diseaseUMLSCUI"),
+            "score": row.get("score"),
+            "n_pmids": row.get("numPMIDs"),
+        }
+
+    @staticmethod
+    def _apply_filters(rows: List[Dict[str, Any]], min_score, limit):
+        if min_score is not None:
+            rows = [r for r in rows if (r.get("score") is not None and r["score"] >= min_score)]
+        if limit:
+            rows = rows[: int(limit)]
+        return rows
+
+    def _err(self, e) -> Dict[str, Any]:
+        if isinstance(e, requests.exceptions.HTTPError) and e.response is not None:
+            code = e.response.status_code
+            if code in (401, 403):
+                return {"status": "error", "error": "DisGeNET API key invalid or unauthorized for this resource (academic keys only access CURATED sources)."}
+            return {"status": "error", "error": f"DisGeNET HTTP error: {code}"}
+        return {"status": "error", "error": f"DisGeNET request failed: {str(e)}"}
+
+    # --------------------------------------------------------------- dispatch
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute DisGeNET API call based on operation type."""
@@ -58,345 +147,115 @@ class DisGeNETTool(BaseTool):
             }
 
         operation = arguments.get("operation", "")
-        # Auto-fill operation from tool config const if not provided by user
         if not operation:
             operation = self.get_schema_const_operation()
 
-        if operation == "search_gene":
-            return self._search_gene(arguments)
-        elif operation == "search_disease":
-            return self._search_disease(arguments)
-        elif operation == "get_gda":
-            return self._get_gene_disease_associations(arguments)
+        if operation in ("search_gene", "get_gda"):
+            return self._gene_disease(arguments)
+        elif operation in ("search_disease", "get_disease_genes"):
+            return self._disease_genes(arguments)
         elif operation == "get_vda":
-            return self._get_variant_disease_associations(arguments)
-        elif operation == "get_disease_genes":
-            return self._get_disease_genes(arguments)
+            return self._variant_disease(arguments)
         else:
             return {
                 "status": "error",
                 "error": f"Unknown operation: {operation}. Supported: search_gene, search_disease, get_gda, get_vda, get_disease_genes",
             }
 
-    def _search_gene(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Search for gene-disease associations by gene symbol.
+    # ---------------------------------------------------------------- operations
 
-        Args:
-            arguments: Dict containing:
-                - gene: Gene symbol (e.g., BRCA1, TP53)
-                - limit: Maximum results (default 10)
-        """
-        gene = arguments.get("gene", "")
-        if not gene:
-            return {"status": "error", "error": "Missing required parameter: gene"}
-
-        limit = arguments.get("limit", 10)
-
-        try:
-            response = requests.get(
-                f"{DISGENET_API_URL}/gda/gene/{gene}",
-                params={"limit": limit},
-                headers=self._get_headers(),
-                timeout=self.timeout,
-            )
-            response.raise_for_status()
-            data = response.json()
-            associations = data if isinstance(data, list) else data.get("results", [])
-            count = len(data) if isinstance(data, list) else data.get("count", 0)
-            metadata = {
-                "source": "DisGeNET",
-                "gene": gene,
-                "api_url": DISGENET_API_URL,
-            }
-            if count == 0:
-                metadata["diagnostic"] = (
-                    "No DisGeNET associations were returned. Verify the gene "
-                    "identifier accepted by the current DisGeNET API and that "
-                    "the configured API plan has access to this endpoint/source."
-                )
-
-            return {
-                "status": "success",
-                "data": {
-                    "gene": gene,
-                    "associations": associations,
-                    "count": count,
-                },
-                "metadata": metadata,
-            }
-
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 401:
-                return {"status": "error", "error": "Invalid or expired API key"}
-            if e.response.status_code == 404:
-                return {
-                    "status": "success",
-                    "data": {"gene": gene, "associations": [], "count": 0},
-                    "metadata": {"note": "No associations found for gene"},
-                }
-            return {"status": "error", "error": f"HTTP error: {e.response.status_code}"}
-        except requests.exceptions.RequestException as e:
-            return {"status": "error", "error": f"Request failed: {str(e)}"}
-        except Exception as e:
-            return {"status": "error", "error": f"Unexpected error: {str(e)}"}
-
-    def _search_disease(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Search for disease information and associated genes.
-
-        Args:
-            arguments: Dict containing:
-                - disease: Disease name or ID (UMLS CUI, e.g., C0006142 for breast cancer)
-                - limit: Maximum results (default 10)
-        """
-        disease = arguments.get("disease", "")
-        if not disease:
-            return {"status": "error", "error": "Missing required parameter: disease"}
-
-        limit = arguments.get("limit", 10)
-
-        try:
-            # Try as UMLS CUI first
-            if disease.startswith("C") and disease[1:].isdigit():
-                endpoint = f"/gda/disease/{disease}"
-            else:
-                endpoint = f"/gda/disease/{disease}"
-
-            response = requests.get(
-                f"{DISGENET_API_URL}{endpoint}",
-                params={"limit": limit},
-                headers=self._get_headers(),
-                timeout=self.timeout,
-            )
-            response.raise_for_status()
-            data = response.json()
-            associations = data if isinstance(data, list) else data.get("results", [])
-            count = len(data) if isinstance(data, list) else data.get("count", 0)
-            metadata = {
-                "source": "DisGeNET",
-                "disease": disease,
-                "api_url": DISGENET_API_URL,
-            }
-            if count == 0:
-                metadata["diagnostic"] = (
-                    "No DisGeNET associations were returned. Verify the disease "
-                    "identifier accepted by the current DisGeNET API and that "
-                    "the configured API plan has access to this endpoint/source."
-                )
-
-            return {
-                "status": "success",
-                "data": {
-                    "disease": disease,
-                    "associations": associations,
-                    "count": count,
-                },
-                "metadata": metadata,
-            }
-
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 404:
-                return {
-                    "status": "success",
-                    "data": {"disease": disease, "associations": [], "count": 0},
-                    "metadata": {"note": "No associations found for disease"},
-                }
-            return {"status": "error", "error": f"HTTP error: {e.response.status_code}"}
-        except requests.exceptions.RequestException as e:
-            return {"status": "error", "error": f"Request failed: {str(e)}"}
-        except Exception as e:
-            return {"status": "error", "error": f"Unexpected error: {str(e)}"}
-
-    def _get_gene_disease_associations(
-        self, arguments: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """
-        Get gene-disease associations with filtering options.
-
-        Args:
-            arguments: Dict containing:
-                - gene: Gene symbol (optional if disease provided)
-                - disease: Disease ID (optional if gene provided)
-                - source: Data source filter (CURATED, ANIMAL_MODELS, LITERATURE, etc.)
-                - min_score: Minimum GDA score (0-1)
-                - limit: Maximum results
-        """
-        gene = arguments.get("gene", "")
-        disease = arguments.get("disease", "")
-
+    def _gene_disease(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Gene-disease associations by gene symbol (or NCBI gene id)."""
+        gene = (arguments.get("gene") or "").strip()
+        disease = (arguments.get("disease") or "").strip()
         if not gene and not disease:
-            return {"status": "error", "error": "Either gene or disease required"}
+            return {"status": "error", "error": "Provide 'gene' (symbol or NCBI id) or 'disease' (UMLS CUI)."}
 
-        params = {"limit": arguments.get("limit", 25)}
-
+        query: Dict[str, Any] = {}
+        if gene:
+            if gene.isdigit():
+                query["gene_ncbi_id"] = gene
+            else:
+                query["gene_symbol"] = gene
+        if disease:
+            code = self._normalize_disease(disease)
+            if code is None:
+                return {"status": "error", "error": f"'{disease}' is not a UMLS CUI. Resolve the disease name to a CUI first (e.g. umls_search_concepts), then pass disease='C0152200'."}
+            query["disease"] = code
         if arguments.get("source"):
-            params["source"] = arguments["source"]
-        if arguments.get("min_score"):
-            params["min_score"] = arguments["min_score"]
+            query["source"] = arguments["source"]
 
         try:
-            if gene:
-                endpoint = f"/gda/gene/{gene}"
-            else:
-                endpoint = f"/gda/disease/{disease}"
+            payload, warnings = self._query_summary("gda", query)
+        except Exception as e:  # noqa: BLE001 - never raise out of run()
+            return self._err(e)
 
-            response = requests.get(
-                f"{DISGENET_API_URL}{endpoint}",
-                params=params,
-                headers=self._get_headers(),
-                timeout=self.timeout,
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            associations = data if isinstance(data, list) else data.get("results", [])
-
-            return {
-                "status": "success",
-                "data": {
-                    "gene": gene if gene else None,
-                    "disease": disease if disease else None,
-                    "associations": associations,
-                    "count": len(associations),
-                },
-                "metadata": {
-                    "source": "DisGeNET GDA",
-                    "filters": params,
-                },
-            }
-
-        except requests.exceptions.RequestException as e:
-            return {"status": "error", "error": f"Request failed: {str(e)}"}
-        except Exception as e:
-            return {"status": "error", "error": f"Unexpected error: {str(e)}"}
-
-    def _get_variant_disease_associations(
-        self, arguments: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """
-        Get variant-disease associations.
-
-        Args:
-            arguments: Dict containing:
-                - variant: Variant ID (rsID, e.g., rs1234)
-                - gene: Gene symbol to get all variants
-                - limit: Maximum results
-        """
-        variant = arguments.get("variant", "")
-        gene = arguments.get("gene", "")
-
-        if not variant and not gene:
-            return {"status": "error", "error": "Either variant or gene required"}
-
-        params = {"limit": arguments.get("limit", 25)}
-
-        try:
-            if variant:
-                endpoint = f"/vda/variant/{variant}"
-            else:
-                endpoint = f"/vda/gene/{gene}"
-
-            response = requests.get(
-                f"{DISGENET_API_URL}{endpoint}",
-                params=params,
-                headers=self._get_headers(),
-                timeout=self.timeout,
-            )
-            response.raise_for_status()
-            data = response.json()
-
-            associations = data if isinstance(data, list) else data.get("results", [])
-
-            return {
-                "status": "success",
-                "data": {
-                    "variant": variant if variant else None,
-                    "gene": gene if gene else None,
-                    "associations": associations,
-                    "count": len(associations),
-                },
-                "metadata": {
-                    "source": "DisGeNET VDA",
-                },
-            }
-
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 404:
-                return {
-                    "status": "success",
-                    "data": {"associations": [], "count": 0},
-                    "metadata": {"note": "No variant associations found"},
-                }
-            return {"status": "error", "error": f"HTTP error: {e.response.status_code}"}
-        except requests.exceptions.RequestException as e:
-            return {"status": "error", "error": f"Request failed: {str(e)}"}
-        except Exception as e:
-            return {"status": "error", "error": f"Unexpected error: {str(e)}"}
-
-    def _get_disease_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Get all genes associated with a disease.
-
-        Args:
-            arguments: Dict containing:
-                - disease: Disease ID (UMLS CUI) or disease name
-                - min_score: Minimum association score (0-1)
-                - limit: Maximum results
-        """
-        disease = arguments.get("disease", "")
-        if not disease:
-            return {"status": "error", "error": "Missing required parameter: disease"}
-
-        params = {
-            "limit": arguments.get("limit", 50),
+        rows = self._apply_filters([self._fmt_gda(r) for r in payload],
+                                   arguments.get("min_score"),
+                                   arguments.get("limit", 25))
+        return {
+            "status": "success",
+            "data": {"gene": gene or None, "disease": disease or None,
+                     "associations": rows, "count": len(rows)},
+            "metadata": {"source": "DisGeNET GDA", "warnings": warnings,
+                         "note": "Academic keys return CURATED sources only."},
         }
-        if arguments.get("min_score"):
-            params["min_score"] = arguments["min_score"]
 
+    def _disease_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """All genes associated with a disease (UMLS CUI)."""
+        disease = (arguments.get("disease") or "").strip()
+        if not disease:
+            return {"status": "error", "error": "Missing required parameter: disease (UMLS CUI, e.g. C0152200)."}
+        code = self._normalize_disease(disease)
+        if code is None:
+            return {"status": "error", "error": f"'{disease}' is not a UMLS CUI. Resolve the disease name to a CUI first (e.g. umls_search_concepts), then pass disease='C0152200'."}
+
+        query: Dict[str, Any] = {"disease": code}
+        if arguments.get("source"):
+            query["source"] = arguments["source"]
         try:
-            response = requests.get(
-                f"{DISGENET_API_URL}/gda/disease/{disease}",
-                params=params,
-                headers=self._get_headers(),
-                timeout=self.timeout,
-            )
-            response.raise_for_status()
-            data = response.json()
+            payload, warnings = self._query_summary("gda", query)
+        except Exception as e:  # noqa: BLE001
+            return self._err(e)
 
-            associations = data if isinstance(data, list) else data.get("results", [])
+        genes, seen = [], set()
+        for row in payload:
+            sym = row.get("symbolOfGene")
+            if sym and sym not in seen:
+                seen.add(sym)
+                genes.append({"symbol": sym, "ncbi_id": row.get("geneNcbiID"),
+                              "score": row.get("score"), "n_pmids": row.get("numPMIDs")})
+        genes = self._apply_filters(genes, arguments.get("min_score"), arguments.get("limit", 50))
+        return {
+            "status": "success",
+            "data": {"disease": disease, "disease_code": code,
+                     "genes": genes, "gene_count": len(genes)},
+            "metadata": {"source": "DisGeNET", "warnings": warnings,
+                         "note": "Academic keys return CURATED sources only."},
+        }
 
-            # Extract unique genes
-            genes = []
-            seen = set()
-            for assoc in associations:
-                gene_symbol = assoc.get("gene_symbol", assoc.get("geneSymbol"))
-                if gene_symbol and gene_symbol not in seen:
-                    seen.add(gene_symbol)
-                    genes.append(
-                        {
-                            "symbol": gene_symbol,
-                            "score": assoc.get("score", assoc.get("gda_score")),
-                            "evidence_count": assoc.get(
-                                "evidence_count", assoc.get("nPublications")
-                            ),
-                        }
-                    )
-
-            return {
-                "status": "success",
-                "data": {
-                    "disease": disease,
-                    "genes": genes,
-                    "gene_count": len(genes),
-                },
-                "metadata": {
-                    "source": "DisGeNET",
-                    "disease": disease,
-                },
-            }
-
-        except requests.exceptions.RequestException as e:
-            return {"status": "error", "error": f"Request failed: {str(e)}"}
-        except Exception as e:
-            return {"status": "error", "error": f"Unexpected error: {str(e)}"}
+    def _variant_disease(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Variant-disease associations by variant rsID or gene symbol."""
+        variant = (arguments.get("variant") or "").strip()
+        gene = (arguments.get("gene") or "").strip()
+        if not variant and not gene:
+            return {"status": "error", "error": "Provide 'variant' (rsID) or 'gene' (symbol)."}
+        query: Dict[str, Any] = {}
+        if variant:
+            query["variant"] = variant
+        elif gene:
+            query["gene_symbol"] = gene
+        try:
+            payload, warnings = self._query_summary("vda", query)
+        except Exception as e:  # noqa: BLE001
+            return self._err(e)
+        rows = self._apply_filters([self._fmt_vda(r) for r in payload],
+                                   arguments.get("min_score"),
+                                   arguments.get("limit", 25))
+        return {
+            "status": "success",
+            "data": {"variant": variant or None, "gene": gene or None,
+                     "associations": rows, "count": len(rows)},
+            "metadata": {"source": "DisGeNET VDA", "warnings": warnings,
+                         "note": "Academic keys return CURATED sources only."},
+        }

--- a/tests/tools/test_disgenet_tool.py
+++ b/tests/tools/test_disgenet_tool.py
@@ -1,5 +1,9 @@
 """
 Unit tests for DisGeNET tool.
+
+Covers the DisGeNET v1 contract: /{gda,vda}/summary query-parameter endpoints,
+raw (non-Bearer) Authorization header, `payload` response parsing, and
+disease-name input validation.
 """
 
 import pytest
@@ -8,25 +12,30 @@ import os
 from unittest.mock import patch, MagicMock
 
 
+def _summary(payload):
+    """Build a mock DisGeNET v1 /summary response."""
+    resp = MagicMock()
+    resp.json.return_value = {"status": "OK", "payload": payload, "warnings": []}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
 class TestDisGeNETToolDirect:
     """Test DisGeNET tool directly (Level 1)."""
 
     @pytest.fixture
     def tool_config(self):
-        """Load tool config from JSON."""
         with open("src/tooluniverse/data/disgenet_tools.json") as f:
             tools = json.load(f)
             return next(t for t in tools if t["name"] == "DisGeNET_search_gene")
 
     @pytest.fixture
     def tool(self, tool_config):
-        """Create tool instance with mock API key."""
         with patch.dict(os.environ, {"DISGENET_API_KEY": "test_key"}):
             from tooluniverse.disgenet_tool import DisGeNETTool
             return DisGeNETTool(tool_config)
 
     def test_missing_api_key(self, tool_config):
-        """Test error when API key is missing."""
         with patch.dict(os.environ, {"DISGENET_API_KEY": ""}, clear=False):
             from tooluniverse.disgenet_tool import DisGeNETTool
             tool = DisGeNETTool(tool_config)
@@ -35,60 +44,89 @@ class TestDisGeNETToolDirect:
             assert "API key" in result["error"]
 
     def test_search_gene_missing_param(self, tool):
-        """Test search_gene with missing gene parameter."""
         result = tool.run({"operation": "search_gene"})
         assert result["status"] == "error"
         assert "gene" in result["error"].lower()
 
     def test_unknown_operation(self, tool):
-        """Test unknown operation."""
         result = tool.run({"operation": "unknown"})
         assert result["status"] == "error"
         assert "unknown" in result["error"].lower()
 
-    @patch("tooluniverse.disgenet_tool.requests.get")
-    def test_search_gene_success(self, mock_get, tool):
-        """Test successful gene search."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = [
-            {"gene_symbol": "BRCA1", "disease_name": "Breast cancer", "score": 0.8}
-        ]
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+    def test_auth_header_has_no_bearer_prefix(self, tool):
+        """DisGeNET v1 expects the raw key, NOT 'Bearer <key>'."""
+        headers = tool._get_headers()
+        assert headers["Authorization"] == "test_key"
+        assert "Bearer" not in headers["Authorization"]
 
-        result = tool.run({"operation": "search_gene", "gene": "BRCA1"})
-        assert result["status"] == "success"
-        assert len(result["data"]["associations"]) > 0
+    def test_disease_name_is_rejected_with_guidance(self, tool):
+        """A free-text disease name must be rejected up front (not silently empty)."""
+        result = tool.run({"operation": "get_disease_genes", "disease": "achromatopsia"})
+        assert result["status"] == "error"
+        assert "CUI" in result["error"]
 
     @patch("tooluniverse.disgenet_tool.requests.get")
-    def test_search_gene_empty_result_includes_diagnostic(self, mock_get, tool):
-        """Test empty gene search includes a troubleshooting diagnostic."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"results": [], "count": 0}
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
-
-        result = tool.run({"operation": "search_gene", "gene": "UNKNOWN"})
-
+    def test_gene_disease_success_parses_payload(self, mock_get, tool):
+        mock_get.return_value = _summary([
+            {"symbolOfGene": "BRCA1", "geneNcbiID": 672,
+             "diseaseName": "Breast cancer", "diseaseUMLSCUI": "C0006142",
+             "score": 0.8, "numPMIDs": 12, "ei": 1.0},
+        ])
+        result = tool.run({"operation": "get_gda", "gene": "BRCA1"})
         assert result["status"] == "success"
-        assert result["data"]["count"] == 0
-        assert "diagnostic" in result["metadata"]
-        assert "api.disgenet.com" in result["metadata"]["api_url"]
+        assoc = result["data"]["associations"]
+        assert len(assoc) == 1
+        assert assoc[0]["gene_symbol"] == "BRCA1"
+        assert assoc[0]["disease_name"] == "Breast cancer"
+        # endpoint must be the /gda/summary query-param form
+        called_url = mock_get.call_args[0][0]
+        assert called_url.endswith("/gda/summary")
+        assert mock_get.call_args.kwargs["params"]["gene_symbol"] == "BRCA1"
 
     @patch("tooluniverse.disgenet_tool.requests.get")
-    def test_search_disease_empty_result_includes_diagnostic(self, mock_get, tool):
-        """Test empty disease search includes a troubleshooting diagnostic."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"results": [], "count": 0}
-        mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
-
-        result = tool.run({"operation": "search_disease", "disease": "UNKNOWN"})
-
+    def test_disease_genes_extracts_unique_genes(self, mock_get, tool):
+        mock_get.return_value = _summary([
+            {"symbolOfGene": "CNGA3", "geneNcbiID": 1261, "score": 0.7, "numPMIDs": 5},
+            {"symbolOfGene": "CNGB3", "geneNcbiID": 54714, "score": 0.6, "numPMIDs": 3},
+            {"symbolOfGene": "CNGA3", "geneNcbiID": 1261, "score": 0.7, "numPMIDs": 5},
+        ])
+        result = tool.run({"operation": "get_disease_genes", "disease": "C0152200"})
         assert result["status"] == "success"
-        assert result["data"]["count"] == 0
-        assert "diagnostic" in result["metadata"]
-        assert "api.disgenet.com" in result["metadata"]["api_url"]
+        syms = [g["symbol"] for g in result["data"]["genes"]]
+        assert syms == ["CNGA3", "CNGB3"]  # de-duplicated
+        # CUI normalized to UMLS_ prefix in the request
+        assert mock_get.call_args.kwargs["params"]["disease"] == "UMLS_C0152200"
+
+    @patch("tooluniverse.disgenet_tool.requests.get")
+    def test_variant_disease_by_rsid(self, mock_get, tool):
+        mock_get.return_value = _summary([
+            {"variantStrID": "rs121913529", "diseaseName": "Noonan syndrome",
+             "diseaseUMLSCUI": "C0028326", "score": 0.9, "numPMIDs": 7},
+        ])
+        result = tool.run({"operation": "get_vda", "variant": "rs121913529"})
+        assert result["status"] == "success"
+        assert result["data"]["associations"][0]["variant"] == "rs121913529"
+        assert mock_get.call_args[0][0].endswith("/vda/summary")
+
+    @patch("tooluniverse.disgenet_tool.requests.get")
+    def test_min_score_filter(self, mock_get, tool):
+        mock_get.return_value = _summary([
+            {"symbolOfGene": "A", "score": 0.9}, {"symbolOfGene": "B", "score": 0.1},
+        ])
+        result = tool.run({"operation": "get_gda", "gene": "TP53", "min_score": 0.5})
+        assert result["data"]["count"] == 1
+        assert result["data"]["associations"][0]["gene_symbol"] == "A"
+
+    @patch("tooluniverse.disgenet_tool.requests.get")
+    def test_http_error_returns_error_dict(self, mock_get, tool):
+        import requests
+        resp = MagicMock()
+        resp.status_code = 403
+        err = requests.exceptions.HTTPError(response=resp)
+        resp.raise_for_status.side_effect = err
+        mock_get.return_value = resp
+        result = tool.run({"operation": "get_gda", "gene": "BRCA1"})
+        assert result["status"] == "error"
 
 
 class TestDisGeNETToolInterface:
@@ -96,19 +134,15 @@ class TestDisGeNETToolInterface:
 
     @pytest.fixture
     def tu(self):
-        """Create ToolUniverse instance."""
         from tooluniverse import ToolUniverse
         tu = ToolUniverse()
         tu.load_tools()
         return tu
 
     def test_tools_registered(self, tu):
-        """Test that DisGeNET tools are registered."""
-        # DisGeNET tools require API key - skip if not loaded
         import os
         if not os.environ.get("DISGENET_API_KEY"):
             pytest.skip("DISGENET_API_KEY not set")
-        
         assert hasattr(tu.tools, "DisGeNET_search_gene")
         assert hasattr(tu.tools, "DisGeNET_search_disease")
         assert hasattr(tu.tools, "DisGeNET_get_gda")


### PR DESCRIPTION
The DisGeNET tools never returned data: every call hit a stale endpoint pattern and a wrong auth header, so the API answered 404 and the tool masked it as an empty "no associations" success.

Root cause (verified against the live api.disgenet.com v1 API):
- Auth header used "Bearer <key>"; v1 expects the raw key in Authorization. Verified: `curl -H "Authorization: <key>" .../gda/summary?disease=UMLS_C0152200` -> HTTP 200.
- Endpoints used path params (`/gda/gene/{g}`, `/gda/disease/{d}`, `/vda/...`); v1 uses `/gda/summary` and `/vda/summary` with query params (gene_symbol, gene_ncbi_id, disease, variant). Path form -> 404.
- Responses were parsed for `results`/`gene_symbol`; v1 returns rows under `payload` with fields `symbolOfGene`, `geneNcbiID`, `diseaseName`, `diseaseUMLSCUI`, `score`.
- 404s were swallowed as empty success, hiding the failure.

Changes:
- Rewrite endpoints to `/{gda,vda}/summary` query-param form; drop "Bearer".
- Parse `payload`; normalize disease input to a UMLS CUI (C0152200 -> UMLS_C0152200).
- Reject free-text disease names up front with guidance to resolve via UMLS (validate-at-input rather than silent empty result).
- Apply min_score/limit client-side; surface API warnings (academic keys are CURATED-only) in metadata; never raise out of run().
- Update unit tests to the v1 payload contract; add coverage for the no-Bearer header, CUI normalization, name-rejection guardrail, and gda/vda parsing.

Validated with a live academic key: get_disease_genes(C0152200) returns 10 curated genes; get_gda(PAX6) -> Aniridia; get_vda(rs121913529) -> 3 rows.