### PR TITLE
Fix: document ArXiv_search_papers AND-query and date-filter semantics

### DIFF
--- a/plugin/commands/literature-sweep.md
+++ b/plugin/commands/literature-sweep.md
@@ -83,10 +83,9 @@ State which sources you chose (and why) in one line before searching.
 - `ArXiv_search_papers`: unprefixed, unquoted space-separated keywords are **ANDed**
   (every keyword must appear) — adding more synonyms NARROWS results, it does not
   broaden them like a typical search box. A query built from many synonyms (e.g.
-  `AI Scientist autonomous research agent automated research self-driving lab
-  agentic science`) can silently collapse to 0-2 hits. To search across
-  synonyms, join them with explicit `OR`, e.g.
-  `"AI Scientist" OR "autonomous research agent" OR "self-driving lab"`.
+  `KRAS G12C inhibitor resistance mechanism secondary mutation bypass rebound`)
+  can silently collapse to 0-2 hits. To search across synonyms, join them with
+  explicit `OR`, e.g. `"KRAS G12C" OR sotorasib OR adagrasib`.
   Also: `date_from`/`date_to` filter on `submittedDate`, the date of the paper's
   **first version** — a paper revised after `date_from` but originally submitted
   earlier is still excluded, so don't be surprised when a known-recent-looking

--- a/plugin/commands/literature-sweep.md
+++ b/plugin/commands/literature-sweep.md
@@ -77,6 +77,20 @@ State which sources you chose (and why) in one line before searching.
 - Preprints: append `SRC:PPR` to the EuropePMC `query` string.
 - `CORE_search_papers` is rate-limited (HTTP 429) without `CORE_API_KEY` — treat
   as best-effort; don't rely on it as a sole source.
+- `SemanticScholar_search_papers` also 429s under load with no API key configured.
+  Retry once; if it 429s again, drop it and note the gap in Caveats rather than
+  blocking the rest of the sweep on it.
+- `ArXiv_search_papers`: unprefixed, unquoted space-separated keywords are **ANDed**
+  (every keyword must appear) — adding more synonyms NARROWS results, it does not
+  broaden them like a typical search box. A query built from many synonyms (e.g.
+  `AI Scientist autonomous research agent automated research self-driving lab
+  agentic science`) can silently collapse to 0-2 hits. To search across
+  synonyms, join them with explicit `OR`, e.g.
+  `"AI Scientist" OR "autonomous research agent" OR "self-driving lab"`.
+  Also: `date_from`/`date_to` filter on `submittedDate`, the date of the paper's
+  **first version** — a paper revised after `date_from` but originally submitted
+  earlier is still excluded, so don't be surprised when a known-recent-looking
+  paper drops out of a date-filtered query.
 
 If a search returns <5 hits, broaden the query. If >50, narrow it. If a source
 errors or needs an unconfigured API key, note it and proceed with the rest —

--- a/src/tooluniverse/data/arxiv_tools.json
+++ b/src/tooluniverse/data/arxiv_tools.json
@@ -8,7 +8,7 @@
       "properties": {
         "query": {
           "type": "string",
-          "description": "Search query for arXiv papers. Use keywords separated by spaces to refine your search."
+          "description": "Search query for arXiv papers. Unquoted, unprefixed space-separated keywords are ANDed together (every keyword must match) -- adding more keywords NARROWS results, it does not broaden them. To search multiple synonyms/phrases and broaden recall, join them with explicit OR, e.g. '\"AI Scientist\" OR \"autonomous research agent\" OR \"self-driving lab\"'. Supports field prefixes (au:, ti:, abs:, cat:, all:) and AND/OR/ANDNOT boolean operators, which are passed through as-is."
         },
         "limit": {
           "type": "integer",
@@ -27,11 +27,11 @@
         },
         "date_from": {
           "type": "string",
-          "description": "Filter results from this date (format: YYYY-MM-DD). Uses submittedDate range."
+          "description": "Filter results from this date (format: YYYY-MM-DD). Uses submittedDate, the date of the paper's FIRST version -- a paper revised/updated after this date but originally submitted earlier is still excluded."
         },
         "date_to": {
           "type": "string",
-          "description": "Filter results up to this date (format: YYYY-MM-DD). Uses submittedDate range."
+          "description": "Filter results up to this date (format: YYYY-MM-DD). Uses submittedDate, the date of the paper's FIRST version -- a paper revised/updated after this date but originally submitted earlier is still included."
         }
       },
       "required": [
@@ -108,6 +108,11 @@
       {
         "query": "computer vision",
         "limit": 3
+      },
+      {
+        "query": "\"AI Scientist\" OR \"autonomous research agent\" OR \"self-driving lab\"",
+        "limit": 3,
+        "sort_by": "relevance"
       }
     ]
   },

