### PR TITLE
Fix #288: correct envelope-style return_schema (batch 3/5, files G-N)

### DIFF
--- a/src/tooluniverse/data/gtopdb_tools.json
+++ b/src/tooluniverse/data/gtopdb_tools.json
@@ -237,420 +237,351 @@
       }
     ],
     "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string",
-                            "enum": [
-                                "success"
-                            ]
-                        },
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string",
-                            "enum": [
-                                "error"
-                            ]
-                        },
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "error"
-                    ]
-                }
-            ]
-        }
-  },
- {
-  "name": "GtoPdb_search_diseases",
-  "description": "Search the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) for diseases by name, and retrieve their curated disease IDs, names, synonyms, and cross-references to external databases (OMIM, Orphanet, Disease Ontology). GtoPdb links diseases to the drug targets and approved/experimental ligands relevant to them. Example: 'epilepsy' returns disease entries such as 'Epilepsy and Intellectual Disability'. No authentication required.",
-  "parameter": {
-   "type": "object",
-   "properties": {
-    "name": {
-     "type": [
-      "string",
-      "null"
-     ],
-     "description": "Disease name to search. Examples: 'epilepsy', 'asthma', 'hypertension', 'breast cancer'."
-    },
-    "query": {
-     "type": [
-      "string",
-      "null"
-     ],
-     "description": "Name/keyword to search for. Alias for the \"name\" parameter."
-    }
-   },
-   "required": []
-  },
-  "fields": {
-   "endpoint": "https://www.guidetopharmacology.org/services/diseases",
-   "params": {}
-  },
-  "type": "GtoPdbRESTTool",
-  "test_examples": [
-   {
-    "name": "epilepsy"
-   },
-   {
-    "query": "asthma"
-   }
-  ],
-  "return_schema": {
-   "oneOf": [
-    {
-     "type": "object",
-     "properties": {
-      "data": {
-       "type": "array",
-       "items": {
-        "type": "object",
-        "properties": {
-         "diseaseId": {
-          "type": [
-           "integer",
-           "null"
-          ],
-          "description": "GtoPdb disease ID"
-         },
-         "name": {
-          "type": [
-           "string",
-           "null"
-          ],
-          "description": "Disease name"
-         },
-         "description": {
-          "type": [
-           "string",
-           "null"
-          ]
-         },
-         "synonyms": {
+      "oneOf": [
+        {
           "type": "array",
           "items": {
-           "type": [
-            "object",
-            "string"
-           ],
-           "description": "GtoPdb returns synonyms as objects like {\"name\": \"...\"}; a plain string is also accepted."
+            "type": "object"
           }
-         },
-         "databaseLinks": {
-          "type": "array"
-         }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-       }
-      }
-     },
-     "required": [
-      "data"
-     ]
-    },
-    {
-     "type": "object",
-     "properties": {
-      "error": {
-       "type": "string"
-      }
-     },
-     "required": [
-      "error"
-     ]
+      ]
     }
-   ]
-  }
- },
- {
-  "name": "GtoPdb_get_ligand_properties",
-  "description": "Get the chemical structure and computed molecular properties of a ligand from the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) by its ligand ID. Merges two keyless endpoints into one record: structure (canonical SMILES, InChI, InChIKey, IUPAC name) and molecularProperties (molecular weight, logP, hydrogen-bond donors/acceptors, rotatable bonds, topological polar surface area, Lipinski rule-of-five violation count). Use GtoPdb_search_ligands first to find a ligand_id (e.g., aspirin = 4139). No authentication required.",
-  "parameter": {
-   "type": "object",
-   "properties": {
-    "ligand_id": {
-     "type": [
-      "integer",
-      "null"
-     ],
-     "description": "GtoPdb ligand ID. Get from GtoPdb_search_ligands. Examples: 4139 (aspirin), 1 (a-bungarotoxin). Alias: ligandId also accepted."
-    },
-    "ligandId": {
-     "type": [
-      "integer",
-      "null"
-     ],
-     "description": "Alias for ligand_id. GtoPdb ligand ID."
-    }
-   },
-   "required": []
   },
-  "fields": {
-   "endpoint": "https://www.guidetopharmacology.org/services/ligands/ligandProperties",
-   "params": {}
-  },
-  "type": "GtoPdbRESTTool",
-  "test_examples": [
-   {
-    "ligand_id": 4139
-   },
-   {
-    "ligandId": 4139
-   }
-  ],
-  "return_schema": {
-   "oneOf": [
-    {
-     "type": "object",
-     "properties": {
-      "status": {
-       "type": "string",
-       "enum": [
-        "success"
-       ]
+  {
+    "name": "GtoPdb_search_diseases",
+    "description": "Search the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) for diseases by name, and retrieve their curated disease IDs, names, synonyms, and cross-references to external databases (OMIM, Orphanet, Disease Ontology). GtoPdb links diseases to the drug targets and approved/experimental ligands relevant to them. Example: 'epilepsy' returns disease entries such as 'Epilepsy and Intellectual Disability'. No authentication required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Disease name to search. Examples: 'epilepsy', 'asthma', 'hypertension', 'breast cancer'."
+        },
+        "query": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Name/keyword to search for. Alias for the \"name\" parameter."
+        }
       },
-      "data": {
-       "type": "object",
-       "properties": {
+      "required": []
+    },
+    "fields": {
+      "endpoint": "https://www.guidetopharmacology.org/services/diseases",
+      "params": {}
+    },
+    "type": "GtoPdbRESTTool",
+    "test_examples": [
+      {
+        "name": "epilepsy"
+      },
+      {
+        "query": "asthma"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "diseaseId": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "description": "GtoPdb disease ID"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Disease name"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "synonyms": {
+                    "type": "array",
+                    "items": {
+                      "type": [
+                        "object",
+                        "string"
+                      ],
+                      "description": "GtoPdb returns synonyms as objects like {\"name\": \"...\"}; a plain string is also accepted."
+                    }
+                  },
+                  "databaseLinks": {
+                    "type": "array"
+                  }
+                }
+              }
+            }
+          },
+          "required": [
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "GtoPdb_get_ligand_properties",
+    "description": "Get the chemical structure and computed molecular properties of a ligand from the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) by its ligand ID. Merges two keyless endpoints into one record: structure (canonical SMILES, InChI, InChIKey, IUPAC name) and molecularProperties (molecular weight, logP, hydrogen-bond donors/acceptors, rotatable bonds, topological polar surface area, Lipinski rule-of-five violation count). Use GtoPdb_search_ligands first to find a ligand_id (e.g., aspirin = 4139). No authentication required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "ligand_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "GtoPdb ligand ID. Get from GtoPdb_search_ligands. Examples: 4139 (aspirin), 1 (a-bungarotoxin). Alias: ligandId also accepted."
+        },
         "ligandId": {
-         "type": [
-          "integer",
-          "null"
-         ]
-        },
-        "ligandName": {
-         "type": [
-          "string",
-          "null"
-         ]
-        },
-        "iupacName": {
-         "type": [
-          "string",
-          "null"
-         ]
-        },
-        "smiles": {
-         "type": [
-          "string",
-          "null"
-         ]
-        },
-        "inchi": {
-         "type": [
-          "string",
-          "null"
-         ]
-        },
-        "inchiKey": {
-         "type": [
-          "string",
-          "null"
-         ]
-        },
-        "molecularProperties": {
-         "type": [
-          "object",
-          "null"
-         ],
-         "properties": {
-          "molecularWeight": {
-           "type": [
-            "number",
-            "null"
-           ]
-          },
-          "logP": {
-           "type": [
-            "number",
-            "null"
-           ]
-          },
-          "hydrogenBondDonors": {
-           "type": [
+          "type": [
             "integer",
             "null"
-           ]
-          },
-          "hydrogenBondAcceptors": {
-           "type": [
-            "integer",
-            "null"
-           ]
-          },
-          "rotatableBonds": {
-           "type": [
-            "integer",
-            "null"
-           ]
-          },
-          "topologicalPolarSurfaceArea": {
-           "type": [
-            "number",
-            "null"
-           ]
-          },
-          "lipinskisRuleOfFive": {
-           "type": [
-            "integer",
-            "null"
-           ]
-          }
-         }
+          ],
+          "description": "Alias for ligand_id. GtoPdb ligand ID."
         }
-       }
-      }
-     },
-     "required": [
-      "status",
-      "data"
-     ]
-    },
-    {
-     "type": "object",
-     "properties": {
-      "status": {
-       "type": "string",
-       "enum": [
-        "error"
-       ]
       },
-      "error": {
-       "type": "string"
-      }
-     },
-     "required": [
-      "status",
-      "error"
-     ]
-    }
-   ]
-  }
- },
- {
-  "name": "GtoPdb_get_disease_associations",
-  "description": "Get curated disease-to-target and disease-to-ligand associations from the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) for a given disease ID. Merges two keyless endpoints into one record: diseaseTargets (drug targets linked to the disease, with roles, references, and ligand-target interactions) and diseaseLigands (approved/experimental ligands linked to the disease, with approval status and clinical-use notes). An empty list is a valid result (some diseases have targets but no curated ligands). Use GtoPdb_search_diseases first to find a disease_id (e.g., non-allergic asthma = 1161). No authentication required.",
-  "parameter": {
-   "type": "object",
-   "properties": {
-    "disease_id": {
-     "type": [
-      "integer",
-      "null"
-     ],
-     "description": "GtoPdb disease ID. Get from GtoPdb_search_diseases. Examples: 1161 (non-allergic asthma), 34 (acute myeloid leukemia). Alias: diseaseId also accepted."
+      "required": []
     },
-    "diseaseId": {
-     "type": [
-      "integer",
-      "null"
-     ],
-     "description": "Alias for disease_id. GtoPdb disease ID."
-    }
-   },
-   "required": []
-  },
-  "fields": {
-   "endpoint": "https://www.guidetopharmacology.org/services/diseases/diseaseAssociations",
-   "params": {}
-  },
-  "type": "GtoPdbRESTTool",
-  "test_examples": [
-   {
-    "disease_id": 1161
-   },
-   {
-    "disease_id": 34
-   }
-  ],
-  "return_schema": {
-   "oneOf": [
-    {
-     "type": "object",
-     "properties": {
-      "status": {
-       "type": "string",
-       "enum": [
-        "success"
-       ]
+    "fields": {
+      "endpoint": "https://www.guidetopharmacology.org/services/ligands/ligandProperties",
+      "params": {}
+    },
+    "type": "GtoPdbRESTTool",
+    "test_examples": [
+      {
+        "ligand_id": 4139
       },
-      "data": {
-       "type": "object",
-       "properties": {
+      {
+        "ligandId": 4139
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ligandId": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "ligandName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "iupacName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "smiles": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "inchi": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "inchiKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "molecularProperties": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "molecularWeight": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "logP": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "hydrogenBondDonors": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "hydrogenBondAcceptors": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "rotatableBonds": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "topologicalPolarSurfaceArea": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "lipinskisRuleOfFive": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              }
+            }
+          },
+          "required": [
+            "ligandId"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "GtoPdb_get_disease_associations",
+    "description": "Get curated disease-to-target and disease-to-ligand associations from the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) for a given disease ID. Merges two keyless endpoints into one record: diseaseTargets (drug targets linked to the disease, with roles, references, and ligand-target interactions) and diseaseLigands (approved/experimental ligands linked to the disease, with approval status and clinical-use notes). An empty list is a valid result (some diseases have targets but no curated ligands). Use GtoPdb_search_diseases first to find a disease_id (e.g., non-allergic asthma = 1161). No authentication required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "disease_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "GtoPdb disease ID. Get from GtoPdb_search_diseases. Examples: 1161 (non-allergic asthma), 34 (acute myeloid leukemia). Alias: diseaseId also accepted."
+        },
         "diseaseId": {
-         "type": [
-          "integer",
-          "null"
-         ]
-        },
-        "diseaseTargets": {
-         "type": "array",
-         "items": {
-          "type": "object"
-         }
-        },
-        "diseaseLigands": {
-         "type": "array",
-         "items": {
-          "type": "object"
-         }
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Alias for disease_id. GtoPdb disease ID."
         }
-       },
-       "required": [
-        "diseaseTargets",
-        "diseaseLigands"
-       ]
       },
-      "target_count": {
-       "type": "integer"
-      },
-      "ligand_count": {
-       "type": "integer"
-      }
-     },
-     "required": [
-      "status",
-      "data"
-     ]
+      "required": []
     },
-    {
-     "type": "object",
-     "properties": {
-      "status": {
-       "type": "string",
-       "enum": [
-        "error"
-       ]
+    "fields": {
+      "endpoint": "https://www.guidetopharmacology.org/services/diseases/diseaseAssociations",
+      "params": {}
+    },
+    "type": "GtoPdbRESTTool",
+    "test_examples": [
+      {
+        "disease_id": 1161
       },
-      "error": {
-       "type": "string"
+      {
+        "disease_id": 34
       }
-     },
-     "required": [
-      "status",
-      "error"
-     ]
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "diseaseId": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "diseaseTargets": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "diseaseLigands": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          },
+          "required": [
+            "diseaseTargets",
+            "diseaseLigands"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
     }
-   ]
   }
- }
 ]

--- a/src/tooluniverse/data/harmonizome_tools.json
+++ b/src/tooluniverse/data/harmonizome_tools.json
@@ -349,131 +349,116 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "attribute": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "attribute": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "dataset": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "symbol": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "ncbi_entrez_gene_id": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "members": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "gene": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "gene_href": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "threshold_value": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "standardized_value": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "associations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "gene_set": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "gene_set_href": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "threshold_value": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "standardized_value": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "dataset": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "symbol": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ncbi_entrez_gene_id": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "members": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "gene": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "gene_href": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "threshold_value": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "standardized_value": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "associations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "gene_set": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "gene_set_href": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "threshold_value": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "standardized_value": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  }
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "members"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/harmonizome_tools.json
+++ b/src/tooluniverse/data/harmonizome_tools.json
@@ -445,8 +445,17 @@
               }
             }
           },
-          "required": [
-            "members"
+          "anyOf": [
+            {
+              "required": [
+                "members"
+              ]
+            },
+            {
+              "required": [
+                "associations"
+              ]
+            }
           ]
         },
         {

--- a/src/tooluniverse/data/hemolytik2_tools.json
+++ b/src/tooluniverse/data/hemolytik2_tools.json
@@ -9,43 +9,52 @@
         "dataType": {
           "type": "string",
           "description": "Field to filter on. One of: 'nature' (peptide nature, e.g. Anticancer, Antimicrobial, CPP), 'source' (source organism, e.g. Human), or 'seq' (sequence). Default: 'nature'.",
-          "enum": ["nature", "source", "seq"]
+          "enum": [
+            "nature",
+            "source",
+            "seq"
+          ]
         },
         "dataValue": {
           "type": "string",
           "description": "Value to match for the chosen dataType. Examples: 'Anticancer' (with dataType=nature) -> ~166 records; 'Human' (with dataType=source) -> ~9255 records."
         }
       },
-      "required": ["dataValue"]
+      "required": [
+        "dataValue"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": { "const": "success" },
-            "data": {
-              "type": "array",
-              "items": { "type": "object" },
-              "description": "Matching hemolytic peptide records. Each has id, pmid, year, seq, name, cter, nter, lyn_cyc, ldmix, non_nat, length, nature, activity (e.g. 'LC50 =1.4 micromolar'), source, origin, exp_str, non_hem."
-            },
-            "metadata": { "type": "object" }
+          "type": "array",
+          "items": {
+            "type": "object"
           },
-          "required": ["status", "data", "metadata"]
+          "description": "Matching hemolytic peptide records. Each has id, pmid, year, seq, name, cter, nter, lyn_cyc, ldmix, non_nat, length, nature, activity (e.g. 'LC50 =1.4 micromolar'), source, origin, exp_str, non_hem."
         },
         {
           "type": "object",
           "properties": {
-            "status": { "const": "error" },
-            "error": { "type": "string" }
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      { "dataType": "nature", "dataValue": "Anticancer" },
-      { "dataType": "source", "dataValue": "Human" }
+      {
+        "dataType": "nature",
+        "dataValue": "Anticancer"
+      },
+      {
+        "dataType": "source",
+        "dataValue": "Human"
+      }
     ]
   }
 ]

--- a/src/tooluniverse/data/hgnc_tools.json
+++ b/src/tooluniverse/data/hgnc_tools.json
@@ -528,92 +528,64 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "description": "Full HGNC record for every member gene of the family",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "hgnc_id": {
-                    "type": "string"
-                  },
-                  "symbol": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "locus_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "location": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_group": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "gene_group_id": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "ensembl_gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "entrez_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "uniprot_ids": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_field": {
-                  "type": "string"
-                },
-                "query_value": {
-                  "type": "string"
-                },
-                "num_found": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "description": "Full HGNC record for every member gene of the family",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hgnc_id": {
+                "type": "string"
+              },
+              "symbol": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "locus_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "location": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_group": {
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "gene_group_id": {
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "ensembl_gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "entrez_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uniprot_ids": {
+                "type": [
+                  "array",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/hlaligandatlas_tools.json
+++ b/src/tooluniverse/data/hlaligandatlas_tools.json
@@ -38,58 +38,43 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "peptides": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "peptide_sequence_id": {
-                        "type": "string"
-                      },
-                      "peptide_sequence": {
-                        "type": "string"
-                      },
-                      "hla_class": {
-                        "type": "string"
-                      },
-                      "donor_alleles": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "tissues": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
+            "peptides": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "peptide_sequence_id": {
+                    "type": "string"
+                  },
+                  "peptide_sequence": {
+                    "type": "string"
+                  },
+                  "hla_class": {
+                    "type": "string"
+                  },
+                  "donor_alleles": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "tissues": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           },
           "required": [
-            "status",
-            "data"
+            "peptides"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
@@ -137,43 +122,28 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "donors": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "donor": {
-                        "type": "string"
-                      },
-                      "hla_allele": {
-                        "type": "string"
-                      }
-                    }
+            "donors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "donor": {
+                    "type": "string"
+                  },
+                  "hla_allele": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           },
           "required": [
-            "status",
-            "data"
+            "donors"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/hpa_tools.json
+++ b/src/tooluniverse/data/hpa_tools.json
@@ -38,48 +38,26 @@
       }
     ],
     "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string",
-                            "enum": [
-                                "success"
-                            ]
-                        },
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string",
-                            "enum": [
-                                "error"
-                            ]
-                        },
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "error"
-                    ]
-                }
-            ]
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
+    }
   },
   {
     "type": "HPASearchGenesTool",

--- a/src/tooluniverse/data/hubmap_sample_tools.json
+++ b/src/tooluniverse/data/hubmap_sample_tools.json
@@ -50,70 +50,84 @@
       "oneOf": [
         {
           "type": "object",
-          "required": ["status"],
           "properties": {
-            "status": {
-              "const": "success"
+            "total": {
+              "type": "integer"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "total": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "samples": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "hubmap_id": {
-                        "type": ["string", "null"]
-                      },
-                      "uuid": {
-                        "type": ["string", "null"]
-                      },
-                      "sample_category": {
-                        "type": ["string", "null"]
-                      },
-                      "organ_code": {
-                        "type": ["string", "null"]
-                      },
-                      "organ_name": {
-                        "type": ["string", "null"]
-                      },
-                      "group_name": {
-                        "type": ["string", "null"]
-                      },
-                      "spatially_registered": {
-                        "type": ["boolean", "null"]
-                      },
-                      "donor_hubmap_id": {
-                        "type": ["string", "null"]
-                      }
-                    }
+            "returned": {
+              "type": "integer"
+            },
+            "samples": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "hubmap_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "uuid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "sample_category": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "organ_code": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "organ_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "group_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "spatially_registered": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "donor_hubmap_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "total"
+          ]
         },
         {
           "type": "object",
-          "required": ["status", "error"],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -129,7 +143,9 @@
           "description": "HuBMAP Sample identifier (e.g. 'HBM658.BXNB.873'). Obtain from HuBMAP_search_samples."
         }
       },
-      "required": ["hubmap_id"]
+      "required": [
+        "hubmap_id"
+      ]
     },
     "fields": {
       "operation": "get_sample"
@@ -147,94 +163,136 @@
       "oneOf": [
         {
           "type": "object",
-          "required": ["status"],
           "properties": {
-            "status": {
-              "const": "success"
+            "hubmap_id": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
+            "uuid": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "entity_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sample_category": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organ_code": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organ_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "group_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "data_access_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "protocol_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "donor_hubmap_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "created_timestamp": {
+              "type": [
+                "integer",
+                "number",
+                "null"
+              ]
+            },
+            "rui_location": {
+              "type": [
+                "object",
+                "null"
+              ],
               "properties": {
-                "hubmap_id": {
-                  "type": ["string", "null"]
+                "registered": {
+                  "type": "boolean"
                 },
-                "uuid": {
-                  "type": ["string", "null"]
+                "placement_target": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "entity_type": {
-                  "type": ["string", "null"]
+                "x_dimension": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
                 },
-                "sample_category": {
-                  "type": ["string", "null"]
+                "y_dimension": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
                 },
-                "organ_code": {
-                  "type": ["string", "null"]
+                "z_dimension": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
                 },
-                "organ_name": {
-                  "type": ["string", "null"]
+                "dimension_units": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "group_name": {
-                  "type": ["string", "null"]
-                },
-                "data_access_level": {
-                  "type": ["string", "null"]
-                },
-                "protocol_url": {
-                  "type": ["string", "null"]
-                },
-                "donor_hubmap_id": {
-                  "type": ["string", "null"]
-                },
-                "created_timestamp": {
-                  "type": ["integer", "number", "null"]
-                },
-                "rui_location": {
-                  "type": ["object", "null"],
-                  "properties": {
-                    "registered": {
-                      "type": "boolean"
-                    },
-                    "placement_target": {
-                      "type": ["string", "null"]
-                    },
-                    "x_dimension": {
-                      "type": ["number", "null"]
-                    },
-                    "y_dimension": {
-                      "type": ["number", "null"]
-                    },
-                    "z_dimension": {
-                      "type": ["number", "null"]
-                    },
-                    "dimension_units": {
-                      "type": ["string", "null"]
-                    },
-                    "ccf_annotations": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
+                "ccf_annotations": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "hubmap_id"
+          ]
         },
         {
           "type": "object",
-          "required": ["status", "error"],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -283,58 +341,57 @@
       "oneOf": [
         {
           "type": "object",
-          "required": ["status"],
           "properties": {
-            "status": {
-              "const": "success"
+            "total": {
+              "type": "integer"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "total": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "donors": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "hubmap_id": {
-                        "type": ["string", "null"]
-                      },
-                      "uuid": {
-                        "type": ["string", "null"]
-                      },
-                      "group_name": {
-                        "type": ["string", "null"]
-                      },
-                      "demographics": {
-                        "type": "object"
-                      }
-                    }
+            "returned": {
+              "type": "integer"
+            },
+            "donors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "hubmap_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "uuid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "group_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "demographics": {
+                    "type": "object"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "total"
+          ]
         },
         {
           "type": "object",
-          "required": ["status", "error"],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/hubmap_tools.json
+++ b/src/tooluniverse/data/hubmap_tools.json
@@ -415,96 +415,81 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "uuid": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "uuid": {
-                  "type": "string"
-                },
-                "ancestor_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "lineage": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "entity_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "hubmap_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "uuid": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "sample_category": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "organ": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "dataset_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "group_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "ancestor_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "lineage": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "entity_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "hubmap_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "uuid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "sample_category": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "organ": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "dataset_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "group_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "uuid"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/huggingface_inference_tools.json
+++ b/src/tooluniverse/data/huggingface_inference_tools.json
@@ -38,46 +38,38 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "top_label": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "labels": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "top_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
             }
           },
           "required": [
-            "data"
+            "model_id"
           ]
         },
         {
@@ -148,35 +140,27 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "dimension": {
-                  "type": "integer"
-                },
-                "embedding": {
-                  "type": "array",
-                  "items": {
-                    "type": "number"
-                  }
-                },
-                "preview": {
-                  "type": "array",
-                  "items": {
-                    "type": "number"
-                  }
-                }
+            "dimension": {
+              "type": "integer"
+            },
+            "embedding": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "preview": {
+              "type": "array",
+              "items": {
+                "type": "number"
               }
             }
           },
           "required": [
-            "data"
+            "model_id"
           ]
         },
         {
@@ -254,52 +238,44 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "top_token": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "predictions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "token_str": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "sequence": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "top_token": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "predictions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "token_str": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "sequence": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
             }
           },
           "required": [
-            "data"
+            "model_id"
           ]
         },
         {
@@ -385,23 +361,15 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "summary_text": {
-                  "type": "string"
-                }
-              }
+            "summary_text": {
+              "type": "string"
             }
           },
           "required": [
-            "data"
+            "model_id"
           ]
         },
         {
@@ -484,46 +452,38 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "top_label": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "labels": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "top_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
             }
           },
           "required": [
-            "data"
+            "model_id"
           ]
         },
         {
@@ -595,61 +555,53 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "entity_count": {
-                  "type": "integer"
-                },
-                "entities": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "entity_group": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "word": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "start": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "end": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+            "entity_count": {
+              "type": "integer"
+            },
+            "entities": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "entity_group": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "word": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "start": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "end": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   }
                 }
               }
             }
           },
           "required": [
-            "data"
+            "model_id"
           ]
         },
         {
@@ -720,44 +672,36 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "answer": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "score": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "start": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "end": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                }
-              }
+            "answer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "score": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "start": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "end": {
+              "type": [
+                "integer",
+                "null"
+              ]
             }
           },
           "required": [
-            "data"
+            "model_id"
           ]
         },
         {
@@ -824,23 +768,15 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "translation_text": {
-                  "type": "string"
-                }
-              }
+            "translation_text": {
+              "type": "string"
             }
           },
           "required": [
-            "data"
+            "model_id"
           ]
         },
         {
@@ -915,46 +851,38 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "top_label": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "labels": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "top_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
             }
           },
           "required": [
-            "data"
+            "model_id"
           ]
         },
         {
@@ -1029,63 +957,55 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "object_count": {
-                  "type": "integer"
-                },
-                "objects": {
-                  "type": "array",
-                  "items": {
+            "object_count": {
+              "type": "integer"
+            },
+            "objects": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "box": {
                     "type": "object",
                     "properties": {
-                      "label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
+                      "xmin": {
                         "type": [
                           "number",
                           "null"
                         ]
                       },
-                      "box": {
-                        "type": "object",
-                        "properties": {
-                          "xmin": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "ymin": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "xmax": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "ymax": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          }
-                        }
+                      "ymin": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      },
+                      "xmax": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      },
+                      "ymax": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
                       }
                     }
                   }
@@ -1094,7 +1014,7 @@
             }
           },
           "required": [
-            "data"
+            "model_id"
           ]
         },
         {

--- a/src/tooluniverse/data/icite_tools.json
+++ b/src/tooluniverse/data/icite_tools.json
@@ -30,286 +30,271 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
             "data": {
-              "type": "object",
-              "properties": {
-                "data": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "_id": {
-                        "type": "string"
-                      },
-                      "authors": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "lastName": {
-                              "type": "string"
-                            },
-                            "fullName": {
-                              "type": "string"
-                            },
-                            "firstName": {
-                              "type": "string"
-                            }
-                          }
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "_id": {
+                    "type": "string"
+                  },
+                  "authors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "lastName": {
+                          "type": "string"
+                        },
+                        "fullName": {
+                          "type": "string"
+                        },
+                        "firstName": {
+                          "type": "string"
                         }
-                      },
-                      "doi": {
-                        "type": "string"
-                      },
-                      "pmid": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "animal": {
-                        "type": "number"
-                      },
-                      "human": {
-                        "type": "number"
-                      },
-                      "apt": {
-                        "type": "number"
-                      },
-                      "citedByClinicalArticle": {
-                        "type": "boolean"
-                      },
-                      "citedByPmidsByYear": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "36244096": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "39507426": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "34717201": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "39359723": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "35359543": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "24939975": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "31555204": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "35359563": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "31518578": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "32679995": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "38359253": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "41414399": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "35209409": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "36236933": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "35473031": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "38394080": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "33804690": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "36010775": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "37420482": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "37361425": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            }
-                          }
-                        }
-                      },
-                      "year": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "journal": {
-                        "type": "string"
-                      },
-                      "is_research_article": {
-                        "type": "boolean"
-                      },
-                      "citation_count": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "field_citation_rate": {
-                        "type": "number"
-                      },
-                      "expected_citations_per_year": {
-                        "type": "number"
-                      },
-                      "citations_per_year": {
-                        "type": "number"
-                      },
-                      "relative_citation_ratio": {
-                        "type": "number"
-                      },
-                      "nih_percentile": {
-                        "type": "number"
-                      },
-                      "molecular_cellular": {
-                        "type": "number"
-                      },
-                      "x_coord": {
-                        "type": "number"
-                      },
-                      "y_coord": {
-                        "type": "number"
-                      },
-                      "is_clinical": {
-                        "type": "boolean"
-                      },
-                      "cited_by_clin": {
-                        "type": "null"
-                      },
-                      "cited_by": {
-                        "type": "array",
-                        "items": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        }
-                      },
-                      "references": {
-                        "type": "array",
-                        "items": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        }
-                      },
-                      "provisional": {
-                        "type": "boolean"
                       }
                     }
+                  },
+                  "doi": {
+                    "type": "string"
+                  },
+                  "pmid": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "animal": {
+                    "type": "number"
+                  },
+                  "human": {
+                    "type": "number"
+                  },
+                  "apt": {
+                    "type": "number"
+                  },
+                  "citedByClinicalArticle": {
+                    "type": "boolean"
+                  },
+                  "citedByPmidsByYear": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "36244096": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "39507426": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "34717201": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "39359723": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "35359543": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "24939975": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "31555204": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "35359563": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "31518578": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "32679995": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "38359253": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "41414399": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "35209409": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "36236933": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "35473031": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "38394080": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "33804690": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "36010775": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "37420482": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "37361425": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "year": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "journal": {
+                    "type": "string"
+                  },
+                  "is_research_article": {
+                    "type": "boolean"
+                  },
+                  "citation_count": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "field_citation_rate": {
+                    "type": "number"
+                  },
+                  "expected_citations_per_year": {
+                    "type": "number"
+                  },
+                  "citations_per_year": {
+                    "type": "number"
+                  },
+                  "relative_citation_ratio": {
+                    "type": "number"
+                  },
+                  "nih_percentile": {
+                    "type": "number"
+                  },
+                  "molecular_cellular": {
+                    "type": "number"
+                  },
+                  "x_coord": {
+                    "type": "number"
+                  },
+                  "y_coord": {
+                    "type": "number"
+                  },
+                  "is_clinical": {
+                    "type": "boolean"
+                  },
+                  "cited_by_clin": {
+                    "type": "null"
+                  },
+                  "cited_by": {
+                    "type": "array",
+                    "items": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    }
+                  },
+                  "references": {
+                    "type": "array",
+                    "items": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    }
+                  },
+                  "provisional": {
+                    "type": "boolean"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "data"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/idigbio_tools.json
+++ b/src/tooluniverse/data/idigbio_tools.json
@@ -1,114 +1,514 @@
 [
-    {
-        "name": "iDigBio_search_records",
-        "description": "Search iDigBio (130M+ digitized biodiversity specimen records from museums, herbaria, and paleo collections) by taxon and/or locality. Filter by scientificname, genus, family, phylum, class, order, country, stateprovince, recordedby, catalognumber, or collectioncode. Returns specimen records with taxon, collector, locality, and catalog identifiers. Use for occurrence/specimen lookup, collection research, and biodiversity/biogeography studies. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "scientificname": {"type": ["string", "null"], "description": "Full scientific name, e.g. 'Puma concolor'."},
-            "genus": {"type": ["string", "null"], "description": "Genus, e.g. 'Quercus'."},
-            "family": {"type": ["string", "null"], "description": "Family name."},
-            "country": {"type": ["string", "null"], "description": "Country, e.g. 'United States'."},
-            "stateprovince": {"type": ["string", "null"], "description": "State/province."},
-            "recordedby": {"type": ["string", "null"], "description": "Collector name."},
-            "catalognumber": {"type": ["string", "null"], "description": "Catalog number."},
-            "collectioncode": {"type": ["string", "null"], "description": "Collection code."},
-            "phylum": {"type": ["string", "null"], "description": "Phylum."},
-            "class": {"type": ["string", "null"], "description": "Class."},
-            "order": {"type": ["string", "null"], "description": "Order."},
-            "limit": {"type": ["integer", "null"], "description": "Max records (default 10, max 100)."}
-        }, "required": []},
-        "fields": {"timeout": 30},
-        "type": "iDigBioSearchTool",
-        "test_examples": [{"genus": "Quercus", "limit": 5}, {"scientificname": "Puma concolor", "limit": 3}, {"family": "Fabaceae", "country": "Mexico", "limit": 3}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Biodiversity specimen records", "properties": {
-                "status": {"type": "string"}, "data": {"type": "array", "items": {"type": "object"}}, "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+  {
+    "name": "iDigBio_search_records",
+    "description": "Search iDigBio (130M+ digitized biodiversity specimen records from museums, herbaria, and paleo collections) by taxon and/or locality. Filter by scientificname, genus, family, phylum, class, order, country, stateprovince, recordedby, catalognumber, or collectioncode. Returns specimen records with taxon, collector, locality, and catalog identifiers. Use for occurrence/specimen lookup, collection research, and biodiversity/biogeography studies. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "scientificname": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Full scientific name, e.g. 'Puma concolor'."
+        },
+        "genus": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Genus, e.g. 'Quercus'."
+        },
+        "family": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Family name."
+        },
+        "country": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Country, e.g. 'United States'."
+        },
+        "stateprovince": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "State/province."
+        },
+        "recordedby": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Collector name."
+        },
+        "catalognumber": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Catalog number."
+        },
+        "collectioncode": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Collection code."
+        },
+        "phylum": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Phylum."
+        },
+        "class": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Class."
+        },
+        "order": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Order."
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Max records (default 10, max 100)."
+        }
+      },
+      "required": []
     },
