### PR TITLE
Document how to enable plugin auto-update for Claude Code

### DIFF
--- a/plugin/skills/setup-tooluniverse/SKILL.md
+++ b/plugin/skills/setup-tooluniverse/SKILL.md
@@ -150,7 +150,7 @@ Make sure Step 2 is done (`uv --version` works).
 > claude plugin marketplace add mims-harvard/ToolUniverse
 > claude plugin install tooluniverse@tooluniverse
 > ```
-> This installs MCP server + 115 skills + slash commands in one step.
+> This installs MCP server + 115 skills + slash commands in one step. Then see the `tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update" step so future releases apply without manual `claude plugin update`.
 
 | Client | File | How to Access |
 |--------|------|---------------|

--- a/plugin/skills/tooluniverse-claude-code-plugin/SKILL.md
+++ b/plugin/skills/tooluniverse-claude-code-plugin/SKILL.md
@@ -15,7 +15,7 @@ uv --version      # must exist; if not:  curl -LsSf https://astral.sh/uv/install
 claude --version  # Claude Code CLI; if not: https://claude.com/claude-code
 ```
 
-## Install (two commands)
+## Install
 
 ```bash
 # 1. Register the ToolUniverse marketplace from GitHub
@@ -26,6 +26,29 @@ claude plugin install tooluniverse@tooluniverse
 ```
 
 That's it. Restart Claude Code. The MCP server auto-starts via `uvx tooluniverse` on first use (~30 s cold start, instant after).
+
+### Recommended: turn on auto-update
+
+Third-party marketplaces default to **no auto-update** — without this, new tools/skills only reach you when you remember to run `claude plugin update tooluniverse` (see Update below). Turn it on once:
+
+```bash
+python3 -c "
+import json, pathlib, sys
+p = pathlib.Path.home() / '.claude/plugins/known_marketplaces.json'
+d = json.loads(p.read_text())
+if 'tooluniverse' not in d:
+    sys.exit('Run the marketplace add command above first')
+d['tooluniverse']['autoUpdate'] = True
+p.write_text(json.dumps(d, indent=2))
+print('autoUpdate enabled for tooluniverse')
+"
+```
+
+Equivalent interactive path: `/plugin` → Marketplaces → `tooluniverse` → Enable auto-update.
+
+With this on, Claude Code checks for marketplace + plugin updates in the background after each session start (up to a ~10 min random delay) and updates the installed plugin on disk automatically. You'll get a `/reload-plugins` prompt when an update lands, or it applies on your next launch — no more manual `claude plugin update`.
+
+This is local, per-machine state — it can't be shipped as a default from the plugin's own manifest. `marketplace.json` has no `autoUpdate` field; Claude Code intentionally keeps this a per-installation trust boundary so a publisher can't force silent auto-updates onto a user's machine.
 
 ### Important: Remove global skills if previously installed
 
@@ -76,6 +99,7 @@ The router skill auto-dispatches to the right specialized skill — no command p
 | **`/tooluniverse:cross-validate`** | Verify a claim across 3+ independent databases | Slash command |
 | **`/tooluniverse:compare`** | N-way side-by-side comparison with domain-appropriate columns | Slash command |
 | **`/tooluniverse:literature-sweep`** | Graded mini-review across PubMed + EuropePMC + Semantic Scholar | Slash command |
+| **`/tooluniverse:verify-references`** | Check that cited references are real and accurately described, including retraction status | Slash command |
 | **`/tooluniverse:researcher`** | Same investigation as `research`, delegated to a forked subagent | Slash command |
 | **120+ skills** | Structured workflows (drug research, variant interpretation, pharmacovigilance, CRISPR screens, statistical modeling, etc.) | Auto-activate on matching questions |
 
@@ -114,6 +138,10 @@ find ~/.claude/plugins -name '.mcp.json' -path '*tooluniverse*'
 Full API-key list: `setup-tooluniverse` skill → `API_KEYS_REFERENCE.md`.
 
 ## Update
+
+If you enabled auto-update above, this happens automatically in the background — no action needed.
+
+Otherwise, update manually:
 
 ```bash
 claude plugin update tooluniverse