--- a/src/tooluniverse/data/arxiv_tools.json
+++ b/src/tooluniverse/data/arxiv_tools.json
@@ -8,7 +8,7 @@
       "properties": {
         "query": {
           "type": "string",
-          "description": "Search query for arXiv papers. Unquoted, unprefixed space-separated keywords are ANDed together (every keyword must match) -- adding more keywords NARROWS results, it does not broaden them. To search multiple synonyms/phrases and broaden recall, join them with explicit OR, e.g. '\"AI Scientist\" OR \"autonomous research agent\" OR \"self-driving lab\"'. Supports field prefixes (au:, ti:, abs:, cat:, all:) and AND/OR/ANDNOT boolean operators, which are passed through as-is."
+          "description": "Search query for arXiv papers. Unquoted, unprefixed space-separated keywords are ANDed together (every keyword must match) -- adding more keywords NARROWS results, it does not broaden them. To search multiple synonyms/phrases and broaden recall, join them with explicit OR, e.g. '\"machine learning\" OR \"deep learning\" OR \"neural networks\"'. Supports field prefixes (au:, ti:, abs:, cat:, all:) and AND/OR/ANDNOT boolean operators, which are passed through as-is."
         },
         "limit": {
           "type": "integer",
@@ -110,7 +110,7 @@
         "limit": 3
       },
       {
-        "query": "\"AI Scientist\" OR \"autonomous research agent\" OR \"self-driving lab\"",
+        "query": "\"machine learning\" OR \"deep learning\" OR \"neural networks\"",
         "limit": 3,
         "sort_by": "relevance"
       }

--- a/src/tooluniverse/tools/ArXiv_search_papers.py
+++ b/src/tooluniverse/tools/ArXiv_search_papers.py
@@ -26,7 +26,7 @@ def ArXiv_search_papers(
     Parameters
     ----------
     query : str
-        Search query for arXiv papers. Use keywords separated by spaces to refine you...
+        Search query for arXiv papers. Unquoted, unprefixed space-separated keywords ...
     limit : int
         Number of papers to return. This sets the maximum number of papers retrieved ...
     sort_by : str
@@ -34,9 +34,9 @@ def ArXiv_search_papers(
     sort_order : str
         Sort direction. Options: 'ascending', 'descending'
     date_from : str
-        Filter results from this date (format: YYYY-MM-DD). Uses submittedDate range.
+        Filter results from this date (format: YYYY-MM-DD). Uses submittedDate, the d...
     date_to : str
-        Filter results up to this date (format: YYYY-MM-DD). Uses submittedDate range.
+        Filter results up to this date (format: YYYY-MM-DD). Uses submittedDate, the ...
     stream_callback : Callable, optional
         Callback for streaming output
     use_cache : bool, default False

--- a/tests/tools/test_arxiv_tool.py
+++ b/tests/tools/test_arxiv_tool.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for ArXivTool's search-query construction.
+
+Covers the AND-by-default tokenization of unprefixed, non-boolean multi-word
+queries: adding more space-separated keywords narrows results (every token
+must match) rather than broadening them. This is intentional but easy to
+trip over -- callers who want broader recall across synonyms must join them
+with an explicit `OR`.
+"""
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def tool():
+    with open("src/tooluniverse/data/arxiv_tools.json") as f:
+        tools = json.load(f)
+    tool_config = next(t for t in tools if t["name"] == "ArXiv_search_papers")
+
+    from tooluniverse.arxiv_tool import ArXivTool
+
+    return ArXivTool(tool_config)
+
+
+class TestBuildSearchQuery:
+    def test_single_keyword(self, tool):
+        assert tool._build_search_query("transformers") == "all:transformers"
+
+    def test_multi_keyword_is_anded(self, tool):
+        """Space-separated keywords are ANDed (all must match) -- narrows,
+        not broadens. More synonyms make the query stricter, not looser."""
+        query = tool._build_search_query("AI Scientist autonomous")
+        assert query == "all:AI AND all:Scientist AND all:autonomous"
+
+    def test_quoted_phrase_kept_intact(self, tool):
+        query = tool._build_search_query('"self-driving lab" agentic')
+        assert query == 'all:"self-driving lab" AND all:agentic'
+
+    def test_explicit_or_passed_through(self, tool):
+        """Callers who want broader recall across synonyms must write OR
+        explicitly -- the tool does not add it automatically."""
+        query = tool._build_search_query(
+            '"AI Scientist" OR "autonomous research agent"'
+        )
+        assert query == '"AI Scientist" OR "autonomous research agent"'
+
+    def test_field_prefix_passed_through(self, tool):
+        assert tool._build_search_query("cat:cs.AI") == "cat:cs.AI"
+
+    def test_single_prefix_multiword_value_autoquoted(self, tool):
+        assert tool._build_search_query("au:Shanghua Gao") == 'au:"Shanghua Gao"'
+
+
+class TestDateRangeSemantics:
+    """date_from/date_to filter on arXiv's submittedDate, i.e. the date of
+    the FIRST version -- a paper revised/updated after date_from but
+    originally submitted before it will still be excluded."""
+
+    def test_date_range_uses_submitted_date_field(self, tool):
+        search_query = tool._build_search_query("quantum computing")
+        assert "submittedDate" not in search_query  # asserted separately in _search
+
+    def test_search_appends_submitted_date_clause(self, tool, monkeypatch):
+        captured = {}
+
+        def fake_request(session, method, url, params, **kwargs):
+            captured["params"] = params
+
+            class Resp:
+                status_code = 200
+                text = '<feed xmlns="http://www.w3.org/2005/Atom"></feed>'
+                reason = "OK"
+
+            return Resp()
+
+        monkeypatch.setattr("tooluniverse.arxiv_tool.request_with_retry", fake_request)
+        monkeypatch.setattr(tool, "_respect_rate_limit", lambda: None)
+
+        tool._search(
+            "quantum computing", 5, "submittedDate", "descending", "2025-01-01", None
+        )
+
+        assert (
+            "submittedDate:[20250101000000 TO 29991231235959]"
+            in captured["params"]["search_query"]
+        )

--- a/tests/tools/test_arxiv_tool.py
+++ b/tests/tools/test_arxiv_tool.py
@@ -31,20 +31,18 @@ class TestBuildSearchQuery:
     def test_multi_keyword_is_anded(self, tool):
         """Space-separated keywords are ANDed (all must match) -- narrows,
         not broadens. More synonyms make the query stricter, not looser."""
-        query = tool._build_search_query("AI Scientist autonomous")
-        assert query == "all:AI AND all:Scientist AND all:autonomous"
+        query = tool._build_search_query("quantum computing hardware")
+        assert query == "all:quantum AND all:computing AND all:hardware"
 
     def test_quoted_phrase_kept_intact(self, tool):
-        query = tool._build_search_query('"self-driving lab" agentic')
-        assert query == 'all:"self-driving lab" AND all:agentic'
+        query = tool._build_search_query('"neural networks" transformers')
+        assert query == 'all:"neural networks" AND all:transformers'
 
     def test_explicit_or_passed_through(self, tool):
         """Callers who want broader recall across synonyms must write OR
         explicitly -- the tool does not add it automatically."""
-        query = tool._build_search_query(
-            '"AI Scientist" OR "autonomous research agent"'
-        )
-        assert query == '"AI Scientist" OR "autonomous research agent"'
+        query = tool._build_search_query('"machine learning" OR "deep learning"')
+        assert query == '"machine learning" OR "deep learning"'
 
     def test_field_prefix_passed_through(self, tool):
         assert tool._build_search_query("cat:cs.AI") == "cat:cs.AI"


### PR DESCRIPTION
## Summary
- `ArXiv_search_papers` ANDs unprefixed, unquoted space-separated keywords together (every keyword must match), so adding synonyms to broaden a search silently narrows it instead -- a query built from several relevant terms can collapse to 0-2 hits. Verified directly against the live arXiv API.
- `date_from`/`date_to` filter on `submittedDate` (the paper's first version), so a paper revised after `date_from` but originally submitted earlier is still excluded -- also verified live.
- Neither behavior was documented anywhere, so callers (including the `literature-sweep` skill) naturally reach for "add more keywords to broaden recall," which backfires on this tool specifically.

## Changes
- Clarify both behaviors in `ArXiv_search_papers`'s parameter descriptions (JSON source of truth; regenerated the wrapper stub to match)
- Add a `test_examples` entry demonstrating the `OR` workaround
- Add `tests/tools/test_arxiv_tool.py` covering `_build_search_query` tokenization (AND-by-default, quoted phrases, explicit OR pass-through, field prefixes) and the `submittedDate` range clause
- Add the same guidance to the `literature-sweep` skill's gotchas list, plus a note that `SemanticScholar_search_papers` 429s under load (same as the already-documented `CORE_search_papers` behavior)

## Test plan
- [x] `pytest tests/tools/test_arxiv_tool.py -v` -- 8 passed
- [x] `ruff check` / `ruff format` -- clean
- [x] Reproduced the original issue against the live arXiv API (an 11-synonym query collapsed from 2 hits to 0 once a `date_from` filter was added) before writing the fix