### PR TITLE
Fix #288: correct envelope-style return_schema (batch 1/5, files A-D)

### DIFF
--- a/src/tooluniverse/data/aging_cohort_tools.json
+++ b/src/tooluniverse/data/aging_cohort_tools.json
@@ -11,93 +11,159 @@
           "description": "Keyword search across study names, descriptions, variable categories, and topics. Examples: 'iron intake longitudinal', 'grip strength aging Europe', 'biomarkers elderly China'."
         },
         "country": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Filter by country or region. Examples: 'USA', 'UK', 'China', 'Europe', 'Netherlands'. Case-insensitive substring match."
         },
         "design": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Filter by study design. One of: 'longitudinal', 'cross-sectional', 'both'.",
-          "enum": ["longitudinal", "cross-sectional", "both", null]
+          "enum": [
+            "longitudinal",
+            "cross-sectional",
+            "both",
+            null
+          ]
         },
         "min_sample_size": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Minimum sample size threshold. Only returns cohorts with sample_size >= this value."
         },
         "has_variable": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Filter for cohorts that include a specific variable category. Substring match against variable categories. Examples: 'iron', 'grip_strength', 'walking_speed', 'nutrition', 'cognitive', 'biomarkers', 'genetics'."
         }
       },
-      "required": ["query"],
+      "required": [
+        "query"
+      ],
       "additionalProperties": false
     },
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {"type": "string"},
-                  "full_name": {"type": "string"},
-                  "country": {"type": "string"},
-                  "design": {"type": "string"},
-                  "sample_size": {"type": "integer"},
-                  "sample_size_note": {"type": "string"},
-                  "age_range": {"type": "string"},
-                  "start_year": {"type": "integer"},
-                  "waves_or_follow_up": {"type": "string"},
-                  "key_variable_categories": {
-                    "type": "array",
-                    "items": {"type": "string"}
-                  },
-                  "description": {"type": "string"},
-                  "access_method": {"type": "string"},
-                  "access_url": {"type": "string"},
-                  "key_publications": {
-                    "type": "array",
-                    "items": {"type": "string"}
-                  }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "full_name": {
+                "type": "string"
+              },
+              "country": {
+                "type": "string"
+              },
+              "design": {
+                "type": "string"
+              },
+              "sample_size": {
+                "type": "integer"
+              },
+              "sample_size_note": {
+                "type": "string"
+              },
+              "age_range": {
+                "type": "string"
+              },
+              "start_year": {
+                "type": "integer"
+              },
+              "waves_or_follow_up": {
+                "type": "string"
+              },
+              "key_variable_categories": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "description": {
+                "type": "string"
+              },
+              "access_method": {
+                "type": "string"
+              },
+              "access_url": {
+                "type": "string"
+              },
+              "key_publications": {
+                "type": "array",
+                "items": {
+                  "type": "string"
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query": {"type": "string"},
-                "filters_applied": {"type": "object"},
-                "total_matched": {"type": "integer"},
-                "total_in_registry": {"type": "integer"}
-              }
             }
-          },
-          "required": ["status", "data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "retryable": {"type": "boolean"}
+            "error": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"query": "iron intake longitudinal"},
-      {"query": "grip strength aging", "country": "Europe"},
-      {"query": "biomarkers elderly", "min_sample_size": 10000},
-      {"query": "walking speed physical function", "has_variable": "walking_speed"},
-      {"query": "nutrition diet", "design": "longitudinal"}
+      {
+        "query": "iron intake longitudinal"
+      },
+      {
+        "query": "grip strength aging",
+        "country": "Europe"
+      },
+      {
+        "query": "biomarkers elderly",
+        "min_sample_size": 10000
+      },
+      {
+        "query": "walking speed physical function",
+        "has_variable": "walking_speed"
+      },
+      {
+        "query": "nutrition diet",
+        "design": "longitudinal"
+      }
     ],
-    "label": ["Aging", "Cohort", "Longitudinal", "Epidemiology", "Gerontology"],
+    "label": [
+      "Aging",
+      "Cohort",
+      "Longitudinal",
+      "Epidemiology",
+      "Gerontology"
+    ],
     "metadata": {
-      "tags": ["aging", "cohort", "longitudinal study", "gerontology", "epidemiology", "nutrition", "physical function", "biomarkers", "geriatrics"],
+      "tags": [
+        "aging",
+        "cohort",
+        "longitudinal study",
+        "gerontology",
+        "epidemiology",
+        "nutrition",
+        "physical function",
+        "biomarkers",
+        "geriatrics"
+      ],
       "estimated_execution_time": "<1 second",
       "note": "Internal curated database; no external API calls. Cohort metadata changes rarely."
     }

--- a/src/tooluniverse/data/allen_brain_tools.json
+++ b/src/tooluniverse/data/allen_brain_tools.json
@@ -586,115 +586,95 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "description": "Per-structure quantified expression values for the ISH dataset",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "StructureUnionize record ID"
+              },
+              "section_data_set_id": {
+                "type": "integer",
+                "description": "Source ISH experiment (SectionDataSet) ID"
+              },
+              "structure_id": {
+                "type": "integer",
+                "description": "Allen Brain Atlas structure (brain region) ID"
+              },
+              "expression_energy": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Expression energy = sum of expressing pixel intensity / total pixels (intensity x density)"
+              },
+              "expression_density": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Fraction of pixels in the structure that express the gene"
+              },
+              "sum_expressing_pixels": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Total number of expressing pixels in the structure"
+              },
+              "sum_expressing_pixel_intensity": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "sum_pixels": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "sum_pixel_intensity": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "voxel_energy_mean": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "voxel_energy_cv": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "structure": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "Linked brain structure record (present when include_structure=true)",
                 "properties": {
                   "id": {
-                    "type": "integer",
-                    "description": "StructureUnionize record ID"
+                    "type": "integer"
                   },
-                  "section_data_set_id": {
-                    "type": "integer",
-                    "description": "Source ISH experiment (SectionDataSet) ID"
-                  },
-                  "structure_id": {
-                    "type": "integer",
-                    "description": "Allen Brain Atlas structure (brain region) ID"
-                  },
-                  "expression_energy": {
+                  "acronym": {
                     "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Expression energy = sum of expressing pixel intensity / total pixels (intensity x density)"
-                  },
-                  "expression_density": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Fraction of pixels in the structure that express the gene"
-                  },
-                  "sum_expressing_pixels": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Total number of expressing pixels in the structure"
-                  },
-                  "sum_expressing_pixel_intensity": {
-                    "type": [
-                      "number",
+                      "string",
                       "null"
                     ]
                   },
-                  "sum_pixels": {
+                  "name": {
                     "type": [
-                      "number",
+                      "string",
                       "null"
                     ]
-                  },
-                  "sum_pixel_intensity": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "voxel_energy_mean": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "voxel_energy_cv": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "structure": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "description": "Linked brain structure record (present when include_structure=true)",
-                    "properties": {
-                      "id": {
-                        "type": "integer"
-                      },
-                      "acronym": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
                   }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "section_data_set_id": {
-                  "type": "integer"
                 }
               }
             }
@@ -703,9 +683,6 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/allen_cell_types_tools.json
+++ b/src/tooluniverse/data/allen_cell_types_tools.json
@@ -1,20 +1,72 @@
 [
-    {
-        "name": "AllenCellTypes_search_specimens",
-        "description": "Search the Allen Cell Types Database for individual neuron specimens characterized by electrophysiology and morphology (human and mouse). Filter by donor species ('Homo Sapiens' or 'Mus musculus') and/or brain structure. Returns per-neuron records: donor species/sex/age/disease state, brain structure, transgenic line, and key electrophysiology features (average firing rate, input resistance, membrane tau, upstroke/downstroke ratio) plus whether a morphological reconstruction exists. Distinct from gene-expression atlas tools. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "species": {"type": ["string", "null"], "description": "Donor species: 'Homo Sapiens' or 'Mus musculus'."},
-            "structure": {"type": ["string", "null"], "description": "Brain structure name substring, e.g. 'frontal gyrus', 'visual cortex'."},
-            "limit": {"type": ["integer", "null"], "description": "Max specimens (default 20, max 100)."}
-        }, "required": []},
-        "fields": {"timeout": 30},
-        "type": "AllenCellTypesSpecimensTool",
-        "test_examples": [{"species": "Homo Sapiens", "limit": 5}, {"species": "Mus musculus", "limit": 3}, {"structure": "frontal gyrus", "limit": 3}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Cell-type specimens", "properties": {
-                "status": {"type": "string"}, "data": {"type": "array", "items": {"type": "object"}}, "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+  {
+    "name": "AllenCellTypes_search_specimens",
+    "description": "Search the Allen Cell Types Database for individual neuron specimens characterized by electrophysiology and morphology (human and mouse). Filter by donor species ('Homo Sapiens' or 'Mus musculus') and/or brain structure. Returns per-neuron records: donor species/sex/age/disease state, brain structure, transgenic line, and key electrophysiology features (average firing rate, input resistance, membrane tau, upstroke/downstroke ratio) plus whether a morphological reconstruction exists. Distinct from gene-expression atlas tools. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "species": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Donor species: 'Homo Sapiens' or 'Mus musculus'."
+        },
+        "structure": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Brain structure name substring, e.g. 'frontal gyrus', 'visual cortex'."
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Max specimens (default 20, max 100)."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "AllenCellTypesSpecimensTool",
+    "test_examples": [
+      {
+        "species": "Homo Sapiens",
+        "limit": 5
+      },
+      {
+        "species": "Mus musculus",
+        "limit": 3
+      },
+      {
+        "structure": "frontal gyrus",
+        "limit": 3
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
     }
+  }
 ]

--- a/src/tooluniverse/data/alphafill_tools.json
+++ b/src/tooluniverse/data/alphafill_tools.json
@@ -1,18 +1,57 @@
 [
-    {
-        "name": "AlphaFill_get_transplants",
-        "description": "Get the ligands, cofactors, and ions that AlphaFill transplants into a protein's AlphaFold model, by UniProt accession. AlphaFold predicts apo (ligand-free) structures; AlphaFill adds small molecules by homology to experimental PDB structures. Returns the distinct transplanted compounds (PDB chemical-component codes), how many homologous hits support each, the best local fit RMSD (lower = better), and the source PDB entries. Use to hypothesize cofactor/metal/ligand/drug binding for a protein whose only structure is an AlphaFold model. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "uniprot": {"type": "string", "description": "UniProt accession, e.g. 'P00520' (ABL1), 'P00533' (EGFR), 'P24941' (CDK2)."}
-        }, "required": ["uniprot"]},
-        "fields": {"timeout": 30},
-        "type": "AlphaFillTransplantsTool",
-        "test_examples": [{"uniprot": "P00520"}, {"uniprot": "P24941"}, {"uniprot": "P00533"}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "AlphaFill transplanted ligands", "properties": {
-                "status": {"type": "string"}, "data": {"type": "object"}, "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+  {
+    "name": "AlphaFill_get_transplants",
+    "description": "Get the ligands, cofactors, and ions that AlphaFill transplants into a protein's AlphaFold model, by UniProt accession. AlphaFold predicts apo (ligand-free) structures; AlphaFill adds small molecules by homology to experimental PDB structures. Returns the distinct transplanted compounds (PDB chemical-component codes), how many homologous hits support each, the best local fit RMSD (lower = better), and the source PDB entries. Use to hypothesize cofactor/metal/ligand/drug binding for a protein whose only structure is an AlphaFold model. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "uniprot": {
+          "type": "string",
+          "description": "UniProt accession, e.g. 'P00520' (ABL1), 'P00533' (EGFR), 'P24941' (CDK2)."
+        }
+      },
+      "required": [
+        "uniprot"
+      ]
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "AlphaFillTransplantsTool",
+    "test_examples": [
+      {
+        "uniprot": "P00520"
+      },
+      {
+        "uniprot": "P24941"
+      },
+      {
+        "uniprot": "P00533"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
     }
+  }
 ]

--- a/src/tooluniverse/data/alphagenome_tools.json
+++ b/src/tooluniverse/data/alphagenome_tools.json
@@ -78,37 +78,26 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "variant": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "variant": {
-                  "type": "string"
-                },
-                "output_type": {
-                  "type": "string"
-                },
-                "scores": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  }
-                }
+            "output_type": {
+              "type": "string"
+            },
+            "scores": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
           },
           "required": [
-            "data"
+            "variant"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
@@ -209,34 +198,23 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "interval": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "interval": {
-                  "type": "string"
-                },
-                "tracks": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  }
-                }
+            "tracks": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
           },
           "required": [
-            "data"
+            "interval"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/alphamissense_tools.json
+++ b/src/tooluniverse/data/alphamissense_tools.json
@@ -1,183 +1,277 @@
 [
-    {
-        "name": "AlphaMissense_get_protein_scores",
-        "description": "Get AlphaMissense pathogenicity scores for EVERY residue of a protein in one call. The upstream hegelab API only exposes per-residue queries; this tool hides that by looking up the protein length from UniProt and concurrently fetching all residues via a thread pool. Returns a list of per-position records (one per residue) plus protein length, count of successful fetches, and the pathogenic/ambiguous/benign thresholds. Use this when you want whole-protein vulnerability assessment, hotspot detection, or to build a (20 × n_positions) AlphaMissense score matrix for benchmarking. Set max_residues > 0 to cap the loop for fast diagnostic calls.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "uniprot_id": {
-                    "type": "string",
-                    "description": "UniProt accession ID (e.g., 'P00533' for EGFR, 'P01116' for KRAS, 'P04637' for TP53)."
-                },
-                "max_residues": {
-                    "type": ["integer", "null"],
-                    "description": "Optional cap on the number of residues fetched. 0 / null / omitted = no cap (fetch every residue of the protein, recommended for whole-protein analysis). Positive integer = fetch only the first N residues (useful for fast diagnostic calls on very long proteins).",
-                    "default": 0
-                }
-            },
-            "required": ["uniprot_id"]
+  {
+    "name": "AlphaMissense_get_protein_scores",
+    "description": "Get AlphaMissense pathogenicity scores for EVERY residue of a protein in one call. The upstream hegelab API only exposes per-residue queries; this tool hides that by looking up the protein length from UniProt and concurrently fetching all residues via a thread pool. Returns a list of per-position records (one per residue) plus protein length, count of successful fetches, and the pathogenic/ambiguous/benign thresholds. Use this when you want whole-protein vulnerability assessment, hotspot detection, or to build a (20 \u00d7 n_positions) AlphaMissense score matrix for benchmarking. Set max_residues > 0 to cap the loop for fast diagnostic calls.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "uniprot_id": {
+          "type": "string",
+          "description": "UniProt accession ID (e.g., 'P00533' for EGFR, 'P01116' for KRAS, 'P04637' for TP53)."
         },
-        "fields": {
-            "operation": "get_protein_scores"
-        },
-        "type": "AlphaMissenseTool",
-        "test_examples": [
-            {
-                "uniprot_id": "P01116",
-                "max_residues": 20
-            },
-            {
-                "uniprot_id": "P00533",
-                "max_residues": 10
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {"type": "string", "enum": ["success"]},
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "uniprot_id": {"type": "string"},
-                                "protein_length": {"type": "integer"},
-                                "scores": {
-                                    "type": "array",
-                                    "description": "Per-residue records, one per position with successful fetch. Each record carries position, uid, aa, resi, benign/ambiguous/pathogenic bin strings (e.g. '6:A,C,D,R,S,V'), benign_all/ambiguous_all/pathogenic_all (covering all 19 substitutions, not just SNV-reachable), and mean/mean_all numeric scores.",
-                                    "items": {"type": "object"}
-                                },
-                                "n_positions_returned": {"type": "integer"},
-                                "n_positions_attempted": {"type": "integer"},
-                                "max_residues_cap": {"type": ["integer", "null"]},
-                                "thresholds": {"type": "object"},
-                                "pdb_download": {"type": "string"}
-                            },
-                            "required": ["uniprot_id", "protein_length", "scores", "n_positions_returned"]
-                        }
-                    },
-                    "required": ["status", "data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {"type": "string", "enum": ["error"]},
-                        "error": {"type": "string"}
-                    },
-                    "required": ["status", "error"]
-                }
-            ]
-        },
-        "label": ["AlphaMissense", "Protein", "Pathogenicity"],
-        "metadata": {
-            "tags": ["pathogenicity", "protein_analysis", "missense", "hotspot"],
-            "estimated_execution_time": "~5-15 seconds for proteins under 500 residues (concurrent per-residue fetch)"
+        "max_residues": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Optional cap on the number of residues fetched. 0 / null / omitted = no cap (fetch every residue of the protein, recommended for whole-protein analysis). Positive integer = fetch only the first N residues (useful for fast diagnostic calls on very long proteins).",
+          "default": 0
         }
+      },
+      "required": [
+        "uniprot_id"
+      ]
     },
-    {
-        "name": "AlphaMissense_get_variant_score",
-        "description": "Get AlphaMissense pathogenicity score for a specific missense variant. Input: UniProt ID and variant (e.g., 'p.R123H'). Returns score and classification (pathogenic/ambiguous/benign). State-of-the-art for VUS interpretation.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "uniprot_id": {
-                    "type": "string",
-                    "description": "UniProt accession ID (e.g., 'P00533' for EGFR)"
-                },
-                "variant": {
-                    "type": "string",
-                    "description": "Variant in protein notation: p.X123Y or X123Y where X is reference amino acid, 123 is position, Y is variant (e.g., 'p.R123H', 'V600E')"
-                }
-            },
-            "required": ["uniprot_id", "variant"]
-        },
-        "fields": {
-            "operation": "get_variant_score"
-        },
-        "type": "AlphaMissenseTool",
-        "test_examples": [
-            {
-                "uniprot_id": "P15056",
-                "variant": "V600E"
-            },
-            {
-                "uniprot_id": "P00533",
-                "variant": "p.L858R"
-            }
-        ],
-        "return_schema": {
-            "type": "object",
-            "properties": {
-                "status": {"type": "string", "enum": ["success", "error"]},
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "uniprot_id": {"type": "string"},
-                        "variant": {"type": "string"},
-                        "pathogenicity_score": {"type": "number"},
-                        "classification": {"type": "string", "enum": ["pathogenic", "ambiguous", "benign"]}
-                    }
-                },
-                "error": {"type": "string"}
-            }
-        },
-        "label": ["AlphaMissense", "Variant", "Pathogenicity"],
-        "metadata": {
-            "tags": ["pathogenicity", "missense", "vus", "variant_interpretation"],
-            "estimated_execution_time": "< 3 seconds"
-        }
+    "fields": {
+      "operation": "get_protein_scores"
     },
-    {
-        "name": "AlphaMissense_get_residue_scores",
-        "description": "Get AlphaMissense scores for all 20 possible amino acid substitutions at a specific protein position. Useful for saturation mutagenesis analysis and identifying pathogenic hotspots.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "uniprot_id": {
-                    "type": "string",
-                    "description": "UniProt accession ID (e.g., 'P00533' for EGFR)"
-                },
-                "position": {
-                    "type": "integer",
-                    "description": "Amino acid position in the protein (1-indexed)"
-                }
+    "type": "AlphaMissenseTool",
+    "test_examples": [
+      {
+        "uniprot_id": "P01116",
+        "max_residues": 20
+      },
+      {
+        "uniprot_id": "P00533",
+        "max_residues": 10
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "uniprot_id": {
+              "type": "string"
             },
-            "required": ["uniprot_id", "position"]
-        },
-        "fields": {
-            "operation": "get_residue_scores"
-        },
-        "type": "AlphaMissenseTool",
-        "test_examples": [
-            {
-                "uniprot_id": "P15056",
-                "position": 600
+            "protein_length": {
+              "type": "integer"
             },
-            {
-                "uniprot_id": "P00533",
-                "position": 858
+            "scores": {
+              "type": "array",
+              "description": "Per-residue records, one per position with successful fetch. Each record carries position, uid, aa, resi, benign/ambiguous/pathogenic bin strings (e.g. '6:A,C,D,R,S,V'), benign_all/ambiguous_all/pathogenic_all (covering all 19 substitutions, not just SNV-reachable), and mean/mean_all numeric scores.",
+              "items": {
+                "type": "object"
+              }
+            },
+            "n_positions_returned": {
+              "type": "integer"
+            },
+            "n_positions_attempted": {
+              "type": "integer"
+            },
+            "max_residues_cap": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "thresholds": {
+              "type": "object"
+            },
+            "pdb_download": {
+              "type": "string"
             }
-        ],
-        "return_schema": {
-            "type": "object",
-            "properties": {
-                "status": {"type": "string", "enum": ["success", "error"]},
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "uniprot_id": {"type": "string"},
-                        "position": {"type": "integer"},
-                        "scores": {"type": "object"},
-                        "thresholds": {"type": "object"}
-                    }
-                },
-                "error": {"type": "string"}
-            }
+          },
+          "required": [
+            "uniprot_id",
+            "protein_length",
+            "scores",
+            "n_positions_returned"
+          ]
         },
-        "label": ["AlphaMissense", "Residue", "Saturation"],
-        "metadata": {
-            "tags": ["pathogenicity", "saturation_mutagenesis", "residue_analysis"],
-            "estimated_execution_time": "< 3 seconds"
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
+    },
+    "label": [
+      "AlphaMissense",
+      "Protein",
+      "Pathogenicity"
+    ],
+    "metadata": {
+      "tags": [
+        "pathogenicity",
+        "protein_analysis",
+        "missense",
+        "hotspot"
+      ],
+      "estimated_execution_time": "~5-15 seconds for proteins under 500 residues (concurrent per-residue fetch)"
     }
+  },
+  {
+    "name": "AlphaMissense_get_variant_score",
+    "description": "Get AlphaMissense pathogenicity score for a specific missense variant. Input: UniProt ID and variant (e.g., 'p.R123H'). Returns score and classification (pathogenic/ambiguous/benign). State-of-the-art for VUS interpretation.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "uniprot_id": {
+          "type": "string",
+          "description": "UniProt accession ID (e.g., 'P00533' for EGFR)"
+        },
+        "variant": {
+          "type": "string",
+          "description": "Variant in protein notation: p.X123Y or X123Y where X is reference amino acid, 123 is position, Y is variant (e.g., 'p.R123H', 'V600E')"
+        }
+      },
+      "required": [
+        "uniprot_id",
+        "variant"
+      ]
+    },
+    "fields": {
+      "operation": "get_variant_score"
+    },
+    "type": "AlphaMissenseTool",
+    "test_examples": [
+      {
+        "uniprot_id": "P15056",
+        "variant": "V600E"
+      },
+      {
+        "uniprot_id": "P00533",
+        "variant": "p.L858R"
+      }
+    ],
+    "return_schema": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "success",
+            "error"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "uniprot_id": {
+              "type": "string"
+            },
+            "variant": {
+              "type": "string"
+            },
+            "pathogenicity_score": {
+              "type": "number"
+            },
+            "classification": {
+              "type": "string",
+              "enum": [
+                "pathogenic",
+                "ambiguous",
+                "benign"
+              ]
+            }
+          }
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "label": [
+      "AlphaMissense",
+      "Variant",
+      "Pathogenicity"
+    ],
+    "metadata": {
+      "tags": [
+        "pathogenicity",
+        "missense",
+        "vus",
+        "variant_interpretation"
+      ],
+      "estimated_execution_time": "< 3 seconds"
+    }
+  },
+  {
+    "name": "AlphaMissense_get_residue_scores",
+    "description": "Get AlphaMissense scores for all 20 possible amino acid substitutions at a specific protein position. Useful for saturation mutagenesis analysis and identifying pathogenic hotspots.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "uniprot_id": {
+          "type": "string",
+          "description": "UniProt accession ID (e.g., 'P00533' for EGFR)"
+        },
+        "position": {
+          "type": "integer",
+          "description": "Amino acid position in the protein (1-indexed)"
+        }
+      },
+      "required": [
+        "uniprot_id",
+        "position"
+      ]
+    },
+    "fields": {
+      "operation": "get_residue_scores"
+    },
+    "type": "AlphaMissenseTool",
+    "test_examples": [
+      {
+        "uniprot_id": "P15056",
+        "position": 600
+      },
+      {
+        "uniprot_id": "P00533",
+        "position": 858
+      }
+    ],
+    "return_schema": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "success",
+            "error"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "uniprot_id": {
+              "type": "string"
+            },
+            "position": {
+              "type": "integer"
+            },
+            "scores": {
+              "type": "object"
+            },
+            "thresholds": {
+              "type": "object"
+            }
+          }
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "label": [
+      "AlphaMissense",
+      "Residue",
+      "Saturation"
+    ],
+    "metadata": {
+      "tags": [
+        "pathogenicity",
+        "saturation_mutagenesis",
+        "residue_analysis"
+      ],
+      "estimated_execution_time": "< 3 seconds"
+    }
+  }
 ]

--- a/src/tooluniverse/data/ampsphere_record_tools.json
+++ b/src/tooluniverse/data/ampsphere_record_tools.json
@@ -11,80 +11,188 @@
           "description": "AMPSphere AMP accession of the form 'AMP10.XXX_XXX'. Example: 'AMP10.000_000' (sequence KKVKSIFKKALAMMGENEVKAWGIGIK, family SPHERE-III.001_493)."
         }
       },
-      "required": ["accession"]
+      "required": [
+        "accession"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Successful AMP lookup.",
+          "description": "Full AMPSphere AMP record.",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "description": "Full AMPSphere AMP record.",
+            "accession": {
+              "type": "string"
+            },
+            "sequence": {
+              "type": "string"
+            },
+            "family": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "length": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "molecular_weight": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "isoelectric_point": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "charge": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "aromaticity": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "instability_index": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "gravy": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "Antifam": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "RNAcode": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "metaproteomes": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "metatranscriptomes": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "coordinates": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "num_genes": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "secondary_structure": {
+              "type": [
+                "object",
+                "null"
+              ],
               "properties": {
-                "accession": {"type": "string"},
-                "sequence": {"type": "string"},
-                "family": {"type": ["string", "null"]},
-                "length": {"type": ["integer", "null"]},
-                "molecular_weight": {"type": ["number", "null"]},
-                "isoelectric_point": {"type": ["number", "null"]},
-                "charge": {"type": ["number", "null"]},
-                "aromaticity": {"type": ["number", "null"]},
-                "instability_index": {"type": ["number", "null"]},
-                "gravy": {"type": ["number", "null"]},
-                "Antifam": {"type": ["string", "null"]},
-                "RNAcode": {"type": ["string", "null"]},
-                "metaproteomes": {"type": ["string", "null"]},
-                "metatranscriptomes": {"type": ["string", "null"]},
-                "coordinates": {"type": ["string", "null"]},
-                "num_genes": {"type": ["integer", "null"]},
-                "secondary_structure": {
-                  "type": ["object", "null"],
-                  "properties": {
-                    "helix": {"type": ["number", "null"]},
-                    "turn": {"type": ["number", "null"]},
-                    "sheet": {"type": ["number", "null"]}
-                  }
+                "helix": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
                 },
-                "metadata": {"type": ["object", "null"]}
+                "turn": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "sheet": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
               }
             },
             "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "url": {"type": "string"},
-                "accession": {"type": "string"},
-                "family": {"type": ["string", "null"]},
-                "length": {"type": ["integer", "null"]},
-                "gene_count": {"type": "integer"}
-              }
+              "type": [
+                "object",
+                "null"
+              ]
             }
           },
-          "required": ["status", "data"]
+          "required": [
+            "accession"
+          ]
         },
         {
           "type": "object",
           "description": "Error result.",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "url": {"type": "string"},
-            "response_snippet": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "response_snippet": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"accession": "AMP10.000_000"},
-      {"accession": "AMP10.000_001"}
+      {
+        "accession": "AMP10.000_000"
+      },
+      {
+        "accession": "AMP10.000_001"
+      }
     ],
-    "label": ["AMPSphere", "Antimicrobial Peptide", "AMP", "Metagenome", "Peptide"],
+    "label": [
+      "AMPSphere",
+      "Antimicrobial Peptide",
+      "AMP",
+      "Metagenome",
+      "Peptide"
+    ],
     "metadata": {
-      "tags": ["antimicrobial peptide", "AMP", "AMPSphere", "metagenome", "metaproteome", "physicochemical", "peptide"],
+      "tags": [
+        "antimicrobial peptide",
+        "AMP",
+        "AMPSphere",
+        "metagenome",
+        "metaproteome",
+        "physicochemical",
+        "peptide"
+      ],
       "estimated_execution_time": "1-3 seconds"
     }
   },
@@ -100,54 +208,76 @@
           "description": "Amino-acid sequence (single-letter code) to test for exact membership. Example: 'KKVKSIFKKALAMMGENEVKAWGIGIK' -> AMP10.000_000."
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Successful exact-match test.",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {"type": "string"},
-                "result": {"type": ["string", "null"]},
-                "matched": {"type": "boolean"}
-              }
+            "query": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "url": {"type": "string"},
-                "accession": {"type": ["string", "null"]}
-              }
+            "result": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "matched": {
+              "type": "boolean"
             }
           },
-          "required": ["status", "data"]
+          "required": [
+            "query"
+          ]
         },
         {
           "type": "object",
           "description": "Error result.",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "url": {"type": "string"},
-            "response_snippet": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "response_snippet": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"query": "KKVKSIFKKALAMMGENEVKAWGIGIK"},
-      {"query": "ACDEFGHIKLMNPQRSTVWYACDEFG"}
+      {
+        "query": "KKVKSIFKKALAMMGENEVKAWGIGIK"
+      },
+      {
+        "query": "ACDEFGHIKLMNPQRSTVWYACDEFG"
+      }
     ],
-    "label": ["AMPSphere", "Antimicrobial Peptide", "AMP", "Sequence", "Peptide"],
+    "label": [
+      "AMPSphere",
+      "Antimicrobial Peptide",
+      "AMP",
+      "Sequence",
+      "Peptide"
+    ],
     "metadata": {
-      "tags": ["antimicrobial peptide", "AMP", "AMPSphere", "sequence match", "exact match", "peptide"],
+      "tags": [
+        "antimicrobial peptide",
+        "AMP",
+        "AMPSphere",
+        "sequence match",
+        "exact match",
+        "peptide"
+      ],
       "estimated_execution_time": "1-3 seconds"
     }
   }

--- a/src/tooluniverse/data/ampsphere_tools.json
+++ b/src/tooluniverse/data/ampsphere_tools.json
@@ -55,11 +55,17 @@
           "description": "Net-charge-at-pH-7 range as 'min,max', e.g. '0,10'. Catalogue range is ~-57 to 44."
         },
         "page_size": {
-          "type": ["integer", "string"],
+          "type": [
+            "integer",
+            "string"
+          ],
           "description": "Results per page (default 20)."
         },
         "page": {
-          "type": ["integer", "string"],
+          "type": [
+            "integer",
+            "string"
+          ],
           "description": "Zero-based page index (default 0)."
         }
       },
@@ -68,51 +74,70 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "description": "Successful AMP search or options listing.",
-          "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "description": "List of AMP records (search), or the filter-options object (list_options)."
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "url": {"type": "string"},
-                "mode": {"type": "string"},
-                "current_page": {"type": ["integer", "null"]},
-                "page_size": {"type": ["integer", "null"]},
-                "total_page": {"type": ["integer", "null"]},
-                "total_item": {"type": ["integer", "null"]},
-                "returned_count": {"type": ["integer", "null"]},
-                "filters": {"type": "object"}
-              }
-            }
-          },
-          "required": ["status", "data", "metadata"]
+          "description": "List of AMP records (search), or the filter-options object (list_options).",
+          "type": [
+            "array",
+            "object"
+          ],
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
         },
         {
           "type": "object",
           "description": "Error result.",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "url": {"type": "string"},
-            "response_snippet": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "response_snippet": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"habitat": "human gut", "page_size": 2, "page": 0},
-      {"family": "SPHERE-III.001_396", "page_size": 3, "page": 0},
-      {"list_options": true}
+      {
+        "habitat": "human gut",
+        "page_size": 2,
+        "page": 0
+      },
+      {
+        "family": "SPHERE-III.001_396",
+        "page_size": 3,
+        "page": 0
+      },
+      {
+        "list_options": true
+      }
     ],
-    "label": ["AMPSphere", "Antimicrobial Peptide", "AMP", "smORF", "Peptide"],
+    "label": [
+      "AMPSphere",
+      "Antimicrobial Peptide",
+      "AMP",
+      "smORF",
+      "Peptide"
+    ],
     "metadata": {
-      "tags": ["antimicrobial peptide", "AMP", "AMPSphere", "smORF", "metagenome", "microbiome", "peptide"],
+      "tags": [
+        "antimicrobial peptide",
+        "AMP",
+        "AMPSphere",
+        "smORF",
+        "metagenome",
+        "microbiome",
+        "peptide"
+      ],
       "estimated_execution_time": "1-3 seconds"
     }
   },
@@ -128,61 +153,93 @@
           "description": "SPHERE family accession. Example: 'SPHERE-III.001_396' (23 member AMPs, consensus 'GDKLXXXXXVDXXXXGGLIVKXGSRMXDXSLXXKLXXLXXAMKXXG')."
         }
       },
-      "required": ["accession"]
+      "required": [
+        "accession"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Successful family lookup.",
+          "description": "Full AMPSphere family record.",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "description": "Full AMPSphere family record.",
-              "properties": {
-                "accession": {"type": "string"},
-                "consensus_sequence": {"type": ["string", "null"]},
-                "num_amps": {"type": ["integer", "null"]},
-                "downloads": {"type": "object"},
-                "associated_amps": {"type": "array"},
-                "feature_statistics": {"type": "object"},
-                "distributions": {"type": "object"}
-              }
+            "accession": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "url": {"type": "string"},
-                "accession": {"type": "string"},
-                "num_amps": {"type": ["integer", "null"]},
-                "member_count": {"type": "integer"}
-              }
+            "consensus_sequence": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "num_amps": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "downloads": {
+              "type": "object"
+            },
+            "associated_amps": {
+              "type": "array"
+            },
+            "feature_statistics": {
+              "type": "object"
+            },
+            "distributions": {
+              "type": "object"
             }
           },
-          "required": ["status", "data", "metadata"]
+          "required": [
+            "accession"
+          ]
         },
         {
           "type": "object",
           "description": "Error result.",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "url": {"type": "string"},
-            "response_snippet": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "response_snippet": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"accession": "SPHERE-III.001_396"},
-      {"accession": "SPHERE-III.001_493"}
+      {
+        "accession": "SPHERE-III.001_396"
+      },
+      {
+        "accession": "SPHERE-III.001_493"
+      }
     ],
-    "label": ["AMPSphere", "Protein Family", "SPHERE", "AMP", "Peptide"],
+    "label": [
+      "AMPSphere",
+      "Protein Family",
+      "SPHERE",
+      "AMP",
+      "Peptide"
+    ],
     "metadata": {
-      "tags": ["antimicrobial peptide", "AMP", "AMPSphere", "protein family", "SPHERE", "consensus", "peptide"],
+      "tags": [
+        "antimicrobial peptide",
+        "AMP",
+        "AMPSphere",
+        "protein family",
+        "SPHERE",
+        "consensus",
+        "peptide"
+      ],
       "estimated_execution_time": "1-3 seconds"
     }
   },
@@ -198,56 +255,75 @@
           "description": "AMPSphere AMP accession. Example: 'AMP10.000_000'."
         }
       },
-      "required": ["accession"]
+      "required": [
+        "accession"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Successful distribution lookup.",
+          "description": "Per-AMP distribution record.",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "description": "Per-AMP distribution record.",
-              "properties": {
-                "geo": {"type": "object"},
-                "habitat": {"type": "object"},
-                "microbial_source": {"type": "object"}
-              }
+            "geo": {
+              "type": "object"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "url": {"type": "string"},
-                "accession": {"type": "string"},
-                "geo_point_count": {"type": ["integer", "null"]}
-              }
+            "habitat": {
+              "type": "object"
+            },
+            "microbial_source": {
+              "type": "object"
             }
           },
-          "required": ["status", "data", "metadata"]
+          "required": [
+            "geo"
+          ]
         },
         {
           "type": "object",
           "description": "Error result.",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "url": {"type": "string"},
-            "response_snippet": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "response_snippet": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"accession": "AMP10.000_000"},
-      {"accession": "AMP10.000_001"}
+      {
+        "accession": "AMP10.000_000"
+      },
+      {
+        "accession": "AMP10.000_001"
+      }
     ],
-    "label": ["AMPSphere", "Biogeography", "Habitat", "AMP", "Peptide"],
+    "label": [
+      "AMPSphere",
+      "Biogeography",
+      "Habitat",
+      "AMP",
+      "Peptide"
+    ],
     "metadata": {
-      "tags": ["antimicrobial peptide", "AMP", "AMPSphere", "biogeography", "habitat", "microbial source", "peptide"],
+      "tags": [
+        "antimicrobial peptide",
+        "AMP",
+        "AMPSphere",
+        "biogeography",
+        "habitat",
+        "microbial source",
+        "peptide"
+      ],
       "estimated_execution_time": "1-3 seconds"
     }
   },
@@ -263,61 +339,114 @@
           "description": "AMPSphere AMP accession. Example: 'AMP10.000_000'."
         }
       },
-      "required": ["accession"]
+      "required": [
+        "accession"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Successful feature lookup.",
+          "description": "Physicochemical feature profile.",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "description": "Physicochemical feature profile.",
-              "properties": {
-                "MW": {"type": ["number", "null"]},
-                "Length": {"type": ["number", "null"]},
-                "Molar_extinction": {"type": "object"},
-                "Aromaticity": {"type": ["number", "null"]},
-                "GRAVY": {"type": ["number", "null"]},
-                "Instability_index": {"type": ["number", "null"]},
-                "Isoelectric_point": {"type": ["number", "null"]},
-                "Charge_at_pH_7": {"type": ["number", "null"]},
-                "Secondary_structure": {"type": "object"}
-              }
+            "MW": {
+              "type": [
+                "number",
+                "null"
+              ]
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "url": {"type": "string"},
-                "accession": {"type": "string"}
-              }
+            "Length": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "Molar_extinction": {
+              "type": "object"
+            },
+            "Aromaticity": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "GRAVY": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "Instability_index": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "Isoelectric_point": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "Charge_at_pH_7": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "Secondary_structure": {
+              "type": "object"
             }
           },
-          "required": ["status", "data", "metadata"]
+          "required": [
+            "Molar_extinction"
+          ]
         },
         {
           "type": "object",
           "description": "Error result.",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "url": {"type": "string"},
-            "response_snippet": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "response_snippet": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"accession": "AMP10.000_000"},
-      {"accession": "AMP10.000_001"}
+      {
+        "accession": "AMP10.000_000"
+      },
+      {
+        "accession": "AMP10.000_001"
+      }
     ],
-    "label": ["AMPSphere", "Physicochemical", "Secondary Structure", "AMP", "Peptide"],
+    "label": [
+      "AMPSphere",
+      "Physicochemical",
+      "Secondary Structure",
+      "AMP",
+      "Peptide"
+    ],
     "metadata": {
-      "tags": ["antimicrobial peptide", "AMP", "AMPSphere", "physicochemical", "GRAVY", "secondary structure", "peptide"],
+      "tags": [
+        "antimicrobial peptide",
+        "AMP",
+        "AMPSphere",
+        "physicochemical",
+        "GRAVY",
+        "secondary structure",
+        "peptide"
+      ],
       "estimated_execution_time": "1-3 seconds"
     }
   }

--- a/src/tooluniverse/data/antibody_registry_tools.json
+++ b/src/tooluniverse/data/antibody_registry_tools.json
@@ -3,7 +3,9 @@
     "type": "AntibodyRegistryTool",
     "name": "AntibodyRegistry_search",
     "description": "Search the Antibody Registry (antibodyregistry.org, a SciCrunch/RRID resource of 3M+ research antibodies) by target, name, or vendor keyword. Returns matching antibodies each with its persistent RRID (e.g. AB_2298772), target (and target UniProt/Entrez id), clonality, clone id, host/source organism, conjugate, applications, vendor, catalog number, and defining citation. Use it to find a validated antibody for a protein target or to obtain the RRID a journal requires for reproducibility. For resolving a known RRID, use AntibodyRegistry_get_by_rrid instead.",
-    "fields": {"operation": "search"},
+    "fields": {
+      "operation": "search"
+    },
     "parameter": {
       "type": "object",
       "properties": {
@@ -25,53 +27,71 @@
           "default": 1
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "rrid": {"type": "string"},
-                  "ab_id": {"type": "integer"},
-                  "abName": {"type": "string"},
-                  "abTarget": {"type": "string"},
-                  "clonality": {"type": "string"},
-                  "vendorName": {"type": "string"},
-                  "catalogNum": {"type": "string"},
-                  "definingCitation": {"type": "string"}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rrid": {
+                "type": "string"
+              },
+              "ab_id": {
+                "type": "integer"
+              },
+              "abName": {
+                "type": "string"
+              },
+              "abTarget": {
+                "type": "string"
+              },
+              "clonality": {
+                "type": "string"
+              },
+              "vendorName": {
+                "type": "string"
+              },
+              "catalogNum": {
+                "type": "string"
+              },
+              "definingCitation": {
+                "type": "string"
               }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"query": "GFAP", "size": 3}
+      {
+        "query": "GFAP",
+        "size": 3
+      }
     ]
   },
   {
     "type": "AntibodyRegistryTool",
     "name": "AntibodyRegistry_get_by_rrid",
     "description": "Resolve a research-antibody RRID (e.g. 'AB_2298772', 'RRID:AB_2298772', or the bare numeric id) to its full Antibody Registry record: name, target (with UniProt/Entrez ids), clonality, clone id, host/source organism, conjugate, isotype, applications, vendor, catalog number, and defining citation. Use it to verify or expand an antibody cited by RRID in a methods section. To discover antibodies for a target, use AntibodyRegistry_search.",
-    "fields": {"operation": "get_by_rrid"},
+    "fields": {
+      "operation": "get_by_rrid"
+    },
     "parameter": {
       "type": "object",
       "properties": {
@@ -80,42 +100,58 @@
           "description": "Antibody RRID, e.g. 'AB_2298772', 'RRID:AB_2298772', or a bare numeric id like '2298772'."
         }
       },
-      "required": ["rrid"]
+      "required": [
+        "rrid"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "properties": {
-                "rrid": {"type": "string"},
-                "ab_id": {"type": "integer"},
-                "abName": {"type": "string"},
-                "abTarget": {"type": "string"},
-                "clonality": {"type": "string"},
-                "vendorName": {"type": "string"},
-                "catalogNum": {"type": "string"}
-              }
+            "rrid": {
+              "type": "string"
             },
-            "metadata": {"type": "object"}
+            "ab_id": {
+              "type": "integer"
+            },
+            "abName": {
+              "type": "string"
+            },
+            "abTarget": {
+              "type": "string"
+            },
+            "clonality": {
+              "type": "string"
+            },
+            "vendorName": {
+              "type": "string"
+            },
+            "catalogNum": {
+              "type": "string"
+            }
           },
-          "required": ["status", "data"]
+          "required": [
+            "rrid"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"rrid": "AB_10000343"}
+      {
+        "rrid": "AB_10000343"
+      }
     ]
   }
 ]

--- a/src/tooluniverse/data/aopwiki_tools.json
+++ b/src/tooluniverse/data/aopwiki_tools.json
@@ -12,18 +12,38 @@
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "integer"},
-          "title": {"type": ["string", "null"]},
-          "short_name": {"type": ["string", "null"]}
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "short_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
       }
     },
     "test_examples": [
       {}
     ],
-    "label": ["AOPWiki", "Toxicology", "Adverse Outcome Pathway"],
+    "label": [
+      "AOPWiki",
+      "Toxicology",
+      "Adverse Outcome Pathway"
+    ],
     "metadata": {
-      "tags": ["toxicology", "adverse outcome pathway", "regulatory"],
+      "tags": [
+        "toxicology",
+        "adverse outcome pathway",
+        "regulatory"
+      ],
       "estimated_execution_time": "2-3 seconds"
     }
   },
@@ -39,23 +59,57 @@
           "description": "AOP numeric identifier. Find IDs using AOPWiki_list_aops. Example: 3 (mitochondrial complex I inhibition leading to parkinsonian motor deficits)."
         }
       },
-      "required": ["aop_id"]
+      "required": [
+        "aop_id"
+      ]
     },
     "return_schema": {
       "type": "object",
       "properties": {
-        "id": {"type": "integer"},
-        "title": {"type": ["string", "null"]},
-        "short_name": {"type": ["string", "null"]},
-        "created_at": {"type": ["string", "null"]},
-        "updated_at": {"type": ["string", "null"]},
+        "id": {
+          "type": "integer"
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "short_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "created_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "updated_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "stressors": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "id": {"type": ["integer", "null"]},
-              "name": {"type": ["string", "null"]}
+              "id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
           }
         },
@@ -64,8 +118,18 @@
           "items": {
             "type": "object",
             "properties": {
-              "event_id": {"type": ["integer", "null"]},
-              "event": {"type": ["string", "null"]}
+              "event_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "event": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
           }
         },
@@ -74,8 +138,18 @@
           "items": {
             "type": "object",
             "properties": {
-              "event_id": {"type": ["integer", "null"]},
-              "event": {"type": ["string", "null"]}
+              "event_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "event": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
           }
         },
@@ -84,8 +158,18 @@
           "items": {
             "type": "object",
             "properties": {
-              "event_id": {"type": ["integer", "null"]},
-              "event": {"type": ["string", "null"]}
+              "event_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "event": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
           }
         },
@@ -94,22 +178,55 @@
           "items": {
             "type": "object",
             "properties": {
-              "upstream_event_id": {"type": ["integer", "null"]},
-              "upstream_event": {"type": ["string", "null"]},
-              "downstream_event_id": {"type": ["integer", "null"]},
-              "downstream_event": {"type": ["string", "null"]}
+              "upstream_event_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "upstream_event": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "downstream_event_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "downstream_event": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
           }
         }
       }
     },
     "test_examples": [
-      {"aop_id": 3},
-      {"aop_id": 12}
+      {
+        "aop_id": 3
+      },
+      {
+        "aop_id": 12
+      }
     ],
-    "label": ["AOPWiki", "Toxicology", "Adverse Outcome Pathway"],
+    "label": [
+      "AOPWiki",
+      "Toxicology",
+      "Adverse Outcome Pathway"
+    ],
     "metadata": {
-      "tags": ["toxicology", "adverse outcome pathway", "regulatory", "stressor"],
+      "tags": [
+        "toxicology",
+        "adverse outcome pathway",
+        "regulatory",
+        "stressor"
+      ],
       "estimated_execution_time": "2-3 seconds"
     }
   },
@@ -125,53 +242,113 @@
           "description": "AOP-Wiki Key Event numeric id, e.g. 18 ('Activation, AhR'). Obtain ids from AOPWiki_get_aop."
         }
       },
-      "required": ["event_id"]
+      "required": [
+        "event_id"
+      ]
     },
-    "settings": {"base_url": "https://aopwiki.org", "timeout": 30, "endpoint_kind": "event"},
+    "settings": {
+      "base_url": "https://aopwiki.org",
+      "timeout": 30,
+      "endpoint_kind": "event"
+    },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Key Event with ontology-annotated event components",
           "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "id": {"type": ["integer", "null"]},
-                "title": {"type": ["string", "null"]},
-                "short_name": {"type": ["string", "null"]},
-                "biological_organization": {"type": ["string", "null"]},
-                "event_components": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {"type": ["integer", "null"]},
-                      "process": {"type": ["object", "null"]},
-                      "object": {"type": ["object", "null"]},
-                      "action": {"type": ["object", "null"]}
-                    }
+            "id": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "short_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "biological_organization": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "event_components": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "process": {
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "object": {
+                    "type": [
+                      "object",
+                      "null"
+                    ]
+                  },
+                  "action": {
+                    "type": [
+                      "object",
+                      "null"
+                    ]
                   }
                 }
               }
             }
           },
-          "required": ["status", "data"]
+          "required": [
+            "event_components"
+          ]
         },
         {
           "type": "object",
-          "properties": {"status": {"type": "string"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"event_id": 18}
+      {
+        "event_id": 18
+      }
     ],
-    "label": ["AOPWiki", "Toxicology", "Key Event", "Ontology"],
+    "label": [
+      "AOPWiki",
+      "Toxicology",
+      "Key Event",
+      "Ontology"
+    ],
     "metadata": {
-      "tags": ["toxicology", "adverse outcome pathway", "key event", "ontology", "regulatory"],
+      "tags": [
+        "toxicology",
+        "adverse outcome pathway",
+        "key event",
+        "ontology",
+        "regulatory"
+      ],
       "estimated_execution_time": "2-3 seconds"
     }
   }

--- a/src/tooluniverse/data/artic_tools.json
+++ b/src/tooluniverse/data/artic_tools.json
@@ -51,158 +51,143 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "preference": {
+              "type": "null"
             },
-            "data": {
+            "pagination": {
               "type": "object",
               "properties": {
-                "preference": {
-                  "type": "null"
+                "total": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
                 },
-                "pagination": {
-                  "type": "object",
-                  "properties": {
-                    "total": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "limit": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "offset": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "total_pages": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "current_page": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
-                  }
+                "limit": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
                 },
-                "data": {
-                  "type": "array",
-                  "items": {
+                "offset": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "total_pages": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "current_page": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
+            },
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "_score": {
+                    "type": "number"
+                  },
+                  "id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "api_model": {
+                    "type": "string"
+                  },
+                  "api_link": {
+                    "type": "string"
+                  },
+                  "is_boosted": {
+                    "type": "boolean"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "thumbnail": {
                     "type": "object",
                     "properties": {
-                      "_score": {
-                        "type": "number"
+                      "lqip": {
+                        "type": "string"
                       },
-                      "id": {
+                      "width": {
                         "type": [
                           "integer",
                           "number"
                         ]
                       },
-                      "api_model": {
-                        "type": "string"
+                      "height": {
+                        "type": [
+                          "integer",
+                          "number"
+                        ]
                       },
-                      "api_link": {
-                        "type": "string"
-                      },
-                      "is_boosted": {
-                        "type": "boolean"
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "thumbnail": {
-                        "type": "object",
-                        "properties": {
-                          "lqip": {
-                            "type": "string"
-                          },
-                          "width": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          },
-                          "height": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          },
-                          "alt_text": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "timestamp": {
+                      "alt_text": {
                         "type": "string"
                       }
                     }
-                  }
-                },
-                "info": {
-                  "type": "object",
-                  "properties": {
-                    "license_text": {
-                      "type": "string"
-                    },
-                    "license_links": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "version": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "config": {
-                  "type": "object",
-                  "properties": {
-                    "iiif_url": {
-                      "type": "string"
-                    },
-                    "website_url": {
-                      "type": "string"
-                    }
+                  },
+                  "timestamp": {
+                    "type": "string"
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "info": {
+              "type": "object",
+              "properties": {
+                "license_text": {
+                  "type": "string"
+                },
+                "license_links": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "version": {
+                  "type": "string"
+                }
+              }
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "iiif_url": {
+                  "type": "string"
+                },
+                "website_url": {
+                  "type": "string"
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "preference"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -244,112 +229,97 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
             "data": {
               "type": "object",
               "properties": {
-                "data": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "title": {
-                      "type": "string"
-                    },
-                    "date_display": {
-                      "type": "string"
-                    },
-                    "artist_display": {
-                      "type": "string"
-                    },
-                    "place_of_origin": {
-                      "type": "string"
-                    },
-                    "description": {
-                      "type": "string"
-                    },
-                    "dimensions": {
-                      "type": "string"
-                    },
-                    "medium_display": {
-                      "type": "string"
-                    },
-                    "credit_line": {
-                      "type": "string"
-                    },
-                    "is_public_domain": {
-                      "type": "boolean"
-                    },
-                    "artwork_type_title": {
-                      "type": "string"
-                    },
-                    "style_title": {
-                      "type": "string"
-                    },
-                    "image_id": {
-                      "type": "string"
-                    }
-                  }
+                "id": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
                 },
-                "info": {
-                  "type": "object",
-                  "properties": {
-                    "license_text": {
-                      "type": "string"
-                    },
-                    "license_links": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "version": {
-                      "type": "string"
-                    }
-                  }
+                "title": {
+                  "type": "string"
                 },
-                "config": {
-                  "type": "object",
-                  "properties": {
-                    "iiif_url": {
-                      "type": "string"
-                    },
-                    "website_url": {
-                      "type": "string"
-                    }
-                  }
+                "date_display": {
+                  "type": "string"
+                },
+                "artist_display": {
+                  "type": "string"
+                },
+                "place_of_origin": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "dimensions": {
+                  "type": "string"
+                },
+                "medium_display": {
+                  "type": "string"
+                },
+                "credit_line": {
+                  "type": "string"
+                },
+                "is_public_domain": {
+                  "type": "boolean"
+                },
+                "artwork_type_title": {
+                  "type": "string"
+                },
+                "style_title": {
+                  "type": "string"
+                },
+                "image_id": {
+                  "type": "string"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "info": {
+              "type": "object",
+              "properties": {
+                "license_text": {
+                  "type": "string"
+                },
+                "license_links": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "version": {
+                  "type": "string"
+                }
+              }
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "iiif_url": {
+                  "type": "string"
+                },
+                "website_url": {
+                  "type": "string"
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "data"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/bgpt_tools.json
+++ b/src/tooluniverse/data/bgpt_tools.json
@@ -27,9 +27,13 @@
           "description": "Optional paid-tier API key, used after the free result allowance is exhausted. If omitted, the BGPT_API_KEY environment variable is used."
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
-    "optional_api_keys": ["BGPT_API_KEY"],
+    "optional_api_keys": [
+      "BGPT_API_KEY"
+    ],
     "api_key_info": {
       "BGPT_API_KEY": {
         "domain": "Literature & Evidence",
@@ -42,44 +46,69 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "array",
-              "description": "Paper records with structured evidence fields.",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "doi": {"type": "string"},
-                  "title": {"type": "string"},
-                  "publication_date": {"type": "string"},
-                  "publication_name": {"type": "string"},
-                  "one_sentence_summary": {"type": "string"},
-                  "results_and_conclusions": {"type": "string"},
-                  "methods_and_experimental_techniques": {"type": "string"},
-                  "sample_size_and_population": {"type": "string"},
-                  "paper_limitations_and_biases": {"type": "string"},
-                  "conflict_of_interest": {"type": "string"},
-                  "data_availability_statements": {"type": "string"},
-                  "how_to_falsify": {"type": "string"},
-                  "study_blindspots": {"type": "string"},
-                  "quality_scores": {"type": "object"}
-                }
+          "type": "array",
+          "description": "Paper records with structured evidence fields.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "doi": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "publication_date": {
+                "type": "string"
+              },
+              "publication_name": {
+                "type": "string"
+              },
+              "one_sentence_summary": {
+                "type": "string"
+              },
+              "results_and_conclusions": {
+                "type": "string"
+              },
+              "methods_and_experimental_techniques": {
+                "type": "string"
+              },
+              "sample_size_and_population": {
+                "type": "string"
+              },
+              "paper_limitations_and_biases": {
+                "type": "string"
+              },
+              "conflict_of_interest": {
+                "type": "string"
+              },
+              "data_availability_statements": {
+                "type": "string"
+              },
+              "how_to_falsify": {
+                "type": "string"
+              },
+              "study_blindspots": {
+                "type": "string"
+              },
+              "quality_scores": {
+                "type": "object"
               }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "detail": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "detail": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/bigg_models_tools.json
+++ b/src/tooluniverse/data/bigg_models_tools.json
@@ -8,31 +8,51 @@
       "properties": {
         "operation": {
           "type": "string",
-          "enum": ["list_models"],
+          "enum": [
+            "list_models"
+          ],
           "description": "Operation type"
         }
       },
-      "required": ["operation"]
+      "required": [
+        "operation"
+      ]
     },
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "models": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "bigg_id": {"type": "string"},
-              "organism": {"type": "string"},
-              "reaction_count": {"type": "integer"},
-              "metabolite_count": {"type": "integer"},
-              "gene_count": {"type": "integer"}
+              "bigg_id": {
+                "type": "string"
+              },
+              "organism": {
+                "type": "string"
+              },
+              "reaction_count": {
+                "type": "integer"
+              },
+              "metabolite_count": {
+                "type": "integer"
+              },
+              "gene_count": {
+                "type": "integer"
+              }
             }
           }
         },
-        "count": {"type": "integer"},
-        "error": {"type": "string"}
+        "count": {
+          "type": "integer"
+        },
+        "error": {
+          "type": "string"
+        }
       }
     },
     "test_examples": [
@@ -50,7 +70,9 @@
       "properties": {
         "operation": {
           "type": "string",
-          "enum": ["get_model"],
+          "enum": [
+            "get_model"
+          ],
           "description": "Operation type"
         },
         "model_id": {
@@ -58,26 +80,49 @@
           "description": "Required: BiGG model ID (e.g., 'iJO1366', 'iMM904', 'Recon3D')"
         }
       },
-      "required": ["operation", "model_id"]
+      "required": [
+        "operation",
+        "model_id"
+      ]
     },
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "model": {
           "type": "object",
           "properties": {
-            "organism": {"type": "string"},
-            "genome": {"type": "string"},
-            "metabolite_count": {"type": "integer"},
-            "gene_count": {"type": "integer"},
-            "reaction_count": {"type": "integer"},
-            "reference_type": {"type": "string"},
-            "reference_id": {"type": "string"}
+            "organism": {
+              "type": "string"
+            },
+            "genome": {
+              "type": "string"
+            },
+            "metabolite_count": {
+              "type": "integer"
+            },
+            "gene_count": {
+              "type": "integer"
+            },
+            "reaction_count": {
+              "type": "integer"
+            },
+            "reference_type": {
+              "type": "string"
+            },
+            "reference_id": {
+              "type": "string"
+            }
           }
         },
-        "model_id": {"type": "string"},
-        "error": {"type": "string"}
+        "model_id": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
       }
     },
     "test_examples": [
@@ -96,7 +141,9 @@
       "properties": {
         "operation": {
           "type": "string",
-          "enum": ["get_model_reactions"],
+          "enum": [
+            "get_model_reactions"
+          ],
           "description": "Operation type"
         },
         "model_id": {
@@ -104,26 +151,43 @@
           "description": "Required: BiGG model ID"
         }
       },
-      "required": ["operation", "model_id"]
+      "required": [
+        "operation",
+        "model_id"
+      ]
     },
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "reactions": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "bigg_id": {"type": "string"},
-              "name": {"type": "string"},
-              "organism": {"type": "string"}
+              "bigg_id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "organism": {
+                "type": "string"
+              }
             }
           }
         },
-        "count": {"type": "integer"},
-        "model_id": {"type": "string"},
-        "error": {"type": "string"}
+        "count": {
+          "type": "integer"
+        },
+        "model_id": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
       }
     },
     "test_examples": [
@@ -142,7 +206,9 @@
       "properties": {
         "operation": {
           "type": "string",
-          "enum": ["get_reaction"],
+          "enum": [
+            "get_reaction"
+          ],
           "description": "Operation type"
         },
         "reaction_id": {
@@ -155,25 +221,46 @@
           "description": "Model ID or 'universal' for universal reaction database"
         }
       },
-      "required": ["operation", "reaction_id"]
+      "required": [
+        "operation",
+        "reaction_id"
+      ]
     },
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "reaction": {
           "type": "object",
           "properties": {
-            "bigg_id": {"type": "string"},
-            "name": {"type": "string"},
-            "metabolites": {"type": "array"},
-            "database_links": {"type": "object"},
-            "models_containing_reaction": {"type": "array"}
+            "bigg_id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "metabolites": {
+              "type": "array"
+            },
+            "database_links": {
+              "type": "object"
+            },
+            "models_containing_reaction": {
+              "type": "array"
+            }
           }
         },
-        "reaction_id": {"type": "string"},
-        "model_id": {"type": "string"},
-        "error": {"type": "string"}
+        "reaction_id": {
+          "type": "string"
+        },
+        "model_id": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
       }
     },
     "test_examples": [
@@ -193,7 +280,9 @@
       "properties": {
         "operation": {
           "type": "string",
-          "enum": ["get_metabolite"],
+          "enum": [
+            "get_metabolite"
+          ],
           "description": "Operation type"
         },
         "metabolite_id": {
@@ -206,25 +295,46 @@
           "description": "Model ID or 'universal' for universal metabolite database"
         }
       },
-      "required": ["operation", "metabolite_id"]
+      "required": [
+        "operation",
+        "metabolite_id"
+      ]
     },
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "metabolite": {
           "type": "object",
           "properties": {
-            "bigg_id": {"type": "string"},
-            "name": {"type": "string"},
-            "formula": {"type": "string"},
-            "database_links": {"type": "object"},
-            "compartments_in_models": {"type": "array"}
+            "bigg_id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "formula": {
+              "type": "string"
+            },
+            "database_links": {
+              "type": "object"
+            },
+            "compartments_in_models": {
+              "type": "array"
+            }
           }
         },
-        "metabolite_id": {"type": "string"},
-        "model_id": {"type": "string"},
-        "error": {"type": "string"}
+        "metabolite_id": {
+          "type": "string"
+        },
+        "model_id": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
       }
     },
     "test_examples": [
@@ -244,7 +354,9 @@
       "properties": {
         "operation": {
           "type": "string",
-          "enum": ["search"],
+          "enum": [
+            "search"
+          ],
           "description": "Operation type"
         },
         "query": {
@@ -253,33 +365,59 @@
         },
         "search_type": {
           "type": "string",
-          "enum": ["models", "reactions", "metabolites", "genes"],
+          "enum": [
+            "models",
+            "reactions",
+            "metabolites",
+            "genes"
+          ],
           "default": "reactions",
           "description": "What to search for"
         }
       },
-      "required": ["operation", "query"]
+      "required": [
+        "operation",
+        "query"
+      ]
     },
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "results": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "bigg_id": {"type": "string"},
-              "name": {"type": "string"},
-              "organism": {"type": "string"},
-              "model_bigg_id": {"type": "string"}
+              "bigg_id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "organism": {
+                "type": "string"
+              },
+              "model_bigg_id": {
+                "type": "string"
+              }
             }
           }
         },
-        "count": {"type": "integer"},
-        "query": {"type": "string"},
-        "search_type": {"type": "string"},
-        "error": {"type": "string"}
+        "count": {
+          "type": "integer"
+        },
+        "query": {
+          "type": "string"
+        },
+        "search_type": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
       }
     },
     "test_examples": [
@@ -299,20 +437,34 @@
       "properties": {
         "operation": {
           "type": "string",
-          "enum": ["get_database_version"],
+          "enum": [
+            "get_database_version"
+          ],
           "description": "Operation type"
         }
       },
-      "required": ["operation"]
+      "required": [
+        "operation"
+      ]
     },
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
-        "bigg_models_version": {"type": "string"},
-        "api_version": {"type": "string"},
-        "last_updated": {"type": "string"},
-        "error": {"type": "string"}
+        "status": {
+          "type": "string"
+        },
+        "bigg_models_version": {
+          "type": "string"
+        },
+        "api_version": {
+          "type": "string"
+        },
+        "last_updated": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
       }
     },
     "test_examples": [
@@ -330,7 +482,9 @@
       "properties": {
         "operation": {
           "type": "string",
-          "enum": ["download_model"],
+          "enum": [
+            "download_model"
+          ],
           "description": "Operation type"
         },
         "model_id": {
@@ -339,62 +493,85 @@
         },
         "format": {
           "type": "string",
-          "enum": ["json", "sbml", "xml"],
+          "enum": [
+            "json",
+            "sbml",
+            "xml"
+          ],
           "description": "Model file format. 'json' (default) returns the parsed COBRA JSON model dict; 'sbml' (alias 'xml') returns the raw SBML XML text.",
           "default": "json"
         }
       },
-      "required": ["operation", "model_id"]
+      "required": [
+        "operation",
+        "model_id"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "data": {
+            "model_id": {
+              "type": "string"
+            },
+            "format": {
+              "type": "string"
+            },
+            "model": {
               "type": "object",
-              "properties": {
-                "model_id": {"type": "string"},
-                "format": {"type": "string"},
-                "model": {
-                  "type": "object",
-                  "description": "Full COBRA JSON model: reactions (with lower_bound/upper_bound/objective_coefficient/metabolites/gene_reaction_rule), metabolites, genes, compartments, id, version. Present only when format='json'."
-                },
-                "sbml": {
-                  "type": "string",
-                  "description": "Raw SBML/XML model text. Present only when format='sbml'."
-                },
-                "reaction_count": {"type": "integer"},
-                "metabolite_count": {"type": "integer"},
-                "gene_count": {"type": "integer"},
-                "compartments": {"type": "object"},
-                "objective_reactions": {
-                  "type": "array",
-                  "description": "Reaction IDs with non-zero objective coefficient (FBA objective / biomass)",
-                  "items": {"type": "string"}
-                },
-                "version": {"type": ["string", "null"]},
-                "size_bytes": {"type": "integer"},
-                "source_url": {"type": "string"}
+              "description": "Full COBRA JSON model: reactions (with lower_bound/upper_bound/objective_coefficient/metabolites/gene_reaction_rule), metabolites, genes, compartments, id, version. Present only when format='json'."
+            },
+            "sbml": {
+              "type": "string",
+              "description": "Raw SBML/XML model text. Present only when format='sbml'."
+            },
+            "reaction_count": {
+              "type": "integer"
+            },
+            "metabolite_count": {
+              "type": "integer"
+            },
+            "gene_count": {
+              "type": "integer"
+            },
+            "compartments": {
+              "type": "object"
+            },
+            "objective_reactions": {
+              "type": "array",
+              "description": "Reaction IDs with non-zero objective coefficient (FBA objective / biomass)",
+              "items": {
+                "type": "string"
               }
+            },
+            "version": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "size_bytes": {
+              "type": "integer"
+            },
+            "source_url": {
+              "type": "string"
             }
           },
-          "required": ["status", "data"]
+          "required": [
+            "model_id"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "error": {"type": "string"}
-              },
-              "required": ["error"]
+            "error": {
+              "type": "string"
             }
           },
-          "required": ["status", "data"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/bindingdb_tools.json
+++ b/src/tooluniverse/data/bindingdb_tools.json
@@ -26,81 +26,66 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "uniprots": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "uniprots": {
-                  "type": "array",
-                  "items": {
+            "cutoff": {
+              "type": "integer"
+            },
+            "affinities": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "query": {
                     "type": "string"
-                  }
-                },
-                "cutoff": {
-                  "type": "integer"
-                },
-                "affinities": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "query": {
-                        "type": "string"
-                      },
-                      "monomerid": {
-                        "type": [
-                          "string",
-                          "integer"
-                        ]
-                      },
-                      "smile": {
-                        "type": "string"
-                      },
-                      "affinity_type": {
-                        "type": "string"
-                      },
-                      "affinity": {
-                        "type": [
-                          "string",
-                          "number"
-                        ]
-                      },
-                      "pmid": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+                  },
+                  "monomerid": {
+                    "type": [
+                      "string",
+                      "integer"
+                    ]
+                  },
+                  "smile": {
+                    "type": "string"
+                  },
+                  "affinity_type": {
+                    "type": "string"
+                  },
+                  "affinity": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  },
+                  "pmid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "uniprots"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -141,81 +126,66 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "uniprots": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "uniprots": {
-                  "type": "array",
-                  "items": {
+            "cutoff": {
+              "type": "integer"
+            },
+            "affinities": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "query": {
                     "type": "string"
-                  }
-                },
-                "cutoff": {
-                  "type": "integer"
-                },
-                "affinities": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "query": {
-                        "type": "string"
-                      },
-                      "monomerid": {
-                        "type": [
-                          "string",
-                          "integer"
-                        ]
-                      },
-                      "smile": {
-                        "type": "string"
-                      },
-                      "affinity_type": {
-                        "type": "string"
-                      },
-                      "affinity": {
-                        "type": [
-                          "string",
-                          "number"
-                        ]
-                      },
-                      "pmid": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+                  },
+                  "monomerid": {
+                    "type": [
+                      "string",
+                      "integer"
+                    ]
+                  },
+                  "smile": {
+                    "type": "string"
+                  },
+                  "affinity_type": {
+                    "type": "string"
+                  },
+                  "affinity": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  },
+                  "pmid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "uniprots"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -256,81 +226,66 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "uniprots": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "uniprots": {
-                  "type": "array",
-                  "items": {
+            "cutoff": {
+              "type": "integer"
+            },
+            "affinities": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "query": {
                     "type": "string"
-                  }
-                },
-                "cutoff": {
-                  "type": "integer"
-                },
-                "affinities": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "query": {
-                        "type": "string"
-                      },
-                      "monomerid": {
-                        "type": [
-                          "string",
-                          "integer"
-                        ]
-                      },
-                      "smile": {
-                        "type": "string"
-                      },
-                      "affinity_type": {
-                        "type": "string"
-                      },
-                      "affinity": {
-                        "type": [
-                          "string",
-                          "number"
-                        ]
-                      },
-                      "pmid": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+                  },
+                  "monomerid": {
+                    "type": [
+                      "string",
+                      "integer"
+                    ]
+                  },
+                  "smile": {
+                    "type": "string"
+                  },
+                  "affinity_type": {
+                    "type": "string"
+                  },
+                  "affinity": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  },
+                  "pmid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "uniprots"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -373,81 +328,66 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "pdbs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "pdbs": {
-                  "type": "array",
-                  "items": {
+            "cutoff": {
+              "type": "integer"
+            },
+            "affinities": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "query": {
                     "type": "string"
-                  }
-                },
-                "cutoff": {
-                  "type": "integer"
-                },
-                "affinities": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "query": {
-                        "type": "string"
-                      },
-                      "monomerid": {
-                        "type": [
-                          "string",
-                          "integer"
-                        ]
-                      },
-                      "smile": {
-                        "type": "string"
-                      },
-                      "affinity_type": {
-                        "type": "string"
-                      },
-                      "affinity": {
-                        "type": [
-                          "string",
-                          "number"
-                        ]
-                      },
-                      "pmid": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+                  },
+                  "monomerid": {
+                    "type": [
+                      "string",
+                      "integer"
+                    ]
+                  },
+                  "smile": {
+                    "type": "string"
+                  },
+                  "affinity_type": {
+                    "type": "string"
+                  },
+                  "affinity": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  },
+                  "pmid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "pdbs"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -481,78 +421,63 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "smiles": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "smiles": {
-                  "type": "string"
-                },
-                "similarity": {
-                  "type": "number"
-                },
-                "affinities": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "query": {
-                        "type": "string"
-                      },
-                      "monomerid": {
-                        "type": [
-                          "string",
-                          "integer"
-                        ]
-                      },
-                      "smile": {
-                        "type": "string"
-                      },
-                      "affinity_type": {
-                        "type": "string"
-                      },
-                      "affinity": {
-                        "type": [
-                          "string",
-                          "number"
-                        ]
-                      },
-                      "pmid": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "similarity": {
+              "type": "number"
+            },
+            "affinities": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  },
+                  "monomerid": {
+                    "type": [
+                      "string",
+                      "integer"
+                    ]
+                  },
+                  "smile": {
+                    "type": "string"
+                  },
+                  "affinity_type": {
+                    "type": "string"
+                  },
+                  "affinity": {
+                    "type": [
+                      "string",
+                      "number"
+                    ]
+                  },
+                  "pmid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "smiles"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/bioimage_archive_tools.json
+++ b/src/tooluniverse/data/bioimage_archive_tools.json
@@ -414,109 +414,58 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "Name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "path": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "size": {
-                    "type": [
-                      "integer",
-                      "number",
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "section": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "annotations": {
-                    "type": "object"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "accession": {
-                  "type": "string"
-                },
-                "records_total": {
-                  "type": [
-                    "integer",
-                    "number",
-                    "null"
-                  ]
-                },
-                "returned": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "offset": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "limit": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "path": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "size": {
+                "type": [
+                  "integer",
+                  "number",
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "section": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "annotations": {
+                "type": "object"
               }
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/biosamples_tools.json
+++ b/src/tooluniverse/data/biosamples_tools.json
@@ -369,60 +369,52 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "accession": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": ["string", "null"]
-                },
-                "relationships": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "source": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "target": {
-                        "type": "string"
-                      },
-                      "direction": {
-                        "type": "string"
-                      },
-                      "related_accession": {
-                        "type": ["string", "null"]
-                      }
-                    }
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "relationships": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  },
+                  "direction": {
+                    "type": "string"
+                  },
+                  "related_accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
-                },
-                "relationship_count": {
-                  "type": "integer"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "relationship_count": {
+              "type": "integer"
             }
           },
           "required": [
-            "data"
+            "accession"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
@@ -445,7 +437,10 @@
           "description": "Free-text query to compute facets over. Examples: 'cancer', 'liver', 'Homo sapiens'."
         },
         "max_values": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum number of top values to return per facet (1-50, default 10)."
         }
       },
@@ -471,62 +466,63 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "facets": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "attribute": {
-                        "type": ["string", "null"]
-                      },
-                      "type": {
-                        "type": ["string", "null"]
-                      },
-                      "count": {
-                        "type": ["integer", "null"]
-                      },
-                      "top_values": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "label": {
-                              "type": ["string", "null"]
-                            },
-                            "count": {
-                              "type": ["integer", "null"]
-                            }
-                          }
+            "facets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "attribute": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "top_values": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "label": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "count": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
                         }
                       }
                     }
                   }
-                },
-                "external_reference_data_facets": {
-                  "type": "array"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "external_reference_data_facets": {
+              "type": "array"
             }
           },
           "required": [
-            "data"
+            "facets"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/bmrb_tools.json
+++ b/src/tooluniverse/data/bmrb_tools.json
@@ -290,61 +290,44 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "description": "Standard envelope; data is a list of sequence-similarity hits",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "count": {
-              "type": "integer",
-              "description": "Number of matching BMRB entries"
-            },
-            "data": {
-              "type": "array",
-              "description": "List of matching BMRB entries ranked by similarity",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "entry_id": {
-                    "type": "string",
-                    "description": "BMRB entry identifier"
-                  },
-                  "entity_id": {
-                    "type": "string",
-                    "description": "Entity (molecule) identifier within the entry"
-                  },
-                  "entry_title": {
-                    "type": "string"
-                  },
-                  "percent_id": {
-                    "type": "number",
-                    "description": "Percent sequence identity of the alignment"
-                  },
-                  "alignment_length": {
-                    "type": "integer"
-                  },
-                  "mismatches": {
-                    "type": "integer"
-                  },
-                  "gap_openings": {
-                    "type": "integer"
-                  },
-                  "e-value": {
-                    "type": "number",
-                    "description": "BLAST expectation value"
-                  },
-                  "bit_score": {
-                    "type": "number"
-                  }
-                }
+          "type": "array",
+          "description": "List of matching BMRB entries ranked by similarity",
+          "items": {
+            "type": "object",
+            "properties": {
+              "entry_id": {
+                "type": "string",
+                "description": "BMRB entry identifier"
+              },
+              "entity_id": {
+                "type": "string",
+                "description": "Entity (molecule) identifier within the entry"
+              },
+              "entry_title": {
+                "type": "string"
+              },
+              "percent_id": {
+                "type": "number",
+                "description": "Percent sequence identity of the alignment"
+              },
+              "alignment_length": {
+                "type": "integer"
+              },
+              "mismatches": {
+                "type": "integer"
+              },
+              "gap_openings": {
+                "type": "integer"
+              },
+              "e-value": {
+                "type": "number",
+                "description": "BLAST expectation value"
+              },
+              "bit_score": {
+                "type": "number"
               }
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -411,34 +394,24 @@
       "oneOf": [
         {
           "type": "object",
-          "description": "Standard envelope; data holds column names and shift rows",
           "properties": {
-            "status": {
-              "type": "string"
+            "columns": {
+              "type": "array",
+              "description": "Column names for each row (e.g. Atom_chem_shift.Entry_ID, .Comp_ID, .Atom_ID, .Val, Sample_conditions.pH, .Temperature_K)",
+              "items": {
+                "type": "string"
+              }
             },
             "data": {
-              "type": "object",
-              "properties": {
-                "columns": {
-                  "type": "array",
-                  "description": "Column names for each row (e.g. Atom_chem_shift.Entry_ID, .Comp_ID, .Atom_ID, .Val, Sample_conditions.pH, .Temperature_K)",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "data": {
-                  "type": "array",
-                  "description": "Rows of chemical-shift records across all BMRB entries",
-                  "items": {
-                    "type": "array"
-                  }
-                }
+              "type": "array",
+              "description": "Rows of chemical-shift records across all BMRB entries",
+              "items": {
+                "type": "array"
               }
             }
           },
           "required": [
-            "status",
-            "data"
+            "columns"
           ]
         },
         {
@@ -486,33 +459,20 @@
       "oneOf": [
         {
           "type": "object",
-          "description": "Standard envelope; data keyed by entry ID with 'avs' and 'panav' validation categories",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "object",
-              "description": "Map of entry_id -> {avs, panav} validation results",
-              "additionalProperties": {
+          "description": "Map of entry_id -> {avs, panav} validation results",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "avs": {
                 "type": "object",
-                "properties": {
-                  "avs": {
-                    "type": "object",
-                    "description": "Assignment Validation Software per-residue consistency analysis"
-                  },
-                  "panav": {
-                    "type": "object",
-                    "description": "PANAV reference-offset and anomalous-shift analysis"
-                  }
-                }
+                "description": "Assignment Validation Software per-residue consistency analysis"
+              },
+              "panav": {
+                "type": "object",
+                "description": "PANAV reference-offset and anomalous-shift analysis"
               }
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/cancerppd2_tools.json
+++ b/src/tooluniverse/data/cancerppd2_tools.json
@@ -9,43 +9,52 @@
         "dataType": {
           "type": "string",
           "description": "Field to filter on. One of: 'cancer_type' (e.g. Fibrosarcoma), 'cell_line' (e.g. A-549), or 'seq' (sequence nature: Natural or Modified). Default: 'cancer_type'.",
-          "enum": ["cancer_type", "cell_line", "seq"]
+          "enum": [
+            "cancer_type",
+            "cell_line",
+            "seq"
+          ]
         },
         "dataValue": {
           "type": "string",
           "description": "Value to match for the chosen dataType. Examples: 'Fibrosarcoma' (with dataType=cancer_type) -> ~101 records; 'A-549' (with dataType=cell_line) -> ~232 records; 'Natural' or 'Modified' (with dataType=seq)."
         }
       },
-      "required": ["dataValue"]
+      "required": [
+        "dataValue"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": { "const": "success" },
-            "data": {
-              "type": "array",
-              "items": { "type": "object" },
-              "description": "Matching anticancer peptide records. Each has id, pmid, year, seq, name, length, lin_cyc, chiral, chem_mod, cter, nter, cell_line, cancer_type, assay, test_time, tissue."
-            },
-            "metadata": { "type": "object" }
+          "type": "array",
+          "items": {
+            "type": "object"
           },
-          "required": ["status", "data", "metadata"]
+          "description": "Matching anticancer peptide records. Each has id, pmid, year, seq, name, length, lin_cyc, chiral, chem_mod, cter, nter, cell_line, cancer_type, assay, test_time, tissue."
         },
         {
           "type": "object",
           "properties": {
-            "status": { "const": "error" },
-            "error": { "type": "string" }
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      { "dataType": "cancer_type", "dataValue": "Fibrosarcoma" },
-      { "dataType": "cell_line", "dataValue": "A-549" }
+      {
+        "dataType": "cancer_type",
+        "dataValue": "Fibrosarcoma"
+      },
+      {
+        "dataType": "cell_line",
+        "dataValue": "A-549"
+      }
     ]
   }
 ]

--- a/src/tooluniverse/data/cbioportal_tools.json
+++ b/src/tooluniverse/data/cbioportal_tools.json
@@ -6,7 +6,11 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "limit": {"type": "integer", "default": 20, "description": "Number of studies to return"}
+        "limit": {
+          "type": "integer",
+          "default": 20,
+          "description": "Number of studies to return"
+        }
       }
     },
     "fields": {
@@ -18,23 +22,62 @@
       "items": {
         "type": "object",
         "properties": {
-          "studyId": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "cancerTypeId": {"type": "string"},
-          "publicStudy": {"type": "boolean"},
-          "pmid": {"type": "string"},
-          "citation": {"type": "string"},
-          "groups": {"type": ["array", "string"]},
-          "status": {"type": ["string", "integer"]},
-          "importDate": {"type": "string"},
-          "allSampleCount": {"type": "integer"},
-          "readPermission": {"type": "boolean"},
-          "referenceGenome": {"type": "string"}
+          "studyId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "cancerTypeId": {
+            "type": "string"
+          },
+          "publicStudy": {
+            "type": "boolean"
+          },
+          "pmid": {
+            "type": "string"
+          },
+          "citation": {
+            "type": "string"
+          },
+          "groups": {
+            "type": [
+              "array",
+              "string"
+            ]
+          },
+          "status": {
+            "type": [
+              "string",
+              "integer"
+            ]
+          },
+          "importDate": {
+            "type": "string"
+          },
+          "allSampleCount": {
+            "type": "integer"
+          },
+          "readPermission": {
+            "type": "boolean"
+          },
+          "referenceGenome": {
+            "type": "string"
+          }
         }
       }
     },
-    "test_examples": [{"limit": 5}, {"limit": 10}]
+    "test_examples": [
+      {
+        "limit": 5
+      },
+      {
+        "limit": 10
+      }
+    ]
   },
   {
     "type": "CBioPortalRESTTool",
@@ -43,11 +86,23 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "study_id": {"type": "string", "description": "Cancer study ID (e.g., 'brca_tcga')"},
-        "gene_list": {"type": "string", "description": "Comma-separated gene symbols (e.g., 'BRCA1,BRCA2')"},
-        "sample_list_id": {"type": "string", "description": "Optional sample list ID. If not provided, uses all samples in the study."}
+        "study_id": {
+          "type": "string",
+          "description": "Cancer study ID (e.g., 'brca_tcga')"
+        },
+        "gene_list": {
+          "type": "string",
+          "description": "Comma-separated gene symbols (e.g., 'BRCA1,BRCA2')"
+        },
+        "sample_list_id": {
+          "type": "string",
+          "description": "Optional sample list ID. If not provided, uses all samples in the study."
+        }
       },
-      "required": ["study_id", "gene_list"]
+      "required": [
+        "study_id",
+        "gene_list"
+      ]
     },
     "fields": {
       "endpoint": "https://www.cbioportal.org/api/molecular-profiles/{study_id}_mutations/mutations/fetch",
@@ -59,35 +114,78 @@
       "items": {
         "type": "object",
         "properties": {
-          "molecularProfileId": {"type": "string"},
-          "sampleId": {"type": "string"},
-          "patientId": {"type": "string"},
-          "studyId": {"type": "string"},
-          "entrezGeneId": {"type": "integer"},
+          "molecularProfileId": {
+            "type": "string"
+          },
+          "sampleId": {
+            "type": "string"
+          },
+          "patientId": {
+            "type": "string"
+          },
+          "studyId": {
+            "type": "string"
+          },
+          "entrezGeneId": {
+            "type": "integer"
+          },
           "gene": {
             "type": "object",
             "properties": {
-              "entrezGeneId": {"type": "integer"},
-              "hugoGeneSymbol": {"type": "string"},
-              "type": {"type": "string"}
+              "entrezGeneId": {
+                "type": "integer"
+              },
+              "hugoGeneSymbol": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
             }
           },
-          "mutationType": {"type": "string"},
-          "proteinChange": {"type": "string"},
-          "mutationStatus": {"type": "string"},
-          "validationStatus": {"type": "string"},
-          "startPosition": {"type": "integer"},
-          "endPosition": {"type": "integer"},
-          "referenceAllele": {"type": "string"},
-          "variantAllele": {"type": "string"},
-          "keyword": {"type": "string"}
+          "mutationType": {
+            "type": "string"
+          },
+          "proteinChange": {
+            "type": "string"
+          },
+          "mutationStatus": {
+            "type": "string"
+          },
+          "validationStatus": {
+            "type": "string"
+          },
+          "startPosition": {
+            "type": "integer"
+          },
+          "endPosition": {
+            "type": "integer"
+          },
+          "referenceAllele": {
+            "type": "string"
+          },
+          "variantAllele": {
+            "type": "string"
+          },
+          "keyword": {
+            "type": "string"
+          }
         }
       }
     },
     "test_examples": [
-      {"study_id": "brca_tcga", "gene_list": "BRCA2"},
-      {"study_id": "brca_tcga", "gene_list": "BRCA1,BRCA2"},
-      {"study_id": "luad_tcga", "gene_list": "EGFR,KRAS"}
+      {
+        "study_id": "brca_tcga",
+        "gene_list": "BRCA2"
+      },
+      {
+        "study_id": "brca_tcga",
+        "gene_list": "BRCA1,BRCA2"
+      },
+      {
+        "study_id": "luad_tcga",
+        "gene_list": "EGFR,KRAS"
+      }
     ]
   },
   {
@@ -97,14 +195,44 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "study_id": {"type": "string", "description": "Cancer study ID (e.g., 'brca_tcga_pan_can_atlas_2018'). The discrete GISTIC profile is resolved automatically."},
-        "gene_list": {"type": "string", "description": "Comma-separated gene symbols (e.g., 'ERBB2' or 'TP53,ERBB2')"},
-        "gene": {"type": "string", "description": "Alias for gene_list: comma-separated gene symbols"},
-        "alteration_type": {"type": "string", "description": "CNA category filter: 'AMP' (amplification), 'GAIN', 'DIPLOID', 'HETLOSS' (shallow loss), 'HOMDEL' (deep deletion), or 'ALL' for every altered sample (default 'ALL').", "enum": ["AMP", "GAIN", "DIPLOID", "HETLOSS", "HOMDEL", "ALL"], "default": "ALL"},
-        "sample_list_id": {"type": "string", "description": "Optional sample list ID. Defaults to '{study_id}_all'."},
-        "molecular_profile_id": {"type": "string", "description": "Optional explicit GISTIC molecular profile ID (overrides auto-resolution)."}
+        "study_id": {
+          "type": "string",
+          "description": "Cancer study ID (e.g., 'brca_tcga_pan_can_atlas_2018'). The discrete GISTIC profile is resolved automatically."
+        },
+        "gene_list": {
+          "type": "string",
+          "description": "Comma-separated gene symbols (e.g., 'ERBB2' or 'TP53,ERBB2')"
+        },
+        "gene": {
+          "type": "string",
+          "description": "Alias for gene_list: comma-separated gene symbols"
+        },
+        "alteration_type": {
+          "type": "string",
+          "description": "CNA category filter: 'AMP' (amplification), 'GAIN', 'DIPLOID', 'HETLOSS' (shallow loss), 'HOMDEL' (deep deletion), or 'ALL' for every altered sample (default 'ALL').",
+          "enum": [
+            "AMP",
+            "GAIN",
+            "DIPLOID",
+            "HETLOSS",
+            "HOMDEL",
+            "ALL"
+          ],
+          "default": "ALL"
+        },
+        "sample_list_id": {
+          "type": "string",
+          "description": "Optional sample list ID. Defaults to '{study_id}_all'."
+        },
+        "molecular_profile_id": {
+          "type": "string",
+          "description": "Optional explicit GISTIC molecular profile ID (overrides auto-resolution)."
+        }
       },
-      "required": ["study_id", "gene_list"]
+      "required": [
+        "study_id",
+        "gene_list"
+      ]
     },
     "fields": {
       "endpoint": "https://www.cbioportal.org/api/molecular-profiles/{study_id}_gistic/discrete-copy-number/fetch",
@@ -114,44 +242,55 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "count": {"type": "integer"},
-            "molecular_profile_id": {"type": "string"},
-            "entrez_gene_ids": {"type": "array", "items": {"type": "integer"}},
-            "alteration_type": {"type": "string"},
-            "alteration_counts": {"type": "object"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "sampleId": {"type": "string"},
-                  "patientId": {"type": "string"},
-                  "entrezGeneId": {"type": "integer"},
-                  "studyId": {"type": "string"},
-                  "molecularProfileId": {"type": "string"},
-                  "alteration": {"type": "integer"}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "sampleId": {
+                "type": "string"
+              },
+              "patientId": {
+                "type": "string"
+              },
+              "entrezGeneId": {
+                "type": "integer"
+              },
+              "studyId": {
+                "type": "string"
+              },
+              "molecularProfileId": {
+                "type": "string"
+              },
+              "alteration": {
+                "type": "integer"
               }
             }
-          },
-          "required": ["status", "data", "count"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"study_id": "brca_tcga_pan_can_atlas_2018", "gene_list": "ERBB2", "alteration_type": "AMP"},
-      {"study_id": "brca_tcga_pan_can_atlas_2018", "gene_list": "TP53", "alteration_type": "ALL"}
+      {
+        "study_id": "brca_tcga_pan_can_atlas_2018",
+        "gene_list": "ERBB2",
+        "alteration_type": "AMP"
+      },
+      {
+        "study_id": "brca_tcga_pan_can_atlas_2018",
+        "gene_list": "TP53",
+        "alteration_type": "ALL"
+      }
     ]
   },
   {
@@ -161,9 +300,14 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "study_id": {"type": "string", "description": "Cancer study ID"}
+        "study_id": {
+          "type": "string",
+          "description": "Cancer study ID"
+        }
       },
-      "required": ["study_id"]
+      "required": [
+        "study_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.cbioportal.org/api/studies/{study_id}/molecular-profiles",
@@ -174,18 +318,34 @@
       "items": {
         "type": "object",
         "properties": {
-          "molecularProfileId": {"type": "string"},
-          "molecularAlterationType": {"type": "string"},
-          "datatype": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "showProfileInAnalysisTab": {"type": "boolean"}
+          "molecularProfileId": {
+            "type": "string"
+          },
+          "molecularAlterationType": {
+            "type": "string"
+          },
+          "datatype": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "showProfileInAnalysisTab": {
+            "type": "boolean"
+          }
         }
       }
     },
     "test_examples": [
-      {"study_id": "brca_tcga"},
-      {"study_id": "luad_tcga"}
+      {
+        "study_id": "brca_tcga"
+      },
+      {
+        "study_id": "luad_tcga"
+      }
     ]
   },
   {
@@ -195,10 +355,19 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "study_id": {"type": "string", "description": "Cancer study ID"},
-        "page_size": {"type": "integer", "default": 100, "description": "Number of samples to return"}
+        "study_id": {
+          "type": "string",
+          "description": "Cancer study ID"
+        },
+        "page_size": {
+          "type": "integer",
+          "default": 100,
+          "description": "Number of samples to return"
+        }
       },
-      "required": ["study_id"]
+      "required": [
+        "study_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.cbioportal.org/api/studies/{study_id}/samples?pageSize={page_size}",
@@ -209,16 +378,30 @@
       "items": {
         "type": "object",
         "properties": {
-          "sampleId": {"type": "string"},
-          "sampleType": {"type": "string"},
-          "patientId": {"type": "string"},
-          "studyId": {"type": "string"}
+          "sampleId": {
+            "type": "string"
+          },
+          "sampleType": {
+            "type": "string"
+          },
+          "patientId": {
+            "type": "string"
+          },
+          "studyId": {
+            "type": "string"
+          }
         }
       }
     },
     "test_examples": [
-      {"study_id": "brca_tcga", "page_size": 10},
-      {"study_id": "luad_tcga", "page_size": 20}
+      {
+        "study_id": "brca_tcga",
+        "page_size": 10
+      },
+      {
+        "study_id": "luad_tcga",
+        "page_size": 20
+      }
     ]
   },
   {
@@ -228,10 +411,19 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "study_id": {"type": "string", "description": "Cancer study ID"},
-        "page_size": {"type": "integer", "default": 100, "description": "Number of patients to return"}
+        "study_id": {
+          "type": "string",
+          "description": "Cancer study ID"
+        },
+        "page_size": {
+          "type": "integer",
+          "default": 100,
+          "description": "Number of patients to return"
+        }
       },
-      "required": ["study_id"]
+      "required": [
+        "study_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.cbioportal.org/api/studies/{study_id}/patients?pageSize={page_size}",
@@ -242,13 +434,20 @@
       "items": {
         "type": "object",
         "properties": {
-          "patientId": {"type": "string"},
-          "studyId": {"type": "string"}
+          "patientId": {
+            "type": "string"
+          },
+          "studyId": {
+            "type": "string"
+          }
         }
       }
     },
     "test_examples": [
-      {"study_id": "brca_tcga", "page_size": 10}
+      {
+        "study_id": "brca_tcga",
+        "page_size": 10
+      }
     ]
   },
   {
@@ -258,8 +457,14 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "keyword": {"type": "string", "description": "Gene symbol or alias to search for (e.g., 'BRCA1', 'TP53')"},
-        "query": {"type": "string", "description": "Alias for keyword: gene symbol or alias to search for"}
+        "keyword": {
+          "type": "string",
+          "description": "Gene symbol or alias to search for (e.g., 'BRCA1', 'TP53')"
+        },
+        "query": {
+          "type": "string",
+          "description": "Alias for keyword: gene symbol or alias to search for"
+        }
       }
     },
     "fields": {
@@ -271,17 +476,29 @@
       "items": {
         "type": "object",
         "properties": {
-          "entrezGeneId": {"type": "integer"},
-          "hugoGeneSymbol": {"type": "string"},
-          "type": {"type": "string"}
+          "entrezGeneId": {
+            "type": "integer"
+          },
+          "hugoGeneSymbol": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
         }
       }
     },
     "test_examples": [
-      {"keyword": "BRCA2"},
-      {"keyword": "TP53"}
+      {
+        "keyword": "BRCA2"
+      },
+      {
+        "keyword": "TP53"
+      }
     ],
-    "aliases": ["cBioPortal_search"]
+    "aliases": [
+      "cBioPortal_search"
+    ]
   },
   {
     "type": "CBioPortalRESTTool",
@@ -300,15 +517,27 @@
       "items": {
         "type": "object",
         "properties": {
-          "cancerTypeId": {"type": "string"},
-          "name": {"type": "string"},
-          "dedicatedColor": {"type": "string"},
-          "shortName": {"type": "string"},
-          "parent": {"type": "string"}
+          "cancerTypeId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "dedicatedColor": {
+            "type": "string"
+          },
+          "shortName": {
+            "type": "string"
+          },
+          "parent": {
+            "type": "string"
+          }
         }
       }
     },
-    "test_examples": [{}]
+    "test_examples": [
+      {}
+    ]
   },
   {
     "type": "CBioPortalRESTTool",
@@ -317,7 +546,11 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "page_size": {"type": "integer", "default": 50, "description": "Number of panels to return"}
+        "page_size": {
+          "type": "integer",
+          "default": 50,
+          "description": "Number of panels to return"
+        }
       }
     },
     "fields": {
@@ -329,12 +562,20 @@
       "items": {
         "type": "object",
         "properties": {
-          "genePanelId": {"type": "string"},
-          "description": {"type": "string"}
+          "genePanelId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
         }
       }
     },
-    "test_examples": [{"page_size": 10}]
+    "test_examples": [
+      {
+        "page_size": 10
+      }
+    ]
   },
   {
     "type": "CBioPortalRESTTool",
@@ -343,9 +584,14 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "gene_panel_id": {"type": "string", "description": "Gene panel ID (e.g., 'IMPACT468')"}
+        "gene_panel_id": {
+          "type": "string",
+          "description": "Gene panel ID (e.g., 'IMPACT468')"
+        }
       },
-      "required": ["gene_panel_id"]
+      "required": [
+        "gene_panel_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.cbioportal.org/api/gene-panels/{gene_panel_id}",
@@ -354,21 +600,36 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "genePanelId": {"type": "string"},
-        "description": {"type": "string"},
+        "genePanelId": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
         "genes": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "entrezGeneId": {"type": "integer"},
-              "hugoGeneSymbol": {"type": "string"}
+              "entrezGeneId": {
+                "type": "integer"
+              },
+              "hugoGeneSymbol": {
+                "type": "string"
+              }
             }
           }
         }
       }
     },
-    "test_examples": [{"gene_panel_id": "IMPACT468"}, {"gene_panel_id": "IMPACT341"}]
+    "test_examples": [
+      {
+        "gene_panel_id": "IMPACT468"
+      },
+      {
+        "gene_panel_id": "IMPACT341"
+      }
+    ]
   },
   {
     "type": "CBioPortalRESTTool",
@@ -377,9 +638,14 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "study_id": {"type": "string", "description": "Cancer study ID (e.g., 'brca_tcga')"}
+        "study_id": {
+          "type": "string",
+          "description": "Cancer study ID (e.g., 'brca_tcga')"
+        }
       },
-      "required": ["study_id"]
+      "required": [
+        "study_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.cbioportal.org/api/studies/{study_id}/clinical-attributes",
@@ -390,16 +656,35 @@
       "items": {
         "type": "object",
         "properties": {
-          "clinicalAttributeId": {"type": "string"},
-          "displayName": {"type": "string"},
-          "description": {"type": "string"},
-          "datatype": {"type": "string"},
-          "patientAttribute": {"type": "boolean"},
-          "priority": {"type": "string"}
+          "clinicalAttributeId": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "datatype": {
+            "type": "string"
+          },
+          "patientAttribute": {
+            "type": "boolean"
+          },
+          "priority": {
+            "type": "string"
+          }
         }
       }
     },
-    "test_examples": [{"study_id": "brca_tcga"}, {"study_id": "luad_tcga"}]
+    "test_examples": [
+      {
+        "study_id": "brca_tcga"
+      },
+      {
+        "study_id": "luad_tcga"
+      }
+    ]
   },
   {
     "type": "CBioPortalRESTTool",
@@ -408,11 +693,23 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "study_id": {"type": "string", "description": "Cancer study ID"},
-        "clinical_attribute_id": {"type": "string", "description": "Optional clinical attribute ID to filter by"},
-        "page_size": {"type": "integer", "default": 100, "description": "Number of records to return"}
+        "study_id": {
+          "type": "string",
+          "description": "Cancer study ID"
+        },
+        "clinical_attribute_id": {
+          "type": "string",
+          "description": "Optional clinical attribute ID to filter by"
+        },
+        "page_size": {
+          "type": "integer",
+          "default": 100,
+          "description": "Number of records to return"
+        }
       },
-      "required": ["study_id"]
+      "required": [
+        "study_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.cbioportal.org/api/studies/{study_id}/clinical-data?pageSize={page_size}&clinicalDataType=SAMPLE",
@@ -423,17 +720,33 @@
       "items": {
         "type": "object",
         "properties": {
-          "clinicalAttributeId": {"type": "string"},
-          "value": {"type": "string"},
-          "sampleId": {"type": "string"},
-          "patientId": {"type": "string"},
-          "studyId": {"type": "string"}
+          "clinicalAttributeId": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "sampleId": {
+            "type": "string"
+          },
+          "patientId": {
+            "type": "string"
+          },
+          "studyId": {
+            "type": "string"
+          }
         }
       }
     },
     "test_examples": [
-      {"study_id": "brca_tcga", "page_size": 50},
-      {"study_id": "luad_tcga", "page_size": 50}
+      {
+        "study_id": "brca_tcga",
+        "page_size": 50
+      },
+      {
+        "study_id": "luad_tcga",
+        "page_size": 50
+      }
     ]
   },
   {
@@ -443,9 +756,14 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "study_id": {"type": "string", "description": "Cancer study ID"}
+        "study_id": {
+          "type": "string",
+          "description": "Cancer study ID"
+        }
       },
-      "required": ["study_id"]
+      "required": [
+        "study_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.cbioportal.org/api/studies/{study_id}/sample-lists",
@@ -456,16 +774,35 @@
       "items": {
         "type": "object",
         "properties": {
-          "sampleListId": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "category": {"type": "string"},
-          "sampleCount": {"type": "integer"},
-          "studyId": {"type": "string"}
+          "sampleListId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "sampleCount": {
+            "type": "integer"
+          },
+          "studyId": {
+            "type": "string"
+          }
         }
       }
     },
-    "test_examples": [{"study_id": "brca_tcga"}, {"study_id": "luad_tcga"}]
+    "test_examples": [
+      {
+        "study_id": "brca_tcga"
+      },
+      {
+        "study_id": "luad_tcga"
+      }
+    ]
   },
   {
     "type": "CBioPortalRESTTool",
@@ -474,9 +811,14 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "entrez_gene_id": {"type": "integer", "description": "Entrez Gene ID (e.g., 672 for BRCA1)"}
+        "entrez_gene_id": {
+          "type": "integer",
+          "description": "Entrez Gene ID (e.g., 672 for BRCA1)"
+        }
       },
-      "required": ["entrez_gene_id"]
+      "required": [
+        "entrez_gene_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.cbioportal.org/api/genes/{entrez_gene_id}",
@@ -485,13 +827,30 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "entrezGeneId": {"type": "integer"},
-        "hugoGeneSymbol": {"type": "string"},
-        "type": {"type": "string"},
-        "cytoband": {"type": "string"},
-        "length": {"type": "integer"}
+        "entrezGeneId": {
+          "type": "integer"
+        },
+        "hugoGeneSymbol": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "cytoband": {
+          "type": "string"
+        },
+        "length": {
+          "type": "integer"
+        }
       }
     },
-    "test_examples": [{"entrez_gene_id": 672}, {"entrez_gene_id": 7157}]
+    "test_examples": [
+      {
+        "entrez_gene_id": 672
+      },
+      {
+        "entrez_gene_id": 7157
+      }
+    ]
   }
 ]

--- a/src/tooluniverse/data/cdc_tools.json
+++ b/src/tooluniverse/data/cdc_tools.json
@@ -34,975 +34,790 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "assetType": {
+                "type": "string"
+              },
+              "averageRating": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "blobFilename": {
+                "type": "string"
+              },
+              "blobFileSize": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "blobId": {
+                "type": "string"
+              },
+              "blobMimeType": {
+                "type": "string"
+              },
+              "category": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "description": {
+                "type": "string"
+              },
+              "diciBackend": {
+                "type": "boolean"
+              },
+              "displayType": {
+                "type": "string"
+              },
+              "downloadCount": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "hideFromCatalog": {
+                "type": "boolean"
+              },
+              "hideFromDataJson": {
+                "type": "boolean"
+              },
+              "locked": {
+                "type": "boolean"
+              },
+              "newBackend": {
+                "type": "boolean"
+              },
+              "numberOfComments": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "oid": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "provenance": {
+                "type": "string"
+              },
+              "publicationAppendEnabled": {
+                "type": "boolean"
+              },
+              "publicationDate": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "publicationGroup": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "publicationStage": {
+                "type": "string"
+              },
+              "rowsUpdatedAt": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "tableId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "totalTimesRated": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "viewCount": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "viewLastModified": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "viewType": {
+                "type": "string"
+              },
+              "approvals": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "reviewedAt": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "reviewedAutomatically": {
+                      "type": "boolean"
+                    },
+                    "state": {
+                      "type": "string"
+                    },
+                    "submissionId": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "submissionObject": {
+                      "type": "string"
+                    },
+                    "submissionOutcome": {
+                      "type": "string"
+                    },
+                    "submittedAt": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "targetAudience": {
+                      "type": "string"
+                    },
+                    "workflowId": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "submissionDetails": {
+                      "type": "object",
+                      "properties": {
+                        "permissionType": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "submissionOutcomeApplication": {
+                      "type": "object",
+                      "properties": {
+                        "endedAt": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "failureCount": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "startedAt": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "status": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "submitter": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "displayName": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "clientContext": {
                 "type": "object",
                 "properties": {
-                  "id": {
-                    "type": "string"
+                  "clientContextVariables": {
+                    "type": "array"
                   },
-                  "name": {
-                    "type": "string"
+                  "inheritedVariables": {
+                    "type": "object"
+                  }
+                }
+              },
+              "grants": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "inherited": {
+                      "type": "boolean"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "flags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "metadata": {
+                "type": "object",
+                "properties": {
+                  "custom_fields": {
+                    "type": "object",
+                    "properties": {
+                      "Common Core": {
+                        "type": "object",
+                        "properties": {
+                          "Contact Email": {
+                            "type": "string"
+                          },
+                          "Contact Name": {
+                            "type": "string"
+                          },
+                          "Program Code": {
+                            "type": "string"
+                          },
+                          "Bureau Code": {
+                            "type": "string"
+                          },
+                          "Homepage": {
+                            "type": "string"
+                          },
+                          "Update Frequency": {
+                            "type": "string"
+                          },
+                          "Temporal Applicability": {
+                            "type": "string"
+                          },
+                          "Collection": {
+                            "type": "string"
+                          },
+                          "Geographic Coverage": {
+                            "type": "string"
+                          },
+                          "Access Level Comment": {
+                            "type": "string"
+                          },
+                          "Publisher": {
+                            "type": "string"
+                          },
+                          "Public Access Level": {
+                            "type": "string"
+                          },
+                          "Language": {
+                            "type": "string"
+                          },
+                          "Described By": {
+                            "type": "string"
+                          },
+                          "References": {
+                            "type": "string"
+                          },
+                          "Issued": {
+                            "type": "string"
+                          },
+                          "Data Standard": {
+                            "type": "string"
+                          },
+                          "Primary IT Investment UII": {
+                            "type": "string"
+                          },
+                          "System of Records": {
+                            "type": "string"
+                          },
+                          "IsQualityData": {
+                            "type": "string"
+                          },
+                          "License": {
+                            "type": "string"
+                          },
+                          "Footnotes": {
+                            "type": "string"
+                          },
+                          "Suggested Citation": {
+                            "type": "string"
+                          },
+                          "test": {
+                            "type": "string"
+                          },
+                          "Is Quality Data": {
+                            "type": "string"
+                          },
+                          "Theme": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "Data Quality": {
+                        "type": "object",
+                        "properties": {
+                          "Footnotes": {
+                            "type": "string"
+                          },
+                          "Suggested Citation": {
+                            "type": "string"
+                          },
+                          "Geospatial Resolution": {
+                            "type": "string"
+                          },
+                          "Geographic Unit of Analysis": {
+                            "type": "string"
+                          },
+                          "Analytical Methods Reference": {
+                            "type": "string"
+                          },
+                          "Geographic Coverage": {
+                            "type": "string"
+                          },
+                          "Update Frequency": {
+                            "type": "string"
+                          },
+                          "Temporal Applicability": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "Dataset Information": {
+                        "type": "object",
+                        "properties": {
+                          "Glossary/Methodology": {
+                            "type": "string"
+                          },
+                          "Glossary/Methodology ": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
                   },
-                  "assetType": {
-                    "type": "string"
+                  "availableDisplayTypes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   },
-                  "averageRating": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "blobFilename": {
-                    "type": "string"
-                  },
-                  "blobFileSize": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "blobId": {
-                    "type": "string"
-                  },
-                  "blobMimeType": {
-                    "type": "string"
-                  },
-                  "category": {
-                    "type": "string"
-                  },
-                  "createdAt": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "diciBackend": {
-                    "type": "boolean"
-                  },
-                  "displayType": {
-                    "type": "string"
-                  },
-                  "downloadCount": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "hideFromCatalog": {
-                    "type": "boolean"
-                  },
-                  "hideFromDataJson": {
-                    "type": "boolean"
-                  },
-                  "locked": {
-                    "type": "boolean"
-                  },
-                  "newBackend": {
-                    "type": "boolean"
-                  },
-                  "numberOfComments": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "oid": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "provenance": {
-                    "type": "string"
-                  },
-                  "publicationAppendEnabled": {
-                    "type": "boolean"
-                  },
-                  "publicationDate": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "publicationGroup": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "publicationStage": {
-                    "type": "string"
-                  },
-                  "rowsUpdatedAt": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "tableId": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "totalTimesRated": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "viewCount": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "viewLastModified": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "viewType": {
-                    "type": "string"
-                  },
-                  "approvals": {
+                  "attachments": {
                     "type": "array",
                     "items": {
                       "type": "object",
                       "properties": {
-                        "reviewedAt": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "reviewedAutomatically": {
-                          "type": "boolean"
-                        },
-                        "state": {
+                        "filename": {
                           "type": "string"
                         },
-                        "submissionId": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "submissionObject": {
+                        "assetId": {
                           "type": "string"
                         },
-                        "submissionOutcome": {
+                        "name": {
                           "type": "string"
                         },
-                        "submittedAt": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "targetAudience": {
+                        "blobId": {
                           "type": "string"
-                        },
-                        "workflowId": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "submissionDetails": {
-                          "type": "object",
-                          "properties": {
-                            "permissionType": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "submissionOutcomeApplication": {
-                          "type": "object",
-                          "properties": {
-                            "endedAt": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "failureCount": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "startedAt": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "status": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "submitter": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "displayName": {
-                              "type": "string"
-                            }
-                          }
                         }
                       }
                     }
                   },
-                  "clientContext": {
-                    "type": "object",
-                    "properties": {
-                      "clientContextVariables": {
-                        "type": "array"
-                      },
-                      "inheritedVariables": {
-                        "type": "object"
-                      }
-                    }
-                  },
-                  "grants": {
+                  "additionalAccessPoints": {
                     "type": "array",
                     "items": {
                       "type": "object",
                       "properties": {
-                        "inherited": {
-                          "type": "boolean"
+                        "urls": {
+                          "type": "object",
+                          "properties": {
+                            "App Process": {
+                              "type": "string"
+                            },
+                            "zip": {
+                              "type": "string"
+                            },
+                            "sas format txt": {
+                              "type": "string"
+                            },
+                            "sas input txt": {
+                              "type": "string"
+                            },
+                            "dct": {
+                              "type": "string"
+                            },
+                            "readme txt": {
+                              "type": "string"
+                            },
+                            "sas label txt": {
+                              "type": "string"
+                            },
+                            "txt": {
+                              "type": "string"
+                            },
+                            "do": {
+                              "type": "string"
+                            },
+                            "sps": {
+                              "type": "string"
+                            },
+                            "SAS zip": {
+                              "type": "string"
+                            },
+                            "SPSS zip": {
+                              "type": "string"
+                            },
+                            "STATA zip": {
+                              "type": "string"
+                            },
+                            "html": {
+                              "type": "string"
+                            },
+                            "htm": {
+                              "type": "string"
+                            },
+                            "rds": {
+                              "type": "string"
+                            },
+                            "dta": {
+                              "type": "string"
+                            },
+                            "sas7bdat": {
+                              "type": "string"
+                            },
+                            "R readme file": {
+                              "type": "string"
+                            },
+                            "STATA input statements": {
+                              "type": "string"
+                            },
+                            "sas input statements": {
+                              "type": "string"
+                            },
+                            "stata input statements": {
+                              "type": "string"
+                            },
+                            "dta ": {
+                              "type": "string"
+                            },
+                            "R datafile (IP)": {
+                              "type": "string"
+                            },
+                            "sas input statements (IP)": {
+                              "type": "string"
+                            },
+                            "stata datafile (IP)": {
+                              "type": "string"
+                            },
+                            "sas datafile (IP)": {
+                              "type": "string"
+                            },
+                            "R readme file (IP)": {
+                              "type": "string"
+                            },
+                            "stata input statements (IP)": {
+                              "type": "string"
+                            },
+                            "r datafile (IP)": {
+                              "type": "string"
+                            },
+                            "stata datafile (ED)": {
+                              "type": "string"
+                            },
+                            "sas datafile (ED)": {
+                              "type": "string"
+                            },
+                            "R readme file (ED)": {
+                              "type": "string"
+                            },
+                            "stata input statements (ED)": {
+                              "type": "string"
+                            },
+                            "sas input statement (ED)": {
+                              "type": "string"
+                            },
+                            "r datafile (ED)": {
+                              "type": "string"
+                            },
+                            "r datafile": {
+                              "type": "string"
+                            },
+                            "sas input statements (ED)": {
+                              "type": "string"
+                            },
+                            "application": {
+                              "type": "string"
+                            },
+                            ".ZIP/.exe data files": {
+                              "type": "string"
+                            },
+                            "Questionnaire": {
+                              "type": "string"
+                            },
+                            "Documentation": {
+                              "type": "string"
+                            },
+                            "readme": {
+                              "type": "string"
+                            },
+                            "documentation": {
+                              "type": "string"
+                            },
+                            "sas format": {
+                              "type": "string"
+                            },
+                            "R datafile": {
+                              "type": "string"
+                            },
+                            ".exe data files": {
+                              "type": "string"
+                            },
+                            ".exe/.zip data files": {
+                              "type": "string"
+                            },
+                            ".txt": {
+                              "type": "string"
+                            },
+                            "HTML": {
+                              "type": "string"
+                            }
+                          }
                         },
-                        "type": {
+                        "description": {
                           "type": "string"
                         },
-                        "flags": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
+                        "describedBy": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "accessPoints": {
+                    "type": "object",
+                    "properties": {
+                      "App Process": {
+                        "type": "string"
+                      },
+                      "zip": {
+                        "type": "string"
+                      },
+                      "sas format txt": {
+                        "type": "string"
+                      },
+                      "sas input txt": {
+                        "type": "string"
+                      },
+                      "dct": {
+                        "type": "string"
+                      },
+                      "readme txt": {
+                        "type": "string"
+                      },
+                      "sas label txt": {
+                        "type": "string"
+                      },
+                      "SAS zip": {
+                        "type": "string"
+                      },
+                      "SPSS zip": {
+                        "type": "string"
+                      },
+                      "STATA zip": {
+                        "type": "string"
+                      },
+                      "html": {
+                        "type": "string"
+                      },
+                      "htm": {
+                        "type": "string"
+                      },
+                      "rds": {
+                        "type": "string"
+                      },
+                      "dta": {
+                        "type": "string"
+                      },
+                      "sas7bdat": {
+                        "type": "string"
+                      },
+                      "R readme file": {
+                        "type": "string"
+                      },
+                      "STATA input statements": {
+                        "type": "string"
+                      },
+                      "sas input statements": {
+                        "type": "string"
+                      },
+                      "R datafile (IP)": {
+                        "type": "string"
+                      },
+                      "sas input statements (IP)": {
+                        "type": "string"
+                      },
+                      "stata datafile (IP)": {
+                        "type": "string"
+                      },
+                      "sas datafile (IP)": {
+                        "type": "string"
+                      },
+                      "R readme file (IP)": {
+                        "type": "string"
+                      },
+                      "stata input statements (IP)": {
+                        "type": "string"
+                      },
+                      "application": {
+                        "type": "string"
+                      },
+                      ".ZIP/.exe data files": {
+                        "type": "string"
+                      },
+                      "Questionnaire": {
+                        "type": "string"
+                      },
+                      "Documentation": {
+                        "type": "string"
+                      },
+                      "readme": {
+                        "type": "string"
+                      },
+                      ".exe data files": {
+                        "type": "string"
+                      },
+                      ".txt": {
+                        "type": "string"
+                      },
+                      "HTML": {
+                        "type": "string"
+                      },
+                      "map-server": {
+                        "type": "string"
+                      },
+                      "application/html": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "rowLabel": {
+                    "type": "string"
+                  },
+                  "jsonQuery": {
+                    "type": "object",
+                    "properties": {
+                      "order": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "columnFieldName": {
+                              "type": "string"
+                            },
+                            "ascending": {
+                              "type": "boolean"
+                            }
                           }
                         }
                       }
                     }
                   },
-                  "metadata": {
+                  "rowIdentifier": {
+                    "type": [
+                      "integer",
+                      "number",
+                      "string"
+                    ]
+                  },
+                  "renderTypeConfig": {
                     "type": "object",
                     "properties": {
-                      "custom_fields": {
+                      "visible": {
                         "type": "object",
                         "properties": {
-                          "Common Core": {
-                            "type": "object",
-                            "properties": {
-                              "Contact Email": {
-                                "type": "string"
-                              },
-                              "Contact Name": {
-                                "type": "string"
-                              },
-                              "Program Code": {
-                                "type": "string"
-                              },
-                              "Bureau Code": {
-                                "type": "string"
-                              },
-                              "Homepage": {
-                                "type": "string"
-                              },
-                              "Update Frequency": {
-                                "type": "string"
-                              },
-                              "Temporal Applicability": {
-                                "type": "string"
-                              },
-                              "Collection": {
-                                "type": "string"
-                              },
-                              "Geographic Coverage": {
-                                "type": "string"
-                              },
-                              "Access Level Comment": {
-                                "type": "string"
-                              },
-                              "Publisher": {
-                                "type": "string"
-                              },
-                              "Public Access Level": {
-                                "type": "string"
-                              },
-                              "Language": {
-                                "type": "string"
-                              },
-                              "Described By": {
-                                "type": "string"
-                              },
-                              "References": {
-                                "type": "string"
-                              },
-                              "Issued": {
-                                "type": "string"
-                              },
-                              "Data Standard": {
-                                "type": "string"
-                              },
-                              "Primary IT Investment UII": {
-                                "type": "string"
-                              },
-                              "System of Records": {
-                                "type": "string"
-                              },
-                              "IsQualityData": {
-                                "type": "string"
-                              },
-                              "License": {
-                                "type": "string"
-                              },
-                              "Footnotes": {
-                                "type": "string"
-                              },
-                              "Suggested Citation": {
-                                "type": "string"
-                              },
-                              "test": {
-                                "type": "string"
-                              },
-                              "Is Quality Data": {
-                                "type": "string"
-                              },
-                              "Theme": {
-                                "type": "string"
-                              }
-                            }
+                          "table": {
+                            "type": "boolean"
                           },
-                          "Data Quality": {
-                            "type": "object",
-                            "properties": {
-                              "Footnotes": {
-                                "type": "string"
-                              },
-                              "Suggested Citation": {
-                                "type": "string"
-                              },
-                              "Geospatial Resolution": {
-                                "type": "string"
-                              },
-                              "Geographic Unit of Analysis": {
-                                "type": "string"
-                              },
-                              "Analytical Methods Reference": {
-                                "type": "string"
-                              },
-                              "Geographic Coverage": {
-                                "type": "string"
-                              },
-                              "Update Frequency": {
-                                "type": "string"
-                              },
-                              "Temporal Applicability": {
-                                "type": "string"
-                              }
-                            }
+                          "story": {
+                            "type": "boolean"
                           },
-                          "Dataset Information": {
-                            "type": "object",
-                            "properties": {
-                              "Glossary/Methodology": {
-                                "type": "string"
-                              },
-                              "Glossary/Methodology ": {
-                                "type": "string"
-                              }
-                            }
+                          "blob": {
+                            "type": "boolean"
+                          },
+                          "fatrow": {
+                            "type": "boolean"
+                          },
+                          "href": {
+                            "type": "boolean"
                           }
                         }
-                      },
-                      "availableDisplayTypes": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "attachments": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "filename": {
-                              "type": "string"
-                            },
-                            "assetId": {
-                              "type": "string"
-                            },
-                            "name": {
-                              "type": "string"
-                            },
-                            "blobId": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "additionalAccessPoints": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "urls": {
-                              "type": "object",
-                              "properties": {
-                                "App Process": {
-                                  "type": "string"
-                                },
-                                "zip": {
-                                  "type": "string"
-                                },
-                                "sas format txt": {
-                                  "type": "string"
-                                },
-                                "sas input txt": {
-                                  "type": "string"
-                                },
-                                "dct": {
-                                  "type": "string"
-                                },
-                                "readme txt": {
-                                  "type": "string"
-                                },
-                                "sas label txt": {
-                                  "type": "string"
-                                },
-                                "txt": {
-                                  "type": "string"
-                                },
-                                "do": {
-                                  "type": "string"
-                                },
-                                "sps": {
-                                  "type": "string"
-                                },
-                                "SAS zip": {
-                                  "type": "string"
-                                },
-                                "SPSS zip": {
-                                  "type": "string"
-                                },
-                                "STATA zip": {
-                                  "type": "string"
-                                },
-                                "html": {
-                                  "type": "string"
-                                },
-                                "htm": {
-                                  "type": "string"
-                                },
-                                "rds": {
-                                  "type": "string"
-                                },
-                                "dta": {
-                                  "type": "string"
-                                },
-                                "sas7bdat": {
-                                  "type": "string"
-                                },
-                                "R readme file": {
-                                  "type": "string"
-                                },
-                                "STATA input statements": {
-                                  "type": "string"
-                                },
-                                "sas input statements": {
-                                  "type": "string"
-                                },
-                                "stata input statements": {
-                                  "type": "string"
-                                },
-                                "dta ": {
-                                  "type": "string"
-                                },
-                                "R datafile (IP)": {
-                                  "type": "string"
-                                },
-                                "sas input statements (IP)": {
-                                  "type": "string"
-                                },
-                                "stata datafile (IP)": {
-                                  "type": "string"
-                                },
-                                "sas datafile (IP)": {
-                                  "type": "string"
-                                },
-                                "R readme file (IP)": {
-                                  "type": "string"
-                                },
-                                "stata input statements (IP)": {
-                                  "type": "string"
-                                },
-                                "r datafile (IP)": {
-                                  "type": "string"
-                                },
-                                "stata datafile (ED)": {
-                                  "type": "string"
-                                },
-                                "sas datafile (ED)": {
-                                  "type": "string"
-                                },
-                                "R readme file (ED)": {
-                                  "type": "string"
-                                },
-                                "stata input statements (ED)": {
-                                  "type": "string"
-                                },
-                                "sas input statement (ED)": {
-                                  "type": "string"
-                                },
-                                "r datafile (ED)": {
-                                  "type": "string"
-                                },
-                                "r datafile": {
-                                  "type": "string"
-                                },
-                                "sas input statements (ED)": {
-                                  "type": "string"
-                                },
-                                "application": {
-                                  "type": "string"
-                                },
-                                ".ZIP/.exe data files": {
-                                  "type": "string"
-                                },
-                                "Questionnaire": {
-                                  "type": "string"
-                                },
-                                "Documentation": {
-                                  "type": "string"
-                                },
-                                "readme": {
-                                  "type": "string"
-                                },
-                                "documentation": {
-                                  "type": "string"
-                                },
-                                "sas format": {
-                                  "type": "string"
-                                },
-                                "R datafile": {
-                                  "type": "string"
-                                },
-                                ".exe data files": {
-                                  "type": "string"
-                                },
-                                ".exe/.zip data files": {
-                                  "type": "string"
-                                },
-                                ".txt": {
-                                  "type": "string"
-                                },
-                                "HTML": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "description": {
-                              "type": "string"
-                            },
-                            "describedBy": {
-                              "type": "string"
-                            },
-                            "title": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "accessPoints": {
-                        "type": "object",
-                        "properties": {
-                          "App Process": {
-                            "type": "string"
-                          },
-                          "zip": {
-                            "type": "string"
-                          },
-                          "sas format txt": {
-                            "type": "string"
-                          },
-                          "sas input txt": {
-                            "type": "string"
-                          },
-                          "dct": {
-                            "type": "string"
-                          },
-                          "readme txt": {
-                            "type": "string"
-                          },
-                          "sas label txt": {
-                            "type": "string"
-                          },
-                          "SAS zip": {
-                            "type": "string"
-                          },
-                          "SPSS zip": {
-                            "type": "string"
-                          },
-                          "STATA zip": {
-                            "type": "string"
-                          },
-                          "html": {
-                            "type": "string"
-                          },
-                          "htm": {
-                            "type": "string"
-                          },
-                          "rds": {
-                            "type": "string"
-                          },
-                          "dta": {
-                            "type": "string"
-                          },
-                          "sas7bdat": {
-                            "type": "string"
-                          },
-                          "R readme file": {
-                            "type": "string"
-                          },
-                          "STATA input statements": {
-                            "type": "string"
-                          },
-                          "sas input statements": {
-                            "type": "string"
-                          },
-                          "R datafile (IP)": {
-                            "type": "string"
-                          },
-                          "sas input statements (IP)": {
-                            "type": "string"
-                          },
-                          "stata datafile (IP)": {
-                            "type": "string"
-                          },
-                          "sas datafile (IP)": {
-                            "type": "string"
-                          },
-                          "R readme file (IP)": {
-                            "type": "string"
-                          },
-                          "stata input statements (IP)": {
-                            "type": "string"
-                          },
-                          "application": {
-                            "type": "string"
-                          },
-                          ".ZIP/.exe data files": {
-                            "type": "string"
-                          },
-                          "Questionnaire": {
-                            "type": "string"
-                          },
-                          "Documentation": {
-                            "type": "string"
-                          },
-                          "readme": {
-                            "type": "string"
-                          },
-                          ".exe data files": {
-                            "type": "string"
-                          },
-                          ".txt": {
-                            "type": "string"
-                          },
-                          "HTML": {
-                            "type": "string"
-                          },
-                          "map-server": {
-                            "type": "string"
-                          },
-                          "application/html": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "rowLabel": {
+                      }
+                    }
+                  },
+                  "isStorytellerAsset": {
+                    "type": "boolean"
+                  },
+                  "initialized": {
+                    "type": "boolean"
+                  },
+                  "tileConfig": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
                         "type": "string"
                       },
-                      "jsonQuery": {
-                        "type": "object",
-                        "properties": {
-                          "order": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "columnFieldName": {
-                                  "type": "string"
-                                },
-                                "ascending": {
-                                  "type": "boolean"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "rowIdentifier": {
-                        "type": [
-                          "integer",
-                          "number",
-                          "string"
-                        ]
-                      },
-                      "renderTypeConfig": {
-                        "type": "object",
-                        "properties": {
-                          "visible": {
-                            "type": "object",
-                            "properties": {
-                              "table": {
-                                "type": "boolean"
-                              },
-                              "story": {
-                                "type": "boolean"
-                              },
-                              "blob": {
-                                "type": "boolean"
-                              },
-                              "fatrow": {
-                                "type": "boolean"
-                              },
-                              "href": {
-                                "type": "boolean"
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "isStorytellerAsset": {
-                        "type": "boolean"
-                      },
-                      "initialized": {
-                        "type": "boolean"
-                      },
-                      "tileConfig": {
-                        "type": "object",
-                        "properties": {
-                          "description": {
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "arcgis_connection": {
-                        "type": "object",
-                        "properties": {
-                          "url": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "filterCondition": {
-                        "type": "object",
-                        "properties": {
-                          "metadata": {
-                            "type": "object",
-                            "properties": {
-                              "advanced": {
-                                "type": "boolean"
-                              },
-                              "unifiedVersion": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              }
-                            }
-                          },
-                          "children": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "metadata": {
-                                  "type": "object",
-                                  "properties": {
-                                    "tableColumnId": {
-                                      "type": "object",
-                                      "properties": {
-                                        "18597387": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "18588514": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "18305543": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "18305385": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "17071854": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "17069086": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "16385308": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "16385114": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "15821117": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "15820938": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "15425966": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "15425931": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "14919580": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "14768094": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "1595946": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "1595912": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "1595906": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "1553919": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        }
-                                      }
-                                    },
-                                    "operator": {
-                                      "type": "string"
-                                    },
-                                    "customValues": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": [
-                                            "integer",
-                                            "number",
-                                            "string"
-                                          ]
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "type": {
-                                  "type": "string"
-                                },
-                                "value": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          },
-                          "type": {
-                            "type": "string"
-                          },
-                          "value": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "rdfSubject": {
+                      "title": {
                         "type": "string"
-                      },
-                      "rdfClass": {
+                      }
+                    }
+                  },
+                  "arcgis_connection": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
                         "type": "string"
-                      },
-                      "customRdfClass": {
-                        "type": "string"
-                      },
-                      "sidebar": {
+                      }
+                    }
+                  },
+                  "filterCondition": {
+                    "type": "object",
+                    "properties": {
+                      "metadata": {
                         "type": "object",
                         "properties": {
-                          "width": {
+                          "advanced": {
+                            "type": "boolean"
+                          },
+                          "unifiedVersion": {
                             "type": [
                               "integer",
                               "number"
@@ -1010,37 +825,211 @@
                           }
                         }
                       },
-                      "richRendererConfigs": {
-                        "type": "object",
-                        "properties": {
-                          "page": {
-                            "type": "object",
-                            "properties": {
-                              "columns": {
-                                "type": "array",
-                                "items": {
+                      "children": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "metadata": {
+                              "type": "object",
+                              "properties": {
+                                "tableColumnId": {
                                   "type": "object",
                                   "properties": {
-                                    "rows": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "fields": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "properties": {
-                                                "tableColumnId": {
-                                                  "type": [
-                                                    "integer",
-                                                    "number"
-                                                  ]
-                                                },
-                                                "type": {
-                                                  "type": "string"
-                                                }
-                                              }
+                                    "18597387": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "18588514": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "18305543": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "18305385": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "17071854": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "17069086": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "16385308": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "16385114": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "15821117": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "15820938": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "15425966": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "15425931": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "14919580": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "14768094": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "1595946": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "1595912": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "1595906": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "1553919": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "customValues": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": [
+                                        "integer",
+                                        "number",
+                                        "string"
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "rdfSubject": {
+                    "type": "string"
+                  },
+                  "rdfClass": {
+                    "type": "string"
+                  },
+                  "customRdfClass": {
+                    "type": "string"
+                  },
+                  "sidebar": {
+                    "type": "object",
+                    "properties": {
+                      "width": {
+                        "type": [
+                          "integer",
+                          "number"
+                        ]
+                      }
+                    }
+                  },
+                  "richRendererConfigs": {
+                    "type": "object",
+                    "properties": {
+                      "page": {
+                        "type": "object",
+                        "properties": {
+                          "columns": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "rows": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "fields": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "tableColumnId": {
+                                              "type": [
+                                                "integer",
+                                                "number"
+                                              ]
+                                            },
+                                            "type": {
+                                              "type": "string"
                                             }
                                           }
                                         }
@@ -1052,147 +1041,82 @@
                             }
                           }
                         }
-                      },
-                      "thumbnail": {
+                      }
+                    }
+                  },
+                  "thumbnail": {
+                    "type": "object",
+                    "properties": {
+                      "page": {
                         "type": "object",
                         "properties": {
-                          "page": {
+                          "filename": {
+                            "type": "string"
+                          },
+                          "selection": {
                             "type": "object",
                             "properties": {
-                              "filename": {
-                                "type": "string"
+                              "width": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
                               },
-                              "selection": {
-                                "type": "object",
-                                "properties": {
-                                  "width": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "y1": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "y2": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "x1": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "x2": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "height": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  }
-                                }
+                              "y1": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
                               },
-                              "created": {
-                                "type": "boolean"
+                              "y2": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "x1": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "x2": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "height": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
                               }
                             }
+                          },
+                          "created": {
+                            "type": "boolean"
                           }
                         }
                       }
                     }
+                  }
+                }
+              },
+              "owner": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
                   },
-                  "owner": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "displayName": {
-                        "type": "string"
-                      },
-                      "screenName": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "flags": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "profileImageUrlLarge": {
-                        "type": "string"
-                      },
-                      "profileImageUrlMedium": {
-                        "type": "string"
-                      },
-                      "profileImageUrlSmall": {
-                        "type": "string"
-                      },
-                      "disabledAt": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      }
-                    }
+                  "displayName": {
+                    "type": "string"
                   },
-                  "rights": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
+                  "screenName": {
+                    "type": "string"
                   },
-                  "tableAuthor": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "displayName": {
-                        "type": "string"
-                      },
-                      "screenName": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "flags": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "profileImageUrlLarge": {
-                        "type": "string"
-                      },
-                      "profileImageUrlMedium": {
-                        "type": "string"
-                      },
-                      "profileImageUrlSmall": {
-                        "type": "string"
-                      },
-                      "disabledAt": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      }
-                    }
+                  "type": {
+                    "type": "string"
                   },
                   "flags": {
                     "type": "array",
@@ -1200,87 +1124,145 @@
                       "type": "string"
                     }
                   },
-                  "tags": {
+                  "profileImageUrlLarge": {
+                    "type": "string"
+                  },
+                  "profileImageUrlMedium": {
+                    "type": "string"
+                  },
+                  "profileImageUrlSmall": {
+                    "type": "string"
+                  },
+                  "disabledAt": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  }
+                }
+              },
+              "rights": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "tableAuthor": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "displayName": {
+                    "type": "string"
+                  },
+                  "screenName": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "flags": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     }
                   },
-                  "rowsUpdatedBy": {
+                  "profileImageUrlLarge": {
                     "type": "string"
                   },
-                  "resourceName": {
+                  "profileImageUrlMedium": {
                     "type": "string"
                   },
-                  "modifyingViewUid": {
+                  "profileImageUrlSmall": {
                     "type": "string"
                   },
-                  "queryString": {
-                    "type": "string"
-                  },
-                  "rowIdentifierColumnId": {
+                  "disabledAt": {
                     "type": [
                       "integer",
                       "number"
                     ]
-                  },
-                  "externalId": {
-                    "type": "string"
-                  },
-                  "indexUpdatedAt": {
+                  }
+                }
+              },
+              "flags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "rowsUpdatedBy": {
+                "type": "string"
+              },
+              "resourceName": {
+                "type": "string"
+              },
+              "modifyingViewUid": {
+                "type": "string"
+              },
+              "queryString": {
+                "type": "string"
+              },
+              "rowIdentifierColumnId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "externalId": {
+                "type": "string"
+              },
+              "indexUpdatedAt": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "rowClass": {
+                "type": "string"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "iconUrl": {
+                "type": "string"
+              },
+              "disabledFeatureFlags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "ratings": {
+                "type": "object",
+                "properties": {
+                  "rating": {
                     "type": [
                       "integer",
                       "number"
                     ]
-                  },
-                  "rowClass": {
-                    "type": "string"
-                  },
-                  "locale": {
-                    "type": "string"
-                  },
-                  "iconUrl": {
-                    "type": "string"
-                  },
-                  "disabledFeatureFlags": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "ratings": {
-                    "type": "object",
-                    "properties": {
-                      "rating": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      }
-                    }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -1333,468 +1315,413 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "meta": {
               "type": "object",
               "properties": {
-                "meta": {
+                "view": {
                   "type": "object",
                   "properties": {
-                    "view": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "assetType": {
+                      "type": "string"
+                    },
+                    "attribution": {
+                      "type": "string"
+                    },
+                    "averageRating": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "category": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "diciBackend": {
+                      "type": "boolean"
+                    },
+                    "displayType": {
+                      "type": "string"
+                    },
+                    "downloadCount": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "hideFromCatalog": {
+                      "type": "boolean"
+                    },
+                    "hideFromDataJson": {
+                      "type": "boolean"
+                    },
+                    "locked": {
+                      "type": "boolean"
+                    },
+                    "newBackend": {
+                      "type": "boolean"
+                    },
+                    "numberOfComments": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "oid": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "provenance": {
+                      "type": "string"
+                    },
+                    "publicationAppendEnabled": {
+                      "type": "boolean"
+                    },
+                    "publicationDate": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "publicationGroup": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "publicationStage": {
+                      "type": "string"
+                    },
+                    "rowsUpdatedAt": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "rowsUpdatedBy": {
+                      "type": "string"
+                    },
+                    "tableId": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "totalTimesRated": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "viewCount": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "viewLastModified": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "viewType": {
+                      "type": "string"
+                    },
+                    "approvals": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "reviewedAt": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "reviewedAutomatically": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "type": "string"
+                          },
+                          "submissionId": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "submissionObject": {
+                            "type": "string"
+                          },
+                          "submissionOutcome": {
+                            "type": "string"
+                          },
+                          "submittedAt": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "targetAudience": {
+                            "type": "string"
+                          },
+                          "workflowId": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "submissionDetails": {
+                            "type": "object",
+                            "properties": {
+                              "permissionType": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "submissionOutcomeApplication": {
+                            "type": "object",
+                            "properties": {
+                              "endedAt": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "failureCount": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "startedAt": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "status": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "submitter": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "displayName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "clientContext": {
+                      "type": "object",
+                      "properties": {
+                        "clientContextVariables": {
+                          "type": "array"
+                        },
+                        "inheritedVariables": {
+                          "type": "object"
+                        }
+                      }
+                    },
+                    "columns": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "dataTypeName": {
+                            "type": "string"
+                          },
+                          "fieldName": {
+                            "type": "string"
+                          },
+                          "position": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "renderTypeName": {
+                            "type": "string"
+                          },
+                          "format": {
+                            "type": "object",
+                            "properties": {
+                              "decimalSeparator": {
+                                "type": "string"
+                              },
+                              "groupSeparator": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "flags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "tableColumnId": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "cachedContents": {
+                            "type": "object",
+                            "properties": {
+                              "non_null": {
+                                "type": "string"
+                              },
+                              "largest": {
+                                "type": "string"
+                              },
+                              "null": {
+                                "type": "string"
+                              },
+                              "top": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "item": {
+                                      "type": "string"
+                                    },
+                                    "count_1": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "smallest": {
+                                "type": "string"
+                              },
+                              "count": {
+                                "type": "string"
+                              },
+                              "cardinality": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "grants": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "inherited": {
+                            "type": "boolean"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "flags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "properties": {
+                        "custom_fields": {
+                          "type": "object",
+                          "properties": {
+                            "Common Core": {
+                              "type": "object",
+                              "properties": {
+                                "Contact Email": {
+                                  "type": "string"
+                                },
+                                "Contact Name": {
+                                  "type": "string"
+                                },
+                                "Program Code": {
+                                  "type": "string"
+                                },
+                                "Geographic Coverage": {
+                                  "type": "string"
+                                },
+                                "Publisher": {
+                                  "type": "string"
+                                },
+                                "Bureau Code": {
+                                  "type": "string"
+                                },
+                                "Public Access Level": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "rowLabel": {
+                          "type": "string"
+                        },
+                        "availableDisplayTypes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "owner": {
                       "type": "object",
                       "properties": {
                         "id": {
                           "type": "string"
                         },
-                        "name": {
+                        "displayName": {
                           "type": "string"
                         },
-                        "assetType": {
+                        "screenName": {
                           "type": "string"
                         },
-                        "attribution": {
+                        "type": {
                           "type": "string"
-                        },
-                        "averageRating": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "category": {
-                          "type": "string"
-                        },
-                        "createdAt": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "description": {
-                          "type": "string"
-                        },
-                        "diciBackend": {
-                          "type": "boolean"
-                        },
-                        "displayType": {
-                          "type": "string"
-                        },
-                        "downloadCount": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "hideFromCatalog": {
-                          "type": "boolean"
-                        },
-                        "hideFromDataJson": {
-                          "type": "boolean"
-                        },
-                        "locked": {
-                          "type": "boolean"
-                        },
-                        "newBackend": {
-                          "type": "boolean"
-                        },
-                        "numberOfComments": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "oid": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "provenance": {
-                          "type": "string"
-                        },
-                        "publicationAppendEnabled": {
-                          "type": "boolean"
-                        },
-                        "publicationDate": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "publicationGroup": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "publicationStage": {
-                          "type": "string"
-                        },
-                        "rowsUpdatedAt": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "rowsUpdatedBy": {
-                          "type": "string"
-                        },
-                        "tableId": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "totalTimesRated": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "viewCount": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "viewLastModified": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "viewType": {
-                          "type": "string"
-                        },
-                        "approvals": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "reviewedAt": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "reviewedAutomatically": {
-                                "type": "boolean"
-                              },
-                              "state": {
-                                "type": "string"
-                              },
-                              "submissionId": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "submissionObject": {
-                                "type": "string"
-                              },
-                              "submissionOutcome": {
-                                "type": "string"
-                              },
-                              "submittedAt": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "targetAudience": {
-                                "type": "string"
-                              },
-                              "workflowId": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "submissionDetails": {
-                                "type": "object",
-                                "properties": {
-                                  "permissionType": {
-                                    "type": "string"
-                                  }
-                                }
-                              },
-                              "submissionOutcomeApplication": {
-                                "type": "object",
-                                "properties": {
-                                  "endedAt": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "failureCount": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "startedAt": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "status": {
-                                    "type": "string"
-                                  }
-                                }
-                              },
-                              "submitter": {
-                                "type": "object",
-                                "properties": {
-                                  "id": {
-                                    "type": "string"
-                                  },
-                                  "displayName": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "clientContext": {
-                          "type": "object",
-                          "properties": {
-                            "clientContextVariables": {
-                              "type": "array"
-                            },
-                            "inheritedVariables": {
-                              "type": "object"
-                            }
-                          }
-                        },
-                        "columns": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "dataTypeName": {
-                                "type": "string"
-                              },
-                              "fieldName": {
-                                "type": "string"
-                              },
-                              "position": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "renderTypeName": {
-                                "type": "string"
-                              },
-                              "format": {
-                                "type": "object",
-                                "properties": {
-                                  "decimalSeparator": {
-                                    "type": "string"
-                                  },
-                                  "groupSeparator": {
-                                    "type": "string"
-                                  }
-                                }
-                              },
-                              "flags": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              },
-                              "description": {
-                                "type": "string"
-                              },
-                              "tableColumnId": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "cachedContents": {
-                                "type": "object",
-                                "properties": {
-                                  "non_null": {
-                                    "type": "string"
-                                  },
-                                  "largest": {
-                                    "type": "string"
-                                  },
-                                  "null": {
-                                    "type": "string"
-                                  },
-                                  "top": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "item": {
-                                          "type": "string"
-                                        },
-                                        "count_1": {
-                                          "type": "string"
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "smallest": {
-                                    "type": "string"
-                                  },
-                                  "count": {
-                                    "type": "string"
-                                  },
-                                  "cardinality": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "grants": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "inherited": {
-                                "type": "boolean"
-                              },
-                              "type": {
-                                "type": "string"
-                              },
-                              "flags": {
-                                "type": "array",
-                                "items": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "metadata": {
-                          "type": "object",
-                          "properties": {
-                            "custom_fields": {
-                              "type": "object",
-                              "properties": {
-                                "Common Core": {
-                                  "type": "object",
-                                  "properties": {
-                                    "Contact Email": {
-                                      "type": "string"
-                                    },
-                                    "Contact Name": {
-                                      "type": "string"
-                                    },
-                                    "Program Code": {
-                                      "type": "string"
-                                    },
-                                    "Geographic Coverage": {
-                                      "type": "string"
-                                    },
-                                    "Publisher": {
-                                      "type": "string"
-                                    },
-                                    "Bureau Code": {
-                                      "type": "string"
-                                    },
-                                    "Public Access Level": {
-                                      "type": "string"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "rowLabel": {
-                              "type": "string"
-                            },
-                            "availableDisplayTypes": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        "owner": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "displayName": {
-                              "type": "string"
-                            },
-                            "screenName": {
-                              "type": "string"
-                            },
-                            "type": {
-                              "type": "string"
-                            },
-                            "flags": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        "query": {
-                          "type": "object"
-                        },
-                        "rights": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "tableAuthor": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "displayName": {
-                              "type": "string"
-                            },
-                            "screenName": {
-                              "type": "string"
-                            },
-                            "type": {
-                              "type": "string"
-                            },
-                            "flags": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        },
-                        "tags": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
                         },
                         "flags": {
                           "type": "array",
@@ -1803,44 +1730,84 @@
                           }
                         }
                       }
-                    }
-                  }
-                },
-                "data": {
-                  "type": "array",
-                  "items": {
-                    "type": "array",
-                    "items": {
-                      "type": [
-                        "integer",
-                        "null",
-                        "number",
-                        "string"
-                      ]
+                    },
+                    "query": {
+                      "type": "object"
+                    },
+                    "rights": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "tableAuthor": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "displayName": {
+                          "type": "string"
+                        },
+                        "screenName": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "flags": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "flags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "integer",
+                    "null",
+                    "number",
+                    "string"
+                  ]
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "meta"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/cellpose_tools.json
+++ b/src/tooluniverse/data/cellpose_tools.json
@@ -71,101 +71,89 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Successful segmentation. Mirrors the content of the 'data' field returned by the tool.",
           "properties": {
-            "status": {
-              "const": "success"
+            "image_path": {
+              "type": "string",
+              "description": "The input image path that was segmented."
             },
-            "data": {
-              "type": "object",
-              "description": "Successful segmentation. Mirrors the content of the 'data' field returned by the tool.",
-              "properties": {
-                "image_path": {
-                  "type": "string",
-                  "description": "The input image path that was segmented."
-                },
-                "model_type_requested": {
-                  "type": "string",
-                  "description": "The model_type the caller asked for."
-                },
-                "model_used": {
-                  "type": "string",
-                  "description": "Identifier of the cellpose model that actually produced the segmentation."
-                },
-                "num_objects": {
-                  "type": "integer",
-                  "description": "Number of segmented cells/nuclei (distinct nonzero labels in the mask)."
-                },
-                "image_shape": {
-                  "type": "array",
-                  "items": {
-                    "type": "integer"
+            "model_type_requested": {
+              "type": "string",
+              "description": "The model_type the caller asked for."
+            },
+            "model_used": {
+              "type": "string",
+              "description": "Identifier of the cellpose model that actually produced the segmentation."
+            },
+            "num_objects": {
+              "type": "integer",
+              "description": "Number of segmented cells/nuclei (distinct nonzero labels in the mask)."
+            },
+            "image_shape": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "description": "Shape of the output label mask, e.g. [height, width]."
+            },
+            "objects": {
+              "type": "array",
+              "description": "One entry per segmented object.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "integer",
+                    "description": "Integer label of this object in the mask."
                   },
-                  "description": "Shape of the output label mask, e.g. [height, width]."
-                },
-                "objects": {
-                  "type": "array",
-                  "description": "One entry per segmented object.",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "label": {
-                        "type": "integer",
-                        "description": "Integer label of this object in the mask."
-                      },
-                      "area": {
-                        "type": "integer",
-                        "description": "Object area in pixels."
-                      },
-                      "centroid_y": {
-                        "type": "number",
-                        "description": "Centroid row (y) coordinate in pixels."
-                      },
-                      "centroid_x": {
-                        "type": "number",
-                        "description": "Centroid column (x) coordinate in pixels."
-                      }
-                    },
-                    "required": [
-                      "label",
-                      "area",
-                      "centroid_y",
-                      "centroid_x"
-                    ]
+                  "area": {
+                    "type": "integer",
+                    "description": "Object area in pixels."
+                  },
+                  "centroid_y": {
+                    "type": "number",
+                    "description": "Centroid row (y) coordinate in pixels."
+                  },
+                  "centroid_x": {
+                    "type": "number",
+                    "description": "Centroid column (x) coordinate in pixels."
                   }
                 },
-                "mask_path": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Path to the saved label-mask image, or null if save_mask was false."
-                },
-                "note": {
-                  "type": "string",
-                  "description": "Present when the cellpose build ignored model_type (unified-model builds)."
-                },
-                "mask_save_error": {
-                  "type": "string",
-                  "description": "Present only if saving the mask failed (segmentation still succeeded)."
-                }
-              },
-              "required": [
-                "image_path",
-                "model_type_requested",
-                "model_used",
-                "num_objects",
-                "image_shape",
-                "objects"
-              ]
+                "required": [
+                  "label",
+                  "area",
+                  "centroid_y",
+                  "centroid_x"
+                ]
+              }
+            },
+            "mask_path": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Path to the saved label-mask image, or null if save_mask was false."
+            },
+            "note": {
+              "type": "string",
+              "description": "Present when the cellpose build ignored model_type (unified-model builds)."
+            },
+            "mask_save_error": {
+              "type": "string",
+              "description": "Present only if saving the mask failed (segmentation still succeeded)."
             }
           },
           "required": [
-            "data"
+            "image_path",
+            "model_type_requested",
+            "model_used",
+            "num_objects",
+            "image_shape",
+            "objects"
           ]
         },
         {
           "type": "object",
-          "description": "Error response (e.g. cellpose not installed, missing/unreadable image, segmentation failure).",
           "properties": {
             "error": {
               "type": "string",

--- a/src/tooluniverse/data/classyfire_tools.json
+++ b/src/tooluniverse/data/classyfire_tools.json
@@ -1,35 +1,107 @@
 [
-    {
-        "name": "ClassyFire_classify_by_inchikey",
-        "description": "Classify a chemical structure into the ClassyFire ChemOnt chemical taxonomy by its InChIKey. Returns the hierarchical classification (kingdom -> superclass -> class -> subclass -> direct parent), intermediate ontology nodes, molecular framework, structural substituents, and a textual description. Use to assign a compound to a standardized chemical class for grouping, filtering, or annotation. Requires a full InChIKey (compute it from a structure via OPSIN/PubChem/RDKit first). Only previously-classified structures are available through this instant cache lookup. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "inchikey": {"type": "string", "description": "Full 27-character InChIKey, e.g. 'BSYNRYMUTXBXSQ-UHFFFAOYSA-N' (aspirin)."}
-        }, "required": ["inchikey"]},
-        "fields": {"timeout": 30},
-        "type": "ClassyFireTool",
-        "test_examples": [
-            {"inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"},
-            {"inchikey": "RYYVLZVUVIJVGH-UHFFFAOYSA-N"},
-            {"inchikey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N"}
-        ],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "ChemOnt classification", "properties": {
-                "status": {"type": "string"},
-                "data": {"type": "object", "properties": {
-                    "inchikey": {"type": "string"},
-                    "classified": {"type": "boolean"},
-                    "kingdom": {"type": ["string", "null"]},
-                    "superclass": {"type": ["string", "null"]},
-                    "class": {"type": ["string", "null"]},
-                    "subclass": {"type": ["string", "null"]},
-                    "direct_parent": {"type": ["string", "null"]},
-                    "molecular_framework": {"type": ["string", "null"]},
-                    "substituents": {"type": "array"},
-                    "description": {"type": ["string", "null"]}
-                }},
-                "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+  {
+    "name": "ClassyFire_classify_by_inchikey",
+    "description": "Classify a chemical structure into the ClassyFire ChemOnt chemical taxonomy by its InChIKey. Returns the hierarchical classification (kingdom -> superclass -> class -> subclass -> direct parent), intermediate ontology nodes, molecular framework, structural substituents, and a textual description. Use to assign a compound to a standardized chemical class for grouping, filtering, or annotation. Requires a full InChIKey (compute it from a structure via OPSIN/PubChem/RDKit first). Only previously-classified structures are available through this instant cache lookup. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "inchikey": {
+          "type": "string",
+          "description": "Full 27-character InChIKey, e.g. 'BSYNRYMUTXBXSQ-UHFFFAOYSA-N' (aspirin)."
+        }
+      },
+      "required": [
+        "inchikey"
+      ]
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "ClassyFireTool",
+    "test_examples": [
+      {
+        "inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+      },
+      {
+        "inchikey": "RYYVLZVUVIJVGH-UHFFFAOYSA-N"
+      },
+      {
+        "inchikey": "ATUOYWHBWRKTHZ-UHFFFAOYSA-N"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "inchikey": {
+              "type": "string"
+            },
+            "classified": {
+              "type": "boolean"
+            },
+            "kingdom": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "superclass": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "class": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "subclass": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "direct_parent": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "molecular_framework": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "substituents": {
+              "type": "array"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "inchikey"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
     }
+  }
 ]

--- a/src/tooluniverse/data/clinical_calculators_tools.json
+++ b/src/tooluniverse/data/clinical_calculators_tools.json
@@ -2,224 +2,909 @@
   {
     "name": "ClinicalCalc_CHA2DS2_VASc",
     "description": "CHA2DS2-VASc score: stroke risk in non-valvular atrial fibrillation, used to decide oral anticoagulation. Deterministic point score (0-9). Provide age plus boolean risk factors. Returns score, anticoagulation interpretation, and per-component points.",
-    "parameter": {"type": "object", "properties": {
-      "age": {"type": "number", "description": "Age in years"},
-      "chf": {"type": "boolean", "description": "Congestive heart failure / LV dysfunction"},
-      "hypertension": {"type": "boolean", "description": "History of hypertension"},
-      "diabetes": {"type": "boolean", "description": "Diabetes mellitus"},
-      "stroke_history": {"type": "boolean", "description": "Prior stroke, TIA, or thromboembolism (2 points)"},
-      "vascular_disease": {"type": "boolean", "description": "Vascular disease (prior MI, PAD, aortic plaque)"},
-      "female": {"type": "boolean", "description": "Female sex"}
-    }, "required": ["age"]},
-    "fields": {"calculator": "cha2ds2_vasc"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "age": {
+          "type": "number",
+          "description": "Age in years"
+        },
+        "chf": {
+          "type": "boolean",
+          "description": "Congestive heart failure / LV dysfunction"
+        },
+        "hypertension": {
+          "type": "boolean",
+          "description": "History of hypertension"
+        },
+        "diabetes": {
+          "type": "boolean",
+          "description": "Diabetes mellitus"
+        },
+        "stroke_history": {
+          "type": "boolean",
+          "description": "Prior stroke, TIA, or thromboembolism (2 points)"
+        },
+        "vascular_disease": {
+          "type": "boolean",
+          "description": "Vascular disease (prior MI, PAD, aortic plaque)"
+        },
+        "female": {
+          "type": "boolean",
+          "description": "Female sex"
+        }
+      },
+      "required": [
+        "age"
+      ]
+    },
+    "fields": {
+      "calculator": "cha2ds2_vasc"
+    },
     "type": "ClinicalCalculatorTool",
     "test_examples": [
-      {"age": 80, "female": true, "hypertension": true, "diabetes": true},
-      {"age": 55, "chf": false, "hypertension": false}
+      {
+        "age": 80,
+        "female": true,
+        "hypertension": true,
+        "diabetes": true
+      },
+      {
+        "age": 55,
+        "chf": false,
+        "hypertension": false
+      }
     ],
-    "return_schema": {"oneOf": [
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["success"]}, "data": {"type": "object", "properties": {"score": {"type": "number"}, "interpretation": {"type": "string"}, "components": {"type": "object"}}}, "metadata": {"type": "object"}}, "required": ["status", "data"]},
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["error"]}, "error": {"type": "string"}}, "required": ["status", "error"]}
-    ]}
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "score": {
+              "type": "number"
+            },
+            "interpretation": {
+              "type": "string"
+            },
+            "components": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "score"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "ClinicalCalc_HAS_BLED",
     "description": "HAS-BLED score: 1-year major bleeding risk in patients with atrial fibrillation on anticoagulation. Point score (0-9); >=3 indicates high risk warranting caution and review of reversible factors. Complements CHA2DS2-VASc.",
-    "parameter": {"type": "object", "properties": {
-      "age": {"type": "number", "description": "Age in years (>65 scores 1 point)"},
-      "hypertension": {"type": "boolean", "description": "Uncontrolled hypertension (SBP >160)"},
-      "renal_disease": {"type": "boolean", "description": "Abnormal renal function (dialysis, transplant, Cr >2.26 mg/dL)"},
-      "liver_disease": {"type": "boolean", "description": "Abnormal liver function (cirrhosis, bilirubin >2x or AST/ALT >3x normal)"},
-      "stroke_history": {"type": "boolean", "description": "Prior stroke"},
-      "bleeding_history": {"type": "boolean", "description": "Prior major bleeding or predisposition"},
-      "labile_inr": {"type": "boolean", "description": "Labile INR (unstable/high, TTR <60%)"},
-      "drugs": {"type": "boolean", "description": "Concomitant antiplatelet or NSAID use"},
-      "alcohol": {"type": "boolean", "description": "Alcohol >=8 drinks/week"}
-    }, "required": ["age"]},
-    "fields": {"calculator": "has_bled"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "age": {
+          "type": "number",
+          "description": "Age in years (>65 scores 1 point)"
+        },
+        "hypertension": {
+          "type": "boolean",
+          "description": "Uncontrolled hypertension (SBP >160)"
+        },
+        "renal_disease": {
+          "type": "boolean",
+          "description": "Abnormal renal function (dialysis, transplant, Cr >2.26 mg/dL)"
+        },
+        "liver_disease": {
+          "type": "boolean",
+          "description": "Abnormal liver function (cirrhosis, bilirubin >2x or AST/ALT >3x normal)"
+        },
+        "stroke_history": {
+          "type": "boolean",
+          "description": "Prior stroke"
+        },
+        "bleeding_history": {
+          "type": "boolean",
+          "description": "Prior major bleeding or predisposition"
+        },
+        "labile_inr": {
+          "type": "boolean",
+          "description": "Labile INR (unstable/high, TTR <60%)"
+        },
+        "drugs": {
+          "type": "boolean",
+          "description": "Concomitant antiplatelet or NSAID use"
+        },
+        "alcohol": {
+          "type": "boolean",
+          "description": "Alcohol >=8 drinks/week"
+        }
+      },
+      "required": [
+        "age"
+      ]
+    },
+    "fields": {
+      "calculator": "has_bled"
+    },
     "type": "ClinicalCalculatorTool",
     "test_examples": [
-      {"age": 70, "hypertension": true, "bleeding_history": true, "labile_inr": true},
-      {"age": 60}
+      {
+        "age": 70,
+        "hypertension": true,
+        "bleeding_history": true,
+        "labile_inr": true
+      },
+      {
+        "age": 60
+      }
     ],
-    "return_schema": {"oneOf": [
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["success"]}, "data": {"type": "object", "properties": {"score": {"type": "number"}, "interpretation": {"type": "string"}, "components": {"type": "object"}}}, "metadata": {"type": "object"}}, "required": ["status", "data"]},
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["error"]}, "error": {"type": "string"}}, "required": ["status", "error"]}
-    ]}
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "score": {
+              "type": "number"
+            },
+            "interpretation": {
+              "type": "string"
+            },
+            "components": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "score"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "ClinicalCalc_CURB_65",
     "description": "CURB-65 score: community-acquired pneumonia severity and disposition (outpatient vs inpatient vs ICU). Point score (0-5) from confusion, urea, respiratory rate, blood pressure, and age >=65.",
-    "parameter": {"type": "object", "properties": {
-      "age": {"type": "number", "description": "Age in years (>=65 scores 1)"},
-      "confusion": {"type": "boolean", "description": "New-onset confusion / altered mental status"},
-      "elevated_urea": {"type": "boolean", "description": "Blood urea nitrogen >7 mmol/L (>19 mg/dL BUN)"},
-      "high_resp_rate": {"type": "boolean", "description": "Respiratory rate >=30/min"},
-      "low_bp": {"type": "boolean", "description": "SBP <90 mmHg or DBP <=60 mmHg"}
-    }, "required": ["age"]},
-    "fields": {"calculator": "curb_65"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "age": {
+          "type": "number",
+          "description": "Age in years (>=65 scores 1)"
+        },
+        "confusion": {
+          "type": "boolean",
+          "description": "New-onset confusion / altered mental status"
+        },
+        "elevated_urea": {
+          "type": "boolean",
+          "description": "Blood urea nitrogen >7 mmol/L (>19 mg/dL BUN)"
+        },
+        "high_resp_rate": {
+          "type": "boolean",
+          "description": "Respiratory rate >=30/min"
+        },
+        "low_bp": {
+          "type": "boolean",
+          "description": "SBP <90 mmHg or DBP <=60 mmHg"
+        }
+      },
+      "required": [
+        "age"
+      ]
+    },
+    "fields": {
+      "calculator": "curb_65"
+    },
     "type": "ClinicalCalculatorTool",
     "test_examples": [
-      {"age": 72, "confusion": true, "elevated_urea": true, "high_resp_rate": false, "low_bp": false},
-      {"age": 40, "confusion": false}
+      {
+        "age": 72,
+        "confusion": true,
+        "elevated_urea": true,
+        "high_resp_rate": false,
+        "low_bp": false
+      },
+      {
+        "age": 40,
+        "confusion": false
+      }
     ],
-    "return_schema": {"oneOf": [
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["success"]}, "data": {"type": "object", "properties": {"score": {"type": "number"}, "interpretation": {"type": "string"}, "components": {"type": "object"}}}, "metadata": {"type": "object"}}, "required": ["status", "data"]},
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["error"]}, "error": {"type": "string"}}, "required": ["status", "error"]}
-    ]}
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "score": {
+              "type": "number"
+            },
+            "interpretation": {
+              "type": "string"
+            },
+            "components": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "score"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "ClinicalCalc_qSOFA",
     "description": "qSOFA (quick SOFA): bedside identification of patients with suspected infection at higher risk of poor outcome. Point score (0-3); >=2 is concerning for sepsis. Uses respiratory rate, mentation, and systolic blood pressure only.",
-    "parameter": {"type": "object", "properties": {
-      "high_resp_rate": {"type": "boolean", "description": "Respiratory rate >=22/min"},
-      "altered_mentation": {"type": "boolean", "description": "Altered mental status (GCS <15)"},
-      "low_sbp": {"type": "boolean", "description": "Systolic blood pressure <=100 mmHg"}
-    }, "required": []},
-    "fields": {"calculator": "qsofa"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "high_resp_rate": {
+          "type": "boolean",
+          "description": "Respiratory rate >=22/min"
+        },
+        "altered_mentation": {
+          "type": "boolean",
+          "description": "Altered mental status (GCS <15)"
+        },
+        "low_sbp": {
+          "type": "boolean",
+          "description": "Systolic blood pressure <=100 mmHg"
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "calculator": "qsofa"
+    },
     "type": "ClinicalCalculatorTool",
     "test_examples": [
-      {"high_resp_rate": true, "altered_mentation": true, "low_sbp": false},
-      {"high_resp_rate": false, "altered_mentation": false, "low_sbp": false}
+      {
+        "high_resp_rate": true,
+        "altered_mentation": true,
+        "low_sbp": false
+      },
+      {
+        "high_resp_rate": false,
+        "altered_mentation": false,
+        "low_sbp": false
+      }
     ],
-    "return_schema": {"oneOf": [
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["success"]}, "data": {"type": "object", "properties": {"score": {"type": "number"}, "interpretation": {"type": "string"}, "components": {"type": "object"}}}, "metadata": {"type": "object"}}, "required": ["status", "data"]},
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["error"]}, "error": {"type": "string"}}, "required": ["status", "error"]}
-    ]}
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "score": {
+              "type": "number"
+            },
+            "interpretation": {
+              "type": "string"
+            },
+            "components": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "score"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "ClinicalCalc_Child_Pugh",
     "description": "Child-Pugh score and class (A/B/C): severity of chronic liver disease / cirrhosis and surgical risk. Sum (5-15) of bilirubin, albumin, INR, ascites, and encephalopathy points. Provide lab values and clinical grades.",
-    "parameter": {"type": "object", "properties": {
-      "bilirubin": {"type": "number", "description": "Total bilirubin in mg/dL"},
-      "albumin": {"type": "number", "description": "Serum albumin in g/dL"},
-      "inr": {"type": "number", "description": "INR (prothrombin time ratio)"},
-      "ascites": {"type": "string", "enum": ["none", "absent", "mild", "slight", "moderate", "severe"], "description": "Ascites severity. Accepted: 'none'/'absent' (1 pt), 'mild'/'slight' (2 pts), 'moderate'/'severe' (3 pts). Unrecognized values are rejected (no silent best-case default).", "default": "none"},
-      "encephalopathy": {"type": "string", "enum": ["none", "absent", "grade1", "grade2", "grade1-2", "grade3", "grade4", "grade3-4"], "description": "Hepatic encephalopathy grade. Accepted: 'none'/'absent' (1 pt), 'grade1-2' (2 pts), 'grade3-4' (3 pts). Unrecognized values are rejected (no silent best-case default).", "default": "none"}
-    }, "required": ["bilirubin", "albumin", "inr"]},
-    "fields": {"calculator": "child_pugh"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "bilirubin": {
+          "type": "number",
+          "description": "Total bilirubin in mg/dL"
+        },
+        "albumin": {
+          "type": "number",
+          "description": "Serum albumin in g/dL"
+        },
+        "inr": {
+          "type": "number",
+          "description": "INR (prothrombin time ratio)"
+        },
+        "ascites": {
+          "type": "string",
+          "enum": [
+            "none",
+            "absent",
+            "mild",
+            "slight",
+            "moderate",
+            "severe"
+          ],
+          "description": "Ascites severity. Accepted: 'none'/'absent' (1 pt), 'mild'/'slight' (2 pts), 'moderate'/'severe' (3 pts). Unrecognized values are rejected (no silent best-case default).",
+          "default": "none"
+        },
+        "encephalopathy": {
+          "type": "string",
+          "enum": [
+            "none",
+            "absent",
+            "grade1",
+            "grade2",
+            "grade1-2",
+            "grade3",
+            "grade4",
+            "grade3-4"
+          ],
+          "description": "Hepatic encephalopathy grade. Accepted: 'none'/'absent' (1 pt), 'grade1-2' (2 pts), 'grade3-4' (3 pts). Unrecognized values are rejected (no silent best-case default).",
+          "default": "none"
+        }
+      },
+      "required": [
+        "bilirubin",
+        "albumin",
+        "inr"
+      ]
+    },
+    "fields": {
+      "calculator": "child_pugh"
+    },
     "type": "ClinicalCalculatorTool",
     "test_examples": [
-      {"bilirubin": 1.0, "albumin": 4.0, "inr": 1.0, "ascites": "none", "encephalopathy": "none"},
-      {"bilirubin": 3.5, "albumin": 2.5, "inr": 2.4, "ascites": "moderate", "encephalopathy": "grade3-4"}
+      {
+        "bilirubin": 1.0,
+        "albumin": 4.0,
+        "inr": 1.0,
+        "ascites": "none",
+        "encephalopathy": "none"
+      },
+      {
+        "bilirubin": 3.5,
+        "albumin": 2.5,
+        "inr": 2.4,
+        "ascites": "moderate",
+        "encephalopathy": "grade3-4"
+      }
     ],
-    "return_schema": {"oneOf": [
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["success"]}, "data": {"type": "object", "properties": {"score": {"type": "number"}, "interpretation": {"type": "string"}, "components": {"type": "object"}, "child_pugh_class": {"type": "string"}}}, "metadata": {"type": "object"}}, "required": ["status", "data"]},
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["error"]}, "error": {"type": "string"}}, "required": ["status", "error"]}
-    ]}
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "score": {
+              "type": "number"
+            },
+            "interpretation": {
+              "type": "string"
+            },
+            "components": {
+              "type": "object"
+            },
+            "child_pugh_class": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "score"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "ClinicalCalc_Wells_DVT",
     "description": "Wells score for deep vein thrombosis (DVT) pretest probability. Sum of clinical features (minus 2 if an alternative diagnosis is as likely); score >=2 means DVT likely. Guides D-dimer vs ultrasound workup.",
-    "parameter": {"type": "object", "properties": {
-      "active_cancer": {"type": "boolean", "description": "Active cancer (treatment within 6 months or palliative)"},
-      "immobilization": {"type": "boolean", "description": "Paralysis, paresis, or recent lower-limb immobilization"},
-      "recent_surgery": {"type": "boolean", "description": "Recently bedridden >=3 days or major surgery within 12 weeks"},
-      "localized_tenderness": {"type": "boolean", "description": "Localized tenderness along deep venous system"},
-      "leg_swollen": {"type": "boolean", "description": "Entire leg swollen"},
-      "calf_swelling": {"type": "boolean", "description": "Calf swelling >3 cm vs asymptomatic side"},
-      "pitting_edema": {"type": "boolean", "description": "Pitting edema confined to symptomatic leg"},
-      "collateral_veins": {"type": "boolean", "description": "Collateral superficial (non-varicose) veins"},
-      "previous_dvt": {"type": "boolean", "description": "Previously documented DVT"},
-      "alternative_diagnosis": {"type": "boolean", "description": "Alternative diagnosis at least as likely as DVT (subtracts 2)"}
-    }, "required": []},
-    "fields": {"calculator": "wells_dvt"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "active_cancer": {
+          "type": "boolean",
+          "description": "Active cancer (treatment within 6 months or palliative)"
+        },
+        "immobilization": {
+          "type": "boolean",
+          "description": "Paralysis, paresis, or recent lower-limb immobilization"
+        },
+        "recent_surgery": {
+          "type": "boolean",
+          "description": "Recently bedridden >=3 days or major surgery within 12 weeks"
+        },
+        "localized_tenderness": {
+          "type": "boolean",
+          "description": "Localized tenderness along deep venous system"
+        },
+        "leg_swollen": {
+          "type": "boolean",
+          "description": "Entire leg swollen"
+        },
+        "calf_swelling": {
+          "type": "boolean",
+          "description": "Calf swelling >3 cm vs asymptomatic side"
+        },
+        "pitting_edema": {
+          "type": "boolean",
+          "description": "Pitting edema confined to symptomatic leg"
+        },
+        "collateral_veins": {
+          "type": "boolean",
+          "description": "Collateral superficial (non-varicose) veins"
+        },
+        "previous_dvt": {
+          "type": "boolean",
+          "description": "Previously documented DVT"
+        },
+        "alternative_diagnosis": {
+          "type": "boolean",
+          "description": "Alternative diagnosis at least as likely as DVT (subtracts 2)"
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "calculator": "wells_dvt"
+    },
     "type": "ClinicalCalculatorTool",
     "test_examples": [
-      {"active_cancer": true, "localized_tenderness": true, "leg_swollen": true},
-      {"alternative_diagnosis": true, "calf_swelling": true}
+      {
+        "active_cancer": true,
+        "localized_tenderness": true,
+        "leg_swollen": true
+      },
+      {
+        "alternative_diagnosis": true,
+        "calf_swelling": true
+      }
     ],
-    "return_schema": {"oneOf": [
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["success"]}, "data": {"type": "object", "properties": {"score": {"type": "number"}, "interpretation": {"type": "string"}, "components": {"type": "object"}}}, "metadata": {"type": "object"}}, "required": ["status", "data"]},
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["error"]}, "error": {"type": "string"}}, "required": ["status", "error"]}
-    ]}
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "score": {
+              "type": "number"
+            },
+            "interpretation": {
+              "type": "string"
+            },
+            "components": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "score"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "ClinicalCalc_Wells_PE",
     "description": "Wells score for pulmonary embolism (PE) pretest probability. Weighted score giving three-tier (low/moderate/high) and two-tier (PE unlikely <=4 / likely >4) risk to guide D-dimer vs CT pulmonary angiography.",
-    "parameter": {"type": "object", "properties": {
-      "clinical_dvt": {"type": "boolean", "description": "Clinical signs/symptoms of DVT (3 points)"},
-      "pe_most_likely": {"type": "boolean", "description": "PE is the most likely diagnosis (3 points)"},
-      "tachycardia": {"type": "boolean", "description": "Heart rate >100 bpm (1.5)"},
-      "immobilization": {"type": "boolean", "description": "Immobilization >=3 days or surgery within 4 weeks (1.5)"},
-      "previous_vte": {"type": "boolean", "description": "Previous DVT or PE (1.5)"},
-      "hemoptysis": {"type": "boolean", "description": "Hemoptysis (1)"},
-      "malignancy": {"type": "boolean", "description": "Malignancy treated within 6 months or palliative (1)"}
-    }, "required": []},
-    "fields": {"calculator": "wells_pe"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "clinical_dvt": {
+          "type": "boolean",
+          "description": "Clinical signs/symptoms of DVT (3 points)"
+        },
+        "pe_most_likely": {
+          "type": "boolean",
+          "description": "PE is the most likely diagnosis (3 points)"
+        },
+        "tachycardia": {
+          "type": "boolean",
+          "description": "Heart rate >100 bpm (1.5)"
+        },
+        "immobilization": {
+          "type": "boolean",
+          "description": "Immobilization >=3 days or surgery within 4 weeks (1.5)"
+        },
+        "previous_vte": {
+          "type": "boolean",
+          "description": "Previous DVT or PE (1.5)"
+        },
+        "hemoptysis": {
+          "type": "boolean",
+          "description": "Hemoptysis (1)"
+        },
+        "malignancy": {
+          "type": "boolean",
+          "description": "Malignancy treated within 6 months or palliative (1)"
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "calculator": "wells_pe"
+    },
     "type": "ClinicalCalculatorTool",
     "test_examples": [
-      {"clinical_dvt": true, "pe_most_likely": true, "tachycardia": true},
-      {"hemoptysis": true}
+      {
+        "clinical_dvt": true,
+        "pe_most_likely": true,
+        "tachycardia": true
+      },
+      {
+        "hemoptysis": true
+      }
     ],
-    "return_schema": {"oneOf": [
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["success"]}, "data": {"type": "object", "properties": {"score": {"type": "number"}, "interpretation": {"type": "string"}, "components": {"type": "object"}, "three_tier": {"type": "string"}, "two_tier": {"type": "string"}}}, "metadata": {"type": "object"}}, "required": ["status", "data"]},
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["error"]}, "error": {"type": "string"}}, "required": ["status", "error"]}
-    ]}
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "score": {
+              "type": "number"
+            },
+            "interpretation": {
+              "type": "string"
+            },
+            "components": {
+              "type": "object"
+            },
+            "three_tier": {
+              "type": "string"
+            },
+            "two_tier": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "score"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "ClinicalCalc_MELD_Na",
     "description": "MELD-Na score (UNOS/OPTN 2016): 90-day mortality risk in chronic liver disease and liver transplant allocation priority. Range 6-40. Uses creatinine, bilirubin, INR, and sodium (with the standard lower/upper bounds and dialysis rule).",
-    "parameter": {"type": "object", "properties": {
-      "creatinine": {"type": "number", "description": "Serum creatinine in mg/dL (bounded 1.0-4.0; set to 4.0 if on dialysis)"},
-      "bilirubin": {"type": "number", "description": "Total bilirubin in mg/dL (lower-bounded at 1.0)"},
-      "inr": {"type": "number", "description": "INR (lower-bounded at 1.0)"},
-      "sodium": {"type": "number", "description": "Serum sodium in mmol/L (bounded 125-137)"},
-      "dialysis": {"type": "boolean", "description": "Two or more dialysis sessions in the past week (forces creatinine to 4.0)"}
-    }, "required": ["creatinine", "bilirubin", "inr", "sodium"]},
-    "fields": {"calculator": "meld_na"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "creatinine": {
+          "type": "number",
+          "description": "Serum creatinine in mg/dL (bounded 1.0-4.0; set to 4.0 if on dialysis)"
+        },
+        "bilirubin": {
+          "type": "number",
+          "description": "Total bilirubin in mg/dL (lower-bounded at 1.0)"
+        },
+        "inr": {
+          "type": "number",
+          "description": "INR (lower-bounded at 1.0)"
+        },
+        "sodium": {
+          "type": "number",
+          "description": "Serum sodium in mmol/L (bounded 125-137)"
+        },
+        "dialysis": {
+          "type": "boolean",
+          "description": "Two or more dialysis sessions in the past week (forces creatinine to 4.0)"
+        }
+      },
+      "required": [
+        "creatinine",
+        "bilirubin",
+        "inr",
+        "sodium"
+      ]
+    },
+    "fields": {
+      "calculator": "meld_na"
+    },
     "type": "ClinicalCalculatorTool",
     "test_examples": [
-      {"creatinine": 1.5, "bilirubin": 2.0, "inr": 1.5, "sodium": 130},
-      {"creatinine": 2.0, "bilirubin": 5.0, "inr": 2.0, "sodium": 128, "dialysis": false}
+      {
+        "creatinine": 1.5,
+        "bilirubin": 2.0,
+        "inr": 1.5,
+        "sodium": 130
+      },
+      {
+        "creatinine": 2.0,
+        "bilirubin": 5.0,
+        "inr": 2.0,
+        "sodium": 128,
+        "dialysis": false
+      }
     ],
-    "return_schema": {"oneOf": [
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["success"]}, "data": {"type": "object", "properties": {"score": {"type": "number"}, "interpretation": {"type": "string"}, "components": {"type": "object"}}}, "metadata": {"type": "object"}}, "required": ["status", "data"]},
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["error"]}, "error": {"type": "string"}}, "required": ["status", "error"]}
-    ]}
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "score": {
+              "type": "number"
+            },
+            "interpretation": {
+              "type": "string"
+            },
+            "components": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "score"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "ClinicalCalc_eGFR_CKD_EPI",
     "description": "Estimated glomerular filtration rate (eGFR) by the CKD-EPI 2021 creatinine equation (race-free, Inker 2021), with CKD stage (G1-G5). Inputs: serum creatinine, age, sex. Reported in mL/min/1.73m^2.",
-    "parameter": {"type": "object", "properties": {
-      "creatinine": {"type": "number", "description": "Serum creatinine in mg/dL"},
-      "age": {"type": "number", "description": "Age in years"},
-      "female": {"type": "boolean", "description": "Female sex"}
-    }, "required": ["creatinine", "age"]},
-    "fields": {"calculator": "ckd_epi"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "creatinine": {
+          "type": "number",
+          "description": "Serum creatinine in mg/dL"
+        },
+        "age": {
+          "type": "number",
+          "description": "Age in years"
+        },
+        "female": {
+          "type": "boolean",
+          "description": "Female sex"
+        }
+      },
+      "required": [
+        "creatinine",
+        "age"
+      ]
+    },
+    "fields": {
+      "calculator": "ckd_epi"
+    },
     "type": "ClinicalCalculatorTool",
     "test_examples": [
-      {"creatinine": 0.9, "age": 60, "female": true},
-      {"creatinine": 1.3, "age": 60, "female": false}
+      {
+        "creatinine": 0.9,
+        "age": 60,
+        "female": true
+      },
+      {
+        "creatinine": 1.3,
+        "age": 60,
+        "female": false
+      }
     ],
-    "return_schema": {"oneOf": [
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["success"]}, "data": {"type": "object", "properties": {"score": {"type": "number"}, "interpretation": {"type": "string"}, "components": {"type": "object"}, "unit": {"type": "string"}}}, "metadata": {"type": "object"}}, "required": ["status", "data"]},
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["error"]}, "error": {"type": "string"}}, "required": ["status", "error"]}
-    ]}
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "score": {
+              "type": "number"
+            },
+            "interpretation": {
+              "type": "string"
+            },
+            "components": {
+              "type": "object"
+            },
+            "unit": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "score"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "ClinicalCalc_ASCVD_risk",
     "description": "10-year atherosclerotic cardiovascular disease (ASCVD) risk by the 2013 ACC/AHA Pooled Cohort Equations (Goff 2013). Validated for ages 40-79. Returns risk percent and category (low/borderline/intermediate/high) used to guide statin therapy. Inputs: age, total and HDL cholesterol, systolic BP (treated or not), smoking, diabetes, sex, and race (White/African American).",
-    "parameter": {"type": "object", "properties": {
-      "age": {"type": "number", "description": "Age in years (40-79)"},
-      "total_cholesterol": {"type": "number", "description": "Total cholesterol in mg/dL"},
-      "hdl_cholesterol": {"type": "number", "description": "HDL cholesterol in mg/dL"},
-      "systolic_bp": {"type": "number", "description": "Systolic blood pressure in mmHg"},
-      "bp_treated": {"type": "boolean", "description": "Currently on blood-pressure-lowering medication"},
-      "smoker": {"type": "boolean", "description": "Current smoker"},
-      "diabetes": {"type": "boolean", "description": "Diabetes mellitus"},
-      "female": {"type": "boolean", "description": "Female sex"},
-      "race": {"type": "string", "description": "'white' (or other) vs 'black'/'African American'; affects the coefficient set", "default": "white"}
-    }, "required": ["age", "total_cholesterol", "hdl_cholesterol", "systolic_bp"]},
-    "fields": {"calculator": "ascvd"},
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "age": {
+          "type": "number",
+          "description": "Age in years (40-79)"
+        },
+        "total_cholesterol": {
+          "type": "number",
+          "description": "Total cholesterol in mg/dL"
+        },
+        "hdl_cholesterol": {
+          "type": "number",
+          "description": "HDL cholesterol in mg/dL"
+        },
+        "systolic_bp": {
+          "type": "number",
+          "description": "Systolic blood pressure in mmHg"
+        },
+        "bp_treated": {
+          "type": "boolean",
+          "description": "Currently on blood-pressure-lowering medication"
+        },
+        "smoker": {
+          "type": "boolean",
+          "description": "Current smoker"
+        },
+        "diabetes": {
+          "type": "boolean",
+          "description": "Diabetes mellitus"
+        },
+        "female": {
+          "type": "boolean",
+          "description": "Female sex"
+        },
+        "race": {
+          "type": "string",
+          "description": "'white' (or other) vs 'black'/'African American'; affects the coefficient set",
+          "default": "white"
+        }
+      },
+      "required": [
+        "age",
+        "total_cholesterol",
+        "hdl_cholesterol",
+        "systolic_bp"
+      ]
+    },
+    "fields": {
+      "calculator": "ascvd"
+    },
     "type": "ClinicalCalculatorTool",
     "test_examples": [
-      {"age": 55, "total_cholesterol": 213, "hdl_cholesterol": 50, "systolic_bp": 120, "bp_treated": false, "smoker": false, "diabetes": false, "female": false, "race": "white"},
-      {"age": 60, "total_cholesterol": 240, "hdl_cholesterol": 40, "systolic_bp": 140, "bp_treated": true, "smoker": true, "diabetes": true, "female": true, "race": "black"}
+      {
+        "age": 55,
+        "total_cholesterol": 213,
+        "hdl_cholesterol": 50,
+        "systolic_bp": 120,
+        "bp_treated": false,
+        "smoker": false,
+        "diabetes": false,
+        "female": false,
+        "race": "white"
+      },
+      {
+        "age": 60,
+        "total_cholesterol": 240,
+        "hdl_cholesterol": 40,
+        "systolic_bp": 140,
+        "bp_treated": true,
+        "smoker": true,
+        "diabetes": true,
+        "female": true,
+        "race": "black"
+      }
     ],
-    "return_schema": {"oneOf": [
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["success"]}, "data": {"type": "object", "properties": {"score": {"type": "number"}, "interpretation": {"type": "string"}, "components": {"type": "object"}, "unit": {"type": "string"}}}, "metadata": {"type": "object"}}, "required": ["status", "data"]},
-      {"type": "object", "properties": {"status": {"type": "string", "enum": ["error"]}, "error": {"type": "string"}}, "required": ["status", "error"]}
-    ]}
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "score": {
+              "type": "number"
+            },
+            "interpretation": {
+              "type": "string"
+            },
+            "components": {
+              "type": "object"
+            },
+            "unit": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "score"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
   }
 ]

--- a/src/tooluniverse/data/clinical_guidelines_tools.json
+++ b/src/tooluniverse/data/clinical_guidelines_tools.json
@@ -17,245 +17,227 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "byName": {
-                    "type": "string"
-                  },
-                  "shortCode": {
-                    "type": "string"
-                  },
-                  "owner": {
-                    "type": "string"
-                  },
-                  "mainEditor": {
-                    "type": "string"
-                  },
-                  "startDate": {
-                    "type": "string"
-                  },
-                  "lastEdit": {
-                    "type": "string"
-                  },
-                  "language": {
-                    "type": "string"
-                  },
-                  "countryFlag": {
-                    "type": "string"
-                  },
-                  "sponsors": {
-                    "type": "string"
-                  },
-                  "disclaimer": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "contactName": {
-                    "type": "string"
-                  },
-                  "contactAddress": {
-                    "type": "string"
-                  },
-                  "contactEmail": {
-                    "type": "string"
-                  },
-                  "contactTelephone": {
-                    "type": "string"
-                  },
-                  "institutionId": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "institutionName": {
-                    "type": "string"
-                  },
-                  "institutionUrl": {
-                    "type": "string"
-                  },
-                  "institutionLogoUrl": {
-                    "type": "string"
-                  },
-                  "institutionShortName": {
-                    "type": "string"
-                  },
-                  "institutionGradeStrength": {
-                    "type": "string"
-                  },
-                  "hasAltGrade": {
-                    "type": "boolean"
-                  },
-                  "guidelineId": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "currentDraftId": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "publishedId": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "editDraft": {
-                    "type": "boolean"
-                  },
-                  "editPublish": {
-                    "type": "boolean"
-                  },
-                  "permissionDraft": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "permissionPublish": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "isLatestPublished": {
-                    "type": "boolean"
-                  },
-                  "isDraftEditable": {
-                    "type": "boolean"
-                  },
-                  "isPublic": {
-                    "type": "boolean"
-                  },
-                  "versionMajor": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "versionMinor": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "versionLabel": {
-                    "type": "string"
-                  },
-                  "draftPicoCount": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "draftRecommendationCount": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "publishedPicoCount": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "publishedRecommendationCount": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "pdfPublishedPath": {
-                    "type": "string"
-                  },
-                  "jsonPath": {
-                    "type": "string"
-                  },
-                  "contentAdmin": {
-                    "type": "boolean"
-                  },
-                  "status": {
-                    "type": "string"
-                  },
-                  "commentsInPublished": {
-                    "type": "boolean"
-                  },
-                  "publishCreationTime": {
-                    "type": "string"
-                  },
-                  "publishDate": {
-                    "type": "string"
-                  },
-                  "publishLastSearchDate": {
-                    "type": "string"
-                  },
-                  "trackChanges": {
-                    "type": "boolean"
-                  },
-                  "sectionNumbers": {
-                    "type": "boolean"
-                  },
-                  "showRecByline": {
-                    "type": "boolean"
-                  },
-                  "showRecNumbers": {
-                    "type": "string"
-                  },
-                  "showConflicts": {
-                    "type": "boolean"
-                  },
-                  "showCertaintyStrengthLabels": {
-                    "type": "boolean"
-                  },
-                  "showSectionPreview": {
-                    "type": "boolean"
-                  },
-                  "subscriptions": {
-                    "type": "boolean"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "byName": {
+                "type": "string"
+              },
+              "shortCode": {
+                "type": "string"
+              },
+              "owner": {
+                "type": "string"
+              },
+              "mainEditor": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "lastEdit": {
+                "type": "string"
+              },
+              "language": {
+                "type": "string"
+              },
+              "countryFlag": {
+                "type": "string"
+              },
+              "sponsors": {
+                "type": "string"
+              },
+              "disclaimer": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "contactName": {
+                "type": "string"
+              },
+              "contactAddress": {
+                "type": "string"
+              },
+              "contactEmail": {
+                "type": "string"
+              },
+              "contactTelephone": {
+                "type": "string"
+              },
+              "institutionId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "institutionName": {
+                "type": "string"
+              },
+              "institutionUrl": {
+                "type": "string"
+              },
+              "institutionLogoUrl": {
+                "type": "string"
+              },
+              "institutionShortName": {
+                "type": "string"
+              },
+              "institutionGradeStrength": {
+                "type": "string"
+              },
+              "hasAltGrade": {
+                "type": "boolean"
+              },
+              "guidelineId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "currentDraftId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "publishedId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "editDraft": {
+                "type": "boolean"
+              },
+              "editPublish": {
+                "type": "boolean"
+              },
+              "permissionDraft": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "permissionPublish": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "isLatestPublished": {
+                "type": "boolean"
+              },
+              "isDraftEditable": {
+                "type": "boolean"
+              },
+              "isPublic": {
+                "type": "boolean"
+              },
+              "versionMajor": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "versionMinor": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "versionLabel": {
+                "type": "string"
+              },
+              "draftPicoCount": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "draftRecommendationCount": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "publishedPicoCount": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "publishedRecommendationCount": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "pdfPublishedPath": {
+                "type": "string"
+              },
+              "jsonPath": {
+                "type": "string"
+              },
+              "contentAdmin": {
+                "type": "boolean"
+              },
+              "status": {
+                "type": "string"
+              },
+              "commentsInPublished": {
+                "type": "boolean"
+              },
+              "publishCreationTime": {
+                "type": "string"
+              },
+              "publishDate": {
+                "type": "string"
+              },
+              "publishLastSearchDate": {
+                "type": "string"
+              },
+              "trackChanges": {
+                "type": "boolean"
+              },
+              "sectionNumbers": {
+                "type": "boolean"
+              },
+              "showRecByline": {
+                "type": "boolean"
+              },
+              "showRecNumbers": {
+                "type": "string"
+              },
+              "showConflicts": {
+                "type": "boolean"
+              },
+              "showCertaintyStrengthLabels": {
+                "type": "boolean"
+              },
+              "showSectionPreview": {
+                "type": "boolean"
+              },
+              "subscriptions": {
+                "type": "boolean"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -294,370 +276,355 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "name": {
+              "type": "string"
             },
-            "data": {
+            "byName": {
+              "type": "string"
+            },
+            "shortCode": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "mainEditor": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "lastEdit": {
+              "type": "string"
+            },
+            "language": {
+              "type": "string"
+            },
+            "countryFlag": {
+              "type": "string"
+            },
+            "sponsors": {
+              "type": "string"
+            },
+            "disclaimer": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "isbn": {
+              "type": "string"
+            },
+            "issn": {
+              "type": "string"
+            },
+            "orgDocId": {
+              "type": "string"
+            },
+            "department": {
+              "type": "string"
+            },
+            "contactName": {
+              "type": "string"
+            },
+            "contactAddress": {
+              "type": "string"
+            },
+            "contactEmail": {
+              "type": "string"
+            },
+            "contactTelephone": {
+              "type": "string"
+            },
+            "contactWeb": {
+              "type": "string"
+            },
+            "institutionId": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "institutionName": {
+              "type": "string"
+            },
+            "institutionLogoUrl": {
+              "type": "string"
+            },
+            "institutionShortName": {
+              "type": "string"
+            },
+            "institutionGradeStrength": {
+              "type": "string"
+            },
+            "hasAltGrade": {
+              "type": "boolean"
+            },
+            "guidelineId": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "currentDraftId": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "publishedId": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "edit": {
+              "type": "boolean"
+            },
+            "permission": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "isLatestPublished": {
+              "type": "boolean"
+            },
+            "isDraftEditable": {
+              "type": "boolean"
+            },
+            "isPublic": {
+              "type": "boolean"
+            },
+            "versionMajor": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "versionMinor": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "draftPicoCount": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "draftRecommendationCount": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "publishedPicoCount": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "publishedRecommendationCount": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "pdfPublishedPath": {
+              "type": "string"
+            },
+            "jsonPath": {
+              "type": "string"
+            },
+            "contentAdmin": {
+              "type": "boolean"
+            },
+            "status": {
+              "type": "string"
+            },
+            "commentsInPublished": {
+              "type": "boolean"
+            },
+            "publishCreationTime": {
+              "type": "string"
+            },
+            "publishDate": {
+              "type": "string"
+            },
+            "publishLastSearchDate": {
+              "type": "string"
+            },
+            "trackChanges": {
+              "type": "boolean"
+            },
+            "sectionNumbers": {
+              "type": "boolean"
+            },
+            "showRecByline": {
+              "type": "boolean"
+            },
+            "showRecNumbers": {
+              "type": "string"
+            },
+            "showConflicts": {
+              "type": "boolean"
+            },
+            "showCertaintyStrengthLabels": {
+              "type": "boolean"
+            },
+            "showSectionPreview": {
+              "type": "boolean"
+            },
+            "subscriptions": {
+              "type": "boolean"
+            },
+            "defaultKeyInfoType": {
+              "type": "string"
+            },
+            "pdfSettings": {
               "type": "object",
               "properties": {
-                "name": {
+                "pdfPageSize": {
                   "type": "string"
                 },
-                "byName": {
-                  "type": "string"
-                },
-                "shortCode": {
-                  "type": "string"
-                },
-                "owner": {
-                  "type": "string"
-                },
-                "mainEditor": {
-                  "type": "string"
-                },
-                "startDate": {
-                  "type": "string"
-                },
-                "lastEdit": {
-                  "type": "string"
-                },
-                "language": {
-                  "type": "string"
-                },
-                "countryFlag": {
-                  "type": "string"
-                },
-                "sponsors": {
-                  "type": "string"
-                },
-                "disclaimer": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "isbn": {
-                  "type": "string"
-                },
-                "issn": {
-                  "type": "string"
-                },
-                "orgDocId": {
-                  "type": "string"
-                },
-                "department": {
-                  "type": "string"
-                },
-                "contactName": {
-                  "type": "string"
-                },
-                "contactAddress": {
-                  "type": "string"
-                },
-                "contactEmail": {
-                  "type": "string"
-                },
-                "contactTelephone": {
-                  "type": "string"
-                },
-                "contactWeb": {
-                  "type": "string"
-                },
-                "institutionId": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "institutionName": {
-                  "type": "string"
-                },
-                "institutionLogoUrl": {
-                  "type": "string"
-                },
-                "institutionShortName": {
-                  "type": "string"
-                },
-                "institutionGradeStrength": {
-                  "type": "string"
-                },
-                "hasAltGrade": {
-                  "type": "boolean"
-                },
-                "guidelineId": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "currentDraftId": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "publishedId": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "edit": {
-                  "type": "boolean"
-                },
-                "permission": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "isLatestPublished": {
-                  "type": "boolean"
-                },
-                "isDraftEditable": {
-                  "type": "boolean"
-                },
-                "isPublic": {
-                  "type": "boolean"
-                },
-                "versionMajor": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "versionMinor": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "draftPicoCount": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "draftRecommendationCount": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "publishedPicoCount": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "publishedRecommendationCount": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "pdfPublishedPath": {
-                  "type": "string"
-                },
-                "jsonPath": {
-                  "type": "string"
-                },
-                "contentAdmin": {
-                  "type": "boolean"
-                },
-                "status": {
-                  "type": "string"
-                },
-                "commentsInPublished": {
-                  "type": "boolean"
-                },
-                "publishCreationTime": {
-                  "type": "string"
-                },
-                "publishDate": {
-                  "type": "string"
-                },
-                "publishLastSearchDate": {
-                  "type": "string"
-                },
-                "trackChanges": {
-                  "type": "boolean"
-                },
-                "sectionNumbers": {
-                  "type": "boolean"
-                },
-                "showRecByline": {
-                  "type": "boolean"
-                },
-                "showRecNumbers": {
-                  "type": "string"
-                },
-                "showConflicts": {
-                  "type": "boolean"
-                },
-                "showCertaintyStrengthLabels": {
-                  "type": "boolean"
-                },
-                "showSectionPreview": {
-                  "type": "boolean"
-                },
-                "subscriptions": {
-                  "type": "boolean"
-                },
-                "defaultKeyInfoType": {
-                  "type": "string"
-                },
-                "pdfSettings": {
+                "pdfCoverPage": {
                   "type": "object",
                   "properties": {
-                    "pdfPageSize": {
+                    "image": {
+                      "type": "null"
+                    },
+                    "fileName": {
                       "type": "string"
                     },
-                    "pdfCoverPage": {
-                      "type": "object",
-                      "properties": {
-                        "image": {
-                          "type": "null"
-                        },
-                        "fileName": {
-                          "type": "string"
-                        },
-                        "fileType": {
-                          "type": "string"
-                        },
-                        "fileUrl": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "pdfLastPage": {
-                      "type": "object",
-                      "properties": {
-                        "image": {
-                          "type": "null"
-                        },
-                        "fileName": {
-                          "type": "string"
-                        },
-                        "fileType": {
-                          "type": "string"
-                        },
-                        "fileUrl": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "pdfSectionTitleColor": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "pdfTabText": {
+                    "fileType": {
                       "type": "string"
                     },
-                    "pdfSectionText": {
+                    "fileUrl": {
                       "type": "string"
-                    },
-                    "pdfPicoReferences": {
-                      "type": "boolean"
-                    },
-                    "pdfPageB": {
-                      "type": "boolean"
-                    },
-                    "pdfSubChpPageBreak": {
-                      "type": "boolean"
-                    },
-                    "pdfPage2": {
-                      "type": "boolean"
-                    },
-                    "pdfTOC": {
-                      "type": "boolean"
-                    },
-                    "pdfSOR": {
-                      "type": "boolean"
-                    },
-                    "pdfTrackChanges": {
-                      "type": "string"
-                    },
-                    "pdfWatermark": {
-                      "type": "boolean"
-                    },
-                    "pdfHideHiddenRecInDraft": {
-                      "type": "boolean"
-                    },
-                    "pdfHeadFont": {
-                      "type": "null"
-                    },
-                    "pdfHeadSize": {
-                      "type": "null"
-                    },
-                    "pdfHeadSub1Size": {
-                      "type": "null"
-                    },
-                    "pdfHeadSub2Size": {
-                      "type": "null"
-                    },
-                    "pdfHeadSub3Size": {
-                      "type": "null"
-                    },
-                    "pdfTextFont": {
-                      "type": "null"
-                    },
-                    "pdfTextSize": {
-                      "type": "null"
-                    },
-                    "pdfOnlySOR": {
-                      "type": "boolean"
-                    },
-                    "pdfPicoInAppendix": {
-                      "type": "boolean"
-                    },
-                    "pdfPicoFootNotes": {
-                      "type": "boolean"
-                    },
-                    "pdfHidePicos": {
-                      "type": "boolean"
-                    },
-                    "pdfCiteSquare": {
-                      "type": "boolean"
-                    },
-                    "saveSettings": {
-                      "type": "boolean"
                     }
                   }
                 },
-                "gradeStrengthLabel": {
+                "pdfLastPage": {
+                  "type": "object",
+                  "properties": {
+                    "image": {
+                      "type": "null"
+                    },
+                    "fileName": {
+                      "type": "string"
+                    },
+                    "fileType": {
+                      "type": "string"
+                    },
+                    "fileUrl": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "pdfSectionTitleColor": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "pdfTabText": {
                   "type": "string"
                 },
-                "keyInfoJudgementType": {
+                "pdfSectionText": {
                   "type": "string"
+                },
+                "pdfPicoReferences": {
+                  "type": "boolean"
+                },
+                "pdfPageB": {
+                  "type": "boolean"
+                },
+                "pdfSubChpPageBreak": {
+                  "type": "boolean"
+                },
+                "pdfPage2": {
+                  "type": "boolean"
+                },
+                "pdfTOC": {
+                  "type": "boolean"
+                },
+                "pdfSOR": {
+                  "type": "boolean"
+                },
+                "pdfTrackChanges": {
+                  "type": "string"
+                },
+                "pdfWatermark": {
+                  "type": "boolean"
+                },
+                "pdfHideHiddenRecInDraft": {
+                  "type": "boolean"
+                },
+                "pdfHeadFont": {
+                  "type": "null"
+                },
+                "pdfHeadSize": {
+                  "type": "null"
+                },
+                "pdfHeadSub1Size": {
+                  "type": "null"
+                },
+                "pdfHeadSub2Size": {
+                  "type": "null"
+                },
+                "pdfHeadSub3Size": {
+                  "type": "null"
+                },
+                "pdfTextFont": {
+                  "type": "null"
+                },
+                "pdfTextSize": {
+                  "type": "null"
+                },
+                "pdfOnlySOR": {
+                  "type": "boolean"
+                },
+                "pdfPicoInAppendix": {
+                  "type": "boolean"
+                },
+                "pdfPicoFootNotes": {
+                  "type": "boolean"
+                },
+                "pdfHidePicos": {
+                  "type": "boolean"
+                },
+                "pdfCiteSquare": {
+                  "type": "boolean"
+                },
+                "saveSettings": {
+                  "type": "boolean"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "gradeStrengthLabel": {
+              "type": "string"
+            },
+            "keyInfoJudgementType": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "name"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -695,17 +662,308 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "recommendationId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "shortCode": {
+                "type": "string"
+              },
+              "guidelineId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "sectionId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "order": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "strength": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "heading": {
+                "type": "string"
+              },
+              "text": {
+                "type": "string"
+              },
+              "remarks": {
+                "type": "string"
+              },
+              "advice": {
+                "type": "string"
+              },
+              "rational": {
+                "type": "string"
+              },
+              "adaptation": {
+                "type": "string"
+              },
+              "implementation": {
+                "type": "string"
+              },
+              "evaluation": {
+                "type": "string"
+              },
+              "research": {
+                "type": "string"
+              },
+              "keyInfoType": {
+                "type": "string"
+              },
+              "keyInfoDisplayMode": {
+                "type": "string"
+              },
+              "hideInPublish": {
+                "type": "boolean"
+              },
+              "picoIds": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
+              },
+              "keyInfo": {
+                "type": "object",
+                "properties": {
+                  "keyInfoType": {
+                    "type": "string"
+                  },
+                  "recommendationId": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "guidelineId": {
+                    "type": "null"
+                  },
+                  "sectionId": {
+                    "type": "null"
+                  },
+                  "benefits": {
+                    "type": "string"
+                  },
+                  "benefitsResearchEvidence": {
+                    "type": "string"
+                  },
+                  "benefitsResearchEvidenceInPublic": {
+                    "type": "boolean"
+                  },
+                  "benefitsAdditionalConsideration": {
+                    "type": "string"
+                  },
+                  "benefitsAdditionalConsiderationInPublic": {
+                    "type": "boolean"
+                  },
+                  "evidence": {
+                    "type": "string"
+                  },
+                  "evidenceResearchEvidence": {
+                    "type": "string"
+                  },
+                  "evidenceResearchEvidenceInPublic": {
+                    "type": "boolean"
+                  },
+                  "evidenceAdditionalConsideration": {
+                    "type": "string"
+                  },
+                  "evidenceAdditionalConsiderationInPublic": {
+                    "type": "boolean"
+                  },
+                  "preferences": {
+                    "type": "string"
+                  },
+                  "preferencesResearchEvidence": {
+                    "type": "string"
+                  },
+                  "preferencesResearchEvidenceInPublic": {
+                    "type": "boolean"
+                  },
+                  "preferencesAdditionalConsideration": {
+                    "type": "string"
+                  },
+                  "preferencesAdditionalConsiderationInPublic": {
+                    "type": "boolean"
+                  },
+                  "resources": {
+                    "type": "string"
+                  },
+                  "resourcesResearchEvidence": {
+                    "type": "string"
+                  },
+                  "resourcesResearchEvidenceInPublic": {
+                    "type": "boolean"
+                  },
+                  "resourcesAdditionalConsideration": {
+                    "type": "string"
+                  },
+                  "resourcesAdditionalConsiderationInPublic": {
+                    "type": "boolean"
+                  },
+                  "benefitsStrength": {
+                    "type": "string"
+                  },
+                  "evidenceStrength": {
+                    "type": "string"
+                  },
+                  "preferencesStrength": {
+                    "type": "string"
+                  },
+                  "resourcesStrength": {
+                    "type": "string"
+                  },
+                  "interventions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "recommendationId": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "picoId": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "picoElement": {
+                          "type": "string"
+                        },
+                        "intervention": {
+                          "type": "string"
+                        },
+                        "isComparator": {
+                          "type": "boolean"
+                        },
+                        "showComparator": {
+                          "type": "boolean"
+                        },
+                        "sortOrder": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "judgements": {
+                          "type": "object",
+                          "properties": {
+                            "BENEFITS_DESIRABLE": {
+                              "type": "string"
+                            },
+                            "BENEFITS_UNDESIRABLE": {
+                              "type": "string"
+                            },
+                            "EVIDENCE": {
+                              "type": "string"
+                            },
+                            "PREFERENCES": {
+                              "type": "string"
+                            },
+                            "RESOURCES": {
+                              "type": "string"
+                            },
+                            "EQUITY": {
+                              "type": "string"
+                            },
+                            "ACCEPTABILITY": {
+                              "type": "string"
+                            },
+                            "FEASIBILITY": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "comparator": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  },
+                  "isSummaryOfJudgementPublic": {
+                    "type": "boolean"
+                  },
+                  "acceptabilityStrength": {
+                    "type": "string"
+                  },
+                  "acceptability": {
+                    "type": "string"
+                  },
+                  "acceptabilityResearchEvidence": {
+                    "type": "string"
+                  },
+                  "acceptabilityResearchEvidenceInPublic": {
+                    "type": "boolean"
+                  },
+                  "acceptabilityAdditionalConsideration": {
+                    "type": "string"
+                  },
+                  "acceptabilityAdditionalConsiderationInPublic": {
+                    "type": "boolean"
+                  },
+                  "equityStrength": {
+                    "type": "string"
+                  },
+                  "equity": {
+                    "type": "string"
+                  },
+                  "equityResearchEvidence": {
+                    "type": "string"
+                  },
+                  "equityResearchEvidenceInPublic": {
+                    "type": "boolean"
+                  },
+                  "equityAdditionalConsideration": {
+                    "type": "string"
+                  },
+                  "equityAdditionalConsiderationInPublic": {
+                    "type": "boolean"
+                  },
+                  "feasibilityStrength": {
+                    "type": "string"
+                  },
+                  "feasibility": {
+                    "type": "string"
+                  },
+                  "feasibilityResearchEvidence": {
+                    "type": "string"
+                  },
+                  "feasibilityResearchEvidenceInPublic": {
+                    "type": "boolean"
+                  },
+                  "feasibilityAdditionalConsideration": {
+                    "type": "string"
+                  },
+                  "feasibilityAdditionalConsiderationInPublic": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "interventions": {
                 "type": "object",
                 "properties": {
                   "recommendationId": {
@@ -729,329 +987,74 @@
                       "number"
                     ]
                   },
-                  "order": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "strength": {
+                  "emrImplement": {
                     "type": "string"
                   },
-                  "status": {
+                  "emrResources": {
                     "type": "string"
                   },
-                  "heading": {
+                  "targetPopulation": {
                     "type": "string"
                   },
-                  "text": {
+                  "recommendedInvention": {
                     "type": "string"
                   },
-                  "remarks": {
-                    "type": "string"
-                  },
-                  "advice": {
-                    "type": "string"
-                  },
-                  "rational": {
-                    "type": "string"
-                  },
-                  "adaptation": {
-                    "type": "string"
-                  },
-                  "implementation": {
-                    "type": "string"
-                  },
-                  "evaluation": {
-                    "type": "string"
-                  },
-                  "research": {
-                    "type": "string"
-                  },
-                  "keyInfoType": {
-                    "type": "string"
-                  },
-                  "keyInfoDisplayMode": {
-                    "type": "string"
-                  },
-                  "hideInPublish": {
-                    "type": "boolean"
-                  },
-                  "picoIds": {
-                    "type": "array",
-                    "items": {
+                  "codes": {
+                    "type": "array"
+                  }
+                }
+              },
+              "emrCodes": {
+                "type": "array"
+              },
+              "picos": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "picoId": {
                       "type": [
                         "integer",
                         "number"
                       ]
-                    }
-                  },
-                  "keyInfo": {
-                    "type": "object",
-                    "properties": {
-                      "keyInfoType": {
-                        "type": "string"
-                      },
-                      "recommendationId": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "guidelineId": {
-                        "type": "null"
-                      },
-                      "sectionId": {
-                        "type": "null"
-                      },
-                      "benefits": {
-                        "type": "string"
-                      },
-                      "benefitsResearchEvidence": {
-                        "type": "string"
-                      },
-                      "benefitsResearchEvidenceInPublic": {
-                        "type": "boolean"
-                      },
-                      "benefitsAdditionalConsideration": {
-                        "type": "string"
-                      },
-                      "benefitsAdditionalConsiderationInPublic": {
-                        "type": "boolean"
-                      },
-                      "evidence": {
-                        "type": "string"
-                      },
-                      "evidenceResearchEvidence": {
-                        "type": "string"
-                      },
-                      "evidenceResearchEvidenceInPublic": {
-                        "type": "boolean"
-                      },
-                      "evidenceAdditionalConsideration": {
-                        "type": "string"
-                      },
-                      "evidenceAdditionalConsiderationInPublic": {
-                        "type": "boolean"
-                      },
-                      "preferences": {
-                        "type": "string"
-                      },
-                      "preferencesResearchEvidence": {
-                        "type": "string"
-                      },
-                      "preferencesResearchEvidenceInPublic": {
-                        "type": "boolean"
-                      },
-                      "preferencesAdditionalConsideration": {
-                        "type": "string"
-                      },
-                      "preferencesAdditionalConsiderationInPublic": {
-                        "type": "boolean"
-                      },
-                      "resources": {
-                        "type": "string"
-                      },
-                      "resourcesResearchEvidence": {
-                        "type": "string"
-                      },
-                      "resourcesResearchEvidenceInPublic": {
-                        "type": "boolean"
-                      },
-                      "resourcesAdditionalConsideration": {
-                        "type": "string"
-                      },
-                      "resourcesAdditionalConsiderationInPublic": {
-                        "type": "boolean"
-                      },
-                      "benefitsStrength": {
-                        "type": "string"
-                      },
-                      "evidenceStrength": {
-                        "type": "string"
-                      },
-                      "preferencesStrength": {
-                        "type": "string"
-                      },
-                      "resourcesStrength": {
-                        "type": "string"
-                      },
-                      "interventions": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "recommendationId": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "picoId": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "picoElement": {
-                              "type": "string"
-                            },
-                            "intervention": {
-                              "type": "string"
-                            },
-                            "isComparator": {
-                              "type": "boolean"
-                            },
-                            "showComparator": {
-                              "type": "boolean"
-                            },
-                            "sortOrder": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "judgements": {
-                              "type": "object",
-                              "properties": {
-                                "BENEFITS_DESIRABLE": {
-                                  "type": "string"
-                                },
-                                "BENEFITS_UNDESIRABLE": {
-                                  "type": "string"
-                                },
-                                "EVIDENCE": {
-                                  "type": "string"
-                                },
-                                "PREFERENCES": {
-                                  "type": "string"
-                                },
-                                "RESOURCES": {
-                                  "type": "string"
-                                },
-                                "EQUITY": {
-                                  "type": "string"
-                                },
-                                "ACCEPTABILITY": {
-                                  "type": "string"
-                                },
-                                "FEASIBILITY": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "comparator": {
-                              "type": "boolean"
-                            }
-                          }
-                        }
-                      },
-                      "isSummaryOfJudgementPublic": {
-                        "type": "boolean"
-                      },
-                      "acceptabilityStrength": {
-                        "type": "string"
-                      },
-                      "acceptability": {
-                        "type": "string"
-                      },
-                      "acceptabilityResearchEvidence": {
-                        "type": "string"
-                      },
-                      "acceptabilityResearchEvidenceInPublic": {
-                        "type": "boolean"
-                      },
-                      "acceptabilityAdditionalConsideration": {
-                        "type": "string"
-                      },
-                      "acceptabilityAdditionalConsiderationInPublic": {
-                        "type": "boolean"
-                      },
-                      "equityStrength": {
-                        "type": "string"
-                      },
-                      "equity": {
-                        "type": "string"
-                      },
-                      "equityResearchEvidence": {
-                        "type": "string"
-                      },
-                      "equityResearchEvidenceInPublic": {
-                        "type": "boolean"
-                      },
-                      "equityAdditionalConsideration": {
-                        "type": "string"
-                      },
-                      "equityAdditionalConsiderationInPublic": {
-                        "type": "boolean"
-                      },
-                      "feasibilityStrength": {
-                        "type": "string"
-                      },
-                      "feasibility": {
-                        "type": "string"
-                      },
-                      "feasibilityResearchEvidence": {
-                        "type": "string"
-                      },
-                      "feasibilityResearchEvidenceInPublic": {
-                        "type": "boolean"
-                      },
-                      "feasibilityAdditionalConsideration": {
-                        "type": "string"
-                      },
-                      "feasibilityAdditionalConsiderationInPublic": {
-                        "type": "boolean"
-                      }
-                    }
-                  },
-                  "interventions": {
-                    "type": "object",
-                    "properties": {
-                      "recommendationId": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "shortCode": {
-                        "type": "string"
-                      },
-                      "guidelineId": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "sectionId": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "emrImplement": {
-                        "type": "string"
-                      },
-                      "emrResources": {
-                        "type": "string"
-                      },
-                      "targetPopulation": {
-                        "type": "string"
-                      },
-                      "recommendedInvention": {
-                        "type": "string"
-                      },
-                      "codes": {
-                        "type": "array"
-                      }
-                    }
-                  },
-                  "emrCodes": {
-                    "type": "array"
-                  },
-                  "picos": {
-                    "type": "array",
-                    "items": {
+                    },
+                    "sectionId": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "order": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "population": {
+                      "type": "string"
+                    },
+                    "populationShortName": {
+                      "type": "string"
+                    },
+                    "intervention": {
+                      "type": "string"
+                    },
+                    "interventionShortName": {
+                      "type": "string"
+                    },
+                    "comparator": {
+                      "type": "string"
+                    },
+                    "comparatorShortName": {
+                      "type": "string"
+                    },
+                    "shortCode": {
+                      "type": "string"
+                    },
+                    "summary": {
+                      "type": "string"
+                    },
+                    "outcomes": {
                       "type": "object",
                       "properties": {
                         "picoId": {
@@ -1066,837 +1069,186 @@
                             "number"
                           ]
                         },
-                        "order": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "population": {
-                          "type": "string"
-                        },
-                        "populationShortName": {
-                          "type": "string"
-                        },
-                        "intervention": {
-                          "type": "string"
-                        },
-                        "interventionShortName": {
-                          "type": "string"
-                        },
-                        "comparator": {
-                          "type": "string"
-                        },
-                        "comparatorShortName": {
-                          "type": "string"
-                        },
-                        "shortCode": {
-                          "type": "string"
-                        },
-                        "summary": {
-                          "type": "string"
-                        },
-                        "outcomes": {
-                          "type": "object",
-                          "properties": {
-                            "picoId": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "sectionId": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "guidelineId": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "dichotomousOutcomes": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "outcomeId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "picoId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "sectionId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "guidelineId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "status": {
-                                    "type": "string"
-                                  },
-                                  "isHidden": {
-                                    "type": "boolean"
-                                  },
-                                  "sortOrder": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "shortCode": {
-                                    "type": "string"
-                                  },
-                                  "outcome": {
-                                    "type": "string"
-                                  },
-                                  "shortName": {
-                                    "type": "string"
-                                  },
-                                  "importanceLevel": {
-                                    "type": "string"
-                                  },
-                                  "interventionStudies": {
-                                    "type": "string"
-                                  },
-                                  "interventionTotalParticipants": {
-                                    "type": "number"
-                                  },
-                                  "interventionReferenceType": {
-                                    "type": "string"
-                                  },
-                                  "interventionStudyType": {
-                                    "type": "string"
-                                  },
-                                  "comparatorStudyType": {
-                                    "type": "string"
-                                  },
-                                  "comparatorReferenceType": {
-                                    "type": "string"
-                                  },
-                                  "comparatorComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityInterventionStudyType": {
-                                    "type": "string"
-                                  },
-                                  "qualityOfEvidenceLevel": {
-                                    "type": "string"
-                                  },
-                                  "qualityOfEvidenceComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityRiskOfBias": {
-                                    "type": "string"
-                                  },
-                                  "qualityInconsistency": {
-                                    "type": "string"
-                                  },
-                                  "qualityIndirectness": {
-                                    "type": "string"
-                                  },
-                                  "qualityIndirectnessComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityImprecision": {
-                                    "type": "string"
-                                  },
-                                  "qualityPublicationBias": {
-                                    "type": "string"
-                                  },
-                                  "qualityUpgrade": {
-                                    "type": "string"
-                                  },
-                                  "plainSummaryComment": {
-                                    "type": "string"
-                                  },
-                                  "directionOfEffectType": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifference": {
-                                    "type": "number"
-                                  },
-                                  "absoluteDifferenceDirection": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifferenceConfidenceType": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifferenceLow": {
-                                    "type": "number"
-                                  },
-                                  "absoluteDifferenceLowDirection": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifferenceHigh": {
-                                    "type": "number"
-                                  },
-                                  "absoluteDifferenceHighDirection": {
-                                    "type": "string"
-                                  },
-                                  "relativeEffect": {
-                                    "type": "number"
-                                  },
-                                  "relativeEffectType": {
-                                    "type": "string"
-                                  },
-                                  "relativeEffectConfidenceType": {
-                                    "type": "string"
-                                  },
-                                  "relativeEffectConfidenceLow": {
-                                    "type": "number"
-                                  },
-                                  "relativeEffectConfidenceHigh": {
-                                    "type": "number"
-                                  },
-                                  "comparatorEffect": {
-                                    "type": "number"
-                                  },
-                                  "comparatorEffectType": {
-                                    "type": "string"
-                                  },
-                                  "interventionEffect": {
-                                    "type": "number"
-                                  },
-                                  "interventionEffectType": {
-                                    "type": "string"
-                                  },
-                                  "autoCalcInterventions": {
-                                    "type": "string"
-                                  },
-                                  "shadow_PARENT_ID_FOR_MERGING": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "qualityRiskOfBiasComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityImprecisionComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityRiskOfBiasIssues": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "value": {
-                                          "type": "string"
-                                        },
-                                        "description": {
-                                          "type": "string"
-                                        },
-                                        "type": {
-                                          "type": "string"
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "comparatorStudies": {
-                                    "type": "string"
-                                  },
-                                  "comparatorTotalParticipants": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "comparatorTotalEvents": {
-                                    "type": "number"
-                                  },
-                                  "qualityUpgradeComment": {
-                                    "type": "string"
-                                  },
-                                  "timeFrame": {
-                                    "type": "string"
-                                  },
-                                  "description": {
-                                    "type": "string"
-                                  },
-                                  "interventionStudyFollowUp": {
-                                    "type": "string"
-                                  },
-                                  "comparatorFollowUp": {
-                                    "type": "string"
-                                  },
-                                  "qualityInconsistencyComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityPublicationBiasComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityInconsistencyIssues": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "value": {
-                                          "type": "string"
-                                        },
-                                        "description": {
-                                          "type": "string"
-                                        },
-                                        "type": {
-                                          "type": "string"
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "qualityPublicationBiasIssues": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "value": {
-                                          "type": "string"
-                                        },
-                                        "description": {
-                                          "type": "string"
-                                        },
-                                        "type": {
-                                          "type": "string"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "continuousOutcomes": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "outcomeId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "picoId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "sectionId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "guidelineId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "status": {
-                                    "type": "string"
-                                  },
-                                  "isHidden": {
-                                    "type": "boolean"
-                                  },
-                                  "sortOrder": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "shortCode": {
-                                    "type": "string"
-                                  },
-                                  "outcome": {
-                                    "type": "string"
-                                  },
-                                  "shortName": {
-                                    "type": "string"
-                                  },
-                                  "importanceLevel": {
-                                    "type": "string"
-                                  },
-                                  "interventionStudies": {
-                                    "type": "string"
-                                  },
-                                  "interventionReferenceType": {
-                                    "type": "string"
-                                  },
-                                  "interventionStudyType": {
-                                    "type": "string"
-                                  },
-                                  "comparatorStudyType": {
-                                    "type": "string"
-                                  },
-                                  "comparatorReferenceType": {
-                                    "type": "string"
-                                  },
-                                  "qualityInterventionStudyType": {
-                                    "type": "string"
-                                  },
-                                  "qualityOfEvidenceLevel": {
-                                    "type": "string"
-                                  },
-                                  "qualityOfEvidenceComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityRiskOfBias": {
-                                    "type": "string"
-                                  },
-                                  "qualityRiskOfBiasComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityInconsistency": {
-                                    "type": "string"
-                                  },
-                                  "qualityIndirectness": {
-                                    "type": "string"
-                                  },
-                                  "qualityImprecision": {
-                                    "type": "string"
-                                  },
-                                  "qualityPublicationBias": {
-                                    "type": "string"
-                                  },
-                                  "qualityPublicationBiasComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityUpgrade": {
-                                    "type": "string"
-                                  },
-                                  "qualityRiskOfBiasIssues": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "value": {
-                                          "type": "string"
-                                        },
-                                        "description": {
-                                          "type": "string"
-                                        },
-                                        "type": {
-                                          "type": "string"
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "qualityPublicationBiasIssues": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "value": {
-                                          "type": "string"
-                                        },
-                                        "description": {
-                                          "type": "string"
-                                        },
-                                        "type": {
-                                          "type": "string"
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "plainSummaryComment": {
-                                    "type": "string"
-                                  },
-                                  "directionOfEffectType": {
-                                    "type": "string"
-                                  },
-                                  "measurementLabel": {
-                                    "type": "string"
-                                  },
-                                  "scaleLow": {
-                                    "type": "string"
-                                  },
-                                  "scaleDirection": {
-                                    "type": "string"
-                                  },
-                                  "unit": {
-                                    "type": "string"
-                                  },
-                                  "interventionEffect": {
-                                    "type": "string"
-                                  },
-                                  "interventionEffectType": {
-                                    "type": "string"
-                                  },
-                                  "interventionEffectConfidenceType": {
-                                    "type": "string"
-                                  },
-                                  "interventionEffectConfidenceLow": {
-                                    "type": "string"
-                                  },
-                                  "interventionEffectConfidenceHigh": {
-                                    "type": "string"
-                                  },
-                                  "comparatorEffect": {
-                                    "type": "string"
-                                  },
-                                  "comparatorEffectType": {
-                                    "type": "string"
-                                  },
-                                  "comparatorEffectConfidenceType": {
-                                    "type": "string"
-                                  },
-                                  "comparatorEffectConfidenceLow": {
-                                    "type": "string"
-                                  },
-                                  "comparatorEffectConfidenceHigh": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifferenceType": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifference": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifferenceDirection": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifferenceConfidenceType": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifferenceLow": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifferenceLowDirection": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifferenceHigh": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifferenceHighDirection": {
-                                    "type": "string"
-                                  },
-                                  "absoluteDifferenceDirectionType": {
-                                    "type": "string"
-                                  },
-                                  "shadow_PARENT_ID_FOR_MERGING": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "qualityInconsistencyComment": {
-                                    "type": "string"
-                                  },
-                                  "description": {
-                                    "type": "string"
-                                  },
-                                  "interventionTotalParticipants": {
-                                    "type": "number"
-                                  },
-                                  "qualityInconsistencyIssues": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "id": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "value": {
-                                          "type": "string"
-                                        },
-                                        "description": {
-                                          "type": "string"
-                                        },
-                                        "type": {
-                                          "type": "string"
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "scaleHigh": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            },
-                            "nonPoolableOutcomes": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "outcomeId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "picoId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "sectionId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "guidelineId": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "status": {
-                                    "type": "string"
-                                  },
-                                  "isHidden": {
-                                    "type": "boolean"
-                                  },
-                                  "sortOrder": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "shortCode": {
-                                    "type": "string"
-                                  },
-                                  "outcome": {
-                                    "type": "string"
-                                  },
-                                  "shortName": {
-                                    "type": "string"
-                                  },
-                                  "importanceLevel": {
-                                    "type": "string"
-                                  },
-                                  "interventionStudies": {
-                                    "type": "string"
-                                  },
-                                  "interventionTotalParticipants": {
-                                    "type": "number"
-                                  },
-                                  "interventionReferenceType": {
-                                    "type": "string"
-                                  },
-                                  "interventionStudyType": {
-                                    "type": "string"
-                                  },
-                                  "comparatorStudyType": {
-                                    "type": "string"
-                                  },
-                                  "comparatorReferenceType": {
-                                    "type": "string"
-                                  },
-                                  "extraReferences": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "referenceId": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "referenceNumber": {
-                                          "type": [
-                                            "integer",
-                                            "number"
-                                          ]
-                                        },
-                                        "authors": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "object",
-                                            "properties": {
-                                              "id": {
-                                                "type": [
-                                                  "integer",
-                                                  "number"
-                                                ]
-                                              },
-                                              "firstName": {
-                                                "type": "string"
-                                              },
-                                              "lastName": {
-                                                "type": "string"
-                                              },
-                                              "formattedName": {
-                                                "type": "string"
-                                              }
-                                            }
-                                          }
-                                        },
-                                        "titleText": {
-                                          "type": "string"
-                                        },
-                                        "url": {
-                                          "type": "string"
-                                        },
-                                        "doi": {
-                                          "type": "string"
-                                        },
-                                        "pmid": {
-                                          "type": "string"
-                                        },
-                                        "journal": {
-                                          "type": "string"
-                                        },
-                                        "year": {
-                                          "type": "string"
-                                        },
-                                        "volume": {
-                                          "type": "string"
-                                        },
-                                        "issue": {
-                                          "type": "string"
-                                        },
-                                        "pageStart": {
-                                          "type": "string"
-                                        },
-                                        "pageEnd": {
-                                          "type": "string"
-                                        },
-                                        "creationType": {
-                                          "type": "string"
-                                        },
-                                        "comment": {
-                                          "type": "string"
-                                        },
-                                        "attachedFiles": {
-                                          "type": "array"
-                                        }
-                                      }
-                                    }
-                                  },
-                                  "qualityInterventionStudyType": {
-                                    "type": "string"
-                                  },
-                                  "qualityOfEvidenceLevel": {
-                                    "type": "string"
-                                  },
-                                  "qualityOfEvidenceComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityRiskOfBias": {
-                                    "type": "string"
-                                  },
-                                  "qualityRiskOfBiasComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityInconsistency": {
-                                    "type": "string"
-                                  },
-                                  "qualityIndirectness": {
-                                    "type": "string"
-                                  },
-                                  "qualityIndirectnessComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityImprecision": {
-                                    "type": "string"
-                                  },
-                                  "qualityImprecisionComment": {
-                                    "type": "string"
-                                  },
-                                  "qualityPublicationBias": {
-                                    "type": "string"
-                                  },
-                                  "qualityUpgrade": {
-                                    "type": "string"
-                                  },
-                                  "plainSummaryComment": {
-                                    "type": "string"
-                                  },
-                                  "directionOfEffectType": {
-                                    "type": "string"
-                                  },
-                                  "estimatesDescription": {
-                                    "type": "string"
-                                  },
-                                  "shadow_PARENT_ID_FOR_MERGING": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  }
-                                }
-                              }
-                            },
-                            "practicalIssues": {
-                              "type": "array"
-                            }
-                          }
-                        },
                         "guidelineId": {
                           "type": [
                             "integer",
                             "number"
                           ]
                         },
-                        "references": {
+                        "dichotomousOutcomes": {
                           "type": "array",
                           "items": {
                             "type": "object",
                             "properties": {
-                              "referenceId": {
+                              "outcomeId": {
                                 "type": [
                                   "integer",
                                   "number"
                                 ]
                               },
-                              "referenceNumber": {
+                              "picoId": {
                                 "type": [
                                   "integer",
                                   "number"
                                 ]
                               },
-                              "authors": {
+                              "sectionId": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "guidelineId": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "isHidden": {
+                                "type": "boolean"
+                              },
+                              "sortOrder": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "shortCode": {
+                                "type": "string"
+                              },
+                              "outcome": {
+                                "type": "string"
+                              },
+                              "shortName": {
+                                "type": "string"
+                              },
+                              "importanceLevel": {
+                                "type": "string"
+                              },
+                              "interventionStudies": {
+                                "type": "string"
+                              },
+                              "interventionTotalParticipants": {
+                                "type": "number"
+                              },
+                              "interventionReferenceType": {
+                                "type": "string"
+                              },
+                              "interventionStudyType": {
+                                "type": "string"
+                              },
+                              "comparatorStudyType": {
+                                "type": "string"
+                              },
+                              "comparatorReferenceType": {
+                                "type": "string"
+                              },
+                              "comparatorComment": {
+                                "type": "string"
+                              },
+                              "qualityInterventionStudyType": {
+                                "type": "string"
+                              },
+                              "qualityOfEvidenceLevel": {
+                                "type": "string"
+                              },
+                              "qualityOfEvidenceComment": {
+                                "type": "string"
+                              },
+                              "qualityRiskOfBias": {
+                                "type": "string"
+                              },
+                              "qualityInconsistency": {
+                                "type": "string"
+                              },
+                              "qualityIndirectness": {
+                                "type": "string"
+                              },
+                              "qualityIndirectnessComment": {
+                                "type": "string"
+                              },
+                              "qualityImprecision": {
+                                "type": "string"
+                              },
+                              "qualityPublicationBias": {
+                                "type": "string"
+                              },
+                              "qualityUpgrade": {
+                                "type": "string"
+                              },
+                              "plainSummaryComment": {
+                                "type": "string"
+                              },
+                              "directionOfEffectType": {
+                                "type": "string"
+                              },
+                              "absoluteDifference": {
+                                "type": "number"
+                              },
+                              "absoluteDifferenceDirection": {
+                                "type": "string"
+                              },
+                              "absoluteDifferenceConfidenceType": {
+                                "type": "string"
+                              },
+                              "absoluteDifferenceLow": {
+                                "type": "number"
+                              },
+                              "absoluteDifferenceLowDirection": {
+                                "type": "string"
+                              },
+                              "absoluteDifferenceHigh": {
+                                "type": "number"
+                              },
+                              "absoluteDifferenceHighDirection": {
+                                "type": "string"
+                              },
+                              "relativeEffect": {
+                                "type": "number"
+                              },
+                              "relativeEffectType": {
+                                "type": "string"
+                              },
+                              "relativeEffectConfidenceType": {
+                                "type": "string"
+                              },
+                              "relativeEffectConfidenceLow": {
+                                "type": "number"
+                              },
+                              "relativeEffectConfidenceHigh": {
+                                "type": "number"
+                              },
+                              "comparatorEffect": {
+                                "type": "number"
+                              },
+                              "comparatorEffectType": {
+                                "type": "string"
+                              },
+                              "interventionEffect": {
+                                "type": "number"
+                              },
+                              "interventionEffectType": {
+                                "type": "string"
+                              },
+                              "autoCalcInterventions": {
+                                "type": "string"
+                              },
+                              "shadow_PARENT_ID_FOR_MERGING": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "qualityRiskOfBiasComment": {
+                                "type": "string"
+                              },
+                              "qualityImprecisionComment": {
+                                "type": "string"
+                              },
+                              "qualityRiskOfBiasIssues": {
                                 "type": "array",
                                 "items": {
                                   "type": "object",
@@ -1907,50 +1259,122 @@
                                         "number"
                                       ]
                                     },
-                                    "firstName": {
+                                    "value": {
                                       "type": "string"
                                     },
-                                    "lastName": {
+                                    "description": {
                                       "type": "string"
                                     },
-                                    "formattedName": {
+                                    "type": {
                                       "type": "string"
                                     }
                                   }
                                 }
                               },
-                              "titleText": {
+                              "comparatorStudies": {
                                 "type": "string"
                               },
-                              "url": {
+                              "comparatorTotalParticipants": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "comparatorTotalEvents": {
+                                "type": "number"
+                              },
+                              "qualityUpgradeComment": {
                                 "type": "string"
                               },
-                              "doi": {
+                              "timeFrame": {
                                 "type": "string"
                               },
-                              "pmid": {
+                              "description": {
                                 "type": "string"
                               },
-                              "journal": {
+                              "interventionStudyFollowUp": {
                                 "type": "string"
                               },
-                              "year": {
+                              "comparatorFollowUp": {
                                 "type": "string"
                               },
-                              "volume": {
+                              "qualityInconsistencyComment": {
                                 "type": "string"
                               },
-                              "issue": {
+                              "qualityPublicationBiasComment": {
                                 "type": "string"
                               },
-                              "pageStart": {
-                                "type": "string"
+                              "qualityInconsistencyIssues": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
                               },
-                              "pageEnd": {
-                                "type": "string"
+                              "qualityPublicationBiasIssues": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "continuousOutcomes": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "outcomeId": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
                               },
-                              "creationType": {
-                                "type": "string"
+                              "picoId": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "sectionId": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
                               },
                               "guidelineId": {
                                 "type": [
@@ -1958,212 +1382,737 @@
                                   "number"
                                 ]
                               },
-                              "shortName": {
+                              "status": {
                                 "type": "string"
                               },
-                              "order": {
+                              "isHidden": {
+                                "type": "boolean"
+                              },
+                              "sortOrder": {
                                 "type": [
                                   "integer",
                                   "number"
                                 ]
                               },
-                              "referenceType": {
+                              "shortCode": {
                                 "type": "string"
                               },
-                              "studyType": {
+                              "outcome": {
                                 "type": "string"
                               },
-                              "attachedFiles": {
-                                "type": "array"
-                              },
-                              "abstractText": {
+                              "shortName": {
                                 "type": "string"
                               },
-                              "comments": {
+                              "importanceLevel": {
                                 "type": "string"
                               },
-                              "selected": {
-                                "type": "boolean"
+                              "interventionStudies": {
+                                "type": "string"
                               },
-                              "usageCount": {
-                                "type": "null"
+                              "interventionReferenceType": {
+                                "type": "string"
                               },
-                              "referencePicos": {
-                                "type": "array"
+                              "interventionStudyType": {
+                                "type": "string"
                               },
-                              "files": {
-                                "type": "array"
+                              "comparatorStudyType": {
+                                "type": "string"
                               },
-                              "results": {
+                              "comparatorReferenceType": {
+                                "type": "string"
+                              },
+                              "qualityInterventionStudyType": {
+                                "type": "string"
+                              },
+                              "qualityOfEvidenceLevel": {
+                                "type": "string"
+                              },
+                              "qualityOfEvidenceComment": {
+                                "type": "string"
+                              },
+                              "qualityRiskOfBias": {
+                                "type": "string"
+                              },
+                              "qualityRiskOfBiasComment": {
+                                "type": "string"
+                              },
+                              "qualityInconsistency": {
+                                "type": "string"
+                              },
+                              "qualityIndirectness": {
+                                "type": "string"
+                              },
+                              "qualityImprecision": {
+                                "type": "string"
+                              },
+                              "qualityPublicationBias": {
+                                "type": "string"
+                              },
+                              "qualityPublicationBiasComment": {
+                                "type": "string"
+                              },
+                              "qualityUpgrade": {
+                                "type": "string"
+                              },
+                              "qualityRiskOfBiasIssues": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "qualityPublicationBiasIssues": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "plainSummaryComment": {
+                                "type": "string"
+                              },
+                              "directionOfEffectType": {
+                                "type": "string"
+                              },
+                              "measurementLabel": {
+                                "type": "string"
+                              },
+                              "scaleLow": {
+                                "type": "string"
+                              },
+                              "scaleDirection": {
+                                "type": "string"
+                              },
+                              "unit": {
+                                "type": "string"
+                              },
+                              "interventionEffect": {
+                                "type": "string"
+                              },
+                              "interventionEffectType": {
+                                "type": "string"
+                              },
+                              "interventionEffectConfidenceType": {
+                                "type": "string"
+                              },
+                              "interventionEffectConfidenceLow": {
+                                "type": "string"
+                              },
+                              "interventionEffectConfidenceHigh": {
+                                "type": "string"
+                              },
+                              "comparatorEffect": {
+                                "type": "string"
+                              },
+                              "comparatorEffectType": {
+                                "type": "string"
+                              },
+                              "comparatorEffectConfidenceType": {
+                                "type": "string"
+                              },
+                              "comparatorEffectConfidenceLow": {
+                                "type": "string"
+                              },
+                              "comparatorEffectConfidenceHigh": {
+                                "type": "string"
+                              },
+                              "absoluteDifferenceType": {
+                                "type": "string"
+                              },
+                              "absoluteDifference": {
+                                "type": "string"
+                              },
+                              "absoluteDifferenceDirection": {
+                                "type": "string"
+                              },
+                              "absoluteDifferenceConfidenceType": {
+                                "type": "string"
+                              },
+                              "absoluteDifferenceLow": {
+                                "type": "string"
+                              },
+                              "absoluteDifferenceLowDirection": {
+                                "type": "string"
+                              },
+                              "absoluteDifferenceHigh": {
+                                "type": "string"
+                              },
+                              "absoluteDifferenceHighDirection": {
+                                "type": "string"
+                              },
+                              "absoluteDifferenceDirectionType": {
+                                "type": "string"
+                              },
+                              "shadow_PARENT_ID_FOR_MERGING": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "qualityInconsistencyComment": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "interventionTotalParticipants": {
+                                "type": "number"
+                              },
+                              "qualityInconsistencyIssues": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "scaleHigh": {
                                 "type": "string"
                               }
                             }
                           }
                         },
-                        "picoCodes": {
-                          "type": "array"
-                        }
-                      }
-                    }
-                  },
-                  "references": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "referenceId": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "referenceNumber": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "authors": {
+                        "nonPoolableOutcomes": {
                           "type": "array",
                           "items": {
                             "type": "object",
                             "properties": {
-                              "id": {
+                              "outcomeId": {
                                 "type": [
                                   "integer",
                                   "number"
                                 ]
                               },
-                              "firstName": {
+                              "picoId": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "sectionId": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "guidelineId": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "status": {
                                 "type": "string"
                               },
-                              "lastName": {
+                              "isHidden": {
+                                "type": "boolean"
+                              },
+                              "sortOrder": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "shortCode": {
                                 "type": "string"
                               },
-                              "formattedName": {
+                              "outcome": {
                                 "type": "string"
+                              },
+                              "shortName": {
+                                "type": "string"
+                              },
+                              "importanceLevel": {
+                                "type": "string"
+                              },
+                              "interventionStudies": {
+                                "type": "string"
+                              },
+                              "interventionTotalParticipants": {
+                                "type": "number"
+                              },
+                              "interventionReferenceType": {
+                                "type": "string"
+                              },
+                              "interventionStudyType": {
+                                "type": "string"
+                              },
+                              "comparatorStudyType": {
+                                "type": "string"
+                              },
+                              "comparatorReferenceType": {
+                                "type": "string"
+                              },
+                              "extraReferences": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "referenceId": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "referenceNumber": {
+                                      "type": [
+                                        "integer",
+                                        "number"
+                                      ]
+                                    },
+                                    "authors": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": [
+                                              "integer",
+                                              "number"
+                                            ]
+                                          },
+                                          "firstName": {
+                                            "type": "string"
+                                          },
+                                          "lastName": {
+                                            "type": "string"
+                                          },
+                                          "formattedName": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "titleText": {
+                                      "type": "string"
+                                    },
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "doi": {
+                                      "type": "string"
+                                    },
+                                    "pmid": {
+                                      "type": "string"
+                                    },
+                                    "journal": {
+                                      "type": "string"
+                                    },
+                                    "year": {
+                                      "type": "string"
+                                    },
+                                    "volume": {
+                                      "type": "string"
+                                    },
+                                    "issue": {
+                                      "type": "string"
+                                    },
+                                    "pageStart": {
+                                      "type": "string"
+                                    },
+                                    "pageEnd": {
+                                      "type": "string"
+                                    },
+                                    "creationType": {
+                                      "type": "string"
+                                    },
+                                    "comment": {
+                                      "type": "string"
+                                    },
+                                    "attachedFiles": {
+                                      "type": "array"
+                                    }
+                                  }
+                                }
+                              },
+                              "qualityInterventionStudyType": {
+                                "type": "string"
+                              },
+                              "qualityOfEvidenceLevel": {
+                                "type": "string"
+                              },
+                              "qualityOfEvidenceComment": {
+                                "type": "string"
+                              },
+                              "qualityRiskOfBias": {
+                                "type": "string"
+                              },
+                              "qualityRiskOfBiasComment": {
+                                "type": "string"
+                              },
+                              "qualityInconsistency": {
+                                "type": "string"
+                              },
+                              "qualityIndirectness": {
+                                "type": "string"
+                              },
+                              "qualityIndirectnessComment": {
+                                "type": "string"
+                              },
+                              "qualityImprecision": {
+                                "type": "string"
+                              },
+                              "qualityImprecisionComment": {
+                                "type": "string"
+                              },
+                              "qualityPublicationBias": {
+                                "type": "string"
+                              },
+                              "qualityUpgrade": {
+                                "type": "string"
+                              },
+                              "plainSummaryComment": {
+                                "type": "string"
+                              },
+                              "directionOfEffectType": {
+                                "type": "string"
+                              },
+                              "estimatesDescription": {
+                                "type": "string"
+                              },
+                              "shadow_PARENT_ID_FOR_MERGING": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
                               }
                             }
                           }
                         },
-                        "titleText": {
-                          "type": "string"
-                        },
-                        "url": {
-                          "type": "string"
-                        },
-                        "doi": {
-                          "type": "string"
-                        },
-                        "pmid": {
-                          "type": "string"
-                        },
-                        "journal": {
-                          "type": "string"
-                        },
-                        "year": {
-                          "type": "string"
-                        },
-                        "volume": {
-                          "type": "string"
-                        },
-                        "issue": {
-                          "type": "string"
-                        },
-                        "pageStart": {
-                          "type": "string"
-                        },
-                        "pageEnd": {
-                          "type": "string"
-                        },
-                        "creationType": {
-                          "type": "string"
-                        },
-                        "guidelineId": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "shortName": {
-                          "type": "string"
-                        },
-                        "order": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "referenceType": {
-                          "type": "string"
-                        },
-                        "studyType": {
-                          "type": "string"
-                        },
-                        "attachedFiles": {
+                        "practicalIssues": {
                           "type": "array"
-                        },
-                        "abstractText": {
-                          "type": "string"
-                        },
-                        "comments": {
-                          "type": "string"
-                        },
-                        "selected": {
-                          "type": "boolean"
-                        },
-                        "usageCount": {
-                          "type": "null"
-                        },
-                        "referencePicos": {
-                          "type": "array"
-                        },
-                        "files": {
-                          "type": "array"
-                        },
-                        "results": {
-                          "type": "string"
                         }
                       }
-                    }
-                  },
-                  "files": {
-                    "type": "array"
-                  },
-                  "images": {
-                    "type": "array"
-                  },
-                  "referenceIds": {
-                    "type": "array",
-                    "items": {
+                    },
+                    "guidelineId": {
                       "type": [
                         "integer",
                         "number"
                       ]
+                    },
+                    "references": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "referenceId": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "referenceNumber": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "authors": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": [
+                                    "integer",
+                                    "number"
+                                  ]
+                                },
+                                "firstName": {
+                                  "type": "string"
+                                },
+                                "lastName": {
+                                  "type": "string"
+                                },
+                                "formattedName": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "titleText": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string"
+                          },
+                          "doi": {
+                            "type": "string"
+                          },
+                          "pmid": {
+                            "type": "string"
+                          },
+                          "journal": {
+                            "type": "string"
+                          },
+                          "year": {
+                            "type": "string"
+                          },
+                          "volume": {
+                            "type": "string"
+                          },
+                          "issue": {
+                            "type": "string"
+                          },
+                          "pageStart": {
+                            "type": "string"
+                          },
+                          "pageEnd": {
+                            "type": "string"
+                          },
+                          "creationType": {
+                            "type": "string"
+                          },
+                          "guidelineId": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "shortName": {
+                            "type": "string"
+                          },
+                          "order": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "referenceType": {
+                            "type": "string"
+                          },
+                          "studyType": {
+                            "type": "string"
+                          },
+                          "attachedFiles": {
+                            "type": "array"
+                          },
+                          "abstractText": {
+                            "type": "string"
+                          },
+                          "comments": {
+                            "type": "string"
+                          },
+                          "selected": {
+                            "type": "boolean"
+                          },
+                          "usageCount": {
+                            "type": "null"
+                          },
+                          "referencePicos": {
+                            "type": "array"
+                          },
+                          "files": {
+                            "type": "array"
+                          },
+                          "results": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "picoCodes": {
+                      "type": "array"
                     }
                   }
                 }
+              },
+              "references": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "referenceId": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "referenceNumber": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "authors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "firstName": {
+                            "type": "string"
+                          },
+                          "lastName": {
+                            "type": "string"
+                          },
+                          "formattedName": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "titleText": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    },
+                    "doi": {
+                      "type": "string"
+                    },
+                    "pmid": {
+                      "type": "string"
+                    },
+                    "journal": {
+                      "type": "string"
+                    },
+                    "year": {
+                      "type": "string"
+                    },
+                    "volume": {
+                      "type": "string"
+                    },
+                    "issue": {
+                      "type": "string"
+                    },
+                    "pageStart": {
+                      "type": "string"
+                    },
+                    "pageEnd": {
+                      "type": "string"
+                    },
+                    "creationType": {
+                      "type": "string"
+                    },
+                    "guidelineId": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "shortName": {
+                      "type": "string"
+                    },
+                    "order": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "referenceType": {
+                      "type": "string"
+                    },
+                    "studyType": {
+                      "type": "string"
+                    },
+                    "attachedFiles": {
+                      "type": "array"
+                    },
+                    "abstractText": {
+                      "type": "string"
+                    },
+                    "comments": {
+                      "type": "string"
+                    },
+                    "selected": {
+                      "type": "boolean"
+                    },
+                    "usageCount": {
+                      "type": "null"
+                    },
+                    "referencePicos": {
+                      "type": "array"
+                    },
+                    "files": {
+                      "type": "array"
+                    },
+                    "results": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "files": {
+                "type": "array"
+              },
+              "images": {
+                "type": "array"
+              },
+              "referenceIds": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -2198,106 +2147,88 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "guidelineId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "sectionId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "parentId": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "order": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "sectionType": {
+                "type": "string"
+              },
+              "shortCode": {
+                "type": "string"
+              },
+              "sectionLabel": {
+                "type": "string"
+              },
+              "sectionNumber": {
+                "type": "string"
+              },
+              "isNumbered": {
+                "type": "boolean"
+              },
+              "heading": {
+                "type": "string"
+              },
+              "text": {
+                "type": "string"
+              },
+              "counts": {
                 "type": "object",
                 "properties": {
-                  "guidelineId": {
+                  "picoCount": {
                     "type": [
                       "integer",
                       "number"
                     ]
                   },
-                  "sectionId": {
+                  "recommendationCount": {
                     "type": [
                       "integer",
                       "number"
                     ]
-                  },
-                  "parentId": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "order": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "sectionType": {
-                    "type": "string"
-                  },
-                  "shortCode": {
-                    "type": "string"
-                  },
-                  "sectionLabel": {
-                    "type": "string"
-                  },
-                  "sectionNumber": {
-                    "type": "string"
-                  },
-                  "isNumbered": {
-                    "type": "boolean"
-                  },
-                  "heading": {
-                    "type": "string"
-                  },
-                  "text": {
-                    "type": "string"
-                  },
-                  "counts": {
-                    "type": "object",
-                    "properties": {
-                      "picoCount": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "recommendationCount": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      }
-                    }
-                  },
-                  "hasUncommittedChanges": {
-                    "type": "boolean"
                   }
                 }
+              },
+              "hasUncommittedChanges": {
+                "type": "boolean"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -2359,222 +2290,174 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "meta": {
               "type": "object",
               "properties": {
-                "meta": {
-                  "type": "object",
-                  "properties": {
-                    "totalResults": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "from": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "originalQuery": {
-                      "type": "string"
-                    }
-                  }
+                "totalResults": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
                 },
-                "results": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "website": {
-                        "type": "string"
-                      },
-                      "body": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "toolTypes": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "key": {
-                              "type": "string"
-                            },
-                            "label": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "toolSubtypes": {
-                        "type": "null"
-                      },
-                      "researchAreas": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "key": {
-                              "type": "string"
-                            },
-                            "label": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "researchTypes": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "key": {
-                              "type": "string"
-                            },
-                            "label": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "resourceAccess": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          },
-                          "notes": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          }
-                        }
-                      },
-                      "doCs": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "key": {
-                              "type": "string"
-                            },
-                            "label": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "poCs": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "object",
-                              "properties": {
-                                "prefix": {
-                                  "type": [
-                                    "null",
-                                    "string"
-                                  ]
-                                },
-                                "firstName": {
-                                  "type": [
-                                    "null",
-                                    "string"
-                                  ]
-                                },
-                                "middleName": {
-                                  "type": "null"
-                                },
-                                "lastName": {
-                                  "type": [
-                                    "null",
-                                    "string"
-                                  ]
-                                },
-                                "suffix": {
-                                  "type": "null"
-                                }
-                              }
-                            },
-                            "title": {
-                              "type": [
-                                "null",
-                                "string"
-                              ]
-                            },
-                            "phone": {
-                              "type": [
-                                "null",
-                                "string"
-                              ]
-                            },
-                            "email": {
-                              "type": "string"
-                            }
-                          }
+                "from": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "originalQuery": {
+                  "type": "string"
+                }
+              }
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "website": {
+                    "type": "string"
+                  },
+                  "body": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "toolTypes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
                         }
                       }
                     }
-                  }
-                },
-                "facets": {
-                  "type": "array",
-                  "items": {
+                  },
+                  "toolSubtypes": {
+                    "type": "null"
+                  },
+                  "researchAreas": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "researchTypes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "resourceAccess": {
                     "type": "object",
                     "properties": {
-                      "title": {
-                        "type": "string"
+                      "type": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
                       },
-                      "param": {
-                        "type": "string"
-                      },
-                      "items": {
-                        "type": "array",
-                        "items": {
+                      "notes": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    }
+                  },
+                  "doCs": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "poCs": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
                           "type": "object",
                           "properties": {
-                            "key": {
-                              "type": "string"
-                            },
-                            "label": {
-                              "type": "string"
-                            },
-                            "count": {
+                            "prefix": {
                               "type": [
-                                "integer",
-                                "number"
+                                "null",
+                                "string"
                               ]
                             },
-                            "selected": {
-                              "type": "boolean"
+                            "firstName": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "middleName": {
+                              "type": "null"
+                            },
+                            "lastName": {
+                              "type": [
+                                "null",
+                                "string"
+                              ]
+                            },
+                            "suffix": {
+                              "type": "null"
                             }
                           }
+                        },
+                        "title": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "phone": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "email": {
+                          "type": "string"
                         }
                       }
                     }
@@ -2582,25 +2465,58 @@
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "facets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "param": {
+                    "type": "string"
+                  },
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "count": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "selected": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "meta"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -2639,100 +2555,85 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "aliases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
             },
-            "data": {
+            "definition": {
               "type": "object",
               "properties": {
-                "aliases": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "definition": {
-                  "type": "object",
-                  "properties": {
-                    "html": {
-                      "type": "string"
-                    },
-                    "text": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "drugInfoSummaryLink": {
-                  "type": "object",
-                  "properties": {
-                    "uri": {
-                      "type": "string"
-                    },
-                    "text": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "nciConceptId": {
+                "html": {
                   "type": "string"
                 },
-                "nciConceptName": {
-                  "type": "string"
-                },
-                "termId": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "name": {
-                  "type": "string"
-                },
-                "firstLetter": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                },
-                "termNameType": {
-                  "type": "string"
-                },
-                "prettyUrlName": {
+                "text": {
                   "type": "string"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "drugInfoSummaryLink": {
+              "type": "object",
+              "properties": {
+                "uri": {
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                }
+              }
+            },
+            "nciConceptId": {
+              "type": "string"
+            },
+            "nciConceptName": {
+              "type": "string"
+            },
+            "termId": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "firstLetter": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "termNameType": {
+              "type": "string"
+            },
+            "prettyUrlName": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "aliases"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -2784,89 +2685,74 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "meta": {
               "type": "object",
               "properties": {
-                "meta": {
-                  "type": "object",
-                  "properties": {
-                    "totalResults": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "from": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
-                  }
+                "totalResults": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
                 },
-                "results": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "preferredName": {
-                        "type": "string"
-                      },
-                      "termId": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "firstLetter": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "termNameType": {
-                        "type": "string"
-                      },
-                      "prettyUrlName": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "links": {
-                  "type": "null"
+                "from": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "preferredName": {
+                    "type": "string"
+                  },
+                  "termId": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "firstLetter": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "termNameType": {
+                    "type": "string"
+                  },
+                  "prettyUrlName": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "links": {
+              "type": "null"
             }
-          }
+          },
+          "required": [
+            "meta"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -2918,107 +2804,92 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
             "data": {
-              "type": "object",
-              "properties": {
-                "data": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "code": {
-                        "type": "string"
-                      },
-                      "codingSystem": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "metadata": {
-                  "type": "object",
-                  "properties": {
-                    "db_published_date": {
-                      "type": "string"
-                    },
-                    "elements_per_page": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "current_url": {
-                      "type": "string"
-                    },
-                    "next_page_url": {
-                      "type": "string"
-                    },
-                    "total_elements": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "total_pages": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "current_page": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "previous_page": {
-                      "type": "string"
-                    },
-                    "previous_page_url": {
-                      "type": "string"
-                    },
-                    "next_page": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "codingSystem": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
                   }
                 }
               }
             },
             "metadata": {
-              "type": "object"
+              "type": "object",
+              "properties": {
+                "db_published_date": {
+                  "type": "string"
+                },
+                "elements_per_page": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "current_url": {
+                  "type": "string"
+                },
+                "next_page_url": {
+                  "type": "string"
+                },
+                "total_elements": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "total_pages": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "current_page": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "previous_page": {
+                  "type": "string"
+                },
+                "previous_page_url": {
+                  "type": "string"
+                },
+                "next_page": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "data"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/clinical_tables_tools.json
+++ b/src/tooluniverse/data/clinical_tables_tools.json
@@ -71,9 +71,6 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
@@ -158,9 +155,6 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
@@ -236,9 +230,6 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/clinical_trial_stats_tools.json
+++ b/src/tooluniverse/data/clinical_trial_stats_tools.json
@@ -52,94 +52,80 @@
       "type": "object",
       "oneOf": [
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "n_subjects": {
+              "type": "integer"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_subjects": {
-                  "type": "integer"
-                },
-                "group_col": {
-                  "type": "string"
-                },
-                "subgroup": {
-                  "type": "string"
-                },
-                "aesev_distribution": {
-                  "type": "object"
-                },
-                "test": {
-                  "type": "string"
-                },
-                "test_statistic": {
-                  "type": "number"
-                },
-                "p_value": {
-                  "type": "number"
-                },
-                "dof": {
-                  "type": "integer"
-                },
-                "contingency_table": {
-                  "type": "object"
-                },
-                "or": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "ci_lower": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "ci_upper": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "odds_ratios": {
-                  "type": "object"
-                },
-                "covariates": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "model_summary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "n_subjects",
-                "group_col",
-                "aesev_distribution"
+            "group_col": {
+              "type": "string"
+            },
+            "subgroup": {
+              "type": "string"
+            },
+            "aesev_distribution": {
+              "type": "object"
+            },
+            "test": {
+              "type": "string"
+            },
+            "test_statistic": {
+              "type": "number"
+            },
+            "p_value": {
+              "type": "number"
+            },
+            "dof": {
+              "type": "integer"
+            },
+            "contingency_table": {
+              "type": "object"
+            },
+            "or": {
+              "type": [
+                "number",
+                "null"
               ]
+            },
+            "ci_lower": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "ci_upper": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "odds_ratios": {
+              "type": "object"
+            },
+            "covariates": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "model_summary": {
+              "type": "string"
             }
           },
           "required": [
-            "status",
-            "data"
+            "n_subjects",
+            "group_col",
+            "aesev_distribution"
           ]
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }

--- a/src/tooluniverse/data/clinicaltrials_gov_tools.json
+++ b/src/tooluniverse/data/clinicaltrials_gov_tools.json
@@ -610,90 +610,72 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "NCT ID": {
-                    "type": "string"
-                  },
-                  "references": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "pmid": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "type": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "citation": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        }
-                      }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "NCT ID": {
+                "type": "string"
+              },
+              "references": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "pmid": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "citation": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
-                  },
-                  "see_also_links": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "url": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        }
-                      }
+                  }
+                }
+              },
+              "see_also_links": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "url": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -745,54 +727,36 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "NCT ID": {
                     "type": "string"
                   },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "NCT ID": {
-                        "type": "string"
-                      },
-                      "outcomes": {
-                        "type": "array"
-                      }
-                    }
+                  "outcomes": {
+                    "type": "array"
                   }
-                ]
+                }
               }
-            },
-            "metadata": {
-              "type": "object"
-            }
+            ]
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -882,93 +846,75 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "NCT ID": {
-                    "type": "string"
-                  },
-                  "freq_threshold": {
-                    "type": [
-                      "string",
-                      "number"
-                    ]
-                  },
-                  "groups": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "description": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        }
-                      }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "NCT ID": {
+                "type": "string"
+              },
+              "freq_threshold": {
+                "type": [
+                  "string",
+                  "number"
+                ]
+              },
+              "groups": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "description": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
-                  },
-                  "serious_adverse_events": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "term": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "organSystem": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        }
-                      }
+                  }
+                }
+              },
+              "serious_adverse_events": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "term": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "organSystem": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/clinvar_submitted_tools.json
+++ b/src/tooluniverse/data/clinvar_submitted_tools.json
@@ -11,109 +11,121 @@
           "description": "ClinVar variant identifier. Accepts a VCV accession (e.g. 'VCV000013961') OR a bare ClinVar variation id (e.g. '13961'); a numeric id is normalized to VCV%09d. Example: 'VCV000013961' (BRAF V600E)."
         }
       },
-      "required": ["variant_id"]
+      "required": [
+        "variant_id"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Successful retrieval of per-submitter ClinVar records.",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": ["success"],
-              "description": "Indicates the request succeeded."
+            "variation_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "ClinVar numeric variation id."
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "variation_id": {
-                  "type": ["string", "null"],
-                  "description": "ClinVar numeric variation id."
-                },
-                "vcv_accession": {
-                  "type": ["string", "null"],
-                  "description": "VCV accession for the variant."
-                },
-                "name": {
-                  "type": ["string", "null"],
-                  "description": "ClinVar preferred variant name (e.g. HGVS expression)."
-                },
-                "aggregate_classification": {
-                  "type": ["string", "null"],
-                  "description": "Record-level aggregate germline classification description (e.g. 'Pathogenic', 'Conflicting classifications of pathogenicity')."
-                },
-                "aggregate_review_status": {
-                  "type": ["string", "null"],
-                  "description": "Record-level aggregate review status."
-                },
-                "total_submissions": {
-                  "type": "integer",
-                  "description": "Number of per-submitter assertions parsed."
-                },
-                "submissions": {
-                  "type": "array",
-                  "description": "Per-submitter (SCV) assertions.",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "scv_accession": {
-                        "type": ["string", "null"],
-                        "description": "Submitter assertion accession with version (e.g. 'SCV001450230.1')."
-                      },
-                      "classification": {
-                        "type": ["string", "null"],
-                        "description": "This submitter's classification value (e.g. 'Pathogenic' for germline, 'Tier I - Strong' for somatic clinical impact, 'Oncogenic' for oncogenicity)."
-                      },
-                      "classification_type": {
-                        "type": ["string", "null"],
-                        "description": "Which classification axis the value belongs to: 'germline', 'somatic_clinical_impact', or 'oncogenicity'."
-                      },
-                      "review_status": {
-                        "type": ["string", "null"],
-                        "description": "This submitter's review status (e.g. 'criteria provided, single submitter')."
-                      },
-                      "submitter": {
-                        "type": ["string", "null"],
-                        "description": "Submitting organization name."
-                      },
-                      "condition": {
-                        "type": ["string", "null"],
-                        "description": "Condition / phenotype the submitter classified against."
-                      },
-                      "last_evaluated": {
-                        "type": ["string", "null"],
-                        "description": "Date the submitter last evaluated the classification (YYYY-MM-DD)."
-                      }
-                    }
+            "vcv_accession": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "VCV accession for the variant."
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "ClinVar preferred variant name (e.g. HGVS expression)."
+            },
+            "aggregate_classification": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Record-level aggregate germline classification description (e.g. 'Pathogenic', 'Conflicting classifications of pathogenicity')."
+            },
+            "aggregate_review_status": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Record-level aggregate review status."
+            },
+            "total_submissions": {
+              "type": "integer",
+              "description": "Number of per-submitter assertions parsed."
+            },
+            "submissions": {
+              "type": "array",
+              "description": "Per-submitter (SCV) assertions.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "scv_accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Submitter assertion accession with version (e.g. 'SCV001450230.1')."
+                  },
+                  "classification": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "This submitter's classification value (e.g. 'Pathogenic' for germline, 'Tier I - Strong' for somatic clinical impact, 'Oncogenic' for oncogenicity)."
+                  },
+                  "classification_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Which classification axis the value belongs to: 'germline', 'somatic_clinical_impact', or 'oncogenicity'."
+                  },
+                  "review_status": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "This submitter's review status (e.g. 'criteria provided, single submitter')."
+                  },
+                  "submitter": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Submitting organization name."
+                  },
+                  "condition": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Condition / phenotype the submitter classified against."
+                  },
+                  "last_evaluated": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Date the submitter last evaluated the classification (YYYY-MM-DD)."
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "description": "Provenance and counts reported by ClinVar.",
-              "properties": {
-                "source": {"type": "string"},
-                "endpoint": {"type": "string"},
-                "queried_id": {"type": "string"},
-                "number_of_submissions_reported": {"type": ["string", "null"]},
-                "number_of_submitters_reported": {"type": ["string", "null"]},
-                "date_last_updated": {"type": ["string", "null"]}
-              }
             }
           },
-          "required": ["status", "data", "metadata"]
+          "required": [
+            "total_submissions"
+          ]
         },
         {
           "type": "object",
           "description": "Error response.",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": ["error"],
-              "description": "Indicates the request failed."
-            },
             "error": {
               "type": "string",
               "description": "Human-readable error message."
@@ -123,7 +135,9 @@
               "description": "Normalized VCV accession that was queried, when available."
             }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -135,7 +149,13 @@
         "variant_id": "13961"
       }
     ],
-    "label": ["clinvar", "variant", "clinical_significance", "submitter", "scv"],
+    "label": [
+      "clinvar",
+      "variant",
+      "clinical_significance",
+      "submitter",
+      "scv"
+    ],
     "metadata": {
       "data_source": "NCBI ClinVar (eutils efetch, rettype=vcv)",
       "requires_api_key": false

--- a/src/tooluniverse/data/cluspro_tools.json
+++ b/src/tooluniverse/data/cluspro_tools.json
@@ -15,17 +15,29 @@
           "description": "Peptide amino-acid sequence (1-letter), e.g. 'KGRRL'. Short peptides only."
         },
         "peptide_motif": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Peptide motif for PDB fragment search (X = wildcard), e.g. 'KXRRL'. Defaults to peptide_sequence if omitted."
         },
         "jobname": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional job name (defaults to a ClusPro job number)."
         }
       },
-      "required": ["receptor_pdb_id", "peptide_sequence"]
+      "required": [
+        "receptor_pdb_id",
+        "peptide_sequence"
+      ]
     },
-    "required_api_keys": ["CLUSPRO_USERNAME", "CLUSPRO_API_SECRET"],
+    "required_api_keys": [
+      "CLUSPRO_USERNAME",
+      "CLUSPRO_API_SECRET"
+    ],
     "api_key_info": {
       "CLUSPRO_USERNAME": {
         "domain": "Proteins & Structure",
@@ -46,31 +58,41 @@
       "oneOf": [
         {
           "type": "object",
-          "description": "Successful job submission.",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "properties": {"job_id": {"type": ["string", "integer"]}}
-            },
-            "metadata": {"type": "object"}
+            "job_id": {
+              "type": [
+                "string",
+                "integer"
+              ]
+            }
           },
-          "required": ["status", "data"]
+          "required": [
+            "job_id"
+          ]
         },
         {
           "type": "object",
           "description": "Error result.",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "url": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"receptor_pdb_id": "1A2K", "peptide_sequence": "KGRRL", "peptide_motif": "KXRRL"}
+      {
+        "receptor_pdb_id": "1A2K",
+        "peptide_sequence": "KGRRL",
+        "peptide_motif": "KXRRL"
+      }
     ]
   }
 ]

--- a/src/tooluniverse/data/coexpression_module_tools.json
+++ b/src/tooluniverse/data/coexpression_module_tools.json
@@ -5,12 +5,35 @@
     "description": "Detect co-expression modules from a genes x samples expression matrix (WGCNA-style): builds a soft-thresholded correlation network and partitions it into modules of co-regulated genes by modularity, returning each module's genes and its module eigengene (first PC = per-sample summary profile). Pure-compute (NumPy + NetworkX). Simplified WGCNA (no TOM / dynamic tree cut).",
     "parameter": {
       "type": "object",
-      "required": ["expression"],
+      "required": [
+        "expression"
+      ],
       "properties": {
-        "expression": {"type": "object", "description": "{gene: [value_per_sample, ...]} — a genes x samples expression matrix (log-normalized)."},
-        "power": {"type": ["integer", "null"], "description": "Soft-threshold exponent on |correlation| (default 6, the WGCNA scale-free default)."},
-        "correlation_threshold": {"type": ["number", "null"], "description": "Minimum |correlation| to connect two genes (default 0.5)."},
-        "min_module_size": {"type": ["integer", "null"], "description": "Minimum genes for a module to be reported (default 5)."}
+        "expression": {
+          "type": "object",
+          "description": "{gene: [value_per_sample, ...]} \u2014 a genes x samples expression matrix (log-normalized)."
+        },
+        "power": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Soft-threshold exponent on |correlation| (default 6, the WGCNA scale-free default)."
+        },
+        "correlation_threshold": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Minimum |correlation| to connect two genes (default 0.5)."
+        },
+        "min_module_size": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Minimum genes for a module to be reported (default 5)."
+        }
       }
     },
     "return_schema": {
@@ -18,32 +41,109 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_genes": {"type": "integer"},
-                "n_samples": {"type": "integer"},
-                "n_modules": {"type": "integer"},
-                "n_unassigned": {"type": "integer"},
-                "modules": {"type": "array", "items": {"type": "object"}}
+            "n_genes": {
+              "type": "integer"
+            },
+            "n_samples": {
+              "type": "integer"
+            },
+            "n_modules": {
+              "type": "integer"
+            },
+            "n_unassigned": {
+              "type": "integer"
+            },
+            "modules": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
           },
-          "required": ["data"]
+          "required": [
+            "n_genes"
+          ]
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
         "expression": {
-          "G1": [6, 5, 4, 3, 2, 1], "G2": [6.1, 4.9, 4.0, 3.1, 1.9, 1.0], "G3": [5.9, 5.1, 3.9, 3.0, 2.1, 0.9], "G4": [6.0, 5.0, 4.1, 2.9, 2.0, 1.1],
-          "G5": [1, 2, 1, 2, 1, 2], "G6": [1.1, 1.9, 1.0, 2.1, 0.9, 2.0], "G7": [0.9, 2.1, 1.1, 1.9, 1.0, 2.1], "G8": [1.0, 2.0, 0.9, 2.0, 1.1, 1.9]
+          "G1": [
+            6,
+            5,
+            4,
+            3,
+            2,
+            1
+          ],
+          "G2": [
+            6.1,
+            4.9,
+            4.0,
+            3.1,
+            1.9,
+            1.0
+          ],
+          "G3": [
+            5.9,
+            5.1,
+            3.9,
+            3.0,
+            2.1,
+            0.9
+          ],
+          "G4": [
+            6.0,
+            5.0,
+            4.1,
+            2.9,
+            2.0,
+            1.1
+          ],
+          "G5": [
+            1,
+            2,
+            1,
+            2,
+            1,
+            2
+          ],
+          "G6": [
+            1.1,
+            1.9,
+            1.0,
+            2.1,
+            0.9,
+            2.0
+          ],
+          "G7": [
+            0.9,
+            2.1,
+            1.1,
+            1.9,
+            1.0,
+            2.1
+          ],
+          "G8": [
+            1.0,
+            2.0,
+            0.9,
+            2.0,
+            1.1,
+            1.9
+          ]
         },
         "min_module_size": 3
       }

--- a/src/tooluniverse/data/col_tools.json
+++ b/src/tooluniverse/data/col_tools.json
@@ -182,9 +182,6 @@
             "id": {
               "type": "string"
             },
-            "status": {
-              "type": "string"
-            },
             "origin": {
               "type": "string"
             },
@@ -215,7 +212,10 @@
             "parentId": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "id"
+          ]
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/colocalization_tools.json
+++ b/src/tooluniverse/data/colocalization_tools.json
@@ -5,17 +5,79 @@
     "description": "Bayesian colocalization (coloc.abf, Giambartolomei 2014) of two GWAS/QTL signals over the same SNP set in a region. Tests whether the two traits share a single causal variant. Returns the five posterior probabilities PP0-PP4; PP4 (>0.8 = strong) is the probability of a shared causal variant - the standard way to link a GWAS locus to a gene via an eQTL. Pure-compute (no R, no LD matrix); pairs with eQTL_get_associations + GWAS summary tools.",
     "parameter": {
       "type": "object",
-      "required": ["beta1", "se1", "beta2", "se2"],
+      "required": [
+        "beta1",
+        "se1",
+        "beta2",
+        "se2"
+      ],
       "properties": {
-        "beta1": {"type": "array", "items": {"type": "number"}, "description": "Trait 1 per-SNP effect sizes over the region (same SNP order as trait 2)."},
-        "se1": {"type": "array", "items": {"type": "number"}, "description": "Standard errors of beta1 (positive)."},
-        "beta2": {"type": "array", "items": {"type": "number"}, "description": "Trait 2 per-SNP effect sizes (same SNP order/alleles)."},
-        "se2": {"type": "array", "items": {"type": "number"}, "description": "Standard errors of beta2 (positive)."},
-        "snp": {"type": ["array", "null"], "items": {"type": "string"}, "description": "Optional SNP identifiers (same order) to label the best shared variant."},
-        "sd_prior": {"type": ["number", "null"], "description": "Prior SD of the effect size (default 0.15; 0.2 common for case/control log-OR)."},
-        "p1": {"type": ["number", "null"], "description": "Prior prob a SNP is causal for trait 1 (default 1e-4)."},
-        "p2": {"type": ["number", "null"], "description": "Prior prob a SNP is causal for trait 2 (default 1e-4)."},
-        "p12": {"type": ["number", "null"], "description": "Prior prob a SNP is causal for both traits (default 1e-5)."}
+        "beta1": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Trait 1 per-SNP effect sizes over the region (same SNP order as trait 2)."
+        },
+        "se1": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Standard errors of beta1 (positive)."
+        },
+        "beta2": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Trait 2 per-SNP effect sizes (same SNP order/alleles)."
+        },
+        "se2": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Standard errors of beta2 (positive)."
+        },
+        "snp": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional SNP identifiers (same order) to label the best shared variant."
+        },
+        "sd_prior": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Prior SD of the effect size (default 0.15; 0.2 common for case/control log-OR)."
+        },
+        "p1": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Prior prob a SNP is causal for trait 1 (default 1e-4)."
+        },
+        "p2": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Prior prob a SNP is causal for trait 2 (default 1e-4)."
+        },
+        "p12": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Prior prob a SNP is causal for both traits (default 1e-5)."
+        }
       }
     },
     "return_schema": {
@@ -23,33 +85,71 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_snps": {"type": "integer"},
-                "posteriors": {"type": "object"},
-                "pp4_colocalization": {"type": "number"},
-                "best_causal_snp": {},
-                "interpretation": {"type": "string"}
-              }
+            "n_snps": {
+              "type": "integer"
+            },
+            "posteriors": {
+              "type": "object"
+            },
+            "pp4_colocalization": {
+              "type": "number"
+            },
+            "best_causal_snp": {},
+            "interpretation": {
+              "type": "string"
             }
           },
-          "required": ["data"]
+          "required": [
+            "n_snps"
+          ]
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "beta1": [0.01, 0.02, 0.03, 0.20, 0.04, 0.01],
-        "se1": [0.02, 0.02, 0.02, 0.02, 0.02, 0.02],
-        "beta2": [0.02, 0.01, 0.04, 0.18, 0.03, 0.02],
-        "se2": [0.02, 0.02, 0.02, 0.02, 0.02, 0.02]
+        "beta1": [
+          0.01,
+          0.02,
+          0.03,
+          0.2,
+          0.04,
+          0.01
+        ],
+        "se1": [
+          0.02,
+          0.02,
+          0.02,
+          0.02,
+          0.02,
+          0.02
+        ],
+        "beta2": [
+          0.02,
+          0.01,
+          0.04,
+          0.18,
+          0.03,
+          0.02
+        ],
+        "se2": [
+          0.02,
+          0.02,
+          0.02,
+          0.02,
+          0.02,
+          0.02
+        ]
       }
     ]
   }

--- a/src/tooluniverse/data/complex_portal_tools.json
+++ b/src/tooluniverse/data/complex_portal_tools.json
@@ -45,107 +45,92 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "query": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string"
-                },
-                "species_filter": {
-                  "type": "string"
-                },
-                "complexes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "complex_id": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "species": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "predicted": {
-                        "type": "boolean"
-                      },
-                      "subunits": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "identifier": {
-                              "type": "string"
-                            },
-                            "name": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": [
-                                "null",
-                                "string"
-                              ]
-                            },
-                            "stoichiometry": {
-                              "type": [
-                                "null",
-                                "string"
-                              ]
-                            },
-                            "interactor_type": {
-                              "type": "string"
-                            }
-                          }
+            "species_filter": {
+              "type": "string"
+            },
+            "complexes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "complex_id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "species": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "predicted": {
+                    "type": "boolean"
+                  },
+                  "subunits": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "identifier": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "stoichiometry": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "interactor_type": {
+                          "type": "string"
                         }
                       }
                     }
                   }
-                },
-                "count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "total_found": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "total_found": {
+              "type": [
+                "integer",
+                "number"
+              ]
             }
-          }
+          },
+          "required": [
+            "query"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -197,133 +182,118 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "complex_id": {
+              "type": "null"
             },
-            "data": {
+            "name": {
+              "type": "null"
+            },
+            "systematic_name": {
+              "type": "string"
+            },
+            "species": {
+              "type": "null"
+            },
+            "taxonomy_id": {
+              "type": "null"
+            },
+            "description": {
+              "type": "null"
+            },
+            "properties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "complex_type": {
+              "type": "null"
+            },
+            "evidence_type": {
               "type": "object",
               "properties": {
-                "complex_id": {
-                  "type": "null"
-                },
-                "name": {
-                  "type": "null"
-                },
-                "systematic_name": {
+                "identifier": {
                   "type": "string"
                 },
-                "species": {
-                  "type": "null"
-                },
-                "taxonomy_id": {
-                  "type": "null"
-                },
                 "description": {
-                  "type": "null"
+                  "type": "string"
                 },
-                "properties": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
+                "searchURL": {
+                  "type": "string"
                 },
-                "complex_type": {
-                  "type": "null"
-                },
-                "evidence_type": {
-                  "type": "object",
-                  "properties": {
-                    "identifier": {
-                      "type": "string"
-                    },
-                    "description": {
-                      "type": "string"
-                    },
-                    "searchURL": {
-                      "type": "string"
-                    },
-                    "confidenceScore": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
-                  }
-                },
-                "subunits": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "identifier": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "stoichiometry": {
-                        "type": "string"
-                      },
-                      "interactor_type": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "cross_references": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "database": {
-                        "type": "string"
-                      },
-                      "identifier": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "diseases": {
-                  "type": "array"
-                },
-                "go_annotations": {
-                  "type": "array"
+                "confidenceScore": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "subunits": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "identifier": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "stoichiometry": {
+                    "type": "string"
+                  },
+                  "interactor_type": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "cross_references": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "database": {
+                    "type": "string"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
+              }
+            },
+            "diseases": {
+              "type": "array"
+            },
+            "go_annotations": {
+              "type": "array"
             }
-          }
+          },
+          "required": [
+            "complex_id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/compound_disease_tools.json
+++ b/src/tooluniverse/data/compound_disease_tools.json
@@ -19,40 +19,31 @@
       "type": "object",
       "oneOf": [
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "query": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string"
-                },
-                "sources_queried": {
-                  "type": "array"
-                },
-                "sources_failed": {
-                  "type": "array"
-                },
-                "profile": {
-                  "type": "object"
-                },
-                "per_source": {
-                  "type": "object"
-                }
-              }
+            "sources_queried": {
+              "type": "array"
+            },
+            "sources_failed": {
+              "type": "array"
+            },
+            "profile": {
+              "type": "object"
+            },
+            "per_source": {
+              "type": "object"
             }
           },
           "required": [
-            "data"
+            "query"
           ]
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/compound_gene_disease_tools.json
+++ b/src/tooluniverse/data/compound_gene_disease_tools.json
@@ -27,40 +27,31 @@
       "type": "object",
       "oneOf": [
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "query": {
+              "type": "object"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "object"
-                },
-                "sources_queried": {
-                  "type": "array"
-                },
-                "sources_failed": {
-                  "type": "array"
-                },
-                "num_associations": {
-                  "type": "integer"
-                },
-                "associations": {
-                  "type": "array"
-                }
-              }
+            "sources_queried": {
+              "type": "array"
+            },
+            "sources_failed": {
+              "type": "array"
+            },
+            "num_associations": {
+              "type": "integer"
+            },
+            "associations": {
+              "type": "array"
             }
           },
           "required": [
-            "data"
+            "query"
           ]
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/compound_variant_tools.json
+++ b/src/tooluniverse/data/compound_variant_tools.json
@@ -34,40 +34,31 @@
       "type": "object",
       "oneOf": [
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "query": {
+              "type": "object"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "object"
-                },
-                "sources_queried": {
-                  "type": "array"
-                },
-                "sources_failed": {
-                  "type": "array"
-                },
-                "summary": {
-                  "type": "object"
-                },
-                "annotations": {
-                  "type": "object"
-                }
-              }
+            "sources_queried": {
+              "type": "array"
+            },
+            "sources_failed": {
+              "type": "array"
+            },
+            "summary": {
+              "type": "object"
+            },
+            "annotations": {
+              "type": "object"
             }
           },
           "required": [
-            "data"
+            "query"
           ]
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/conoserver_tools.json
+++ b/src/tooluniverse/data/conoserver_tools.json
@@ -11,57 +11,143 @@
           "description": "ConoServer protein ID, e.g. 'P00001' (alpha-conotoxin SI, sequence ICCNPACGPKYSCX, from Conus striatus). Case-insensitive."
         }
       },
-      "required": ["conoserver_id"]
+      "required": [
+        "conoserver_id"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Successful conopeptide lookup.",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "properties": {
-                "id": {"type": ["string", "null"]},
-                "name": {"type": ["string", "null"]},
-                "alternative_names": {"type": "array"},
-                "class": {"type": ["string", "null"]},
-                "gene_superfamily": {"type": ["string", "null"]},
-                "cysteine_framework": {"type": ["string", "null"]},
-                "pharmacological_family": {"type": ["string", "null"]},
-                "organism_latin": {"type": ["string", "null"]},
-                "organism_diet": {"type": ["string", "null"]},
-                "organism_region": {"type": ["string", "null"]},
-                "sequence": {"type": ["string", "null"]},
-                "sequence_modifications": {"type": "array"},
-                "sequence_evidence": {"type": ["string", "null"]},
-                "average_mass": {"type": ["string", "null"]},
-                "monoisotopic_mass": {"type": ["string", "null"]},
-                "isoelectric_point": {"type": ["string", "null"]},
-                "extinction_coefficient": {"type": ["string", "null"]},
-                "references": {"type": "array"}
-              }
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "metadata": {"type": "object"}
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "alternative_names": {
+              "type": "array"
+            },
+            "class": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "gene_superfamily": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cysteine_framework": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pharmacological_family": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organism_latin": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organism_diet": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organism_region": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sequence": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sequence_modifications": {
+              "type": "array"
+            },
+            "sequence_evidence": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "average_mass": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "monoisotopic_mass": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "isoelectric_point": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "extinction_coefficient": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "references": {
+              "type": "array"
+            }
           },
-          "required": ["status", "data"]
+          "required": [
+            "alternative_names"
+          ]
         },
         {
           "type": "object",
           "description": "Error result.",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "url": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"conoserver_id": "P00001"},
-      {"conoserver_id": "P00022"}
+      {
+        "conoserver_id": "P00001"
+      },
+      {
+        "conoserver_id": "P00022"
+      }
     ]
   },
   {
@@ -71,51 +157,89 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "name": {"type": "string", "description": "Peptide name substring."},
-        "sequence": {"type": "string", "description": "Amino-acid sequence substring (e.g. 'GCCS')."},
-        "pharmacological_family": {"type": "string", "description": "e.g. 'alpha conotoxin', 'omega conotoxin'."},
-        "gene_superfamily": {"type": "string", "description": "e.g. 'A superfamily', 'O1 superfamily'."},
-        "cysteine_framework": {"type": "string", "description": "Cysteine framework, e.g. 'I', 'III', 'VI/VII'."},
-        "organism": {"type": "string", "description": "Source Conus species, e.g. 'Conus geographus'."},
-        "conopeptide_class": {"type": "string", "description": "Conopeptide class, e.g. 'conotoxin'."},
-        "limit": {"type": "integer", "description": "Max records to return (default 25, max 200)."}
+        "name": {
+          "type": "string",
+          "description": "Peptide name substring."
+        },
+        "sequence": {
+          "type": "string",
+          "description": "Amino-acid sequence substring (e.g. 'GCCS')."
+        },
+        "pharmacological_family": {
+          "type": "string",
+          "description": "e.g. 'alpha conotoxin', 'omega conotoxin'."
+        },
+        "gene_superfamily": {
+          "type": "string",
+          "description": "e.g. 'A superfamily', 'O1 superfamily'."
+        },
+        "cysteine_framework": {
+          "type": "string",
+          "description": "Cysteine framework, e.g. 'I', 'III', 'VI/VII'."
+        },
+        "organism": {
+          "type": "string",
+          "description": "Source Conus species, e.g. 'Conus geographus'."
+        },
+        "conopeptide_class": {
+          "type": "string",
+          "description": "Conopeptide class, e.g. 'conotoxin'."
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Max records to return (default 25, max 200)."
+        }
       }
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Successful search.",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "properties": {
-                "count": {"type": "integer"},
-                "returned": {"type": "integer"},
-                "results": {"type": "array"}
-              }
+            "count": {
+              "type": "integer"
             },
-            "metadata": {"type": "object"}
+            "returned": {
+              "type": "integer"
+            },
+            "results": {
+              "type": "array"
+            }
           },
-          "required": ["status", "data"]
+          "required": [
+            "count"
+          ]
         },
         {
           "type": "object",
           "description": "Error result.",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "url": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"organism": "Conus geographus", "limit": 3},
-      {"pharmacological_family": "omega conotoxin", "limit": 5},
-      {"sequence": "GCCS", "limit": 5}
+      {
+        "organism": "Conus geographus",
+        "limit": 3
+      },
+      {
+        "pharmacological_family": "omega conotoxin",
+        "limit": 5
+      },
+      {
+        "sequence": "GCCS",
+        "limit": 5
+      }
     ]
   }
 ]

--- a/src/tooluniverse/data/cpic_tools.json
+++ b/src/tooluniverse/data/cpic_tools.json
@@ -29,101 +29,83 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "symbol": {
-                    "type": "string"
-                  },
-                  "chr": {
-                    "type": "string"
-                  },
-                  "genesequenceid": {
-                    "type": "string"
-                  },
-                  "proteinsequenceid": {
-                    "type": "string"
-                  },
-                  "chromosequenceid": {
-                    "type": "string"
-                  },
-                  "mrnasequenceid": {
-                    "type": "string"
-                  },
-                  "hgncid": {
-                    "type": "string"
-                  },
-                  "ncbiid": {
-                    "type": "string"
-                  },
-                  "ensemblid": {
-                    "type": "string"
-                  },
-                  "clinpgxid": {
-                    "type": "string"
-                  },
-                  "frequencymethods": {
-                    "type": "string"
-                  },
-                  "lookupmethod": {
-                    "type": "string"
-                  },
-                  "version": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "notesondiplotype": {
-                    "type": "null"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "functionmethods": {
-                    "type": "null"
-                  },
-                  "notesonallelenaming": {
-                    "type": "string"
-                  },
-                  "includephenotypefrequencies": {
-                    "type": "boolean"
-                  },
-                  "includediplotypefrequencies": {
-                    "type": "boolean"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "symbol": {
+                "type": "string"
+              },
+              "chr": {
+                "type": "string"
+              },
+              "genesequenceid": {
+                "type": "string"
+              },
+              "proteinsequenceid": {
+                "type": "string"
+              },
+              "chromosequenceid": {
+                "type": "string"
+              },
+              "mrnasequenceid": {
+                "type": "string"
+              },
+              "hgncid": {
+                "type": "string"
+              },
+              "ncbiid": {
+                "type": "string"
+              },
+              "ensemblid": {
+                "type": "string"
+              },
+              "clinpgxid": {
+                "type": "string"
+              },
+              "frequencymethods": {
+                "type": "string"
+              },
+              "lookupmethod": {
+                "type": "string"
+              },
+              "version": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "notesondiplotype": {
+                "type": "null"
+              },
+              "url": {
+                "type": "string"
+              },
+              "functionmethods": {
+                "type": "null"
+              },
+              "notesonallelenaming": {
+                "type": "string"
+              },
+              "includephenotypefrequencies": {
+                "type": "boolean"
+              },
+              "includediplotypefrequencies": {
+                "type": "boolean"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -145,131 +127,113 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "symbol": {
-                    "type": "string"
-                  },
-                  "chr": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "genesequenceid": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "proteinsequenceid": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "chromosequenceid": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "mrnasequenceid": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "hgncid": {
-                    "type": "string"
-                  },
-                  "ncbiid": {
-                    "type": "string"
-                  },
-                  "ensemblid": {
-                    "type": "string"
-                  },
-                  "clinpgxid": {
-                    "type": "string"
-                  },
-                  "frequencymethods": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "lookupmethod": {
-                    "type": "string"
-                  },
-                  "version": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "notesondiplotype": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "url": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "functionmethods": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "notesonallelenaming": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "includephenotypefrequencies": {
-                    "type": "boolean"
-                  },
-                  "includediplotypefrequencies": {
-                    "type": "boolean"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "symbol": {
+                "type": "string"
+              },
+              "chr": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "genesequenceid": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "proteinsequenceid": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "chromosequenceid": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "mrnasequenceid": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "hgncid": {
+                "type": "string"
+              },
+              "ncbiid": {
+                "type": "string"
+              },
+              "ensemblid": {
+                "type": "string"
+              },
+              "clinpgxid": {
+                "type": "string"
+              },
+              "frequencymethods": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "lookupmethod": {
+                "type": "string"
+              },
+              "version": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "notesondiplotype": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "url": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "functionmethods": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "notesonallelenaming": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "includephenotypefrequencies": {
+                "type": "boolean"
+              },
+              "includediplotypefrequencies": {
+                "type": "boolean"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -291,7 +255,9 @@
     },
     "fields": {
       "endpoint": "https://api.cpicpgx.org/v1/drug?name=eq.{name}",
-      "lowercase_params": ["name"]
+      "lowercase_params": [
+        "name"
+      ]
     },
     "type": "BaseRESTTool",
     "test_examples": [
@@ -305,83 +271,65 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "drugid": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "clinpgxid": {
-                    "type": "string"
-                  },
-                  "rxnormid": {
-                    "type": "string"
-                  },
-                  "drugbankid": {
-                    "type": "string"
-                  },
-                  "atcid": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "umlscui": {
-                    "type": "null"
-                  },
-                  "flowchart": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "version": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "guidelineid": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "drugid": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "clinpgxid": {
+                "type": "string"
+              },
+              "rxnormid": {
+                "type": "string"
+              },
+              "drugbankid": {
+                "type": "string"
+              },
+              "atcid": {
+                "type": "array",
+                "items": {
+                  "type": "string"
                 }
+              },
+              "umlscui": {
+                "type": "null"
+              },
+              "flowchart": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "version": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "guidelineid": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -434,116 +382,98 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pairid": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "genesymbol": {
+                "type": "string"
+              },
+              "drugid": {
+                "type": "string"
+              },
+              "guidelineid": {
+                "type": [
+                  "integer",
+                  "null",
+                  "number"
+                ]
+              },
+              "usedforrecommendation": {
+                "type": "boolean"
+              },
+              "version": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "cpiclevel": {
+                "type": "string"
+              },
+              "clinpgxlevel": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "pgxtesting": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "citations": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "removed": {
+                "type": "boolean"
+              },
+              "removeddate": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "removedreason": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "drug": {
                 "type": "object",
                 "properties": {
-                  "pairid": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "genesymbol": {
+                  "name": {
                     "type": "string"
-                  },
-                  "drugid": {
-                    "type": "string"
-                  },
-                  "guidelineid": {
-                    "type": [
-                      "integer",
-                      "null",
-                      "number"
-                    ]
-                  },
-                  "usedforrecommendation": {
-                    "type": "boolean"
-                  },
-                  "version": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "cpiclevel": {
-                    "type": "string"
-                  },
-                  "clinpgxlevel": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "pgxtesting": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "citations": {
-                    "type": [
-                      "array",
-                      "null"
-                    ],
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "removed": {
-                    "type": "boolean"
-                  },
-                  "removeddate": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "removedreason": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "drug": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      }
-                    }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -580,85 +510,67 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "version": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "url": {
-                    "type": "string"
-                  },
-                  "genes": {
-                    "type": "array",
-                    "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "version": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              },
+              "genes": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "notesonusage": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "clinpgxid": {
+                "type": "string"
+              },
+              "drug": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
                       "type": "string"
-                    }
-                  },
-                  "notesonusage": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "clinpgxid": {
-                    "type": "string"
-                  },
-                  "drug": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string"
-                        }
-                      }
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -713,153 +625,138 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "guideline_id": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "guideline_id": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "recommendations": {
-                  "type": "array",
-                  "items": {
+            "recommendations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "guidelineid": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "drugid": {
+                    "type": "string"
+                  },
+                  "implications": {
                     "type": "object",
                     "properties": {
-                      "id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "guidelineid": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "drugid": {
+                      "CYP2D6": {
                         "type": "string"
                       },
-                      "implications": {
-                        "type": "object",
-                        "properties": {
-                          "CYP2D6": {
-                            "type": "string"
-                          },
-                          "HLA-B": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "drugrecommendation": {
+                      "HLA-B": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "drugrecommendation": {
+                    "type": "string"
+                  },
+                  "classification": {
+                    "type": "string"
+                  },
+                  "phenotypes": {
+                    "type": "object",
+                    "properties": {
+                      "CYP2D6": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "activityscore": {
+                    "type": "object",
+                    "properties": {
+                      "CYP2D6": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "allelestatus": {
+                    "type": "object",
+                    "properties": {
+                      "HLA-B": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "lookupkey": {
+                    "type": "object",
+                    "properties": {
+                      "CYP2D6": {
                         "type": "string"
                       },
-                      "classification": {
+                      "HLA-B": {
                         "type": "string"
-                      },
-                      "phenotypes": {
-                        "type": "object",
-                        "properties": {
-                          "CYP2D6": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "activityscore": {
-                        "type": "object",
-                        "properties": {
-                          "CYP2D6": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "allelestatus": {
-                        "type": "object",
-                        "properties": {
-                          "HLA-B": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "lookupkey": {
-                        "type": "object",
-                        "properties": {
-                          "CYP2D6": {
-                            "type": "string"
-                          },
-                          "HLA-B": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "population": {
+                      }
+                    }
+                  },
+                  "population": {
+                    "type": "string"
+                  },
+                  "comments": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "dosinginformation": {
+                    "type": "boolean"
+                  },
+                  "alternatedrugavailable": {
+                    "type": "boolean"
+                  },
+                  "otherprescribingguidance": {
+                    "type": "boolean"
+                  },
+                  "drug": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
                         "type": "string"
-                      },
-                      "comments": {
-                        "type": "string"
-                      },
-                      "version": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "dosinginformation": {
-                        "type": "boolean"
-                      },
-                      "alternatedrugavailable": {
-                        "type": "boolean"
-                      },
-                      "otherprescribingguidance": {
-                        "type": "boolean"
-                      },
-                      "drug": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string"
-                          }
-                        }
                       }
                     }
                   }
-                },
-                "count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "count": {
+              "type": [
+                "integer",
+                "number"
+              ]
             }
-          }
+          },
+          "required": [
+            "guideline_id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -926,72 +823,54 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "genesymbol": {
-                    "type": "string"
-                  },
-                  "drugid": {
-                    "type": "string"
-                  },
-                  "cpiclevel": {
-                    "type": "string"
-                  },
-                  "guidelineid": {
-                    "type": [
-                      "integer",
-                      "null",
-                      "number"
-                    ]
-                  },
-                  "usedforrecommendation": {
-                    "type": "boolean"
-                  },
-                  "clinpgxlevel": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "pgxtesting": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "genesymbol": {
+                "type": "string"
+              },
+              "drugid": {
+                "type": "string"
+              },
+              "cpiclevel": {
+                "type": "string"
+              },
+              "guidelineid": {
+                "type": [
+                  "integer",
+                  "null",
+                  "number"
+                ]
+              },
+              "usedforrecommendation": {
+                "type": "boolean"
+              },
+              "clinpgxlevel": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "pgxtesting": {
+                "type": [
+                  "null",
+                  "string"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -1014,51 +893,33 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "guidelineid": {
-                    "type": [
-                      "integer",
-                      "null",
-                      "number"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "guidelineid": {
+                "type": [
+                  "integer",
+                  "null",
+                  "number"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -1102,56 +963,38 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "functionalstatus": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "activityvalue": {
-                    "type": "string"
-                  },
-                  "clinicalfunctionalstatus": {
-                    "type": "string"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "functionalstatus": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "activityvalue": {
+                "type": "string"
+              },
+              "clinicalfunctionalstatus": {
+                "type": "string"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/crossref_tools.json
+++ b/src/tooluniverse/data/crossref_tools.json
@@ -474,22 +474,21 @@
             "coverage": {
               "type": "object"
             }
-          }
+          },
+          "required": [
+            "id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/cryoet_tools.json
+++ b/src/tooluniverse/data/cryoet_tools.json
@@ -50,96 +50,81 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "count": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "datasets": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "organismName": {
-                        "type": "string"
-                      },
-                      "tissueName": {
-                        "type": "string"
-                      },
-                      "cellName": {
-                        "type": "string"
-                      },
-                      "sampleType": {
-                        "type": "string"
-                      },
-                      "depositionDate": {
-                        "type": "string"
-                      },
-                      "releaseDate": {
-                        "type": "string"
-                      },
-                      "relatedDatabaseEntries": {
-                        "type": "null"
-                      },
-                      "datasetPublications": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "s3Prefix": {
-                        "type": "string"
-                      },
-                      "httpsPrefix": {
-                        "type": "string"
-                      }
-                    }
+            "datasets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "organismName": {
+                    "type": "string"
+                  },
+                  "tissueName": {
+                    "type": "string"
+                  },
+                  "cellName": {
+                    "type": "string"
+                  },
+                  "sampleType": {
+                    "type": "string"
+                  },
+                  "depositionDate": {
+                    "type": "string"
+                  },
+                  "releaseDate": {
+                    "type": "string"
+                  },
+                  "relatedDatabaseEntries": {
+                    "type": "null"
+                  },
+                  "datasetPublications": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "s3Prefix": {
+                    "type": "string"
+                  },
+                  "httpsPrefix": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "count"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -183,117 +168,102 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "dataset": {
               "type": "object",
               "properties": {
-                "dataset": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "title": {
-                      "type": "string"
-                    },
-                    "description": {
-                      "type": "string"
-                    },
-                    "organismName": {
-                      "type": "string"
-                    },
-                    "organismTaxid": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "tissueName": {
-                      "type": "string"
-                    },
-                    "tissueId": {
-                      "type": "string"
-                    },
-                    "cellName": {
-                      "type": "string"
-                    },
-                    "cellTypeId": {
-                      "type": "string"
-                    },
-                    "cellStrainName": {
-                      "type": "string"
-                    },
-                    "sampleType": {
-                      "type": "string"
-                    },
-                    "samplePreparation": {
-                      "type": "string"
-                    },
-                    "gridPreparation": {
-                      "type": "null"
-                    },
-                    "otherSetup": {
-                      "type": "null"
-                    },
-                    "depositionDate": {
-                      "type": "string"
-                    },
-                    "releaseDate": {
-                      "type": "string"
-                    },
-                    "lastModifiedDate": {
-                      "type": "string"
-                    },
-                    "datasetPublications": {
-                      "type": "string"
-                    },
-                    "relatedDatabaseEntries": {
-                      "type": "string"
-                    },
-                    "keyPhotoUrl": {
-                      "type": "string"
-                    },
-                    "s3Prefix": {
-                      "type": "string"
-                    },
-                    "httpsPrefix": {
-                      "type": "string"
-                    },
-                    "fileSize": {
-                      "type": "number"
-                    }
-                  }
+                "id": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "organismName": {
+                  "type": "string"
+                },
+                "organismTaxid": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "tissueName": {
+                  "type": "string"
+                },
+                "tissueId": {
+                  "type": "string"
+                },
+                "cellName": {
+                  "type": "string"
+                },
+                "cellTypeId": {
+                  "type": "string"
+                },
+                "cellStrainName": {
+                  "type": "string"
+                },
+                "sampleType": {
+                  "type": "string"
+                },
+                "samplePreparation": {
+                  "type": "string"
+                },
+                "gridPreparation": {
+                  "type": "null"
+                },
+                "otherSetup": {
+                  "type": "null"
+                },
+                "depositionDate": {
+                  "type": "string"
+                },
+                "releaseDate": {
+                  "type": "string"
+                },
+                "lastModifiedDate": {
+                  "type": "string"
+                },
+                "datasetPublications": {
+                  "type": "string"
+                },
+                "relatedDatabaseEntries": {
+                  "type": "string"
+                },
+                "keyPhotoUrl": {
+                  "type": "string"
+                },
+                "s3Prefix": {
+                  "type": "string"
+                },
+                "httpsPrefix": {
+                  "type": "string"
+                },
+                "fileSize": {
+                  "type": "number"
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "dataset"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -346,78 +316,63 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "dataset_id": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "dataset_id": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "runs": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "datasetId": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "s3Prefix": {
-                        "type": "string"
-                      },
-                      "httpsPrefix": {
-                        "type": "string"
-                      }
-                    }
+            "count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "runs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "datasetId": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "s3Prefix": {
+                    "type": "string"
+                  },
+                  "httpsPrefix": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "dataset_id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -471,132 +426,117 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "run_id": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "run_id": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "tomograms": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "runId": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "voxelSpacing": {
-                        "type": "number"
-                      },
-                      "sizeX": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "sizeY": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "sizeZ": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "reconstructionMethod": {
-                        "type": "string"
-                      },
-                      "processing": {
-                        "type": "string"
-                      },
-                      "processingSoftware": {
-                        "type": "null"
-                      },
-                      "reconstructionSoftware": {
-                        "type": "string"
-                      },
-                      "isPortalStandard": {
-                        "type": "boolean"
-                      },
-                      "isAuthorSubmitted": {
-                        "type": "boolean"
-                      },
-                      "isVisualizationDefault": {
-                        "type": "boolean"
-                      },
-                      "ctfCorrected": {
-                        "type": "boolean"
-                      },
-                      "s3OmezarrDir": {
-                        "type": "string"
-                      },
-                      "httpsMrcFile": {
-                        "type": "string"
-                      },
-                      "s3MrcFile": {
-                        "type": "string"
-                      },
-                      "depositionDate": {
-                        "type": "string"
-                      },
-                      "releaseDate": {
-                        "type": "string"
-                      }
-                    }
+            "count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "tomograms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "runId": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "voxelSpacing": {
+                    "type": "number"
+                  },
+                  "sizeX": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "sizeY": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "sizeZ": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "reconstructionMethod": {
+                    "type": "string"
+                  },
+                  "processing": {
+                    "type": "string"
+                  },
+                  "processingSoftware": {
+                    "type": "null"
+                  },
+                  "reconstructionSoftware": {
+                    "type": "string"
+                  },
+                  "isPortalStandard": {
+                    "type": "boolean"
+                  },
+                  "isAuthorSubmitted": {
+                    "type": "boolean"
+                  },
+                  "isVisualizationDefault": {
+                    "type": "boolean"
+                  },
+                  "ctfCorrected": {
+                    "type": "boolean"
+                  },
+                  "s3OmezarrDir": {
+                    "type": "string"
+                  },
+                  "httpsMrcFile": {
+                    "type": "string"
+                  },
+                  "s3MrcFile": {
+                    "type": "string"
+                  },
+                  "depositionDate": {
+                    "type": "string"
+                  },
+                  "releaseDate": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "run_id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -654,114 +594,99 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "run_id": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "run_id": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "annotations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "objectName": {
-                        "type": "string"
-                      },
-                      "objectId": {
-                        "type": "string"
-                      },
-                      "objectDescription": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "objectState": {
-                        "type": "null"
-                      },
-                      "objectCount": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "annotationMethod": {
-                        "type": "string"
-                      },
-                      "annotationSoftware": {
-                        "type": "string"
-                      },
-                      "groundTruthStatus": {
-                        "type": "boolean"
-                      },
-                      "isCuratorRecommended": {
-                        "type": "boolean"
-                      },
-                      "methodType": {
-                        "type": "string"
-                      },
-                      "depositionDate": {
-                        "type": "string"
-                      },
-                      "releaseDate": {
-                        "type": "string"
-                      },
-                      "annotationPublication": {
-                        "type": "string"
-                      },
-                      "s3MetadataPath": {
-                        "type": "string"
-                      },
-                      "httpsMetadataPath": {
-                        "type": "string"
-                      }
-                    }
+            "count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "objectName": {
+                    "type": "string"
+                  },
+                  "objectId": {
+                    "type": "string"
+                  },
+                  "objectDescription": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "objectState": {
+                    "type": "null"
+                  },
+                  "objectCount": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "annotationMethod": {
+                    "type": "string"
+                  },
+                  "annotationSoftware": {
+                    "type": "string"
+                  },
+                  "groundTruthStatus": {
+                    "type": "boolean"
+                  },
+                  "isCuratorRecommended": {
+                    "type": "boolean"
+                  },
+                  "methodType": {
+                    "type": "string"
+                  },
+                  "depositionDate": {
+                    "type": "string"
+                  },
+                  "releaseDate": {
+                    "type": "string"
+                  },
+                  "annotationPublication": {
+                    "type": "string"
+                  },
+                  "s3MetadataPath": {
+                    "type": "string"
+                  },
+                  "httpsMetadataPath": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "run_id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -816,179 +741,164 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "run_id": {
+              "type": [
+                "integer",
+                "number",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "run_id": {
-                  "type": [
-                    "integer",
-                    "number",
-                    "null"
-                  ]
-                },
-                "count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "tiltseries": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "runId": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "microscopeManufacturer": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "microscopeModel": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "accelerationVoltage": {
-                        "type": [
-                          "integer",
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "sphericalAberrationConstant": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "tiltMin": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "tiltMax": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "tiltStep": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "tiltAxis": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "totalFlux": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "cameraModel": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "cameraManufacturer": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "dataAcquisitionSoftware": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "binningFromFrames": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "pixelSpacing": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "isAligned": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      },
-                      "httpsMrcFile": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "s3MrcFile": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "httpsOmezarrDir": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "tiltseries": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "runId": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "microscopeManufacturer": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "microscopeModel": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "accelerationVoltage": {
+                    "type": [
+                      "integer",
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "sphericalAberrationConstant": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "tiltMin": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "tiltMax": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "tiltStep": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "tiltAxis": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "totalFlux": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "cameraModel": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cameraManufacturer": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "dataAcquisitionSoftware": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "binningFromFrames": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "pixelSpacing": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "isAligned": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "httpsMrcFile": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "s3MrcFile": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "httpsOmezarrDir": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "count"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -1048,105 +958,90 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "count": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "depositions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "title": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "depositionDate": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "releaseDate": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "lastModifiedDate": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "relatedDatabaseEntries": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "depositionPublications": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "keyPhotoUrl": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "depositions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "title": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "depositionDate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "releaseDate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "lastModifiedDate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "relatedDatabaseEntries": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "depositionPublications": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "keyPhotoUrl": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "count"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/ctd_tools.json
+++ b/src/tooluniverse/data/ctd_tools.json
@@ -30,122 +30,79 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "source_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "CURIE of the subject node (e.g., CHEBI:15365)"
-                  },
-                  "source_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Human-readable name of the subject"
-                  },
-                  "target_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "CURIE of the object node (e.g., NCBIGene:7076)"
-                  },
-                  "target_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Human-readable name of the object"
-                  },
-                  "predicate": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "biolink predicate (e.g., biolink:affects)"
-                  },
-                  "qualified_predicate": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Causal flavour of the predicate (e.g., biolink:causes)"
-                  },
-                  "object_direction_qualifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Direction of effect on the object (e.g., increased, decreased)"
-                  },
-                  "knowledge_level": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "How the edge was obtained (e.g., knowledge_assertion)"
-                  },
-                  "agent_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Who created the edge (e.g., manual_agent)"
-                  },
-                  "primary_knowledge_source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "InfoRes id of the source database (e.g., infores:ctd)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "backend": {
-                  "type": "string"
-                },
-                "data_as_of": {
-                  "type": "string"
-                },
-                "input_terms": {
-                  "type": "string"
-                },
-                "input_type": {
-                  "type": "string"
-                },
-                "report_type": {
-                  "type": "string"
-                },
-                "canonical_curie": {
-                  "type": "string"
-                },
-                "source_category": {
-                  "type": "string"
-                },
-                "target_category": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "CURIE of the subject node (e.g., CHEBI:15365)"
+              },
+              "source_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable name of the subject"
+              },
+              "target_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "CURIE of the object node (e.g., NCBIGene:7076)"
+              },
+              "target_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable name of the object"
+              },
+              "predicate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "biolink predicate (e.g., biolink:affects)"
+              },
+              "qualified_predicate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Causal flavour of the predicate (e.g., biolink:causes)"
+              },
+              "object_direction_qualifier": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Direction of effect on the object (e.g., increased, decreased)"
+              },
+              "knowledge_level": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "How the edge was obtained (e.g., knowledge_assertion)"
+              },
+              "agent_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Who created the edge (e.g., manual_agent)"
+              },
+              "primary_knowledge_source": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "InfoRes id of the source database (e.g., infores:ctd)"
               }
             }
           }
@@ -153,13 +110,9 @@
         {
           "type": "object",
           "required": [
-            "status",
             "error"
           ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             },
@@ -205,122 +158,79 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "source_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "CURIE of the subject node (e.g., CHEBI:15365)"
-                  },
-                  "source_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Human-readable name of the subject"
-                  },
-                  "target_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "CURIE of the object node (e.g., NCBIGene:7076)"
-                  },
-                  "target_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Human-readable name of the object"
-                  },
-                  "predicate": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "biolink predicate (e.g., biolink:affects)"
-                  },
-                  "qualified_predicate": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Causal flavour of the predicate (e.g., biolink:causes)"
-                  },
-                  "object_direction_qualifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Direction of effect on the object (e.g., increased, decreased)"
-                  },
-                  "knowledge_level": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "How the edge was obtained (e.g., knowledge_assertion)"
-                  },
-                  "agent_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Who created the edge (e.g., manual_agent)"
-                  },
-                  "primary_knowledge_source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "InfoRes id of the source database (e.g., infores:ctd)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "backend": {
-                  "type": "string"
-                },
-                "data_as_of": {
-                  "type": "string"
-                },
-                "input_terms": {
-                  "type": "string"
-                },
-                "input_type": {
-                  "type": "string"
-                },
-                "report_type": {
-                  "type": "string"
-                },
-                "canonical_curie": {
-                  "type": "string"
-                },
-                "source_category": {
-                  "type": "string"
-                },
-                "target_category": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "CURIE of the subject node (e.g., CHEBI:15365)"
+              },
+              "source_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable name of the subject"
+              },
+              "target_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "CURIE of the object node (e.g., NCBIGene:7076)"
+              },
+              "target_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable name of the object"
+              },
+              "predicate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "biolink predicate (e.g., biolink:affects)"
+              },
+              "qualified_predicate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Causal flavour of the predicate (e.g., biolink:causes)"
+              },
+              "object_direction_qualifier": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Direction of effect on the object (e.g., increased, decreased)"
+              },
+              "knowledge_level": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "How the edge was obtained (e.g., knowledge_assertion)"
+              },
+              "agent_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Who created the edge (e.g., manual_agent)"
+              },
+              "primary_knowledge_source": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "InfoRes id of the source database (e.g., infores:ctd)"
               }
             }
           }
@@ -328,13 +238,9 @@
         {
           "type": "object",
           "required": [
-            "status",
             "error"
           ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             },
@@ -379,122 +285,79 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "source_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "CURIE of the subject node (e.g., CHEBI:15365)"
-                  },
-                  "source_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Human-readable name of the subject"
-                  },
-                  "target_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "CURIE of the object node (e.g., NCBIGene:7076)"
-                  },
-                  "target_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Human-readable name of the object"
-                  },
-                  "predicate": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "biolink predicate (e.g., biolink:affects)"
-                  },
-                  "qualified_predicate": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Causal flavour of the predicate (e.g., biolink:causes)"
-                  },
-                  "object_direction_qualifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Direction of effect on the object (e.g., increased, decreased)"
-                  },
-                  "knowledge_level": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "How the edge was obtained (e.g., knowledge_assertion)"
-                  },
-                  "agent_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Who created the edge (e.g., manual_agent)"
-                  },
-                  "primary_knowledge_source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "InfoRes id of the source database (e.g., infores:ctd)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "backend": {
-                  "type": "string"
-                },
-                "data_as_of": {
-                  "type": "string"
-                },
-                "input_terms": {
-                  "type": "string"
-                },
-                "input_type": {
-                  "type": "string"
-                },
-                "report_type": {
-                  "type": "string"
-                },
-                "canonical_curie": {
-                  "type": "string"
-                },
-                "source_category": {
-                  "type": "string"
-                },
-                "target_category": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "CURIE of the subject node (e.g., CHEBI:15365)"
+              },
+              "source_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable name of the subject"
+              },
+              "target_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "CURIE of the object node (e.g., NCBIGene:7076)"
+              },
+              "target_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable name of the object"
+              },
+              "predicate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "biolink predicate (e.g., biolink:affects)"
+              },
+              "qualified_predicate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Causal flavour of the predicate (e.g., biolink:causes)"
+              },
+              "object_direction_qualifier": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Direction of effect on the object (e.g., increased, decreased)"
+              },
+              "knowledge_level": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "How the edge was obtained (e.g., knowledge_assertion)"
+              },
+              "agent_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Who created the edge (e.g., manual_agent)"
+              },
+              "primary_knowledge_source": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "InfoRes id of the source database (e.g., infores:ctd)"
               }
             }
           }
@@ -502,13 +365,9 @@
         {
           "type": "object",
           "required": [
-            "status",
             "error"
           ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             },
@@ -554,122 +413,79 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "source_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "CURIE of the subject node (e.g., CHEBI:15365)"
-                  },
-                  "source_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Human-readable name of the subject"
-                  },
-                  "target_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "CURIE of the object node (e.g., NCBIGene:7076)"
-                  },
-                  "target_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Human-readable name of the object"
-                  },
-                  "predicate": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "biolink predicate (e.g., biolink:affects)"
-                  },
-                  "qualified_predicate": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Causal flavour of the predicate (e.g., biolink:causes)"
-                  },
-                  "object_direction_qualifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Direction of effect on the object (e.g., increased, decreased)"
-                  },
-                  "knowledge_level": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "How the edge was obtained (e.g., knowledge_assertion)"
-                  },
-                  "agent_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Who created the edge (e.g., manual_agent)"
-                  },
-                  "primary_knowledge_source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "InfoRes id of the source database (e.g., infores:ctd)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "backend": {
-                  "type": "string"
-                },
-                "data_as_of": {
-                  "type": "string"
-                },
-                "input_terms": {
-                  "type": "string"
-                },
-                "input_type": {
-                  "type": "string"
-                },
-                "report_type": {
-                  "type": "string"
-                },
-                "canonical_curie": {
-                  "type": "string"
-                },
-                "source_category": {
-                  "type": "string"
-                },
-                "target_category": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "CURIE of the subject node (e.g., CHEBI:15365)"
+              },
+              "source_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable name of the subject"
+              },
+              "target_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "CURIE of the object node (e.g., NCBIGene:7076)"
+              },
+              "target_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable name of the object"
+              },
+              "predicate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "biolink predicate (e.g., biolink:affects)"
+              },
+              "qualified_predicate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Causal flavour of the predicate (e.g., biolink:causes)"
+              },
+              "object_direction_qualifier": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Direction of effect on the object (e.g., increased, decreased)"
+              },
+              "knowledge_level": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "How the edge was obtained (e.g., knowledge_assertion)"
+              },
+              "agent_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Who created the edge (e.g., manual_agent)"
+              },
+              "primary_knowledge_source": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "InfoRes id of the source database (e.g., infores:ctd)"
               }
             }
           }
@@ -677,13 +493,9 @@
         {
           "type": "object",
           "required": [
-            "status",
             "error"
           ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             },
@@ -729,122 +541,79 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "source_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "CURIE of the subject node (e.g., CHEBI:15365)"
-                  },
-                  "source_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Human-readable name of the subject"
-                  },
-                  "target_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "CURIE of the object node (e.g., NCBIGene:7076)"
-                  },
-                  "target_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Human-readable name of the object"
-                  },
-                  "predicate": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "biolink predicate (e.g., biolink:affects)"
-                  },
-                  "qualified_predicate": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Causal flavour of the predicate (e.g., biolink:causes)"
-                  },
-                  "object_direction_qualifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Direction of effect on the object (e.g., increased, decreased)"
-                  },
-                  "knowledge_level": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "How the edge was obtained (e.g., knowledge_assertion)"
-                  },
-                  "agent_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Who created the edge (e.g., manual_agent)"
-                  },
-                  "primary_knowledge_source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "InfoRes id of the source database (e.g., infores:ctd)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "backend": {
-                  "type": "string"
-                },
-                "data_as_of": {
-                  "type": "string"
-                },
-                "input_terms": {
-                  "type": "string"
-                },
-                "input_type": {
-                  "type": "string"
-                },
-                "report_type": {
-                  "type": "string"
-                },
-                "canonical_curie": {
-                  "type": "string"
-                },
-                "source_category": {
-                  "type": "string"
-                },
-                "target_category": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "CURIE of the subject node (e.g., CHEBI:15365)"
+              },
+              "source_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable name of the subject"
+              },
+              "target_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "CURIE of the object node (e.g., NCBIGene:7076)"
+              },
+              "target_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable name of the object"
+              },
+              "predicate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "biolink predicate (e.g., biolink:affects)"
+              },
+              "qualified_predicate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Causal flavour of the predicate (e.g., biolink:causes)"
+              },
+              "object_direction_qualifier": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Direction of effect on the object (e.g., increased, decreased)"
+              },
+              "knowledge_level": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "How the edge was obtained (e.g., knowledge_assertion)"
+              },
+              "agent_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Who created the edge (e.g., manual_agent)"
+              },
+              "primary_knowledge_source": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "InfoRes id of the source database (e.g., infores:ctd)"
               }
             }
           }
@@ -852,13 +621,9 @@
         {
           "type": "object",
           "required": [
-            "status",
             "error"
           ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             },

--- a/src/tooluniverse/data/ctis_tools.json
+++ b/src/tooluniverse/data/ctis_tools.json
@@ -1,378 +1,334 @@
 [
-    {
-        "name": "CTIS_search_trials",
-        "description": "Search the EU Clinical Trials Information System (CTIS) \u2014 the European clinical-trials register under the Clinical Trials Regulation (since 2022), complementing ClinicalTrials.gov. Free-text search returns matching authorized trials with CT number, title, status, conditions, therapeutic areas, phase, sponsor, participating countries, enrollment, and dates. Use to find EU/EEA clinical trials for a condition, drug, or sponsor. No API key required.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Free-text search, e.g. 'breast cancer', 'pembrolizumab', 'cystic fibrosis'."
-                },
-                "limit": {
-                    "type": [
-                        "integer",
-                        "null"
-                    ],
-                    "description": "Results per page (default 10, max 100)."
-                },
-                "page": {
-                    "type": [
-                        "integer",
-                        "null"
-                    ],
-                    "description": "Page number (default 1)."
-                }
-            },
-            "required": [
-                "query"
-            ]
+  {
+    "name": "CTIS_search_trials",
+    "description": "Search the EU Clinical Trials Information System (CTIS) \u2014 the European clinical-trials register under the Clinical Trials Regulation (since 2022), complementing ClinicalTrials.gov. Free-text search returns matching authorized trials with CT number, title, status, conditions, therapeutic areas, phase, sponsor, participating countries, enrollment, and dates. Use to find EU/EEA clinical trials for a condition, drug, or sponsor. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Free-text search, e.g. 'breast cancer', 'pembrolizumab', 'cystic fibrosis'."
         },
-        "fields": {
-            "timeout": 30
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Results per page (default 10, max 100)."
         },
-        "type": "CTISSearchTrialsTool",
-        "test_examples": [
-            {
-                "query": "breast cancer",
-                "limit": 5
-            },
-            {
-                "query": "cystic fibrosis",
-                "limit": 3
-            },
-            {
-                "query": "pembrolizumab",
-                "limit": 3
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "description": "Matching CTIS trials",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object"
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "description": "Includes total_records"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
+        "page": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Page number (default 1)."
         }
+      },
+      "required": [
+        "query"
+      ]
     },
-    {
-        "name": "CTIS_search_trials_filtered",
-        "description": "Structured (filtered) search of the EU Clinical Trials Information System (CTIS) — the European clinical-trials register under the Clinical Trials Regulation. Unlike the free-text CTIS_search_trials, this narrows results with registry filters: medical condition, trial status code, trial phase code, age group code, gender code, has-results flag, sponsor name, therapeutic area, and country/member-state-concerned (MSC) or trial region. Combine filters to count and list precisely matching authorized EU/EEA trials. Status codes: 1=under evaluation, 2=authorised/not started, 3=ongoing/recruiting, 4=ended, 5=expired, etc. Phase codes are strings like '1','2','3','4'. Age group codes: '1'=in utero, '2'=preterm/newborn through children, '3'=adults, '4'=elderly (use the CTIS public portal facet for exact codes). No API key required.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Optional free-text term applied as CTIS 'containAll' (e.g. 'cancer', 'pembrolizumab'). Combine with structured filters below."
-                },
-                "medical_condition": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Medical condition / indication filter, e.g. 'breast cancer', 'leukemia'."
-                },
-                "status": {
-                    "type": [
-                        "array",
-                        "integer",
-                        "string",
-                        "null"
-                    ],
-                    "items": {
-                        "type": [
-                            "integer",
-                            "string"
-                        ]
-                    },
-                    "description": "Trial status code(s), e.g. [3] for ongoing. Accepts a single value or a list."
-                },
-                "trial_phase_code": {
-                    "type": [
-                        "array",
-                        "string",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Trial phase code(s) as strings, e.g. ['3'] for Phase III. Accepts a single value or a list."
-                },
-                "age_group_code": {
-                    "type": [
-                        "array",
-                        "string",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Age group code(s) as strings, e.g. ['2']. Accepts a single value or a list."
-                },
-                "gender_code": {
-                    "type": [
-                        "array",
-                        "string",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Gender code(s) as strings. Accepts a single value or a list."
-                },
-                "therapeutic_area": {
-                    "type": [
-                        "array",
-                        "string",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Therapeutic area code(s). Accepts a single value or a list."
-                },
-                "has_study_results": {
-                    "type": [
-                        "boolean",
-                        "null"
-                    ],
-                    "description": "If true, return only trials that have posted study results."
-                },
-                "sponsor": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Sponsor name filter, e.g. 'Pfizer'."
-                },
-                "sponsor_type_code": {
-                    "type": [
-                        "array",
-                        "string",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Sponsor type code(s). Accepts a single value or a list."
-                },
-                "country": {
-                    "type": [
-                        "array",
-                        "string",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Member State Concerned (MSC) country code(s). Accepts a single value or a list (alias for msc)."
-                },
-                "msc": {
-                    "type": [
-                        "array",
-                        "string",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Member State Concerned (MSC) code(s). Accepts a single value or a list."
-                },
-                "trial_region_code": {
-                    "type": [
-                        "array",
-                        "string",
-                        "null"
-                    ],
-                    "items": {
-                        "type": "string"
-                    },
-                    "description": "Trial region code(s) (e.g. EU/EEA vs partly outside). Accepts a single value or a list."
-                },
-                "sort_by": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Optional CTIS sort key (e.g. by decision date)."
-                },
-                "limit": {
-                    "type": [
-                        "integer",
-                        "null"
-                    ],
-                    "description": "Results per page (default 10, max 100)."
-                },
-                "page": {
-                    "type": [
-                        "integer",
-                        "null"
-                    ],
-                    "description": "Page number (default 1)."
-                }
-            },
-            "required": []
-        },
-        "fields": {
-            "timeout": 30
-        },
-        "type": "CTISSearchTrialsTool",
-        "test_examples": [
-            {
-                "medical_condition": "breast cancer",
-                "status": [
-                    3
-                ],
-                "limit": 3
-            },
-            {
-                "query": "cancer",
-                "has_study_results": true,
-                "limit": 2
-            },
-            {
-                "query": "cancer",
-                "trial_phase_code": [
-                    "3"
-                ],
-                "limit": 2
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "description": "Filtered CTIS trials",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object"
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "description": "Includes total_records and the applied search_criteria"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
-        }
+    "fields": {
+      "timeout": 30
     },
-    {
-        "name": "CTIS_get_trial",
-        "description": "Retrieve a single EU CTIS clinical trial by its CT number (format like '2022-503001-38-01'). Returns the trial's status, key dates, trial region, the authorized application (Part I/II details, member states concerned, EudraCT link), events, and results availability. Use after CTIS_search_trials to get full detail on a specific EU trial. No API key required.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "ct_number": {
-                    "type": "string",
-                    "description": "CTIS CT number, e.g. '2022-503001-38-01'."
-                }
-            },
-            "required": [
-                "ct_number"
-            ]
+    "type": "CTISSearchTrialsTool",
+    "test_examples": [
+      {
+        "query": "breast cancer",
+        "limit": 5
+      },
+      {
+        "query": "cystic fibrosis",
+        "limit": 3
+      },
+      {
+        "query": "pembrolizumab",
+        "limit": 3
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
         },
-        "fields": {
-            "timeout": 30
-        },
-        "type": "CTISGetTrialTool",
-        "test_examples": [
-            {
-                "ct_number": "2022-503001-38-01"
-            },
-            {
-                "ct_number": "2022-501024-20-00"
-            },
-            {
-                "ct_number": "2024-514022-23-00"
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "description": "Full CTIS trial record",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "object"
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "CTIS_search_trials_filtered",
+    "description": "Structured (filtered) search of the EU Clinical Trials Information System (CTIS) \u2014 the European clinical-trials register under the Clinical Trials Regulation. Unlike the free-text CTIS_search_trials, this narrows results with registry filters: medical condition, trial status code, trial phase code, age group code, gender code, has-results flag, sponsor name, therapeutic area, and country/member-state-concerned (MSC) or trial region. Combine filters to count and list precisely matching authorized EU/EEA trials. Status codes: 1=under evaluation, 2=authorised/not started, 3=ongoing/recruiting, 4=ended, 5=expired, etc. Phase codes are strings like '1','2','3','4'. Age group codes: '1'=in utero, '2'=preterm/newborn through children, '3'=adults, '4'=elderly (use the CTIS public portal facet for exact codes). No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional free-text term applied as CTIS 'containAll' (e.g. 'cancer', 'pembrolizumab'). Combine with structured filters below."
+        },
+        "medical_condition": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Medical condition / indication filter, e.g. 'breast cancer', 'leukemia'."
+        },
+        "status": {
+          "type": [
+            "array",
+            "integer",
+            "string",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "description": "Trial status code(s), e.g. [3] for ongoing. Accepts a single value or a list."
+        },
+        "trial_phase_code": {
+          "type": [
+            "array",
+            "string",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Trial phase code(s) as strings, e.g. ['3'] for Phase III. Accepts a single value or a list."
+        },
+        "age_group_code": {
+          "type": [
+            "array",
+            "string",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Age group code(s) as strings, e.g. ['2']. Accepts a single value or a list."
+        },
+        "gender_code": {
+          "type": [
+            "array",
+            "string",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Gender code(s) as strings. Accepts a single value or a list."
+        },
+        "therapeutic_area": {
+          "type": [
+            "array",
+            "string",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Therapeutic area code(s). Accepts a single value or a list."
+        },
+        "has_study_results": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "If true, return only trials that have posted study results."
+        },
+        "sponsor": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Sponsor name filter, e.g. 'Pfizer'."
+        },
+        "sponsor_type_code": {
+          "type": [
+            "array",
+            "string",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Sponsor type code(s). Accepts a single value or a list."
+        },
+        "country": {
+          "type": [
+            "array",
+            "string",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Member State Concerned (MSC) country code(s). Accepts a single value or a list (alias for msc)."
+        },
+        "msc": {
+          "type": [
+            "array",
+            "string",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Member State Concerned (MSC) code(s). Accepts a single value or a list."
+        },
+        "trial_region_code": {
+          "type": [
+            "array",
+            "string",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Trial region code(s) (e.g. EU/EEA vs partly outside). Accepts a single value or a list."
+        },
+        "sort_by": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional CTIS sort key (e.g. by decision date)."
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Results per page (default 10, max 100)."
+        },
+        "page": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Page number (default 1)."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "CTISSearchTrialsTool",
+    "test_examples": [
+      {
+        "medical_condition": "breast cancer",
+        "status": [
+          3
+        ],
+        "limit": 3
+      },
+      {
+        "query": "cancer",
+        "has_study_results": true,
+        "limit": 2
+      },
+      {
+        "query": "cancer",
+        "trial_phase_code": [
+          "3"
+        ],
+        "limit": 2
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "CTIS_get_trial",
+    "description": "Retrieve a single EU CTIS clinical trial by its CT number (format like '2022-503001-38-01'). Returns the trial's status, key dates, trial region, the authorized application (Part I/II details, member states concerned, EudraCT link), events, and results availability. Use after CTIS_search_trials to get full detail on a specific EU trial. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "ct_number": {
+          "type": "string",
+          "description": "CTIS CT number, e.g. '2022-503001-38-01'."
+        }
+      },
+      "required": [
+        "ct_number"
+      ]
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "CTISGetTrialTool",
+    "test_examples": [
+      {
+        "ct_number": "2022-503001-38-01"
+      },
+      {
+        "ct_number": "2022-501024-20-00"
+      },
+      {
+        "ct_number": "2024-514022-23-00"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/dailymed_tools.json
+++ b/src/tooluniverse/data/dailymed_tools.json
@@ -84,13 +84,21 @@
               "type": "integer"
             },
             "previous_page": {
-              "type": ["string", "integer", "null"]
+              "type": [
+                "string",
+                "integer",
+                "null"
+              ]
             },
             "previous_page_url": {
               "type": "string"
             },
             "next_page": {
-              "type": ["string", "integer", "null"]
+              "type": [
+                "string",
+                "integer",
+                "null"
+              ]
             }
           }
         }
@@ -391,50 +399,46 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "setid": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "setid": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": ["string", "null"]
-                },
-                "spl_version": {
-                  "type": ["integer", "null"]
-                },
-                "media": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "mime_type": {
-                        "type": "string",
-                        "description": "Image MIME type, e.g., image/jpeg"
-                      },
-                      "name": {
-                        "type": "string",
-                        "description": "Media file name"
-                      },
-                      "url": {
-                        "type": "string",
-                        "description": "Direct image URL"
-                      }
-                    }
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "spl_version": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "media": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "mime_type": {
+                    "type": "string",
+                    "description": "Image MIME type, e.g., image/jpeg"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Media file name"
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "Direct image URL"
                   }
                 }
-              },
-              "required": ["setid", "media"]
-            },
-            "metadata": {
-              "type": "object",
-              "additionalProperties": true
+              }
             }
           },
-          "required": ["data"]
+          "required": [
+            "setid",
+            "media"
+          ]
         },
         {
           "type": "object",
@@ -443,7 +447,9 @@
               "type": "string"
             }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -478,43 +484,36 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "setid": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "setid": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": ["string", "null"]
-                },
-                "history": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "spl_version": {
-                        "type": "integer",
-                        "description": "SPL version number"
-                      },
-                      "published_date": {
-                        "type": "string",
-                        "description": "Publication date, e.g., 'Jul 22, 2022'"
-                      }
-                    }
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "history": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "spl_version": {
+                    "type": "integer",
+                    "description": "SPL version number"
+                  },
+                  "published_date": {
+                    "type": "string",
+                    "description": "Publication date, e.g., 'Jul 22, 2022'"
                   }
                 }
-              },
-              "required": ["setid", "history"]
-            },
-            "metadata": {
-              "type": "object",
-              "additionalProperties": true
+              }
             }
           },
-          "required": ["data"]
+          "required": [
+            "setid",
+            "history"
+          ]
         },
         {
           "type": "object",
@@ -523,7 +522,9 @@
               "type": "string"
             }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/dbaasp_tools.json
+++ b/src/tooluniverse/data/dbaasp_tools.json
@@ -7,80 +7,153 @@
       "type": "object",
       "properties": {
         "peptideId": {
-          "type": ["integer", "string"],
+          "type": [
+            "integer",
+            "string"
+          ],
           "description": "DBAASP numeric peptide ID. Example: 107 (Dermaseptin S4 (1-16)[M4K], sequence ALWKTLLKKVLKAAAK). Accepts a bare integer or a 'DBAASPR_107'-style ID (digits are extracted)."
         }
       },
-      "required": ["peptideId"]
+      "required": [
+        "peptideId"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Successful peptide lookup.",
+          "description": "Full DBAASP peptide record.",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "description": "Full DBAASP peptide record.",
-              "properties": {
-                "id": {"type": "integer"},
-                "dbaaspId": {"type": "string"},
-                "name": {"type": "string"},
-                "sequence": {"type": "string"},
-                "sequenceLength": {"type": "integer"},
-                "nTerminus": {"type": ["string", "object", "null"]},
-                "cTerminus": {"type": ["string", "object", "null"]},
-                "synthesisType": {"type": ["string", "object", "null"]},
-                "complexity": {"type": ["string", "object", "null"]},
-                "pdbs": {"type": "array"},
-                "structureModel": {"type": ["object", "null"]},
-                "targetGroups": {"type": "array"},
-                "targetActivities": {"type": "array"},
-                "hemoliticCytotoxicActivities": {"type": "array"},
-                "antibiofilmActivities": {"type": "array"},
-                "uniprots": {"type": "array"},
-                "sourceGenes": {"type": "array"},
-                "smiles": {"type": ["string", "array", "null"]},
-                "articles": {"type": "array"}
-              }
+            "id": {
+              "type": "integer"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "url": {"type": "string"},
-                "peptide_id": {"type": "integer"},
-                "dbaasp_id": {"type": "string"},
-                "name": {"type": "string"},
-                "sequence": {"type": "string"},
-                "sequence_length": {"type": "integer"},
-                "target_activity_count": {"type": "integer"}
-              }
+            "dbaaspId": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "sequence": {
+              "type": "string"
+            },
+            "sequenceLength": {
+              "type": "integer"
+            },
+            "nTerminus": {
+              "type": [
+                "string",
+                "object",
+                "null"
+              ]
+            },
+            "cTerminus": {
+              "type": [
+                "string",
+                "object",
+                "null"
+              ]
+            },
+            "synthesisType": {
+              "type": [
+                "string",
+                "object",
+                "null"
+              ]
+            },
+            "complexity": {
+              "type": [
+                "string",
+                "object",
+                "null"
+              ]
+            },
+            "pdbs": {
+              "type": "array"
+            },
+            "structureModel": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "targetGroups": {
+              "type": "array"
+            },
+            "targetActivities": {
+              "type": "array"
+            },
+            "hemoliticCytotoxicActivities": {
+              "type": "array"
+            },
+            "antibiofilmActivities": {
+              "type": "array"
+            },
+            "uniprots": {
+              "type": "array"
+            },
+            "sourceGenes": {
+              "type": "array"
+            },
+            "smiles": {
+              "type": [
+                "string",
+                "array",
+                "null"
+              ]
+            },
+            "articles": {
+              "type": "array"
             }
           },
-          "required": ["status", "data"]
+          "required": [
+            "id"
+          ]
         },
         {
           "type": "object",
           "description": "Error result.",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "url": {"type": "string"},
-            "response_snippet": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "response_snippet": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"peptideId": 107},
-      {"peptideId": "2975"}
+      {
+        "peptideId": 107
+      },
+      {
+        "peptideId": "2975"
+      }
     ],
-    "label": ["DBAASP", "Antimicrobial Peptide", "AMP", "MIC", "Peptide"],
+    "label": [
+      "DBAASP",
+      "Antimicrobial Peptide",
+      "AMP",
+      "MIC",
+      "Peptide"
+    ],
     "metadata": {
-      "tags": ["antimicrobial peptide", "AMP", "DBAASP", "MIC", "hemolytic", "antibiofilm", "peptide"],
+      "tags": [
+        "antimicrobial peptide",
+        "AMP",
+        "DBAASP",
+        "MIC",
+        "hemolytic",
+        "antibiofilm",
+        "peptide"
+      ],
       "estimated_execution_time": "1-3 seconds"
     }
   },
@@ -112,7 +185,10 @@
           "description": "Target group (e.g. 'Gram+', 'Gram-'). Maps to targetGroup.value."
         },
         "sequence_length": {
-          "type": ["integer", "string"],
+          "type": [
+            "integer",
+            "string"
+          ],
           "description": "Exact peptide length filter. Maps to sequenceLength.value."
         },
         "synthesis_type": {
@@ -128,7 +204,10 @@
           "description": "UniProt accession cross-reference. Maps to uniprot.value."
         },
         "dbaasp_id": {
-          "type": ["integer", "string"],
+          "type": [
+            "integer",
+            "string"
+          ],
           "description": "DBAASP numeric ID filter. Maps to id.value."
         },
         "limit": {
@@ -145,65 +224,131 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "description": "Successful search.",
-          "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "array",
-              "description": "List of matching peptide summaries.",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {"type": "integer"},
-                  "dbaaspId": {"type": "string"},
-                  "name": {"type": ["string", "null"]},
-                  "sequence": {"type": ["string", "null"]},
-                  "sequenceLength": {"type": ["integer", "null"]},
-                  "nTerminus": {"type": ["string", "object", "null"]},
-                  "cTerminus": {"type": ["string", "object", "null"]},
-                  "complexity": {"type": ["string", "object", "null"]},
-                  "synthesisType": {"type": ["string", "object", "null"]},
-                  "pdb": {"type": ["string", "null"]},
-                  "pubchemCid": {"type": ["integer", "string", "null"]}
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "url": {"type": "string"},
-                "total_count": {"type": "integer"},
-                "returned_count": {"type": "integer"},
-                "limit": {"type": "integer"},
-                "offset": {"type": "integer"}
+          "type": "array",
+          "description": "List of matching peptide summaries.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "dbaaspId": {
+                "type": "string"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sequence": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "sequenceLength": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "nTerminus": {
+                "type": [
+                  "string",
+                  "object",
+                  "null"
+                ]
+              },
+              "cTerminus": {
+                "type": [
+                  "string",
+                  "object",
+                  "null"
+                ]
+              },
+              "complexity": {
+                "type": [
+                  "string",
+                  "object",
+                  "null"
+                ]
+              },
+              "synthesisType": {
+                "type": [
+                  "string",
+                  "object",
+                  "null"
+                ]
+              },
+              "pdb": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pubchemCid": {
+                "type": [
+                  "integer",
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": ["status", "data"]
+          }
         },
         {
           "type": "object",
           "description": "Error result.",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"},
-            "url": {"type": "string"},
-            "response_snippet": {"type": "string"}
+            "error": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            },
+            "response_snippet": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"sequence": "GLFDIVKKVVGALGSL", "sequence_option": "full", "limit": 3},
-      {"name": "Magainin", "limit": 3},
-      {"target_species": "Staphylococcus aureus", "limit": 2}
+      {
+        "sequence": "GLFDIVKKVVGALGSL",
+        "sequence_option": "full",
+        "limit": 3
+      },
+      {
+        "name": "Magainin",
+        "limit": 3
+      },
+      {
+        "target_species": "Staphylococcus aureus",
+        "limit": 2
+      }
     ],
-    "label": ["DBAASP", "Antimicrobial Peptide", "AMP", "Search", "Peptide"],
+    "label": [
+      "DBAASP",
+      "Antimicrobial Peptide",
+      "AMP",
+      "Search",
+      "Peptide"
+    ],
     "metadata": {
-      "tags": ["antimicrobial peptide", "AMP", "DBAASP", "search", "sequence", "target organism", "peptide"],
+      "tags": [
+        "antimicrobial peptide",
+        "AMP",
+        "DBAASP",
+        "search",
+        "sequence",
+        "target organism",
+        "peptide"
+      ],
       "estimated_execution_time": "1-3 seconds"
     }
   }

--- a/src/tooluniverse/data/dblp_tools.json
+++ b/src/tooluniverse/data/dblp_tools.json
@@ -167,49 +167,38 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
+          "description": "DBLP author search response",
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "result": {
               "type": "object",
-              "description": "DBLP author search response",
               "properties": {
-                "result": {
+                "query": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "object"
+                },
+                "hits": {
                   "type": "object",
+                  "description": "Matched author records",
                   "properties": {
-                    "query": {
+                    "@total": {
                       "type": "string"
                     },
-                    "status": {
-                      "type": "object"
-                    },
-                    "hits": {
-                      "type": "object",
-                      "description": "Matched author records",
-                      "properties": {
-                        "@total": {
-                          "type": "string"
-                        },
-                        "hit": {
-                          "type": "array",
-                          "items": {
+                    "hit": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "@id": {
+                            "type": "string"
+                          },
+                          "@score": {
+                            "type": "string"
+                          },
+                          "info": {
                             "type": "object",
-                            "properties": {
-                              "@id": {
-                                "type": "string"
-                              },
-                              "@score": {
-                                "type": "string"
-                              },
-                              "info": {
-                                "type": "object",
-                                "description": "Author info including 'author' name, 'url' (PID URL), optional 'aliases', 'notes' (affiliations/awards)"
-                              }
-                            }
+                            "description": "Author info including 'author' name, 'url' (PID URL), optional 'aliases', 'notes' (affiliations/awards)"
                           }
                         }
                       }
@@ -217,26 +206,22 @@
                   }
                 }
               }
-            },
-            "url": {
-              "type": "string"
             }
-          }
+          },
+          "required": [
+            "result"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -286,49 +271,38 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
+          "description": "DBLP venue search response",
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "result": {
               "type": "object",
-              "description": "DBLP venue search response",
               "properties": {
-                "result": {
+                "query": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "object"
+                },
+                "hits": {
                   "type": "object",
+                  "description": "Matched venue records",
                   "properties": {
-                    "query": {
+                    "@total": {
                       "type": "string"
                     },
-                    "status": {
-                      "type": "object"
-                    },
-                    "hits": {
-                      "type": "object",
-                      "description": "Matched venue records",
-                      "properties": {
-                        "@total": {
-                          "type": "string"
-                        },
-                        "hit": {
-                          "type": "array",
-                          "items": {
+                    "hit": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "@id": {
+                            "type": "string"
+                          },
+                          "@score": {
+                            "type": "string"
+                          },
+                          "info": {
                             "type": "object",
-                            "properties": {
-                              "@id": {
-                                "type": "string"
-                              },
-                              "@score": {
-                                "type": "string"
-                              },
-                              "info": {
-                                "type": "object",
-                                "description": "Venue info including 'venue' name, optional 'acronym', 'type' (Conference/Journal), and 'url'"
-                              }
-                            }
+                            "description": "Venue info including 'venue' name, optional 'acronym', 'type' (Conference/Journal), and 'url'"
                           }
                         }
                       }
@@ -336,26 +310,22 @@
                   }
                 }
               }
-            },
-            "url": {
-              "type": "string"
             }
-          }
+          },
+          "required": [
+            "result"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/decoupler_ulm_tools.json
+++ b/src/tooluniverse/data/decoupler_ulm_tools.json
@@ -5,13 +5,51 @@
     "description": "Infer transcription-factor / pathway activities from a per-gene statistic (e.g. a DESeq2/edgeR t-stat or logFC) and a regulatory network (source=TF/pathway, target=gene, weight=mode of regulation), using decoupleR's univariate-linear-model (ULM) method. Returns per-source activity (slope t-value; +=active) and p-value. Pure-compute; pairs with the DoRothEA/PROGENy networks from OmniPath_get_dorothea_regulon.",
     "parameter": {
       "type": "object",
-      "required": ["network"],
+      "required": [
+        "network"
+      ],
       "properties": {
-        "gene_stats": {"type": ["object", "null"], "description": "{gene: statistic} mapping (e.g. DE t-statistic per gene). Alternative to genes+stats."},
-        "genes": {"type": ["array", "null"], "items": {"type": "string"}, "description": "Gene identifiers (use with `stats`, same order)."},
-        "stats": {"type": ["array", "null"], "items": {"type": "number"}, "description": "Per-gene statistic (same order as `genes`)."},
-        "network": {"type": "array", "items": {"type": "object"}, "description": "Regulatory edges: [{source, target, weight}] (weight defaults to 1; 'mor' accepted as an alias)."},
-        "min_targets": {"type": ["integer", "null"], "description": "Minimum targets present in the gene list for a source to be tested (default 5)."}
+        "gene_stats": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "description": "{gene: statistic} mapping (e.g. DE t-statistic per gene). Alternative to genes+stats."
+        },
+        "genes": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Gene identifiers (use with `stats`, same order)."
+        },
+        "stats": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-gene statistic (same order as `genes`)."
+        },
+        "network": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "Regulatory edges: [{source, target, weight}] (weight defaults to 1; 'mor' accepted as an alias)."
+        },
+        "min_targets": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Minimum targets present in the gene list for a source to be tested (default 5)."
+        }
       }
     },
     "return_schema": {
@@ -19,31 +57,121 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_genes": {"type": "integer"},
-                "n_sources_tested": {"type": "integer"},
-                "activities": {"type": "array", "items": {"type": "object"}}
+            "n_genes": {
+              "type": "integer"
+            },
+            "n_sources_tested": {
+              "type": "integer"
+            },
+            "activities": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
           },
-          "required": ["data"]
+          "required": [
+            "n_genes"
+          ]
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "gene_stats": {"G1": 4.0, "G2": 3.5, "G3": 3.0, "G4": 2.8, "G5": 2.5, "G6": 2.2, "G7": 2.0, "G8": 1.8, "G9": 0.2, "G10": 0.0, "G11": -0.1, "G12": 0.1, "G13": -1.8, "G14": -2.0, "G15": -2.4, "G16": -2.7, "G17": -3.0, "G18": -3.3, "G19": -3.6, "G20": -4.0},
+        "gene_stats": {
+          "G1": 4.0,
+          "G2": 3.5,
+          "G3": 3.0,
+          "G4": 2.8,
+          "G5": 2.5,
+          "G6": 2.2,
+          "G7": 2.0,
+          "G8": 1.8,
+          "G9": 0.2,
+          "G10": 0.0,
+          "G11": -0.1,
+          "G12": 0.1,
+          "G13": -1.8,
+          "G14": -2.0,
+          "G15": -2.4,
+          "G16": -2.7,
+          "G17": -3.0,
+          "G18": -3.3,
+          "G19": -3.6,
+          "G20": -4.0
+        },
         "network": [
-          {"source": "TF_A", "target": "G1", "weight": 1}, {"source": "TF_A", "target": "G2", "weight": 1}, {"source": "TF_A", "target": "G3", "weight": 1}, {"source": "TF_A", "target": "G4", "weight": 1}, {"source": "TF_A", "target": "G5", "weight": 1}, {"source": "TF_A", "target": "G6", "weight": 1},
-          {"source": "TF_B", "target": "G15", "weight": 1}, {"source": "TF_B", "target": "G16", "weight": 1}, {"source": "TF_B", "target": "G17", "weight": 1}, {"source": "TF_B", "target": "G18", "weight": 1}, {"source": "TF_B", "target": "G19", "weight": 1}, {"source": "TF_B", "target": "G20", "weight": 1}
+          {
+            "source": "TF_A",
+            "target": "G1",
+            "weight": 1
+          },
+          {
+            "source": "TF_A",
+            "target": "G2",
+            "weight": 1
+          },
+          {
+            "source": "TF_A",
+            "target": "G3",
+            "weight": 1
+          },
+          {
+            "source": "TF_A",
+            "target": "G4",
+            "weight": 1
+          },
+          {
+            "source": "TF_A",
+            "target": "G5",
+            "weight": 1
+          },
+          {
+            "source": "TF_A",
+            "target": "G6",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G15",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G16",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G17",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G18",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G19",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G20",
+            "weight": 1
+          }
         ]
       }
     ]

--- a/src/tooluniverse/data/deseq2_tools.json
+++ b/src/tooluniverse/data/deseq2_tools.json
@@ -95,23 +95,17 @@
       "type": "object",
       "oneOf": [
         {
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/dfam_tools.json
+++ b/src/tooluniverse/data/dfam_tools.json
@@ -41,68 +41,50 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "accession": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "length": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "repeat_type": {
-                    "type": "string"
-                  },
-                  "repeat_subtype": {
-                    "type": "string"
-                  },
-                  "classification": {
-                    "type": "string"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "length": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "repeat_type": {
+                "type": "string"
+              },
+              "repeat_subtype": {
+                "type": "string"
+              },
+              "classification": {
+                "type": "string"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -138,119 +120,104 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "accession": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "length": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "classification": {
-                  "type": "string"
-                },
-                "repeat_type": {
-                  "type": "string"
-                },
-                "repeat_subtype": {
-                  "type": "string"
-                },
-                "consensus_sequence": {
-                  "type": "string"
-                },
-                "author": {
-                  "type": "string"
-                },
-                "date_created": {
-                  "type": "string"
-                },
-                "date_modified": {
-                  "type": "string"
-                },
-                "curation_state": {
-                  "type": "string"
-                },
-                "clades": {
-                  "type": "array",
-                  "items": {
+            "name": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "length": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "classification": {
+              "type": "string"
+            },
+            "repeat_type": {
+              "type": "string"
+            },
+            "repeat_subtype": {
+              "type": "string"
+            },
+            "consensus_sequence": {
+              "type": "string"
+            },
+            "author": {
+              "type": "string"
+            },
+            "date_created": {
+              "type": "string"
+            },
+            "date_modified": {
+              "type": "string"
+            },
+            "curation_state": {
+              "type": "string"
+            },
+            "clades": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "citations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pmid": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "title": {
                     "type": "string"
-                  }
-                },
-                "citations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pmid": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "authors": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "aliases": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "database": {
-                        "type": "string"
-                      },
-                      "alias": {
-                        "type": "string"
-                      }
-                    }
+                  },
+                  "authors": {
+                    "type": "string"
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "aliases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "database": {
+                    "type": "string"
+                  },
+                  "alias": {
+                    "type": "string"
+                  }
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "accession"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -310,98 +277,80 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "accession": {
-                    "type": "string"
-                  },
-                  "query": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "type": "string"
-                  },
-                  "strand": {
-                    "type": "string"
-                  },
-                  "bit_score": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "e_value": {
-                    "type": "string"
-                  },
-                  "seq_start": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "seq_end": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "ali_start": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "ali_end": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "model_start": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "model_end": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession": {
+                "type": "string"
+              },
+              "query": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "strand": {
+                "type": "string"
+              },
+              "bit_score": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "e_value": {
+                "type": "string"
+              },
+              "seq_start": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "seq_end": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "ali_start": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "ali_end": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "model_start": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "model_end": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/dn_ds_tools.json
+++ b/src/tooluniverse/data/dn_ds_tools.json
@@ -2,26 +2,71 @@
   {
     "name": "Sequence_dn_ds",
     "type": "DnDsTool",
-    "description": "Compute dN/dS (Ka/Ks) between two coding sequences via the Nei-Gojobori (1986) estimator with Jukes-Cantor correction — the standard test for selection: dN/dS > 1 = positive/diversifying, << 1 = purifying, ~ 1 = near-neutral. Give two in-frame, codon-aligned coding sequences inline ('seq1'/'seq2') or as single-record FASTA files. Returns dN, dS, the ratio, per-site counts, and an interpretation. Pure Python, no API key. Works for any organisms/genes.",
+    "description": "Compute dN/dS (Ka/Ks) between two coding sequences via the Nei-Gojobori (1986) estimator with Jukes-Cantor correction \u2014 the standard test for selection: dN/dS > 1 = positive/diversifying, << 1 = purifying, ~ 1 = near-neutral. Give two in-frame, codon-aligned coding sequences inline ('seq1'/'seq2') or as single-record FASTA files. Returns dN, dS, the ratio, per-site counts, and an interpretation. Pure Python, no API key. Works for any organisms/genes.",
     "parameter": {
       "type": "object",
       "required": [],
       "properties": {
-        "seq1": {"type": ["string", "null"], "description": "First coding sequence (in-frame, codon-aligned to seq2). DNA/RNA letters."},
-        "seq2": {"type": ["string", "null"], "description": "Second coding sequence (same length/frame as seq1)."},
-        "fasta1_path": {"type": ["string", "null"], "description": "Alternative to seq1: path to a single-record FASTA"},
-        "fasta2_path": {"type": ["string", "null"], "description": "Alternative to seq2: path to a single-record FASTA"}
+        "seq1": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "First coding sequence (in-frame, codon-aligned to seq2). DNA/RNA letters."
+        },
+        "seq2": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Second coding sequence (same length/frame as seq1)."
+        },
+        "fasta1_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Alternative to seq1: path to a single-record FASTA"
+        },
+        "fasta2_path": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Alternative to seq2: path to a single-record FASTA"
+        }
       }
     },
     "return_schema": {
       "type": "object",
       "oneOf": [
-        {"properties": {"status": {"const": "success"}, "data": {"type": "object"}}, "required": ["data"]},
-        {"properties": {"status": {"const": "error"}, "error": {"type": "string"}}, "required": ["error"]}
+        {
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
       ]
     },
     "test_examples": [
-      {"seq1": "ATGGCCAAATTTGAAGATCTGAGCACCGTGCGTGGC", "seq2": "ATGGCCAAGTTCGAAAATCTGAGCACCGTACGTGGC"}
+      {
+        "seq1": "ATGGCCAAATTTGAAGATCTGAGCACCGTGCGTGGC",
+        "seq2": "ATGGCCAAGTTCGAAAATCTGAGCACCGTACGTGGC"
+      }
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Part 1 of 5 batches fixing #288 — 111 of the 552 tools with envelope-style `return_schema` beyond the 9 already fixed in #287.

## Root cause

`tu test` validates `jsonschema.validate(result.get("data"), return_schema)` — only the inner `data` payload, never the full `{"status","data","metadata"}` envelope. These tools declared `return_schema` as a `oneOf` with a branch requiring/declaring `status`, which can never be satisfied by a bare `data` payload, so `tu test` always failed regardless of how correct the live API response was.

## Fix

For each affected tool:
- Extracted the nested `oneOf[...].properties.data` sub-schema (or, where the success branch had no `data`/`error` wrapper at all, just the fields flattened alongside `status`) and promoted it to the top level.
- Normalized the error branch to the documented plain form `{"type":"object","properties":{"error":{"type":"string"}},"required":["error"]}`.
- Added a disambiguating `required` field on object-shaped success branches that had none, so the two `oneOf` branches stay disjoint from the error branch (verified programmatically: a synthetic `{"error": "..."}` payload now matches exactly one branch for every tool in this batch).

Files in this batch (alphabetically A-D): `aging_cohort`, `allen_brain`, `allen_cell_types`, `alphafill`, `alphagenome`, `alphamissense`, `ampsphere*`, `antibody_registry`, `aopwiki`, `artic`, `bgpt`, `bigg_models`, `bindingdb`, `bioimage_archive`, `biosamples`, `bmrb`, `cancerppd2`, `cbioportal`, `cdc`, `cellpose`, `classyfire`, `clinical_calculators`, `clinical_guidelines`, `clinical_tables`, `clinical_trial_stats`, `clinicaltrials_gov`, `clinvar_submitted`, `cluspro`, `coexpression_module`, `col`, `colocalization`, `complex_portal`, `compound_disease`, `compound_gene_disease`, `compound_variant`, `conoserver`, `cpic`, `crossref`, `cryoet`, `ctd`, `ctis`, `dailymed`, `dbaasp`, `dblp`, `decoupler_ulm`, `deseq2`, `dfam`, `dn_ds`.

## Validation

- All 232 changed files (across all 5 planned batches) parse as valid JSON.
- Every changed tool's `return_schema.oneOf` compiles under `jsonschema.Draft7Validator` and stays disjoint (checked programmatically with a synthetic error payload against every branch).
- `tu list` loads the full registry cleanly (2599 tools, no load errors) with this batch applied.
- Live-tested a representative sample from this batch with `tu test <ToolName>` against real APIs, spanning both the common "wrap `data` under `oneOf`" shape and the trickier "bare open-object success branch" shape that needed the disambiguating `required`/`not` fix:
  - `AlphaFill_get_transplants`, `AMPSphere_search_amps`, `Crossref_get_member`, `CTIS_get_trial`, `Sequence_dn_ds`, `CoL_get_taxon`, `BiGG_download_model`, `CPIC_get_gene_info`, `CTD_get_chemical_gene_interactions`, `DBLP_search_authors`, `ComplexPortal_search_complexes`, `ClinicalCalc_CHA2DS2_VASc`, `ArtIC_search_artworks`, `Dfam_search_families` — all pass.
  - Three other tools tested surfaced pre-existing, unrelated failures (not caused by this change, confirmed by diffing against the current `main` schema before this fix): `run_deseq2_analysis` (stale test_examples file path), `CryoET_list_datasets` (a `relatedDatabaseEntries` field pre-typed as `"type": "null"` on `main`, unrelated to the envelope wrapping), `ConoServer_get_conopeptide` (upstream site returning 403). None are return_schema-envelope issues; flagging for a separate follow-up rather than bundling into this fix.

## Follow-up (not included here)

- `CELLxGENE_get_census_versions` / `CELLxGENE_get_presence_matrix` (in `cellxgene_census_tools.json`) share the same detection signature but have a different root cause: `CELLxGENECensusTool.run()` doesn't wrap results under a `data` key at all, so their current `return_schema` relies on a `{"type": "null"}` branch as a workaround and currently passes `tu test`. Fixing them properly needs a code change to the tool's `run()` method, not just a schema edit, so they're intentionally excluded from this batch.
- The `CryoET_list_datasets` nullable-field bug found during live testing above.

## Test coverage

Schema-only change; correctness is validated via the programmatic disjointness check plus live `tu test` runs above, matching the fix recipe from #288 (no new unit test needed — existing `tu test` machinery is exactly what this PR fixes to pass).