--- a/skills/setup-tooluniverse/SKILL.md
+++ b/skills/setup-tooluniverse/SKILL.md
@@ -150,7 +150,7 @@ Make sure Step 2 is done (`uv --version` works).
 > claude plugin marketplace add mims-harvard/ToolUniverse
 > claude plugin install tooluniverse@tooluniverse
 > ```
-> This installs MCP server + 115 skills + slash commands in one step.
+> This installs MCP server + 115 skills + slash commands in one step. Then see the `tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update" step so future releases apply without manual `claude plugin update`.
 
 | Client | File | How to Access |
 |--------|------|---------------|

--- a/skills/tooluniverse-claude-code-plugin/SKILL.md
+++ b/skills/tooluniverse-claude-code-plugin/SKILL.md
@@ -15,7 +15,7 @@ uv --version      # must exist; if not:  curl -LsSf https://astral.sh/uv/install
 claude --version  # Claude Code CLI; if not: https://claude.com/claude-code
 ```
 
-## Install (two commands)
+## Install
 
 ```bash
 # 1. Register the ToolUniverse marketplace from GitHub
@@ -26,6 +26,29 @@ claude plugin install tooluniverse@tooluniverse
 ```
 
 That's it. Restart Claude Code. The MCP server auto-starts via `uvx tooluniverse` on first use (~30 s cold start, instant after).
+
+### Recommended: turn on auto-update
+
+Third-party marketplaces default to **no auto-update** — without this, new tools/skills only reach you when you remember to run `claude plugin update tooluniverse` (see Update below). Turn it on once:
+
+```bash
+python3 -c "
+import json, pathlib, sys
+p = pathlib.Path.home() / '.claude/plugins/known_marketplaces.json'
+d = json.loads(p.read_text())
+if 'tooluniverse' not in d:
+    sys.exit('Run the marketplace add command above first')
+d['tooluniverse']['autoUpdate'] = True
+p.write_text(json.dumps(d, indent=2))
+print('autoUpdate enabled for tooluniverse')
+"
+```
+
+Equivalent interactive path: `/plugin` → Marketplaces → `tooluniverse` → Enable auto-update.
+
+With this on, Claude Code checks for marketplace + plugin updates in the background after each session start (up to a ~10 min random delay) and updates the installed plugin on disk automatically. You'll get a `/reload-plugins` prompt when an update lands, or it applies on your next launch — no more manual `claude plugin update`.
+
+This is local, per-machine state — it can't be shipped as a default from the plugin's own manifest. `marketplace.json` has no `autoUpdate` field; Claude Code intentionally keeps this a per-installation trust boundary so a publisher can't force silent auto-updates onto a user's machine.
 
 ### Important: Remove global skills if previously installed
 
@@ -114,6 +137,10 @@ find ~/.claude/plugins -name '.mcp.json' -path '*tooluniverse*'
 Full API-key list: `setup-tooluniverse` skill → `API_KEYS_REFERENCE.md`.
 
 ## Update
+
+If you enabled auto-update above, this happens automatically in the background — no action needed.
+
+Otherwise, update manually:
 
 ```bash
 claude plugin update tooluniverse


### PR DESCRIPTION
## Summary
- Third-party marketplaces (including `tooluniverse`) default to no auto-update, so an installed plugin silently stays on whatever version was current at install time until someone manually runs `claude plugin update`.
- Adds a "Recommended: turn on auto-update" step to the `tooluniverse-claude-code-plugin` skill's install flow — a copy-pasteable script that sets `autoUpdate: true` for the `tooluniverse` entry in `~/.claude/plugins/known_marketplaces.json`, plus a note in the `Update` section that this makes manual updates unnecessary.
- Points to the same step from the `setup-tooluniverse` skill's Claude Code install block.
- Confirmed there's no way to ship this as a default from the plugin's own manifest — `marketplace.json` has no `autoUpdate` field; it's intentionally local, per-installation state.

## Test plan
- [x] Verified the `autoUpdate` script logic against a scratch copy of `known_marketplaces.json`
- [x] Confirmed `skills/` and `plugin/skills/` mirrors stay byte-for-byte in sync for the touched sections