-    {
-        "name": "iDigBio_get_record",
-        "description": "Retrieve a single iDigBio biodiversity specimen record by its UUID. Returns the curated summary plus the full Darwin Core data record (all collection/locality/taxonomy fields). No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "uuid": {"type": "string", "description": "iDigBio record UUID (from iDigBio_search_records)."}
-        }, "required": ["uuid"]},
-        "fields": {"timeout": 30},
-        "type": "iDigBioRecordTool",
-        "test_examples": [{"uuid": "b659bd7f-7fa7-434b-80e7-2be10d1c4e80"}, {"uuid": "25e65e9a-8ca8-4477-8802-001fb51e459f"}, {"uuid": "9d0283aa-e6be-4b7e-a810-1ad0ec8df79a"}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Single specimen record", "properties": {
-                "status": {"type": "string"}, "data": {"type": "object"}, "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+    "fields": {
+      "timeout": 30
     },
-    {
-        "name": "iDigBio_summary_facets",
-        "description": "Get aggregate specimen statistics from iDigBio for a Darwin Core query: the exact total record count plus top-value facet breakdowns (e.g. specimens per country, institution, or collector). Unlike iDigBio_search_records (which only paginates raw records, max 100), this returns counts over the entire matching set, enabling distribution/abundance statistics without full pagination. Filter with scientificname, genus, family, country, etc.; set top_fields to the field(s) to break down by. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "scientificname": {"type": ["string", "null"], "description": "Full scientific name, e.g. 'Puma concolor'."},
-            "genus": {"type": ["string", "null"], "description": "Genus, e.g. 'Puma'."},
-            "family": {"type": ["string", "null"], "description": "Family name."},
-            "country": {"type": ["string", "null"], "description": "Country, e.g. 'United States'."},
-            "stateprovince": {"type": ["string", "null"], "description": "State/province."},
-            "recordedby": {"type": ["string", "null"], "description": "Collector name."},
-            "phylum": {"type": ["string", "null"], "description": "Phylum."},
-            "class": {"type": ["string", "null"], "description": "Class."},
-            "order": {"type": ["string", "null"], "description": "Order."},
-            "top_fields": {"type": ["string", "null"], "description": "Darwin Core field(s) to break down counts by, e.g. 'country', 'institutioncode', or 'recordedby'. Comma-separate multiple fields. If omitted, only the total count is returned."},
-            "count": {"type": ["integer", "null"], "description": "Number of top values to return per facet field (default 10, max 100)."}
-        }, "required": []},
-        "fields": {"timeout": 30, "mode": "summary"},
-        "type": "iDigBioSearchTool",
-        "test_examples": [{"genus": "puma", "top_fields": "country", "count": 5}, {"scientificname": "puma concolor"}, {"family": "Felidae", "top_fields": "country", "count": 3}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Aggregate count and facet breakdown", "properties": {
-                "status": {"type": "string"},
-                "data": {"type": "object", "properties": {
-                    "itemCount": {"type": ["integer", "null"]},
-                    "facets": {"type": "object"}
-                }},
-                "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"status": {"type": "string"}, "error": {"type": "string"}}, "required": ["error"]}
-        ]}
-    },
-    {
-        "name": "iDigBio_search_media",
-        "description": "Search the iDigBio specimen MEDIA index (specimen photographs and scans) for a Darwin Core query. Distinct from iDigBio_search_records (occurrence records): returns image/media records with media type (StillImage), provider-managed ID, creator, rights owner, usage/licensing terms (e.g. CC BY-NC-SA), and access URIs. Filter with scientificname, genus, family, country, etc. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "scientificname": {"type": ["string", "null"], "description": "Full scientific name, e.g. 'Puma concolor'."},
-            "genus": {"type": ["string", "null"], "description": "Genus, e.g. 'Puma'."},
-            "family": {"type": ["string", "null"], "description": "Family name."},
-            "country": {"type": ["string", "null"], "description": "Country, e.g. 'United States'."},
-            "stateprovince": {"type": ["string", "null"], "description": "State/province."},
-            "recordedby": {"type": ["string", "null"], "description": "Collector name."},
-            "catalognumber": {"type": ["string", "null"], "description": "Catalog number."},
-            "collectioncode": {"type": ["string", "null"], "description": "Collection code."},
-            "phylum": {"type": ["string", "null"], "description": "Phylum."},
-            "class": {"type": ["string", "null"], "description": "Class."},
-            "order": {"type": ["string", "null"], "description": "Order."},
-            "limit": {"type": ["integer", "null"], "description": "Max media records (default 10, max 100)."}
-        }, "required": []},
-        "fields": {"timeout": 30, "mode": "media"},
-        "type": "iDigBioSearchTool",
-        "test_examples": [{"scientificname": "puma concolor", "limit": 2}, {"genus": "Quercus", "limit": 2}, {"family": "Felidae", "limit": 2}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Specimen media (image) records", "properties": {
-                "status": {"type": "string"},
-                "data": {"type": "array", "items": {"type": "object", "properties": {
-                    "uuid": {"type": ["string", "null"]},
-                    "type": {"type": ["string", "null"]},
-                    "format": {"type": ["string", "null"]},
-                    "provider_managed_id": {"type": ["string", "null"]},
-                    "creator": {"type": ["string", "null"]},
-                    "rights_owner": {"type": ["string", "null"]},
-                    "usage_terms": {"type": ["string", "null"]},
-                    "access_uri": {"type": ["string", "null"]}
-                }}},
-                "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"status": {"type": "string"}, "error": {"type": "string"}}, "required": ["error"]}
-        ]}
+    "type": "iDigBioSearchTool",
+    "test_examples": [
+      {
+        "genus": "Quercus",
+        "limit": 5
+      },
+      {
+        "scientificname": "Puma concolor",
+        "limit": 3
+      },
+      {
+        "family": "Fabaceae",
+        "country": "Mexico",
+        "limit": 3
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
     }
+  },
+  {
+    "name": "iDigBio_get_record",
+    "description": "Retrieve a single iDigBio biodiversity specimen record by its UUID. Returns the curated summary plus the full Darwin Core data record (all collection/locality/taxonomy fields). No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "uuid": {
+          "type": "string",
+          "description": "iDigBio record UUID (from iDigBio_search_records)."
+        }
+      },
+      "required": [
+        "uuid"
+      ]
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "iDigBioRecordTool",
+    "test_examples": [
+      {
+        "uuid": "b659bd7f-7fa7-434b-80e7-2be10d1c4e80"
+      },
+      {
+        "uuid": "25e65e9a-8ca8-4477-8802-001fb51e459f"
+      },
+      {
+        "uuid": "9d0283aa-e6be-4b7e-a810-1ad0ec8df79a"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "iDigBio_summary_facets",
+    "description": "Get aggregate specimen statistics from iDigBio for a Darwin Core query: the exact total record count plus top-value facet breakdowns (e.g. specimens per country, institution, or collector). Unlike iDigBio_search_records (which only paginates raw records, max 100), this returns counts over the entire matching set, enabling distribution/abundance statistics without full pagination. Filter with scientificname, genus, family, country, etc.; set top_fields to the field(s) to break down by. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "scientificname": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Full scientific name, e.g. 'Puma concolor'."
+        },
+        "genus": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Genus, e.g. 'Puma'."
+        },
+        "family": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Family name."
+        },
+        "country": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Country, e.g. 'United States'."
+        },
+        "stateprovince": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "State/province."
+        },
+        "recordedby": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Collector name."
+        },
+        "phylum": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Phylum."
+        },
+        "class": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Class."
+        },
+        "order": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Order."
+        },
+        "top_fields": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Darwin Core field(s) to break down counts by, e.g. 'country', 'institutioncode', or 'recordedby'. Comma-separate multiple fields. If omitted, only the total count is returned."
+        },
+        "count": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of top values to return per facet field (default 10, max 100)."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "timeout": 30,
+      "mode": "summary"
+    },
+    "type": "iDigBioSearchTool",
+    "test_examples": [
+      {
+        "genus": "puma",
+        "top_fields": "country",
+        "count": 5
+      },
+      {
+        "scientificname": "puma concolor"
+      },
+      {
+        "family": "Felidae",
+        "top_fields": "country",
+        "count": 3
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "itemCount": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "facets": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "facets"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "iDigBio_search_media",
+    "description": "Search the iDigBio specimen MEDIA index (specimen photographs and scans) for a Darwin Core query. Distinct from iDigBio_search_records (occurrence records): returns image/media records with media type (StillImage), provider-managed ID, creator, rights owner, usage/licensing terms (e.g. CC BY-NC-SA), and access URIs. Filter with scientificname, genus, family, country, etc. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "scientificname": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Full scientific name, e.g. 'Puma concolor'."
+        },
+        "genus": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Genus, e.g. 'Puma'."
+        },
+        "family": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Family name."
+        },
+        "country": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Country, e.g. 'United States'."
+        },
+        "stateprovince": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "State/province."
+        },
+        "recordedby": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Collector name."
+        },
+        "catalognumber": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Catalog number."
+        },
+        "collectioncode": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Collection code."
+        },
+        "phylum": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Phylum."
+        },
+        "class": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Class."
+        },
+        "order": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Order."
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Max media records (default 10, max 100)."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "timeout": 30,
+      "mode": "media"
+    },
+    "type": "iDigBioSearchTool",
+    "test_examples": [
+      {
+        "scientificname": "puma concolor",
+        "limit": 2
+      },
+      {
+        "genus": "Quercus",
+        "limit": 2
+      },
+      {
+        "family": "Felidae",
+        "limit": 2
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "uuid": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "format": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "provider_managed_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "creator": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "rights_owner": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "usage_terms": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "access_uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/idr_searchengine_tools.json
+++ b/src/tooluniverse/data/idr_searchengine_tools.json
@@ -73,78 +73,67 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "query": {
               "type": "object",
               "properties": {
-                "query": {
-                  "type": "object",
-                  "properties": {
-                    "key": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "value": {
-                      "type": "string"
-                    },
-                    "operator": {
-                      "type": "string"
-                    }
-                  }
+                "key": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "image_count": {
-                  "type": "integer"
+                "value": {
+                  "type": "string"
                 },
-                "images": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "image_id": {
-                        "type": [
-                          "integer",
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "image_webclient_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "study": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "key_values": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string"
-                            },
-                            "value": {
-                              "type": "string"
-                            }
-                          }
+                "operator": {
+                  "type": "string"
+                }
+              }
+            },
+            "image_count": {
+              "type": "integer"
+            },
+            "images": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "image_id": {
+                    "type": [
+                      "integer",
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "image_webclient_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "study": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "key_values": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
                         }
                       }
                     }
@@ -152,22 +141,21 @@
                 }
               }
             }
-          }
+          },
+          "required": [
+            "query"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -237,79 +225,68 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "query": {
               "type": "object",
               "properties": {
-                "query": {
-                  "type": "object",
-                  "properties": {
-                    "key": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "value": {
-                      "type": "string"
-                    },
-                    "operator": {
-                      "type": "string"
-                    }
-                  }
+                "key": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "container_count": {
-                  "type": "integer"
+                "value": {
+                  "type": "string"
                 },
-                "containers": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "integer",
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "image_count": {
-                        "type": [
-                          "integer",
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "key_values": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string"
-                            },
-                            "value": {
-                              "type": "string"
-                            }
-                          }
+                "operator": {
+                  "type": "string"
+                }
+              }
+            },
+            "container_count": {
+              "type": "integer"
+            },
+            "containers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "image_count": {
+                    "type": [
+                      "integer",
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "key_values": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
                         }
                       }
                     }
@@ -317,22 +294,21 @@
                 }
               }
             }
