### PR TITLE
Fix: correct return_schema envelope mismatch for 9 tools

### DIFF
--- a/src/tooluniverse/data/clinicaltrials_gov_tools.json
+++ b/src/tooluniverse/data/clinicaltrials_gov_tools.json
@@ -1084,94 +1084,86 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "studies": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "nct_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "brief_title": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "status": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "study_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "phases": {
-                        "type": "array"
-                      },
-                      "enrollment": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "conditions": {
-                        "type": "array"
-                      },
-                      "interventions": {
-                        "type": "array"
-                      },
-                      "sponsor": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "start_date": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "completion_date": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "studies": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "nct_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "brief_title": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "status": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "study_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "phases": {
+                    "type": "array"
+                  },
+                  "enrollment": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "conditions": {
+                    "type": "array"
+                  },
+                  "interventions": {
+                    "type": "array"
+                  },
+                  "sponsor": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "start_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "completion_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
-                },
-                "total_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "next_page_token": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "total_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "next_page_token": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
-            "data"
+            "studies"
           ]
         },
         {
@@ -1572,35 +1564,27 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_studies": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "average_byte_size": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "largest_studies": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                }
-              }
+            "total_studies": {
+              "type": [
+                "integer",
+                "null"
+              ]
             },
-            "metadata": {
-              "type": "object"
+            "average_byte_size": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "largest_studies": {
+              "type": [
+                "array",
+                "null"
+              ]
             }
           },
           "required": [
-            "data"
+            "largest_studies"
           ]
         },
         {

--- a/src/tooluniverse/data/epigenomics_tools.json
+++ b/src/tooluniverse/data/epigenomics_tools.json
@@ -78,49 +78,41 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total": {
-                  "type": "integer"
-                },
-                "experiments": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "histone_mark": {
-                        "type": "string"
-                      },
-                      "biosample_summary": {
-                        "type": "string"
-                      },
-                      "status": {
-                        "type": "string"
-                      },
-                      "lab": {
-                        "type": "string"
-                      },
-                      "date_released": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "total": {
+              "type": "integer"
+            },
+            "experiments": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "histone_mark": {
+                    "type": "string"
+                  },
+                  "biosample_summary": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "lab": {
+                    "type": "string"
+                  },
+                  "date_released": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           },
           "required": [
-            "data"
+            "experiments"
           ]
         },
         {

--- a/src/tooluniverse/data/gnomad_tools.json
+++ b/src/tooluniverse/data/gnomad_tools.json
@@ -33,95 +33,83 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "gene": {
               "type": "object",
               "properties": {
-                "gene": {
+                "symbol": {
+                  "type": "string"
+                },
+                "gene_id": {
+                  "type": "string"
+                },
+                "exac_constraint": {
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "gnomad_constraint": {
                   "type": "object",
                   "properties": {
-                    "symbol": {
-                      "type": "string"
+                    "exp_lof": {
+                      "type": "number"
                     },
-                    "gene_id": {
-                      "type": "string"
+                    "obs_lof": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
                     },
-                    "exac_constraint": {
-                      "type": "null"
+                    "oe_lof": {
+                      "type": "number"
                     },
-                    "gnomad_constraint": {
-                      "type": "object",
-                      "properties": {
-                        "exp_lof": {
-                          "type": "number"
-                        },
-                        "obs_lof": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "oe_lof": {
-                          "type": "number"
-                        },
-                        "pLI": {
-                          "type": "number"
-                        },
-                        "exp_mis": {
-                          "type": "number"
-                        },
-                        "obs_mis": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "oe_mis": {
-                          "type": "number"
-                        },
-                        "exp_syn": {
-                          "type": "number"
-                        },
-                        "obs_syn": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "oe_syn": {
-                          "type": "number"
-                        }
-                      }
+                    "pLI": {
+                      "type": "number"
+                    },
+                    "exp_mis": {
+                      "type": "number"
+                    },
+                    "obs_mis": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "oe_mis": {
+                      "type": "number"
+                    },
+                    "exp_syn": {
+                      "type": "number"
+                    },
+                    "obs_syn": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "oe_syn": {
+                      "type": "number"
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "gene"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/gtex_v2_tools.json
+++ b/src/tooluniverse/data/gtex_v2_tools.json
@@ -172,246 +172,228 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tissueSiteDetailId": {
+                "type": "string"
+              },
+              "colorHex": {
+                "type": "string"
+              },
+              "colorRgb": {
+                "type": "string"
+              },
+              "datasetId": {
+                "type": "string"
+              },
+              "eGeneCount": {
+                "type": [
+                  "integer",
+                  "null",
+                  "number"
+                ]
+              },
+              "expressedGeneCount": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "hasEGenes": {
+                "type": "boolean"
+              },
+              "hasSGenes": {
+                "type": "boolean"
+              },
+              "mappedInHubmap": {
+                "type": "boolean"
+              },
+              "eqtlSampleSummary": {
                 "type": "object",
                 "properties": {
-                  "tissueSiteDetailId": {
-                    "type": "string"
-                  },
-                  "colorHex": {
-                    "type": "string"
-                  },
-                  "colorRgb": {
-                    "type": "string"
-                  },
-                  "datasetId": {
-                    "type": "string"
-                  },
-                  "eGeneCount": {
-                    "type": [
-                      "integer",
-                      "null",
-                      "number"
-                    ]
-                  },
-                  "expressedGeneCount": {
+                  "totalCount": {
                     "type": [
                       "integer",
                       "number"
                     ]
                   },
-                  "hasEGenes": {
-                    "type": "boolean"
-                  },
-                  "hasSGenes": {
-                    "type": "boolean"
-                  },
-                  "mappedInHubmap": {
-                    "type": "boolean"
-                  },
-                  "eqtlSampleSummary": {
+                  "female": {
                     "type": "object",
                     "properties": {
-                      "totalCount": {
+                      "ageMax": {
+                        "type": [
+                          "integer",
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "ageMin": {
+                        "type": [
+                          "integer",
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "ageMean": {
+                        "type": [
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "count": {
                         "type": [
                           "integer",
                           "number"
                         ]
-                      },
-                      "female": {
-                        "type": "object",
-                        "properties": {
-                          "ageMax": {
-                            "type": [
-                              "integer",
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "ageMin": {
-                            "type": [
-                              "integer",
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "ageMean": {
-                            "type": [
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "count": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          }
-                        }
-                      },
-                      "male": {
-                        "type": "object",
-                        "properties": {
-                          "ageMax": {
-                            "type": [
-                              "integer",
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "ageMin": {
-                            "type": [
-                              "integer",
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "ageMean": {
-                            "type": [
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "count": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          }
-                        }
                       }
                     }
                   },
-                  "rnaSeqSampleSummary": {
+                  "male": {
                     "type": "object",
                     "properties": {
-                      "totalCount": {
+                      "ageMax": {
+                        "type": [
+                          "integer",
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "ageMin": {
+                        "type": [
+                          "integer",
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "ageMean": {
+                        "type": [
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "count": {
                         "type": [
                           "integer",
                           "number"
                         ]
-                      },
-                      "female": {
-                        "type": "object",
-                        "properties": {
-                          "ageMax": {
-                            "type": [
-                              "integer",
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "ageMin": {
-                            "type": [
-                              "integer",
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "ageMean": {
-                            "type": [
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "count": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          }
-                        }
-                      },
-                      "male": {
-                        "type": "object",
-                        "properties": {
-                          "ageMax": {
-                            "type": [
-                              "integer",
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "ageMin": {
-                            "type": [
-                              "integer",
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "ageMean": {
-                            "type": [
-                              "null",
-                              "number"
-                            ]
-                          },
-                          "count": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          }
-                        }
                       }
                     }
-                  },
-                  "sGeneCount": {
-                    "type": [
-                      "integer",
-                      "null",
-                      "number"
-                    ]
-                  },
-                  "samplingSite": {
-                    "type": "string"
-                  },
-                  "tissueSite": {
-                    "type": "string"
-                  },
-                  "tissueSiteDetail": {
-                    "type": "string"
-                  },
-                  "tissueSiteDetailAbbr": {
-                    "type": "string"
-                  },
-                  "ontologyId": {
-                    "type": "string"
-                  },
-                  "ontologyIri": {
-                    "type": "string"
                   }
                 }
+              },
+              "rnaSeqSampleSummary": {
+                "type": "object",
+                "properties": {
+                  "totalCount": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "female": {
+                    "type": "object",
+                    "properties": {
+                      "ageMax": {
+                        "type": [
+                          "integer",
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "ageMin": {
+                        "type": [
+                          "integer",
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "ageMean": {
+                        "type": [
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "count": {
+                        "type": [
+                          "integer",
+                          "number"
+                        ]
+                      }
+                    }
+                  },
+                  "male": {
+                    "type": "object",
+                    "properties": {
+                      "ageMax": {
+                        "type": [
+                          "integer",
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "ageMin": {
+                        "type": [
+                          "integer",
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "ageMean": {
+                        "type": [
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "count": {
+                        "type": [
+                          "integer",
+                          "number"
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              "sGeneCount": {
+                "type": [
+                  "integer",
+                  "null",
+                  "number"
+                ]
+              },
+              "samplingSite": {
+                "type": "string"
+              },
+              "tissueSite": {
+                "type": "string"
+              },
+              "tissueSiteDetail": {
+                "type": "string"
+              },
+              "tissueSiteDetailAbbr": {
+                "type": "string"
+              },
+              "ontologyId": {
+                "type": "string"
+              },
+              "ontologyIri": {
+                "type": "string"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/gwas_tools.json
+++ b/src/tooluniverse/data/gwas_tools.json
@@ -8,7 +8,7 @@
       "properties": {
         "disease_trait": {
           "type": "string",
-          "description": "Disease or trait name for text-based search (e.g., 'diabetes', 'coronary artery disease', 'breast cancer'). NOTE: GWAS associations are indexed by trait/disease, not by gene or drug name — passing a gene symbol or drug name here will fail. Use efo_id for precise filtering."
+          "description": "Disease or trait name for text-based search (e.g., 'diabetes', 'coronary artery disease', 'breast cancer'). NOTE: GWAS associations are indexed by trait/disease, not by gene or drug name \u2014 passing a gene symbol or drug name here will fail. Use efo_id for precise filtering."
         },
         "query": {
           "type": "string",
@@ -68,10 +68,8 @@
       "Search"
     ],
     "return_schema": {
-      "type": "object",
-      "description": "GWAS associations search results with pagination metadata",
-      "properties": {
-        "data": {
+      "oneOf": [
+        {
           "type": "array",
           "description": "Array of GWAS association objects",
           "items": {
@@ -179,34 +177,18 @@
             }
           }
         },
-        "metadata": {
+        {
           "type": "object",
-          "description": "Pagination and navigation metadata",
           "properties": {
-            "pagination": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "integer"
-                },
-                "totalElements": {
-                  "type": "integer"
-                },
-                "totalPages": {
-                  "type": "integer"
-                },
-                "number": {
-                  "type": "integer"
-                }
-              }
-            },
-            "links": {
-              "type": "object",
-              "description": "Navigation links"
+            "error": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     },
     "test_examples": [
       {

--- a/src/tooluniverse/data/pharmgkb_tools.json
+++ b/src/tooluniverse/data/pharmgkb_tools.json
@@ -34,12 +34,8 @@
       }
     ],
     "return_schema": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "type": "string"
-        },
-        "data": {
+      "oneOf": [
+        {
           "type": "array",
           "items": {
             "type": "object",
@@ -67,8 +63,19 @@
               }
             }
           }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {

--- a/src/tooluniverse/data/rcsb_data_tools.json
+++ b/src/tooluniverse/data/rcsb_data_tools.json
@@ -44,130 +44,114 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "pdb_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "PDB entry ID"
-                },
-                "title": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Structure title"
-                },
-                "method": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Experimental method (X-RAY DIFFRACTION, ELECTRON MICROSCOPY, NMR, etc.)"
-                },
-                "resolution": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "description": "Resolution in Angstroms"
-                },
-                "deposit_date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Deposition date"
-                },
-                "release_date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Initial release date"
-                },
-                "revision_date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Last revision date"
-                },
-                "polymer_entity_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of polymer entities (proteins, nucleic acids)"
-                },
-                "nonpolymer_entity_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of non-polymer entities (ligands, ions)"
-                },
-                "deposited_atom_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Total deposited atom count"
-                },
-                "deposited_model_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Deposited modeled polymer monomer count"
-                },
-                "molecular_weight": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "description": "Total molecular weight in kDa"
-                },
-                "assembly_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of biological assemblies"
-                },
-                "space_group": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Crystal space group"
-                },
-                "unit_cell": {
-                  "type": [
-                    "object",
-                    "null"
-                  ],
-                  "description": "Unit cell dimensions (a, b, c, alpha, beta, gamma)"
-                }
-              }
+            "pdb_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "PDB entry ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "pdb_id": {
-                  "type": "string"
-                }
-              }
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Structure title"
+            },
+            "method": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Experimental method (X-RAY DIFFRACTION, ELECTRON MICROSCOPY, NMR, etc.)"
+            },
+            "resolution": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Resolution in Angstroms"
+            },
+            "deposit_date": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Deposition date"
+            },
+            "release_date": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Initial release date"
+            },
+            "revision_date": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Last revision date"
+            },
+            "polymer_entity_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of polymer entities (proteins, nucleic acids)"
+            },
+            "nonpolymer_entity_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of non-polymer entities (ligands, ions)"
+            },
+            "deposited_atom_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Total deposited atom count"
+            },
+            "deposited_model_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Deposited modeled polymer monomer count"
+            },
+            "molecular_weight": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Total molecular weight in kDa"
+            },
+            "assembly_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of biological assemblies"
+            },
+            "space_group": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Crystal space group"
+            },
+            "unit_cell": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "Unit cell dimensions (a, b, c, alpha, beta, gamma)"
             }
           },
           "required": [
-            "data"
+            "pdb_id"
           ]
         },
         {

--- a/src/tooluniverse/data/uniprot_tools.json
+++ b/src/tooluniverse/data/uniprot_tools.json
@@ -34,197 +34,182 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "entryType": {
+              "type": "string"
             },
-            "data": {
+            "primaryAccession": {
+              "type": "string"
+            },
+            "uniProtkbId": {
+              "type": "string"
+            },
+            "protein_name": {
+              "type": "string"
+            },
+            "gene_names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "organism": {
               "type": "object",
               "properties": {
-                "entryType": {
+                "scientificName": {
                   "type": "string"
                 },
-                "primaryAccession": {
+                "commonName": {
                   "type": "string"
                 },
-                "uniProtkbId": {
-                  "type": "string"
+                "taxonId": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
                 },
-                "protein_name": {
-                  "type": "string"
-                },
-                "gene_names": {
+                "lineage": {
                   "type": "array",
                   "items": {
                     "type": "string"
                   }
-                },
-                "organism": {
-                  "type": "object",
-                  "properties": {
-                    "scientificName": {
-                      "type": "string"
-                    },
-                    "commonName": {
-                      "type": "string"
-                    },
-                    "taxonId": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "lineage": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "sequence": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "string"
-                    },
-                    "length": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "molWeight": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "crc64": {
-                      "type": "string"
-                    },
-                    "md5": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "annotationScore": {
-                  "type": "number"
-                },
-                "proteinExistence": {
+                }
+              }
+            },
+            "sequence": {
+              "type": "object",
+              "properties": {
+                "value": {
                   "type": "string"
                 },
-                "keywords": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "category": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
+                "length": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "molWeight": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "crc64": {
+                  "type": "string"
+                },
+                "md5": {
+                  "type": "string"
+                }
+              }
+            },
+            "annotationScore": {
+              "type": "number"
+            },
+            "proteinExistence": {
+              "type": "string"
+            },
+            "keywords": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "comments": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "commentType": {
+                    "type": "string"
+                  },
+                  "texts": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
                   }
-                },
-                "comments": {
-                  "type": "array",
-                  "items": {
+                }
+              }
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "location": {
                     "type": "object",
                     "properties": {
-                      "commentType": {
-                        "type": "string"
-                      },
-                      "texts": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                },
-                "features": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "location": {
+                      "start": {
                         "type": "object",
                         "properties": {
-                          "start": {
-                            "type": "object",
-                            "properties": {
-                              "value": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "modifier": {
-                                "type": "string"
-                              }
-                            }
+                          "value": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
                           },
-                          "end": {
-                            "type": "object",
-                            "properties": {
-                              "value": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "modifier": {
-                                "type": "string"
-                              }
-                            }
+                          "modifier": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "end": {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "modifier": {
+                            "type": "string"
                           }
                         }
                       }
                     }
                   }
-                },
-                "xref_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "xref_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
             }
-          }
+          },
+          "required": [
+            "primaryAccession"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/tests/tools/test_return_schema_data_shapes.py
+++ b/tests/tools/test_return_schema_data_shapes.py
@@ -1,0 +1,193 @@
+"""
+Regression tests for return_schema mismatches reported in issue #246.
+
+`tu test` (see tooluniverse/cli.py) validates a tool's response via
+``jsonschema.validate(result.get("data"), return_schema)`` -- i.e. it
+validates only the inner ``data`` payload, not the full ``{"status", "data"}``
+envelope. The nine tools covered here previously declared ``return_schema``
+as a full envelope (``oneOf`` branches requiring ``status``/``data``/
+``metadata`` or ``status``/``error``), which can never match a bare
+``data`` payload and always failed validation regardless of how correct
+the live API response was. This file pins down the fix: each declared
+``return_schema`` must validate a representative live-shaped payload
+under the exact call cli.py makes, and must reject the old enveloped
+shape as a payload (proving the schema now genuinely describes ``data``,
+not the envelope).
+"""
+
+import json
+
+import jsonschema
+import pytest
+
+from tooluniverse import ToolUniverse
+
+
+@pytest.fixture(scope="module")
+def tool_configs():
+    tu = ToolUniverse()
+    tu.load_tools()
+    return {tool["name"]: tool for tool in tu.all_tools if isinstance(tool, dict)}
+
+
+CASES = [
+    (
+        "UniProt_get_entry_by_accession",
+        {
+            "entryType": "UniProtKB reviewed (Swiss-Prot)",
+            "primaryAccession": "P04637",
+            "uniProtkbId": "P53_HUMAN",
+            "protein_name": "Cellular tumor antigen p53",
+            "gene_names": ["TP53"],
+            "organism": {"scientificName": "Homo sapiens", "taxonId": 9606},
+            "sequence": {"value": "MEEP", "length": 393},
+            "xref_count": 1079,
+        },
+    ),
+    (
+        "RCSBData_get_entry",
+        {
+            "pdb_id": "4HHB",
+            "title": "THE CRYSTAL STRUCTURE OF HUMAN DEOXYHAEMOGLOBIN",
+            "method": "X-RAY DIFFRACTION",
+            "resolution": 1.74,
+            "unit_cell": {"a": 63.15, "b": 83.59, "c": 53.8},
+        },
+    ),
+    (
+        "ClinicalTrials_search_studies",
+        {
+            "studies": [
+                {
+                    "nct_id": "NCT05732831",
+                    "brief_title": "Safety and Tolerability of TNG462",
+                    "phases": ["PHASE1", "PHASE2"],
+                    "enrollment": 225,
+                }
+            ],
+            "total_count": 104,
+            "next_page_token": "ZVNj7o2Elu8o3lp3Utj4srbumpOQJJxuZ_Gt1fYW",
+        },
+    ),
+    (
+        "ClinicalTrials_get_database_stats",
+        {
+            # gaierror-free: total_studies/average_byte_size legitimately null upstream
+            "total_studies": None,
+            "average_byte_size": None,
+            "largest_studies": [{"id": "NCT02723955", "sizeBytes": 3596689}],
+        },
+    ),
+    (
+        "gnomad_get_gene_constraints",
+        {
+            "gene": {
+                "symbol": "BRCA1",
+                "gene_id": "ENSG00000012048",
+                "exac_constraint": None,
+                "gnomad_constraint": {
+                    "exp_lof": 173.65,
+                    "obs_lof": 140,
+                    "oe_lof": 0.806,
+                    "pLI": 5.5e-38,
+                    "exp_mis": 2172.4,
+                    "obs_mis": 1983,
+                    "oe_mis": 0.912,
+                    "exp_syn": 756.0,
+                    "obs_syn": 662,
+                    "oe_syn": 0.875,
+                },
+            }
+        },
+    ),
+    (
+        "GTEx_get_tissue_sites",
+        [
+            {
+                "tissueSiteDetailId": "Adipose_Subcutaneous",
+                "colorHex": "FF6600",
+                "colorRgb": "255,102,0",
+                "datasetId": "gtex_v8",
+                "expressedGeneCount": 28830,
+                "hasEGenes": True,
+                "hasSGenes": True,
+                "mappedInHubmap": False,
+            }
+        ],
+    ),
+    (
+        "gwas_search_associations",
+        [
+            {
+                "association_id": 214063945,
+                "p_value": 2e-10,
+                "beta": "6.365012 z-score increase",
+                "efo_traits": [
+                    {"efo_id": "MONDO_0005010", "efo_trait": "coronary artery disorder"}
+                ],
+                "accession_id": "GCST90668075",
+            }
+        ],
+    ),
+    (
+        "PharmGKB_search_drugs",
+        [
+            {
+                "objCls": "Chemical",
+                "id": "PA451906",
+                "name": "warfarin",
+                "types": ["Drug"],
+            }
+        ],
+    ),
+    (
+        "ENCODE_search_histone_experiments",
+        {
+            "total": 458,
+            "experiments": [
+                {
+                    "accession": "ENCSR864OOO",
+                    "histone_mark": "H3K27ac",
+                    "biosample_summary": "Homo sapiens liver tissue",
+                    "status": "released",
+                    "lab": "Bradley Bernstein, Broad",
+                    "date_released": None,
+                }
+            ],
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize("tool_name,sample_data", CASES)
+def test_return_schema_validates_live_shaped_data(tool_configs, tool_name, sample_data):
+    """The exact call cli.py's `tu test` makes must accept a real-shaped payload."""
+    return_schema = tool_configs[tool_name]["return_schema"]
+    result = {"status": "success", "data": sample_data}
+
+    jsonschema.validate(result.get("data"), return_schema)
+
+
+@pytest.mark.parametrize("tool_name,sample_data", CASES)
+def test_return_schema_accepts_error_shape(tool_configs, tool_name, sample_data):
+    """The oneOf error branch must still validate a plain {"error": ...} payload."""
+    return_schema = tool_configs[tool_name]["return_schema"]
+
+    jsonschema.validate({"error": "upstream request failed"}, return_schema)
+
+
+@pytest.mark.parametrize("tool_name,sample_data", CASES)
+def test_return_schema_rejects_old_envelope_shape(tool_configs, tool_name, sample_data):
+    """Guards against regressing to the issue #246 bug: a schema describing the
+    full {"status", "data", "metadata"} envelope can never match a bare `data`
+    payload, so re-wrapping `sample_data` in an envelope must fail validation."""
+    return_schema = tool_configs[tool_name]["return_schema"]
+    enveloped = {"status": "success", "data": sample_data, "metadata": {}}
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(enveloped, return_schema)
+
+
+def test_all_cases_reference_real_tools(tool_configs):
+    missing = [name for name, _ in CASES if name not in tool_configs]
+    assert not missing, f"Tool(s) not found in registry: {missing}"


### PR DESCRIPTION
## Summary

Fixes #246. `tu test` validates a tool's response via `jsonschema.validate(result.get("data"), return_schema)` (`cli.py`) — i.e. it validates only the inner `data` payload, not the full response. The documented convention (`skills/tooluniverse-custom-tool/references/json-tool.md`) is explicit that `return_schema` must describe `result["data"]`'s shape directly, not the envelope.

The 9 tools reported in the issue (and its follow-up comment) had `return_schema` authored as the full `{"status", "data", "metadata"}` / `{"status", "error"}` envelope instead. A bare `data` payload can never satisfy a schema requiring a top-level `status` key, so `tu test` failed even on fully correct, successfully-retrieved live data — a validation-metadata bug, not a functional one, matching the issue's own diagnosis.

## Changes

- Unwrapped `return_schema` for all 9 reported tools (`UniProt_get_entry_by_accession`, `RCSBData_get_entry`, `ClinicalTrials_search_studies`, `ClinicalTrials_get_database_stats`, `gnomad_get_gene_constraints`, `GTEx_get_tissue_sites`, `gwas_search_associations`, `PharmGKB_search_drugs`, `ENCODE_search_histone_experiments`) to describe the data payload directly, per the documented convention.
- Added a disambiguating `required` field on each object-shaped success branch (e.g. `["primaryAccession"]`, `["studies"]`, `["gene"]`) so it can no longer also match the `{"error": ...}` branch — without this, `oneOf` matched both branches for any object payload and raised a different validation error.
- Widened gnomAD's `exac_constraint` from a null-only type to nullable object: the GraphQL query requests it as an object, and gnomAD legitimately returns `null` for many genes since ExAC was superseded by gnomAD, but the schema previously forbade it from ever being anything but null.
- Added `tests/tools/test_return_schema_data_shapes.py`: for each of the 9 tools, validates a live-shaped payload and an error payload both pass, and that re-wrapping the payload in the old envelope shape now correctly fails — pinning down the regression this issue described.

## Scope note

While auditing this, the same envelope-vs-data-only `return_schema` authoring mistake was found in ~554 other tools across 233 files (vs. ~2000 tools using the correct data-only convention) — same root cause, same false-positive `tu test` failure. Fixing all of those is a much larger, separate effort and out of scope here; this PR only covers the 9 tools explicitly reported in #246. Filing a follow-up issue to track the rest.

## Test plan

- [x] `tu test` passes for all 9 tools against live API data (was failing before the fix)
- [x] New regression suite (`pytest tests/tools/test_return_schema_data_shapes.py`) passes — 28 tests
- [x] Existing related tests (`test_uniprot_compact_entry.py`, `test_gwas_tool_params.py`, `test_gtex_v2_tool.py`) still pass
- [x] Full `tests/unit` suite passes with no new failures