-          }
+          },
+          "required": [
+            "query"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -364,46 +340,34 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "resource": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "resource": {
-                  "type": "string"
-                },
-                "key_count": {
-                  "type": "integer"
-                },
-                "keys": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
+            "key_count": {
+              "type": "integer"
+            },
+            "keys": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
-          }
+          },
+          "required": [
+            "resource"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -452,64 +416,52 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "resource": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "resource": {
-                  "type": "string"
-                },
-                "key": {
-                  "type": "string"
-                },
-                "value_count": {
-                  "type": "integer"
-                },
-                "values": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "value": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "image_count": {
-                        "type": [
-                          "integer",
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "key": {
+              "type": "string"
+            },
+            "value_count": {
+              "type": "integer"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "image_count": {
+                    "type": [
+                      "integer",
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
             }
-          }
+          },
+          "required": [
+            "resource"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/idr_tools.json
+++ b/src/tooluniverse/data/idr_tools.json
@@ -39,300 +39,285 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
             "data": {
-              "type": "object",
-              "properties": {
-                "data": {
-                  "type": "array",
-                  "items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "@type": {
+                    "type": "string"
+                  },
+                  "@id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "omero:details": {
                     "type": "object",
                     "properties": {
                       "@type": {
                         "type": "string"
                       },
-                      "@id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "omero:details": {
+                      "owner": {
                         "type": "object",
                         "properties": {
                           "@type": {
                             "type": "string"
                           },
-                          "owner": {
+                          "@id": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "omero:details": {
                             "type": "object",
                             "properties": {
                               "@type": {
                                 "type": "string"
                               },
-                              "@id": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "omero:details": {
+                              "permissions": {
                                 "type": "object",
                                 "properties": {
                                   "@type": {
                                     "type": "string"
                                   },
-                                  "permissions": {
-                                    "type": "object",
-                                    "properties": {
-                                      "@type": {
-                                        "type": "string"
-                                      },
-                                      "perm": {
-                                        "type": "string"
-                                      },
-                                      "canAnnotate": {
-                                        "type": "boolean"
-                                      },
-                                      "canDelete": {
-                                        "type": "boolean"
-                                      },
-                                      "canEdit": {
-                                        "type": "boolean"
-                                      },
-                                      "canLink": {
-                                        "type": "boolean"
-                                      },
-                                      "isWorldWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isWorldRead": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupRead": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupAnnotate": {
-                                        "type": "boolean"
-                                      },
-                                      "isUserWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isUserRead": {
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
-                                }
-                              },
-                              "FirstName": {
-                                "type": "string"
-                              },
-                              "MiddleName": {
-                                "type": "string"
-                              },
-                              "LastName": {
-                                "type": "string"
-                              },
-                              "Email": {
-                                "type": "string"
-                              },
-                              "Institution": {
-                                "type": "string"
-                              },
-                              "UserName": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "group": {
-                            "type": "object",
-                            "properties": {
-                              "@type": {
-                                "type": "string"
-                              },
-                              "@id": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "omero:details": {
-                                "type": "object",
-                                "properties": {
-                                  "@type": {
+                                  "perm": {
                                     "type": "string"
                                   },
-                                  "permissions": {
-                                    "type": "object",
-                                    "properties": {
-                                      "@type": {
-                                        "type": "string"
-                                      },
-                                      "perm": {
-                                        "type": "string"
-                                      },
-                                      "canAnnotate": {
-                                        "type": "boolean"
-                                      },
-                                      "canDelete": {
-                                        "type": "boolean"
-                                      },
-                                      "canEdit": {
-                                        "type": "boolean"
-                                      },
-                                      "canLink": {
-                                        "type": "boolean"
-                                      },
-                                      "isWorldWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isWorldRead": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupRead": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupAnnotate": {
-                                        "type": "boolean"
-                                      },
-                                      "isUserWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isUserRead": {
-                                        "type": "boolean"
-                                      }
-                                    }
+                                  "canAnnotate": {
+                                    "type": "boolean"
+                                  },
+                                  "canDelete": {
+                                    "type": "boolean"
+                                  },
+                                  "canEdit": {
+                                    "type": "boolean"
+                                  },
+                                  "canLink": {
+                                    "type": "boolean"
+                                  },
+                                  "isWorldWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isWorldRead": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupRead": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupAnnotate": {
+                                    "type": "boolean"
+                                  },
+                                  "isUserWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isUserRead": {
+                                    "type": "boolean"
                                   }
                                 }
-                              },
-                              "Name": {
-                                "type": "string"
                               }
                             }
                           },
-                          "permissions": {
-                            "type": "object",
-                            "properties": {
-                              "@type": {
-                                "type": "string"
-                              },
-                              "perm": {
-                                "type": "string"
-                              },
-                              "canAnnotate": {
-                                "type": "boolean"
-                              },
-                              "canDelete": {
-                                "type": "boolean"
-                              },
-                              "canEdit": {
-                                "type": "boolean"
-                              },
-                              "canLink": {
-                                "type": "boolean"
-                              },
-                              "isWorldWrite": {
-                                "type": "boolean"
-                              },
-                              "isWorldRead": {
-                                "type": "boolean"
-                              },
-                              "isGroupWrite": {
-                                "type": "boolean"
-                              },
-                              "isGroupRead": {
-                                "type": "boolean"
-                              },
-                              "isGroupAnnotate": {
-                                "type": "boolean"
-                              },
-                              "isUserWrite": {
-                                "type": "boolean"
-                              },
-                              "isUserRead": {
-                                "type": "boolean"
-                              }
-                            }
+                          "FirstName": {
+                            "type": "string"
+                          },
+                          "MiddleName": {
+                            "type": "string"
+                          },
+                          "LastName": {
+                            "type": "string"
+                          },
+                          "Email": {
+                            "type": "string"
+                          },
+                          "Institution": {
+                            "type": "string"
+                          },
+                          "UserName": {
+                            "type": "string"
                           }
                         }
                       },
-                      "Name": {
-                        "type": "string"
+                      "group": {
+                        "type": "object",
+                        "properties": {
+                          "@type": {
+                            "type": "string"
+                          },
+                          "@id": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "omero:details": {
+                            "type": "object",
+                            "properties": {
+                              "@type": {
+                                "type": "string"
+                              },
+                              "permissions": {
+                                "type": "object",
+                                "properties": {
+                                  "@type": {
+                                    "type": "string"
+                                  },
+                                  "perm": {
+                                    "type": "string"
+                                  },
+                                  "canAnnotate": {
+                                    "type": "boolean"
+                                  },
+                                  "canDelete": {
+                                    "type": "boolean"
+                                  },
+                                  "canEdit": {
+                                    "type": "boolean"
+                                  },
+                                  "canLink": {
+                                    "type": "boolean"
+                                  },
+                                  "isWorldWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isWorldRead": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupRead": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupAnnotate": {
+                                    "type": "boolean"
+                                  },
+                                  "isUserWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isUserRead": {
+                                    "type": "boolean"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "Name": {
+                            "type": "string"
+                          }
+                        }
                       },
-                      "Description": {
-                        "type": "string"
-                      },
-                      "url:datasets": {
-                        "type": "string"
-                      },
-                      "url:project": {
-                        "type": "string"
+                      "permissions": {
+                        "type": "object",
+                        "properties": {
+                          "@type": {
+                            "type": "string"
+                          },
+                          "perm": {
+                            "type": "string"
+                          },
+                          "canAnnotate": {
+                            "type": "boolean"
+                          },
+                          "canDelete": {
+                            "type": "boolean"
+                          },
+                          "canEdit": {
+                            "type": "boolean"
+                          },
+                          "canLink": {
+                            "type": "boolean"
+                          },
+                          "isWorldWrite": {
+                            "type": "boolean"
+                          },
+                          "isWorldRead": {
+                            "type": "boolean"
+                          },
+                          "isGroupWrite": {
+                            "type": "boolean"
+                          },
+                          "isGroupRead": {
+                            "type": "boolean"
+                          },
+                          "isGroupAnnotate": {
+                            "type": "boolean"
+                          },
+                          "isUserWrite": {
+                            "type": "boolean"
+                          },
+                          "isUserRead": {
+                            "type": "boolean"
+                          }
+                        }
                       }
                     }
-                  }
-                },
-                "meta": {
-                  "type": "object",
-                  "properties": {
-                    "offset": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "limit": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "maxLimit": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "totalCount": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
+                  },
+                  "Name": {
+                    "type": "string"
+                  },
+                  "Description": {
+                    "type": "string"
+                  },
+                  "url:datasets": {
+                    "type": "string"
+                  },
+                  "url:project": {
+                    "type": "string"
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "meta": {
+              "type": "object",
+              "properties": {
+                "offset": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "limit": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "maxLimit": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "totalCount": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "data"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -368,265 +353,250 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
             "data": {
               "type": "object",
               "properties": {
-                "data": {
+                "@type": {
+                  "type": "string"
+                },
+                "@id": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "omero:details": {
                   "type": "object",
                   "properties": {
                     "@type": {
                       "type": "string"
                     },
-                    "@id": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "omero:details": {
+                    "owner": {
                       "type": "object",
                       "properties": {
                         "@type": {
                           "type": "string"
                         },
-                        "owner": {
+                        "@id": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "omero:details": {
                           "type": "object",
                           "properties": {
                             "@type": {
                               "type": "string"
                             },
-                            "@id": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "omero:details": {
+                            "permissions": {
                               "type": "object",
                               "properties": {
                                 "@type": {
                                   "type": "string"
                                 },
-                                "permissions": {
-                                  "type": "object",
-                                  "properties": {
-                                    "@type": {
-                                      "type": "string"
-                                    },
-                                    "perm": {
-                                      "type": "string"
-                                    },
-                                    "canAnnotate": {
-                                      "type": "boolean"
-                                    },
-                                    "canDelete": {
-                                      "type": "boolean"
-                                    },
-                                    "canEdit": {
-                                      "type": "boolean"
-                                    },
-                                    "canLink": {
-                                      "type": "boolean"
-                                    },
-                                    "isWorldWrite": {
-                                      "type": "boolean"
-                                    },
-                                    "isWorldRead": {
-                                      "type": "boolean"
-                                    },
-                                    "isGroupWrite": {
-                                      "type": "boolean"
-                                    },
-                                    "isGroupRead": {
-                                      "type": "boolean"
-                                    },
-                                    "isGroupAnnotate": {
-                                      "type": "boolean"
-                                    },
-                                    "isUserWrite": {
-                                      "type": "boolean"
-                                    },
-                                    "isUserRead": {
-                                      "type": "boolean"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "FirstName": {
-                              "type": "string"
-                            },
-                            "MiddleName": {
-                              "type": "string"
-                            },
-                            "LastName": {
-                              "type": "string"
-                            },
-                            "Email": {
-                              "type": "string"
-                            },
-                            "Institution": {
-                              "type": "string"
-                            },
-                            "UserName": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "group": {
-                          "type": "object",
-                          "properties": {
-                            "@type": {
-                              "type": "string"
-                            },
-                            "@id": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "omero:details": {
-                              "type": "object",
-                              "properties": {
-                                "@type": {
+                                "perm": {
                                   "type": "string"
                                 },
-                                "permissions": {
-                                  "type": "object",
-                                  "properties": {
-                                    "@type": {
-                                      "type": "string"
-                                    },
-                                    "perm": {
-                                      "type": "string"
-                                    },
-                                    "canAnnotate": {
-                                      "type": "boolean"
-                                    },
-                                    "canDelete": {
-                                      "type": "boolean"
-                                    },
-                                    "canEdit": {
-                                      "type": "boolean"
-                                    },
-                                    "canLink": {
-                                      "type": "boolean"
-                                    },
-                                    "isWorldWrite": {
-                                      "type": "boolean"
-                                    },
-                                    "isWorldRead": {
-                                      "type": "boolean"
-                                    },
-                                    "isGroupWrite": {
-                                      "type": "boolean"
-                                    },
-                                    "isGroupRead": {
-                                      "type": "boolean"
-                                    },
-                                    "isGroupAnnotate": {
-                                      "type": "boolean"
-                                    },
-                                    "isUserWrite": {
-                                      "type": "boolean"
-                                    },
-                                    "isUserRead": {
-                                      "type": "boolean"
-                                    }
-                                  }
+                                "canAnnotate": {
+                                  "type": "boolean"
+                                },
+                                "canDelete": {
+                                  "type": "boolean"
+                                },
+                                "canEdit": {
+                                  "type": "boolean"
+                                },
+                                "canLink": {
+                                  "type": "boolean"
+                                },
+                                "isWorldWrite": {
+                                  "type": "boolean"
+                                },
+                                "isWorldRead": {
+                                  "type": "boolean"
+                                },
+                                "isGroupWrite": {
+                                  "type": "boolean"
+                                },
+                                "isGroupRead": {
+                                  "type": "boolean"
+                                },
+                                "isGroupAnnotate": {
+                                  "type": "boolean"
+                                },
+                                "isUserWrite": {
+                                  "type": "boolean"
+                                },
+                                "isUserRead": {
+                                  "type": "boolean"
                                 }
                               }
-                            },
-                            "Name": {
-                              "type": "string"
                             }
                           }
                         },
-                        "permissions": {
-                          "type": "object",
-                          "properties": {
-                            "@type": {
-                              "type": "string"
-                            },
-                            "perm": {
-                              "type": "string"
-                            },
-                            "canAnnotate": {
-                              "type": "boolean"
-                            },
-                            "canDelete": {
-                              "type": "boolean"
-                            },
-                            "canEdit": {
-                              "type": "boolean"
-                            },
-                            "canLink": {
-                              "type": "boolean"
-                            },
-                            "isWorldWrite": {
-                              "type": "boolean"
-                            },
-                            "isWorldRead": {
-                              "type": "boolean"
-                            },
-                            "isGroupWrite": {
-                              "type": "boolean"
-                            },
-                            "isGroupRead": {
-                              "type": "boolean"
-                            },
-                            "isGroupAnnotate": {
-                              "type": "boolean"
-                            },
-                            "isUserWrite": {
-                              "type": "boolean"
-                            },
-                            "isUserRead": {
-                              "type": "boolean"
-                            }
-                          }
+                        "FirstName": {
+                          "type": "string"
+                        },
+                        "MiddleName": {
+                          "type": "string"
+                        },
+                        "LastName": {
+                          "type": "string"
+                        },
+                        "Email": {
+                          "type": "string"
+                        },
+                        "Institution": {
+                          "type": "string"
+                        },
+                        "UserName": {
+                          "type": "string"
                         }
                       }
                     },
-                    "Name": {
-                      "type": "string"
+                    "group": {
+                      "type": "object",
+                      "properties": {
+                        "@type": {
+                          "type": "string"
+                        },
+                        "@id": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "omero:details": {
+                          "type": "object",
+                          "properties": {
+                            "@type": {
+                              "type": "string"
+                            },
+                            "permissions": {
+                              "type": "object",
+                              "properties": {
+                                "@type": {
+                                  "type": "string"
+                                },
+                                "perm": {
+                                  "type": "string"
+                                },
+                                "canAnnotate": {
+                                  "type": "boolean"
+                                },
+                                "canDelete": {
+                                  "type": "boolean"
+                                },
+                                "canEdit": {
+                                  "type": "boolean"
+                                },
+                                "canLink": {
+                                  "type": "boolean"
+                                },
+                                "isWorldWrite": {
+                                  "type": "boolean"
+                                },
+                                "isWorldRead": {
+                                  "type": "boolean"
+                                },
+                                "isGroupWrite": {
+                                  "type": "boolean"
+                                },
+                                "isGroupRead": {
+                                  "type": "boolean"
+                                },
+                                "isGroupAnnotate": {
+                                  "type": "boolean"
+                                },
+                                "isUserWrite": {
+                                  "type": "boolean"
+                                },
+                                "isUserRead": {
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "Name": {
+                          "type": "string"
+                        }
+                      }
                     },
-                    "Description": {
-                      "type": "string"
-                    },
-                    "url:datasets": {
-                      "type": "string"
+                    "permissions": {
+                      "type": "object",
+                      "properties": {
+                        "@type": {
+                          "type": "string"
+                        },
+                        "perm": {
+                          "type": "string"
+                        },
+                        "canAnnotate": {
+                          "type": "boolean"
+                        },
+                        "canDelete": {
+                          "type": "boolean"
+                        },
+                        "canEdit": {
+                          "type": "boolean"
+                        },
+                        "canLink": {
+                          "type": "boolean"
+                        },
+                        "isWorldWrite": {
+                          "type": "boolean"
+                        },
+                        "isWorldRead": {
+                          "type": "boolean"
+                        },
+                        "isGroupWrite": {
+                          "type": "boolean"
+                        },
+                        "isGroupRead": {
+                          "type": "boolean"
+                        },
+                        "isGroupAnnotate": {
+                          "type": "boolean"
+                        },
+                        "isUserWrite": {
+                          "type": "boolean"
+                        },
+                        "isUserRead": {
+                          "type": "boolean"
+                        }
+                      }
                     }
                   }
+                },
+                "Name": {
+                  "type": "string"
+                },
+                "Description": {
+                  "type": "string"
+                },
+                "url:datasets": {
+                  "type": "string"
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "data"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -678,300 +648,285 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
             "data": {
-              "type": "object",
-              "properties": {
-                "data": {
-                  "type": "array",
-                  "items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "@type": {
+                    "type": "string"
+                  },
+                  "@id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "omero:details": {
                     "type": "object",
                     "properties": {
                       "@type": {
                         "type": "string"
                       },
-                      "@id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "omero:details": {
+                      "owner": {
                         "type": "object",
                         "properties": {
                           "@type": {
                             "type": "string"
                           },
-                          "owner": {
+                          "@id": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "omero:details": {
                             "type": "object",
                             "properties": {
                               "@type": {
                                 "type": "string"
                               },
-                              "@id": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "omero:details": {
+                              "permissions": {
                                 "type": "object",
                                 "properties": {
                                   "@type": {
                                     "type": "string"
                                   },
-                                  "permissions": {
-                                    "type": "object",
-                                    "properties": {
-                                      "@type": {
-                                        "type": "string"
-                                      },
-                                      "perm": {
-                                        "type": "string"
-                                      },
-                                      "canAnnotate": {
-                                        "type": "boolean"
-                                      },
-                                      "canDelete": {
-                                        "type": "boolean"
-                                      },
-                                      "canEdit": {
-                                        "type": "boolean"
-                                      },
-                                      "canLink": {
-                                        "type": "boolean"
-                                      },
-                                      "isWorldWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isWorldRead": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupRead": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupAnnotate": {
-                                        "type": "boolean"
-                                      },
-                                      "isUserWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isUserRead": {
-                                        "type": "boolean"
-                                      }
-                                    }
-                                  }
-                                }
-                              },
-                              "FirstName": {
-                                "type": "string"
-                              },
-                              "MiddleName": {
-                                "type": "string"
-                              },
-                              "LastName": {
-                                "type": "string"
-                              },
-                              "Email": {
-                                "type": "string"
-                              },
-                              "Institution": {
-                                "type": "string"
-                              },
-                              "UserName": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "group": {
-                            "type": "object",
-                            "properties": {
-                              "@type": {
-                                "type": "string"
-                              },
-                              "@id": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "omero:details": {
-                                "type": "object",
-                                "properties": {
-                                  "@type": {
+                                  "perm": {
                                     "type": "string"
                                   },
-                                  "permissions": {
-                                    "type": "object",
-                                    "properties": {
-                                      "@type": {
-                                        "type": "string"
-                                      },
-                                      "perm": {
-                                        "type": "string"
-                                      },
-                                      "canAnnotate": {
-                                        "type": "boolean"
-                                      },
-                                      "canDelete": {
-                                        "type": "boolean"
-                                      },
-                                      "canEdit": {
-                                        "type": "boolean"
-                                      },
-                                      "canLink": {
-                                        "type": "boolean"
-                                      },
-                                      "isWorldWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isWorldRead": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupRead": {
-                                        "type": "boolean"
-                                      },
-                                      "isGroupAnnotate": {
-                                        "type": "boolean"
-                                      },
-                                      "isUserWrite": {
-                                        "type": "boolean"
-                                      },
-                                      "isUserRead": {
-                                        "type": "boolean"
-                                      }
-                                    }
+                                  "canAnnotate": {
+                                    "type": "boolean"
+                                  },
+                                  "canDelete": {
+                                    "type": "boolean"
+                                  },
+                                  "canEdit": {
+                                    "type": "boolean"
+                                  },
+                                  "canLink": {
+                                    "type": "boolean"
+                                  },
+                                  "isWorldWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isWorldRead": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupRead": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupAnnotate": {
+                                    "type": "boolean"
+                                  },
+                                  "isUserWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isUserRead": {
+                                    "type": "boolean"
                                   }
                                 }
-                              },
-                              "Name": {
-                                "type": "string"
                               }
                             }
                           },
-                          "permissions": {
-                            "type": "object",
-                            "properties": {
-                              "@type": {
-                                "type": "string"
-                              },
-                              "perm": {
-                                "type": "string"
-                              },
-                              "canAnnotate": {
-                                "type": "boolean"
-                              },
-                              "canDelete": {
-                                "type": "boolean"
-                              },
-                              "canEdit": {
-                                "type": "boolean"
-                              },
-                              "canLink": {
-                                "type": "boolean"
-                              },
-                              "isWorldWrite": {
-                                "type": "boolean"
-                              },
-                              "isWorldRead": {
-                                "type": "boolean"
-                              },
-                              "isGroupWrite": {
-                                "type": "boolean"
-                              },
-                              "isGroupRead": {
-                                "type": "boolean"
-                              },
-                              "isGroupAnnotate": {
-                                "type": "boolean"
-                              },
-                              "isUserWrite": {
-                                "type": "boolean"
-                              },
-                              "isUserRead": {
-                                "type": "boolean"
-                              }
-                            }
+                          "FirstName": {
+                            "type": "string"
+                          },
+                          "MiddleName": {
+                            "type": "string"
+                          },
+                          "LastName": {
+                            "type": "string"
+                          },
+                          "Email": {
+                            "type": "string"
+                          },
+                          "Institution": {
+                            "type": "string"
+                          },
+                          "UserName": {
+                            "type": "string"
                           }
                         }
                       },
-                      "Name": {
-                        "type": "string"
+                      "group": {
+                        "type": "object",
+                        "properties": {
+                          "@type": {
+                            "type": "string"
+                          },
+                          "@id": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "omero:details": {
+                            "type": "object",
+                            "properties": {
+                              "@type": {
+                                "type": "string"
+                              },
+                              "permissions": {
+                                "type": "object",
+                                "properties": {
+                                  "@type": {
+                                    "type": "string"
+                                  },
+                                  "perm": {
+                                    "type": "string"
+                                  },
+                                  "canAnnotate": {
+                                    "type": "boolean"
+                                  },
+                                  "canDelete": {
+                                    "type": "boolean"
+                                  },
+                                  "canEdit": {
+                                    "type": "boolean"
+                                  },
+                                  "canLink": {
+                                    "type": "boolean"
+                                  },
+                                  "isWorldWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isWorldRead": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupRead": {
+                                    "type": "boolean"
+                                  },
+                                  "isGroupAnnotate": {
+                                    "type": "boolean"
+                                  },
+                                  "isUserWrite": {
+                                    "type": "boolean"
+                                  },
+                                  "isUserRead": {
+                                    "type": "boolean"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "Name": {
+                            "type": "string"
+                          }
+                        }
                       },
-                      "url:images": {
-                        "type": "string"
-                      },
-                      "url:dataset": {
-                        "type": "string"
-                      },
-                      "url:projects": {
-                        "type": "string"
+                      "permissions": {
+                        "type": "object",
+                        "properties": {
+                          "@type": {
+                            "type": "string"
+                          },
+                          "perm": {
+                            "type": "string"
+                          },
+                          "canAnnotate": {
+                            "type": "boolean"
+                          },
+                          "canDelete": {
+                            "type": "boolean"
+                          },
+                          "canEdit": {
+                            "type": "boolean"
+                          },
+                          "canLink": {
+                            "type": "boolean"
+                          },
+                          "isWorldWrite": {
+                            "type": "boolean"
+                          },
+                          "isWorldRead": {
+                            "type": "boolean"
+                          },
+                          "isGroupWrite": {
+                            "type": "boolean"
+                          },
+                          "isGroupRead": {
+                            "type": "boolean"
+                          },
+                          "isGroupAnnotate": {
+                            "type": "boolean"
+                          },
+                          "isUserWrite": {
+                            "type": "boolean"
+                          },
+                          "isUserRead": {
+                            "type": "boolean"
+                          }
+                        }
                       }
                     }
-                  }
-                },
-                "meta": {
-                  "type": "object",
-                  "properties": {
-                    "offset": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "limit": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "maxLimit": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "totalCount": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
+                  },
+                  "Name": {
+                    "type": "string"
+                  },
+                  "url:images": {
+                    "type": "string"
+                  },
+                  "url:dataset": {
+                    "type": "string"
+                  },
+                  "url:projects": {
+                    "type": "string"
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "meta": {
+              "type": "object",
+              "properties": {
+                "offset": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "limit": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "maxLimit": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "totalCount": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "data"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -1024,86 +979,71 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
             "data": {
-              "type": "object",
-              "properties": {
-                "data": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "@type": {
-                        "type": "string"
-                      },
-                      "@id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "Name": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "meta": {
-                  "type": "object",
-                  "properties": {
-                    "offset": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "limit": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "maxLimit": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "totalCount": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "@type": {
+                    "type": "string"
+                  },
+                  "@id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "Name": {
+                    "type": "string"
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "meta": {
+              "type": "object",
+              "properties": {
+                "offset": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "limit": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "maxLimit": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "totalCount": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "data"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -1142,69 +1082,54 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "annotations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "ns": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "values": {
-                        "type": "array",
-                        "items": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        }
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "ns": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
                       }
                     }
                   }
-                },
-                "experimenters": {
-                  "type": "array"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "experimenters": {
+              "type": "array"
             }
-          }
+          },
+          "required": [
+            "annotations"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/iedb_prediction_tools.json
+++ b/src/tooluniverse/data/iedb_prediction_tools.json
@@ -286,56 +286,55 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "peptide": {
-                    "type": "string"
-                  },
-                  "proteasome_score": {
-                    "type": ["number", "string"]
-                  },
-                  "tap_score": {
-                    "type": ["number", "string"]
-                  },
-                  "mhc_score": {
-                    "type": ["number", "string"]
-                  },
-                  "processing_score": {
-                    "type": ["number", "string"]
-                  },
-                  "total_score": {
-                    "type": ["number", "string"]
-                  },
-                  "ic50_score": {
-                    "type": ["number", "string"]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "peptide": {
+                "type": "string"
+              },
+              "proteasome_score": {
+                "type": [
+                  "number",
+                  "string"
+                ]
+              },
+              "tap_score": {
+                "type": [
+                  "number",
+                  "string"
+                ]
+              },
+              "mhc_score": {
+                "type": [
+                  "number",
+                  "string"
+                ]
+              },
+              "processing_score": {
+                "type": [
+                  "number",
+                  "string"
+                ]
+              },
+              "total_score": {
+                "type": [
+                  "number",
+                  "string"
+                ]
+              },
+              "ic50_score": {
+                "type": [
+                  "number",
+                  "string"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/imgt_tools.json
+++ b/src/tooluniverse/data/imgt_tools.json
@@ -83,55 +83,44 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "const": "success"
+            "gene_type": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_type": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "fasta": {
-                  "type": "string"
-                },
-                "record_count": {
-                  "type": "integer"
-                },
-                "first_records": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": ["gene_type", "fasta", "record_count"]
+            "species": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object"
+            "query": {
+              "type": "string"
+            },
+            "fasta": {
+              "type": "string"
+            },
+            "record_count": {
+              "type": "integer"
+            },
+            "first_records": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
-          "required": ["status", "data"]
+          "required": [
+            "gene_type",
+            "fasta",
+            "record_count"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/impc_tools.json
+++ b/src/tooluniverse/data/impc_tools.json
@@ -31,91 +31,76 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "mgi_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "mgi_id": {
-                  "type": "string"
-                },
-                "symbol": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "human_ortholog": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "marker_type": {
-                  "type": "string"
-                },
-                "phenotype_status": {
-                  "type": "null"
-                },
-                "production_status": {
-                  "type": "null"
-                },
-                "phenotyping_centre": {
-                  "type": "null"
-                },
-                "production_centre": {
-                  "type": "null"
-                },
-                "has_phenotype_data": {
-                  "type": "boolean"
-                },
-                "mp_terms": {
-                  "type": "array"
-                },
-                "mp_ids": {
-                  "type": "array"
-                },
-                "top_level_mp_terms": {
-                  "type": "array"
-                },
-                "hp_terms": {
-                  "type": "array"
-                },
-                "disease_associations": {
-                  "type": "array"
-                }
+            "symbol": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
-            "metadata": {
-              "type": "object"
+            "human_ortholog": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "marker_type": {
+              "type": "string"
+            },
+            "phenotype_status": {
+              "type": "null"
+            },
+            "production_status": {
+              "type": "null"
+            },
+            "phenotyping_centre": {
+              "type": "null"
+            },
+            "production_centre": {
+              "type": "null"
+            },
+            "has_phenotype_data": {
+              "type": "boolean"
+            },
+            "mp_terms": {
+              "type": "array"
+            },
+            "mp_ids": {
+              "type": "array"
+            },
+            "top_level_mp_terms": {
+              "type": "array"
+            },
+            "hp_terms": {
+              "type": "array"
+            },
+            "disease_associations": {
+              "type": "array"
             }
-          }
+          },
+          "required": [
+            "mgi_id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -178,140 +163,125 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_symbol": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_symbol": {
-                  "type": "string"
-                },
-                "mgi_id": {
-                  "type": "string"
-                },
-                "total_phenotype_calls": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "unique_phenotypes": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "phenotypes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "mp_term_id": {
-                        "type": "string"
-                      },
-                      "mp_term_name": {
-                        "type": "string"
-                      },
-                      "top_level_mp_term_id": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "top_level_mp_term_name": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "zygosity": {
-                        "type": "string"
-                      },
-                      "sex": {
-                        "type": "string"
-                      },
-                      "life_stage": {
-                        "type": "string"
-                      },
-                      "procedure": {
-                        "type": "string"
-                      },
-                      "parameter": {
-                        "type": "string"
-                      },
-                      "p_value": {
-                        "type": "number"
-                      },
-                      "effect_size": {
-                        "type": [
-                          "null",
-                          "number"
-                        ]
-                      },
-                      "phenotyping_center": {
-                        "type": "string"
-                      },
-                      "allele_symbol": {
-                        "type": "string"
-                      }
+            "mgi_id": {
+              "type": "string"
+            },
+            "total_phenotype_calls": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "unique_phenotypes": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "phenotypes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "mp_term_id": {
+                    "type": "string"
+                  },
+                  "mp_term_name": {
+                    "type": "string"
+                  },
+                  "top_level_mp_term_id": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
-                  }
-                },
-                "phenotype_summary_by_system": {
-                  "type": "object",
-                  "properties": {
-                    "behavior/neurological phenotype": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "homeostasis/metabolism phenotype": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "mortality/aging": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "vision/eye phenotype": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
+                  },
+                  "top_level_mp_term_name": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "zygosity": {
+                    "type": "string"
+                  },
+                  "sex": {
+                    "type": "string"
+                  },
+                  "life_stage": {
+                    "type": "string"
+                  },
+                  "procedure": {
+                    "type": "string"
+                  },
+                  "parameter": {
+                    "type": "string"
+                  },
+                  "p_value": {
+                    "type": "number"
+                  },
+                  "effect_size": {
+                    "type": [
+                      "null",
+                      "number"
+                    ]
+                  },
+                  "phenotyping_center": {
+                    "type": "string"
+                  },
+                  "allele_symbol": {
+                    "type": "string"
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "phenotype_summary_by_system": {
+              "type": "object",
+              "properties": {
+                "behavior/neurological phenotype": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "homeostasis/metabolism phenotype": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "mortality/aging": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "vision/eye phenotype": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "gene_symbol"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -370,87 +340,72 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "query": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string"
-                },
-                "genes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "mgi_id": {
-                        "type": "string"
-                      },
-                      "symbol": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "synonyms": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "human_ortholog": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "phenotype_status": {
-                        "type": "null"
-                      },
-                      "production_status": {
-                        "type": "null"
-                      }
+            "genes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "mgi_id": {
+                    "type": "string"
+                  },
+                  "symbol": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "synonyms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "human_ortholog": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "phenotype_status": {
+                    "type": "null"
+                  },
+                  "production_status": {
+                    "type": "null"
                   }
-                },
-                "count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "total_found": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "total_found": {
+              "type": [
+                "integer",
+                "number"
+              ]
             }
-          }
+          },
+          "required": [
+            "query"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -514,126 +469,111 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_symbol": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_symbol": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "results_returned": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "significant_only": {
-                  "type": "boolean"
-                },
-                "hits": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "parameter": {
-                        "type": "string"
-                      },
-                      "procedure": {
-                        "type": "string"
-                      },
-                      "mp_term_id": {
-                        "type": "string"
-                      },
-                      "mp_term_name": {
-                        "type": "string"
-                      },
-                      "top_level_mp_term": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "p_value": {
-                        "type": "number"
-                      },
-                      "effect_size": {
-                        "type": "number"
-                      },
-                      "significant": {
-                        "type": "boolean"
-                      },
-                      "zygosity": {
-                        "type": "string"
-                      },
-                      "sex": {
-                        "type": "string"
-                      },
-                      "life_stage": {
-                        "type": "string"
-                      },
-                      "statistical_method": {
-                        "type": "string"
-                      },
-                      "classification_tag": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "female_ko_estimate": {
-                        "type": [
-                          "null",
-                          "number"
-                        ]
-                      },
-                      "male_ko_estimate": {
-                        "type": [
-                          "null",
-                          "number"
-                        ]
-                      },
-                      "phenotyping_center": {
-                        "type": "string"
-                      },
-                      "allele_symbol": {
-                        "type": "string"
-                      }
+            "total_results": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "results_returned": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "significant_only": {
+              "type": "boolean"
+            },
+            "hits": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "parameter": {
+                    "type": "string"
+                  },
+                  "procedure": {
+                    "type": "string"
+                  },
+                  "mp_term_id": {
+                    "type": "string"
+                  },
+                  "mp_term_name": {
+                    "type": "string"
+                  },
+                  "top_level_mp_term": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "p_value": {
+                    "type": "number"
+                  },
+                  "effect_size": {
+                    "type": "number"
+                  },
+                  "significant": {
+                    "type": "boolean"
+                  },
+                  "zygosity": {
+                    "type": "string"
+                  },
+                  "sex": {
+                    "type": "string"
+                  },
+                  "life_stage": {
+                    "type": "string"
+                  },
+                  "statistical_method": {
+                    "type": "string"
+                  },
+                  "classification_tag": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "female_ko_estimate": {
+                    "type": [
+                      "null",
+                      "number"
+                    ]
+                  },
+                  "male_ko_estimate": {
+                    "type": [
+                      "null",
+                      "number"
+                    ]
+                  },
+                  "phenotyping_center": {
+                    "type": "string"
+                  },
+                  "allele_symbol": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "gene_symbol"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/intact_tools.json
+++ b/src/tooluniverse/data/intact_tools.json
@@ -248,43 +248,11 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array"
-            },
-            "count": {
-              "type": "integer"
-            },
-            "hitCount": {
-              "type": "integer"
-            },
-            "interaction_ids": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "array"
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/interpro_domain_arch_tools.json
+++ b/src/tooluniverse/data/interpro_domain_arch_tools.json
@@ -30,87 +30,72 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "accession": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": "string"
-                },
-                "protein_length": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "domain_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "domains": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pfam_accession": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "integrated_interpro": {
-                        "type": "string"
-                      },
-                      "start": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "end": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "score": {
-                        "type": "number"
-                      }
-                    }
+            "protein_length": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "domain_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "domains": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pfam_accession": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "integrated_interpro": {
+                    "type": "string"
+                  },
+                  "start": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "end": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "score": {
+                    "type": "number"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "accession"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -153,72 +138,57 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "pfam_accession": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "pfam_accession": {
-                  "type": "string"
-                },
-                "total_structures": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "returned": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "structures": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pdb_id": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "experiment_type": {
-                        "type": "string"
-                      },
-                      "resolution": {
-                        "type": "number"
-                      }
-                    }
+            "total_structures": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "returned": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "structures": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pdb_id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "experiment_type": {
+                    "type": "string"
+                  },
+                  "resolution": {
+                    "type": "number"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "pfam_accession"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -260,75 +230,60 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "clan_accession": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "clan_accession": {
-                  "type": "string"
-                },
-                "clan_name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "member_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "members": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "short_name": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "score": {
-                        "type": "number"
-                      }
-                    }
+            "clan_name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "member_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "members": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "short_name": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "score": {
+                    "type": "number"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "clan_accession"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/interpro_entry_tools.json
+++ b/src/tooluniverse/data/interpro_entry_tools.json
@@ -30,66 +30,51 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "protein_accession": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "protein_accession": {
-                  "type": "string"
-                },
-                "total_entries": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "entries": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "source_database": {
-                        "type": "string"
-                      }
-                    }
+            "total_entries": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "entries": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "source_database": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "protein_accession"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -136,78 +121,63 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "query": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "returned": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "entries": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "protein_count": {
-                        "type": "null"
-                      },
-                      "structure_count": {
-                        "type": "null"
-                      },
-                      "taxa_count": {
-                        "type": "null"
-                      }
-                    }
+            "total_results": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "returned": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "entries": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "protein_count": {
+                    "type": "null"
+                  },
+                  "structure_count": {
+                    "type": "null"
+                  },
+                  "taxa_count": {
+                    "type": "null"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "query"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/interpro_ext_tools.json
+++ b/src/tooluniverse/data/interpro_ext_tools.json
@@ -42,84 +42,69 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "domain_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "domain_id": {
-                  "type": "string"
-                },
-                "total_proteins": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "proteins": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "source_database": {
-                        "type": "string"
-                      },
-                      "length": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "source_organism": {
-                        "type": "string"
-                      },
-                      "tax_id": {
-                        "type": "string"
-                      }
-                    }
+            "total_proteins": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "proteins": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "source_database": {
+                    "type": "string"
+                  },
+                  "length": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "source_organism": {
+                    "type": "string"
+                  },
+                  "tax_id": {
+                    "type": "string"
                   }
-                },
-                "page_size": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "reviewed_only": {
-                  "type": "boolean"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "page_size": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "reviewed_only": {
+              "type": "boolean"
             }
-          }
+          },
+          "required": [
+            "domain_id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/interpro_member_db_tools.json
+++ b/src/tooluniverse/data/interpro_member_db_tools.json
@@ -28,113 +28,101 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Member-database signature detail.",
           "properties": {
-            "status": {
-              "const": "success"
+            "accession": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "description": "Member-database signature detail.",
-              "properties": {
-                "accession": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "source_database": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "integrated_interpro": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "go_terms": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "identifier": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "category": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "counters": {
-                  "type": "object",
-                  "properties": {
-                    "proteins": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "structures": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "taxa": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    }
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source_database": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "integrated_interpro": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "go_terms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "identifier": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "category": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": [
-                "accession",
-                "source_database"
-              ]
+              }
+            },
+            "counters": {
+              "type": "object",
+              "properties": {
+                "proteins": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "structures": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "taxa": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              }
             }
           },
           "required": [
-            "data"
+            "accession",
+            "source_database"
           ]
         },
         {
           "type": "object",
-          "description": "Error response.",
           "properties": {
             "error": {
               "type": "string"
@@ -193,72 +181,60 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "A page of member-database signatures.",
           "properties": {
-            "status": {
-              "const": "success"
+            "member_database": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "description": "A page of member-database signatures.",
-              "properties": {
-                "member_database": {
-                  "type": "string"
-                },
-                "total_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "entries": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "integrated_interpro": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "total_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "returned": {
+              "type": "integer"
+            },
+            "entries": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "integrated_interpro": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": [
-                "member_database",
-                "entries"
-              ]
+              }
             }
           },
           "required": [
-            "data"
+            "member_database",
+            "entries"
           ]
         },
         {
           "type": "object",
-          "description": "Error response.",
           "properties": {
             "error": {
               "type": "string"
@@ -314,72 +290,60 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "PDB structures containing the InterPro domain.",
           "properties": {
-            "status": {
-              "const": "success"
+            "interpro_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "description": "PDB structures containing the InterPro domain.",
-              "properties": {
-                "interpro_id": {
-                  "type": "string"
-                },
-                "total_structures": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "structures": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pdb_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "title": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "experiment_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "resolution": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "total_structures": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "returned": {
+              "type": "integer"
+            },
+            "structures": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pdb_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "title": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "experiment_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "resolution": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": [
-                "interpro_id",
-                "structures"
-              ]
+              }
             }
           },
           "required": [
-            "data"
+            "interpro_id",
+            "structures"
           ]
         },
         {
           "type": "object",
-          "description": "Error response.",
           "properties": {
             "error": {
               "type": "string"
@@ -419,68 +383,56 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Member-database catalog with counts.",
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "object",
-              "description": "Member-database catalog with counts.",
-              "properties": {
-                "databases": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "member_database": {
-                        "type": "string"
-                      },
-                      "entry_count": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+            "databases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "member_database": {
+                    "type": "string"
+                  },
+                  "entry_count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   }
-                },
-                "integrated_total": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "unintegrated_total": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "interpro_total": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "all_total": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
                 }
-              },
-              "required": [
-                "databases"
+              }
+            },
+            "integrated_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "unintegrated_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "interpro_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "all_total": {
+              "type": [
+                "integer",
+                "null"
               ]
             }
           },
           "required": [
-            "data"
+            "databases"
           ]
         },
         {
           "type": "object",
-          "description": "Error response.",
           "properties": {
             "error": {
               "type": "string"

--- a/src/tooluniverse/data/interpro_tools.json
+++ b/src/tooluniverse/data/interpro_tools.json
@@ -23,206 +23,126 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "metadata": {
                 "type": "object",
                 "properties": {
-                  "metadata": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "source_database": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "integrated": {
+                    "type": "null"
+                  },
+                  "member_databases": {
                     "type": "object",
                     "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "source_database": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "integrated": {
-                        "type": "null"
-                      },
-                      "member_databases": {
+                      "panther": {
                         "type": "object",
                         "properties": {
-                          "panther": {
-                            "type": "object",
-                            "properties": {
-                              "PTHR11447": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "prints": {
-                            "type": "object",
-                            "properties": {
-                              "PR00386": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "ssf": {
-                            "type": "object",
-                            "properties": {
-                              "SSF49417": {
-                                "type": "string"
-                              },
-                              "SSF47719": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "pfam": {
-                            "type": "object",
-                            "properties": {
-                              "PF07710": {
-                                "type": "string"
-                              },
-                              "PF00870": {
-                                "type": "string"
-                              },
-                              "PF08563": {
-                                "type": "string"
-                              },
-                              "PF18521": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "cdd": {
-                            "type": "object",
-                            "properties": {
-                              "cd08367": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "cathgene3d": {
-                            "type": "object",
-                            "properties": {
-                              "G3DSA:2.60.40.720": {
-                                "type": "string"
-                              },
-                              "G3DSA:4.10.170.10": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "prosite": {
-                            "type": "object",
-                            "properties": {
-                              "PS00348": {
-                                "type": "string"
-                              }
-                            }
+                          "PTHR11447": {
+                            "type": "string"
                           }
                         }
                       },
-                      "go_terms": {
-                        "type": [
-                          "array",
-                          "null"
-                        ],
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "identifier": {
-                              "type": "string"
-                            },
-                            "name": {
-                              "type": "string"
-                            },
-                            "category": {
-                              "type": "object",
-                              "properties": {
-                                "code": {
-                                  "type": "string"
-                                },
-                                "name": {
-                                  "type": "string"
-                                }
-                              }
-                            }
+                      "prints": {
+                        "type": "object",
+                        "properties": {
+                          "PR00386": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "ssf": {
+                        "type": "object",
+                        "properties": {
+                          "SSF49417": {
+                            "type": "string"
+                          },
+                          "SSF47719": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "pfam": {
+                        "type": "object",
+                        "properties": {
+                          "PF07710": {
+                            "type": "string"
+                          },
+                          "PF00870": {
+                            "type": "string"
+                          },
+                          "PF08563": {
+                            "type": "string"
+                          },
+                          "PF18521": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cdd": {
+                        "type": "object",
+                        "properties": {
+                          "cd08367": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cathgene3d": {
+                        "type": "object",
+                        "properties": {
+                          "G3DSA:2.60.40.720": {
+                            "type": "string"
+                          },
+                          "G3DSA:4.10.170.10": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "prosite": {
+                        "type": "object",
+                        "properties": {
+                          "PS00348": {
+                            "type": "string"
                           }
                         }
                       }
                     }
                   },
-                  "proteins": {
-                    "type": "array",
+                  "go_terms": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "object",
                       "properties": {
-                        "accession": {
+                        "identifier": {
                           "type": "string"
                         },
-                        "protein_length": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "source_database": {
+                        "name": {
                           "type": "string"
                         },
-                        "organism": {
-                          "type": "string"
-                        },
-                        "in_alphafold": {
-                          "type": "boolean"
-                        },
-                        "in_bfvd": {
-                          "type": "boolean"
-                        },
-                        "entry_protein_locations": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "fragments": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "start": {
-                                      "type": [
-                                        "integer",
-                                        "number"
-                                      ]
-                                    },
-                                    "end": {
-                                      "type": [
-                                        "integer",
-                                        "number"
-                                      ]
-                                    },
-                                    "dc-status": {
-                                      "type": "string"
-                                    }
-                                  }
-                                }
-                              },
-                              "representative": {
-                                "type": "boolean"
-                              },
-                              "model": {
-                                "type": "null"
-                              },
-                              "score": {
-                                "type": "null"
-                              }
+                        "category": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
                             }
                           }
                         }
@@ -230,27 +150,89 @@
                     }
                   }
                 }
+              },
+              "proteins": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "accession": {
+                      "type": "string"
+                    },
+                    "protein_length": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "source_database": {
+                      "type": "string"
+                    },
+                    "organism": {
+                      "type": "string"
+                    },
+                    "in_alphafold": {
+                      "type": "boolean"
+                    },
+                    "in_bfvd": {
+                      "type": "boolean"
+                    },
+                    "entry_protein_locations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "fragments": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "start": {
+                                  "type": [
+                                    "integer",
+                                    "number"
+                                  ]
+                                },
+                                "end": {
+                                  "type": [
+                                    "integer",
+                                    "number"
+                                  ]
+                                },
+                                "dc-status": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "representative": {
+                            "type": "boolean"
+                          },
+                          "model": {
+                            "type": "null"
+                          },
+                          "score": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -284,62 +266,51 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "object",
-              "description": "Object keyed by member-database signature accession (e.g., 'PIRSR000617-2').",
-              "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "accession": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "source_database": {
-                    "type": "string"
-                  },
-                  "locations": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "description": {
-                          "type": [
-                            "string",
-                            "null"
-                          ],
-                          "description": "Site type and label, e.g. 'BINDING: ATP' or 'ACT_SITE: Proton acceptor.'"
-                        },
-                        "fragments": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "start": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "end": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "residues": {
-                                "type": "string",
-                                "description": "Residue letter(s) at this position"
-                              }
-                            }
+          "description": "Object keyed by member-database signature accession (e.g., 'PIRSR000617-2').",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "accession": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "source_database": {
+                "type": "string"
+              },
+              "locations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "description": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Site type and label, e.g. 'BINDING: ATP' or 'ACT_SITE: Proton acceptor.'"
+                    },
+                    "fragments": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "start": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "end": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "residues": {
+                            "type": "string",
+                            "description": "Residue letter(s) at this position"
                           }
                         }
                       }
@@ -347,32 +318,19 @@
                   }
                 }
               }
-            },
-            "url": {
-              "type": "string"
-            },
-            "count": {
-              "type": [
-                "integer",
-                "number"
-              ]
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -413,281 +371,270 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "metadata": {
                 "type": "object",
                 "properties": {
-                  "metadata": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "source_database": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "integrated": {
+                    "type": "null"
+                  },
+                  "member_databases": {
                     "type": "object",
                     "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "source_database": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "integrated": {
-                        "type": "null"
-                      },
-                      "member_databases": {
+                      "pfam": {
                         "type": "object",
                         "properties": {
-                          "pfam": {
-                            "type": "object",
-                            "properties": {
-                              "PF00365": {
-                                "type": "string"
-                              },
-                              "PF00794": {
-                                "type": "string"
-                              },
-                              "PF00454": {
-                                "type": "string"
-                              },
-                              "PF02110": {
-                                "type": "string"
-                              },
-                              "PF01288": {
-                                "type": "string"
-                              },
-                              "PF01214": {
-                                "type": "string"
-                              },
-                              "PF00069": {
-                                "type": "string"
-                              },
-                              "PF00609": {
-                                "type": "string"
-                              },
-                              "PF01111": {
-                                "type": "string"
-                              },
-                              "PF00871": {
-                                "type": "string"
-                              }
-                            }
+                          "PF00365": {
+                            "type": "string"
                           },
-                          "prints": {
-                            "type": "object",
-                            "properties": {
-                              "PR00717": {
-                                "type": "string"
-                              },
-                              "PR00653": {
-                                "type": "string"
-                              },
-                              "PR01099": {
-                                "type": "string"
-                              },
-                              "PR00472": {
-                                "type": "string"
-                              },
-                              "PR00473": {
-                                "type": "string"
-                              },
-                              "PR00296": {
-                                "type": "string"
-                              },
-                              "PR00094": {
-                                "type": "string"
-                              },
-                              "PR00471": {
-                                "type": "string"
-                              }
-                            }
+                          "PF00794": {
+                            "type": "string"
                           },
-                          "panther": {
-                            "type": "object",
-                            "properties": {
-                              "PTHR23255": {
-                                "type": "string"
-                              },
-                              "PTHR11740": {
-                                "type": "string"
-                              },
-                              "PTHR23359": {
-                                "type": "string"
-                              },
-                              "PTHR21060": {
-                                "type": "string"
-                              }
-                            }
+                          "PF00454": {
+                            "type": "string"
                           },
-                          "profile": {
-                            "type": "object",
-                            "properties": {
-                              "PS51546": {
-                                "type": "string"
-                              },
-                              "PS50290": {
-                                "type": "string"
-                              },
-                              "PS50011": {
-                                "type": "string"
-                              },
-                              "PS51285": {
-                                "type": "string"
-                              }
-                            }
+                          "PF02110": {
+                            "type": "string"
                           },
-                          "smart": {
-                            "type": "object",
-                            "properties": {
-                              "SM00144": {
-                                "type": "string"
-                              },
-                              "SM00146": {
-                                "type": "string"
-                              },
-                              "SM00090": {
-                                "type": "string"
-                              },
-                              "SM01085": {
-                                "type": "string"
-                              },
-                              "SM00220": {
-                                "type": "string"
-                              },
-                              "SM00045": {
-                                "type": "string"
-                              },
-                              "SM01084": {
-                                "type": "string"
-                              },
-                              "SM00133": {
-                                "type": "string"
-                              }
-                            }
+                          "PF01288": {
+                            "type": "string"
                           },
-                          "cdd": {
-                            "type": "object",
-                            "properties": {
-                              "cd01170": {
-                                "type": "string"
-                              },
-                              "cd00483": {
-                                "type": "string"
-                              },
-                              "cd00464": {
-                                "type": "string"
-                              },
-                              "cd02023": {
-                                "type": "string"
-                              },
-                              "cd01428": {
-                                "type": "string"
-                              }
-                            }
+                          "PF01214": {
+                            "type": "string"
                           },
-                          "hamap": {
-                            "type": "object",
-                            "properties": {
-                              "MF_00228": {
-                                "type": "string"
-                              },
-                              "MF_00109": {
-                                "type": "string"
-                              },
-                              "MF_00235": {
-                                "type": "string"
-                              },
-                              "MF_00384": {
-                                "type": "string"
-                              }
-                            }
+                          "PF00069": {
+                            "type": "string"
                           },
-                          "ncbifam": {
-                            "type": "object",
-                            "properties": {
-                              "TIGR00694": {
-                                "type": "string"
-                              },
-                              "TIGR01498": {
-                                "type": "string"
-                              },
-                              "TIGR00131": {
-                                "type": "string"
-                              },
-                              "TIGR00235": {
-                                "type": "string"
-                              },
-                              "TIGR00191": {
-                                "type": "string"
-                              }
-                            }
+                          "PF00609": {
+                            "type": "string"
                           },
-                          "pirsf": {
-                            "type": "object",
-                            "properties": {
-                              "PIRSF000513": {
-                                "type": "string"
-                              },
-                              "PIRSF000538": {
-                                "type": "string"
-                              },
-                              "PIRSF000676": {
-                                "type": "string"
-                              }
-                            }
+                          "PF01111": {
+                            "type": "string"
                           },
-                          "prosite": {
-                            "type": "object",
-                            "properties": {
-                              "PS00794": {
-                                "type": "string"
-                              },
-                              "PS01101": {
-                                "type": "string"
-                              },
-                              "PS00945": {
-                                "type": "string"
-                              },
-                              "PS00944": {
-                                "type": "string"
-                              }
-                            }
+                          "PF00871": {
+                            "type": "string"
                           }
                         }
                       },
-                      "go_terms": {
-                        "type": [
-                          "array",
-                          "null"
-                        ],
-                        "items": {
+                      "prints": {
+                        "type": "object",
+                        "properties": {
+                          "PR00717": {
+                            "type": "string"
+                          },
+                          "PR00653": {
+                            "type": "string"
+                          },
+                          "PR01099": {
+                            "type": "string"
+                          },
+                          "PR00472": {
+                            "type": "string"
+                          },
+                          "PR00473": {
+                            "type": "string"
+                          },
+                          "PR00296": {
+                            "type": "string"
+                          },
+                          "PR00094": {
+                            "type": "string"
+                          },
+                          "PR00471": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "panther": {
+                        "type": "object",
+                        "properties": {
+                          "PTHR23255": {
+                            "type": "string"
+                          },
+                          "PTHR11740": {
+                            "type": "string"
+                          },
+                          "PTHR23359": {
+                            "type": "string"
+                          },
+                          "PTHR21060": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "profile": {
+                        "type": "object",
+                        "properties": {
+                          "PS51546": {
+                            "type": "string"
+                          },
+                          "PS50290": {
+                            "type": "string"
+                          },
+                          "PS50011": {
+                            "type": "string"
+                          },
+                          "PS51285": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "smart": {
+                        "type": "object",
+                        "properties": {
+                          "SM00144": {
+                            "type": "string"
+                          },
+                          "SM00146": {
+                            "type": "string"
+                          },
+                          "SM00090": {
+                            "type": "string"
+                          },
+                          "SM01085": {
+                            "type": "string"
+                          },
+                          "SM00220": {
+                            "type": "string"
+                          },
+                          "SM00045": {
+                            "type": "string"
+                          },
+                          "SM01084": {
+                            "type": "string"
+                          },
+                          "SM00133": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cdd": {
+                        "type": "object",
+                        "properties": {
+                          "cd01170": {
+                            "type": "string"
+                          },
+                          "cd00483": {
+                            "type": "string"
+                          },
+                          "cd00464": {
+                            "type": "string"
+                          },
+                          "cd02023": {
+                            "type": "string"
+                          },
+                          "cd01428": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "hamap": {
+                        "type": "object",
+                        "properties": {
+                          "MF_00228": {
+                            "type": "string"
+                          },
+                          "MF_00109": {
+                            "type": "string"
+                          },
+                          "MF_00235": {
+                            "type": "string"
+                          },
+                          "MF_00384": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "ncbifam": {
+                        "type": "object",
+                        "properties": {
+                          "TIGR00694": {
+                            "type": "string"
+                          },
+                          "TIGR01498": {
+                            "type": "string"
+                          },
+                          "TIGR00131": {
+                            "type": "string"
+                          },
+                          "TIGR00235": {
+                            "type": "string"
+                          },
+                          "TIGR00191": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "pirsf": {
+                        "type": "object",
+                        "properties": {
+                          "PIRSF000513": {
+                            "type": "string"
+                          },
+                          "PIRSF000538": {
+                            "type": "string"
+                          },
+                          "PIRSF000676": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "prosite": {
+                        "type": "object",
+                        "properties": {
+                          "PS00794": {
+                            "type": "string"
+                          },
+                          "PS01101": {
+                            "type": "string"
+                          },
+                          "PS00945": {
+                            "type": "string"
+                          },
+                          "PS00944": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "go_terms": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "identifier": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "category": {
                           "type": "object",
                           "properties": {
-                            "identifier": {
+                            "code": {
                               "type": "string"
                             },
                             "name": {
                               "type": "string"
-                            },
-                            "category": {
-                              "type": "object",
-                              "properties": {
-                                "code": {
-                                  "type": "string"
-                                },
-                                "name": {
-                                  "type": "string"
-                                }
-                              }
                             }
                           }
                         }
@@ -696,26 +643,19 @@
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -750,699 +690,92 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "metadata": {
               "type": "object",
               "properties": {
-                "metadata": {
+                "accession": {
+                  "type": "string"
+                },
+                "entry_id": {
+                  "type": "null"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "go_terms": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "identifier": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "category": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "source_database": {
+                  "type": "string"
+                },
+                "member_databases": {
+                  "type": "object",
+                  "properties": {
+                    "profile": {
+                      "type": "object",
+                      "properties": {
+                        "PS50011": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "pfam": {
+                      "type": "object",
+                      "properties": {
+                        "PF00069": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "smart": {
+                      "type": "object",
+                      "properties": {
+                        "SM00220": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "integrated": {
+                  "type": "null"
+                },
+                "hierarchy": {
                   "type": "object",
                   "properties": {
                     "accession": {
                       "type": "string"
                     },
-                    "entry_id": {
-                      "type": "null"
+                    "name": {
+                      "type": "string"
                     },
                     "type": {
                       "type": "string"
                     },
-                    "go_terms": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "identifier": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "category": {
-                            "type": "object",
-                            "properties": {
-                              "code": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "source_database": {
-                      "type": "string"
-                    },
-                    "member_databases": {
-                      "type": "object",
-                      "properties": {
-                        "profile": {
-                          "type": "object",
-                          "properties": {
-                            "PS50011": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "pfam": {
-                          "type": "object",
-                          "properties": {
-                            "PF00069": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "smart": {
-                          "type": "object",
-                          "properties": {
-                            "SM00220": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "integrated": {
-                      "type": "null"
-                    },
-                    "hierarchy": {
-                      "type": "object",
-                      "properties": {
-                        "accession": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "type": {
-                          "type": "string"
-                        },
-                        "children": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "accession": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "type": "string"
-                              },
-                              "type": {
-                                "type": "string"
-                              },
-                              "children": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "accession": {
-                                      "type": "string"
-                                    },
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "type": {
-                                      "type": "string"
-                                    },
-                                    "children": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "object",
-                                        "properties": {
-                                          "accession": {
-                                            "type": "string"
-                                          },
-                                          "name": {
-                                            "type": "string"
-                                          },
-                                          "type": {
-                                            "type": "string"
-                                          },
-                                          "children": {
-                                            "type": "array"
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "name": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string"
-                        },
-                        "short": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "description": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "text": {
-                            "type": "string"
-                          },
-                          "llm": {
-                            "type": "boolean"
-                          },
-                          "checked": {
-                            "type": "boolean"
-                          },
-                          "updated": {
-                            "type": "boolean"
-                          }
-                        }
-                      }
-                    },
-                    "wikipedia": {
-                      "type": "null"
-                    },
-                    "literature": {
-                      "type": "object",
-                      "properties": {
-                        "PUB00001530": {
-                          "type": "object",
-                          "properties": {
-                            "PMID": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "ISBN": {
-                              "type": "null"
-                            },
-                            "volume": {
-                              "type": "string"
-                            },
-                            "issue": {
-                              "type": "string"
-                            },
-                            "year": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "URL": {
-                              "type": "null"
-                            },
-                            "raw_pages": {
-                              "type": "string"
-                            },
-                            "medline_journal": {
-                              "type": "string"
-                            },
-                            "ISO_journal": {
-                              "type": "string"
-                            },
-                            "authors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "DOI_URL": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "PUB00003568": {
-                          "type": "object",
-                          "properties": {
-                            "PMID": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "ISBN": {
-                              "type": "null"
-                            },
-                            "volume": {
-                              "type": "string"
-                            },
-                            "issue": {
-                              "type": "null"
-                            },
-                            "year": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "URL": {
-                              "type": "null"
-                            },
-                            "raw_pages": {
-                              "type": "string"
-                            },
-                            "medline_journal": {
-                              "type": "string"
-                            },
-                            "ISO_journal": {
-                              "type": "string"
-                            },
-                            "authors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "DOI_URL": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "PUB00003569": {
-                          "type": "object",
-                          "properties": {
-                            "PMID": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "ISBN": {
-                              "type": "null"
-                            },
-                            "volume": {
-                              "type": "string"
-                            },
-                            "issue": {
-                              "type": "null"
-                            },
-                            "year": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "URL": {
-                              "type": "null"
-                            },
-                            "raw_pages": {
-                              "type": "string"
-                            },
-                            "medline_journal": {
-                              "type": "string"
-                            },
-                            "ISO_journal": {
-                              "type": "string"
-                            },
-                            "authors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "DOI_URL": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "PUB00005115": {
-                          "type": "object",
-                          "properties": {
-                            "PMID": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "ISBN": {
-                              "type": "null"
-                            },
-                            "volume": {
-                              "type": "string"
-                            },
-                            "issue": {
-                              "type": "string"
-                            },
-                            "year": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "URL": {
-                              "type": "null"
-                            },
-                            "raw_pages": {
-                              "type": "string"
-                            },
-                            "medline_journal": {
-                              "type": "string"
-                            },
-                            "ISO_journal": {
-                              "type": "string"
-                            },
-                            "authors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "DOI_URL": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "PUB00005145": {
-                          "type": "object",
-                          "properties": {
-                            "PMID": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "ISBN": {
-                              "type": "null"
-                            },
-                            "volume": {
-                              "type": "string"
-                            },
-                            "issue": {
-                              "type": "string"
-                            },
-                            "year": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "URL": {
-                              "type": "null"
-                            },
-                            "raw_pages": {
-                              "type": "string"
-                            },
-                            "medline_journal": {
-                              "type": "string"
-                            },
-                            "ISO_journal": {
-                              "type": "string"
-                            },
-                            "authors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "DOI_URL": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "PUB00015293": {
-                          "type": "object",
-                          "properties": {
-                            "PMID": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "ISBN": {
-                              "type": "null"
-                            },
-                            "volume": {
-                              "type": "string"
-                            },
-                            "issue": {
-                              "type": "string"
-                            },
-                            "year": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "URL": {
-                              "type": "null"
-                            },
-                            "raw_pages": {
-                              "type": "string"
-                            },
-                            "medline_journal": {
-                              "type": "string"
-                            },
-                            "ISO_journal": {
-                              "type": "string"
-                            },
-                            "authors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "DOI_URL": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "PUB00020114": {
-                          "type": "object",
-                          "properties": {
-                            "PMID": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "ISBN": {
-                              "type": "null"
-                            },
-                            "volume": {
-                              "type": "string"
-                            },
-                            "issue": {
-                              "type": "string"
-                            },
-                            "year": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "URL": {
-                              "type": "null"
-                            },
-                            "raw_pages": {
-                              "type": "string"
-                            },
-                            "medline_journal": {
-                              "type": "string"
-                            },
-                            "ISO_journal": {
-                              "type": "string"
-                            },
-                            "authors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "DOI_URL": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "PUB00015362": {
-                          "type": "object",
-                          "properties": {
-                            "PMID": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "ISBN": {
-                              "type": "null"
-                            },
-                            "volume": {
-                              "type": "string"
-                            },
-                            "issue": {
-                              "type": "string"
-                            },
-                            "year": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "URL": {
-                              "type": "null"
-                            },
-                            "raw_pages": {
-                              "type": "string"
-                            },
-                            "medline_journal": {
-                              "type": "string"
-                            },
-                            "ISO_journal": {
-                              "type": "string"
-                            },
-                            "authors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "DOI_URL": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "PUB00034898": {
-                          "type": "object",
-                          "properties": {
-                            "PMID": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "ISBN": {
-                              "type": "null"
-                            },
-                            "volume": {
-                              "type": "string"
-                            },
-                            "issue": {
-                              "type": "string"
-                            },
-                            "year": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "URL": {
-                              "type": "null"
-                            },
-                            "raw_pages": {
-                              "type": "string"
-                            },
-                            "medline_journal": {
-                              "type": "string"
-                            },
-                            "ISO_journal": {
-                              "type": "string"
-                            },
-                            "authors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "DOI_URL": {
-                              "type": "string"
-                            }
-                          }
-                        },
-                        "PUB00034899": {
-                          "type": "object",
-                          "properties": {
-                            "PMID": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "ISBN": {
-                              "type": "null"
-                            },
-                            "volume": {
-                              "type": "string"
-                            },
-                            "issue": {
-                              "type": "string"
-                            },
-                            "year": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "URL": {
-                              "type": "null"
-                            },
-                            "raw_pages": {
-                              "type": "string"
-                            },
-                            "medline_journal": {
-                              "type": "string"
-                            },
-                            "ISO_journal": {
-                              "type": "string"
-                            },
-                            "authors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "DOI_URL": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "set_info": {
-                      "type": "null"
-                    },
-                    "overlaps_with": {
+                    "children": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -1455,199 +788,39 @@
                           },
                           "type": {
                             "type": "string"
-                          }
-                        }
-                      }
-                    },
-                    "counters": {
-                      "type": "object",
-                      "properties": {
-                        "subfamilies": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "domain_architectures": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "interactions": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "matches": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "pathways": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "proteins": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "proteomes": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "sets": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "structural_models": {
-                          "type": "object",
-                          "properties": {
-                            "alphafold": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "bfvd": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            }
-                          }
-                        },
-                        "structures": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "taxa": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        }
-                      }
-                    },
-                    "entry_annotations": {
-                      "type": "object",
-                      "properties": {
-                        "alignment:seed": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "alignment:full": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        }
-                      }
-                    },
-                    "cross_references": {
-                      "type": "object",
-                      "properties": {
-                        "prositedoc": {
-                          "type": "object",
-                          "properties": {
-                            "displayName": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            },
-                            "rank": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "accessions": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "accession": {
-                                    "type": "string"
-                                  },
-                                  "url": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "gp": {
-                          "type": "object",
-                          "properties": {
-                            "displayName": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            },
-                            "rank": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "accessions": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "accession": {
-                                    "type": "string"
-                                  },
-                                  "url": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "ec": {
-                          "type": "object",
-                          "properties": {
-                            "displayName": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            },
-                            "rank": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "accessions": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "accession": {
-                                    "type": "string"
-                                  },
-                                  "url": {
-                                    "type": "string"
+                          },
+                          "children": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "accession": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "children": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "accession": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "children": {
+                                        "type": "array"
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -1655,50 +828,802 @@
                           }
                         }
                       }
+                    }
+                  }
+                },
+                "name": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
                     },
-                    "is_llm": {
-                      "type": "boolean"
-                    },
-                    "is_reviewed_llm": {
-                      "type": "boolean"
-                    },
-                    "is_updated_llm": {
-                      "type": "boolean"
-                    },
-                    "representative_structure": {
+                    "short": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "description": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "text": {
+                        "type": "string"
+                      },
+                      "llm": {
+                        "type": "boolean"
+                      },
+                      "checked": {
+                        "type": "boolean"
+                      },
+                      "updated": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                },
+                "wikipedia": {
+                  "type": "null"
+                },
+                "literature": {
+                  "type": "object",
+                  "properties": {
+                    "PUB00001530": {
                       "type": "object",
                       "properties": {
-                        "accession": {
+                        "PMID": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "ISBN": {
+                          "type": "null"
+                        },
+                        "volume": {
                           "type": "string"
                         },
-                        "name": {
+                        "issue": {
+                          "type": "string"
+                        },
+                        "year": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "URL": {
+                          "type": "null"
+                        },
+                        "raw_pages": {
+                          "type": "string"
+                        },
+                        "medline_journal": {
+                          "type": "string"
+                        },
+                        "ISO_journal": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "DOI_URL": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "PUB00003568": {
+                      "type": "object",
+                      "properties": {
+                        "PMID": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "ISBN": {
+                          "type": "null"
+                        },
+                        "volume": {
+                          "type": "string"
+                        },
+                        "issue": {
+                          "type": "null"
+                        },
+                        "year": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "URL": {
+                          "type": "null"
+                        },
+                        "raw_pages": {
+                          "type": "string"
+                        },
+                        "medline_journal": {
+                          "type": "string"
+                        },
+                        "ISO_journal": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "DOI_URL": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "PUB00003569": {
+                      "type": "object",
+                      "properties": {
+                        "PMID": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "ISBN": {
+                          "type": "null"
+                        },
+                        "volume": {
+                          "type": "string"
+                        },
+                        "issue": {
+                          "type": "null"
+                        },
+                        "year": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "URL": {
+                          "type": "null"
+                        },
+                        "raw_pages": {
+                          "type": "string"
+                        },
+                        "medline_journal": {
+                          "type": "string"
+                        },
+                        "ISO_journal": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "DOI_URL": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "PUB00005115": {
+                      "type": "object",
+                      "properties": {
+                        "PMID": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "ISBN": {
+                          "type": "null"
+                        },
+                        "volume": {
+                          "type": "string"
+                        },
+                        "issue": {
+                          "type": "string"
+                        },
+                        "year": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "URL": {
+                          "type": "null"
+                        },
+                        "raw_pages": {
+                          "type": "string"
+                        },
+                        "medline_journal": {
+                          "type": "string"
+                        },
+                        "ISO_journal": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "DOI_URL": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "PUB00005145": {
+                      "type": "object",
+                      "properties": {
+                        "PMID": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "ISBN": {
+                          "type": "null"
+                        },
+                        "volume": {
+                          "type": "string"
+                        },
+                        "issue": {
+                          "type": "string"
+                        },
+                        "year": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "URL": {
+                          "type": "null"
+                        },
+                        "raw_pages": {
+                          "type": "string"
+                        },
+                        "medline_journal": {
+                          "type": "string"
+                        },
+                        "ISO_journal": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "DOI_URL": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "PUB00015293": {
+                      "type": "object",
+                      "properties": {
+                        "PMID": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "ISBN": {
+                          "type": "null"
+                        },
+                        "volume": {
+                          "type": "string"
+                        },
+                        "issue": {
+                          "type": "string"
+                        },
+                        "year": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "URL": {
+                          "type": "null"
+                        },
+                        "raw_pages": {
+                          "type": "string"
+                        },
+                        "medline_journal": {
+                          "type": "string"
+                        },
+                        "ISO_journal": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "DOI_URL": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "PUB00020114": {
+                      "type": "object",
+                      "properties": {
+                        "PMID": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "ISBN": {
+                          "type": "null"
+                        },
+                        "volume": {
+                          "type": "string"
+                        },
+                        "issue": {
+                          "type": "string"
+                        },
+                        "year": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "URL": {
+                          "type": "null"
+                        },
+                        "raw_pages": {
+                          "type": "string"
+                        },
+                        "medline_journal": {
+                          "type": "string"
+                        },
+                        "ISO_journal": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "DOI_URL": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "PUB00015362": {
+                      "type": "object",
+                      "properties": {
+                        "PMID": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "ISBN": {
+                          "type": "null"
+                        },
+                        "volume": {
+                          "type": "string"
+                        },
+                        "issue": {
+                          "type": "string"
+                        },
+                        "year": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "URL": {
+                          "type": "null"
+                        },
+                        "raw_pages": {
+                          "type": "string"
+                        },
+                        "medline_journal": {
+                          "type": "string"
+                        },
+                        "ISO_journal": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "DOI_URL": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "PUB00034898": {
+                      "type": "object",
+                      "properties": {
+                        "PMID": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "ISBN": {
+                          "type": "null"
+                        },
+                        "volume": {
+                          "type": "string"
+                        },
+                        "issue": {
+                          "type": "string"
+                        },
+                        "year": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "URL": {
+                          "type": "null"
+                        },
+                        "raw_pages": {
+                          "type": "string"
+                        },
+                        "medline_journal": {
+                          "type": "string"
+                        },
+                        "ISO_journal": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "DOI_URL": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "PUB00034899": {
+                      "type": "object",
+                      "properties": {
+                        "PMID": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "ISBN": {
+                          "type": "null"
+                        },
+                        "volume": {
+                          "type": "string"
+                        },
+                        "issue": {
+                          "type": "string"
+                        },
+                        "year": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "URL": {
+                          "type": "null"
+                        },
+                        "raw_pages": {
+                          "type": "string"
+                        },
+                        "medline_journal": {
+                          "type": "string"
+                        },
+                        "ISO_journal": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "DOI_URL": {
                           "type": "string"
                         }
                       }
                     }
                   }
+                },
+                "set_info": {
+                  "type": "null"
+                },
+                "overlaps_with": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "accession": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "counters": {
+                  "type": "object",
+                  "properties": {
+                    "subfamilies": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "domain_architectures": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "interactions": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "matches": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "pathways": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "proteins": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "proteomes": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "sets": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "structural_models": {
+                      "type": "object",
+                      "properties": {
+                        "alphafold": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "bfvd": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        }
+                      }
+                    },
+                    "structures": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "taxa": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    }
+                  }
+                },
+                "entry_annotations": {
+                  "type": "object",
+                  "properties": {
+                    "alignment:seed": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "alignment:full": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    }
+                  }
+                },
+                "cross_references": {
+                  "type": "object",
+                  "properties": {
+                    "prositedoc": {
+                      "type": "object",
+                      "properties": {
+                        "displayName": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "rank": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "accessions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "accession": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "gp": {
+                      "type": "object",
+                      "properties": {
+                        "displayName": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "rank": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "accessions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "accession": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ec": {
+                      "type": "object",
+                      "properties": {
+                        "displayName": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "rank": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "accessions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "accession": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "is_llm": {
+                  "type": "boolean"
+                },
+                "is_reviewed_llm": {
+                  "type": "boolean"
+                },
+                "is_updated_llm": {
+                  "type": "boolean"
+                },
+                "representative_structure": {
+                  "type": "object",
+                  "properties": {
+                    "accession": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "metadata"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/interproscan_tools.json
+++ b/src/tooluniverse/data/interproscan_tools.json
@@ -45,147 +45,132 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "job_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "job_id": {
-                  "type": "string"
-                },
-                "domains": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "database": {
-                        "type": "string"
-                      },
-                      "interpro_accession": {
-                        "type": "string"
-                      },
-                      "interpro_name": {
-                        "type": "string"
-                      },
-                      "interpro_type": {
-                        "type": "string"
-                      },
-                      "locations": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "start": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "end": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "score": {
-                              "type": [
-                                "null",
-                                "number"
-                              ]
-                            },
-                            "evalue": {
-                              "type": [
-                                "null",
-                                "number"
-                              ]
-                            }
-                          }
+            "domains": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "database": {
+                    "type": "string"
+                  },
+                  "interpro_accession": {
+                    "type": "string"
+                  },
+                  "interpro_name": {
+                    "type": "string"
+                  },
+                  "interpro_type": {
+                    "type": "string"
+                  },
+                  "locations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "start": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "end": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "score": {
+                          "type": [
+                            "null",
+                            "number"
+                          ]
+                        },
+                        "evalue": {
+                          "type": [
+                            "null",
+                            "number"
+                          ]
                         }
                       }
                     }
                   }
-                },
-                "domain_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "go_annotations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "category": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "pathways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "database": {
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "sequence_length": {
-                  "type": "null"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "domain_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "go_annotations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "pathways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "database": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "sequence_length": {
+              "type": "null"
             }
-          }
+          },
+          "required": [
+            "job_id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -231,49 +216,34 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "job_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "job_id": {
-                  "type": "string"
-                },
-                "job_status": {
-                  "type": "string"
-                },
-                "is_finished": {
-                  "type": "boolean"
-                },
-                "has_error": {
-                  "type": "boolean"
-                }
-              }
+            "job_status": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object"
+            "is_finished": {
+              "type": "boolean"
+            },
+            "has_error": {
+              "type": "boolean"
             }
-          }
+          },
+          "required": [
+            "job_id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -318,46 +288,31 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "job_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "job_id": {
-                  "type": "string"
-                },
-                "job_status": {
-                  "type": "string"
-                },
-                "message": {
-                  "type": "string"
-                }
-              }
+            "job_status": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object"
+            "message": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "job_id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/ipd_imgt_hla_tools.json
+++ b/src/tooluniverse/data/ipd_imgt_hla_tools.json
@@ -1,315 +1,270 @@
 [
-    {
-        "type": "IPDIMGTHLATool",
-        "name": "IPD_search_hla_alleles",
-        "description": "Search the IPD-IMGT/HLA database for human HLA alleles by allele name prefix or substring (e.g. 'A*01:01', 'DRB1*15', 'B*07'). Returns matching alleles with their IPD accession (e.g. HLA00001) and full allele name. Use this to resolve an HLA type or partial type into specific allele accessions for follow-up detail lookups. Keyless EMBL-EBI API.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "HLA allele name or partial name to search (e.g. 'A*01:01', 'DRB1*15:01', 'B*07'). The filter expression is built for you."
-                },
-                "match": {
-                    "type": "string",
-                    "enum": [
-                        "startsWith",
-                        "contains",
-                        "eq"
-                    ],
-                    "description": "How to match the name: 'startsWith' (default, prefix match), 'contains' (substring), or 'eq' (exact full name).",
-                    "default": "startsWith"
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum number of alleles to return (default 10, max 100).",
-                    "default": 10
-                }
-            },
-            "required": [
-                "name"
-            ]
+  {
+    "type": "IPDIMGTHLATool",
+    "name": "IPD_search_hla_alleles",
+    "description": "Search the IPD-IMGT/HLA database for human HLA alleles by allele name prefix or substring (e.g. 'A*01:01', 'DRB1*15', 'B*07'). Returns matching alleles with their IPD accession (e.g. HLA00001) and full allele name. Use this to resolve an HLA type or partial type into specific allele accessions for follow-up detail lookups. Keyless EMBL-EBI API.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "HLA allele name or partial name to search (e.g. 'A*01:01', 'DRB1*15:01', 'B*07'). The filter expression is built for you."
         },
-        "label": [
-            "IPD-IMGT/HLA",
-            "HLA",
-            "MHC",
-            "allele",
-            "immunogenetics",
-            "EMBL-EBI"
-        ],
-        "test_examples": [
-            {
-                "name": "A*01:01",
-                "limit": 3
-            },
-            {
-                "name": "DRB1*15:01",
-                "match": "startsWith",
-                "limit": 5
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "alleles": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "accession": {
-                                                "type": "string"
-                                            },
-                                            "name": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "count": {
-                                    "type": "integer"
-                                },
-                                "total": {
-                                    "type": [
-                                        "integer",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
+        "match": {
+          "type": "string",
+          "enum": [
+            "startsWith",
+            "contains",
+            "eq"
+          ],
+          "description": "How to match the name: 'startsWith' (default, prefix match), 'contains' (substring), or 'eq' (exact full name).",
+          "default": "startsWith"
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Maximum number of alleles to return (default 10, max 100).",
+          "default": 10
         }
+      },
+      "required": [
+        "name"
+      ]
     },
-    {
-        "type": "IPDIMGTHLATool",
-        "name": "IPD_get_hla_allele",
-        "description": "Fetch the full IPD-IMGT/HLA record for a single HLA allele by its IPD accession (e.g. 'HLA00001'). Returns the complete record including allele name, locus, class, sequence, confirmation status, citations, CWD (common/well-documented) status, release history, and cross-references. Use IPD_search_hla_alleles first to obtain an accession. Keyless EMBL-EBI API.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "accession": {
-                    "type": "string",
-                    "description": "IPD-IMGT/HLA allele accession (e.g. 'HLA00001'). Obtain via IPD_search_hla_alleles."
+    "label": [
+      "IPD-IMGT/HLA",
+      "HLA",
+      "MHC",
+      "allele",
+      "immunogenetics",
+      "EMBL-EBI"
+    ],
+    "test_examples": [
+      {
+        "name": "A*01:01",
+        "limit": 3
+      },
+      {
+        "name": "DRB1*15:01",
+        "match": "startsWith",
+        "limit": 5
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "alleles": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
                 }
+              }
             },
-            "required": [
-                "accession"
-            ]
-        },
-        "label": [
-            "IPD-IMGT/HLA",
-            "HLA",
-            "MHC",
-            "allele",
-            "sequence",
-            "EMBL-EBI"
-        ],
-        "test_examples": [
-            {
-                "accession": "HLA00001"
+            "count": {
+              "type": "integer"
             },
-            {
-                "accession": "HLA01244"
+            "total": {
+              "type": [
+                "integer",
+                "null"
+              ]
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "accession": {
-                                    "type": "string"
-                                },
-                                "name": {
-                                    "type": "string"
-                                },
-                                "locus": {
-                                    "type": "string"
-                                },
-                                "class": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "type": "IPDIMGTHLATool",
-        "name": "IPD_search_cells",
-        "description": "Search IPD cell lines (HLA reference cells with their HLA typing) by a field value. By default searches the cell's primary name; set 'field' to search other fields such as 'lab_of_origin'. Returns matching cells with their IPD cell id and primary name. Useful for finding HLA-typed reference cell lines. Keyless EMBL-EBI API.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Text to search for (e.g. a cell primary name, or a lab name when field='lab_of_origin'). The filter expression is built for you."
-                },
-                "field": {
-                    "type": "string",
-                    "description": "Cell field to search (default 'primary_name'). Other useful fields include 'lab_of_origin'.",
-                    "default": "primary_name"
-                },
-                "match": {
-                    "type": "string",
-                    "enum": [
-                        "startsWith",
-                        "contains",
-                        "eq"
-                    ],
-                    "description": "How to match: 'contains' (default, substring), 'startsWith' (prefix), or 'eq' (exact).",
-                    "default": "contains"
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum number of cells to return (default 10, max 100).",
-                    "default": 10
-                }
-            },
-            "required": [
-                "query"
-            ]
+          },
+          "required": [
+            "alleles"
+          ]
         },
-        "label": [
-            "IPD-IMGT/HLA",
-            "HLA",
-            "cell line",
-            "reference cell",
-            "immunogenetics",
-            "EMBL-EBI"
-        ],
-        "test_examples": [
-            {
-                "query": "Roche",
-                "field": "lab_of_origin",
-                "limit": 3
-            },
-            {
-                "query": "10839496",
-                "field": "primary_name",
-                "match": "eq"
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "cells": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "cellid": {
-                                                "type": "string"
-                                            },
-                                            "primary_name": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "count": {
-                                    "type": "integer"
-                                },
-                                "total": {
-                                    "type": [
-                                        "integer",
-                                        "null"
-                                    ]
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "type": "IPDIMGTHLATool",
+    "name": "IPD_get_hla_allele",
+    "description": "Fetch the full IPD-IMGT/HLA record for a single HLA allele by its IPD accession (e.g. 'HLA00001'). Returns the complete record including allele name, locus, class, sequence, confirmation status, citations, CWD (common/well-documented) status, release history, and cross-references. Use IPD_search_hla_alleles first to obtain an accession. Keyless EMBL-EBI API.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "IPD-IMGT/HLA allele accession (e.g. 'HLA00001'). Obtain via IPD_search_hla_alleles."
+        }
+      },
+      "required": [
+        "accession"
+      ]
+    },
+    "label": [
+      "IPD-IMGT/HLA",
+      "HLA",
+      "MHC",
+      "allele",
+      "sequence",
+      "EMBL-EBI"
+    ],
+    "test_examples": [
+      {
+        "accession": "HLA00001"
+      },
+      {
+        "accession": "HLA01244"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "accession": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "locus": {
+              "type": "string"
+            },
+            "class": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "accession"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "type": "IPDIMGTHLATool",
+    "name": "IPD_search_cells",
+    "description": "Search IPD cell lines (HLA reference cells with their HLA typing) by a field value. By default searches the cell's primary name; set 'field' to search other fields such as 'lab_of_origin'. Returns matching cells with their IPD cell id and primary name. Useful for finding HLA-typed reference cell lines. Keyless EMBL-EBI API.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Text to search for (e.g. a cell primary name, or a lab name when field='lab_of_origin'). The filter expression is built for you."
+        },
+        "field": {
+          "type": "string",
+          "description": "Cell field to search (default 'primary_name'). Other useful fields include 'lab_of_origin'.",
+          "default": "primary_name"
+        },
+        "match": {
+          "type": "string",
+          "enum": [
+            "startsWith",
+            "contains",
+            "eq"
+          ],
+          "description": "How to match: 'contains' (default, substring), 'startsWith' (prefix), or 'eq' (exact).",
+          "default": "contains"
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Maximum number of cells to return (default 10, max 100).",
+          "default": 10
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "label": [
+      "IPD-IMGT/HLA",
+      "HLA",
+      "cell line",
+      "reference cell",
+      "immunogenetics",
+      "EMBL-EBI"
+    ],
+    "test_examples": [
+      {
+        "query": "Roche",
+        "field": "lab_of_origin",
+        "limit": 3
+      },
+      {
+        "query": "10839496",
+        "field": "primary_name",
+        "match": "eq"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cells": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "cellid": {
+                    "type": "string"
+                  },
+                  "primary_name": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "count": {
+              "type": "integer"
+            },
+            "total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "cells"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/iptmnet_tools.json
+++ b/src/tooluniverse/data/iptmnet_tools.json
@@ -406,77 +406,54 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": ["success"]
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "protein_1_pro_id": {
-                    "type": "string",
-                    "description": "PRO ontology proteoform ID of the first interactant (e.g., PR:000025934)"
-                  },
-                  "protein_1_label": {
-                    "type": "string",
-                    "description": "Human-readable proteoform label encoding isoform + modification state (e.g., hSMAD2/iso:Long/Phos:1)"
-                  },
-                  "relation": {
-                    "type": "string",
-                    "description": "Interaction relation type (e.g., Interaction)"
-                  },
-                  "protein_2_pro_id": {
-                    "type": "string",
-                    "description": "PRO ontology proteoform ID of the second interactant (e.g., PR:Q13485)"
-                  },
-                  "protein_2_label": {
-                    "type": "string",
-                    "description": "Human-readable proteoform label of the second interactant (e.g., hSMAD4)"
-                  },
-                  "source": {
-                    "type": "string",
-                    "description": "Data source (e.g., PRO)"
-                  },
-                  "pmids": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "PubMed IDs supporting the interaction"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "uniprot_id": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "protein_1_pro_id": {
+                "type": "string",
+                "description": "PRO ontology proteoform ID of the first interactant (e.g., PR:000025934)"
+              },
+              "protein_1_label": {
+                "type": "string",
+                "description": "Human-readable proteoform label encoding isoform + modification state (e.g., hSMAD2/iso:Long/Phos:1)"
+              },
+              "relation": {
+                "type": "string",
+                "description": "Interaction relation type (e.g., Interaction)"
+              },
+              "protein_2_pro_id": {
+                "type": "string",
+                "description": "PRO ontology proteoform ID of the second interactant (e.g., PR:Q13485)"
+              },
+              "protein_2_label": {
+                "type": "string",
+                "description": "Human-readable proteoform label of the second interactant (e.g., hSMAD4)"
+              },
+              "source": {
+                "type": "string",
+                "description": "Data source (e.g., PRO)"
+              },
+              "pmids": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 },
-                "total_interactions": {
-                  "type": "integer"
-                }
+                "description": "PubMed IDs supporting the interaction"
               }
             }
-          },
-          "required": ["status", "data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": ["error"]
-            },
             "error": {
               "type": "string"
             }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/isrctn_tools.json
+++ b/src/tooluniverse/data/isrctn_tools.json
@@ -1,289 +1,245 @@
 [
-    {
-        "name": "ISRCTN_search_trials",
-        "description": "Search the ISRCTN clinical trial registry \u2014 a WHO-primary registry (UK-based, international scope) \u2014 by free text. Returns matching trials with ISRCTN id, title, scientific title, acronym, study hypothesis, primary study design, end date, and cross-reference ids (DOI, EudraCT, ClinicalTrials.gov). A third trial source alongside ClinicalTrials.gov and EU CTIS. No API key required.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Free-text search, e.g. 'cystic fibrosis', 'diabetes prevention'."
-                },
-                "limit": {
-                    "type": [
-                        "integer",
-                        "null"
-                    ],
-                    "description": "Max trials to return (default 10, max 100)."
-                }
-            },
-            "required": [
-                "query"
-            ]
+  {
+    "name": "ISRCTN_search_trials",
+    "description": "Search the ISRCTN clinical trial registry \u2014 a WHO-primary registry (UK-based, international scope) \u2014 by free text. Returns matching trials with ISRCTN id, title, scientific title, acronym, study hypothesis, primary study design, end date, and cross-reference ids (DOI, EudraCT, ClinicalTrials.gov). A third trial source alongside ClinicalTrials.gov and EU CTIS. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Free-text search, e.g. 'cystic fibrosis', 'diabetes prevention'."
         },
-        "fields": {
-            "timeout": 30
-        },
-        "type": "ISRCTNSearchTool",
-        "test_examples": [
-            {
-                "query": "cystic fibrosis",
-                "limit": 5
-            },
-            {
-                "query": "diabetes prevention",
-                "limit": 3
-            },
-            {
-                "query": "breast cancer",
-                "limit": 3
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "description": "Matching ISRCTN trials",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object"
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "description": "Includes total_available"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Max trials to return (default 10, max 100)."
         }
+      },
+      "required": [
+        "query"
+      ]
     },
-    {
-        "name": "ISRCTN_search_trials_fielded",
-        "description": "Field-scoped (fielded) search of the ISRCTN clinical trial registry using its boolean query DSL. Unlike the free-text ISRCTN_search_trials, this lets you scope a query to specific registry fields so results are precise. Pass a raw 'q' DSL string such as 'condition:diabetes', 'phase:\"Phase III\"', or combine fields with AND/OR: 'gender:Female AND condition:asthma'. Alternatively pass field helpers (condition, phase, gender, intervention, sponsor, funder, country, drug_name) which are joined with AND. Returns detailed trial records (interventions, primary/secondary outcomes, inclusion/exclusion eligibility, sponsors, funders, recruitment countries and dates, drug names, enrolment, IPD-sharing, plain-English summary). No API key required.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "q": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Raw ISRCTN field-scoped boolean query, used verbatim. Examples: 'condition:diabetes', 'phase:\"Phase III\"', 'gender:Female AND condition:asthma'."
-                },
-                "query": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Alias for 'q'; a full field-scoped DSL string."
-                },
-                "condition": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Condition field helper (compiled to condition:VALUE), e.g. 'diabetes'."
-                },
-                "phase": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Phase field helper (compiled to phase:VALUE), e.g. 'Phase III'."
-                },
-                "gender": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Gender field helper (compiled to gender:VALUE), e.g. 'Female'."
-                },
-                "intervention": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Intervention field helper (compiled to intervention:VALUE)."
-                },
-                "sponsor": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Sponsor field helper (compiled to sponsor:VALUE)."
-                },
-                "funder": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Funder field helper (compiled to funder:VALUE)."
-                },
-                "country": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Recruitment country field helper (compiled to recruitmentCountry:VALUE)."
-                },
-                "drug_name": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Drug name field helper (compiled to drugName:VALUE)."
-                },
-                "limit": {
-                    "type": [
-                        "integer",
-                        "null"
-                    ],
-                    "description": "Max trials to return (default 10, max 100)."
-                }
-            },
-            "required": []
-        },
-        "fields": {
-            "timeout": 30
-        },
-        "type": "ISRCTNSearchTool",
-        "test_examples": [
-            {
-                "q": "condition:diabetes",
-                "limit": 2
-            },
-            {
-                "q": "phase:\"Phase III\"",
-                "limit": 2
-            },
-            {
-                "q": "gender:Female AND condition:asthma",
-                "limit": 2
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "description": "Field-scoped ISRCTN trials",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object"
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "description": "Includes total_available and the compiled query"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
-        }
+    "fields": {
+      "timeout": 30
     },
-    {
-        "name": "ISRCTN_get_trial",
-        "description": "Retrieve a single ISRCTN clinical trial by its ISRCTN id (e.g. 'ISRCTN12336055'). Returns the full record: title, scientific title, acronym, study hypothesis, plain-English summary, primary and secondary study design, phase, conditions, interventions, primary and secondary outcomes, inclusion/exclusion eligibility (gender, age range, healthy volunteers), sponsors, funders, contacts, recruitment countries, recruitment start/end dates, drug names, target and final enrolment, IPD-sharing statement, end date, and cross-reference ids (DOI, EudraCT, ClinicalTrials.gov). No API key required.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "isrctn_id": {
-                    "type": "string",
-                    "description": "ISRCTN id, e.g. 'ISRCTN12336055' (the 'ISRCTN' prefix is optional)."
-                }
-            },
-            "required": [
-                "isrctn_id"
-            ]
+    "type": "ISRCTNSearchTool",
+    "test_examples": [
+      {
+        "query": "cystic fibrosis",
+        "limit": 5
+      },
+      {
+        "query": "diabetes prevention",
+        "limit": 3
+      },
+      {
+        "query": "breast cancer",
+        "limit": 3
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
         },
-        "fields": {
-            "timeout": 30
-        },
-        "type": "ISRCTNGetTrialTool",
-        "test_examples": [
-            {
-                "isrctn_id": "ISRCTN12336055"
-            },
-            {
-                "isrctn_id": "ISRCTN30134752"
-            },
-            {
-                "isrctn_id": "18761383"
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "description": "Single ISRCTN trial",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "object"
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "ISRCTN_search_trials_fielded",
+    "description": "Field-scoped (fielded) search of the ISRCTN clinical trial registry using its boolean query DSL. Unlike the free-text ISRCTN_search_trials, this lets you scope a query to specific registry fields so results are precise. Pass a raw 'q' DSL string such as 'condition:diabetes', 'phase:\"Phase III\"', or combine fields with AND/OR: 'gender:Female AND condition:asthma'. Alternatively pass field helpers (condition, phase, gender, intervention, sponsor, funder, country, drug_name) which are joined with AND. Returns detailed trial records (interventions, primary/secondary outcomes, inclusion/exclusion eligibility, sponsors, funders, recruitment countries and dates, drug names, enrolment, IPD-sharing, plain-English summary). No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "q": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Raw ISRCTN field-scoped boolean query, used verbatim. Examples: 'condition:diabetes', 'phase:\"Phase III\"', 'gender:Female AND condition:asthma'."
+        },
+        "query": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Alias for 'q'; a full field-scoped DSL string."
+        },
+        "condition": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Condition field helper (compiled to condition:VALUE), e.g. 'diabetes'."
+        },
+        "phase": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Phase field helper (compiled to phase:VALUE), e.g. 'Phase III'."
+        },
+        "gender": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Gender field helper (compiled to gender:VALUE), e.g. 'Female'."
+        },
+        "intervention": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Intervention field helper (compiled to intervention:VALUE)."
+        },
+        "sponsor": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Sponsor field helper (compiled to sponsor:VALUE)."
+        },
+        "funder": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Funder field helper (compiled to funder:VALUE)."
+        },
+        "country": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Recruitment country field helper (compiled to recruitmentCountry:VALUE)."
+        },
+        "drug_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Drug name field helper (compiled to drugName:VALUE)."
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Max trials to return (default 10, max 100)."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "ISRCTNSearchTool",
+    "test_examples": [
+      {
+        "q": "condition:diabetes",
+        "limit": 2
+      },
+      {
+        "q": "phase:\"Phase III\"",
+        "limit": 2
+      },
+      {
+        "q": "gender:Female AND condition:asthma",
+        "limit": 2
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "ISRCTN_get_trial",
+    "description": "Retrieve a single ISRCTN clinical trial by its ISRCTN id (e.g. 'ISRCTN12336055'). Returns the full record: title, scientific title, acronym, study hypothesis, plain-English summary, primary and secondary study design, phase, conditions, interventions, primary and secondary outcomes, inclusion/exclusion eligibility (gender, age range, healthy volunteers), sponsors, funders, contacts, recruitment countries, recruitment start/end dates, drug names, target and final enrolment, IPD-sharing statement, end date, and cross-reference ids (DOI, EudraCT, ClinicalTrials.gov). No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "isrctn_id": {
+          "type": "string",
+          "description": "ISRCTN id, e.g. 'ISRCTN12336055' (the 'ISRCTN' prefix is optional)."
+        }
+      },
+      "required": [
+        "isrctn_id"
+      ]
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "ISRCTNGetTrialTool",
+    "test_examples": [
+      {
+        "isrctn_id": "ISRCTN12336055"
+      },
+      {
+        "isrctn_id": "ISRCTN30134752"
+      },
+      {
+        "isrctn_id": "18761383"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/iupred3_tools.json
+++ b/src/tooluniverse/data/iupred3_tools.json
@@ -31,122 +31,110 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Successful disorder prediction (content of the data field).",
           "properties": {
-            "status": {
-              "const": "success"
+            "accession": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "description": "Successful disorder prediction (content of the data field).",
-              "properties": {
-                "accession": {
-                  "type": "string"
-                },
-                "iupred_type": {
-                  "type": "string"
-                },
-                "sequence_length": {
-                  "type": "integer"
-                },
-                "mean_disorder_score": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "description": "Mean per-residue disorder score (0-1)"
-                },
-                "disordered_residues": {
-                  "type": "integer",
-                  "description": "Count of residues with disorder score >= 0.5"
-                },
-                "disordered_fraction": {
-                  "type": "number",
-                  "description": "Fraction of the sequence predicted disordered"
-                },
-                "disordered_regions": {
-                  "type": "array",
-                  "description": "Contiguous disordered segments (score >= 0.5), 1-based inclusive positions.",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "start": {
-                        "type": "integer"
-                      },
-                      "end": {
-                        "type": "integer"
-                      },
-                      "length": {
-                        "type": "integer"
-                      }
-                    }
+            "iupred_type": {
+              "type": "string"
+            },
+            "sequence_length": {
+              "type": "integer"
+            },
+            "mean_disorder_score": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Mean per-residue disorder score (0-1)"
+            },
+            "disordered_residues": {
+              "type": "integer",
+              "description": "Count of residues with disorder score >= 0.5"
+            },
+            "disordered_fraction": {
+              "type": "number",
+              "description": "Fraction of the sequence predicted disordered"
+            },
+            "disordered_regions": {
+              "type": "array",
+              "description": "Contiguous disordered segments (score >= 0.5), 1-based inclusive positions.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "start": {
+                    "type": "integer"
+                  },
+                  "end": {
+                    "type": "integer"
+                  },
+                  "length": {
+                    "type": "integer"
                   }
-                },
-                "anchor_binding_regions": {
-                  "type": "array",
-                  "description": "ANCHOR2 protein-binding regions (only present when iupred_type='anchor').",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "start": {
-                        "type": "integer"
-                      },
-                      "end": {
-                        "type": "integer"
-                      },
-                      "length": {
-                        "type": "integer"
-                      }
-                    }
-                  }
-                },
-                "redox_sensitive_regions": {
-                  "type": "array",
-                  "description": "Redox-sensitive regions (only present when iupred_type='redox')."
-                },
-                "per_residue": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "position": {
-                        "type": "integer"
-                      },
-                      "residue": {
-                        "type": "string"
-                      },
-                      "disorder_score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "anchor_score": {
-                        "type": "number"
-                      }
-                    }
-                  }
-                },
-                "sequence": {
-                  "type": "string",
-                  "description": "The amino acid sequence used for prediction"
                 }
-              },
-              "required": [
-                "accession",
-                "iupred_type",
-                "sequence_length",
-                "disordered_regions",
-                "per_residue"
-              ]
+              }
+            },
+            "anchor_binding_regions": {
+              "type": "array",
+              "description": "ANCHOR2 protein-binding regions (only present when iupred_type='anchor').",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "start": {
+                    "type": "integer"
+                  },
+                  "end": {
+                    "type": "integer"
+                  },
+                  "length": {
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "redox_sensitive_regions": {
+              "type": "array",
+              "description": "Redox-sensitive regions (only present when iupred_type='redox')."
+            },
+            "per_residue": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "position": {
+                    "type": "integer"
+                  },
+                  "residue": {
+                    "type": "string"
+                  },
+                  "disorder_score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "anchor_score": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            "sequence": {
+              "type": "string",
+              "description": "The amino acid sequence used for prediction"
             }
           },
           "required": [
-            "data"
+            "accession",
+            "iupred_type",
+            "sequence_length",
+            "disordered_regions",
+            "per_residue"
           ]
         },
         {
           "type": "object",
-          "description": "Error response.",
           "properties": {
             "error": {
               "type": "string"

--- a/src/tooluniverse/data/kegg_tools.json
+++ b/src/tooluniverse/data/kegg_tools.json
@@ -22,52 +22,29 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "description": "Wrapped response with status, data (pathway list), url, count",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "pathway_id": {
-                    "type": "string",
-                    "description": "KEGG pathway identifier"
-                  },
-                  "description": {
-                    "type": "string",
-                    "description": "Pathway description"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pathway_id": {
+                "type": "string",
+                "description": "KEGG pathway identifier"
+              },
+              "description": {
+                "type": "string",
+                "description": "Pathway description"
               }
-            },
-            "url": {
-              "type": "string"
-            },
-            "count": {
-              "type": "integer"
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }
@@ -199,52 +176,29 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "description": "Wrapped response with status, data (gene list), url, count",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_id": {
-                    "type": "string",
-                    "description": "KEGG gene identifier"
-                  },
-                  "description": {
-                    "type": "string",
-                    "description": "Gene description"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene_id": {
+                "type": "string",
+                "description": "KEGG gene identifier"
+              },
+              "description": {
+                "type": "string",
+                "description": "Gene description"
               }
-            },
-            "url": {
-              "type": "string"
-            },
-            "count": {
-              "type": "integer"
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }
@@ -365,56 +319,33 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "description": "Wrapped response with status, data (organism list), url, count",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "organism_code": {
-                    "type": "string",
-                    "description": "KEGG organism code (e.g., 'hsa', 'mmu')"
-                  },
-                  "organism_name": {
-                    "type": "string",
-                    "description": "Organism scientific name"
-                  },
-                  "description": {
-                    "type": "string",
-                    "description": "Organism description"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "organism_code": {
+                "type": "string",
+                "description": "KEGG organism code (e.g., 'hsa', 'mmu')"
+              },
+              "organism_name": {
+                "type": "string",
+                "description": "Organism scientific name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Organism description"
               }
-            },
-            "url": {
-              "type": "string"
-            },
-            "count": {
-              "type": "integer"
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }

--- a/src/tooluniverse/data/lipidmaps_gene_tools.json
+++ b/src/tooluniverse/data/lipidmaps_gene_tools.json
@@ -50,7 +50,6 @@
       }
     ],
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "array",
@@ -201,7 +200,6 @@
       }
     ],
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "array",

--- a/src/tooluniverse/data/lipidmaps_gene_tools.json
+++ b/src/tooluniverse/data/lipidmaps_gene_tools.json
@@ -53,112 +53,93 @@
       "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "lmp_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_synonyms": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "alt_names": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "chromosome": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "map_location": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "summary": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "taxid": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species_long": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "lmp_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_synonyms": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "alt_names": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "chromosome": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "map_location": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "summary": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "taxid": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "species_long": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
-          "description": "Error envelope returned when the request fails.",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }
@@ -223,130 +204,111 @@
       "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "lmp_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "uniprot_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "protein_entry": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "protein_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "refseq_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "mrna_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "protein_gi": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "seqlength": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "seq": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "taxid": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species_long": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "lmp_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uniprot_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "protein_entry": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "protein_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "refseq_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "mrna_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "protein_gi": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "seqlength": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "seq": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "taxid": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "species_long": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
-          "description": "Error envelope returned when the request fails.",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }

--- a/src/tooluniverse/data/lipidmaps_tools.json
+++ b/src/tooluniverse/data/lipidmaps_tools.json
@@ -37,68 +37,119 @@
       "type": "object",
       "properties": {
         "lm_id": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "sys_name": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "formula": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "exactmass": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "smiles": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "inchi_key": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "core": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "main_class": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "sub_class": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "kegg_id": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "hmdb_id": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "chebi_id": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "pubchem_cid": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "input": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "regno": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "abbrev": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }
   },
   {
     "name": "LipidMaps_search_by_name",
-    "description": "Search for lipids by exact abbreviation in LIPID MAPS Structure Database. IMPORTANT: Only exact lipidomics abbreviations work (e.g., 'DHA', 'EPA', 'PC 16:0/18:1', 'SM 34:1'). Class names like 'ceramide' or 'sphingomyelin' will NOT match — use LipidMaps_search_by_formula for class-level searches. Returns matching lipid records with structures and classification.",
+    "description": "Search for lipids by exact abbreviation in LIPID MAPS Structure Database. IMPORTANT: Only exact lipidomics abbreviations work (e.g., 'DHA', 'EPA', 'PC 16:0/18:1', 'SM 34:1'). Class names like 'ceramide' or 'sphingomyelin' will NOT match \u2014 use LipidMaps_search_by_formula for class-level searches. Returns matching lipid records with structures and classification.",
     "parameter": {
       "type": "object",
       "properties": {
         "input_value": {
           "type": "string",
-          "description": "Exact lipid abbreviation used in lipidomics (e.g., 'DHA', 'EPA', 'PC 16:0/18:1', 'SM 34:1'). Class names like 'ceramide' will not match — use exact abbreviations only."
+          "description": "Exact lipid abbreviation used in lipidomics (e.g., 'DHA', 'EPA', 'PC 16:0/18:1', 'SM 34:1'). Class names like 'ceramide' will not match \u2014 use exact abbreviations only."
         },
         "output_item": {
           "type": "string",
@@ -129,13 +180,48 @@
         {
           "type": "object",
           "properties": {
-            "lm_id": {"type": ["string", "null"]},
-            "name": {"type": ["string", "null"]},
-            "formula": {"type": ["string", "null"]},
-            "exactmass": {"type": ["string", "null"]},
-            "smiles": {"type": ["string", "null"]},
-            "core": {"type": ["string", "null"]},
-            "abbrev": {"type": ["string", "null"]}
+            "lm_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "formula": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "exactmass": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "smiles": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "core": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "abbrev": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           }
         },
         {
@@ -143,10 +229,30 @@
           "items": {
             "type": "object",
             "properties": {
-              "lm_id": {"type": ["string", "null"]},
-              "name": {"type": ["string", "null"]},
-              "formula": {"type": ["string", "null"]},
-              "abbrev": {"type": ["string", "null"]}
+              "lm_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "formula": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "abbrev": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
           }
         }
@@ -302,7 +408,14 @@
         "xref_type": {
           "type": "string",
           "description": "Namespace of input_value. One of: 'kegg_id', 'hmdb_id', 'chebi_id', 'pubchem_cid', 'inchi_key', 'abbrev_chains'.",
-          "enum": ["kegg_id", "hmdb_id", "chebi_id", "pubchem_cid", "inchi_key", "abbrev_chains"],
+          "enum": [
+            "kegg_id",
+            "hmdb_id",
+            "chebi_id",
+            "pubchem_cid",
+            "inchi_key",
+            "abbrev_chains"
+          ],
           "default": "kegg_id"
         },
         "output_item": {
@@ -311,7 +424,9 @@
           "default": "all"
         }
       },
-      "required": ["input_value"]
+      "required": [
+        "input_value"
+      ]
     },
     "fields": {
       "context": "compound",
@@ -335,24 +450,28 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": ["object", "array"],
-              "description": "LMSD record (single object) or list of records with lm_id, name, formula, exactmass, and cross-references (kegg_id, hmdb_id, chebi_id, pubchem_cid)."
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["status", "data"]
+          "type": [
+            "object",
+            "array"
+          ],
+          "description": "LMSD record (single object) or list of records with lm_id, name, formula, exactmass, and cross-references (kegg_id, hmdb_id, chebi_id, pubchem_cid).",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/marine_regions_tools.json
+++ b/src/tooluniverse/data/marine_regions_tools.json
@@ -218,16 +218,16 @@
             "preferredGazetteerNameLang": {
               "type": "string"
             },
-            "status": {
-              "type": "string"
-            },
             "accepted": {
               "type": [
                 "integer",
                 "null"
               ]
             }
-          }
+          },
+          "required": [
+            "MRGID"
+          ]
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/marrvel_tools.json
+++ b/src/tooluniverse/data/marrvel_tools.json
@@ -1,34 +1,109 @@
 [
-    {
-        "name": "MARRVEL_get_gene",
-        "description": "Get aggregated identity and annotation for a human gene by symbol from MARRVEL: cross-references (OMIM, HGNC, Ensembl, Entrez, UniProt), chromosome/cytogenetic location, gene type, aliases, previous symbols, and the Entrez gene summary. Use as a one-call gene-identity resolver in rare-disease / Mendelian variant triage workflows. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "symbol": {"type": "string", "description": "HGNC gene symbol, e.g. 'CFTR', 'BRCA1'."}
-        }, "required": ["symbol"]},
-        "fields": {"timeout": 30},
-        "type": "MARRVELGeneTool",
-        "test_examples": [{"symbol": "CFTR"}, {"symbol": "BRCA1"}, {"symbol": "TP53"}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Aggregated gene record", "properties": {
-                "status": {"type": "string"}, "data": {"type": "object"}, "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+  {
+    "name": "MARRVEL_get_gene",
+    "description": "Get aggregated identity and annotation for a human gene by symbol from MARRVEL: cross-references (OMIM, HGNC, Ensembl, Entrez, UniProt), chromosome/cytogenetic location, gene type, aliases, previous symbols, and the Entrez gene summary. Use as a one-call gene-identity resolver in rare-disease / Mendelian variant triage workflows. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "description": "HGNC gene symbol, e.g. 'CFTR', 'BRCA1'."
+        }
+      },
+      "required": [
+        "symbol"
+      ]
     },
-    {
-        "name": "MARRVEL_get_omim_phenotypes",
-        "description": "Get OMIM phenotype/disease associations for a human gene by symbol via MARRVEL: each association's phenotype name, gene and phenotype MIM numbers, mode of inheritance, and phenotypic series. Use to enumerate the Mendelian diseases linked to a gene and their inheritance patterns. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "symbol": {"type": "string", "description": "HGNC gene symbol, e.g. 'CFTR', 'BRCA1'."}
-        }, "required": ["symbol"]},
-        "fields": {"timeout": 30},
-        "type": "MARRVELOmimTool",
-        "test_examples": [{"symbol": "CFTR"}, {"symbol": "FBN1"}, {"symbol": "LMNA"}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "OMIM phenotype list", "properties": {
-                "status": {"type": "string"}, "data": {"type": "array", "items": {"type": "object"}}, "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+    "fields": {
+      "timeout": 30
+    },
+    "type": "MARRVELGeneTool",
+    "test_examples": [
+      {
+        "symbol": "CFTR"
+      },
+      {
+        "symbol": "BRCA1"
+      },
+      {
+        "symbol": "TP53"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
     }
+  },
+  {
+    "name": "MARRVEL_get_omim_phenotypes",
+    "description": "Get OMIM phenotype/disease associations for a human gene by symbol via MARRVEL: each association's phenotype name, gene and phenotype MIM numbers, mode of inheritance, and phenotypic series. Use to enumerate the Mendelian diseases linked to a gene and their inheritance patterns. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "description": "HGNC gene symbol, e.g. 'CFTR', 'BRCA1'."
+        }
+      },
+      "required": [
+        "symbol"
+      ]
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "MARRVELOmimTool",
+    "test_examples": [
+      {
+        "symbol": "CFTR"
+      },
+      {
+        "symbol": "FBN1"
+      },
+      {
+        "symbol": "LMNA"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/massbank_tools.json
+++ b/src/tooluniverse/data/massbank_tools.json
@@ -254,43 +254,25 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "description": "Ranked library matches, highest cosine score first",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "accession": {
-                    "type": "string",
-                    "description": "MassBank record accession (e.g., MSBNK-BAFG-CSL2311094669). Resolve full record with MassBank_get_record_by_accession."
-                  },
-                  "score": {
-                    "type": "number",
-                    "description": "Cosine similarity score in [0,1]; 1.0 = identical spectrum"
-                  }
-                }
+          "type": "array",
+          "description": "Ranked library matches, highest cosine score first",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession": {
+                "type": "string",
+                "description": "MassBank record accession (e.g., MSBNK-BAFG-CSL2311094669). Resolve full record with MassBank_get_record_by_accession."
+              },
+              "score": {
+                "type": "number",
+                "description": "Cosine similarity score in [0,1]; 1.0 = identical spectrum"
               }
-            },
-            "count": {
-              "type": "integer"
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
@@ -333,81 +315,69 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Full MassBank spectrum record",
           "properties": {
-            "status": {
+            "accession": {
               "type": "string"
             },
-            "data": {
+            "title": {
+              "type": "string",
+              "description": "Spectrum title with compound, instrument, MS level, collision energy and precursor type"
+            },
+            "compound": {
               "type": "object",
-              "description": "Full MassBank spectrum record",
               "properties": {
-                "accession": {
+                "names": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "formula": {
                   "type": "string"
                 },
-                "title": {
-                  "type": "string",
-                  "description": "Spectrum title with compound, instrument, MS level, collision energy and precursor type"
+                "mass": {
+                  "type": "number"
                 },
-                "compound": {
-                  "type": "object",
-                  "properties": {
-                    "names": {
-                      "type": "array",
-                      "items": {
+                "smiles": {
+                  "type": "string"
+                },
+                "inchi": {
+                  "type": "string"
+                },
+                "link": {
+                  "type": "array",
+                  "description": "External DB cross-references (CAS, CHEBI, KEGG, PubChem)",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "database": {
                         "type": "string"
-                      }
-                    },
-                    "formula": {
-                      "type": "string"
-                    },
-                    "mass": {
-                      "type": "number"
-                    },
-                    "smiles": {
-                      "type": "string"
-                    },
-                    "inchi": {
-                      "type": "string"
-                    },
-                    "link": {
-                      "type": "array",
-                      "description": "External DB cross-references (CAS, CHEBI, KEGG, PubChem)",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "database": {
-                            "type": "string"
-                          },
-                          "identifier": {
-                            "type": "string"
-                          }
-                        }
+                      },
+                      "identifier": {
+                        "type": "string"
                       }
                     }
                   }
-                },
-                "acquisition": {
-                  "type": "object",
-                  "description": "Instrument and MS acquisition parameters"
-                },
-                "peak": {
-                  "type": "object",
-                  "description": "Spectral peaks with SPLASH hash"
                 }
               }
+            },
+            "acquisition": {
+              "type": "object",
+              "description": "Instrument and MS acquisition parameters"
+            },
+            "peak": {
+              "type": "object",
+              "description": "Spectral peaks with SPLASH hash"
             }
           },
           "required": [
-            "status",
-            "data"
+            "accession"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
@@ -519,39 +489,21 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "description": "Matching MassBank records (filtered set)",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "accession": {
-                    "type": "string",
-                    "description": "MassBank record accession. Resolve full record with MassBank_get_record_by_accession."
-                  }
-                }
+          "type": "array",
+          "description": "Matching MassBank records (filtered set)",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession": {
+                "type": "string",
+                "description": "MassBank record accession. Resolve full record with MassBank_get_record_by_accession."
               }
-            },
-            "count": {
-              "type": "integer"
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/massive_tools.json
+++ b/src/tooluniverse/data/massive_tools.json
@@ -1,195 +1,346 @@
 [
-    {
-        "name": "MassIVE_search_datasets",
-        "description": "Search the MassIVE proteomics repository for mass spectrometry datasets. MassIVE hosts thousands of proteomics datasets accessible via the ProXI standard API. Returns dataset accessions, titles, species, instruments, and keywords. Optionally filter by NCBI taxonomy ID for species.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "page_size": {
-                    "type": "integer",
-                    "default": 10,
-                    "description": "Number of results to return (max 100)"
-                },
-                "species": {
-                    "type": ["string", "null"],
-                    "description": "NCBI taxonomy ID to filter by species (e.g., '9606' for human, '10090' for mouse)"
-                }
-            },
-            "required": []
+  {
+    "name": "MassIVE_search_datasets",
+    "description": "Search the MassIVE proteomics repository for mass spectrometry datasets. MassIVE hosts thousands of proteomics datasets accessible via the ProXI standard API. Returns dataset accessions, titles, species, instruments, and keywords. Optionally filter by NCBI taxonomy ID for species.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "page_size": {
+          "type": "integer",
+          "default": 10,
+          "description": "Number of results to return (max 100)"
         },
-        "fields": {
-            "operation": "search_datasets"
-        },
-        "type": "MassIVETool",
-        "test_examples": [
-            {
-                "page_size": 3
-            },
-            {
-                "page_size": 3,
-                "species": "9606"
-            }
-        ],
-        "return_schema": {
+        "species": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "NCBI taxonomy ID to filter by species (e.g., '9606' for human, '10090' for mouse)"
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "operation": "search_datasets"
+    },
+    "type": "MassIVETool",
+    "test_examples": [
+      {
+        "page_size": 3
+      },
+      {
+        "page_size": 3,
+        "species": "9606"
+      }
+    ],
+    "return_schema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "accessions": {
             "type": "array",
             "items": {
+              "type": "string"
+            }
+          },
+          "title": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "species": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "instruments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "label": [
+      "MassIVE",
+      "Proteomics",
+      "Datasets"
+    ],
+    "metadata": {
+      "tags": [
+        "proteomics",
+        "mass_spectrometry",
+        "datasets",
+        "repository"
+      ],
+      "estimated_execution_time": "3-5 seconds"
+    }
+  },
+  {
+    "name": "MassIVE_get_dataset",
+    "description": "Get detailed information about a specific MassIVE proteomics dataset by its accession number (MSV or PXD format). Returns title, summary, species, instruments, keywords, contacts, publications, and post-translational modifications.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "MassIVE dataset accession (e.g., 'MSV000079514') or ProteomeXchange accession (e.g., 'PXD003971')"
+        }
+      },
+      "required": [
+        "accession"
+      ]
+    },
+    "fields": {
+      "operation": "get_dataset"
+    },
+    "type": "MassIVETool",
+    "test_examples": [
+      {
+        "accession": "MSV000079514"
+      }
+    ],
+    "return_schema": {
+      "type": "object",
+      "properties": {
+        "accessions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "title": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "species": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "instruments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "contacts": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "publications": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "modifications": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "label": [
+      "MassIVE",
+      "Proteomics",
+      "Dataset Detail"
+    ],
+    "metadata": {
+      "tags": [
+        "proteomics",
+        "mass_spectrometry",
+        "dataset_detail",
+        "repository"
+      ],
+      "estimated_execution_time": "3-5 seconds"
+    }
+  },
+  {
+    "name": "MassIVE_get_protein_identifications",
+    "description": "Identification-level access to MassIVE datasets via the ProXI standard API. MassIVE's other tools return only dataset metadata; this tool exposes the actual protein identifications. Three modes: (1) per-dataset protein summaries - pass 'accession' (e.g. 'PXD000561') to get identified proteins with countPSM/countPeptides/countPeptidoforms/countDatasets; (2) cross-dataset protein lookup - pass 'protein_accession' (e.g. 'A2M_MOUSE') to find how many MassIVE datasets identified a protein; (3) peptide-spectrum matches - set result_type='psms' with a dataset 'accession' to get PSMs (peptide sequence + charge). Returns a structured success/error envelope.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "accession": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Dataset accession (ProteomeXchange PXD or MassIVE MSV, e.g. 'PXD000561'). Required for per-dataset protein summaries and for PSM lookups."
+        },
+        "protein_accession": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Protein accession for a cross-dataset lookup (e.g. 'A2M_MOUSE', 'A2MP_MOUSE'). Returns the count of MassIVE datasets that identified this protein."
+        },
+        "result_type": {
+          "type": "string",
+          "enum": [
+            "proteins",
+            "psms"
+          ],
+          "default": "proteins",
+          "description": "'proteins' (default) for protein identification summaries, or 'psms' for peptide-spectrum matches (use with a dataset 'accession')."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "operation": "get_protein_identifications"
+    },
+    "type": "MassIVETool",
+    "test_examples": [
+      {
+        "accession": "PXD000561"
+      },
+      {
+        "protein_accession": "A2M_MOUSE"
+      },
+      {
+        "accession": "PXD000561",
+        "result_type": "psms"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "result_type": {
+              "type": "string",
+              "enum": [
+                "proteins",
+                "psms"
+              ]
+            },
+            "accession": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "protein_accession": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "count": {
+              "type": "integer"
+            },
+            "proteins": {
+              "type": "array",
+              "items": {
                 "type": "object",
                 "properties": {
-                    "accessions": {"type": "array", "items": {"type": "string"}},
-                    "title": {"type": "string"},
-                    "summary": {"type": "string"},
-                    "species": {"type": "array", "items": {"type": "string"}},
-                    "instruments": {"type": "array", "items": {"type": "string"}},
-                    "keywords": {"type": "array", "items": {"type": "string"}}
+                  "proteinAccession": {
+                    "type": "string"
+                  },
+                  "countPSM": {
+                    "type": [
+                      "integer",
+                      "string"
+                    ]
+                  },
+                  "countPeptides": {
+                    "type": [
+                      "integer",
+                      "string"
+                    ]
+                  },
+                  "countPeptidoforms": {
+                    "type": [
+                      "integer",
+                      "string"
+                    ]
+                  },
+                  "countDatasets": {
+                    "type": [
+                      "integer",
+                      "string"
+                    ]
+                  }
                 }
+              }
+            },
+            "psms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "peptideSequence": {
+                    "type": "string"
+                  },
+                  "charge": {
+                    "type": [
+                      "integer",
+                      "string"
+                    ]
+                  },
+                  "usi": {
+                    "type": "string"
+                  }
+                }
+              }
             }
+          },
+          "required": [
+            "result_type",
+            "count"
+          ]
         },
-        "label": ["MassIVE", "Proteomics", "Datasets"],
-        "metadata": {
-            "tags": ["proteomics", "mass_spectrometry", "datasets", "repository"],
-            "estimated_execution_time": "3-5 seconds"
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     },
-    {
-        "name": "MassIVE_get_dataset",
-        "description": "Get detailed information about a specific MassIVE proteomics dataset by its accession number (MSV or PXD format). Returns title, summary, species, instruments, keywords, contacts, publications, and post-translational modifications.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "accession": {
-                    "type": "string",
-                    "description": "MassIVE dataset accession (e.g., 'MSV000079514') or ProteomeXchange accession (e.g., 'PXD003971')"
-                }
-            },
-            "required": ["accession"]
-        },
-        "fields": {
-            "operation": "get_dataset"
-        },
-        "type": "MassIVETool",
-        "test_examples": [
-            {
-                "accession": "MSV000079514"
-            }
-        ],
-        "return_schema": {
-            "type": "object",
-            "properties": {
-                "accessions": {"type": "array", "items": {"type": "string"}},
-                "title": {"type": "string"},
-                "summary": {"type": "string"},
-                "species": {"type": "array", "items": {"type": "string"}},
-                "instruments": {"type": "array", "items": {"type": "string"}},
-                "keywords": {"type": "array", "items": {"type": "string"}},
-                "contacts": {"type": "array", "items": {"type": "object"}},
-                "publications": {"type": "array", "items": {"type": "object"}},
-                "modifications": {"type": "array", "items": {"type": "string"}}
-            }
-        },
-        "label": ["MassIVE", "Proteomics", "Dataset Detail"],
-        "metadata": {
-            "tags": ["proteomics", "mass_spectrometry", "dataset_detail", "repository"],
-            "estimated_execution_time": "3-5 seconds"
-        }
-    },
-    {
-        "name": "MassIVE_get_protein_identifications",
-        "description": "Identification-level access to MassIVE datasets via the ProXI standard API. MassIVE's other tools return only dataset metadata; this tool exposes the actual protein identifications. Three modes: (1) per-dataset protein summaries - pass 'accession' (e.g. 'PXD000561') to get identified proteins with countPSM/countPeptides/countPeptidoforms/countDatasets; (2) cross-dataset protein lookup - pass 'protein_accession' (e.g. 'A2M_MOUSE') to find how many MassIVE datasets identified a protein; (3) peptide-spectrum matches - set result_type='psms' with a dataset 'accession' to get PSMs (peptide sequence + charge). Returns a structured success/error envelope.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "accession": {
-                    "type": ["string", "null"],
-                    "description": "Dataset accession (ProteomeXchange PXD or MassIVE MSV, e.g. 'PXD000561'). Required for per-dataset protein summaries and for PSM lookups."
-                },
-                "protein_accession": {
-                    "type": ["string", "null"],
-                    "description": "Protein accession for a cross-dataset lookup (e.g. 'A2M_MOUSE', 'A2MP_MOUSE'). Returns the count of MassIVE datasets that identified this protein."
-                },
-                "result_type": {
-                    "type": "string",
-                    "enum": ["proteins", "psms"],
-                    "default": "proteins",
-                    "description": "'proteins' (default) for protein identification summaries, or 'psms' for peptide-spectrum matches (use with a dataset 'accession')."
-                }
-            },
-            "required": []
-        },
-        "fields": {
-            "operation": "get_protein_identifications"
-        },
-        "type": "MassIVETool",
-        "test_examples": [
-            {
-                "accession": "PXD000561"
-            },
-            {
-                "protein_accession": "A2M_MOUSE"
-            },
-            {
-                "accession": "PXD000561",
-                "result_type": "psms"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "description": "Successful identification-level lookup.",
-                    "properties": {
-                        "status": {"type": "string", "enum": ["success"]},
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "result_type": {"type": "string", "enum": ["proteins", "psms"]},
-                                "accession": {"type": ["string", "null"]},
-                                "protein_accession": {"type": ["string", "null"]},
-                                "count": {"type": "integer"},
-                                "proteins": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "proteinAccession": {"type": "string"},
-                                            "countPSM": {"type": ["integer", "string"]},
-                                            "countPeptides": {"type": ["integer", "string"]},
-                                            "countPeptidoforms": {"type": ["integer", "string"]},
-                                            "countDatasets": {"type": ["integer", "string"]}
-                                        }
-                                    }
-                                },
-                                "psms": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "peptideSequence": {"type": "string"},
-                                            "charge": {"type": ["integer", "string"]},
-                                            "usi": {"type": "string"}
-                                        }
-                                    }
-                                }
-                            },
-                            "required": ["result_type", "count"]
-                        }
-                    },
-                    "required": ["status", "data"]
-                },
-                {
-                    "type": "object",
-                    "description": "Error envelope returned on failure.",
-                    "properties": {
-                        "status": {"type": "string", "enum": ["error"]},
-                        "error": {"type": "string"}
-                    },
-                    "required": ["status", "error"]
-                }
-            ]
-        },
-        "label": ["MassIVE", "Proteomics", "Protein Identifications"],
-        "metadata": {
-            "tags": ["proteomics", "mass_spectrometry", "protein_identification", "psm", "repository"],
-            "estimated_execution_time": "3-5 seconds"
-        }
+    "label": [
+      "MassIVE",
+      "Proteomics",
+      "Protein Identifications"
+    ],
+    "metadata": {
+      "tags": [
+        "proteomics",
+        "mass_spectrometry",
+        "protein_identification",
+        "psm",
+        "repository"
+      ],
+      "estimated_execution_time": "3-5 seconds"
     }
+  }
 ]

--- a/src/tooluniverse/data/mavedb_tools.json
+++ b/src/tooluniverse/data/mavedb_tools.json
@@ -15,7 +15,9 @@
           "default": 20
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "fields": {
       "operation": "search"
@@ -35,11 +37,36 @@
       "items": {
         "type": "object",
         "properties": {
-          "urn": {"type": ["string", "null"]},
-          "title": {"type": ["string", "null"]},
-          "short_description": {"type": ["string", "null"]},
-          "num_variants": {"type": ["integer", "null"]},
-          "published_date": {"type": ["string", "null"]}
+          "urn": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "short_description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "num_variants": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "published_date": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
       }
     }
@@ -55,7 +82,9 @@
           "description": "MaveDB score set URN (e.g., 'urn:mavedb:00000001-a-1'). Obtain URNs from MaveDB_search_score_sets."
         }
       },
-      "required": ["urn"]
+      "required": [
+        "urn"
+      ]
     },
     "fields": {
       "operation": "get_score_set"
@@ -72,39 +101,107 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "urn": {"type": ["string", "null"]},
-        "title": {"type": ["string", "null"]},
-        "short_description": {"type": ["string", "null"]},
-        "abstract": {"type": ["string", "null"]},
-        "method": {"type": ["string", "null"]},
-        "num_variants": {"type": ["integer", "null"]},
-        "published_date": {"type": ["string", "null"]},
-        "license": {"type": ["string", "null"]},
+        "urn": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "short_description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "abstract": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "method": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "num_variants": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "published_date": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "license": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "target_genes": {
-          "type": ["array", "null"],
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "type": "object",
             "properties": {
-              "name": {"type": ["string", "null"]},
-              "category": {"type": ["string", "null"]},
-              "uniprot_id": {"type": ["string", "null"]}
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "category": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uniprot_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
           }
         },
         "doi_identifiers": {
-          "type": ["array", "null"],
-          "items": {"type": "string"}
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         },
         "primary_publications": {
-          "type": ["array", "null"],
-          "items": {"type": "string"}
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       }
     }
   },
   {
     "name": "MaveDB_get_variant_scores",
-    "description": "Get functional variant effect scores from a MaveDB score set. Returns HGVS-annotated variants with their functional scores from deep mutational scanning or other MAVE assays. Scores indicate variant effect on protein function (interpretation depends on the specific assay - check score set metadata). Optionally filter by HGVS protein notation (e.g., 'Arg175' to find all R175 substitutions). The /scores endpoint returns every variant in one CSV; `limit` is client-side truncation only — set `limit=0` (or omit) to receive ALL variants in one call (use this for whole-protein DMS analyses, e.g. KRAS folding ΔΔG has ~2200 variants).",
+    "description": "Get functional variant effect scores from a MaveDB score set. Returns HGVS-annotated variants with their functional scores from deep mutational scanning or other MAVE assays. Scores indicate variant effect on protein function (interpretation depends on the specific assay - check score set metadata). Optionally filter by HGVS protein notation (e.g., 'Arg175' to find all R175 substitutions). The /scores endpoint returns every variant in one CSV; `limit` is client-side truncation only \u2014 set `limit=0` (or omit) to receive ALL variants in one call (use this for whole-protein DMS analyses, e.g. KRAS folding \u0394\u0394G has ~2200 variants).",
     "parameter": {
       "type": "object",
       "properties": {
@@ -117,12 +214,17 @@
           "description": "Optional filter: HGVS protein notation substring (e.g., 'Arg175', 'p.Arg175His'). Case-insensitive partial match on protein-level HGVS."
         },
         "limit": {
-          "type": ["integer", "null"],
-          "description": "Maximum variants to return after client-side filtering. Set to 0 or null to return all variants in the score set (default — needed for whole-protein DMS workflows). Set to a positive integer to truncate. The MaveDB API returns the full CSV in one HTTP call regardless, so 'unlimited' has no extra cost.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Maximum variants to return after client-side filtering. Set to 0 or null to return all variants in the score set (default \u2014 needed for whole-protein DMS workflows). Set to a positive integer to truncate. The MaveDB API returns the full CSV in one HTTP call regardless, so 'unlimited' has no extra cost.",
           "default": 0
         }
       },
-      "required": ["urn"]
+      "required": [
+        "urn"
+      ]
     },
     "fields": {
       "operation": "get_variant_scores"
@@ -142,21 +244,59 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "urn": {"type": "string"},
-        "total_variants_in_set": {"type": "integer"},
-        "returned": {"type": "integer"},
-        "truncated": {"type": "boolean"},
-        "limit_applied": {"type": ["integer", "null"]},
-        "hgvs_filter": {"type": ["string", "null"]},
+        "urn": {
+          "type": "string"
+        },
+        "total_variants_in_set": {
+          "type": "integer"
+        },
+        "returned": {
+          "type": "integer"
+        },
+        "truncated": {
+          "type": "boolean"
+        },
+        "limit_applied": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "hgvs_filter": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "variants": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "hgvs_nt": {"type": ["string", "null"]},
-              "hgvs_splice": {"type": ["string", "null"]},
-              "hgvs_pro": {"type": ["string", "null"]},
-              "score": {"type": ["number", "null"]}
+              "hgvs_nt": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "hgvs_splice": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "hgvs_pro": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "score": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
             }
           }
         }
@@ -174,7 +314,9 @@
           "description": "Search query: gene symbol (e.g., 'TP53', 'BRCA1'), protein name, or keywords describing the experiment."
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "fields": {
       "operation": "search_experiments"
@@ -191,30 +333,73 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "query": {"type": "string"},
-        "total_experiments": {"type": "integer"},
+        "query": {
+          "type": "string"
+        },
+        "total_experiments": {
+          "type": "integer"
+        },
         "experiments": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "urn": {"type": ["string", "null"]},
-              "title": {"type": ["string", "null"]},
-              "short_description": {"type": ["string", "null"]},
-              "published_date": {"type": ["string", "null"]},
+              "urn": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "title": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "short_description": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "published_date": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "score_set_urns": {
                 "type": "array",
-                "items": {"type": "string"}
+                "items": {
+                  "type": "string"
+                }
               },
-              "num_score_sets": {"type": "integer"},
+              "num_score_sets": {
+                "type": "integer"
+              },
               "publications": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "identifier": {"type": ["string", "null"]},
-                    "db_name": {"type": ["string", "null"]},
-                    "title": {"type": ["string", "null"]}
+                    "identifier": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "db_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "title": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
                   }
                 }
               }
@@ -226,7 +411,7 @@
   },
   {
     "name": "MaveDB_get_effect_matrix",
-    "description": "One-shot DMS data loader: fetch a MaveDB score set, parse HGVS to (ref_aa, position, alt_aa), filter to single missense, optionally verify position numbering against a UniProt canonical sequence, and reshape into a (20 amino acids × n_positions) effect matrix ready for downstream analysis. Hides the boilerplate that variant-effect-prediction benchmarking and residue-mechanism interpretation skills used to inline. Returns the matrix, the position list, the standard amino acid order, and explicit numbering / drop / score-field metadata so the caller can audit what was loaded.",
+    "description": "One-shot DMS data loader: fetch a MaveDB score set, parse HGVS to (ref_aa, position, alt_aa), filter to single missense, optionally verify position numbering against a UniProt canonical sequence, and reshape into a (20 amino acids \u00d7 n_positions) effect matrix ready for downstream analysis. Hides the boilerplate that variant-effect-prediction benchmarking and residue-mechanism interpretation skills used to inline. Returns the matrix, the position list, the standard amino acid order, and explicit numbering / drop / score-field metadata so the caller can audit what was loaded.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -235,15 +420,23 @@
           "description": "MaveDB score set URN (e.g., 'urn:mavedb:00000115-a-7'). Obtain from MaveDB_search_score_sets."
         },
         "uniprot_id": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional UniProt accession (e.g., 'P01116' for KRAS). If supplied, the tool fetches the canonical sequence and verifies the MaveDB position numbering against it via a landmark check; sets numbering_offset and surfaces a warning in numbering_check if the positions don't match (silent off-by-N is the #1 silent bug in DMS analysis)."
         },
         "score_field": {
-          "type": ["string", "null"],
-          "description": "Optional explicit column name to use as the variant score (e.g., 'score', 'ddG', 'fitness'). If omitted, tries 'score' → 'ddG' → 'fitness' → first numeric non-HGVS field in that order. The actual field used is reported in data.score_field_used."
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional explicit column name to use as the variant score (e.g., 'score', 'ddG', 'fitness'). If omitted, tries 'score' \u2192 'ddG' \u2192 'fitness' \u2192 first numeric non-HGVS field in that order. The actual field used is reported in data.score_field_used."
         }
       },
-      "required": ["urn"]
+      "required": [
+        "urn"
+      ]
     },
     "fields": {
       "operation": "get_effect_matrix"
@@ -260,52 +453,83 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "properties": {
-                "urn": {"type": "string"},
-                "matrix": {
-                  "type": "array",
-                  "description": "(20 × n_positions) effect matrix. Rows = 20 standard amino acids in 'ACDEFGHIKLMNPQRSTVWY' order. Cells = score for that (alt_aa, position) variant, or null for unmeasured / WT-diagonal.",
-                  "items": {
-                    "type": "array",
-                    "items": {"type": ["number", "null"]}
-                  }
-                },
-                "positions": {
-                  "type": "array",
-                  "description": "Sorted list of 1-based residue positions (length = matrix's column count).",
-                  "items": {"type": "integer"}
-                },
-                "amino_acid_order": {
-                  "type": "string",
-                  "description": "Always 'ACDEFGHIKLMNPQRSTVWY' for consistency across downstream skills."
-                },
-                "shape": {
-                  "type": "array",
-                  "items": {"type": "integer"}
-                },
-                "n_parsed_single_missense": {"type": "integer"},
-                "n_dropped": {"type": "integer"},
-                "n_total_rows": {"type": "integer"},
-                "score_field_used": {"type": ["string", "null"]},
-                "numbering_check": {"type": ["object", "null"]},
-                "numbering_offset": {"type": ["integer", "null"]}
-              },
-              "required": ["matrix", "positions", "amino_acid_order"]
+            "urn": {
+              "type": "string"
             },
-            "metadata": {"type": "object"}
+            "matrix": {
+              "type": "array",
+              "description": "(20 \u00d7 n_positions) effect matrix. Rows = 20 standard amino acids in 'ACDEFGHIKLMNPQRSTVWY' order. Cells = score for that (alt_aa, position) variant, or null for unmeasured / WT-diagonal.",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "positions": {
+              "type": "array",
+              "description": "Sorted list of 1-based residue positions (length = matrix's column count).",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "amino_acid_order": {
+              "type": "string",
+              "description": "Always 'ACDEFGHIKLMNPQRSTVWY' for consistency across downstream skills."
+            },
+            "shape": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "n_parsed_single_missense": {
+              "type": "integer"
+            },
+            "n_dropped": {
+              "type": "integer"
+            },
+            "n_total_rows": {
+              "type": "integer"
+            },
+            "score_field_used": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "numbering_check": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "numbering_offset": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
           },
-          "required": ["status", "data"]
+          "required": [
+            "matrix",
+            "positions",
+            "amino_acid_order"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -321,12 +545,17 @@
           "description": "MaveDB score set URN (e.g., 'urn:mavedb:00001263-a-2' for BRCA2 SGE). Obtain from MaveDB_search_score_sets."
         },
         "limit": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum number of mapped variants to return (client-side truncation). Set to 0 or null to return all (the API returns the full list in one call).",
           "default": 0
         }
       },
-      "required": ["urn"]
+      "required": [
+        "urn"
+      ]
     },
     "fields": {
       "operation": "get_mapped_variants"
@@ -343,57 +572,143 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "properties": {
-                "urn": {"type": "string"},
-                "total_mapped_variants": {"type": "integer"},
-                "returned": {"type": "integer"},
-                "truncated": {"type": "boolean"},
-                "n_with_genomic_location": {"type": "integer"},
-                "n_with_clingen_allele_id": {"type": "integer"},
-                "mapped_variants": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
+            "urn": {
+              "type": "string"
+            },
+            "total_mapped_variants": {
+              "type": "integer"
+            },
+            "returned": {
+              "type": "integer"
+            },
+            "truncated": {
+              "type": "boolean"
+            },
+            "n_with_genomic_location": {
+              "type": "integer"
+            },
+            "n_with_clingen_allele_id": {
+              "type": "integer"
+            },
+            "mapped_variants": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "variant_urn": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clingen_allele_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "alignment_level": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "vrs_version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "current": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "error_message": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "post_mapped": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
                     "properties": {
-                      "variant_urn": {"type": ["string", "null"]},
-                      "clingen_allele_id": {"type": ["string", "null"]},
-                      "alignment_level": {"type": ["string", "null"]},
-                      "vrs_version": {"type": ["string", "null"]},
-                      "current": {"type": ["boolean", "null"]},
-                      "error_message": {"type": ["string", "null"]},
-                      "post_mapped": {
-                        "type": ["object", "null"],
-                        "properties": {
-                          "vrs_id": {"type": ["string", "null"]},
-                          "sequence_reference_label": {"type": ["string", "null"]},
-                          "refget_accession": {"type": ["string", "null"]},
-                          "start": {"type": ["integer", "null"]},
-                          "end": {"type": ["integer", "null"]},
-                          "state_sequence": {"type": ["string", "null"]},
-                          "hgvs_expressions": {"type": ["array", "null"], "items": {"type": "string"}}
-                        }
+                      "vrs_id": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
-                      "pre_mapped": {"type": ["object", "null"]}
+                      "sequence_reference_label": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "refget_accession": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "start": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "end": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "state_sequence": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "hgvs_expressions": {
+                        "type": [
+                          "array",
+                          "null"
+                        ],
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     }
+                  },
+                  "pre_mapped": {
+                    "type": [
+                      "object",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": ["urn", "mapped_variants"]
-            },
-            "metadata": {"type": "object"}
+              }
+            }
           },
-          "required": ["status", "data"]
+          "required": [
+            "urn",
+            "mapped_variants"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -409,16 +724,24 @@
           "description": "MaveDB score set URN (e.g., 'urn:mavedb:00001263-a-2' for BRCA2 SGE). Obtain from MaveDB_search_score_sets."
         },
         "clinical_significance": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional exact-match filter on ClinVar clinical significance (case-insensitive), e.g. 'Pathogenic', 'Benign', 'Uncertain significance'."
         },
         "limit": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum number of clinical controls to return (client-side truncation). Set to 0 or null to return all.",
           "default": 0
         }
       },
-      "required": ["urn"]
+      "required": [
+        "urn"
+      ]
     },
     "fields": {
       "operation": "get_clinical_controls"
@@ -440,45 +763,93 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "properties": {
-                "urn": {"type": "string"},
-                "total_clinical_controls": {"type": "integer"},
-                "returned": {"type": "integer"},
-                "truncated": {"type": "boolean"},
-                "significance_filter": {"type": ["string", "null"]},
-                "significance_breakdown": {"type": "object"},
-                "clinical_controls": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "db_name": {"type": ["string", "null"]},
-                      "db_identifier": {"type": ["string", "null"]},
-                      "db_version": {"type": ["string", "null"]},
-                      "gene_symbol": {"type": ["string", "null"]},
-                      "clinical_significance": {"type": ["string", "null"]},
-                      "clinical_review_status": {"type": ["string", "null"]},
-                      "mapped_variant_urns": {"type": "array", "items": {"type": "string"}}
+            "urn": {
+              "type": "string"
+            },
+            "total_clinical_controls": {
+              "type": "integer"
+            },
+            "returned": {
+              "type": "integer"
+            },
+            "truncated": {
+              "type": "boolean"
+            },
+            "significance_filter": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "significance_breakdown": {
+              "type": "object"
+            },
+            "clinical_controls": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "db_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "db_identifier": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "db_version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "gene_symbol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clinical_significance": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clinical_review_status": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "mapped_variant_urns": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
                   }
                 }
-              },
-              "required": ["urn", "clinical_controls"]
-            },
-            "metadata": {"type": "object"}
+              }
+            }
           },
-          "required": ["status", "data"]
+          "required": [
+            "urn",
+            "clinical_controls"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -494,12 +865,17 @@
           "description": "MaveDB score set URN (e.g., 'urn:mavedb:00001263-a-2' for BRCA2 SGE). Obtain from MaveDB_search_score_sets."
         },
         "limit": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum number of gnomAD variants to return (client-side truncation). Set to 0 or null to return all.",
           "default": 0
         }
       },
-      "required": ["urn"]
+      "required": [
+        "urn"
+      ]
     },
     "fields": {
       "operation": "get_gnomad_variants"
@@ -515,46 +891,84 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "properties": {
-                "urn": {"type": "string"},
-                "total_gnomad_variants": {"type": "integer"},
-                "returned": {"type": "integer"},
-                "truncated": {"type": "boolean"},
-                "gnomad_variants": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "db_name": {"type": ["string", "null"]},
-                      "db_identifier": {"type": ["string", "null"]},
-                      "db_version": {"type": ["string", "null"]},
-                      "allele_count": {"type": ["integer", "null"]},
-                      "allele_number": {"type": ["integer", "null"]},
-                      "allele_frequency": {"type": ["number", "null"]},
-                      "mapped_genomic_alleles": {
-                        "type": "array",
-                        "items": {"type": "object"}
-                      }
+            "urn": {
+              "type": "string"
+            },
+            "total_gnomad_variants": {
+              "type": "integer"
+            },
+            "returned": {
+              "type": "integer"
+            },
+            "truncated": {
+              "type": "boolean"
+            },
+            "gnomad_variants": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "db_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "db_identifier": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "db_version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "allele_count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "allele_number": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "allele_frequency": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "mapped_genomic_alleles": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
                     }
                   }
                 }
-              },
-              "required": ["urn", "gnomad_variants"]
-            },
-            "metadata": {"type": "object"}
+              }
+            }
           },
-          "required": ["status", "data"]
+          "required": [
+            "urn",
+            "gnomad_variants"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/mendelian_randomization_tools.json
+++ b/src/tooluniverse/data/mendelian_randomization_tools.json
@@ -5,12 +5,41 @@
     "description": "Two-sample Mendelian randomization causal estimate from harmonized instrument summary statistics (SNP-exposure + SNP-outcome betas and SEs, e.g. from OpenGWAS_get_mr_instruments). Returns IVW (primary), MR-Egger (with directional-pleiotropy intercept), weighted-median estimates, and Cochran's Q / I^2 heterogeneity. Pure-compute (no R, no API key); reimplements TwoSampleMR's core estimators.",
     "parameter": {
       "type": "object",
-      "required": ["beta_exposure", "se_exposure", "beta_outcome", "se_outcome"],
+      "required": [
+        "beta_exposure",
+        "se_exposure",
+        "beta_outcome",
+        "se_outcome"
+      ],
       "properties": {
-        "beta_exposure": {"type": "array", "items": {"type": "number"}, "description": "Per-instrument SNP-exposure effect sizes (harmonized to the same effect allele; non-zero)."},
-        "se_exposure": {"type": "array", "items": {"type": "number"}, "description": "Standard errors of beta_exposure (positive)."},
-        "beta_outcome": {"type": "array", "items": {"type": "number"}, "description": "Per-instrument SNP-outcome effect sizes (same SNP order / effect allele)."},
-        "se_outcome": {"type": "array", "items": {"type": "number"}, "description": "Standard errors of beta_outcome (positive)."}
+        "beta_exposure": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-instrument SNP-exposure effect sizes (harmonized to the same effect allele; non-zero)."
+        },
+        "se_exposure": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Standard errors of beta_exposure (positive)."
+        },
+        "beta_outcome": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-instrument SNP-outcome effect sizes (same SNP order / effect allele)."
+        },
+        "se_outcome": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Standard errors of beta_outcome (positive)."
+        }
       }
     },
     "return_schema": {
@@ -18,39 +47,81 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
+            "n_instruments": {
+              "type": "integer"
+            },
+            "estimates": {
               "type": "object",
               "properties": {
-                "n_instruments": {"type": "integer"},
-                "estimates": {
-                  "type": "object",
-                  "properties": {
-                    "ivw": {"type": "object"},
-                    "mr_egger": {"type": "object"},
-                    "weighted_median": {"type": "object"}
-                  }
+                "ivw": {
+                  "type": "object"
                 },
-                "egger_intercept": {"type": "object"},
-                "heterogeneity": {"type": "object"}
+                "mr_egger": {
+                  "type": "object"
+                },
+                "weighted_median": {
+                  "type": "object"
+                }
               }
+            },
+            "egger_intercept": {
+              "type": "object"
+            },
+            "heterogeneity": {
+              "type": "object"
             }
           },
-          "required": ["data"]
+          "required": [
+            "n_instruments"
+          ]
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "beta_exposure": [0.10, 0.15, 0.08, 0.20, 0.12, 0.18],
-        "se_exposure": [0.02, 0.03, 0.02, 0.03, 0.02, 0.03],
-        "beta_outcome": [0.05, 0.08, 0.03, 0.11, 0.07, 0.09],
-        "se_outcome": [0.02, 0.02, 0.02, 0.03, 0.02, 0.02]
+        "beta_exposure": [
+          0.1,
+          0.15,
+          0.08,
+          0.2,
+          0.12,
+          0.18
+        ],
+        "se_exposure": [
+          0.02,
+          0.03,
+          0.02,
+          0.03,
+          0.02,
+          0.03
+        ],
+        "beta_outcome": [
+          0.05,
+          0.08,
+          0.03,
+          0.11,
+          0.07,
+          0.09
+        ],
+        "se_outcome": [
+          0.02,
+          0.02,
+          0.02,
+          0.03,
+          0.02,
+          0.02
+        ]
       }
     ]
   }

--- a/src/tooluniverse/data/metabolights_tools.json
+++ b/src/tooluniverse/data/metabolights_tools.json
@@ -42,7 +42,7 @@
   {
     "type": "MetaboLightsRESTTool",
     "name": "metabolights_search_studies",
-    "description": "List MetaboLights study IDs. NOTE: The MetaboLights API does not support keyword filtering — the query parameter is accepted but has no effect; all public study IDs are returned regardless of query. To find studies on a specific topic, use metabolights_get_study on individual IDs. Returns all public MetaboLights study accessions (MTBLS###).",
+    "description": "List MetaboLights study IDs. NOTE: The MetaboLights API does not support keyword filtering \u2014 the query parameter is accepted but has no effect; all public study IDs are returned regardless of query. To find studies on a specific topic, use metabolights_get_study on individual IDs. Returns all public MetaboLights study accessions (MTBLS###).",
     "parameter": {
       "type": "object",
       "properties": {
@@ -62,7 +62,9 @@
           "default": 0
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "fields": {
       "endpoint": "https://www.ebi.ac.uk/metabolights/ws/studies",
@@ -98,7 +100,9 @@
           "description": "MetaboLights study ID (e.g., 'MTBLS1')"
         }
       },
-      "required": ["study_id"]
+      "required": [
+        "study_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.ebi.ac.uk/metabolights/ws/studies/{study_id}",
@@ -134,7 +138,9 @@
           "description": "MetaboLights study ID"
         }
       },
-      "required": ["study_id"]
+      "required": [
+        "study_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.ebi.ac.uk/metabolights/ws/studies/{study_id}/assays",
@@ -165,7 +171,9 @@
           "description": "MetaboLights study ID"
         }
       },
-      "required": ["study_id"]
+      "required": [
+        "study_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.ebi.ac.uk/metabolights/ws/studies/{study_id}/samples",
@@ -196,7 +204,9 @@
           "description": "MetaboLights study ID"
         }
       },
-      "required": ["study_id"]
+      "required": [
+        "study_id"
+      ]
     },
     "fields": {
       "endpoint": "https://www.ebi.ac.uk/metabolights/ws/studies/{study_id}/files",
@@ -367,25 +377,28 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": ["object", "array"],
-              "description": "Reference compound record (object) with name, formula, inchi, inchikey, chebiId, metSpecies, hasNMR, hasMS, hasPathways flags; or the full list of MTBLC* accessions (array) when list=true."
-            },
-            "url": {"type": "string"},
-            "count": {"type": "integer"}
-          },
-          "required": ["status", "data"]
+          "type": [
+            "object",
+            "array"
+          ],
+          "description": "Reference compound record (object) with name, formula, inchi, inchikey, chebiId, metSpecies, hasNMR, hasMS, hasPathways flags; or the full list of MTBLC* accessions (array) when list=true.",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/metabolite_tools.json
+++ b/src/tooluniverse/data/metabolite_tools.json
@@ -215,83 +215,88 @@
           "description": "Compound name or molecular formula to search"
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Successful search result",
           "properties": {
-            "status": {
-              "const": "success"
+            "query": {
+              "type": "string",
+              "description": "The search query that was submitted"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string",
-                  "description": "The search query that was submitted"
-                },
-                "results": {
-                  "type": "array",
-                  "description": "Matching compounds from PubChem",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pubchem_cid": {
-                        "type": ["integer", "null"]
-                      },
-                      "name": {
-                        "type": ["string", "null"]
-                      },
-                      "formula": {
-                        "type": ["string", "null"]
-                      },
-                      "molecular_weight": {
-                        "type": ["string", "null"]
-                      },
-                      "smiles": {
-                        "type": ["string", "null"]
-                      }
-                    }
+            "results": {
+              "type": "array",
+              "description": "Matching compounds from PubChem",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pubchem_cid": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "formula": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "molecular_weight": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "smiles": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
-                },
-                "count": {
-                  "type": "integer",
-                  "description": "Number of compounds returned"
-                }
-              },
-              "required": ["query", "results", "count"]
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
                 }
               }
+            },
+            "count": {
+              "type": "integer",
+              "description": "Number of compounds returned"
             }
           },
-          "required": ["status", "data"]
+          "required": [
+            "query",
+            "results",
+            "count"
+          ]
         },
         {
           "type": "object",
-          "description": "Error response",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string",
               "description": "Error message"
             }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
-    "test_examples": [{"query": "glucose"}]
+    "test_examples": [
+      {
+        "query": "glucose"
+      }
+    ]
   },
   {
     "name": "HMDB_get_metabolite",
@@ -319,69 +324,73 @@
       "oneOf": [
         {
           "type": "object",
-          "description": "Compound information",
           "properties": {
-            "status": {
-              "const": "success"
+            "pubchem_cid": {
+              "type": [
+                "integer",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "pubchem_cid": {
-                  "type": ["integer", "null"]
-                },
-                "name": {
-                  "type": ["string", "null"]
-                },
-                "iupac_name": {
-                  "type": ["string", "null"]
-                },
-                "formula": {
-                  "type": ["string", "null"]
-                },
-                "molecular_weight": {
-                  "type": ["string", "null"]
-                },
-                "smiles": {
-                  "type": ["string", "null"]
-                },
-                "inchikey": {
-                  "type": ["string", "null"]
-                }
-              },
-              "required": ["pubchem_cid"]
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "pubchem_url": {
-                  "type": "string"
-                }
-              }
+            "iupac_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "formula": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "molecular_weight": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "smiles": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "inchikey": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
-          "required": ["status", "data"]
+          "required": [
+            "pubchem_cid"
+          ]
         },
         {
           "type": "object",
-          "description": "Error response",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string",
               "description": "Error message"
             }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
-    "test_examples": [{"hmdb_id": "HMDB0000122"}]
+    "test_examples": [
+      {
+        "hmdb_id": "HMDB0000122"
+      }
+    ]
   },
   {
     "name": "HMDB_get_diseases",
@@ -409,91 +418,94 @@
       "oneOf": [
         {
           "type": "object",
-          "description": "Disease associations for the metabolite",
           "properties": {
-            "status": {
-              "const": "success"
+            "identifier": {
+              "type": "string",
+              "description": "The identifier that was submitted"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "identifier": {
-                  "type": "string",
-                  "description": "The identifier that was submitted"
-                },
-                "compound_name": {
-                  "type": "string",
-                  "description": "Canonical compound name resolved via PubChem"
-                },
-                "pubchem_cid": {
-                  "type": ["integer", "null"]
-                },
-                "ctd_query_term": {
-                  "type": "string",
-                  "description": "The name variant used to query CTD"
-                },
-                "disease_count": {
-                  "type": "integer"
-                },
-                "diseases": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "disease_name": {
-                        "type": ["string", "null"]
-                      },
-                      "disease_id": {
-                        "type": ["string", "null"]
-                      },
-                      "disease_categories": {
-                        "type": ["string", "array", "null"]
-                      },
-                      "direct_evidence": {
-                        "type": ["string", "null"]
-                      },
-                      "pubmed_ids": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
+            "compound_name": {
+              "type": "string",
+              "description": "Canonical compound name resolved via PubChem"
+            },
+            "pubchem_cid": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "ctd_query_term": {
+              "type": "string",
+              "description": "The name variant used to query CTD"
+            },
+            "disease_count": {
+              "type": "integer"
+            },
+            "diseases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "disease_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "disease_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "disease_categories": {
+                    "type": [
+                      "string",
+                      "array",
+                      "null"
+                    ]
+                  },
+                  "direct_evidence": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "pubmed_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
                   }
-                }
-              },
-              "required": ["identifier", "compound_name", "disease_count", "diseases"]
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "pubchem_url": {
-                  "type": "string"
                 }
               }
             }
           },
-          "required": ["status", "data"]
+          "required": [
+            "identifier",
+            "compound_name",
+            "disease_count",
+            "diseases"
+          ]
         },
         {
           "type": "object",
-          "description": "Error response",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string",
               "description": "Error message"
             }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
-    "test_examples": [{"hmdb_id": "HMDB0000122", "limit": 5}]
+    "test_examples": [
+      {
+        "hmdb_id": "HMDB0000122",
+        "limit": 5
+      }
+    ]
   }
 ]

--- a/src/tooluniverse/data/metabolomics_workbench_tools.json
+++ b/src/tooluniverse/data/metabolomics_workbench_tools.json
@@ -43,39 +43,21 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": [
-                "array",
-                "string"
-              ]
-            },
-            "metadata": {
-              "type": "object"
-            }
-          }
+          "type": [
+            "array",
+            "string"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -120,70 +102,55 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "name": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "pubchem_cid": {
-                  "type": "string"
-                },
-                "inchi_key": {
-                  "type": "string"
-                },
-                "exactmass": {
-                  "type": "number"
-                },
-                "formula": {
-                  "type": "string"
-                },
-                "super_class": {
-                  "type": "string"
-                },
-                "main_class": {
-                  "type": "string"
-                },
-                "sub_class": {
-                  "type": "string"
-                },
-                "smiles": {
-                  "type": "string"
-                },
-                "regno": {
-                  "type": "string"
-                },
-                "refmet_id": {
-                  "type": "string"
-                }
-              }
+            "pubchem_cid": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object"
+            "inchi_key": {
+              "type": "string"
+            },
+            "exactmass": {
+              "type": "number"
+            },
+            "formula": {
+              "type": "string"
+            },
+            "super_class": {
+              "type": "string"
+            },
+            "main_class": {
+              "type": "string"
+            },
+            "sub_class": {
+              "type": "string"
+            },
+            "smiles": {
+              "type": "string"
+            },
+            "regno": {
+              "type": "string"
+            },
+            "refmet_id": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "name"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -234,73 +201,58 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "pubchem_cid": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "pubchem_cid": {
-                  "type": "string"
-                },
-                "regno": {
-                  "type": "string"
-                },
-                "formula": {
-                  "type": "string"
-                },
-                "exactmass": {
-                  "type": "number"
-                },
-                "inchi_key": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "sys_name": {
-                  "type": "string"
-                },
-                "hmdb_id": {
-                  "type": "string"
-                },
-                "kegg_id": {
-                  "type": "string"
-                },
-                "chebi_id": {
-                  "type": "string"
-                },
-                "metacyc_id": {
-                  "type": "string"
-                },
-                "smiles": {
-                  "type": "string"
-                }
-              }
+            "regno": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object"
+            "formula": {
+              "type": "string"
+            },
+            "exactmass": {
+              "type": "number"
+            },
+            "inchi_key": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "sys_name": {
+              "type": "string"
+            },
+            "hmdb_id": {
+              "type": "string"
+            },
+            "kegg_id": {
+              "type": "string"
+            },
+            "chebi_id": {
+              "type": "string"
+            },
+            "metacyc_id": {
+              "type": "string"
+            },
+            "smiles": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "pubchem_cid"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -342,70 +294,55 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "name": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "pubchem_cid": {
-                  "type": "string"
-                },
-                "inchi_key": {
-                  "type": "string"
-                },
-                "exactmass": {
-                  "type": "number"
-                },
-                "formula": {
-                  "type": "string"
-                },
-                "super_class": {
-                  "type": "string"
-                },
-                "main_class": {
-                  "type": "string"
-                },
-                "sub_class": {
-                  "type": "string"
-                },
-                "smiles": {
-                  "type": "string"
-                },
-                "regno": {
-                  "type": "string"
-                },
-                "refmet_id": {
-                  "type": "string"
-                }
-              }
+            "pubchem_cid": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object"
+            "inchi_key": {
+              "type": "string"
+            },
+            "exactmass": {
+              "type": "number"
+            },
+            "formula": {
+              "type": "string"
+            },
+            "super_class": {
+              "type": "string"
+            },
+            "main_class": {
+              "type": "string"
+            },
+            "sub_class": {
+              "type": "string"
+            },
+            "smiles": {
+              "type": "string"
+            },
+            "regno": {
+              "type": "string"
+            },
+            "refmet_id": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "name"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -464,36 +401,18 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "string"
-            },
-            "metadata": {
-              "type": "object"
-            }
-          }
+          "type": "string"
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -535,36 +454,18 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "string"
-            },
-            "metadata": {
-              "type": "object"
-            }
-          }
+          "type": "string"
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -653,51 +554,33 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "description": "Matching studies",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "study": {
-                    "type": "string",
-                    "description": "Study id (e.g. ST003897)"
-                  },
-                  "study_title": {
-                    "type": "string"
-                  },
-                  "species": {
-                    "type": "string"
-                  },
-                  "source": {
-                    "type": "string"
-                  },
-                  "disease": {
-                    "type": "string"
-                  }
-                }
+          "type": "array",
+          "description": "Matching studies",
+          "items": {
+            "type": "object",
+            "properties": {
+              "study": {
+                "type": "string",
+                "description": "Study id (e.g. ST003897)"
+              },
+              "study_title": {
+                "type": "string"
+              },
+              "species": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              },
+              "disease": {
+                "type": "string"
               }
-            },
-            "count": {
-              "type": "integer"
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
@@ -758,62 +641,44 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "description": "Gene or protein MGP record(s)",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_symbol": {
-                    "type": "string"
-                  },
-                  "gene_id": {
-                    "type": "string"
-                  },
-                  "gene_name": {
-                    "type": "string"
-                  },
-                  "mgp_id": {
-                    "type": "string"
-                  },
-                  "uniprot_id": {
-                    "type": "string"
-                  },
-                  "protein_entry": {
-                    "type": "string"
-                  },
-                  "mrna_id": {
-                    "type": "string"
-                  },
-                  "refseq_id": {
-                    "type": "string"
-                  },
-                  "seqlength": {
-                    "type": "string"
-                  }
-                }
+          "type": "array",
+          "description": "Gene or protein MGP record(s)",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene_symbol": {
+                "type": "string"
+              },
+              "gene_id": {
+                "type": "string"
+              },
+              "gene_name": {
+                "type": "string"
+              },
+              "mgp_id": {
+                "type": "string"
+              },
+              "uniprot_id": {
+                "type": "string"
+              },
+              "protein_entry": {
+                "type": "string"
+              },
+              "mrna_id": {
+                "type": "string"
+              },
+              "refseq_id": {
+                "type": "string"
+              },
+              "seqlength": {
+                "type": "string"
               }
-            },
-            "count": {
-              "type": "integer"
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/mgnify_expanded_tools.json
+++ b/src/tooluniverse/data/mgnify_expanded_tools.json
@@ -416,7 +416,9 @@
           "default": 25
         }
       },
-      "required": ["analysis_id"]
+      "required": [
+        "analysis_id"
+      ]
     },
     "fields": {
       "endpoint_type": "analysis",
@@ -439,18 +441,44 @@
       "items": {
         "type": "object",
         "properties": {
-          "organism_id": {"type": "string"},
-          "name": {"type": "string"},
-          "rank": {"type": "string"},
-          "domain": {"type": ["string", "null"]},
-          "count": {"type": "integer"},
-          "lineage": {"type": "string"}
+          "organism_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "rank": {
+            "type": "string"
+          },
+          "domain": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "count": {
+            "type": "integer"
+          },
+          "lineage": {
+            "type": "string"
+          }
         }
       }
     },
-    "label": ["MGnify", "Microbiome", "Taxonomy", "Metagenomics"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "Taxonomy",
+      "Metagenomics"
+    ],
     "metadata": {
-      "tags": ["taxonomy", "microbiome", "16S", "metagenomics", "community_composition"],
+      "tags": [
+        "taxonomy",
+        "microbiome",
+        "16S",
+        "metagenomics",
+        "community_composition"
+      ],
       "estimated_execution_time": "< 5 seconds"
     }
   },
@@ -470,7 +498,9 @@
           "default": 25
         }
       },
-      "required": ["analysis_id"]
+      "required": [
+        "analysis_id"
+      ]
     },
     "fields": {
       "endpoint_type": "analysis",
@@ -492,16 +522,34 @@
       "items": {
         "type": "object",
         "properties": {
-          "go_id": {"type": "string"},
-          "description": {"type": "string"},
-          "count": {"type": "integer"},
-          "category": {"type": "string"}
+          "go_id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "category": {
+            "type": "string"
+          }
         }
       }
     },
-    "label": ["MGnify", "Microbiome", "GO Terms", "Functional Annotation"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "GO Terms",
+      "Functional Annotation"
+    ],
     "metadata": {
-      "tags": ["go_terms", "functional_annotation", "microbiome", "metagenomics"],
+      "tags": [
+        "go_terms",
+        "functional_annotation",
+        "microbiome",
+        "metagenomics"
+      ],
       "estimated_execution_time": "< 5 seconds"
     }
   },
@@ -521,7 +569,9 @@
           "default": 25
         }
       },
-      "required": ["analysis_id"]
+      "required": [
+        "analysis_id"
+      ]
     },
     "fields": {
       "endpoint_type": "analysis",
@@ -543,15 +593,32 @@
       "items": {
         "type": "object",
         "properties": {
-          "interpro_id": {"type": "string"},
-          "description": {"type": "string"},
-          "count": {"type": "integer"}
+          "interpro_id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          }
         }
       }
     },
-    "label": ["MGnify", "Microbiome", "InterPro", "Protein Domains"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "InterPro",
+      "Protein Domains"
+    ],
     "metadata": {
-      "tags": ["interpro", "protein_domains", "functional_annotation", "microbiome", "metagenomics"],
+      "tags": [
+        "interpro",
+        "protein_domains",
+        "functional_annotation",
+        "microbiome",
+        "metagenomics"
+      ],
       "estimated_execution_time": "< 5 seconds"
     }
   },
@@ -562,23 +629,38 @@
       "type": "object",
       "properties": {
         "sample_accession": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Fetch a single sample by its MGnify/ENA accession (e.g., 'SRS10016989'). If provided, study_accession/biome/page are ignored."
         },
         "study_accession": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Filter samples belonging to a study (e.g., 'MGYS00002008')."
         },
         "biome": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Filter by biome name lineage (e.g., 'root:Host-associated:Human:Digestive system')."
         },
         "page": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Page number (default 1)."
         },
         "page_size": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Samples per page (default 25, max 100)."
         }
       },
@@ -600,43 +682,102 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "sample_accession": {"type": "string"},
-                  "biosample": {"type": ["string", "null"]},
-                  "latitude": {"type": ["number", "string", "null"]},
-                  "longitude": {"type": ["number", "string", "null"]},
-                  "geo_loc_name": {"type": ["string", "null"]},
-                  "collection_date": {"type": ["string", "null"]},
-                  "host_tax_id": {"type": ["string", "integer", "null"]},
-                  "environment_biome": {"type": ["string", "null"]},
-                  "environment_feature": {"type": ["string", "null"]},
-                  "environment_material": {"type": ["string", "null"]}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "sample_accession": {
+                "type": "string"
+              },
+              "biosample": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "latitude": {
+                "type": [
+                  "number",
+                  "string",
+                  "null"
+                ]
+              },
+              "longitude": {
+                "type": [
+                  "number",
+                  "string",
+                  "null"
+                ]
+              },
+              "geo_loc_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "collection_date": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "host_tax_id": {
+                "type": [
+                  "string",
+                  "integer",
+                  "null"
+                ]
+              },
+              "environment_biome": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "environment_feature": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "environment_material": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
-    "label": ["MGnify", "Microbiome", "Samples", "Metadata"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "Samples",
+      "Metadata"
+    ],
     "metadata": {
-      "tags": ["samples", "sample_metadata", "geography", "host", "environment", "microbiome", "metagenomics"],
+      "tags": [
+        "samples",
+        "sample_metadata",
+        "geography",
+        "host",
+        "environment",
+        "microbiome",
+        "metagenomics"
+      ],
       "estimated_execution_time": "< 5 seconds"
     }
   },
@@ -651,11 +792,16 @@
           "description": "MGnify analysis accession (e.g., 'MGYA00585482'). Find IDs via MGnify_list_analyses."
         },
         "page_size": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Number of download entries to return (default 100, max 100)."
         }
       },
-      "required": ["analysis_id"]
+      "required": [
+        "analysis_id"
+      ]
     },
     "fields": {
       "endpoint_type": "analysis",
@@ -674,40 +820,83 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "file_id": {"type": "string"},
-                  "label": {"type": ["string", "null"]},
-                  "description": {"type": ["string", "null"]},
-                  "file_format": {"type": ["string", "null"]},
-                  "compression": {"type": ["boolean", "string", "null"]},
-                  "group_type": {"type": ["string", "null"]},
-                  "download_url": {"type": ["string", "null"]}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file_id": {
+                "type": "string"
+              },
+              "label": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "file_format": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "compression": {
+                "type": [
+                  "boolean",
+                  "string",
+                  "null"
+                ]
+              },
+              "group_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "download_url": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
-    "label": ["MGnify", "Microbiome", "Downloads", "Files"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "Downloads",
+      "Files"
+    ],
     "metadata": {
-      "tags": ["downloads", "files", "predicted_cds", "eggnog", "interpro", "diamond", "microbiome", "metagenomics"],
+      "tags": [
+        "downloads",
+        "files",
+        "predicted_cds",
+        "eggnog",
+        "interpro",
+        "diamond",
+        "microbiome",
+        "metagenomics"
+      ],
       "estimated_execution_time": "< 5 seconds"
     }
   }

--- a/src/tooluniverse/data/mgnify_tools.json
+++ b/src/tooluniverse/data/mgnify_tools.json
@@ -19,7 +19,7 @@
           "default": 10,
           "minimum": 1,
           "maximum": 100,
-          "description": "Number of records per page (1–100)."
+          "description": "Number of records per page (1\u2013100)."
         }
       }
     },
@@ -33,8 +33,14 @@
       "items": {
         "type": "object",
         "properties": {
-          "id": {"type": "string", "description": "MGnify study accession (e.g., MGYS00006860)"},
-          "type": {"type": "string", "description": "Resource type (studies)"},
+          "id": {
+            "type": "string",
+            "description": "MGnify study accession (e.g., MGYS00006860)"
+          },
+          "type": {
+            "type": "string",
+            "description": "Resource type (studies)"
+          },
           "attributes": {
             "type": "object",
             "description": "Study metadata (bioproject, accession, study-name, etc.)"
@@ -51,11 +57,22 @@
       }
     },
     "test_examples": [
-      {"biome": "root:Host-associated", "size": 1}
+      {
+        "biome": "root:Host-associated",
+        "size": 1
+      }
     ],
-    "label": ["MGnify", "Microbiome", "Study"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "Study"
+    ],
     "metadata": {
-      "tags": ["microbiome", "metagenomics", "study"],
+      "tags": [
+        "microbiome",
+        "metagenomics",
+        "study"
+      ],
       "estimated_execution_time": "< 2 seconds"
     }
   },
@@ -75,86 +92,77 @@
           "default": 10,
           "minimum": 1,
           "maximum": 100,
-          "description": "Number of records per page (1–100)."
+          "description": "Number of records per page (1\u2013100)."
         }
       },
-      "required": ["study_accession"]
+      "required": [
+        "study_accession"
+      ]
     },
     "fields": {
       "endpoint": "https://www.ebi.ac.uk/metagenomics/api/latest/analyses",
       "format": "json"
     },
     "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string",
-                            "enum": [
-                                "success"
-                            ]
-                        },
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "string",
-                                        "description": "MGnify analysis accession"
-                                    },
-                                    "type": {
-                                        "type": "string",
-                                        "description": "Resource type (analyses)"
-                                    },
-                                    "attributes": {
-                                        "type": "object",
-                                        "description": "Analysis metadata (pipeline version, taxonomy/function results, etc.)"
-                                    },
-                                    "relationships": {
-                                        "type": "object",
-                                        "description": "Links to related resources (study, sample, downloads, etc.)"
-                                    },
-                                    "links": {
-                                        "type": "object",
-                                        "description": "API links for this analysis"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {
-                            "type": "string",
-                            "enum": [
-                                "error"
-                            ]
-                        },
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "error"
-                    ]
-                }
-            ]
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "MGnify analysis accession"
+              },
+              "type": {
+                "type": "string",
+                "description": "Resource type (analyses)"
+              },
+              "attributes": {
+                "type": "object",
+                "description": "Analysis metadata (pipeline version, taxonomy/function results, etc.)"
+              },
+              "relationships": {
+                "type": "object",
+                "description": "Links to related resources (study, sample, downloads, etc.)"
+              },
+              "links": {
+                "type": "object",
+                "description": "API links for this analysis"
+              }
+            }
+          }
         },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    },
     "test_examples": [
-      {"study_accession": "MGYS00002012", "size": 1}
+      {
+        "study_accession": "MGYS00002012",
+        "size": 1
+      }
     ],
-    "label": ["MGnify", "Microbiome", "Analysis"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "Analysis"
+    ],
     "metadata": {
-      "tags": ["analysis", "taxonomy", "function"],
+      "tags": [
+        "analysis",
+        "taxonomy",
+        "function"
+      ],
       "estimated_execution_time": "< 2 seconds"
     }
   }

--- a/src/tooluniverse/data/mhcmotifatlas_tools.json
+++ b/src/tooluniverse/data/mhcmotifatlas_tools.json
@@ -35,55 +35,40 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "allele": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "allele": {
-                  "type": "string"
-                },
-                "mhc_class": {
-                  "type": "string"
-                },
-                "peptides": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "peptide": {
-                        "type": "string"
-                      },
-                      "core": {
-                        "type": "string"
-                      }
-                    }
+            "mhc_class": {
+              "type": "string"
+            },
+            "peptides": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "peptide": {
+                    "type": "string"
+                  },
+                  "core": {
+                    "type": "string"
                   }
-                },
-                "sequence": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "sequence": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
-            "status",
-            "data"
+            "allele"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/mibig_tools.json
+++ b/src/tooluniverse/data/mibig_tools.json
@@ -25,84 +25,66 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "accession": {
-                    "type": "string"
-                  },
-                  "quality": {
-                    "type": "string"
-                  },
-                  "completeness": {
-                    "type": "string"
-                  },
-                  "status": {
-                    "type": "string"
-                  },
-                  "products": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string"
-                        }
-                      }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession": {
+                "type": "string"
+              },
+              "quality": {
+                "type": "string"
+              },
+              "completeness": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "products": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
                     }
-                  },
-                  "classes": {
-                    "type": [
-                      "array",
-                      "null"
-                    ],
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string"
-                        },
-                        "css_class": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "organism": {
-                    "type": "string"
                   }
                 }
+              },
+              "classes": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "css_class": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "organism": {
+                "type": "string"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -126,118 +108,103 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "counts": {
               "type": "object",
               "properties": {
-                "counts": {
-                  "type": "object",
-                  "properties": {
-                    "total": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "complete": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "partial": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "pending": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "active": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "retired": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
-                  }
+                "total": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
                 },
-                "clusters": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "count": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "css_class": {
-                        "type": "string"
-                      }
-                    }
-                  }
+                "complete": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
                 },
-                "phyla": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "description": {
-                        "type": "string"
-                      },
-                      "count": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      }
-                    }
+                "partial": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "pending": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "active": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "retired": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
+            },
+            "clusters": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "css_class": {
+                    "type": "string"
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "phyla": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  }
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "counts"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/mpd_tools.json
+++ b/src/tooluniverse/data/mpd_tools.json
@@ -36,738 +36,723 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "@context": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "@context": {
-                  "type": "string"
-                },
-                "@graph": {
-                  "type": "array",
-                  "items": {
+            "@graph": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "@id": {
+                    "type": "string"
+                  },
+                  "@type": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "accession": {
+                    "type": "string"
+                  },
+                  "assay_term_name": {
+                    "type": "string"
+                  },
+                  "assay_title": {
+                    "type": "string"
+                  },
+                  "audit": {
                     "type": "object",
                     "properties": {
-                      "@id": {
-                        "type": "string"
-                      },
-                      "@type": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "accession": {
-                        "type": "string"
-                      },
-                      "assay_term_name": {
-                        "type": "string"
-                      },
-                      "assay_title": {
-                        "type": "string"
-                      },
-                      "audit": {
-                        "type": "object",
-                        "properties": {
-                          "INTERNAL_ACTION": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "path": {
-                                  "type": "string"
-                                },
-                                "level_name": {
-                                  "type": "string"
-                                },
-                                "level": {
-                                  "type": [
-                                    "integer",
-                                    "number"
-                                  ]
-                                },
-                                "name": {
-                                  "type": "string"
-                                },
-                                "detail": {
-                                  "type": "string"
-                                },
-                                "category": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          },
-                          "NOT_COMPLIANT": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "path": {
-                                  "type": "string"
-                                },
-                                "level_name": {
-                                  "type": "string"
-                                },
-                                "level": {
-                                  "type": [
-                                    "integer",
-                                    "number"
-                                  ]
-                                },
-                                "name": {
-                                  "type": "string"
-                                },
-                                "detail": {
-                                  "type": "string"
-                                },
-                                "category": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          },
-                          "WARNING": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "path": {
-                                  "type": "string"
-                                },
-                                "level_name": {
-                                  "type": "string"
-                                },
-                                "level": {
-                                  "type": [
-                                    "integer",
-                                    "number"
-                                  ]
-                                },
-                                "name": {
-                                  "type": "string"
-                                },
-                                "detail": {
-                                  "type": "string"
-                                },
-                                "category": {
-                                  "type": "string"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "award": {
-                        "type": "object",
-                        "properties": {
-                          "project": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "biosample_ontology": {
-                        "type": "object",
-                        "properties": {
-                          "term_name": {
-                            "type": "string"
-                          },
-                          "classification": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "biosample_summary": {
-                        "type": "string"
-                      },
-                      "dbxrefs": {
-                        "type": "array"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "files": {
+                      "INTERNAL_ACTION": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "@id": {
+                            "path": {
+                              "type": "string"
+                            },
+                            "level_name": {
+                              "type": "string"
+                            },
+                            "level": {
+                              "type": [
+                                "integer",
+                                "number"
+                              ]
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "detail": {
+                              "type": "string"
+                            },
+                            "category": {
                               "type": "string"
                             }
                           }
                         }
                       },
-                      "lab": {
-                        "type": "object",
-                        "properties": {
-                          "title": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "related_series": {
-                        "type": "array"
-                      },
-                      "replicates": {
+                      "NOT_COMPLIANT": {
                         "type": "array",
                         "items": {
                           "type": "object",
                           "properties": {
-                            "library": {
+                            "path": {
+                              "type": "string"
+                            },
+                            "level_name": {
+                              "type": "string"
+                            },
+                            "level": {
+                              "type": [
+                                "integer",
+                                "number"
+                              ]
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "detail": {
+                              "type": "string"
+                            },
+                            "category": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "WARNING": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "path": {
+                              "type": "string"
+                            },
+                            "level_name": {
+                              "type": "string"
+                            },
+                            "level": {
+                              "type": [
+                                "integer",
+                                "number"
+                              ]
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "detail": {
+                              "type": "string"
+                            },
+                            "category": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "award": {
+                    "type": "object",
+                    "properties": {
+                      "project": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "biosample_ontology": {
+                    "type": "object",
+                    "properties": {
+                      "term_name": {
+                        "type": "string"
+                      },
+                      "classification": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "biosample_summary": {
+                    "type": "string"
+                  },
+                  "dbxrefs": {
+                    "type": "array"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "@id": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "lab": {
+                    "type": "object",
+                    "properties": {
+                      "title": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "related_series": {
+                    "type": "array"
+                  },
+                  "replicates": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "library": {
+                          "type": "object",
+                          "properties": {
+                            "biosample": {
                               "type": "object",
                               "properties": {
-                                "biosample": {
+                                "organism": {
                                   "type": "object",
                                   "properties": {
-                                    "organism": {
-                                      "type": "object",
-                                      "properties": {
-                                        "scientific_name": {
-                                          "type": "string"
-                                        }
-                                      }
-                                    },
-                                    "life_stage": {
-                                      "type": "string"
-                                    },
-                                    "accession": {
+                                    "scientific_name": {
                                       "type": "string"
                                     }
                                   }
+                                },
+                                "life_stage": {
+                                  "type": "string"
+                                },
+                                "accession": {
+                                  "type": "string"
                                 }
                               }
-                            },
-                            "@id": {
-                              "type": "string"
-                            },
-                            "technical_replicate_number": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "biological_replicate_number": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
                             }
                           }
+                        },
+                        "@id": {
+                          "type": "string"
+                        },
+                        "technical_replicate_number": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "biological_replicate_number": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
                         }
-                      },
-                      "status": {
-                        "type": "string"
                       }
                     }
-                  }
-                },
-                "@id": {
-                  "type": "string"
-                },
-                "@type": {
-                  "type": "array",
-                  "items": {
+                  },
+                  "status": {
                     "type": "string"
                   }
-                },
-                "all": {
-                  "type": "string"
-                },
-                "clear_filters": {
-                  "type": "string"
-                },
-                "columns": {
-                  "type": "object",
-                  "properties": {
-                    "@id": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "accession": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "assay_term_name": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "assay_title": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "biosample_ontology.classification": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "target.@id": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "target.label": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "target.genes.symbol": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "biosample_summary": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "biosample_ontology.term_name": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "dbxrefs": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "description": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "lab.title": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "award.project": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "status": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "files.@id": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "related_series": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.accession": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.biological_replicate_number": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.technical_replicate_number": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.antibody.accession": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.organism.scientific_name": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.life_stage": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.age_display": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.treatments.treatment_term_name": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.treatments.treatment_term_id": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.treatments.amount": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.treatments.amount_units": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.treatments.duration": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.treatments.duration_units": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.synchronization": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.post_synchronization_time": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.post_synchronization_time_units": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.applied_modifications.modified_site_by_target_id.organism": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.applied_modifications.introduced_gene.organism": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.@id": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.mixed_biosamples": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.biosample.subcellular_fraction_term_name": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.construction_platform.term_name": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "replicates.library.construction_method": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                },
-                "facet_groups": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "facet_fields": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                },
-                "facets": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "field": {
-                        "type": "string"
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "terms": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "key": {
-                              "type": [
-                                "integer",
-                                "number",
-                                "string"
-                              ]
-                            },
-                            "doc_count": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "key_as_string": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "total": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "appended": {
-                        "type": "boolean"
-                      },
-                      "open_on_load": {
-                        "type": "boolean"
-                      }
-                    }
-                  }
-                },
-                "filters": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "field": {
-                        "type": "string"
-                      },
-                      "term": {
-                        "type": "string"
-                      },
-                      "remove": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "notification": {
-                  "type": "string"
-                },
-                "sort": {
-                  "type": "object",
-                  "properties": {
-                    "date_created": {
-                      "type": "object",
-                      "properties": {
-                        "order": {
-                          "type": "string"
-                        },
-                        "unmapped_type": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "label": {
-                      "type": "object",
-                      "properties": {
-                        "order": {
-                          "type": "string"
-                        },
-                        "unmapped_type": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "uuid": {
-                      "type": "object",
-                      "properties": {
-                        "order": {
-                          "type": "string"
-                        },
-                        "unmapped_type": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                },
-                "title": {
-                  "type": "string"
-                },
-                "total": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "@id": {
+              "type": "string"
+            },
+            "@type": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "all": {
+              "type": "string"
+            },
+            "clear_filters": {
+              "type": "string"
+            },
+            "columns": {
+              "type": "object",
+              "properties": {
+                "@id": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "accession": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "assay_term_name": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "assay_title": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "biosample_ontology.classification": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "target.@id": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "target.label": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "target.genes.symbol": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "biosample_summary": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "biosample_ontology.term_name": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "dbxrefs": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "description": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "lab.title": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "award.project": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "status": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "files.@id": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "related_series": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.accession": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.biological_replicate_number": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.technical_replicate_number": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.antibody.accession": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.organism.scientific_name": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.life_stage": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.age_display": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.treatments.treatment_term_name": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.treatments.treatment_term_id": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.treatments.amount": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.treatments.amount_units": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.treatments.duration": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.treatments.duration_units": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.synchronization": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.post_synchronization_time": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.post_synchronization_time_units": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.applied_modifications.modified_site_by_target_id.organism": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.applied_modifications.introduced_gene.organism": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.@id": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.mixed_biosamples": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.biosample.subcellular_fraction_term_name": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.construction_platform.term_name": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicates.library.construction_method": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "facet_groups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "facet_fields": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "facets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "field": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "terms": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "key": {
+                          "type": [
+                            "integer",
+                            "number",
+                            "string"
+                          ]
+                        },
+                        "doc_count": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "key_as_string": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "total": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "appended": {
+                    "type": "boolean"
+                  },
+                  "open_on_load": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "filters": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "field": {
+                    "type": "string"
+                  },
+                  "term": {
+                    "type": "string"
+                  },
+                  "remove": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "notification": {
+              "type": "string"
+            },
+            "sort": {
+              "type": "object",
+              "properties": {
+                "date_created": {
+                  "type": "object",
+                  "properties": {
+                    "order": {
+                      "type": "string"
+                    },
+                    "unmapped_type": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "label": {
+                  "type": "object",
+                  "properties": {
+                    "order": {
+                      "type": "string"
+                    },
+                    "unmapped_type": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "uuid": {
+                  "type": "object",
+                  "properties": {
+                    "order": {
+                      "type": "string"
+                    },
+                    "unmapped_type": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "title": {
+              "type": "string"
+            },
+            "total": {
+              "type": [
+                "integer",
+                "number"
+              ]
             }
-          }
+          },
+          "required": [
+            "@context"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/msigdb_tools.json
+++ b/src/tooluniverse/data/msigdb_tools.json
@@ -204,37 +204,26 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_set_name": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_set_name": {
-                  "type": "string"
-                },
-                "gene": {
-                  "type": "string"
-                },
-                "is_member": {
-                  "type": "boolean"
-                },
-                "total_genes_in_set": {
-                  "type": "integer"
-                }
-              }
+            "gene": {
+              "type": "string"
+            },
+            "is_member": {
+              "type": "boolean"
+            },
+            "total_genes_in_set": {
+              "type": "integer"
             }
           },
           "required": [
-            "data"
+            "gene_set_name"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
@@ -284,37 +273,26 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_set_name": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_set_name": {
-                  "type": "string"
-                },
-                "num_genes": {
-                  "type": "integer"
-                },
-                "genes": {
-                  "type": "array"
-                },
-                "collection": {
-                  "type": "string"
-                }
-              }
+            "num_genes": {
+              "type": "integer"
+            },
+            "genes": {
+              "type": "array"
+            },
+            "collection": {
+              "type": "string"
             }
           },
           "required": [
-            "data"
+            "gene_set_name"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/nasa_sbdb_tools.json
+++ b/src/tooluniverse/data/nasa_sbdb_tools.json
@@ -45,227 +45,112 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "orbit": {
               "type": "object",
               "properties": {
-                "orbit": {
-                  "type": "object",
-                  "properties": {
-                    "data_arc": {
-                      "type": "string"
-                    },
-                    "not_valid_after": {
-                      "type": "null"
-                    },
-                    "n_dop_obs_used": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "soln_date": {
-                      "type": "string"
-                    },
-                    "cov_epoch": {
-                      "type": "string"
-                    },
-                    "producer": {
-                      "type": "string"
-                    },
-                    "epoch": {
-                      "type": "string"
-                    },
-                    "moid": {
-                      "type": "string"
-                    },
-                    "moid_jup": {
-                      "type": "string"
-                    },
-                    "sb_used": {
-                      "type": "string"
-                    },
-                    "source": {
-                      "type": "string"
-                    },
-                    "not_valid_before": {
-                      "type": "null"
-                    },
-                    "orbit_id": {
-                      "type": "string"
-                    },
-                    "two_body": {
-                      "type": "null"
-                    },
-                    "n_obs_used": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "last_obs": {
-                      "type": "string"
-                    },
-                    "model_pars": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string"
-                          },
-                          "units": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          },
-                          "desc": {
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "n": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          },
-                          "sigma": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          },
-                          "kind": {
-                            "type": "string"
-                          }
-                        }
+                "data_arc": {
+                  "type": "string"
+                },
+                "not_valid_after": {
+                  "type": "null"
+                },
+                "n_dop_obs_used": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "soln_date": {
+                  "type": "string"
+                },
+                "cov_epoch": {
+                  "type": "string"
+                },
+                "producer": {
+                  "type": "string"
+                },
+                "epoch": {
+                  "type": "string"
+                },
+                "moid": {
+                  "type": "string"
+                },
+                "moid_jup": {
+                  "type": "string"
+                },
+                "sb_used": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "not_valid_before": {
+                  "type": "null"
+                },
+                "orbit_id": {
+                  "type": "string"
+                },
+                "two_body": {
+                  "type": "null"
+                },
+                "n_obs_used": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "last_obs": {
+                  "type": "string"
+                },
+                "model_pars": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      },
+                      "units": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "desc": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "n": {
+                        "type": [
+                          "integer",
+                          "number"
+                        ]
+                      },
+                      "sigma": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "kind": {
+                        "type": "string"
                       }
-                    },
-                    "t_jup": {
-                      "type": "string"
-                    },
-                    "rms": {
-                      "type": "string"
-                    },
-                    "elements": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string"
-                          },
-                          "value": {
-                            "type": "string"
-                          },
-                          "sigma": {
-                            "type": "string"
-                          },
-                          "units": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          },
-                          "label": {
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    },
-                    "pe_used": {
-                      "type": "string"
-                    },
-                    "first_obs": {
-                      "type": "string"
-                    },
-                    "n_del_obs_used": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "equinox": {
-                      "type": "string"
-                    },
-                    "condition_code": {
-                      "type": "string"
-                    },
-                    "comment": {
-                      "type": "null"
                     }
                   }
                 },
-                "signature": {
-                  "type": "object",
-                  "properties": {
-                    "source": {
-                      "type": "string"
-                    },
-                    "version": {
-                      "type": "string"
-                    }
-                  }
+                "t_jup": {
+                  "type": "string"
                 },
-                "object": {
-                  "type": "object",
-                  "properties": {
-                    "des": {
-                      "type": "string"
-                    },
-                    "fullname": {
-                      "type": "string"
-                    },
-                    "orbit_class": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string"
-                        },
-                        "code": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "orbit_id": {
-                      "type": "string"
-                    },
-                    "spkid": {
-                      "type": "string"
-                    },
-                    "prefix": {
-                      "type": "null"
-                    },
-                    "pha": {
-                      "type": "boolean"
-                    },
-                    "shortname": {
-                      "type": "string"
-                    },
-                    "neo": {
-                      "type": "boolean"
-                    },
-                    "kind": {
-                      "type": "string"
-                    }
-                  }
+                "rms": {
+                  "type": "string"
                 },
-                "phys_par": {
+                "elements": {
                   "type": "array",
                   "items": {
                     "type": "object",
@@ -276,17 +161,8 @@
                       "value": {
                         "type": "string"
                       },
-                      "notes": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
                       "sigma": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
+                        "type": "string"
                       },
                       "units": {
                         "type": [
@@ -294,39 +170,148 @@
                           "string"
                         ]
                       },
-                      "ref": {
+                      "label": {
                         "type": "string"
                       },
                       "title": {
                         "type": "string"
-                      },
-                      "desc": {
-                        "type": "string"
                       }
                     }
                   }
+                },
+                "pe_used": {
+                  "type": "string"
+                },
+                "first_obs": {
+                  "type": "string"
+                },
+                "n_del_obs_used": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "equinox": {
+                  "type": "string"
+                },
+                "condition_code": {
+                  "type": "string"
+                },
+                "comment": {
+                  "type": "null"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "signature": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              }
+            },
+            "object": {
+              "type": "object",
+              "properties": {
+                "des": {
+                  "type": "string"
+                },
+                "fullname": {
+                  "type": "string"
+                },
+                "orbit_class": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "orbit_id": {
+                  "type": "string"
+                },
+                "spkid": {
+                  "type": "string"
+                },
+                "prefix": {
+                  "type": "null"
+                },
+                "pha": {
+                  "type": "boolean"
+                },
+                "shortname": {
+                  "type": "string"
+                },
+                "neo": {
+                  "type": "boolean"
+                },
+                "kind": {
+                  "type": "string"
+                }
+              }
+            },
+            "phys_par": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  },
+                  "notes": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "sigma": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "units": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "ref": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "desc": {
+                    "type": "string"
+                  }
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "orbit"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -409,75 +394,60 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
+            "signature": {
               "type": "object",
               "properties": {
-                "signature": {
-                  "type": "object",
-                  "properties": {
-                    "version": {
-                      "type": "string"
-                    },
-                    "source": {
-                      "type": "string"
-                    }
-                  }
+                "version": {
+                  "type": "string"
                 },
-                "count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "total": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "fields": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "data": {
-                  "type": "array",
-                  "items": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
+                "source": {
+                  "type": "string"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "total": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "fields": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "signature"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/ncbi_datasets_tools.json
+++ b/src/tooluniverse/data/ncbi_datasets_tools.json
@@ -1,933 +1,890 @@
 [
-    {
-        "name": "NCBIDatasets_get_gene",
-        "description": "Get comprehensive gene information from NCBI by Gene ID. Returns gene symbol, description, chromosomal location, genomic coordinates, cross-references to UniProt/Ensembl/OMIM, synonyms, and annotation details. Covers all organisms in NCBI Gene database. Example: gene_id 7157 returns TP53 (tumor protein p53) on chromosome 17.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "gene_id": {
-                    "type": "string",
-                    "description": "NCBI Gene ID (numeric). Examples: '7157' (TP53), '672' (BRCA1), '3630' (INS), '22059' (mouse Trp53)."
-                }
-            },
-            "required": [
-                "gene_id"
-            ]
-        },
-        "fields": {
-            "endpoint_type": "gene_by_id"
-        },
-        "type": "NCBIDatasetsTool",
-        "test_examples": [
-            {
-                "gene_id": "7157"
-            },
-            {
-                "gene_id": "672"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "gene_id": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "NCBI Gene ID"
-                                },
-                                "symbol": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Gene symbol"
-                                },
-                                "description": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Gene description/full name"
-                                },
-                                "tax_id": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "NCBI Taxonomy ID"
-                                },
-                                "taxname": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Species scientific name"
-                                },
-                                "common_name": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Species common name"
-                                },
-                                "type": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Gene biotype (e.g., PROTEIN_CODING)"
-                                },
-                                "chromosomes": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "orientation": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                },
-                                "swiss_prot_accessions": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "ensembl_gene_ids": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "omim_ids": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "synonyms": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "nomenclature_authority": {
-                                    "type": [
-                                        "object",
-                                        "null"
-                                    ]
-                                },
-                                "genomic_locations": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "assembly": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ]
-                                            },
-                                            "accession": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ]
-                                            },
-                                            "chromosome": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ]
-                                            },
-                                            "begin": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ]
-                                            },
-                                            "end": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ]
-                                            },
-                                            "orientation": {
-                                                "type": [
-                                                    "string",
-                                                    "null"
-                                                ]
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "total_results": {
-                                    "type": "integer"
-                                },
-                                "query_gene_id": {
-                                    "type": "string"
-                                },
-                                "source": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "required": [
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
+  {
+    "name": "NCBIDatasets_get_gene",
+    "description": "Get comprehensive gene information from NCBI by Gene ID. Returns gene symbol, description, chromosomal location, genomic coordinates, cross-references to UniProt/Ensembl/OMIM, synonyms, and annotation details. Covers all organisms in NCBI Gene database. Example: gene_id 7157 returns TP53 (tumor protein p53) on chromosome 17.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "gene_id": {
+          "type": "string",
+          "description": "NCBI Gene ID (numeric). Examples: '7157' (TP53), '672' (BRCA1), '3630' (INS), '22059' (mouse Trp53)."
         }
+      },
+      "required": [
+        "gene_id"
+      ]
     },
-    {
-        "name": "NCBIDatasets_get_gene_by_symbol",
-        "description": "Look up gene information by gene symbol and organism. Searches NCBI Gene database using official gene symbols. Specify the taxon as common name (human, mouse, rat) or taxonomy ID. Returns gene ID, description, chromosomal location, and database cross-references.",
-        "parameter": {
-            "type": "object",
-            "properties": {
+    "fields": {
+      "endpoint_type": "gene_by_id"
+    },
+    "type": "NCBIDatasetsTool",
+    "test_examples": [
+      {
+        "gene_id": "7157"
+      },
+      {
+        "gene_id": "672"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "gene_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "NCBI Gene ID"
+                },
                 "symbol": {
-                    "type": "string",
-                    "description": "Gene symbol. Examples: 'TP53', 'BRCA1', 'INS', 'EGFR'."
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Gene symbol"
                 },
-                "taxon": {
-                    "type": "string",
-                    "description": "Organism as common name or taxonomy ID. Examples: 'human', 'mouse', 'rat', '9606', '10090'. Default: 'human'."
-                }
-            },
-            "required": [
-                "symbol"
-            ]
-        },
-        "fields": {
-            "endpoint_type": "gene_by_symbol"
-        },
-        "type": "NCBIDatasetsTool",
-        "test_examples": [
-            {
-                "symbol": "BRCA1",
-                "taxon": "human"
-            },
-            {
-                "symbol": "Trp53",
-                "taxon": "mouse"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "gene_id": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "symbol": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "description": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "tax_id": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "taxname": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "type": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "chromosomes": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "swiss_prot_accessions": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "ensembl_gene_ids": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "synonyms": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "total_results": {
-                                    "type": "integer"
-                                },
-                                "query_symbol": {
-                                    "type": "string"
-                                },
-                                "query_taxon": {
-                                    "type": "string"
-                                },
-                                "source": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Gene description/full name"
                 },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "name": "NCBIDatasets_get_orthologs",
-        "description": "Get orthologous genes across species for a given NCBI Gene ID. Returns orthologs identified by NCBI's Ortholog pipeline, including gene symbols, species, and gene types for each ortholog. Useful for comparative genomics and cross-species gene function studies. Example: gene_id 7157 (TP53) returns mouse Trp53, rat Tp53, zebrafish tp53, etc.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "gene_id": {
-                    "type": "string",
-                    "description": "NCBI Gene ID (numeric). Examples: '7157' (TP53), '672' (BRCA1), '3630' (INS)."
-                },
-                "page_size": {
-                    "type": "integer",
-                    "description": "Maximum number of orthologs to return (1-100). Default: 20."
-                }
-            },
-            "required": [
-                "gene_id"
-            ]
-        },
-        "fields": {
-            "endpoint_type": "gene_orthologs"
-        },
-        "type": "NCBIDatasetsTool",
-        "test_examples": [
-            {
-                "gene_id": "7157",
-                "page_size": 10
-            },
-            {
-                "gene_id": "672"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "gene_id": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "symbol": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "description": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "tax_id": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "taxname": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "common_name": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "type": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "chromosomes": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "total_results": {
-                                    "type": "integer"
-                                },
-                                "query_gene_id": {
-                                    "type": "string"
-                                },
-                                "source": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "required": [
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "name": "NCBIDatasets_get_taxonomy",
-        "description": "Get detailed taxonomy information from NCBI by taxonomy ID. Returns organism name, rank, full lineage, counts of genes/assemblies/RNA types, and child taxa. Covers all organisms in NCBI Taxonomy including bacteria, archaea, eukaryotes, and viruses. Example: tax_id 9606 returns Homo sapiens with 20,625 protein-coding genes.",
-        "parameter": {
-            "type": "object",
-            "properties": {
                 "tax_id": {
-                    "type": "string",
-                    "description": "NCBI Taxonomy ID (numeric). Examples: '9606' (Homo sapiens), '10090' (Mus musculus), '7227' (Drosophila melanogaster), '562' (E. coli)."
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "NCBI Taxonomy ID"
+                },
+                "taxname": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Species scientific name"
+                },
+                "common_name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Species common name"
+                },
+                "type": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Gene biotype (e.g., PROTEIN_CODING)"
+                },
+                "chromosomes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "orientation": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "swiss_prot_accessions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ensembl_gene_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "omim_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "synonyms": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "nomenclature_authority": {
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "genomic_locations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "assembly": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "accession": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "chromosome": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "begin": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "end": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "orientation": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  }
                 }
+              }
             },
-            "required": [
-                "tax_id"
-            ]
-        },
-        "fields": {
-            "endpoint_type": "taxonomy"
-        },
-        "type": "NCBIDatasetsTool",
-        "test_examples": [
-            {
-                "tax_id": "9606"
-            },
-            {
-                "tax_id": "7227"
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "total_results": {
+                  "type": "integer"
+                },
+                "query_gene_id": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                }
+              }
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "tax_id": {
-                                    "type": [
-                                        "integer",
-                                        "null"
-                                    ]
-                                },
-                                "organism_name": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                },
-                                "genbank_common_name": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                },
-                                "rank": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                },
-                                "blast_name": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ]
-                                },
-                                "lineage": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "integer"
-                                    }
-                                },
-                                "children": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "integer"
-                                    }
-                                },
-                                "counts": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "type": {
-                                                "type": "string"
-                                            },
-                                            "count": {
-                                                "type": "integer"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "total_results": {
-                                    "type": "integer"
-                                },
-                                "query_tax_id": {
-                                    "type": "string"
-                                },
-                                "source": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "required": [
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "name": "NCBIDatasets_suggest_taxonomy",
-        "description": "Suggest taxonomic names matching a query string. Searches NCBI Taxonomy for organisms by partial name, returning matching scientific names, taxonomy IDs, common names, and ranks. Useful for finding taxonomy IDs from partial organism names. Example: 'drosophila' returns D. melanogaster (7227), D. simulans (7240), etc.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Partial organism name to search. Examples: 'drosophila', 'escherichia', 'arabidopsis', 'saccharomyces'."
-                }
-            },
-            "required": [
-                "query"
-            ]
+          },
+          "required": [
+            "data"
+          ]
         },
-        "fields": {
-            "endpoint_type": "taxonomy_suggest"
-        },
-        "type": "NCBIDatasetsTool",
-        "test_examples": [
-            {
-                "query": "drosophila"
-            },
-            {
-                "query": "arabidopsis"
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "scientific_name": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "tax_id": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "common_name": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "rank": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "group_name": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    },
-                                    "matched_term": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "total_results": {
-                                    "type": "integer"
-                                },
-                                "query": {
-                                    "type": "string"
-                                },
-                                "source": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "required": [
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
+          },
+          "required": [
+            "error"
+          ]
         }
-    },
-    {
-        "name": "NCBIDatasets_get_genome_assembly",
-        "description": "Get genome assembly metadata for an assembly accession (RefSeq GCF_ or GenBank GCA_) from the NCBI Datasets v2 API. Returns organism/strain, assembly name/level/status, RefSeq category (e.g. reference genome), release date, submitter, BioProject, and assembly statistics (total length, chromosome count, contig/scaffold N50, GC%, annotation provider). Use to characterize a specific genome assembly across any organism (bacteria, fungi, plant, animal). No API key required.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "accession": {
-                    "type": "string",
-                    "description": "Assembly accession, e.g. 'GCF_000005845.2' (E. coli K-12) or 'GCF_000001405.40' (human GRCh38.p14)."
-                }
-            },
-            "required": [
-                "accession"
-            ]
-        },
-        "fields": {
-            "endpoint_type": "genome_assembly"
-        },
-        "type": "NCBIDatasetsTool",
-        "test_examples": [
-            {
-                "accession": "GCF_000005845.2"
-            },
-            {
-                "accession": "GCF_000001405.40"
-            },
-            {
-                "accession": "GCF_000146045.2"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "description": "Assembly metadata",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "object",
-                            "description": "Curated assembly fields (accession, organism, level, stats)"
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "name": "NCBIDatasets_list_genomes_by_taxon",
-        "description": "List genome assemblies available for a taxon (NCBI tax id or scientific name) via the NCBI Datasets v2 API. Returns a summary list of assemblies (accession, assembly name/level, RefSeq category, release date, total length, N50, GC%) plus the total count available. Use to discover what genomes exist for an organism or clade, e.g. all Escherichia coli or Mycobacterium tuberculosis assemblies. Set reference_only to restrict to reference/representative genomes. No API key required.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "taxon": {
-                    "type": "string",
-                    "description": "NCBI tax id or scientific name, e.g. '562', 'Escherichia coli', 'Saccharomyces cerevisiae'."
-                },
-                "limit": {
-                    "type": [
-                        "integer",
-                        "null"
-                    ],
-                    "description": "Max assemblies to return (default 20, max 100)."
-                },
-                "reference_only": {
-                    "type": [
-                        "boolean",
-                        "null"
-                    ],
-                    "description": "If true, return only reference/representative genomes."
-                }
-            },
-            "required": [
-                "taxon"
-            ]
-        },
-        "fields": {
-            "endpoint_type": "genomes_by_taxon"
-        },
-        "type": "NCBIDatasetsTool",
-        "test_examples": [
-            {
-                "taxon": "Saccharomyces cerevisiae",
-                "limit": 5,
-                "reference_only": true
-            },
-            {
-                "taxon": "562",
-                "limit": 3
-            },
-            {
-                "taxon": "Mycobacterium tuberculosis",
-                "limit": 5
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "description": "List of assemblies",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object"
-                            },
-                            "description": "Assembly summaries"
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "description": "Includes total_available count"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "name": "NCBIDatasets_get_sequence_reports",
-        "description": "Get per-sequence (chromosome/plasmid/scaffold) reports for a genome assembly via the NCBI Datasets v2 API. Returns each molecule's chromosome name, role, location type, RefSeq and GenBank accessions, length, and GC%. Use to map an assembly to its individual sequence accessions (e.g. resolve E. coli K-12 to NC_000913.3, or human chromosomes to their RefSeq NC_ accessions). No API key required.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "accession": {
-                    "type": "string",
-                    "description": "Assembly accession, e.g. 'GCF_000005845.2'."
-                }
-            },
-            "required": [
-                "accession"
-            ]
-        },
-        "fields": {
-            "endpoint_type": "sequence_reports"
-        },
-        "type": "NCBIDatasetsTool",
-        "test_examples": [
-            {
-                "accession": "GCF_000005845.2"
-            },
-            {
-                "accession": "GCF_000146045.2"
-            },
-            {
-                "accession": "GCF_000001405.40"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "description": "Per-sequence reports",
-                    "properties": {
-                        "status": {
-                            "type": "string"
-                        },
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object"
-                            },
-                            "description": "Sequence records"
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": [
-                        "status",
-                        "data"
-                    ]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "error"
-                    ]
-                }
-            ]
-        }
+      ]
     }
+  },
+  {
+    "name": "NCBIDatasets_get_gene_by_symbol",
+    "description": "Look up gene information by gene symbol and organism. Searches NCBI Gene database using official gene symbols. Specify the taxon as common name (human, mouse, rat) or taxonomy ID. Returns gene ID, description, chromosomal location, and database cross-references.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "description": "Gene symbol. Examples: 'TP53', 'BRCA1', 'INS', 'EGFR'."
+        },
+        "taxon": {
+          "type": "string",
+          "description": "Organism as common name or taxonomy ID. Examples: 'human', 'mouse', 'rat', '9606', '10090'. Default: 'human'."
+        }
+      },
+      "required": [
+        "symbol"
+      ]
+    },
+    "fields": {
+      "endpoint_type": "gene_by_symbol"
+    },
+    "type": "NCBIDatasetsTool",
+    "test_examples": [
+      {
+        "symbol": "BRCA1",
+        "taxon": "human"
+      },
+      {
+        "symbol": "Trp53",
+        "taxon": "mouse"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "gene_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "symbol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "tax_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "taxname": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "chromosomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "swiss_prot_accessions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "ensembl_gene_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "synonyms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "total_results": {
+                  "type": "integer"
+                },
+                "query_symbol": {
+                  "type": "string"
+                },
+                "query_taxon": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": [
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "NCBIDatasets_get_orthologs",
+    "description": "Get orthologous genes across species for a given NCBI Gene ID. Returns orthologs identified by NCBI's Ortholog pipeline, including gene symbols, species, and gene types for each ortholog. Useful for comparative genomics and cross-species gene function studies. Example: gene_id 7157 (TP53) returns mouse Trp53, rat Tp53, zebrafish tp53, etc.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "gene_id": {
+          "type": "string",
+          "description": "NCBI Gene ID (numeric). Examples: '7157' (TP53), '672' (BRCA1), '3630' (INS)."
+        },
+        "page_size": {
+          "type": "integer",
+          "description": "Maximum number of orthologs to return (1-100). Default: 20."
+        }
+      },
+      "required": [
+        "gene_id"
+      ]
+    },
+    "fields": {
+      "endpoint_type": "gene_orthologs"
+    },
+    "type": "NCBIDatasetsTool",
+    "test_examples": [
+      {
+        "gene_id": "7157",
+        "page_size": 10
+      },
+      {
+        "gene_id": "672"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "gene_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "symbol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "tax_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "taxname": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "common_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "chromosomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "total_results": {
+                  "type": "integer"
+                },
+                "query_gene_id": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": [
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "NCBIDatasets_get_taxonomy",
+    "description": "Get detailed taxonomy information from NCBI by taxonomy ID. Returns organism name, rank, full lineage, counts of genes/assemblies/RNA types, and child taxa. Covers all organisms in NCBI Taxonomy including bacteria, archaea, eukaryotes, and viruses. Example: tax_id 9606 returns Homo sapiens with 20,625 protein-coding genes.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "tax_id": {
+          "type": "string",
+          "description": "NCBI Taxonomy ID (numeric). Examples: '9606' (Homo sapiens), '10090' (Mus musculus), '7227' (Drosophila melanogaster), '562' (E. coli)."
+        }
+      },
+      "required": [
+        "tax_id"
+      ]
+    },
+    "fields": {
+      "endpoint_type": "taxonomy"
+    },
+    "type": "NCBIDatasetsTool",
+    "test_examples": [
+      {
+        "tax_id": "9606"
+      },
+      {
+        "tax_id": "7227"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "tax_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "organism_name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "genbank_common_name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "rank": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "blast_name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "lineage": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "children": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "counts": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string"
+                      },
+                      "count": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "total_results": {
+                  "type": "integer"
+                },
+                "query_tax_id": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": [
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "NCBIDatasets_suggest_taxonomy",
+    "description": "Suggest taxonomic names matching a query string. Searches NCBI Taxonomy for organisms by partial name, returning matching scientific names, taxonomy IDs, common names, and ranks. Useful for finding taxonomy IDs from partial organism names. Example: 'drosophila' returns D. melanogaster (7227), D. simulans (7240), etc.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Partial organism name to search. Examples: 'drosophila', 'escherichia', 'arabidopsis', 'saccharomyces'."
+        }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "fields": {
+      "endpoint_type": "taxonomy_suggest"
+    },
+    "type": "NCBIDatasetsTool",
+    "test_examples": [
+      {
+        "query": "drosophila"
+      },
+      {
+        "query": "arabidopsis"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "scientific_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "tax_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "common_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rank": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "group_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "matched_term": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "total_results": {
+                  "type": "integer"
+                },
+                "query": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "required": [
+            "data"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "NCBIDatasets_get_genome_assembly",
+    "description": "Get genome assembly metadata for an assembly accession (RefSeq GCF_ or GenBank GCA_) from the NCBI Datasets v2 API. Returns organism/strain, assembly name/level/status, RefSeq category (e.g. reference genome), release date, submitter, BioProject, and assembly statistics (total length, chromosome count, contig/scaffold N50, GC%, annotation provider). Use to characterize a specific genome assembly across any organism (bacteria, fungi, plant, animal). No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "Assembly accession, e.g. 'GCF_000005845.2' (E. coli K-12) or 'GCF_000001405.40' (human GRCh38.p14)."
+        }
+      },
+      "required": [
+        "accession"
+      ]
+    },
+    "fields": {
+      "endpoint_type": "genome_assembly"
+    },
+    "type": "NCBIDatasetsTool",
+    "test_examples": [
+      {
+        "accession": "GCF_000005845.2"
+      },
+      {
+        "accession": "GCF_000001405.40"
+      },
+      {
+        "accession": "GCF_000146045.2"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "Curated assembly fields (accession, organism, level, stats)",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "NCBIDatasets_list_genomes_by_taxon",
+    "description": "List genome assemblies available for a taxon (NCBI tax id or scientific name) via the NCBI Datasets v2 API. Returns a summary list of assemblies (accession, assembly name/level, RefSeq category, release date, total length, N50, GC%) plus the total count available. Use to discover what genomes exist for an organism or clade, e.g. all Escherichia coli or Mycobacterium tuberculosis assemblies. Set reference_only to restrict to reference/representative genomes. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "taxon": {
+          "type": "string",
+          "description": "NCBI tax id or scientific name, e.g. '562', 'Escherichia coli', 'Saccharomyces cerevisiae'."
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Max assemblies to return (default 20, max 100)."
+        },
+        "reference_only": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "If true, return only reference/representative genomes."
+        }
+      },
+      "required": [
+        "taxon"
+      ]
+    },
+    "fields": {
+      "endpoint_type": "genomes_by_taxon"
+    },
+    "type": "NCBIDatasetsTool",
+    "test_examples": [
+      {
+        "taxon": "Saccharomyces cerevisiae",
+        "limit": 5,
+        "reference_only": true
+      },
+      {
+        "taxon": "562",
+        "limit": 3
+      },
+      {
+        "taxon": "Mycobacterium tuberculosis",
+        "limit": 5
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "Assembly summaries"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "NCBIDatasets_get_sequence_reports",
+    "description": "Get per-sequence (chromosome/plasmid/scaffold) reports for a genome assembly via the NCBI Datasets v2 API. Returns each molecule's chromosome name, role, location type, RefSeq and GenBank accessions, length, and GC%. Use to map an assembly to its individual sequence accessions (e.g. resolve E. coli K-12 to NC_000913.3, or human chromosomes to their RefSeq NC_ accessions). No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "Assembly accession, e.g. 'GCF_000005845.2'."
+        }
+      },
+      "required": [
+        "accession"
+      ]
+    },
+    "fields": {
+      "endpoint_type": "sequence_reports"
+    },
+    "type": "NCBIDatasetsTool",
+    "test_examples": [
+      {
+        "accession": "GCF_000005845.2"
+      },
+      {
+        "accession": "GCF_000146045.2"
+      },
+      {
+        "accession": "GCF_000001405.40"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "Sequence records"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]


### PR DESCRIPTION
## Summary

Part 3 of 5 batches fixing #288 — 113 of the 552 tools with envelope-style `return_schema` beyond the 9 already fixed in #287. Same root cause and fix recipe as batch 1 (#290); see that PR for the full write-up.

## Files in this batch (alphabetically G-N)

`gtopdb`, `harmonizome`, `hemolytik2`, `hgnc`, `hlaligandatlas`, `hpa`, `hubmap_sample`, `hubmap`, `huggingface_inference`, `icite`, `idigbio`, `idr_searchengine`, `idr`, `iedb_prediction`, `imgt`, `impc`, `intact`, `interpro_domain_arch`, `interpro_entry`, `interpro_ext`, `interpro_member_db`, `interpro`, `interproscan`, `ipd_imgt_hla`, `iptmnet`, `isrctn`, `iupred3`, `kegg`, `lipidmaps_gene`, `lipidmaps`, `marine_regions`, `marrvel`, `massbank`, `massive`, `mavedb`, `mendelian_randomization`, `metabolights`, `metabolite`, `metabolomics_workbench`, `mgnify_expanded`, `mgnify`, `mhcmotifatlas`, `mibig`, `mpd`, `msigdb`, `nasa_sbdb`, `ncbi_datasets`.

## A real bug this batch caught (beyond the mechanical fix)

`Harmonizome_get_gene_set_members` has two mutually exclusive success shapes depending on `mode`: `gene_set` mode returns `members`, `gene` mode returns `associations`, never both. The mechanical fix initially picked a single disambiguating `required: ["members"]`, which broke `gene` mode. Live-testing this tool's full example set (rather than just checking schema validity statically) caught the regression before push; fixed by changing to `anyOf: [{"required":["members"]}, {"required":["associations"]}]`, confirmed live against both modes.

That finding prompted a targeted sweep across all 552 tools in #288 for the same risk pattern (a test_examples parameter that varies a mode/operation/type-like key across examples, combined with a single-field `required` on the promoted success branch). It surfaced 4 more candidates; all 4 were live-tested and confirmed already correct (`BiGG_download_model`, `OpenAIRE_search_publications`, `web_search`, `EBI_msa_align`, `IDR_list_metadata_keys` — the last two required checking `EBI_msa_align` from the already-pushed batch 2 PR (#291) as well, which also passed).

## Validation

- Every changed tool's `return_schema.oneOf` compiles under `jsonschema.Draft7Validator` and stays disjoint (synthetic error-payload check).
- `tu list` loads the full registry cleanly with this batch applied.
- Live-tested a representative sample against real APIs: `GtoPdb_get_interactions`, `Harmonizome_get_gene_set_members` (both modes), `HGNC_fetch_gene_family_members`, `HuBMAP_search_samples`, `iCite_get_publications`, `iDigBio_search_records`, `IMPC_get_gene_summary`, `InterPro_search_entries`, `ISRCTN_search_trials`, `kegg_search_pathway`, `LipidMaps_get_compound_by_xref`, `MarineRegions_get_record`, `MARRVEL_get_gene`, `MassBank_get_record_by_accession`, `HMDB_search`, `MetabolomicsWorkbench_get_study`, `MGnify_get_samples`, `MSigDB_get_gene_set_members`, `NASASBDB_get_body`, `NCBIDatasets_get_genome_assembly`, `IDR_list_metadata_keys` — all pass.

## Test coverage

Schema-only change; correctness validated via the programmatic disjointness check plus the live `tu test` runs above.