### PR TITLE
Fix #288: correct envelope-style return_schema (batch 5/5, files R-Z)

### DIFF
--- a/src/tooluniverse/data/rnacentral_tools.json
+++ b/src/tooluniverse/data/rnacentral_tools.json
@@ -15,10 +15,12 @@
           "default": 10,
           "minimum": 1,
           "maximum": 100,
-          "description": "Number of records per page (1–100)."
+          "description": "Number of records per page (1\u2013100)."
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "fields": {
       "endpoint": "https://rnacentral.org/api/v1/rna/",
@@ -28,35 +30,72 @@
       "type": "object",
       "description": "RNAcentral rna list response",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "data": {
           "type": "object",
           "properties": {
-            "count": {"type": "integer"},
+            "count": {
+              "type": "integer"
+            },
             "results": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "rnacentral_id": {"type": "string"},
-                  "description": {"type": "string"},
-                  "rna_type": {"type": "string"},
-                  "taxon": {"type": "object", "properties": {"scientific_name": {"type": "string"}, "taxid": {"type": "integer"}}}
+                  "rnacentral_id": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "rna_type": {
+                    "type": "string"
+                  },
+                  "taxon": {
+                    "type": "object",
+                    "properties": {
+                      "scientific_name": {
+                        "type": "string"
+                      },
+                      "taxid": {
+                        "type": "integer"
+                      }
+                    }
+                  }
                 }
               }
             }
           }
         },
-        "url": {"type": "string"}
+        "url": {
+          "type": "string"
+        }
       }
     },
     "test_examples": [
-      {"query": "let-7", "page_size": 1},
-      {"query": "U6", "page_size": 1}
+      {
+        "query": "let-7",
+        "page_size": 1
+      },
+      {
+        "query": "U6",
+        "page_size": 1
+      }
     ],
-    "label": ["RNAcentral", "ncRNA", "Search"],
+    "label": [
+      "RNAcentral",
+      "ncRNA",
+      "Search"
+    ],
     "metadata": {
-      "tags": ["rna", "mirna", "lncrna", "annotation"],
+      "tags": [
+        "rna",
+        "mirna",
+        "lncrna",
+        "annotation"
+      ],
       "estimated_execution_time": "< 2 seconds"
     }
   },
@@ -72,7 +111,9 @@
           "description": "RNAcentral accession (e.g., 'URS000075C808')."
         }
       },
-      "required": ["accession"]
+      "required": [
+        "accession"
+      ]
     },
     "fields": {
       "endpoint": "https://rnacentral.org/api/v1/rna/{accession}",
@@ -82,17 +123,33 @@
       "type": "object",
       "description": "RNAcentral accession response",
       "properties": {
-        "status": {"type": "string"},
-        "data": {"type": "object"},
-        "url": {"type": "string"}
+        "status": {
+          "type": "string"
+        },
+        "data": {
+          "type": "object"
+        },
+        "url": {
+          "type": "string"
+        }
       }
     },
     "test_examples": [
-      {"accession": "URS000075C808"}
+      {
+        "accession": "URS000075C808"
+      }
     ],
-    "label": ["RNAcentral", "ncRNA", "Record"],
+    "label": [
+      "RNAcentral",
+      "ncRNA",
+      "Record"
+    ],
     "metadata": {
-      "tags": ["rna", "accession", "annotation"],
+      "tags": [
+        "rna",
+        "accession",
+        "annotation"
+      ],
       "estimated_execution_time": "< 2 seconds"
     }
   },
@@ -108,11 +165,16 @@
           "description": "RNAcentral URS identifier (e.g., 'URS000063A371', 'URS000075C808')."
         }
       },
-      "required": ["accession"]
+      "required": [
+        "accession"
+      ]
     },
     "fields": {
       "endpoint": "https://rnacentral.org/api/v1/rna/{accession}/[xrefs,publications]",
-      "sub_resources": ["xrefs", "publications"],
+      "sub_resources": [
+        "xrefs",
+        "publications"
+      ],
       "format": "json"
     },
     "return_schema": {
@@ -120,46 +182,69 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "accession": {"type": "string"},
-            "data": {
+            "xrefs": {
               "type": "object",
               "properties": {
-                "xrefs": {
-                  "type": "object",
-                  "properties": {
-                    "count": {"type": "integer"},
-                    "results": {"type": "array", "items": {"type": "object"}}
-                  }
+                "count": {
+                  "type": "integer"
                 },
-                "publications": {
-                  "type": "object",
-                  "properties": {
-                    "count": {"type": "integer"},
-                    "results": {"type": "array", "items": {"type": "object"}}
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            },
+            "publications": {
+              "type": "object",
+              "properties": {
+                "count": {
+                  "type": "integer"
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
                   }
                 }
               }
             }
           },
-          "required": ["data"]
+          "required": [
+            "xrefs"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"accession": "URS000063A371"}
+      {
+        "accession": "URS000063A371"
+      }
     ],
-    "label": ["RNAcentral", "ncRNA", "CrossReference"],
+    "label": [
+      "RNAcentral",
+      "ncRNA",
+      "CrossReference"
+    ],
     "metadata": {
-      "tags": ["rna", "xrefs", "publications", "annotation"],
+      "tags": [
+        "rna",
+        "xrefs",
+        "publications",
+        "annotation"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   },
@@ -171,23 +256,38 @@
       "type": "object",
       "properties": {
         "region": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Locus as 'chr:start-end' (1-based), e.g. '2:39745816-39826679'. Omit if giving chromosome/start/end."
         },
         "species": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Ensembl species slug (default 'homo_sapiens'). E.g. 'mus_musculus', 'danio_rerio'."
         },
         "chromosome": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Chromosome name without 'chr' prefix, e.g. '2'. Used with start/end when 'region' is omitted."
         },
         "start": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Region start (1-based). Used with chromosome/end when 'region' is omitted."
         },
         "end": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Region end (1-based). Used with chromosome/start when 'region' is omitted."
         }
       },
@@ -203,38 +303,67 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "species": {"type": "string"},
-            "region": {"type": "string"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "features": {"type": "array", "items": {"type": "object"}},
-                "transcripts": {"type": "array", "items": {"type": "object"}},
-                "exons": {"type": "array", "items": {"type": "object"}},
-                "transcript_count": {"type": "integer"},
-                "exon_count": {"type": "integer"}
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
+            },
+            "transcripts": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "exons": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "transcript_count": {
+              "type": "integer"
+            },
+            "exon_count": {
+              "type": "integer"
             }
           },
-          "required": ["data"]
+          "required": [
+            "features"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"region": "2:39745816-39826679", "species": "homo_sapiens"}
+      {
+        "region": "2:39745816-39826679",
+        "species": "homo_sapiens"
+      }
     ],
-    "label": ["RNAcentral", "ncRNA", "GenomeRegion"],
+    "label": [
+      "RNAcentral",
+      "ncRNA",
+      "GenomeRegion"
+    ],
     "metadata": {
-      "tags": ["rna", "ncrna", "genome", "region", "annotation"],
+      "tags": [
+        "rna",
+        "ncrna",
+        "genome",
+        "region",
+        "annotation"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   }

--- a/src/tooluniverse/data/roc_analysis_tools.json
+++ b/src/tooluniverse/data/roc_analysis_tools.json
@@ -72,23 +72,17 @@
       "type": "object",
       "oneOf": [
         {
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/ror_tools.json
+++ b/src/tooluniverse/data/ror_tools.json
@@ -78,22 +78,21 @@
                 }
               }
             }
-          }
+          },
+          "required": [
+            "number_of_results"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -315,10 +314,6 @@
                 "type": "string"
               }
             },
-            "status": {
-              "type": "string",
-              "description": "Organization status (active, withdrawn, inactive)"
-            },
             "established": {
               "type": [
                 "integer",
@@ -363,7 +358,10 @@
                 "type": "string"
               }
             }
-          }
+          },
+          "required": [
+            "id"
+          ]
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/rxclass_tools.json
+++ b/src/tooluniverse/data/rxclass_tools.json
@@ -7,19 +7,31 @@
       "type": "object",
       "properties": {
         "drug_name": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Drug name to classify. Examples: 'metformin', 'aspirin', 'ibuprofen', 'metoprolol'."
         },
         "rxcui": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "RxNorm RXCUI identifier (alternative to drug_name). Examples: '6809' (metformin), '1191' (aspirin)."
         },
         "rela_source": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Classification source. Options: 'ATC' (WHO Anatomical Therapeutic Chemical, default), 'FDASPL' (FDA pharmacologic classes including EPC/MoA/PE), 'MESH', 'VA', 'DAILYMED', 'ALL'. Default: 'ATC'."
         },
         "limit": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum results to return (default 20)."
         }
       },
@@ -31,43 +43,63 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "const": "success"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "classId": {"type": "string"},
-                  "className": {"type": "string"},
-                  "classType": {"type": "string"},
-                  "rxcui": {"type": "string"},
-                  "drugName": {"type": "string"},
-                  "tty": {"type": "string"},
-                  "rela": {"type": "string"},
-                  "relaSource": {"type": "string"}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "classId": {
+                "type": "string"
+              },
+              "className": {
+                "type": "string"
+              },
+              "classType": {
+                "type": "string"
+              },
+              "rxcui": {
+                "type": "string"
+              },
+              "drugName": {
+                "type": "string"
+              },
+              "tty": {
+                "type": "string"
+              },
+              "rela": {
+                "type": "string"
+              },
+              "relaSource": {
+                "type": "string"
               }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "const": "error"},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"drug_name": "metformin", "rela_source": "ATC"},
-      {"drug_name": "ibuprofen", "rela_source": "FDASPL"},
-      {"rxcui": "1191", "rela_source": "ATC"}
+      {
+        "drug_name": "metformin",
+        "rela_source": "ATC"
+      },
+      {
+        "drug_name": "ibuprofen",
+        "rela_source": "FDASPL"
+      },
+      {
+        "rxcui": "1191",
+        "rela_source": "ATC"
+      }
     ]
   },
   {
@@ -82,19 +114,30 @@
           "description": "Drug class identifier. ATC class codes: 'M01AE' (propionic acid derivatives), 'N02BA' (salicylic acid derivatives), 'A10BA' (biguanides). FDA EPC IDs are long numeric strings."
         },
         "rela_source": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Classification source system. Options: 'ATC' (default), 'FDASPL', 'MESH', 'VA', 'DAILYMED'."
         },
         "ttys": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "RxNorm term types to include. Options: 'IN' (ingredients, default), 'PIN' (precise ingredients), 'MIN' (multi-ingredients), 'SCD' (semantic clinical drugs). Default: 'IN'."
         },
         "limit": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum number of drugs to return (default 50)."
         }
       },
-      "required": ["class_id"]
+      "required": [
+        "class_id"
+      ]
     },
     "fields": {
       "operation": "get_class_members"
@@ -102,37 +145,46 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "const": "success"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "rxcui": {"type": "string"},
-                  "name": {"type": "string"},
-                  "tty": {"type": "string"}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rxcui": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tty": {
+                "type": "string"
               }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "const": "error"},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"class_id": "M01AE", "rela_source": "ATC", "ttys": "IN"},
-      {"class_id": "N02BA", "rela_source": "ATC", "ttys": "IN"}
+      {
+        "class_id": "M01AE",
+        "rela_source": "ATC",
+        "ttys": "IN"
+      },
+      {
+        "class_id": "N02BA",
+        "rela_source": "ATC",
+        "ttys": "IN"
+      }
     ]
   },
   {
@@ -147,15 +199,23 @@
           "description": "Keyword to search in class names. Examples: 'analgesic', 'beta blocker', 'antidiabetic', 'statin', 'NSAID', 'ACE inhibitor'."
         },
         "class_type": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Filter by class type. Options: 'ATC1-4' (ATC codes), 'EPC' (Established Pharmacologic Class), 'MOA' (Mechanism of Action), 'PE' (Physiologic Effect), 'DISEASE', 'VA', 'SCHEDULE'."
         },
         "limit": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum results to return (default 20)."
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "fields": {
       "operation": "find_classes"
@@ -163,38 +223,46 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "const": "success"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "classId": {"type": "string"},
-                  "className": {"type": "string"},
-                  "classType": {"type": "string"}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "classId": {
+                "type": "string"
+              },
+              "className": {
+                "type": "string"
+              },
+              "classType": {
+                "type": "string"
               }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "const": "error"},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"query": "beta blocker"},
-      {"query": "statin", "class_type": "EPC"},
-      {"query": "propionic acid"}
+      {
+        "query": "beta blocker"
+      },
+      {
+        "query": "statin",
+        "class_type": "EPC"
+      },
+      {
+        "query": "propionic acid"
+      }
     ]
   },
   {
@@ -209,11 +277,16 @@
           "description": "Drug class identifier whose ancestor chain to traverse. ATC class codes: 'N02BA' (salicylic acid derivatives), 'M01AE' (propionic acid derivatives), 'A10BA' (biguanides), 'C09AA' (ACE inhibitors)."
         },
         "source": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional classification source/vocabulary for the graph. Default: ATC (the API default when omitted). Most ATC class IDs do not require this."
         }
       },
-      "required": ["class_id"]
+      "required": [
+        "class_id"
+      ]
     },
     "fields": {
       "operation": "get_class_hierarchy"
@@ -223,63 +296,85 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "nodes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "classId": {"type": "string"},
-                      "className": {"type": "string"},
-                      "classType": {"type": "string"}
-                    }
-                  }
-                },
-                "edges": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "child": {"type": "string"},
-                      "rela": {"type": "string"},
-                      "parent": {"type": "string"}
-                    }
-                  }
-                },
-                "ancestor_path": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "classId": {"type": "string"},
-                      "className": {"type": "string"},
-                      "classType": {"type": "string"}
-                    }
+            "nodes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "classId": {
+                    "type": "string"
+                  },
+                  "className": {
+                    "type": "string"
+                  },
+                  "classType": {
+                    "type": "string"
                   }
                 }
               }
             },
-            "metadata": {"type": "object"}
+            "edges": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "child": {
+                    "type": "string"
+                  },
+                  "rela": {
+                    "type": "string"
+                  },
+                  "parent": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "ancestor_path": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "classId": {
+                    "type": "string"
+                  },
+                  "className": {
+                    "type": "string"
+                  },
+                  "classType": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
           },
-          "required": ["status", "data"]
+          "required": [
+            "nodes"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "const": "error"},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"class_id": "N02BA"},
-      {"class_id": "M01AE"},
-      {"class_id": "A10BA"}
+      {
+        "class_id": "N02BA"
+      },
+      {
+        "class_id": "M01AE"
+      },
+      {
+        "class_id": "A10BA"
+      }
     ]
   },
   {
@@ -290,23 +385,38 @@
       "type": "object",
       "properties": {
         "drug_name": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Forward lookup: drug name. Examples: 'albuterol', 'aspirin', 'metoprolol'. Provide this OR 'rxcui' OR 'class_id'."
         },
         "rxcui": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Forward lookup: RxNorm RXCUI (alternative to drug_name)."
         },
         "class_id": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Reverse lookup: MED-RT/MeSH disease class ID to find all related drugs for. Examples: 'D001249' (Asthma), 'D001986' (Bronchial Spasm), 'D003920' (Diabetes Mellitus)."
         },
         "rela": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "MED-RT relationship to filter on. Options: 'may_treat', 'may_prevent', 'CI_with' (contraindicated with), 'induces', 'has_PE' (has physiologic effect), 'has_MoA', 'has_EPC'. Default: all relations."
         },
         "ttys": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Reverse lookup only: RxNorm term types for returned drugs. Options: 'IN' (ingredients, default), 'PIN', 'MIN', 'SCD'. Default: 'IN'."
         }
       },
@@ -318,43 +428,63 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "const": "success"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "classId": {"type": "string"},
-                  "className": {"type": "string"},
-                  "classType": {"type": "string"},
-                  "rela": {"type": "string"},
-                  "rxcui": {"type": "string"},
-                  "drugName": {"type": "string"},
-                  "name": {"type": "string"},
-                  "tty": {"type": "string"}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "classId": {
+                "type": "string"
+              },
+              "className": {
+                "type": "string"
+              },
+              "classType": {
+                "type": "string"
+              },
+              "rela": {
+                "type": "string"
+              },
+              "rxcui": {
+                "type": "string"
+              },
+              "drugName": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tty": {
+                "type": "string"
               }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "const": "error"},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"drug_name": "albuterol", "rela": "may_treat"},
-      {"class_id": "D001249", "rela": "may_treat", "ttys": "IN"},
-      {"drug_name": "aspirin"}
+      {
+        "drug_name": "albuterol",
+        "rela": "may_treat"
+      },
+      {
+        "class_id": "D001249",
+        "rela": "may_treat",
+        "ttys": "IN"
+      },
+      {
+        "drug_name": "aspirin"
+      }
     ]
   }
 ]

--- a/src/tooluniverse/data/rxn_chemistry_tools.json
+++ b/src/tooluniverse/data/rxn_chemistry_tools.json
@@ -11,7 +11,7 @@
         "domain": "Drugs & Chemistry",
         "type": "secret",
         "register_url": "https://rxn.app.accelerate.science",
-        "purpose": "IBM RXN for Chemistry API key — runs ML forward reaction prediction and retrosynthesis.",
+        "purpose": "IBM RXN for Chemistry API key \u2014 runs ML forward reaction prediction and retrosynthesis.",
         "without": "RXN tools return a clear missing-key error and cannot run predictions."
       }
     },
@@ -56,67 +56,55 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "reactants": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "reactants": {
-                  "type": "string"
-                },
-                "product_smiles": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "confidence": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "attempts": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "smiles": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "confidence": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "product_smiles": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "confidence": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "attempts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "smiles": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "confidence": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
-                },
-                "prediction_id": {
-                  "type": "string"
-                },
-                "ai_model": {
-                  "type": "string"
                 }
               }
+            },
+            "prediction_id": {
+              "type": "string"
+            },
+            "ai_model": {
+              "type": "string"
             }
           },
           "required": [
-            "status",
-            "data"
+            "reactants"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
@@ -146,7 +134,7 @@
         "domain": "Drugs & Chemistry",
         "type": "secret",
         "register_url": "https://rxn.app.accelerate.science",
-        "purpose": "IBM RXN for Chemistry API key — runs ML forward reaction prediction and retrosynthesis.",
+        "purpose": "IBM RXN for Chemistry API key \u2014 runs ML forward reaction prediction and retrosynthesis.",
         "without": "RXN tools return a clear missing-key error and cannot run predictions."
       }
     },
@@ -195,64 +183,52 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "product": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "product": {
-                  "type": "string"
-                },
-                "routes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "smiles": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "confidence": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "count": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+            "routes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "smiles": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "confidence": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   }
-                },
-                "route_count": {
-                  "type": "integer"
-                },
-                "prediction_id": {
-                  "type": "string"
-                },
-                "ai_model": {
-                  "type": "string"
                 }
               }
+            },
+            "route_count": {
+              "type": "integer"
+            },
+            "prediction_id": {
+              "type": "string"
+            },
+            "ai_model": {
+              "type": "string"
             }
           },
           "required": [
-            "status",
-            "data"
+            "product"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/rxnorm_extended_tools.json
+++ b/src/tooluniverse/data/rxnorm_extended_tools.json
@@ -11,7 +11,9 @@
           "description": "Drug name to look up (generic, brand, or synonym). Examples: 'metformin', 'Lipitor', 'acetaminophen', 'warfarin sodium'."
         }
       },
-      "required": ["drug_name"]
+      "required": [
+        "drug_name"
+      ]
     },
     "fields": {
       "operation": "find_rxcui",
@@ -20,27 +22,63 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "data": {
           "type": "object",
           "properties": {
-            "drug_name": {"type": "string"},
-            "rxcuis": {"type": "array", "items": {"type": "string"}},
-            "primary_rxcui": {"type": ["string", "null"]},
-            "found": {"type": "boolean"}
+            "drug_name": {
+              "type": "string"
+            },
+            "rxcuis": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "primary_rxcui": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "found": {
+              "type": "boolean"
+            }
           }
         },
-        "metadata": {"type": "object", "additionalProperties": true}
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
       }
     },
     "test_examples": [
-      {"drug_name": "metformin"},
-      {"drug_name": "warfarin"},
-      {"drug_name": "atorvastatin"}
+      {
+        "drug_name": "metformin"
+      },
+      {
+        "drug_name": "warfarin"
+      },
+      {
+        "drug_name": "atorvastatin"
+      }
     ],
-    "label": ["RxNorm", "RXCUI", "drug", "NLM", "standardization"],
+    "label": [
+      "RxNorm",
+      "RXCUI",
+      "drug",
+      "NLM",
+      "standardization"
+    ],
     "metadata": {
-      "tags": ["drug_standardization", "drug_identifier", "NLM", "rxnorm"],
+      "tags": [
+        "drug_standardization",
+        "drug_identifier",
+        "NLM",
+        "rxnorm"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   },
@@ -68,29 +106,78 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "data": {
           "type": "object",
           "properties": {
-            "rxcui": {"type": "string"},
-            "name": {"type": ["string", "null"]},
-            "synonym": {"type": ["string", "null"]},
-            "term_type": {"type": ["string", "null"]},
-            "term_type_label": {"type": ["string", "null"]},
-            "language": {"type": ["string", "null"]}
+            "rxcui": {
+              "type": "string"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "synonym": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "term_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "term_type_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "language": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           }
         },
-        "metadata": {"type": "object", "additionalProperties": true}
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
       }
     },
     "test_examples": [
-      {"rxcui": "6809"},
-      {"drug_name": "warfarin"},
-      {"rxcui": "860975"}
+      {
+        "rxcui": "6809"
+      },
+      {
+        "drug_name": "warfarin"
+      },
+      {
+        "rxcui": "860975"
+      }
     ],
-    "label": ["RxNorm", "drug", "properties", "NLM", "terminology"],
+    "label": [
+      "RxNorm",
+      "drug",
+      "properties",
+      "NLM",
+      "terminology"
+    ],
     "metadata": {
-      "tags": ["drug_information", "drug_properties", "NLM", "rxnorm"],
+      "tags": [
+        "drug_information",
+        "drug_properties",
+        "NLM",
+        "rxnorm"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   },
@@ -123,11 +210,15 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "data": {
           "type": "object",
           "properties": {
-            "rxcui": {"type": "string"},
+            "rxcui": {
+              "type": "string"
+            },
             "related_drugs": {
               "type": "object",
               "description": "Grouped by term-type label. Keys are human-readable type labels.",
@@ -136,27 +227,67 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "rxcui": {"type": ["string", "null"]},
-                    "name": {"type": ["string", "null"]},
-                    "synonym": {"type": ["string", "null"]}
+                    "rxcui": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "synonym": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
                   }
                 }
               }
             },
-            "total_related": {"type": "integer"}
+            "total_related": {
+              "type": "integer"
+            }
           }
         },
-        "metadata": {"type": "object", "additionalProperties": true}
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
       }
     },
     "test_examples": [
-      {"rxcui": "6809"},
-      {"drug_name": "atorvastatin"},
-      {"rxcui": "11289", "tty": "BN+SBD"}
+      {
+        "rxcui": "6809"
+      },
+      {
+        "drug_name": "atorvastatin"
+      },
+      {
+        "rxcui": "11289",
+        "tty": "BN+SBD"
+      }
     ],
-    "label": ["RxNorm", "drug", "brand", "generic", "related", "NLM"],
+    "label": [
+      "RxNorm",
+      "drug",
+      "brand",
+      "generic",
+      "related",
+      "NLM"
+    ],
     "metadata": {
-      "tags": ["drug_products", "brand_generic", "drug_lookup", "NLM", "rxnorm"],
+      "tags": [
+        "drug_products",
+        "brand_generic",
+        "drug_lookup",
+        "NLM",
+        "rxnorm"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   },
@@ -172,7 +303,9 @@
           "description": "National Drug Code, 11-digit. Accepts hyphenated (e.g., '00093-0058-01') or plain digits (e.g., '00093005801')."
         }
       },
-      "required": ["ndc"]
+      "required": [
+        "ndc"
+      ]
     },
     "fields": {
       "operation": "get_ndc_status_history",
@@ -183,52 +316,129 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "ndc": {"type": "string"},
-                "found": {"type": "boolean"},
-                "ndc11": {"type": ["string", "null"]},
-                "status": {"type": ["string", "null"]},
-                "active": {"type": ["string", "null"]},
-                "rxcui": {"type": ["string", "null"]},
-                "concept_name": {"type": ["string", "null"]},
-                "concept_status": {"type": ["string", "null"]},
-                "sources": {"type": "array", "items": {"type": "string"}},
-                "ndc_history": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "active_rxcui": {"type": ["string", "null"]},
-                      "original_rxcui": {"type": ["string", "null"]},
-                      "start_date": {"type": ["string", "null"]},
-                      "end_date": {"type": ["string", "null"]}
-                    }
+            "ndc": {
+              "type": "string"
+            },
+            "found": {
+              "type": "boolean"
+            },
+            "ndc11": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "active": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "rxcui": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "concept_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "concept_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sources": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ndc_history": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "active_rxcui": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "original_rxcui": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "start_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "end_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": ["ndc", "found"]
-            },
-            "metadata": {"type": "object", "additionalProperties": true}
+              }
+            }
           },
-          "required": ["data"]
+          "required": [
+            "ndc",
+            "found"
+          ]
         },
         {
           "type": "object",
-          "properties": {"error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"ndc": "00093-0058-01"},
-      {"ndc": "00093005801"}
+      {
+        "ndc": "00093-0058-01"
+      },
+      {
+        "ndc": "00093005801"
+      }
     ],
-    "label": ["RxNorm", "NDC", "status", "history", "drug_safety", "NLM"],
+    "label": [
+      "RxNorm",
+      "NDC",
+      "status",
+      "history",
+      "drug_safety",
+      "NLM"
+    ],
     "metadata": {
-      "tags": ["ndc", "drug_status", "remapping", "NLM", "rxnorm"],
+      "tags": [
+        "ndc",
+        "drug_status",
+        "remapping",
+        "NLM",
+        "rxnorm"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   },
@@ -244,7 +454,9 @@
           "description": "National Drug Code. Accepts hyphenated (e.g., '0781-1506-10') or plain-digit form."
         }
       },
-      "required": ["ndc"]
+      "required": [
+        "ndc"
+      ]
     },
     "fields": {
       "operation": "get_ndc_properties",
@@ -255,54 +467,142 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "ndc": {"type": "string"},
-                "found": {"type": "boolean"},
-                "products": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "ndc_item": {"type": ["string", "null"]},
-                      "ndc10": {"type": ["string", "null"]},
-                      "ndc9": {"type": ["string", "null"]},
-                      "rxcui": {"type": ["string", "null"]},
-                      "spl_set_id": {"type": ["string", "null"]},
-                      "imprint_code": {"type": ["string", "null"]},
-                      "color": {"type": ["string", "null"]},
-                      "shape": {"type": ["string", "null"]},
-                      "labeler": {"type": ["string", "null"]},
-                      "marketing_category": {"type": ["string", "null"]},
-                      "anda": {"type": ["string", "null"]},
-                      "nda": {"type": ["string", "null"]},
-                      "packaging": {"type": "array", "items": {"type": "string"}},
-                      "properties": {"type": "object", "additionalProperties": true}
+            "ndc": {
+              "type": "string"
+            },
+            "found": {
+              "type": "boolean"
+            },
+            "products": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ndc_item": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ndc10": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ndc9": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rxcui": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "spl_set_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "imprint_code": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "color": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "shape": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "labeler": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "marketing_category": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "anda": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "nda": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "packaging": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "properties": {
+                    "type": "object",
+                    "additionalProperties": true
                   }
                 }
-              },
-              "required": ["ndc", "found"]
-            },
-            "metadata": {"type": "object", "additionalProperties": true}
+              }
+            }
           },
-          "required": ["data"]
+          "required": [
+            "ndc",
+            "found"
+          ]
         },
         {
           "type": "object",
-          "properties": {"error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"ndc": "0781-1506-10"}
+      {
+        "ndc": "0781-1506-10"
+      }
     ],
-    "label": ["RxNorm", "NDC", "pill_id", "imprint", "packaging", "NLM"],
+    "label": [
+      "RxNorm",
+      "NDC",
+      "pill_id",
+      "imprint",
+      "packaging",
+      "NLM"
+    ],
     "metadata": {
-      "tags": ["ndc", "pill_identification", "imprint", "NLM", "rxnorm"],
+      "tags": [
+        "ndc",
+        "pill_identification",
+        "imprint",
+        "NLM",
+        "rxnorm"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   }

--- a/src/tooluniverse/data/sabdab_tools.json
+++ b/src/tooluniverse/data/sabdab_tools.json
@@ -113,88 +113,128 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "const": "success"
+            "pdb_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "pdb_id": {
-                  "type": "string"
-                },
-                "antigen_name": {
-                  "type": ["string", "null"]
-                },
-                "antigen_species": {
-                  "type": ["string", "null"]
-                },
-                "heavy_species": {
-                  "type": ["string", "null"]
-                },
-                "light_species": {
-                  "type": ["string", "null"]
-                },
-                "resolution": {
-                  "type": ["number", "string", "null"]
-                },
-                "method": {
-                  "type": ["string", "null"]
-                },
-                "r_free": {
-                  "type": ["number", "string", "null"]
-                },
-                "r_factor": {
-                  "type": ["number", "string", "null"]
-                },
-                "heavy_subclass": {
-                  "type": ["string", "null"]
-                },
-                "light_subclass": {
-                  "type": ["string", "null"]
-                },
-                "scfv": {
-                  "type": ["boolean", "null"]
-                },
-                "engineered": {
-                  "type": ["boolean", "null"]
-                },
-                "affinity": {
-                  "type": ["number", "string", "null"]
-                },
-                "delta_g": {
-                  "type": ["number", "string", "null"]
-                },
-                "pmid": {
-                  "type": ["integer", "string", "null"]
-                },
-                "chains": {
-                  "type": "array"
-                },
-                "count": {
-                  "type": "integer"
-                }
-              },
-              "required": ["pdb_id", "chains", "count"]
+            "antigen_name": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "metadata": {
-              "type": "object"
+            "antigen_species": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "heavy_species": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "light_species": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "resolution": {
+              "type": [
+                "number",
+                "string",
+                "null"
+              ]
+            },
+            "method": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "r_free": {
+              "type": [
+                "number",
+                "string",
+                "null"
+              ]
+            },
+            "r_factor": {
+              "type": [
+                "number",
+                "string",
+                "null"
+              ]
+            },
+            "heavy_subclass": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "light_subclass": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "scfv": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "engineered": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "affinity": {
+              "type": [
+                "number",
+                "string",
+                "null"
+              ]
+            },
+            "delta_g": {
+              "type": [
+                "number",
+                "string",
+                "null"
+              ]
+            },
+            "pmid": {
+              "type": [
+                "integer",
+                "string",
+                "null"
+              ]
+            },
+            "chains": {
+              "type": "array"
+            },
+            "count": {
+              "type": "integer"
             }
           },
-          "required": ["status", "data"]
+          "required": [
+            "pdb_id",
+            "chains",
+            "count"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/sasbdb_tools.json
+++ b/src/tooluniverse/data/sasbdb_tools.json
@@ -11,32 +11,35 @@
           "description": "Search query: UniProt accession (e.g., 'P02769' for BSA) or free-text term. Note: SASBDB has no full-text search API; UniProt accessions are resolved directly."
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {"type": "array"},
-            "note": {"type": "string"}
-          },
-          "required": ["status", "data"]
+          "type": "array"
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"query": "P02769"},
-      {"query": "BSA"}
+      {
+        "query": "P02769"
+      },
+      {
+        "query": "BSA"
+      }
     ]
   },
   {

--- a/src/tooluniverse/data/scanprosite_tools.json
+++ b/src/tooluniverse/data/scanprosite_tools.json
@@ -115,7 +115,11 @@
         },
         "db": {
           "type": "string",
-          "enum": ["sprot", "trembl", "uniprot"],
+          "enum": [
+            "sprot",
+            "trembl",
+            "uniprot"
+          ],
           "default": "sprot",
           "description": "Sequence database to search: 'sprot' = Swiss-Prot (reviewed, default), 'trembl' = TrEMBL (unreviewed), 'uniprot' = both."
         },
@@ -132,89 +136,92 @@
           "description": "Maximum number of matching protein records to return (default 50, max 1000). The 'total_matches' metadata reports the full count found by the server."
         }
       },
-      "required": ["signature_ac"]
+      "required": [
+        "signature_ac"
+      ]
     },
     "fields": {
       "endpoint": "find_proteins_with_motif"
     },
     "test_examples": [
-      {"signature_ac": "PS00029"},
-      {"signature_ac": "PS00029", "max_results": 10}
+      {
+        "signature_ac": "PS00029"
+      },
+      {
+        "signature_ac": "PS00029",
+        "max_results": 10
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": ["success"]
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "sequence_ac": {
-                    "type": ["string", "null"],
-                    "description": "UniProt accession of the matching protein (e.g., Q6GZW6)"
-                  },
-                  "sequence_id": {
-                    "type": ["string", "null"],
-                    "description": "UniProt entry name (e.g., 009L_FRG3G)"
-                  },
-                  "sequence_db": {
-                    "type": ["string", "null"],
-                    "description": "Sequence database (sp for Swiss-Prot, tr for TrEMBL)"
-                  },
-                  "start": {
-                    "type": ["integer", "null"],
-                    "description": "Start position of the motif match in the protein"
-                  },
-                  "stop": {
-                    "type": ["integer", "null"],
-                    "description": "End position of the motif match"
-                  },
-                  "signature_ac": {
-                    "type": ["string", "null"],
-                    "description": "PROSITE signature accession that matched (e.g., PS00029)"
-                  },
-                  "signature_id": {
-                    "type": ["string", "null"],
-                    "description": "PROSITE signature name (e.g., LEUCINE_ZIPPER)"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "sequence_ac": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "UniProt accession of the matching protein (e.g., Q6GZW6)"
               },
-              "description": "Array of matching UniProt proteins with motif positions"
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "signature_ac": {"type": "string"},
-                "database": {"type": "string"},
-                "total_matches": {"type": "integer"},
-                "total_sequences": {"type": ["integer", "null"]},
-                "capped": {"type": "boolean"},
-                "returned": {"type": "integer"},
-                "skip_frequent_patterns": {"type": "boolean"}
+              "sequence_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "UniProt entry name (e.g., 009L_FRG3G)"
+              },
+              "sequence_db": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Sequence database (sp for Swiss-Prot, tr for TrEMBL)"
+              },
+              "start": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Start position of the motif match in the protein"
+              },
+              "stop": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "End position of the motif match"
+              },
+              "signature_ac": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "PROSITE signature accession that matched (e.g., PS00029)"
+              },
+              "signature_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "PROSITE signature name (e.g., LEUCINE_ZIPPER)"
               }
             }
           },
-          "required": ["status", "data"]
+          "description": "Array of matching UniProt proteins with motif positions"
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": ["error"]
-            },
             "error": {
               "type": "string"
             }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/screen_tools.json
+++ b/src/tooluniverse/data/screen_tools.json
@@ -37,72 +37,57 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_name": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_name": {
-                  "type": "string"
-                },
-                "element_type": {
-                  "type": "string"
-                },
-                "count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "regulatory_elements": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "assay_title": {
-                        "type": "string"
-                      },
-                      "target": {
-                        "type": "string"
-                      },
-                      "biosample": {
-                        "type": "string"
-                      },
-                      "status": {
-                        "type": "string"
-                      }
-                    }
+            "element_type": {
+              "type": "string"
+            },
+            "count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "regulatory_elements": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "assay_title": {
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  },
+                  "biosample": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "gene_name"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/scxa_tools.json
+++ b/src/tooluniverse/data/scxa_tools.json
@@ -246,77 +246,59 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "cell_group_value": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "cell_group_value_where_marker": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "value": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "p_value": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "expression_unit": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "cell_group_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "cell_group_value_where_marker": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "value": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "p_value": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "expression_unit": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/semantic_scholar_ext_tools.json
+++ b/src/tooluniverse/data/semantic_scholar_ext_tools.json
@@ -287,75 +287,57 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "total": {
+              "type": "integer"
+            },
+            "offset": {
+              "type": "integer"
+            },
+            "next": {
+              "type": "integer"
             },
             "data": {
-              "type": "object",
-              "properties": {
-                "total": {
-                  "type": "integer"
-                },
-                "offset": {
-                  "type": "integer"
-                },
-                "next": {
-                  "type": "integer"
-                },
-                "data": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "authorId": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "affiliations": {
-                        "type": "array"
-                      },
-                      "paperCount": {
-                        "type": "integer"
-                      },
-                      "citationCount": {
-                        "type": "integer"
-                      },
-                      "hIndex": {
-                        "type": "integer"
-                      }
-                    }
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "authorId": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "affiliations": {
+                    "type": "array"
+                  },
+                  "paperCount": {
+                    "type": "integer"
+                  },
+                  "citationCount": {
+                    "type": "integer"
+                  },
+                  "hIndex": {
+                    "type": "integer"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
-            },
-            "url": {
-              "type": "string"
             }
-          }
+          },
+          "required": [
+            "total"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -550,43 +532,28 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "recommendedPapers": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  }
-                }
+            "recommendedPapers": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
-            },
-            "url": {
-              "type": "string"
             }
-          }
+          },
+          "required": [
+            "recommendedPapers"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -642,83 +609,65 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
+          "description": "Citation list page from Semantic Scholar",
           "properties": {
-            "status": {
-              "const": "success"
+            "offset": {
+              "type": "integer",
+              "description": "Pagination offset of this page"
+            },
+            "next": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Offset of the next page, if more results exist"
             },
             "data": {
-              "type": "object",
-              "description": "Citation list page from Semantic Scholar",
-              "properties": {
-                "offset": {
-                  "type": "integer",
-                  "description": "Pagination offset of this page"
-                },
-                "next": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Offset of the next page, if more results exist"
-                },
-                "data": {
-                  "type": "array",
-                  "description": "Citing-paper records",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "intents": {
-                        "type": "array",
-                        "description": "Citation intents: background, methodology, and/or result",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "isInfluential": {
-                        "type": "boolean",
-                        "description": "Whether this is a highly influential citation"
-                      },
-                      "contexts": {
-                        "type": "array",
-                        "description": "Citing-sentence context strings (when requested)",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "citingPaper": {
-                        "type": "object",
-                        "description": "Metadata of the citing paper (fields depend on requested fields)"
-                      }
+              "type": "array",
+              "description": "Citing-paper records",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "intents": {
+                    "type": "array",
+                    "description": "Citation intents: background, methodology, and/or result",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "isInfluential": {
+                    "type": "boolean",
+                    "description": "Whether this is a highly influential citation"
+                  },
+                  "contexts": {
+                    "type": "array",
+                    "description": "Citing-sentence context strings (when requested)",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "citingPaper": {
+                    "type": "object",
+                    "description": "Metadata of the citing paper (fields depend on requested fields)"
                   }
                 }
               }
-            },
-            "url": {
-              "type": "string"
-            },
-            "count": {
-              "type": "integer"
             }
-          }
+          },
+          "required": [
+            "offset"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -774,87 +723,69 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
+          "description": "Reference list page from Semantic Scholar",
           "properties": {
-            "status": {
-              "const": "success"
+            "offset": {
+              "type": "integer",
+              "description": "Pagination offset of this page"
+            },
+            "next": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Offset of the next page, if more results exist"
+            },
+            "citingPaperInfo": {
+              "type": "object",
+              "description": "Metadata of the source (citing) paper"
             },
             "data": {
-              "type": "object",
-              "description": "Reference list page from Semantic Scholar",
-              "properties": {
-                "offset": {
-                  "type": "integer",
-                  "description": "Pagination offset of this page"
-                },
-                "next": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Offset of the next page, if more results exist"
-                },
-                "citingPaperInfo": {
-                  "type": "object",
-                  "description": "Metadata of the source (citing) paper"
-                },
-                "data": {
-                  "type": "array",
-                  "description": "Cited-paper records",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "intents": {
-                        "type": "array",
-                        "description": "Citation intents: background, methodology, and/or result",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "isInfluential": {
-                        "type": "boolean",
-                        "description": "Whether this is a highly influential reference"
-                      },
-                      "contexts": {
-                        "type": "array",
-                        "description": "Citing-sentence context strings (when requested)",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "citedPaper": {
-                        "type": "object",
-                        "description": "Metadata of the cited paper (fields depend on requested fields)"
-                      }
+              "type": "array",
+              "description": "Cited-paper records",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "intents": {
+                    "type": "array",
+                    "description": "Citation intents: background, methodology, and/or result",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "isInfluential": {
+                    "type": "boolean",
+                    "description": "Whether this is a highly influential reference"
+                  },
+                  "contexts": {
+                    "type": "array",
+                    "description": "Citing-sentence context strings (when requested)",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "citedPaper": {
+                    "type": "object",
+                    "description": "Metadata of the cited paper (fields depend on requested fields)"
                   }
                 }
               }
-            },
-            "url": {
-              "type": "string"
-            },
-            "count": {
-              "type": "integer"
             }
-          }
+          },
+          "required": [
+            "offset"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -910,91 +841,73 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
+          "description": "Author paper list page from Semantic Scholar",
           "properties": {
-            "status": {
-              "const": "success"
+            "offset": {
+              "type": "integer",
+              "description": "Pagination offset of this page"
+            },
+            "next": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Offset of the next page, if more results exist"
             },
             "data": {
-              "type": "object",
-              "description": "Author paper list page from Semantic Scholar",
-              "properties": {
-                "offset": {
-                  "type": "integer",
-                  "description": "Pagination offset of this page"
-                },
-                "next": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Offset of the next page, if more results exist"
-                },
-                "data": {
-                  "type": "array",
-                  "description": "Author's papers",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "paperId": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "title": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "year": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "citationCount": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "venue": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+              "type": "array",
+              "description": "Author's papers",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "paperId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "title": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "year": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "citationCount": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "venue": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "url": {
-              "type": "string"
-            },
-            "count": {
-              "type": "integer"
             }
-          }
+          },
+          "required": [
+            "offset"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/sgd_protein_tools.json
+++ b/src/tooluniverse/data/sgd_protein_tools.json
@@ -25,86 +25,75 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "systematic_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "sgd_link": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "domain_count": {
-                  "type": "integer"
-                },
-                "domains": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "source": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "start": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "end": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "domain_link": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "systematic_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sgd_link": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "domain_count": {
+              "type": "integer"
+            },
+            "domains": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "start": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "end": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "domain_link": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": [
-                "domain_count",
-                "domains"
-              ]
+              }
             }
           },
           "required": [
-            "data"
+            "domain_count",
+            "domains"
           ]
         },
         {
@@ -158,80 +147,69 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "systematic_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "sgd_link": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "site_count": {
-                  "type": "integer"
-                },
-                "sites": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "modification": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "residue": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "position": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "reference": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "pubmed_id": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+            "systematic_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sgd_link": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "site_count": {
+              "type": "integer"
+            },
+            "sites": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "modification": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "residue": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "position": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "reference": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "pubmed_id": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": [
-                "site_count",
-                "sites"
-              ]
+              }
             }
           },
           "required": [
-            "data"
+            "site_count",
+            "sites"
           ]
         },
         {
@@ -285,72 +263,61 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "query": {
+              "type": "string"
             },
-            "data": {
+            "total_references": {
+              "type": "integer"
+            },
+            "counts_by_category": {
               "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string"
-                },
-                "total_references": {
-                  "type": "integer"
-                },
-                "counts_by_category": {
+              "additionalProperties": {
+                "type": "integer"
+              }
+            },
+            "references": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
                   "type": "object",
-                  "additionalProperties": {
-                    "type": "integer"
-                  }
-                },
-                "references": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "citation": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "pubmed_id": {
-                          "type": [
-                            "integer",
-                            "null"
-                          ]
-                        },
-                        "year": {
-                          "type": [
-                            "integer",
-                            "null"
-                          ]
-                        },
-                        "reference_link": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        }
-                      }
+                  "properties": {
+                    "citation": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "pubmed_id": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "year": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "reference_link": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   }
-                },
-                "truncated_per_category": {
-                  "type": "integer"
                 }
-              },
-              "required": [
-                "total_references",
-                "counts_by_category",
-                "references"
-              ]
+              }
+            },
+            "truncated_per_category": {
+              "type": "integer"
             }
           },
           "required": [
-            "data"
+            "total_references",
+            "counts_by_category",
+            "references"
           ]
         },
         {

--- a/src/tooluniverse/data/signor_tools.json
+++ b/src/tooluniverse/data/signor_tools.json
@@ -297,111 +297,69 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "source_entity": {
-                    "type": "string"
-                  },
-                  "source_type": {
-                    "type": "string"
-                  },
-                  "source_id": {
-                    "type": "string"
-                  },
-                  "target_entity": {
-                    "type": "string"
-                  },
-                  "target_type": {
-                    "type": "string"
-                  },
-                  "target_id": {
-                    "type": "string"
-                  },
-                  "effect": {
-                    "type": "string"
-                  },
-                  "mechanism": {
-                    "type": "string"
-                  },
-                  "residue": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "pmid": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "direct": {
-                    "type": "boolean"
-                  },
-                  "score": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "signor_id": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "proteins": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "level": {
-                  "type": "integer"
-                },
-                "total_interactions": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source_entity": {
+                "type": "string"
+              },
+              "source_type": {
+                "type": "string"
+              },
+              "source_id": {
+                "type": "string"
+              },
+              "target_entity": {
+                "type": "string"
+              },
+              "target_type": {
+                "type": "string"
+              },
+              "target_id": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string"
+              },
+              "mechanism": {
+                "type": "string"
+              },
+              "residue": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pmid": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "direct": {
+                "type": "boolean"
+              },
+              "score": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "signor_id": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }

--- a/src/tooluniverse/data/spredixcan_tools.json
+++ b/src/tooluniverse/data/spredixcan_tools.json
@@ -5,13 +5,58 @@
     "description": "Summary-based transcriptome-wide association (S-PrediXcan, Barbeira 2018): test a gene for trait association by combining its eQTL prediction weights with GWAS per-SNP z-scores. Returns the gene TWAS z-score and p-value. Pure-compute (no individual-level data, no LD panel needed when SNPs are independent/LD-pruned; optionally supply a SNP covariance matrix). Pairs with eQTL_get_associations + GWAS summary tools.",
     "parameter": {
       "type": "object",
-      "required": ["weight", "gwas_z"],
+      "required": [
+        "weight",
+        "gwas_z"
+      ],
       "properties": {
-        "weight": {"type": "array", "items": {"type": "number"}, "description": "Per-SNP eQTL prediction weights for the gene (same SNP order as gwas_z)."},
-        "gwas_z": {"type": "array", "items": {"type": "number"}, "description": "Per-SNP GWAS z-scores (beta/se), same SNP order."},
-        "snp_sd": {"type": ["array", "null"], "items": {"type": "number"}, "description": "Per-SNP standard deviation (~sqrt(2*MAF*(1-MAF))); default 1.0 (standardized)."},
-        "covariance": {"type": ["array", "null"], "items": {"type": "array", "items": {"type": "number"}}, "description": "Optional SNP covariance matrix (n x n, same SNP order). If omitted, SNPs are assumed independent."},
-        "snp": {"type": ["array", "null"], "items": {"type": "string"}, "description": "Optional SNP identifiers (same order), for reference."}
+        "weight": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-SNP eQTL prediction weights for the gene (same SNP order as gwas_z)."
+        },
+        "gwas_z": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-SNP GWAS z-scores (beta/se), same SNP order."
+        },
+        "snp_sd": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-SNP standard deviation (~sqrt(2*MAF*(1-MAF))); default 1.0 (standardized)."
+        },
+        "covariance": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          "description": "Optional SNP covariance matrix (n x n, same SNP order). If omitted, SNPs are assumed independent."
+        },
+        "snp": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional SNP identifiers (same order), for reference."
+        }
       }
     },
     "return_schema": {
@@ -19,31 +64,59 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_snps": {"type": "integer"},
-                "twas_zscore": {"type": "number"},
-                "p_value": {"type": "number"},
-                "direction": {"type": "string"}
-              }
+            "n_snps": {
+              "type": "integer"
+            },
+            "twas_zscore": {
+              "type": "number"
+            },
+            "p_value": {
+              "type": "number"
+            },
+            "direction": {
+              "type": "string"
             }
           },
-          "required": ["data"]
+          "required": [
+            "n_snps"
+          ]
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "weight": [0.5, 0.3, 0.2, 0.4, 0.25],
-        "gwas_z": [3.0, 2.0, 1.0, 2.5, 1.5],
-        "snp": ["rs1", "rs2", "rs3", "rs4", "rs5"]
+        "weight": [
+          0.5,
+          0.3,
+          0.2,
+          0.4,
+          0.25
+        ],
+        "gwas_z": [
+          3.0,
+          2.0,
+          1.0,
+          2.5,
+          1.5
+        ],
+        "snp": [
+          "rs1",
+          "rs2",
+          "rs3",
+          "rs4",
+          "rs5"
+        ]
       }
     ]
   }

--- a/src/tooluniverse/data/ssgsea_tools.json
+++ b/src/tooluniverse/data/ssgsea_tools.json
@@ -5,13 +5,48 @@
     "description": "Single-sample GSEA (Barbie 2009): score each sample for each gene set from an expression matrix (genes x samples), producing a gene_set x sample signature-score matrix. Positive = the set's genes are among that sample's highly-expressed genes. Basis for per-sample signature scoring (immune infiltration, pathway activity). Pure-compute (no R); supply gene sets from MSigDB/Enrichr.",
     "parameter": {
       "type": "object",
-      "required": ["expression"],
+      "required": [
+        "expression"
+      ],
       "properties": {
-        "expression": {"type": "object", "description": "{gene: [value_per_sample, ...]} — a genes x samples expression matrix (e.g. log-normalized)."},
-        "samples": {"type": ["array", "null"], "items": {"type": "string"}, "description": "Sample names (same order as the per-gene value lists); defaults to sample_1.."},
-        "gene_sets": {"type": ["object", "null"], "description": "{set_name: [gene, ...]} collection to score. Alternative to gene_set."},
-        "gene_set": {"type": ["array", "null"], "items": {"type": "string"}, "description": "A single gene set (list of gene symbols)."},
-        "alpha": {"type": ["number", "null"], "description": "Rank-weighting exponent (default 0.25, the ssGSEA standard)."}
+        "expression": {
+          "type": "object",
+          "description": "{gene: [value_per_sample, ...]} \u2014 a genes x samples expression matrix (e.g. log-normalized)."
+        },
+        "samples": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Sample names (same order as the per-gene value lists); defaults to sample_1.."
+        },
+        "gene_sets": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "description": "{set_name: [gene, ...]} collection to score. Alternative to gene_set."
+        },
+        "gene_set": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "A single gene set (list of gene symbols)."
+        },
+        "alpha": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Rank-weighting exponent (default 0.25, the ssGSEA standard)."
+        }
       }
     },
     "return_schema": {
@@ -19,32 +54,106 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_genes": {"type": "integer"},
-                "n_samples": {"type": "integer"},
-                "samples": {"type": "array", "items": {"type": "string"}},
-                "enrichment_scores": {"type": "object"},
-                "skipped_sets": {"type": "array"}
+            "n_genes": {
+              "type": "integer"
+            },
+            "n_samples": {
+              "type": "integer"
+            },
+            "samples": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
+            },
+            "enrichment_scores": {
+              "type": "object"
+            },
+            "skipped_sets": {
+              "type": "array"
             }
           },
-          "required": ["data"]
+          "required": [
+            "n_genes"
+          ]
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "expression": {"G1": [12, 1], "G2": [11, 2], "G3": [10, 3], "G4": [9, 4], "G5": [8, 5], "G6": [7, 6], "G7": [6, 7], "G8": [5, 8], "G9": [4, 9], "G10": [3, 10], "G11": [2, 11], "G12": [1, 12]},
-        "samples": ["tumor", "normal"],
-        "gene_sets": {"TOP_SIG": ["G1", "G2", "G3", "G4"]}
+        "expression": {
+          "G1": [
+            12,
+            1
+          ],
+          "G2": [
+            11,
+            2
+          ],
+          "G3": [
+            10,
+            3
+          ],
+          "G4": [
+            9,
+            4
+          ],
+          "G5": [
+            8,
+            5
+          ],
+          "G6": [
+            7,
+            6
+          ],
+          "G7": [
+            6,
+            7
+          ],
+          "G8": [
+            5,
+            8
+          ],
+          "G9": [
+            4,
+            9
+          ],
+          "G10": [
+            3,
+            10
+          ],
+          "G11": [
+            2,
+            11
+          ],
+          "G12": [
+            1,
+            12
+          ]
+        },
+        "samples": [
+          "tumor",
+          "normal"
+        ],
+        "gene_sets": {
+          "TOP_SIG": [
+            "G1",
+            "G2",
+            "G3",
+            "G4"
+          ]
+        }
       }
     ]
   }

--- a/src/tooluniverse/data/stitch_tools.json
+++ b/src/tooluniverse/data/stitch_tools.json
@@ -54,54 +54,34 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "stringId_A": {
-                    "type": "string",
-                    "description": "STITCH ID of first entity"
-                  },
-                  "stringId_B": {
-                    "type": "string",
-                    "description": "STITCH ID of second entity"
-                  },
-                  "preferredName_A": {
-                    "type": "string"
-                  },
-                  "preferredName_B": {
-                    "type": "string"
-                  },
-                  "score": {
-                    "type": "number",
-                    "description": "Combined confidence score (0-1)"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "stringId_A": {
+                "type": "string",
+                "description": "STITCH ID of first entity"
+              },
+              "stringId_B": {
+                "type": "string",
+                "description": "STITCH ID of second entity"
+              },
+              "preferredName_A": {
+                "type": "string"
+              },
+              "preferredName_B": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number",
+                "description": "Combined confidence score (0-1)"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             }
@@ -161,45 +141,25 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "stringId": {
-                    "type": "string"
-                  },
-                  "preferredName": {
-                    "type": "string"
-                  },
-                  "annotation": {
-                    "type": "string"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "stringId": {
+                "type": "string"
+              },
+              "preferredName": {
+                "type": "string"
+              },
+              "annotation": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             }
@@ -246,49 +206,29 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "stringId": {
-                    "type": "string",
-                    "description": "STITCH identifier"
-                  },
-                  "preferredName": {
-                    "type": "string"
-                  },
-                  "taxonId": {
-                    "type": "integer"
-                  },
-                  "annotation": {
-                    "type": "string"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "stringId": {
+                "type": "string",
+                "description": "STITCH identifier"
+              },
+              "preferredName": {
+                "type": "string"
+              },
+              "taxonId": {
+                "type": "integer"
+              },
+              "annotation": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/structure_annotation_tools.json
+++ b/src/tooluniverse/data/structure_annotation_tools.json
@@ -78,12 +78,6 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
             "pdb_id": {
               "type": [
                 "string",
@@ -169,7 +163,6 @@
             }
           },
           "required": [
-            "status",
             "target_chain",
             "n_residues",
             "annotations"
@@ -178,18 +171,11 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }

--- a/src/tooluniverse/data/sunrise_sunset_tools.json
+++ b/src/tooluniverse/data/sunrise_sunset_tools.json
@@ -93,15 +93,14 @@
                 }
               }
             },
-            "status": {
-              "type": "string",
-              "description": "OK or error message"
-            },
             "tzid": {
               "type": "string",
               "description": "Timezone identifier"
             }
-          }
+          },
+          "required": [
+            "results"
+          ]
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/swiss_target_tools.json
+++ b/src/tooluniverse/data/swiss_target_tools.json
@@ -154,57 +154,45 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "organisms": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "value": {
-                        "type": "string"
-                      },
-                      "display_name": {
-                        "type": "string"
-                      },
-                      "common_name": {
-                        "type": "string"
-                      },
-                      "taxonomy_id": {
-                        "type": "integer"
-                      }
-                    }
+            "organisms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  },
+                  "display_name": {
+                    "type": "string"
+                  },
+                  "common_name": {
+                    "type": "string"
+                  },
+                  "taxonomy_id": {
+                    "type": "integer"
                   }
-                },
-                "total": {
-                  "type": "integer"
                 }
               }
+            },
+            "total": {
+              "type": "integer"
             }
-          }
+          },
+          "required": [
+            "organisms"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/swisslipids_tools.json
+++ b/src/tooluniverse/data/swisslipids_tools.json
@@ -2,8 +2,10 @@
   {
     "type": "SwissLipidsTool",
     "name": "SwissLipids_search",
-    "description": "Search SwissLipids (swisslipids.org, SIB Swiss Institute of Bioinformatics) for lipids by name or shorthand abbreviation (e.g. 'PC(16:0/18:1)', 'cholesterol', 'ceramide'). Returns matching entries each with its SwissLipids id (SLM:...), name, type, and position in the lipid structural hierarchy (class / species / structural subspecies / isomeric subspecies). Complementary to the LIPID MAPS tools — an independently curated lipid database from a different organisation. Use SwissLipids_get_lipid with an SLM id for full details. No API key required.",
-    "fields": {"operation": "search"},
+    "description": "Search SwissLipids (swisslipids.org, SIB Swiss Institute of Bioinformatics) for lipids by name or shorthand abbreviation (e.g. 'PC(16:0/18:1)', 'cholesterol', 'ceramide'). Returns matching entries each with its SwissLipids id (SLM:...), name, type, and position in the lipid structural hierarchy (class / species / structural subspecies / isomeric subspecies). Complementary to the LIPID MAPS tools \u2014 an independently curated lipid database from a different organisation. Use SwissLipids_get_lipid with an SLM id for full details. No API key required.",
+    "fields": {
+      "operation": "search"
+    },
     "parameter": {
       "type": "object",
       "properties": {
@@ -19,49 +21,59 @@
           "default": 10
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "entity_id": {"type": "string"},
-                  "entity_name": {"type": "string"},
-                  "entity_type": {"type": "string"},
-                  "classification_level": {"type": "string"}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "entity_id": {
+                "type": "string"
+              },
+              "entity_name": {
+                "type": "string"
+              },
+              "entity_type": {
+                "type": "string"
+              },
+              "classification_level": {
+                "type": "string"
               }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"query": "PC(16:0/18:1)", "limit": 3}
+      {
+        "query": "PC(16:0/18:1)",
+        "limit": 3
+      }
     ]
   },
   {
     "type": "SwissLipidsTool",
     "name": "SwissLipids_get_lipid",
-    "description": "Retrieve a full SwissLipids entry by its id (e.g. 'SLM:000000510'). Returns the lipid's name, molecular formula, monoisotopic mass, charge, a table of adduct m/z values ([M+H]+, [M-H]-, [M+Na]+, etc. — useful for matching lipidomics mass-spectrometry peaks), its structural classification, synonyms, and cross-references to ChEBI, HMDB, LIPID MAPS, Rhea, and MetaNetX. Find ids with SwissLipids_search. No API key required.",
-    "fields": {"operation": "get_lipid"},
+    "description": "Retrieve a full SwissLipids entry by its id (e.g. 'SLM:000000510'). Returns the lipid's name, molecular formula, monoisotopic mass, charge, a table of adduct m/z values ([M+H]+, [M-H]-, [M+Na]+, etc. \u2014 useful for matching lipidomics mass-spectrometry peaks), its structural classification, synonyms, and cross-references to ChEBI, HMDB, LIPID MAPS, Rhea, and MetaNetX. Find ids with SwissLipids_search. No API key required.",
+    "fields": {
+      "operation": "get_lipid"
+    },
     "parameter": {
       "type": "object",
       "properties": {
@@ -70,51 +82,73 @@
           "description": "SwissLipids id, e.g. 'SLM:000000510' (a bare number is also accepted)."
         }
       },
-      "required": ["entity_id"]
+      "required": [
+        "entity_id"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "object",
-              "properties": {
-                "entity_id": {"type": "string"},
-                "entity_name": {"type": "string"},
-                "formula": {"type": "string"},
-                "mass": {"type": "number"},
-                "charge": {"type": "number"},
-                "adduct_mz": {"type": "object"},
-                "classification": {"type": "array"},
-                "synonyms": {"type": "array"},
-                "xrefs": {"type": "array"}
-              }
+            "entity_id": {
+              "type": "string"
             },
-            "metadata": {"type": "object"}
+            "entity_name": {
+              "type": "string"
+            },
+            "formula": {
+              "type": "string"
+            },
+            "mass": {
+              "type": "number"
+            },
+            "charge": {
+              "type": "number"
+            },
+            "adduct_mz": {
+              "type": "object"
+            },
+            "classification": {
+              "type": "array"
+            },
+            "synonyms": {
+              "type": "array"
+            },
+            "xrefs": {
+              "type": "array"
+            }
           },
-          "required": ["status", "data"]
+          "required": [
+            "entity_id"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"entity_id": "SLM:000000510"}
+      {
+        "entity_id": "SLM:000000510"
+      }
     ]
   },
   {
     "type": "SwissLipidsTool",
     "name": "SwissLipids_get_children",
     "description": "List the direct children of a SwissLipids hierarchy node, i.e. descend the lipid structural classification tree one level (category -> class -> species -> structural subspecies -> isomeric subspecies). Pass the parent's SwissLipids id (e.g. 'SLM:000001193', the Glycerophospholipids category) and receive its immediate child entities, each with its SLM id, name, type, formula, mass, and InChIKey. Useful for browsing or enumerating all lipids under a class. Find parent ids with SwissLipids_search. No API key required.",
-    "fields": {"operation": "get_children"},
+    "fields": {
+      "operation": "get_children"
+    },
     "parameter": {
       "type": "object",
       "properties": {
@@ -123,44 +157,70 @@
           "description": "SwissLipids id of the parent node whose direct children to list, e.g. 'SLM:000001193' (a bare number is also accepted)."
         }
       },
-      "required": ["entity_id"]
+      "required": [
+        "entity_id"
+      ]
     },
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string", "enum": ["success"]},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "entity_id": {"type": "string"},
-                  "entity_name": {"type": ["string", "null"]},
-                  "entity_type": {"type": ["string", "null"]},
-                  "formula": {"type": ["string", "null"]},
-                  "mass": {"type": ["string", "null"]},
-                  "inchikey": {"type": ["string", "null"]}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "entity_id": {
+                "type": "string"
+              },
+              "entity_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "entity_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "formula": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "mass": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "inchikey": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string", "enum": ["error"]},
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"entity_id": "SLM:000001193"}
+      {
+        "entity_id": "SLM:000001193"
+      }
     ]
   }
 ]

--- a/src/tooluniverse/data/tark_tools.json
+++ b/src/tooluniverse/data/tark_tools.json
@@ -1,65 +1,138 @@
 [
-    {
-        "name": "Tark_get_mane_transcripts",
-        "description": "Look up the MANE (Matched Annotation from NCBI and EMBL-EBI) transcript(s) for a gene, mapping the Ensembl transcript (ENST) to its equivalent RefSeq transcript (NM_). Returns MANE Select and, where defined, MANE Plus Clinical pairings from the Ensembl Tark transcript archive. Query by HGNC gene symbol, an Ensembl transcript id, or a RefSeq transcript id (versions optional — they are matched on the base id). Use to find the clinically-recommended representative transcript for a gene and to convert between RefSeq and Ensembl transcript namespaces. No API key required.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "gene": {"type": ["string", "null"], "description": "HGNC gene symbol, e.g. 'BRCA2', 'CFTR'."},
-                "ensembl_id": {"type": ["string", "null"], "description": "Ensembl transcript id, e.g. 'ENST00000380152' (version optional)."},
-                "refseq_id": {"type": ["string", "null"], "description": "RefSeq transcript id, e.g. 'NM_000059' (version optional)."}
-            },
-            "required": []
+  {
+    "name": "Tark_get_mane_transcripts",
+    "description": "Look up the MANE (Matched Annotation from NCBI and EMBL-EBI) transcript(s) for a gene, mapping the Ensembl transcript (ENST) to its equivalent RefSeq transcript (NM_). Returns MANE Select and, where defined, MANE Plus Clinical pairings from the Ensembl Tark transcript archive. Query by HGNC gene symbol, an Ensembl transcript id, or a RefSeq transcript id (versions optional \u2014 they are matched on the base id). Use to find the clinically-recommended representative transcript for a gene and to convert between RefSeq and Ensembl transcript namespaces. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "gene": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "HGNC gene symbol, e.g. 'BRCA2', 'CFTR'."
         },
-        "fields": {"timeout": 30},
-        "type": "TarkManeTranscriptsTool",
-        "test_examples": [
-            {"gene": "BRCA2"},
-            {"gene": "CFTR"},
-            {"refseq_id": "NM_000059"}
-        ],
-        "return_schema": {
-            "oneOf": [
-                {"type": "object", "description": "MANE transcript pairings", "properties": {
-                    "status": {"type": "string"},
-                    "data": {"type": "array", "items": {"type": "object", "properties": {
-                        "gene": {"type": "string"},
-                        "mane_type": {"type": "string", "description": "MANE SELECT or MANE PLUS CLINICAL"},
-                        "ensembl_transcript": {"type": "string", "description": "Versioned ENST id"},
-                        "refseq_transcript": {"type": "string", "description": "Versioned RefSeq NM id"}
-                    }}},
-                    "metadata": {"type": "object"}
-                }, "required": ["status", "data"]},
-                {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-            ]
+        "ensembl_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Ensembl transcript id, e.g. 'ENST00000380152' (version optional)."
+        },
+        "refseq_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "RefSeq transcript id, e.g. 'NM_000059' (version optional)."
         }
+      },
+      "required": []
     },
-    {
-        "name": "Tark_get_transcript",
-        "description": "Get the archived transcript record for an Ensembl transcript id (ENST) from the Ensembl Tark transcript archive: assembly, biotype, genomic location (region/start/end/strand), the transcript sequence checksum, and the Ensembl release versions in which the transcript appears. Use to resolve transcript versions and verify transcript identity/equivalence across releases. No API key required.",
-        "parameter": {
+    "fields": {
+      "timeout": 30
+    },
+    "type": "TarkManeTranscriptsTool",
+    "test_examples": [
+      {
+        "gene": "BRCA2"
+      },
+      {
+        "gene": "CFTR"
+      },
+      {
+        "refseq_id": "NM_000059"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
             "type": "object",
             "properties": {
-                "stable_id": {"type": "string", "description": "Ensembl transcript stable id, e.g. 'ENST00000380152' (version optional)."}
-            },
-            "required": ["stable_id"]
+              "gene": {
+                "type": "string"
+              },
+              "mane_type": {
+                "type": "string",
+                "description": "MANE SELECT or MANE PLUS CLINICAL"
+              },
+              "ensembl_transcript": {
+                "type": "string",
+                "description": "Versioned ENST id"
+              },
+              "refseq_transcript": {
+                "type": "string",
+                "description": "Versioned RefSeq NM id"
+              }
+            }
+          }
         },
-        "fields": {"timeout": 30},
-        "type": "TarkTranscriptTool",
-        "test_examples": [
-            {"stable_id": "ENST00000380152"},
-            {"stable_id": "ENST00000357654"},
-            {"stable_id": "ENST00000003084"}
-        ],
-        "return_schema": {
-            "oneOf": [
-                {"type": "object", "description": "Transcript archive records", "properties": {
-                    "status": {"type": "string"},
-                    "data": {"type": "array", "items": {"type": "object"}},
-                    "metadata": {"type": "object"}
-                }, "required": ["status", "data"]},
-                {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-            ]
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "Tark_get_transcript",
+    "description": "Get the archived transcript record for an Ensembl transcript id (ENST) from the Ensembl Tark transcript archive: assembly, biotype, genomic location (region/start/end/strand), the transcript sequence checksum, and the Ensembl release versions in which the transcript appears. Use to resolve transcript versions and verify transcript identity/equivalence across releases. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "stable_id": {
+          "type": "string",
+          "description": "Ensembl transcript stable id, e.g. 'ENST00000380152' (version optional)."
+        }
+      },
+      "required": [
+        "stable_id"
+      ]
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "TarkTranscriptTool",
+    "test_examples": [
+      {
+        "stable_id": "ENST00000380152"
+      },
+      {
+        "stable_id": "ENST00000357654"
+      },
+      {
+        "stable_id": "ENST00000003084"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/tdc_dataset_tools.json
+++ b/src/tooluniverse/data/tdc_dataset_tools.json
@@ -47,108 +47,96 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Successful dataset load. Mirrors the 'data' field returned by the tool.",
           "properties": {
-            "status": {
-              "const": "success"
+            "problem": {
+              "type": "string",
+              "description": "Canonical TDC problem name used."
             },
-            "data": {
-              "type": "object",
-              "description": "Successful dataset load. Mirrors the 'data' field returned by the tool.",
+            "name": {
+              "type": "string",
+              "description": "Dataset name that was loaded."
+            },
+            "n_rows": {
+              "type": "integer",
+              "description": "Total number of rows in the dataset."
+            },
+            "columns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Column names of the dataset DataFrame (e.g. Drug_ID, Drug, Y)."
+            },
+            "label_summary": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "Summary of the 'Y' label column, or null if there is no 'Y' column.",
               "properties": {
-                "problem": {
+                "label_type": {
                   "type": "string",
-                  "description": "Canonical TDC problem name used."
+                  "description": "One of 'categorical', 'continuous', or 'other'."
                 },
-                "name": {
-                  "type": "string",
-                  "description": "Dataset name that was loaded."
+                "n_unique": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "Number of distinct label values."
                 },
-                "n_rows": {
-                  "type": "integer",
-                  "description": "Total number of rows in the dataset."
-                },
-                "columns": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Column names of the dataset DataFrame (e.g. Drug_ID, Drug, Y)."
-                },
-                "label_summary": {
+                "distribution": {
                   "type": [
                     "object",
                     "null"
                   ],
-                  "description": "Summary of the 'Y' label column, or null if there is no 'Y' column.",
-                  "properties": {
-                    "label_type": {
-                      "type": "string",
-                      "description": "One of 'categorical', 'continuous', or 'other'."
-                    },
-                    "n_unique": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ],
-                      "description": "Number of distinct label values."
-                    },
-                    "distribution": {
-                      "type": [
-                        "object",
-                        "null"
-                      ],
-                      "description": "Value-count distribution for categorical labels, otherwise null."
-                    },
-                    "statistics": {
-                      "type": [
-                        "object",
-                        "null"
-                      ],
-                      "description": "Summary statistics (count, mean, std, min, quartiles, max) for continuous labels, otherwise null."
-                    }
-                  },
-                  "required": [
-                    "label_type"
-                  ]
+                  "description": "Value-count distribution for categorical labels, otherwise null."
                 },
-                "split_sizes": {
+                "statistics": {
                   "type": [
                     "object",
                     "null"
                   ],
-                  "description": "Row counts per split (train/valid/test), or null if the split could not be computed.",
-                  "additionalProperties": {
-                    "type": "integer"
-                  }
-                },
-                "sample_rows": {
-                  "type": "integer",
-                  "description": "Number of rows included in the sample."
-                },
-                "sample": {
-                  "type": "array",
-                  "description": "A small head() sample of rows as JSON objects keyed by column name.",
-                  "items": {
-                    "type": "object"
-                  }
+                  "description": "Summary statistics (count, mean, std, min, quartiles, max) for continuous labels, otherwise null."
                 }
               },
               "required": [
-                "problem",
-                "name",
-                "n_rows",
-                "columns",
-                "sample"
+                "label_type"
               ]
+            },
+            "split_sizes": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "Row counts per split (train/valid/test), or null if the split could not be computed.",
+              "additionalProperties": {
+                "type": "integer"
+              }
+            },
+            "sample_rows": {
+              "type": "integer",
+              "description": "Number of rows included in the sample."
+            },
+            "sample": {
+              "type": "array",
+              "description": "A small head() sample of rows as JSON objects keyed by column name.",
+              "items": {
+                "type": "object"
+              }
             }
           },
           "required": [
-            "data"
+            "problem",
+            "name",
+            "n_rows",
+            "columns",
+            "sample"
           ]
         },
         {
           "type": "object",
-          "description": "Error response (e.g. PyTDC not installed, unknown problem/name, or a problem module that cannot be imported).",
           "properties": {
             "error": {
               "type": "string",
@@ -196,44 +184,32 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Successful listing. Mirrors the 'data' field returned by the tool.",
           "properties": {
-            "status": {
-              "const": "success"
+            "problem": {
+              "type": "string",
+              "description": "Canonical TDC problem name used."
             },
-            "data": {
-              "type": "object",
-              "description": "Successful listing. Mirrors the 'data' field returned by the tool.",
-              "properties": {
-                "problem": {
-                  "type": "string",
-                  "description": "Canonical TDC problem name used."
-                },
-                "n_datasets": {
-                  "type": "integer",
-                  "description": "Number of available datasets for this problem."
-                },
-                "dataset_names": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Normalized (lowercase) dataset names accepted case-insensitively by TDC_load_dataset."
-                }
+            "n_datasets": {
+              "type": "integer",
+              "description": "Number of available datasets for this problem."
+            },
+            "dataset_names": {
+              "type": "array",
+              "items": {
+                "type": "string"
               },
-              "required": [
-                "problem",
-                "n_datasets",
-                "dataset_names"
-              ]
+              "description": "Normalized (lowercase) dataset names accepted case-insensitively by TDC_load_dataset."
             }
           },
           "required": [
-            "data"
+            "problem",
+            "n_datasets",
+            "dataset_names"
           ]
         },
         {
           "type": "object",
-          "description": "Error response (e.g. PyTDC not installed or unknown problem).",
           "properties": {
             "error": {
               "type": "string",

--- a/src/tooluniverse/data/tdc_oracle_tools.json
+++ b/src/tooluniverse/data/tdc_oracle_tools.json
@@ -63,71 +63,59 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Successful oracle scoring. Mirrors the content of the 'data' field returned by the tool.",
           "properties": {
-            "status": {
-              "const": "success"
+            "oracle": {
+              "type": "string",
+              "description": "Canonical oracle name that was used."
             },
-            "data": {
-              "type": "object",
-              "description": "Successful oracle scoring. Mirrors the content of the 'data' field returned by the tool.",
-              "properties": {
-                "oracle": {
-                  "type": "string",
-                  "description": "Canonical oracle name that was used."
-                },
-                "oracle_description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Human-readable description of the oracle."
-                },
-                "results": {
-                  "type": "array",
-                  "description": "One entry per input SMILES, in input order.",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "smiles": {
-                        "type": "string",
-                        "description": "The input SMILES string."
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "description": "The oracle score for this molecule, or null if scoring failed."
-                      },
-                      "error": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Error message if scoring this molecule failed, otherwise null."
-                      }
-                    },
-                    "required": [
-                      "smiles",
-                      "score",
-                      "error"
-                    ]
+            "oracle_description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Human-readable description of the oracle."
+            },
+            "results": {
+              "type": "array",
+              "description": "One entry per input SMILES, in input order.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "smiles": {
+                    "type": "string",
+                    "description": "The input SMILES string."
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "The oracle score for this molecule, or null if scoring failed."
+                  },
+                  "error": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Error message if scoring this molecule failed, otherwise null."
                   }
-                }
-              },
-              "required": [
-                "oracle",
-                "results"
-              ]
+                },
+                "required": [
+                  "smiles",
+                  "score",
+                  "error"
+                ]
+              }
             }
           },
           "required": [
-            "data"
+            "oracle",
+            "results"
           ]
         },
         {
           "type": "object",
-          "description": "Error response (e.g. PyTDC not installed, empty input, or unknown oracle).",
           "properties": {
             "error": {
               "type": "string",

--- a/src/tooluniverse/data/therasabdab_tools.json
+++ b/src/tooluniverse/data/therasabdab_tools.json
@@ -1,204 +1,369 @@
 [
-    {
-        "name": "TheraSAbDab_search_therapeutics",
-        "description": "Search therapeutic antibodies by name in Thera-SAbDab. Returns WHO INN name, target antigen, format (IgG, bispecific, ADC), clinical phase, and PDB structures. Use for finding approved/clinical antibody drugs.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Search query - antibody name (e.g., 'trastuzumab', 'pembrolizumab', 'rituximab')"
-                }
-            },
-            "required": ["query"]
-        },
-        "fields": {
-            "operation": "search_therapeutics"
-        },
-        "type": "TheraSAbDabTool",
-        "test_examples": [
-            {"query": "trastuzumab"},
-            {"query": "pembrolizumab"}
-        ],
-        "return_schema": {
-            "type": "object",
-            "properties": {
-                "status": {"type": "string", "enum": ["success", "error"]},
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "query": {"type": "string"},
-                        "therapeutics": {"type": "array"},
-                        "count": {"type": "integer"}
-                    }
-                },
-                "error": {"type": "string"}
-            }
-        },
-        "label": ["TheraSAbDab", "Therapeutic", "Antibody"],
-        "metadata": {
-            "tags": ["therapeutic_antibody", "biologics", "inn"],
-            "estimated_execution_time": "< 5 seconds"
+  {
+    "name": "TheraSAbDab_search_therapeutics",
+    "description": "Search therapeutic antibodies by name in Thera-SAbDab. Returns WHO INN name, target antigen, format (IgG, bispecific, ADC), clinical phase, and PDB structures. Use for finding approved/clinical antibody drugs.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Search query - antibody name (e.g., 'trastuzumab', 'pembrolizumab', 'rituximab')"
         }
+      },
+      "required": [
+        "query"
+      ]
     },
-    {
-        "name": "TheraSAbDab_get_all_therapeutics",
-        "description": "Get summary of all therapeutic antibodies in Thera-SAbDab database. Returns counts by format (IgG, bispecific, ADC) and clinical phase. Use for landscape analysis of antibody therapeutics.",
-        "parameter": {
-            "type": "object",
-            "properties": {}
-        },
-        "fields": {
-            "operation": "get_all_therapeutics"
-        },
-        "type": "TheraSAbDabTool",
-        "test_examples": [
-            {}
-        ],
-        "return_schema": {
-            "type": "object",
-            "properties": {
-                "status": {"type": "string", "enum": ["success", "error"]},
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "total_count": {"type": "integer"},
-                        "by_format": {"type": "object"},
-                        "by_phase": {"type": "object"},
-                        "sample": {"type": "array"}
-                    }
-                },
-                "error": {"type": "string"}
-            }
-        },
-        "label": ["TheraSAbDab", "Summary", "Statistics"],
-        "metadata": {
-            "tags": ["summary", "statistics", "landscape"],
-            "estimated_execution_time": "< 10 seconds"
-        }
+    "fields": {
+      "operation": "search_therapeutics"
     },
-    {
-        "name": "TheraSAbDab_search_by_target",
-        "description": "Find therapeutic antibodies targeting a specific antigen. Returns all clinical/approved antibodies against the target (e.g., all anti-PD1 antibodies). Essential for competitive landscape analysis.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "target": {
-                    "type": "string",
-                    "description": "Target antigen name (e.g., 'PD-1', 'HER2', 'CD20', 'TNF-alpha', 'VEGF')"
-                }
+    "type": "TheraSAbDabTool",
+    "test_examples": [
+      {
+        "query": "trastuzumab"
+      },
+      {
+        "query": "pembrolizumab"
+      }
+    ],
+    "return_schema": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "success",
+            "error"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string"
             },
-            "required": ["target"]
-        },
-        "fields": {
-            "operation": "search_by_target"
-        },
-        "type": "TheraSAbDabTool",
-        "test_examples": [
-            {"target": "HER2"},
-            {"target": "PD-1"}
-        ],
-        "return_schema": {
-            "type": "object",
-            "properties": {
-                "status": {"type": "string", "enum": ["success", "error"]},
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "target": {"type": "string"},
-                        "therapeutics": {"type": "array"},
-                        "count": {"type": "integer"}
-                    }
-                },
-                "error": {"type": "string"}
+            "therapeutics": {
+              "type": "array"
+            },
+            "count": {
+              "type": "integer"
             }
+          }
         },
-        "label": ["TheraSAbDab", "Target", "Search"],
-        "metadata": {
-            "tags": ["target", "competitive_analysis", "antibody"],
-            "estimated_execution_time": "< 5 seconds"
+        "error": {
+          "type": "string"
         }
+      }
     },
-    {
-        "name": "TheraSAbDab_get_therapeutic_sequences",
-        "description": "Get the full curated record for a clinical/approved therapeutic antibody from Thera-SAbDab by WHO INN name. Returns the VH/VL amino-acid sequences (heavy1/light1, plus heavy2/light2 for bispecifics), isotype, target antigen, PDB structural coverage at 100%/99%/95-98% sequence identity (struc100/struc99/struc95to98 as 'pdbid:chains'), originator companies, and approved/active/discontinued conditions. Use for antibody sequence retrieval and developability analysis. No authentication required.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "WHO INN of the therapeutic antibody (e.g., 'adalimumab', 'abciximab', 'pembrolizumab'). Aliases: inn, query."
-                },
-                "inn": {
-                    "type": "string",
-                    "description": "Alias for name."
-                },
-                "query": {
-                    "type": "string",
-                    "description": "Alias for name."
-                }
-            },
-            "required": []
-        },
-        "fields": {
-            "operation": "get_therapeutic_sequences"
-        },
-        "type": "TheraSAbDabTool",
-        "test_examples": [
-            {"name": "abciximab"},
-            {"name": "adalimumab"}
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {"type": "string", "const": "success"},
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "query": {"type": "string"},
-                                "matched": {"type": ["string", "null"]},
-                                "therapeutic": {
-                                    "type": "object",
-                                    "properties": {
-                                        "inn_name": {"type": ["string", "null"]},
-                                        "format": {"type": ["string", "null"]},
-                                        "isotype": {"type": ["string", "null"]},
-                                        "target": {"type": ["string", "null"]},
-                                        "heavy1": {"type": ["string", "null"]},
-                                        "light1": {"type": ["string", "null"]},
-                                        "heavy2": {"type": ["string", "null"]},
-                                        "light2": {"type": ["string", "null"]},
-                                        "struc100": {"type": ["string", "null"]},
-                                        "struc99": {"type": ["string", "null"]},
-                                        "struc95to98": {"type": ["string", "null"]},
-                                        "companies": {"type": ["string", "null"]},
-                                        "conditions_approved": {"type": ["string", "null"]}
-                                    }
-                                },
-                                "match_count": {"type": "integer"}
-                            },
-                            "required": ["query", "therapeutic"]
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["status", "data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "status": {"type": "string", "const": "error"},
-                        "error": {"type": "string"}
-                    },
-                    "required": ["status", "error"]
-                }
-            ]
-        },
-        "label": ["TheraSAbDab", "Sequence", "Antibody"],
-        "metadata": {
-            "tags": ["therapeutic_antibody", "sequence", "biologics", "inn"],
-            "estimated_execution_time": "< 10 seconds"
-        }
+    "label": [
+      "TheraSAbDab",
+      "Therapeutic",
+      "Antibody"
+    ],
+    "metadata": {
+      "tags": [
+        "therapeutic_antibody",
+        "biologics",
+        "inn"
+      ],
+      "estimated_execution_time": "< 5 seconds"
     }
+  },
+  {
+    "name": "TheraSAbDab_get_all_therapeutics",
+    "description": "Get summary of all therapeutic antibodies in Thera-SAbDab database. Returns counts by format (IgG, bispecific, ADC) and clinical phase. Use for landscape analysis of antibody therapeutics.",
+    "parameter": {
+      "type": "object",
+      "properties": {}
+    },
+    "fields": {
+      "operation": "get_all_therapeutics"
+    },
+    "type": "TheraSAbDabTool",
+    "test_examples": [
+      {}
+    ],
+    "return_schema": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "success",
+            "error"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "total_count": {
+              "type": "integer"
+            },
+            "by_format": {
+              "type": "object"
+            },
+            "by_phase": {
+              "type": "object"
+            },
+            "sample": {
+              "type": "array"
+            }
+          }
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "label": [
+      "TheraSAbDab",
+      "Summary",
+      "Statistics"
+    ],
+    "metadata": {
+      "tags": [
+        "summary",
+        "statistics",
+        "landscape"
+      ],
+      "estimated_execution_time": "< 10 seconds"
+    }
+  },
+  {
+    "name": "TheraSAbDab_search_by_target",
+    "description": "Find therapeutic antibodies targeting a specific antigen. Returns all clinical/approved antibodies against the target (e.g., all anti-PD1 antibodies). Essential for competitive landscape analysis.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "Target antigen name (e.g., 'PD-1', 'HER2', 'CD20', 'TNF-alpha', 'VEGF')"
+        }
+      },
+      "required": [
+        "target"
+      ]
+    },
+    "fields": {
+      "operation": "search_by_target"
+    },
+    "type": "TheraSAbDabTool",
+    "test_examples": [
+      {
+        "target": "HER2"
+      },
+      {
+        "target": "PD-1"
+      }
+    ],
+    "return_schema": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "success",
+            "error"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "target": {
+              "type": "string"
+            },
+            "therapeutics": {
+              "type": "array"
+            },
+            "count": {
+              "type": "integer"
+            }
+          }
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "label": [
+      "TheraSAbDab",
+      "Target",
+      "Search"
+    ],
+    "metadata": {
+      "tags": [
+        "target",
+        "competitive_analysis",
+        "antibody"
+      ],
+      "estimated_execution_time": "< 5 seconds"
+    }
+  },
+  {
+    "name": "TheraSAbDab_get_therapeutic_sequences",
+    "description": "Get the full curated record for a clinical/approved therapeutic antibody from Thera-SAbDab by WHO INN name. Returns the VH/VL amino-acid sequences (heavy1/light1, plus heavy2/light2 for bispecifics), isotype, target antigen, PDB structural coverage at 100%/99%/95-98% sequence identity (struc100/struc99/struc95to98 as 'pdbid:chains'), originator companies, and approved/active/discontinued conditions. Use for antibody sequence retrieval and developability analysis. No authentication required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "WHO INN of the therapeutic antibody (e.g., 'adalimumab', 'abciximab', 'pembrolizumab'). Aliases: inn, query."
+        },
+        "inn": {
+          "type": "string",
+          "description": "Alias for name."
+        },
+        "query": {
+          "type": "string",
+          "description": "Alias for name."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "operation": "get_therapeutic_sequences"
+    },
+    "type": "TheraSAbDabTool",
+    "test_examples": [
+      {
+        "name": "abciximab"
+      },
+      {
+        "name": "adalimumab"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string"
+            },
+            "matched": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "therapeutic": {
+              "type": "object",
+              "properties": {
+                "inn_name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "format": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "isotype": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "target": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "heavy1": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "light1": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "heavy2": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "light2": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "struc100": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "struc99": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "struc95to98": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "companies": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "conditions_approved": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "match_count": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "query",
+            "therapeutic"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    },
+    "label": [
+      "TheraSAbDab",
+      "Sequence",
+      "Antibody"
+    ],
+    "metadata": {
+      "tags": [
+        "therapeutic_antibody",
+        "sequence",
+        "biologics",
+        "inn"
+      ],
+      "estimated_execution_time": "< 10 seconds"
+    }
+  }
 ]

--- a/src/tooluniverse/data/togoid_tools.json
+++ b/src/tooluniverse/data/togoid_tools.json
@@ -1,40 +1,124 @@
 [
-    {
-        "name": "TogoID_convert",
-        "description": "Convert biological identifiers between databases using TogoID (DBCLS), which links 117 ID types (genes, proteins, transcripts, compounds, diseases, pathways, variants, cell lines, organisms, etc.). Provide the source ID(s), the source dataset name, and the target dataset name. Works for directly-related dataset pairs (e.g. ensembl_gene->uniprot, ncbigene->hgnc, pubchem_compound->chebi, uniprot->pdb); unrelated pairs return a 'no route' error — convert via an intermediate. Call TogoID_list_datasets for the exact dataset names. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "ids": {"type": "string", "description": "Source identifier(s), comma-separated, in the source dataset's native format (e.g. 'ENSG00000139618', '675', '2244')."},
-            "source": {"type": "string", "description": "Source TogoID dataset name, e.g. 'ensembl_gene', 'ncbigene', 'uniprot', 'pubchem_compound', 'hgnc'."},
-            "target": {"type": "string", "description": "Target TogoID dataset name, e.g. 'uniprot', 'hgnc', 'chebi', 'pdb', 'ensembl_transcript'."}
-        }, "required": ["ids", "source", "target"]},
-        "fields": {"timeout": 30},
-        "type": "TogoIDConvertTool",
-        "test_examples": [
-            {"ids": "ENSG00000139618", "source": "ensembl_gene", "target": "uniprot"},
-            {"ids": "675", "source": "ncbigene", "target": "hgnc"},
-            {"ids": "2244", "source": "pubchem_compound", "target": "chebi"}
-        ],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Converted identifiers", "properties": {
-                "status": {"type": "string"}, "data": {"type": "object"}, "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+  {
+    "name": "TogoID_convert",
+    "description": "Convert biological identifiers between databases using TogoID (DBCLS), which links 117 ID types (genes, proteins, transcripts, compounds, diseases, pathways, variants, cell lines, organisms, etc.). Provide the source ID(s), the source dataset name, and the target dataset name. Works for directly-related dataset pairs (e.g. ensembl_gene->uniprot, ncbigene->hgnc, pubchem_compound->chebi, uniprot->pdb); unrelated pairs return a 'no route' error \u2014 convert via an intermediate. Call TogoID_list_datasets for the exact dataset names. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "string",
+          "description": "Source identifier(s), comma-separated, in the source dataset's native format (e.g. 'ENSG00000139618', '675', '2244')."
+        },
+        "source": {
+          "type": "string",
+          "description": "Source TogoID dataset name, e.g. 'ensembl_gene', 'ncbigene', 'uniprot', 'pubchem_compound', 'hgnc'."
+        },
+        "target": {
+          "type": "string",
+          "description": "Target TogoID dataset name, e.g. 'uniprot', 'hgnc', 'chebi', 'pdb', 'ensembl_transcript'."
+        }
+      },
+      "required": [
+        "ids",
+        "source",
+        "target"
+      ]
     },
-    {
-        "name": "TogoID_list_datasets",
-        "description": "List the biological identifier datasets TogoID can convert between (117 types across categories such as Gene, Protein, Transcript, Compound, Disease, Phenotype, Drug, Pathway, Variant, CellLine, Organism). Returns each dataset's name (use as source/target in TogoID_convert), human label, and category. Optionally filter by category. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "category": {"type": ["string", "null"], "description": "Optional category filter, e.g. 'Gene', 'Protein', 'Compound', 'Disease', 'Pathway', 'Variant'."}
-        }, "required": []},
-        "fields": {"timeout": 30},
-        "type": "TogoIDDatasetsTool",
-        "test_examples": [{"category": "Compound"}, {"category": "Gene"}, {}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Supported ID datasets", "properties": {
-                "status": {"type": "string"}, "data": {"type": "array", "items": {"type": "object"}}, "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+    "fields": {
+      "timeout": 30
+    },
+    "type": "TogoIDConvertTool",
+    "test_examples": [
+      {
+        "ids": "ENSG00000139618",
+        "source": "ensembl_gene",
+        "target": "uniprot"
+      },
+      {
+        "ids": "675",
+        "source": "ncbigene",
+        "target": "hgnc"
+      },
+      {
+        "ids": "2244",
+        "source": "pubchem_compound",
+        "target": "chebi"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
     }
+  },
+  {
+    "name": "TogoID_list_datasets",
+    "description": "List the biological identifier datasets TogoID can convert between (117 types across categories such as Gene, Protein, Transcript, Compound, Disease, Phenotype, Drug, Pathway, Variant, CellLine, Organism). Returns each dataset's name (use as source/target in TogoID_convert), human label, and category. Optionally filter by category. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional category filter, e.g. 'Gene', 'Protein', 'Compound', 'Disease', 'Pathway', 'Variant'."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "TogoIDDatasetsTool",
+    "test_examples": [
+      {
+        "category": "Compound"
+      },
+      {
+        "category": "Gene"
+      },
+      {}
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/tumorhope2_tools.json
+++ b/src/tooluniverse/data/tumorhope2_tools.json
@@ -28,31 +28,32 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": { "const": "success" },
-            "data": {
-              "type": "array",
-              "items": { "type": "object" },
-              "description": "Matching tumor-homing peptide records. Each has id, title, pmid, year, source, name_source, sequence, n_term, c_term, motif, target_tumor, target_cell, receptors_biomarker, phage_display, invitro, invivo."
-            },
-            "metadata": { "type": "object" }
+          "type": "array",
+          "items": {
+            "type": "object"
           },
-          "required": ["status", "data", "metadata"]
+          "description": "Matching tumor-homing peptide records. Each has id, title, pmid, year, source, name_source, sequence, n_term, c_term, motif, target_tumor, target_cell, receptors_biomarker, phage_display, invitro, invivo."
         },
         {
           "type": "object",
           "properties": {
-            "status": { "const": "error" },
-            "error": { "type": "string" }
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["status", "error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      { "source": "A33H" },
-      { "target_tumor": "Brain tumor" }
+      {
+        "source": "A33H"
+      },
+      {
+        "target_tumor": "Brain tumor"
+      }
     ]
   }
 ]

--- a/src/tooluniverse/data/unibind_tools.json
+++ b/src/tooluniverse/data/unibind_tools.json
@@ -78,59 +78,48 @@
       "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tf_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "total_peaks": {
-                    "type": [
-                      "string",
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "dataset_url": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "dataset_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tf_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "total_peaks": {
+                "type": [
+                  "string",
+                  "integer",
+                  "null"
+                ]
+              },
+              "dataset_url": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "dataset_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
-          "required": [
-            "error"
-          ],
           "properties": {
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -187,146 +176,135 @@
       "oneOf": [
         {
           "type": "object",
+          "required": [
+            "dataset_id",
+            "tf_name",
+            "tfbs_models"
+          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "dataset_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "required": [
-                "dataset_id",
-                "tf_name",
-                "tfbs_models"
-              ],
-              "properties": {
-                "dataset_id": {
-                  "type": "string"
-                },
-                "tf_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "cell_line": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "biological_condition": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "identifier": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "jaspar_id": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "prediction_models": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "tfbs_models": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "prediction_model": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "jaspar_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "jaspar_version": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "total_tfbs": {
-                        "type": [
-                          "string",
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "score_threshold": {
-                        "type": [
-                          "string",
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "distance_threshold": {
-                        "type": [
-                          "string",
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "adj_centrimo_pvalue": {
-                        "type": [
-                          "number",
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "bed_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "fasta_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "summary_plot_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "tf_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cell_line": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "biological_condition": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "identifier": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "jaspar_id": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "prediction_models": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "tfbs_models": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "prediction_model": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "jaspar_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "jaspar_version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "total_tfbs": {
+                    "type": [
+                      "string",
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "score_threshold": {
+                    "type": [
+                      "string",
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "distance_threshold": {
+                    "type": [
+                      "string",
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "adj_centrimo_pvalue": {
+                    "type": [
+                      "number",
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "bed_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "fasta_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "summary_plot_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
-          "required": [
-            "error"
-          ],
           "properties": {
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -381,32 +359,21 @@
       "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         {
           "type": "object",
-          "required": [
-            "error"
-          ],
           "properties": {
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/unibind_tools.json
+++ b/src/tooluniverse/data/unibind_tools.json
@@ -75,7 +75,6 @@
       "return_format": "JSON"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "array",
@@ -356,7 +355,6 @@
       "return_format": "JSON"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "array",

--- a/src/tooluniverse/data/uniprot_idmapping_tools.json
+++ b/src/tooluniverse/data/uniprot_idmapping_tools.json
@@ -52,66 +52,51 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "from_db": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "from_db": {
-                  "type": "string"
-                },
-                "to_db": {
-                  "type": "string"
-                },
-                "result_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "results": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "from": {
-                        "type": "string"
-                      },
-                      "to": {
-                        "type": "string"
-                      }
-                    }
+            "to_db": {
+              "type": "string"
+            },
+            "result_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string"
+                  },
+                  "to": {
+                    "type": "string"
                   }
-                },
-                "failed_ids": {
-                  "type": "array"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "failed_ids": {
+              "type": "array"
             }
-          }
+          },
+          "required": [
+            "from_db"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -147,60 +132,45 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "query_ids": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "query_ids": {
-                  "type": "string"
-                },
-                "result_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "results": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "from": {
-                        "type": "string"
-                      },
-                      "to": {
-                        "type": "string"
-                      }
-                    }
+            "result_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string"
+                  },
+                  "to": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "query_ids"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -251,66 +221,51 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_names": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_names": {
-                  "type": "string"
-                },
-                "species_taxid": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "result_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "results": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "from": {
-                        "type": "string"
-                      },
-                      "to": {
-                        "type": "string"
-                      }
-                    }
+            "species_taxid": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "result_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string"
+                  },
+                  "to": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "gene_names"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -334,71 +289,56 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "group_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "group_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "groups": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "group_name": {
-                        "type": "string"
-                      },
-                      "databases": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string"
-                            },
-                            "display_name": {
-                              "type": "string"
-                            },
-                            "from_supported": {
-                              "type": "boolean"
-                            }
-                          }
+            "groups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "group_name": {
+                    "type": "string"
+                  },
+                  "databases": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "display_name": {
+                          "type": "string"
+                        },
+                        "from_supported": {
+                          "type": "boolean"
                         }
                       }
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "group_count"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/uniprot_locations_tools.json
+++ b/src/tooluniverse/data/uniprot_locations_tools.json
@@ -30,115 +30,100 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
+            "name": {
+              "type": "string"
+            },
+            "definition": {
+              "type": "string"
+            },
+            "content": {
+              "type": "string"
+            },
+            "category": {
+              "type": "string"
+            },
+            "note": {
+              "type": "null"
+            },
+            "synonyms": {
+              "type": "array"
+            },
+            "keyword": {
+              "type": [
+                "null",
+                "object"
+              ],
               "properties": {
                 "id": {
                   "type": "string"
                 },
                 "name": {
                   "type": "string"
-                },
-                "definition": {
-                  "type": "string"
-                },
-                "content": {
-                  "type": "string"
-                },
-                "category": {
-                  "type": "string"
-                },
-                "note": {
-                  "type": "null"
-                },
-                "synonyms": {
-                  "type": "array"
-                },
-                "keyword": {
-                  "type": [
-                    "null",
-                    "object"
-                  ],
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "gene_ontologies": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "go_id": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "reviewed_protein_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "unreviewed_protein_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "part_of": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "children": {
-                  "type": "array"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "gene_ontologies": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "go_id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "reviewed_protein_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "unreviewed_protein_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "part_of": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "children": {
+              "type": "array"
             }
-          }
+          },
+          "required": [
+            "id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -179,136 +164,118 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "definition": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
+              },
+              "category": {
+                "type": "string"
+              },
+              "note": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "synonyms": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "keyword": {
+                "type": [
+                  "null",
+                  "object"
+                ],
                 "properties": {
                   "id": {
                     "type": "string"
                   },
                   "name": {
                     "type": "string"
-                  },
-                  "definition": {
-                    "type": "string"
-                  },
-                  "content": {
-                    "type": "string"
-                  },
-                  "category": {
-                    "type": "string"
-                  },
-                  "note": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "synonyms": {
-                    "type": "array",
-                    "items": {
+                  }
+                }
+              },
+              "gene_ontologies": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "go_id": {
+                      "type": "string"
+                    },
+                    "name": {
                       "type": "string"
                     }
-                  },
-                  "keyword": {
-                    "type": [
-                      "null",
-                      "object"
-                    ],
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
+                  }
+                }
+              },
+              "reviewed_protein_count": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "unreviewed_protein_count": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "part_of": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
                     }
-                  },
-                  "gene_ontologies": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "go_id": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "reviewed_protein_count": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "unreviewed_protein_count": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "part_of": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "children": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        }
-                      }
+                  }
+                }
+              },
+              "children": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/uniprot_proteomes_tools.json
+++ b/src/tooluniverse/data/uniprot_proteomes_tools.json
@@ -44,388 +44,373 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "results": {
-                  "type": "array",
-                  "items": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "taxonomy": {
                     "type": "object",
                     "properties": {
-                      "id": {
+                      "scientificName": {
                         "type": "string"
                       },
-                      "description": {
+                      "commonName": {
                         "type": "string"
                       },
-                      "taxonomy": {
-                        "type": "object",
-                        "properties": {
-                          "scientificName": {
-                            "type": "string"
-                          },
-                          "commonName": {
-                            "type": "string"
-                          },
-                          "taxonId": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          },
-                          "mnemonic": {
-                            "type": "string"
-                          },
-                          "synonyms": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "modified": {
-                        "type": "string"
-                      },
-                      "proteomeType": {
-                        "type": "string"
-                      },
-                      "components": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "name": {
-                              "type": "string"
-                            },
-                            "description": {
-                              "type": "string"
-                            },
-                            "proteinCount": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "genomeAnnotation": {
-                              "type": "object",
-                              "properties": {
-                                "source": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "proteomeCrossReferences": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "database": {
-                                    "type": "string"
-                                  },
-                                  "id": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "citations": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "citationType": {
-                              "type": "string"
-                            },
-                            "authors": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "citationCrossReferences": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "database": {
-                                    "type": "string"
-                                  },
-                                  "id": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            },
-                            "title": {
-                              "type": "string"
-                            },
-                            "publicationDate": {
-                              "type": "string"
-                            },
-                            "journal": {
-                              "type": "string"
-                            },
-                            "firstPage": {
-                              "type": "string"
-                            },
-                            "lastPage": {
-                              "type": "string"
-                            },
-                            "volume": {
-                              "type": "string"
-                            },
-                            "authoringGroup": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            },
-                            "submissionDatabase": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "annotationScore": {
+                      "taxonId": {
                         "type": [
                           "integer",
                           "number"
                         ]
                       },
-                      "superkingdom": {
+                      "mnemonic": {
                         "type": "string"
                       },
-                      "proteomeCompletenessReport": {
-                        "type": "object",
-                        "properties": {
-                          "buscoReport": {
+                      "synonyms": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "modified": {
+                    "type": "string"
+                  },
+                  "proteomeType": {
+                    "type": "string"
+                  },
+                  "components": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "proteinCount": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "genomeAnnotation": {
+                          "type": "object",
+                          "properties": {
+                            "source": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "proteomeCrossReferences": {
+                          "type": "array",
+                          "items": {
                             "type": "object",
                             "properties": {
-                              "complete": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "completeSingle": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "completeDuplicated": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "fragmented": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "missing": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "total": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "lineageDb": {
+                              "database": {
                                 "type": "string"
                               },
-                              "score": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
+                              "id": {
+                                "type": "string"
                               }
                             }
-                          },
-                          "cpdReport": {
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "citations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "citationType": {
+                          "type": "string"
+                        },
+                        "authors": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "citationCrossReferences": {
+                          "type": "array",
+                          "items": {
                             "type": "object",
                             "properties": {
-                              "proteomeCount": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
+                              "database": {
+                                "type": "string"
                               },
-                              "stdCdss": {
-                                "type": "number"
-                              },
-                              "averageCdss": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "confidence": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "status": {
+                              "id": {
                                 "type": "string"
                               }
                             }
                           }
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "publicationDate": {
+                          "type": "string"
+                        },
+                        "journal": {
+                          "type": "string"
+                        },
+                        "firstPage": {
+                          "type": "string"
+                        },
+                        "lastPage": {
+                          "type": "string"
+                        },
+                        "volume": {
+                          "type": "string"
+                        },
+                        "authoringGroup": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "submissionDatabase": {
+                          "type": "string"
                         }
-                      },
-                      "genomeAssembly": {
+                      }
+                    }
+                  },
+                  "annotationScore": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "superkingdom": {
+                    "type": "string"
+                  },
+                  "proteomeCompletenessReport": {
+                    "type": "object",
+                    "properties": {
+                      "buscoReport": {
                         "type": "object",
                         "properties": {
-                          "assemblyId": {
+                          "complete": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "completeSingle": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "completeDuplicated": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "fragmented": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "missing": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "total": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "lineageDb": {
                             "type": "string"
                           },
-                          "genomeAssemblyUrl": {
-                            "type": "string"
-                          },
-                          "level": {
-                            "type": "string"
-                          },
-                          "source": {
-                            "type": "string"
+                          "score": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
                           }
                         }
                       },
-                      "geneCount": {
+                      "cpdReport": {
+                        "type": "object",
+                        "properties": {
+                          "proteomeCount": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "stdCdss": {
+                            "type": "number"
+                          },
+                          "averageCdss": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "confidence": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "status": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "genomeAssembly": {
+                    "type": "object",
+                    "properties": {
+                      "assemblyId": {
+                        "type": "string"
+                      },
+                      "genomeAssemblyUrl": {
+                        "type": "string"
+                      },
+                      "level": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "geneCount": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "proteinCount": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "genomeAnnotation": {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string"
+                      },
+                      "url": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "taxonLineage": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "scientificName": {
+                          "type": "string"
+                        },
+                        "taxonId": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        },
+                        "rank": {
+                          "type": "string"
+                        },
+                        "hidden": {
+                          "type": "boolean"
+                        },
+                        "commonName": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "proteomeStatistics": {
+                    "type": "object",
+                    "properties": {
+                      "reviewedProteinCount": {
                         "type": [
                           "integer",
                           "number"
                         ]
                       },
-                      "proteinCount": {
+                      "unreviewedProteinCount": {
                         "type": [
                           "integer",
                           "number"
                         ]
                       },
-                      "genomeAnnotation": {
-                        "type": "object",
-                        "properties": {
-                          "source": {
-                            "type": "string"
-                          },
-                          "url": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "taxonLineage": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "scientificName": {
-                              "type": "string"
-                            },
-                            "taxonId": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            },
-                            "rank": {
-                              "type": "string"
-                            },
-                            "hidden": {
-                              "type": "boolean"
-                            },
-                            "commonName": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "proteomeStatistics": {
-                        "type": "object",
-                        "properties": {
-                          "reviewedProteinCount": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          },
-                          "unreviewedProteinCount": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          },
-                          "isoformProteinCount": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          }
-                        }
-                      },
-                      "panproteome": {
-                        "type": "string"
-                      },
-                      "strain": {
-                        "type": "string"
-                      },
-                      "redundantProteomes": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "similarity": {
-                              "type": "number"
-                            }
-                          }
+                      "isoformProteinCount": {
+                        "type": [
+                          "integer",
+                          "number"
+                        ]
+                      }
+                    }
+                  },
+                  "panproteome": {
+                    "type": "string"
+                  },
+                  "strain": {
+                    "type": "string"
+                  },
+                  "redundantProteomes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "similarity": {
+                          "type": "number"
                         }
                       }
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "results"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -467,371 +452,356 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "id": {
+              "type": "string"
             },
-            "data": {
+            "description": {
+              "type": "string"
+            },
+            "taxonomy": {
               "type": "object",
               "properties": {
-                "id": {
+                "scientificName": {
                   "type": "string"
                 },
-                "description": {
+                "commonName": {
                   "type": "string"
                 },
-                "taxonomy": {
-                  "type": "object",
-                  "properties": {
-                    "scientificName": {
-                      "type": "string"
-                    },
-                    "commonName": {
-                      "type": "string"
-                    },
-                    "taxonId": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "mnemonic": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "modified": {
-                  "type": "string"
-                },
-                "proteomeType": {
-                  "type": "string"
-                },
-                "components": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "proteinCount": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "genomeAnnotation": {
-                        "type": "object",
-                        "properties": {
-                          "source": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "proteomeCrossReferences": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "database": {
-                              "type": "string"
-                            },
-                            "id": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "citations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "citationType": {
-                        "type": "string"
-                      },
-                      "authors": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "citationCrossReferences": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "database": {
-                              "type": "string"
-                            },
-                            "id": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "publicationDate": {
-                        "type": "string"
-                      },
-                      "journal": {
-                        "type": "string"
-                      },
-                      "firstPage": {
-                        "type": "string"
-                      },
-                      "lastPage": {
-                        "type": "string"
-                      },
-                      "volume": {
-                        "type": "string"
-                      },
-                      "authoringGroup": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                },
-                "annotationScore": {
+                "taxonId": {
                   "type": [
                     "integer",
                     "number"
                   ]
                 },
-                "superkingdom": {
-                  "type": "string"
-                },
-                "proteomeCompletenessReport": {
-                  "type": "object",
-                  "properties": {
-                    "buscoReport": {
-                      "type": "object",
-                      "properties": {
-                        "complete": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "completeSingle": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "completeDuplicated": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "fragmented": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "missing": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "total": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "lineageDb": {
-                          "type": "string"
-                        },
-                        "score": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        }
-                      }
-                    },
-                    "cpdReport": {
-                      "type": "object",
-                      "properties": {
-                        "proteomeCount": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "stdCdss": {
-                          "type": "number"
-                        },
-                        "averageCdss": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "confidence": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "status": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                },
-                "genomeAssembly": {
-                  "type": "object",
-                  "properties": {
-                    "assemblyId": {
-                      "type": "string"
-                    },
-                    "genomeAssemblyUrl": {
-                      "type": "string"
-                    },
-                    "level": {
-                      "type": "string"
-                    },
-                    "source": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "geneCount": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "proteinCount": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "genomeAnnotation": {
-                  "type": "object",
-                  "properties": {
-                    "source": {
-                      "type": "string"
-                    },
-                    "url": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "taxonLineage": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "scientificName": {
-                        "type": "string"
-                      },
-                      "taxonId": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "rank": {
-                        "type": "string"
-                      },
-                      "hidden": {
-                        "type": "boolean"
-                      },
-                      "commonName": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "proteomeStatistics": {
-                  "type": "object",
-                  "properties": {
-                    "reviewedProteinCount": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "unreviewedProteinCount": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "isoformProteinCount": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
-                  }
-                },
-                "strain": {
-                  "type": "string"
-                },
-                "redundantProteomes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "similarity": {
-                        "type": "number"
-                      }
-                    }
-                  }
-                },
-                "panproteome": {
+                "mnemonic": {
                   "type": "string"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "modified": {
+              "type": "string"
+            },
+            "proteomeType": {
+              "type": "string"
+            },
+            "components": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "proteinCount": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "genomeAnnotation": {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "proteomeCrossReferences": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "database": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "citations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "citationType": {
+                    "type": "string"
+                  },
+                  "authors": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "citationCrossReferences": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "database": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "publicationDate": {
+                    "type": "string"
+                  },
+                  "journal": {
+                    "type": "string"
+                  },
+                  "firstPage": {
+                    "type": "string"
+                  },
+                  "lastPage": {
+                    "type": "string"
+                  },
+                  "volume": {
+                    "type": "string"
+                  },
+                  "authoringGroup": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "annotationScore": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "superkingdom": {
+              "type": "string"
+            },
+            "proteomeCompletenessReport": {
+              "type": "object",
+              "properties": {
+                "buscoReport": {
+                  "type": "object",
+                  "properties": {
+                    "complete": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "completeSingle": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "completeDuplicated": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "fragmented": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "missing": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "total": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "lineageDb": {
+                      "type": "string"
+                    },
+                    "score": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    }
+                  }
+                },
+                "cpdReport": {
+                  "type": "object",
+                  "properties": {
+                    "proteomeCount": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "stdCdss": {
+                      "type": "number"
+                    },
+                    "averageCdss": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "confidence": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "genomeAssembly": {
+              "type": "object",
+              "properties": {
+                "assemblyId": {
+                  "type": "string"
+                },
+                "genomeAssemblyUrl": {
+                  "type": "string"
+                },
+                "level": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                }
+              }
+            },
+            "geneCount": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "proteinCount": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "genomeAnnotation": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              }
+            },
+            "taxonLineage": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "scientificName": {
+                    "type": "string"
+                  },
+                  "taxonId": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "rank": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "commonName": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "proteomeStatistics": {
+              "type": "object",
+              "properties": {
+                "reviewedProteinCount": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "unreviewedProteinCount": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "isoformProteinCount": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
+            },
+            "strain": {
+              "type": "string"
+            },
+            "redundantProteomes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "similarity": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            "panproteome": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/uniprot_ref_tools.json
+++ b/src/tooluniverse/data/uniprot_ref_tools.json
@@ -34,79 +34,61 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "acronym": {
-                    "type": "string"
-                  },
-                  "definition": {
-                    "type": "string"
-                  },
-                  "alternative_names": {
-                    "type": "array",
-                    "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "acronym": {
+                "type": "string"
+              },
+              "definition": {
+                "type": "string"
+              },
+              "alternative_names": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "cross_references": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "database": {
+                      "type": "string"
+                    },
+                    "id": {
                       "type": "string"
                     }
-                  },
-                  "cross_references": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "database": {
-                          "type": "string"
-                        },
-                        "id": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "reviewed_protein_count": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
                   }
                 }
+              },
+              "reviewed_protein_count": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -142,87 +124,72 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "acronym": {
-                  "type": "string"
-                },
-                "definition": {
-                  "type": "string"
-                },
-                "alternative_names": {
-                  "type": "array",
-                  "items": {
+            "name": {
+              "type": "string"
+            },
+            "acronym": {
+              "type": "string"
+            },
+            "definition": {
+              "type": "string"
+            },
+            "alternative_names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "cross_references": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "database": {
                     "type": "string"
-                  }
-                },
-                "cross_references": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "database": {
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "string"
-                      },
-                      "properties": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "properties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
                   }
-                },
-                "reviewed_protein_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "unreviewed_protein_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "reviewed_protein_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "unreviewed_protein_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
             }
-          }
+          },
+          "required": [
+            "id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -262,59 +229,41 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "category": {
-                    "type": "string"
-                  },
-                  "definition": {
-                    "type": "string"
-                  },
-                  "reviewed_protein_count": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "category": {
+                "type": "string"
+              },
+              "definition": {
+                "type": "string"
+              },
+              "reviewed_protein_count": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -350,89 +299,74 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "category": {
-                  "type": "string"
-                },
-                "definition": {
-                  "type": "string"
-                },
-                "parents": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
-                    }
+            "name": {
+              "type": "string"
+            },
+            "category": {
+              "type": "string"
+            },
+            "definition": {
+              "type": "string"
+            },
+            "parents": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
                   }
-                },
-                "go_mappings": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "go_id": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "reviewed_protein_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "unreviewed_protein_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "go_mappings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "go_id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "reviewed_protein_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "unreviewed_protein_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
             }
-          }
+          },
+          "required": [
+            "id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -468,66 +402,26 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "id": {
+              "type": "string"
             },
-            "data": {
+            "description": {
+              "type": "string"
+            },
+            "organism": {
               "type": "object",
               "properties": {
-                "id": {
+                "scientific_name": {
                   "type": "string"
                 },
-                "description": {
-                  "type": "string"
+                "common_name": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
-                "organism": {
-                  "type": "object",
-                  "properties": {
-                    "scientific_name": {
-                      "type": "string"
-                    },
-                    "common_name": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "taxon_id": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
-                  }
-                },
-                "proteome_type": {
-                  "type": "string"
-                },
-                "components": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "protein_count": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "genome_accession": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "total_protein_count": {
+                "taxon_id": {
                   "type": [
                     "integer",
                     "number"
@@ -535,25 +429,50 @@
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "proteome_type": {
+              "type": "string"
+            },
+            "components": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "protein_count": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "genome_accession": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "total_protein_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
             }
-          }
+          },
+          "required": [
+            "id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -593,68 +512,50 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "organism": {
-                    "type": "string"
-                  },
-                  "common_name": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "taxon_id": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "proteome_type": {
-                    "type": "string"
-                  },
-                  "protein_count": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "organism": {
+                "type": "string"
+              },
+              "common_name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "taxon_id": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "proteome_type": {
+                "type": "string"
+              },
+              "protein_count": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/uniprot_taxonomy_tools.json
+++ b/src/tooluniverse/data/uniprot_taxonomy_tools.json
@@ -30,95 +30,80 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "taxon_id": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
+            "scientific_name": {
+              "type": "string"
+            },
+            "common_name": {
+              "type": "string"
+            },
+            "mnemonic": {
+              "type": "string"
+            },
+            "rank": {
+              "type": "string"
+            },
+            "lineage": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "taxon_id": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "scientific_name": {
+                    "type": "string"
+                  },
+                  "rank": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "statistics": {
               "type": "object",
               "properties": {
-                "taxon_id": {
+                "reviewed_protein_count": {
                   "type": [
                     "integer",
                     "number"
                   ]
                 },
-                "scientific_name": {
-                  "type": "string"
-                },
-                "common_name": {
-                  "type": "string"
-                },
-                "mnemonic": {
-                  "type": "string"
-                },
-                "rank": {
-                  "type": "string"
-                },
-                "lineage": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "taxon_id": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "scientific_name": {
-                        "type": "string"
-                      },
-                      "rank": {
-                        "type": "string"
-                      },
-                      "hidden": {
-                        "type": "boolean"
-                      }
-                    }
-                  }
-                },
-                "statistics": {
-                  "type": "object",
-                  "properties": {
-                    "reviewed_protein_count": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "unreviewed_protein_count": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
-                  }
+                "unreviewed_protein_count": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "taxon_id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -158,74 +143,56 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "taxon_id": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "scientific_name": {
-                    "type": "string"
-                  },
-                  "common_name": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "mnemonic": {
-                    "type": "string"
-                  },
-                  "rank": {
-                    "type": "string"
-                  },
-                  "reviewed_protein_count": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "unreviewed_protein_count": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "taxon_id": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "scientific_name": {
+                "type": "string"
+              },
+              "common_name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "mnemonic": {
+                "type": "string"
+              },
+              "rank": {
+                "type": "string"
+              },
+              "reviewed_protein_count": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "unreviewed_protein_count": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/uniprot_tools.json
+++ b/src/tooluniverse/data/uniprot_tools.json
@@ -716,81 +716,66 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "total_results": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "returned": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "results": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "string"
-                      },
-                      "protein_name": {
-                        "type": "string"
-                      },
-                      "gene_names": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "organism": {
-                        "type": "string"
-                      },
-                      "length": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      }
+            "returned": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "protein_name": {
+                    "type": "string"
+                  },
+                  "gene_names": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "organism": {
+                    "type": "string"
+                  },
+                  "length": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "total_results"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -853,71 +838,56 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "mapped_count": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "mapped_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "results": {
-                  "type": "array",
-                  "items": {
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "type": "string"
+                  },
+                  "to": {
                     "type": "object",
                     "properties": {
-                      "from": {
+                      "accession": {
                         "type": "string"
                       },
-                      "to": {
-                        "type": "object",
-                        "properties": {
-                          "accession": {
-                            "type": "string"
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "gene_name": {
-                            "type": "string"
-                          }
-                        }
+                      "id": {
+                        "type": "string"
+                      },
+                      "gene_name": {
+                        "type": "string"
                       }
                     }
                   }
-                },
-                "failed_ids": {
-                  "type": "array"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "failed_ids": {
+              "type": "array"
             }
-          }
+          },
+          "required": [
+            "mapped_count"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -952,351 +922,336 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "id": {
+              "type": "string"
             },
-            "data": {
+            "description": {
+              "type": "string"
+            },
+            "taxonomy": {
               "type": "object",
               "properties": {
-                "id": {
+                "scientificName": {
                   "type": "string"
                 },
-                "description": {
+                "commonName": {
                   "type": "string"
                 },
-                "taxonomy": {
-                  "type": "object",
-                  "properties": {
-                    "scientificName": {
-                      "type": "string"
-                    },
-                    "commonName": {
-                      "type": "string"
-                    },
-                    "taxonId": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "mnemonic": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "modified": {
-                  "type": "string"
-                },
-                "proteomeType": {
-                  "type": "string"
-                },
-                "components": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "proteinCount": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "genomeAnnotation": {
-                        "type": "object",
-                        "properties": {
-                          "source": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "proteomeCrossReferences": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "database": {
-                              "type": "string"
-                            },
-                            "id": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "citations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "citationType": {
-                        "type": "string"
-                      },
-                      "authors": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "citationCrossReferences": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "database": {
-                              "type": "string"
-                            },
-                            "id": {
-                              "type": "string"
-                            }
-                          }
-                        }
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "publicationDate": {
-                        "type": "string"
-                      },
-                      "journal": {
-                        "type": "string"
-                      },
-                      "firstPage": {
-                        "type": "string"
-                      },
-                      "lastPage": {
-                        "type": "string"
-                      },
-                      "volume": {
-                        "type": "string"
-                      },
-                      "authoringGroup": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                },
-                "annotationScore": {
+                "taxonId": {
                   "type": [
                     "integer",
                     "number"
                   ]
                 },
-                "superkingdom": {
+                "mnemonic": {
                   "type": "string"
-                },
-                "proteomeCompletenessReport": {
-                  "type": "object",
-                  "properties": {
-                    "buscoReport": {
+                }
+              }
+            },
+            "modified": {
+              "type": "string"
+            },
+            "proteomeType": {
+              "type": "string"
+            },
+            "components": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "proteinCount": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "genomeAnnotation": {
+                    "type": "object",
+                    "properties": {
+                      "source": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "proteomeCrossReferences": {
+                    "type": "array",
+                    "items": {
                       "type": "object",
                       "properties": {
-                        "complete": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "completeSingle": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "completeDuplicated": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "fragmented": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "missing": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "total": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "lineageDb": {
+                        "database": {
                           "type": "string"
                         },
-                        "score": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        }
-                      }
-                    },
-                    "cpdReport": {
-                      "type": "object",
-                      "properties": {
-                        "proteomeCount": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "stdCdss": {
-                          "type": "number"
-                        },
-                        "averageCdss": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "confidence": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "status": {
+                        "id": {
                           "type": "string"
                         }
                       }
-                    }
-                  }
-                },
-                "genomeAssembly": {
-                  "type": "object",
-                  "properties": {
-                    "assemblyId": {
-                      "type": "string"
-                    },
-                    "genomeAssemblyUrl": {
-                      "type": "string"
-                    },
-                    "level": {
-                      "type": "string"
-                    },
-                    "source": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "geneCount": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "proteinCount": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "genomeAnnotation": {
-                  "type": "object",
-                  "properties": {
-                    "source": {
-                      "type": "string"
-                    },
-                    "url": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "taxonLineage": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "scientificName": {
-                        "type": "string"
-                      },
-                      "taxonId": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      },
-                      "rank": {
-                        "type": "string"
-                      },
-                      "hidden": {
-                        "type": "boolean"
-                      },
-                      "commonName": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "proteomeStatistics": {
-                  "type": "object",
-                  "properties": {
-                    "reviewedProteinCount": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "unreviewedProteinCount": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    },
-                    "isoformProteinCount": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
                     }
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "citations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "citationType": {
+                    "type": "string"
+                  },
+                  "authors": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "citationCrossReferences": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "database": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "publicationDate": {
+                    "type": "string"
+                  },
+                  "journal": {
+                    "type": "string"
+                  },
+                  "firstPage": {
+                    "type": "string"
+                  },
+                  "lastPage": {
+                    "type": "string"
+                  },
+                  "volume": {
+                    "type": "string"
+                  },
+                  "authoringGroup": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "annotationScore": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "superkingdom": {
+              "type": "string"
+            },
+            "proteomeCompletenessReport": {
+              "type": "object",
+              "properties": {
+                "buscoReport": {
+                  "type": "object",
+                  "properties": {
+                    "complete": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "completeSingle": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "completeDuplicated": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "fragmented": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "missing": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "total": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "lineageDb": {
+                      "type": "string"
+                    },
+                    "score": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    }
+                  }
+                },
+                "cpdReport": {
+                  "type": "object",
+                  "properties": {
+                    "proteomeCount": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "stdCdss": {
+                      "type": "number"
+                    },
+                    "averageCdss": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "confidence": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "genomeAssembly": {
+              "type": "object",
+              "properties": {
+                "assemblyId": {
+                  "type": "string"
+                },
+                "genomeAssemblyUrl": {
+                  "type": "string"
+                },
+                "level": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                }
+              }
+            },
+            "geneCount": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "proteinCount": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "genomeAnnotation": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              }
+            },
+            "taxonLineage": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "scientificName": {
+                    "type": "string"
+                  },
+                  "taxonId": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "rank": {
+                    "type": "string"
+                  },
+                  "hidden": {
+                    "type": "boolean"
+                  },
+                  "commonName": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "proteomeStatistics": {
+              "type": "object",
+              "properties": {
+                "reviewedProteinCount": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "unreviewedProteinCount": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                },
+                "isoformProteinCount": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "id"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -1535,203 +1490,188 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "total_results": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "returned": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "results": {
-                  "type": "array",
-                  "items": {
+            "returned": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "updated": {
+                    "type": "string"
+                  },
+                  "entryType": {
+                    "type": "string"
+                  },
+                  "commonTaxon": {
                     "type": "object",
                     "properties": {
-                      "id": {
+                      "scientificName": {
                         "type": "string"
                       },
-                      "name": {
+                      "taxonId": {
+                        "type": [
+                          "integer",
+                          "number"
+                        ]
+                      }
+                    }
+                  },
+                  "memberCount": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "organismCount": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "representativeMember": {
+                    "type": "object",
+                    "properties": {
+                      "memberIdType": {
                         "type": "string"
                       },
-                      "updated": {
+                      "memberId": {
                         "type": "string"
                       },
-                      "entryType": {
+                      "organismName": {
                         "type": "string"
                       },
-                      "commonTaxon": {
-                        "type": "object",
-                        "properties": {
-                          "scientificName": {
-                            "type": "string"
-                          },
-                          "taxonId": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          }
-                        }
-                      },
-                      "memberCount": {
+                      "organismTaxId": {
                         "type": [
                           "integer",
                           "number"
                         ]
                       },
-                      "organismCount": {
+                      "sequenceLength": {
                         "type": [
                           "integer",
                           "number"
                         ]
                       },
-                      "representativeMember": {
-                        "type": "object",
-                        "properties": {
-                          "memberIdType": {
-                            "type": "string"
-                          },
-                          "memberId": {
-                            "type": "string"
-                          },
-                          "organismName": {
-                            "type": "string"
-                          },
-                          "organismTaxId": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          },
-                          "sequenceLength": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          },
-                          "proteinName": {
-                            "type": "string"
-                          },
-                          "accessions": {
-                            "type": "array",
-                            "items": {
-                              "type": "string"
-                            }
-                          },
-                          "uniref50Id": {
-                            "type": "string"
-                          },
-                          "uniref100Id": {
-                            "type": "string"
-                          },
-                          "uniparcId": {
-                            "type": "string"
-                          },
-                          "sequence": {
-                            "type": "object",
-                            "properties": {
-                              "value": {
-                                "type": "string"
-                              },
-                              "length": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "molWeight": {
-                                "type": [
-                                  "integer",
-                                  "number"
-                                ]
-                              },
-                              "crc64": {
-                                "type": "string"
-                              },
-                              "md5": {
-                                "type": "string"
-                              }
-                            }
-                          },
-                          "uniref90Id": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "seedId": {
+                      "proteinName": {
                         "type": "string"
                       },
-                      "memberIdTypes": {
+                      "accessions": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         }
                       },
-                      "members": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
+                      "uniref50Id": {
+                        "type": "string"
                       },
-                      "organisms": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "scientificName": {
-                              "type": "string"
-                            },
-                            "commonName": {
-                              "type": "string"
-                            },
-                            "taxonId": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            }
+                      "uniref100Id": {
+                        "type": "string"
+                      },
+                      "uniparcId": {
+                        "type": "string"
+                      },
+                      "sequence": {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string"
+                          },
+                          "length": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "molWeight": {
+                            "type": [
+                              "integer",
+                              "number"
+                            ]
+                          },
+                          "crc64": {
+                            "type": "string"
+                          },
+                          "md5": {
+                            "type": "string"
                           }
+                        }
+                      },
+                      "uniref90Id": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "seedId": {
+                    "type": "string"
+                  },
+                  "memberIdTypes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "members": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "organisms": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "scientificName": {
+                          "type": "string"
+                        },
+                        "commonName": {
+                          "type": "string"
+                        },
+                        "taxonId": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
                         }
                       }
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "total_results"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -1957,172 +1897,157 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "total_results": {
+              "type": [
+                "integer",
+                "number"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "returned": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "results": {
-                  "type": "array",
-                  "items": {
+            "returned": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "uniParcId": {
+                    "type": "string"
+                  },
+                  "crossReferenceCount": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  },
+                  "commonTaxons": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "topLevel": {
+                          "type": "string"
+                        },
+                        "commonTaxon": {
+                          "type": "string"
+                        },
+                        "commonTaxonId": {
+                          "type": [
+                            "integer",
+                            "number"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "uniProtKBAccessions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "sequence": {
                     "type": "object",
                     "properties": {
-                      "uniParcId": {
+                      "value": {
                         "type": "string"
                       },
-                      "crossReferenceCount": {
+                      "length": {
                         "type": [
                           "integer",
                           "number"
                         ]
                       },
-                      "commonTaxons": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "topLevel": {
-                              "type": "string"
-                            },
-                            "commonTaxon": {
-                              "type": "string"
-                            },
-                            "commonTaxonId": {
-                              "type": [
-                                "integer",
-                                "number"
-                              ]
-                            }
-                          }
-                        }
+                      "molWeight": {
+                        "type": [
+                          "integer",
+                          "number"
+                        ]
                       },
-                      "uniProtKBAccessions": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "sequence": {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string"
-                          },
-                          "length": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          },
-                          "molWeight": {
-                            "type": [
-                              "integer",
-                              "number"
-                            ]
-                          },
-                          "crc64": {
-                            "type": "string"
-                          },
-                          "md5": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "sequenceFeatures": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "interproGroup": {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string"
-                                },
-                                "name": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "database": {
-                              "type": "string"
-                            },
-                            "databaseId": {
-                              "type": "string"
-                            },
-                            "locations": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "start": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "end": {
-                                    "type": [
-                                      "integer",
-                                      "number"
-                                    ]
-                                  },
-                                  "alignment": {
-                                    "type": "string"
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      },
-                      "oldestCrossRefCreated": {
+                      "crc64": {
                         "type": "string"
                       },
-                      "mostRecentCrossRefUpdated": {
+                      "md5": {
                         "type": "string"
                       }
                     }
+                  },
+                  "sequenceFeatures": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "interproGroup": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "database": {
+                          "type": "string"
+                        },
+                        "databaseId": {
+                          "type": "string"
+                        },
+                        "locations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "start": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "end": {
+                                "type": [
+                                  "integer",
+                                  "number"
+                                ]
+                              },
+                              "alignment": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "oldestCrossRefCreated": {
+                    "type": "string"
+                  },
+                  "mostRecentCrossRefUpdated": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          }
+          },
+          "required": [
+            "total_results"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/usda_plants_tools.json
+++ b/src/tooluniverse/data/usda_plants_tools.json
@@ -1,151 +1,553 @@
 [
-    {
-        "name": "USDA_plants_get_profile",
-        "description": "Get a USDA PLANTS Database profile for a plant by its PLANTS symbol (e.g. 'ABBA' = balsam fir): scientific name, common name, taxonomic group/rank, duration (annual/perennial), growth habits (tree/shrub/forb), native status, synonyms, and US distribution FIPS codes. Authoritative US plant taxonomy. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "symbol": {"type": "string", "description": "USDA PLANTS symbol, e.g. 'ABBA' (balsam fir), 'ACRU' (red maple), 'QUAL' (white oak)."}
-        }, "required": ["symbol"]},
-        "fields": {"timeout": 30},
-        "type": "USDAPlantsProfileTool",
-        "test_examples": [{"symbol": "ABBA"}, {"symbol": "ACRU"}, {"symbol": "QUAL"}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Plant profile", "properties": {
-                "status": {"type": "string"}, "data": {"type": "object"}, "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+  {
+    "name": "USDA_plants_get_profile",
+    "description": "Get a USDA PLANTS Database profile for a plant by its PLANTS symbol (e.g. 'ABBA' = balsam fir): scientific name, common name, taxonomic group/rank, duration (annual/perennial), growth habits (tree/shrub/forb), native status, synonyms, and US distribution FIPS codes. Authoritative US plant taxonomy. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "description": "USDA PLANTS symbol, e.g. 'ABBA' (balsam fir), 'ACRU' (red maple), 'QUAL' (white oak)."
+        }
+      },
+      "required": [
+        "symbol"
+      ]
     },
-    {
-        "name": "USDA_plants_get_characteristics",
-        "description": "Get the USDA PLANTS morphology/physiology, growth-requirement, and reproduction characteristics for a plant by its PLANTS symbol (e.g. 'ABBA'). Returns a list of characteristic name/value/category entries (e.g. active growth period, shade tolerance, drought tolerance, mature height, bloom period). Resolves the symbol to the plant id automatically. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "symbol": {"type": "string", "description": "USDA PLANTS symbol, e.g. 'ABBA', 'ACRU'."}
-        }, "required": ["symbol"]},
-        "fields": {"timeout": 30},
-        "type": "USDAPlantsCharacteristicsTool",
-        "test_examples": [{"symbol": "ABBA"}, {"symbol": "ACRU"}, {"symbol": "QUAL"}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Plant characteristics", "properties": {
-                "status": {"type": "string"}, "data": {"type": "array", "items": {"type": "object"}}, "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+    "fields": {
+      "timeout": 30
     },
-    {
-        "name": "USDA_plants_search_by_name",
-        "description": "Resolve a plant scientific name, common name, or genus to USDA PLANTS symbol(s). The other USDA PLANTS tools (USDA_plants_get_profile, USDA_plants_get_characteristics) require a PLANTS symbol (e.g. 'ABBA') as input; use this tool first when you only know the plant by name. Returns a list of matching plants, each with its Symbol, ScientificName, CommonName, and Rank (Species/Genus/Variety). Example: 'white oak' -> QUAR / Quercus arizonica (Arizona white oak); 'red maple' -> ACRU / Acer rubrum; 'Quercus' -> QUERC (Genus). No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "searchText": {"type": "string", "description": "Plant scientific name, common name, or genus to search. Examples: 'white oak', 'red maple', 'Quercus', 'Acer rubrum'."},
-            "limit": {"type": ["integer", "null"], "description": "Maximum number of matches to return (default 25, max 200)."}
-        }, "required": ["searchText"]},
-        "fields": {"timeout": 30, "action": "search"},
-        "type": "USDAPlantsProfileTool",
-        "test_examples": [{"searchText": "white oak"}, {"searchText": "red maple"}, {"searchText": "Quercus"}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Matching plants with PLANTS symbols", "properties": {
-                "status": {"type": "string"},
-                "data": {"type": "array", "items": {"type": "object", "properties": {
-                    "symbol": {"type": ["string", "null"]},
-                    "scientific_name": {"type": ["string", "null"]},
-                    "common_name": {"type": ["string", "null"]},
-                    "rank": {"type": ["string", "null"]},
-                    "id": {"type": ["integer", "null"]}
-                }}},
-                "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
-    },
-    {
-        "name": "USDA_plants_get_wetland_status",
-        "description": "Get USACE wetland indicator status by geographic region for a plant from the USDA PLANTS Database. Returns the wetland indicator code per region: OBL (obligate wetland), FACW (facultative wetland), FAC (facultative), FACU (facultative upland), or UPL (upland). Core data for wetland delineation, restoration ecology, and Clean Water Act jurisdictional determinations. Provide a PLANTS 'symbol' (e.g. 'TYLA' = common cattail, resolved to its plant Id automatically) or a numeric 'id' directly. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "symbol": {"type": ["string", "null"], "description": "USDA PLANTS symbol, e.g. 'TYLA' (Typha latifolia / common cattail). Resolved to the plant Id automatically. Use USDA_plants_search_by_name to find a symbol from a name."},
-            "id": {"type": ["integer", "null"], "description": "Numeric USDA PLANTS Id (e.g. 27001). Use instead of 'symbol' if known."}
-        }, "required": []},
-        "fields": {"timeout": 30, "action": "wetland"},
-        "type": "USDAPlantsProfileTool",
-        "test_examples": [{"symbol": "TYLA"}, {"id": 27001}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Wetland indicator statuses by region", "properties": {
-                "status": {"type": "string"},
-                "data": {"type": "array", "items": {"type": "object", "properties": {
-                    "id": {"type": ["integer", "null"]},
-                    "scientific_name": {"type": ["string", "null"]},
-                    "wetland_designations": {"type": "array", "items": {"type": "object", "properties": {
-                        "region": {"type": ["string", "null"]},
-                        "sub_region": {"type": ["string", "null"]},
-                        "wetland_code": {"type": ["string", "null"]}
-                    }}}
-                }}},
-                "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
-    },
-    {
-        "name": "USDA_plants_get_invasive_status",
-        "description": "Get state-by-state invasive and noxious-weed legal status for a plant from the USDA PLANTS Database. Returns per-jurisdiction invasive listings (e.g. 'Invasive', 'Potentially Invasive', 'Prohibited' by state) and federal/state noxious-weed statuses. Critical for agriculture, land management, and regulatory compliance. Provide a PLANTS 'symbol' (e.g. 'PUMO' = kudzu, resolved to its plant Id automatically) or a numeric 'id' directly. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "symbol": {"type": ["string", "null"], "description": "USDA PLANTS symbol, e.g. 'PUMO' (Pueraria montana / kudzu). Resolved to the plant Id automatically. Use USDA_plants_search_by_name to find a symbol from a name."},
-            "id": {"type": ["integer", "null"], "description": "Numeric USDA PLANTS Id (e.g. 82047). Use instead of 'symbol' if known."}
-        }, "required": []},
-        "fields": {"timeout": 30, "action": "invasive"},
-        "type": "USDAPlantsProfileTool",
-        "test_examples": [{"symbol": "PUMO"}, {"id": 82047}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Invasive and noxious legal status by jurisdiction", "properties": {
-                "status": {"type": "string"},
-                "data": {"type": "object", "properties": {
-                    "invasive": {"type": "array", "items": {"type": "object", "properties": {
-                        "locality_name": {"type": ["string", "null"]},
-                        "common_names": {"type": "array", "items": {"type": "string"}},
-                        "statuses": {"type": "array", "items": {"type": "string"}}
-                    }}},
-                    "noxious": {"type": "array", "items": {"type": "object", "properties": {
-                        "locality_name": {"type": ["string", "null"]},
-                        "common_names": {"type": "array", "items": {"type": "string"}},
-                        "statuses": {"type": "array", "items": {"type": "string"}}
-                    }}}
-                }},
-                "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
-    },
-    {
-        "name": "USDA_plants_get_wildlife_value",
-        "description": "Get wildlife food and cover value ratings for a plant from the USDA PLANTS Database. Returns forage/cover importance ratings (e.g. Minor, Low, Moderate, High) to large mammals, small mammals, water birds, and terrestrial birds, by source, plus the cited sources. Used in habitat/restoration and conservation planning. Provide a PLANTS 'symbol' (e.g. 'SANIC4' = elderberry, resolved to its plant Id automatically) or a numeric 'id' directly. No API key required.",
-        "parameter": {"type": "object", "properties": {
-            "symbol": {"type": ["string", "null"], "description": "USDA PLANTS symbol, e.g. 'SANIC4' (Sambucus nigra ssp. canadensis / elderberry). Resolved to the plant Id automatically. Use USDA_plants_search_by_name to find a symbol from a name."},
-            "id": {"type": ["integer", "null"], "description": "Numeric USDA PLANTS Id (e.g. 42834). Use instead of 'symbol' if known."}
-        }, "required": []},
-        "fields": {"timeout": 30, "action": "wildlife"},
-        "type": "USDAPlantsProfileTool",
-        "test_examples": [{"symbol": "SANIC4"}, {"id": 42834}],
-        "return_schema": {"oneOf": [
-            {"type": "object", "description": "Wildlife food and cover value ratings", "properties": {
-                "status": {"type": "string"},
-                "data": {"type": "object", "properties": {
-                    "food": {"type": "array", "items": {"type": "object", "properties": {
-                        "source": {"type": ["string", "null"]},
-                        "large_mammals": {"type": ["string", "null"]},
-                        "small_mammals": {"type": ["string", "null"]},
-                        "water_birds": {"type": ["string", "null"]},
-                        "terrestrial_birds": {"type": ["string", "null"]}
-                    }}},
-                    "cover": {"type": "array", "items": {"type": "object", "properties": {
-                        "source": {"type": ["string", "null"]},
-                        "large_mammals": {"type": ["string", "null"]},
-                        "small_mammals": {"type": ["string", "null"]},
-                        "water_birds": {"type": ["string", "null"]},
-                        "terrestrial_birds": {"type": ["string", "null"]}
-                    }}},
-                    "sources": {"type": "array", "items": {"type": "object"}}
-                }},
-                "metadata": {"type": "object"}
-            }, "required": ["status", "data"]},
-            {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
-        ]}
+    "type": "USDAPlantsProfileTool",
+    "test_examples": [
+      {
+        "symbol": "ABBA"
+      },
+      {
+        "symbol": "ACRU"
+      },
+      {
+        "symbol": "QUAL"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
     }
+  },
+  {
+    "name": "USDA_plants_get_characteristics",
+    "description": "Get the USDA PLANTS morphology/physiology, growth-requirement, and reproduction characteristics for a plant by its PLANTS symbol (e.g. 'ABBA'). Returns a list of characteristic name/value/category entries (e.g. active growth period, shade tolerance, drought tolerance, mature height, bloom period). Resolves the symbol to the plant id automatically. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "description": "USDA PLANTS symbol, e.g. 'ABBA', 'ACRU'."
+        }
+      },
+      "required": [
+        "symbol"
+      ]
+    },
+    "fields": {
+      "timeout": 30
+    },
+    "type": "USDAPlantsCharacteristicsTool",
+    "test_examples": [
+      {
+        "symbol": "ABBA"
+      },
+      {
+        "symbol": "ACRU"
+      },
+      {
+        "symbol": "QUAL"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "USDA_plants_search_by_name",
+    "description": "Resolve a plant scientific name, common name, or genus to USDA PLANTS symbol(s). The other USDA PLANTS tools (USDA_plants_get_profile, USDA_plants_get_characteristics) require a PLANTS symbol (e.g. 'ABBA') as input; use this tool first when you only know the plant by name. Returns a list of matching plants, each with its Symbol, ScientificName, CommonName, and Rank (Species/Genus/Variety). Example: 'white oak' -> QUAR / Quercus arizonica (Arizona white oak); 'red maple' -> ACRU / Acer rubrum; 'Quercus' -> QUERC (Genus). No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "searchText": {
+          "type": "string",
+          "description": "Plant scientific name, common name, or genus to search. Examples: 'white oak', 'red maple', 'Quercus', 'Acer rubrum'."
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Maximum number of matches to return (default 25, max 200)."
+        }
+      },
+      "required": [
+        "searchText"
+      ]
+    },
+    "fields": {
+      "timeout": 30,
+      "action": "search"
+    },
+    "type": "USDAPlantsProfileTool",
+    "test_examples": [
+      {
+        "searchText": "white oak"
+      },
+      {
+        "searchText": "red maple"
+      },
+      {
+        "searchText": "Quercus"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "scientific_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "common_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "rank": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "USDA_plants_get_wetland_status",
+    "description": "Get USACE wetland indicator status by geographic region for a plant from the USDA PLANTS Database. Returns the wetland indicator code per region: OBL (obligate wetland), FACW (facultative wetland), FAC (facultative), FACU (facultative upland), or UPL (upland). Core data for wetland delineation, restoration ecology, and Clean Water Act jurisdictional determinations. Provide a PLANTS 'symbol' (e.g. 'TYLA' = common cattail, resolved to its plant Id automatically) or a numeric 'id' directly. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "USDA PLANTS symbol, e.g. 'TYLA' (Typha latifolia / common cattail). Resolved to the plant Id automatically. Use USDA_plants_search_by_name to find a symbol from a name."
+        },
+        "id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Numeric USDA PLANTS Id (e.g. 27001). Use instead of 'symbol' if known."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "timeout": 30,
+      "action": "wetland"
+    },
+    "type": "USDAPlantsProfileTool",
+    "test_examples": [
+      {
+        "symbol": "TYLA"
+      },
+      {
+        "id": 27001
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "scientific_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "wetland_designations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "region": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "sub_region": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "wetland_code": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "USDA_plants_get_invasive_status",
+    "description": "Get state-by-state invasive and noxious-weed legal status for a plant from the USDA PLANTS Database. Returns per-jurisdiction invasive listings (e.g. 'Invasive', 'Potentially Invasive', 'Prohibited' by state) and federal/state noxious-weed statuses. Critical for agriculture, land management, and regulatory compliance. Provide a PLANTS 'symbol' (e.g. 'PUMO' = kudzu, resolved to its plant Id automatically) or a numeric 'id' directly. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "USDA PLANTS symbol, e.g. 'PUMO' (Pueraria montana / kudzu). Resolved to the plant Id automatically. Use USDA_plants_search_by_name to find a symbol from a name."
+        },
+        "id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Numeric USDA PLANTS Id (e.g. 82047). Use instead of 'symbol' if known."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "timeout": 30,
+      "action": "invasive"
+    },
+    "type": "USDAPlantsProfileTool",
+    "test_examples": [
+      {
+        "symbol": "PUMO"
+      },
+      {
+        "id": 82047
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "invasive": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "locality_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "common_names": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "statuses": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "noxious": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "locality_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "common_names": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "statuses": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": [
+            "invasive"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "USDA_plants_get_wildlife_value",
+    "description": "Get wildlife food and cover value ratings for a plant from the USDA PLANTS Database. Returns forage/cover importance ratings (e.g. Minor, Low, Moderate, High) to large mammals, small mammals, water birds, and terrestrial birds, by source, plus the cited sources. Used in habitat/restoration and conservation planning. Provide a PLANTS 'symbol' (e.g. 'SANIC4' = elderberry, resolved to its plant Id automatically) or a numeric 'id' directly. No API key required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "USDA PLANTS symbol, e.g. 'SANIC4' (Sambucus nigra ssp. canadensis / elderberry). Resolved to the plant Id automatically. Use USDA_plants_search_by_name to find a symbol from a name."
+        },
+        "id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Numeric USDA PLANTS Id (e.g. 42834). Use instead of 'symbol' if known."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "timeout": 30,
+      "action": "wildlife"
+    },
+    "type": "USDAPlantsProfileTool",
+    "test_examples": [
+      {
+        "symbol": "SANIC4"
+      },
+      {
+        "id": 42834
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "food": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "large_mammals": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "small_mammals": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "water_birds": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "terrestrial_birds": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "cover": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "large_mammals": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "small_mammals": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "water_birds": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "terrestrial_birds": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "sources": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          },
+          "required": [
+            "food"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/variant_fraction_tools.json
+++ b/src/tooluniverse/data/variant_fraction_tools.json
@@ -49,68 +49,54 @@
       "type": "object",
       "oneOf": [
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "total_variants": {
+              "type": "integer"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_variants": {
-                  "type": "integer"
-                },
-                "vaf_filtered": {
-                  "type": "integer"
-                },
-                "coding_variants_below_vaf": {
-                  "type": "integer"
-                },
-                "matching_annotation": {
-                  "type": "integer"
-                },
-                "fraction": {
-                  "type": "number"
-                },
-                "naive_fraction": {
-                  "type": "number"
-                },
-                "vaf_column": {
-                  "type": "string"
-                },
-                "so_column": {
-                  "type": "string"
-                },
-                "vaf_threshold": {
-                  "type": "number"
-                },
-                "annotation": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "total_variants",
-                "coding_variants_below_vaf",
-                "matching_annotation",
-                "fraction"
-              ]
+            "vaf_filtered": {
+              "type": "integer"
+            },
+            "coding_variants_below_vaf": {
+              "type": "integer"
+            },
+            "matching_annotation": {
+              "type": "integer"
+            },
+            "fraction": {
+              "type": "number"
+            },
+            "naive_fraction": {
+              "type": "number"
+            },
+            "vaf_column": {
+              "type": "string"
+            },
+            "so_column": {
+              "type": "string"
+            },
+            "vaf_threshold": {
+              "type": "number"
+            },
+            "annotation": {
+              "type": "string"
             }
           },
           "required": [
-            "status",
-            "data"
+            "total_variants",
+            "coding_variants_below_vaf",
+            "matching_annotation",
+            "fraction"
           ]
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }

--- a/src/tooluniverse/data/vcf_stats_tools.json
+++ b/src/tooluniverse/data/vcf_stats_tools.json
@@ -6,25 +6,80 @@
     "requires_local_input": true,
     "parameter": {
       "type": "object",
-      "required": ["operation", "vcf_path"],
+      "required": [
+        "operation",
+        "vcf_path"
+      ],
       "properties": {
-        "operation": {"const": "summary_stats", "description": "Operation (fixed)"},
-        "vcf_path": {"type": "string", "description": "Path to a local .vcf, .vcf.gz, or .bcf file"},
-        "pass_only": {"type": ["boolean", "null"], "description": "If true, count only FILTER=PASS or '.' records"},
-        "regions": {"type": ["string", "null"], "description": "Restrict to a region, e.g. 'chr1' or 'chr1:1-1000000' (streamed, no index needed)"},
-        "min_qual": {"type": ["number", "null"], "description": "Keep only records with QUAL >= this value"},
-        "include_expr": {"type": ["string", "null"], "description": "Extra bcftools -i include expression, e.g. 'INFO/DP>10'"}
+        "operation": {
+          "const": "summary_stats",
+          "description": "Operation (fixed)"
+        },
+        "vcf_path": {
+          "type": "string",
+          "description": "Path to a local .vcf, .vcf.gz, or .bcf file"
+        },
+        "pass_only": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "If true, count only FILTER=PASS or '.' records"
+        },
+        "regions": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Restrict to a region, e.g. 'chr1' or 'chr1:1-1000000' (streamed, no index needed)"
+        },
+        "min_qual": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Keep only records with QUAL >= this value"
+        },
+        "include_expr": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Extra bcftools -i include expression, e.g. 'INFO/DP>10'"
+        }
       }
     },
     "return_schema": {
       "type": "object",
       "oneOf": [
-        {"properties": {"status": {"const": "success"}, "data": {"type": "object"}}, "required": ["data"]},
-        {"properties": {"status": {"const": "error"}, "error": {"type": "string"}}, "required": ["error"]}
+        {
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
       ]
     },
     "test_examples": [
-      {"operation": "summary_stats", "vcf_path": "/tmp/sample.vcf.gz", "pass_only": true}
+      {
+        "operation": "summary_stats",
+        "vcf_path": "/tmp/sample.vcf.gz",
+        "pass_only": true
+      }
     ]
   },
   {
@@ -34,25 +89,80 @@
     "requires_local_input": true,
     "parameter": {
       "type": "object",
-      "required": ["operation", "vcf_path"],
+      "required": [
+        "operation",
+        "vcf_path"
+      ],
       "properties": {
-        "operation": {"const": "count_variants", "description": "Operation (fixed)"},
-        "vcf_path": {"type": "string", "description": "Path to a local .vcf, .vcf.gz, or .bcf file"},
-        "pass_only": {"type": ["boolean", "null"], "description": "If true, count only FILTER=PASS or '.' records"},
-        "regions": {"type": ["string", "null"], "description": "Restrict to a region, e.g. 'chr1' or 'chr1:1-1000000'"},
-        "min_qual": {"type": ["number", "null"], "description": "Keep only records with QUAL >= this value"},
-        "include_expr": {"type": ["string", "null"], "description": "Extra bcftools -i include expression, e.g. 'INFO/AF>0.01'"}
+        "operation": {
+          "const": "count_variants",
+          "description": "Operation (fixed)"
+        },
+        "vcf_path": {
+          "type": "string",
+          "description": "Path to a local .vcf, .vcf.gz, or .bcf file"
+        },
+        "pass_only": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "If true, count only FILTER=PASS or '.' records"
+        },
+        "regions": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Restrict to a region, e.g. 'chr1' or 'chr1:1-1000000'"
+        },
+        "min_qual": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Keep only records with QUAL >= this value"
+        },
+        "include_expr": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Extra bcftools -i include expression, e.g. 'INFO/AF>0.01'"
+        }
       }
     },
     "return_schema": {
       "type": "object",
       "oneOf": [
-        {"properties": {"status": {"const": "success"}, "data": {"type": "object"}}, "required": ["data"]},
-        {"properties": {"status": {"const": "error"}, "error": {"type": "string"}}, "required": ["error"]}
+        {
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
       ]
     },
     "test_examples": [
-      {"operation": "count_variants", "vcf_path": "/tmp/sample.vcf.gz", "min_qual": 30}
+      {
+        "operation": "count_variants",
+        "vcf_path": "/tmp/sample.vcf.gz",
+        "min_qual": 30
+      }
     ]
   },
   {
@@ -62,23 +172,72 @@
     "requires_local_input": true,
     "parameter": {
       "type": "object",
-      "required": ["operation", "vcf_path"],
+      "required": [
+        "operation",
+        "vcf_path"
+      ],
       "properties": {
-        "operation": {"const": "normalize", "description": "Operation (fixed)"},
-        "vcf_path": {"type": "string", "description": "Path to a local .vcf, .vcf.gz, or .bcf file"},
-        "multiallelics": {"type": ["string", "null"], "enum": ["split", "join", "none", null], "description": "'split' (default) breaks multiallelic records into biallelic; 'join' merges; 'none' leaves as-is"},
-        "reference_fasta": {"type": ["string", "null"], "description": "Optional reference FASTA path; enables indel left-alignment (-f)"}
+        "operation": {
+          "const": "normalize",
+          "description": "Operation (fixed)"
+        },
+        "vcf_path": {
+          "type": "string",
+          "description": "Path to a local .vcf, .vcf.gz, or .bcf file"
+        },
+        "multiallelics": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "split",
+            "join",
+            "none",
+            null
+          ],
+          "description": "'split' (default) breaks multiallelic records into biallelic; 'join' merges; 'none' leaves as-is"
+        },
+        "reference_fasta": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional reference FASTA path; enables indel left-alignment (-f)"
+        }
       }
     },
     "return_schema": {
       "type": "object",
       "oneOf": [
-        {"properties": {"status": {"const": "success"}, "data": {"type": "object"}}, "required": ["data"]},
-        {"properties": {"status": {"const": "error"}, "error": {"type": "string"}}, "required": ["error"]}
+        {
+          "type": "object",
+          "not": {
+            "type": "object",
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
       ]
     },
     "test_examples": [
-      {"operation": "normalize", "vcf_path": "/tmp/sample.vcf.gz", "multiallelics": "split"}
+      {
+        "operation": "normalize",
+        "vcf_path": "/tmp/sample.vcf.gz",
+        "multiallelics": "split"
+      }
     ]
   }
 ]

--- a/src/tooluniverse/data/veupathdb_tools.json
+++ b/src/tooluniverse/data/veupathdb_tools.json
@@ -239,92 +239,52 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "primary_key": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "source_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "product": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "organism": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "location_text": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "project": {
-                  "type": "string"
-                },
-                "organism": {
-                  "type": "string"
-                },
-                "total_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "operation": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "primary_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "product": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "organism": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "location_text": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
@@ -397,90 +357,62 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
+            "primary_key": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "primary_key": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "source_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "product": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "organism": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "gene_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "location_text": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "chromosome": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "transcript_count": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
+            "source_id": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "project": {
-                  "type": "string"
-                },
-                "gene_id": {
-                  "type": "string"
-                },
-                "operation": {
-                  "type": "string"
-                }
-              }
+            "product": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organism": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "gene_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "location_text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "chromosome": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "transcript_count": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
-            "data"
+            "primary_key"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/waqi_tools.json
+++ b/src/tooluniverse/data/waqi_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "WAQI_get_air_quality",
-    "description": "Get real-time Air Quality Index (AQI) data for a city or monitoring station using the World Air Quality Index API. Returns AQI values, dominant pollutant, and individual pollutant readings (PM2.5, PM10, NO2, O3, SO2, CO). IMPORTANT: without a personal token the public 'demo' token is used, which returns a fixed sample station (Shanghai) regardless of the requested city \u2014 do NOT treat demo results as the requested city's air quality. Set the free WAQI_API_KEY environment variable (register at https://aqicn.org/data-platform/token/) to get real per-city data.",
+    "description": "Get real-time Air Quality Index (AQI) data for a city or monitoring station using the World Air Quality Index API. Returns AQI values, dominant pollutant, and individual pollutant readings (PM2.5, PM10, NO2, O3, SO2, CO). IMPORTANT: without a personal token the public 'demo' token is used, which returns a fixed sample station (Shanghai) regardless of the requested city — do NOT treat demo results as the requested city's air quality. Set the free WAQI_API_KEY environment variable (register at https://aqicn.org/data-platform/token/) to get real per-city data.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -34,103 +34,110 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Air quality data for the location",
           "properties": {
-            "aqi": {
-              "type": "integer",
-              "description": "AQI value (0-500+). 0-50=Good, 51-100=Moderate, 101-150=Unhealthy for Sensitive, 151-200=Unhealthy, 201-300=Very Unhealthy, 300+=Hazardous"
-            },
-            "dominentpol": {
+            "status": {
               "type": "string",
-              "description": "Dominant pollutant: pm25, pm10, o3, no2, so2, co"
+              "description": "API status: ok or error"
             },
-            "city": {
+            "data": {
               "type": "object",
               "properties": {
-                "name": {
+                "aqi": {
+                  "type": "integer",
+                  "description": "AQI value (0-500+). 0-50=Good, 51-100=Moderate, 101-150=Unhealthy for Sensitive, 151-200=Unhealthy, 201-300=Very Unhealthy, 300+=Hazardous"
+                },
+                "dominentpol": {
                   "type": "string",
-                  "description": "Station/city name"
+                  "description": "Dominant pollutant: pm25, pm10, o3, no2, so2, co"
                 },
-                "geo": {
-                  "type": "array",
-                  "items": {
-                    "type": "number"
-                  },
-                  "description": "[latitude, longitude]"
-                },
-                "url": {
-                  "type": "string"
-                }
-              }
-            },
-            "iaqi": {
-              "type": "object",
-              "description": "Individual pollutant AQI values",
-              "properties": {
-                "pm25": {
+                "city": {
                   "type": "object",
                   "properties": {
-                    "v": {
-                      "type": "number",
-                      "description": "PM2.5 AQI value"
+                    "name": {
+                      "type": "string",
+                      "description": "Station/city name"
+                    },
+                    "geo": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      },
+                      "description": "[latitude, longitude]"
+                    },
+                    "url": {
+                      "type": "string"
                     }
                   }
                 },
-                "pm10": {
+                "iaqi": {
                   "type": "object",
+                  "description": "Individual pollutant AQI values",
                   "properties": {
-                    "v": {
-                      "type": "number",
-                      "description": "PM10 AQI value"
+                    "pm25": {
+                      "type": "object",
+                      "properties": {
+                        "v": {
+                          "type": "number",
+                          "description": "PM2.5 AQI value"
+                        }
+                      }
+                    },
+                    "pm10": {
+                      "type": "object",
+                      "properties": {
+                        "v": {
+                          "type": "number",
+                          "description": "PM10 AQI value"
+                        }
+                      }
+                    },
+                    "no2": {
+                      "type": "object",
+                      "properties": {
+                        "v": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "o3": {
+                      "type": "object",
+                      "properties": {
+                        "v": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "so2": {
+                      "type": "object",
+                      "properties": {
+                        "v": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "co": {
+                      "type": "object",
+                      "properties": {
+                        "v": {
+                          "type": "number"
+                        }
+                      }
                     }
                   }
                 },
-                "no2": {
+                "time": {
                   "type": "object",
                   "properties": {
-                    "v": {
-                      "type": "number"
+                    "s": {
+                      "type": "string",
+                      "description": "Timestamp of the measurement"
                     }
                   }
-                },
-                "o3": {
-                  "type": "object",
-                  "properties": {
-                    "v": {
-                      "type": "number"
-                    }
-                  }
-                },
-                "so2": {
-                  "type": "object",
-                  "properties": {
-                    "v": {
-                      "type": "number"
-                    }
-                  }
-                },
-                "co": {
-                  "type": "object",
-                  "properties": {
-                    "v": {
-                      "type": "number"
-                    }
-                  }
-                }
-              }
-            },
-            "time": {
-              "type": "object",
-              "properties": {
-                "s": {
-                  "type": "string",
-                  "description": "Timestamp of the measurement"
                 }
               }
             }
-          },
-          "required": [
-            "aqi"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/waqi_tools.json
+++ b/src/tooluniverse/data/waqi_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "WAQI_get_air_quality",
-    "description": "Get real-time Air Quality Index (AQI) data for a city or monitoring station using the World Air Quality Index API. Returns AQI values, dominant pollutant, and individual pollutant readings (PM2.5, PM10, NO2, O3, SO2, CO). IMPORTANT: without a personal token the public 'demo' token is used, which returns a fixed sample station (Shanghai) regardless of the requested city — do NOT treat demo results as the requested city's air quality. Set the free WAQI_API_KEY environment variable (register at https://aqicn.org/data-platform/token/) to get real per-city data.",
+    "description": "Get real-time Air Quality Index (AQI) data for a city or monitoring station using the World Air Quality Index API. Returns AQI values, dominant pollutant, and individual pollutant readings (PM2.5, PM10, NO2, O3, SO2, CO). IMPORTANT: without a personal token the public 'demo' token is used, which returns a fixed sample station (Shanghai) regardless of the requested city \u2014 do NOT treat demo results as the requested city's air quality. Set the free WAQI_API_KEY environment variable (register at https://aqicn.org/data-platform/token/) to get real per-city data.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -34,110 +34,103 @@
       "oneOf": [
         {
           "type": "object",
-          "description": "Air quality data for the location",
           "properties": {
-            "status": {
-              "type": "string",
-              "description": "API status: ok or error"
+            "aqi": {
+              "type": "integer",
+              "description": "AQI value (0-500+). 0-50=Good, 51-100=Moderate, 101-150=Unhealthy for Sensitive, 151-200=Unhealthy, 201-300=Very Unhealthy, 300+=Hazardous"
             },
-            "data": {
+            "dominentpol": {
+              "type": "string",
+              "description": "Dominant pollutant: pm25, pm10, o3, no2, so2, co"
+            },
+            "city": {
               "type": "object",
               "properties": {
-                "aqi": {
-                  "type": "integer",
-                  "description": "AQI value (0-500+). 0-50=Good, 51-100=Moderate, 101-150=Unhealthy for Sensitive, 151-200=Unhealthy, 201-300=Very Unhealthy, 300+=Hazardous"
-                },
-                "dominentpol": {
+                "name": {
                   "type": "string",
-                  "description": "Dominant pollutant: pm25, pm10, o3, no2, so2, co"
+                  "description": "Station/city name"
                 },
-                "city": {
+                "geo": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "description": "[latitude, longitude]"
+                },
+                "url": {
+                  "type": "string"
+                }
+              }
+            },
+            "iaqi": {
+              "type": "object",
+              "description": "Individual pollutant AQI values",
+              "properties": {
+                "pm25": {
                   "type": "object",
                   "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "Station/city name"
-                    },
-                    "geo": {
-                      "type": "array",
-                      "items": {
-                        "type": "number"
-                      },
-                      "description": "[latitude, longitude]"
-                    },
-                    "url": {
-                      "type": "string"
+                    "v": {
+                      "type": "number",
+                      "description": "PM2.5 AQI value"
                     }
                   }
                 },
-                "iaqi": {
+                "pm10": {
                   "type": "object",
-                  "description": "Individual pollutant AQI values",
                   "properties": {
-                    "pm25": {
-                      "type": "object",
-                      "properties": {
-                        "v": {
-                          "type": "number",
-                          "description": "PM2.5 AQI value"
-                        }
-                      }
-                    },
-                    "pm10": {
-                      "type": "object",
-                      "properties": {
-                        "v": {
-                          "type": "number",
-                          "description": "PM10 AQI value"
-                        }
-                      }
-                    },
-                    "no2": {
-                      "type": "object",
-                      "properties": {
-                        "v": {
-                          "type": "number"
-                        }
-                      }
-                    },
-                    "o3": {
-                      "type": "object",
-                      "properties": {
-                        "v": {
-                          "type": "number"
-                        }
-                      }
-                    },
-                    "so2": {
-                      "type": "object",
-                      "properties": {
-                        "v": {
-                          "type": "number"
-                        }
-                      }
-                    },
-                    "co": {
-                      "type": "object",
-                      "properties": {
-                        "v": {
-                          "type": "number"
-                        }
-                      }
+                    "v": {
+                      "type": "number",
+                      "description": "PM10 AQI value"
                     }
                   }
                 },
-                "time": {
+                "no2": {
                   "type": "object",
                   "properties": {
-                    "s": {
-                      "type": "string",
-                      "description": "Timestamp of the measurement"
+                    "v": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "o3": {
+                  "type": "object",
+                  "properties": {
+                    "v": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "so2": {
+                  "type": "object",
+                  "properties": {
+                    "v": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "co": {
+                  "type": "object",
+                  "properties": {
+                    "v": {
+                      "type": "number"
                     }
                   }
                 }
               }
+            },
+            "time": {
+              "type": "object",
+              "properties": {
+                "s": {
+                  "type": "string",
+                  "description": "Timestamp of the measurement"
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "aqi"
+          ]
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/web_search_tools.json
+++ b/src/tooluniverse/data/web_search_tools.json
@@ -73,92 +73,77 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
             "status": {
-              "const": "success"
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "status": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "search_type": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "results": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "title": {
-                        "type": "string"
-                      },
-                      "url": {
-                        "type": "string"
-                      },
-                      "snippet": {
-                        "type": "string"
-                      },
-                      "rank": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "backend_used": {
-                  "type": "string"
-                },
-                "attempted_backends": {
-                  "type": "array",
-                  "items": {
+            "query": {
+              "type": "string"
+            },
+            "search_type": {
+              "type": "string"
+            },
+            "total_results": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
                     "type": "string"
-                  }
-                },
-                "provider_errors": {
-                  "type": "object",
-                  "properties": {
-                    "duckduckgo": {
-                      "type": "string"
-                    }
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "snippet": {
+                    "type": "string"
+                  },
+                  "rank": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "backend_used": {
+              "type": "string"
+            },
+            "attempted_backends": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "provider_errors": {
+              "type": "object",
+              "properties": {
+                "duckduckgo": {
+                  "type": "string"
+                }
+              }
             }
-          }
+          },
+          "required": [
+            "status"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
@@ -238,98 +223,83 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "status"
-          ],
           "properties": {
             "status": {
-              "const": "success"
+              "type": "string"
             },
-            "data": {
+            "query": {
+              "type": "string"
+            },
+            "search_type": {
+              "type": "string"
+            },
+            "total_results": {
+              "type": [
+                "integer",
+                "number"
+              ]
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "snippet": {
+                    "type": "string"
+                  },
+                  "rank": {
+                    "type": [
+                      "integer",
+                      "number"
+                    ]
+                  }
+                }
+              }
+            },
+            "backend_used": {
+              "type": "string"
+            },
+            "attempted_backends": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "provider_errors": {
               "type": "object",
               "properties": {
-                "status": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "search_type": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
-                },
-                "results": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "title": {
-                        "type": "string"
-                      },
-                      "url": {
-                        "type": "string"
-                      },
-                      "snippet": {
-                        "type": "string"
-                      },
-                      "rank": {
-                        "type": [
-                          "integer",
-                          "number"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "backend_used": {
-                  "type": "string"
-                },
-                "attempted_backends": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "provider_errors": {
-                  "type": "object",
-                  "properties": {
-                    "duckduckgo": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "focus": {
-                  "type": "string"
-                },
-                "enhanced_query": {
+                "duckduckgo": {
                   "type": "string"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "focus": {
+              "type": "string"
+            },
+            "enhanced_query": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "status"
+          ]
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/wikipathways_tools.json
+++ b/src/tooluniverse/data/wikipathways_tools.json
@@ -26,53 +26,35 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "status"
-          ],
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "wpid": {
-                    "type": "string"
-                  },
-                  "uri": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "organism": {
-                    "type": "string"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "wpid": {
+                "type": "string"
+              },
+              "uri": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "organism": {
+                "type": "string"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
         {
           "type": "object",
-          "required": [
-            "status",
-            "error"
-          ],
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/worms_tools.json
+++ b/src/tooluniverse/data/worms_tools.json
@@ -6,10 +6,19 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "query": {"type": "string", "description": "Species name or search term"},
-        "limit": {"type": "integer", "default": 20, "description": "Number of results"}
+        "query": {
+          "type": "string",
+          "description": "Species name or search term"
+        },
+        "limit": {
+          "type": "integer",
+          "default": 20,
+          "description": "Number of results"
+        }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "fields": {
       "endpoint": "https://www.marinespecies.org/rest/AphiaIDByName/{query}",
@@ -20,40 +29,135 @@
       "items": {
         "type": "object",
         "properties": {
-          "AphiaID": {"type": "integer"},
-          "url": {"type": "string"},
-          "scientificname": {"type": "string"},
-          "authority": {"type": ["string", "null"]},
-          "status": {"type": "string"},
-          "unacceptreason": {"type": ["string", "null"]},
-          "taxonRankID": {"type": "integer"},
-          "rank": {"type": "string"},
-          "valid_AphiaID": {"type": "integer"},
-          "valid_name": {"type": "string"},
-          "valid_authority": {"type": ["string", "null"]},
-          "parentNameUsageID": {"type": "integer"},
-          "originalNameUsageID": {"type": ["integer", "null"]},
-          "kingdom": {"type": "string"},
-          "phylum": {"type": "string"},
-          "class": {"type": "string"},
-          "order": {"type": "string"},
-          "family": {"type": ["string", "null"]},
-          "genus": {"type": ["string", "null"]},
-          "citation": {"type": "string"},
-          "lsid": {"type": "string"},
-          "isMarine": {"type": ["integer", "null"]},
-          "isBrackish": {"type": ["integer", "null"]},
-          "isFreshwater": {"type": ["integer", "null"]},
-          "isTerrestrial": {"type": ["integer", "null"]},
-          "isExtinct": {"type": ["integer", "null"]},
-          "match_type": {"type": "string"},
-          "modified": {"type": "string"}
+          "AphiaID": {
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          },
+          "scientificname": {
+            "type": "string"
+          },
+          "authority": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "unacceptreason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "taxonRankID": {
+            "type": "integer"
+          },
+          "rank": {
+            "type": "string"
+          },
+          "valid_AphiaID": {
+            "type": "integer"
+          },
+          "valid_name": {
+            "type": "string"
+          },
+          "valid_authority": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "parentNameUsageID": {
+            "type": "integer"
+          },
+          "originalNameUsageID": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "kingdom": {
+            "type": "string"
+          },
+          "phylum": {
+            "type": "string"
+          },
+          "class": {
+            "type": "string"
+          },
+          "order": {
+            "type": "string"
+          },
+          "family": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "genus": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "citation": {
+            "type": "string"
+          },
+          "lsid": {
+            "type": "string"
+          },
+          "isMarine": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "isBrackish": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "isFreshwater": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "isTerrestrial": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "isExtinct": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "match_type": {
+            "type": "string"
+          },
+          "modified": {
+            "type": "string"
+          }
         }
       }
     },
     "test_examples": [
-      {"query": "Actinia equina", "limit": 5},
-      {"query": "Scleractinia", "limit": 10}
+      {
+        "query": "Actinia equina",
+        "limit": 5
+      },
+      {
+        "query": "Scleractinia",
+        "limit": 10
+      }
     ]
   },
   {
@@ -63,9 +167,14 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea, common sole). Obtain from WoRMS_search_species."}
+        "AphiaID": {
+          "type": "integer",
+          "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea, common sole). Obtain from WoRMS_search_species."
+        }
       },
-      "required": ["AphiaID"]
+      "required": [
+        "AphiaID"
+      ]
     },
     "fields": {
       "operation": "classification",
@@ -73,35 +182,49 @@
       "return_format": "JSON"
     },
     "test_examples": [
-      {"AphiaID": 127160},
-      {"AphiaID": 126436}
+      {
+        "AphiaID": 127160
+      },
+      {
+        "AphiaID": 126436
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
-          "description": "Nested classification tree",
+          "description": "Recursive classification node",
           "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "object",
-              "description": "Recursive classification node",
-              "properties": {
-                "AphiaID": {"type": "integer"},
-                "rank": {"type": "string"},
-                "scientificname": {"type": "string"},
-                "child": {"type": ["object", "null"]}
-              }
+            "AphiaID": {
+              "type": "integer"
             },
-            "url": {"type": "string"},
-            "AphiaID": {"type": "integer"}
+            "rank": {
+              "type": "string"
+            },
+            "scientificname": {
+              "type": "string"
+            },
+            "child": {
+              "type": [
+                "object",
+                "null"
+              ]
+            }
           },
-          "required": ["status", "data"]
+          "required": [
+            "AphiaID"
+          ]
         },
         {
           "type": "object",
-          "properties": {"status": {"type": "string"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -113,9 +236,14 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species."}
+        "AphiaID": {
+          "type": "integer",
+          "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species."
+        }
       },
-      "required": ["AphiaID"]
+      "required": [
+        "AphiaID"
+      ]
     },
     "fields": {
       "operation": "vernaculars",
@@ -123,37 +251,48 @@
       "return_format": "JSON"
     },
     "test_examples": [
-      {"AphiaID": 127160},
-      {"AphiaID": 126436}
+      {
+        "AphiaID": 127160
+      },
+      {
+        "AphiaID": 126436
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "description": "Vernacular (common) names with language codes",
-          "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "vernacular": {"type": "string"},
-                  "language_code": {"type": ["string", "null"]},
-                  "language": {"type": ["string", "null"]}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "vernacular": {
+                "type": "string"
+              },
+              "language_code": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "language": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
-            },
-            "url": {"type": "string"},
-            "count": {"type": "integer"},
-            "AphiaID": {"type": "integer"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"type": "string"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -165,9 +304,14 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species."}
+        "AphiaID": {
+          "type": "integer",
+          "description": "WoRMS AphiaID of the taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species."
+        }
       },
-      "required": ["AphiaID"]
+      "required": [
+        "AphiaID"
+      ]
     },
     "fields": {
       "operation": "distributions",
@@ -175,44 +319,93 @@
       "return_format": "JSON"
     },
     "test_examples": [
-      {"AphiaID": 127160},
-      {"AphiaID": 126436}
+      {
+        "AphiaID": 127160
+      },
+      {
+        "AphiaID": 126436
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "description": "Marine distribution localities",
-          "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "locality": {"type": ["string", "null"]},
-                  "locationID": {"type": ["string", "null"]},
-                  "higherGeography": {"type": ["string", "null"]},
-                  "higherGeographyID": {"type": ["string", "null"]},
-                  "recordStatus": {"type": ["string", "null"]},
-                  "establishmentMeans": {"type": ["string", "null"]},
-                  "invasiveness": {"type": ["string", "null"]},
-                  "occurrence": {"type": ["string", "null"]},
-                  "decimalLatitude": {"type": ["number", "null"]},
-                  "decimalLongitude": {"type": ["number", "null"]}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "locality": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "locationID": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "higherGeography": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "higherGeographyID": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "recordStatus": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "establishmentMeans": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "invasiveness": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "occurrence": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "decimalLatitude": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "decimalLongitude": {
+                "type": [
+                  "number",
+                  "null"
+                ]
               }
-            },
-            "url": {"type": "string"},
-            "count": {"type": "integer"},
-            "AphiaID": {"type": "integer"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"type": "string"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -224,9 +417,14 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "AphiaID": {"type": "integer", "description": "WoRMS AphiaID of the accepted taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species."}
+        "AphiaID": {
+          "type": "integer",
+          "description": "WoRMS AphiaID of the accepted taxon, e.g. 127160 (Solea solea). Obtain from WoRMS_search_species."
+        }
       },
-      "required": ["AphiaID"]
+      "required": [
+        "AphiaID"
+      ]
     },
     "fields": {
       "operation": "synonyms",
@@ -234,42 +432,63 @@
       "return_format": "JSON"
     },
     "test_examples": [
-      {"AphiaID": 127160},
-      {"AphiaID": 126436}
+      {
+        "AphiaID": 127160
+      },
+      {
+        "AphiaID": 126436
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "description": "Taxonomic synonyms",
-          "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "AphiaID": {"type": "integer"},
-                  "scientificname": {"type": "string"},
-                  "authority": {"type": ["string", "null"]},
-                  "status": {"type": "string"},
-                  "unacceptreason": {"type": ["string", "null"]},
-                  "rank": {"type": "string"},
-                  "valid_AphiaID": {"type": "integer"},
-                  "valid_name": {"type": "string"}
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "AphiaID": {
+                "type": "integer"
+              },
+              "scientificname": {
+                "type": "string"
+              },
+              "authority": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "unacceptreason": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "rank": {
+                "type": "string"
+              },
+              "valid_AphiaID": {
+                "type": "integer"
+              },
+              "valid_name": {
+                "type": "string"
               }
-            },
-            "url": {"type": "string"},
-            "count": {"type": "integer"},
-            "AphiaID": {"type": "integer"}
-          },
-          "required": ["status", "data"]
+            }
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"type": "string"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/zfin_tools.json
+++ b/src/tooluniverse/data/zfin_tools.json
@@ -650,74 +650,52 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
+            "total_annotations": {
+              "type": "integer"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_annotations": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "annotations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "stage": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "location": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "data_provider": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "reference": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "returned": {
+              "type": "integer"
+            },
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "stage": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "data_provider": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "reference": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
                 }
               }
             }
           },
           "required": [
-            "data"
+            "total_annotations"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
@@ -873,45 +851,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "symbol": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_id": {
-                    "type": "string"
-                  },
-                  "category": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "symbol": {
+                "type": "string"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_id": {
+                "type": "string"
+              },
+              "category": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/zinc_tools.json
+++ b/src/tooluniverse/data/zinc_tools.json
@@ -28,116 +28,97 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "zinc_id": {
               "type": "string",
-              "enum": [
-                "success"
-              ]
+              "description": "ZINC compound identifier"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "zinc_id": {
-                  "type": "string",
-                  "description": "ZINC compound identifier"
-                },
-                "smiles": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Canonical SMILES structure"
-                },
-                "formula": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Molecular formula"
-                },
-                "mwt": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "description": "Molecular weight (Da)"
-                },
-                "logp": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "description": "Calculated LogP (octanol-water partition)"
-                },
-                "heavy_atoms": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of heavy (non-hydrogen) atoms"
-                },
-                "hetero_atoms": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of heteroatoms"
-                },
-                "rings": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of rings"
-                },
-                "inchi": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "InChI string"
-                },
-                "inchikey": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "InChIKey hash"
-                },
-                "database": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Source database (zinc20 or zinc22)"
-                },
-                "n_catalogs": {
-                  "type": "integer",
-                  "description": "Number of vendor catalogs offering this compound"
-                }
-              }
+            "smiles": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Canonical SMILES structure"
+            },
+            "formula": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Molecular formula"
+            },
+            "mwt": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Molecular weight (Da)"
+            },
+            "logp": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Calculated LogP (octanol-water partition)"
+            },
+            "heavy_atoms": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of heavy (non-hydrogen) atoms"
+            },
+            "hetero_atoms": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of heteroatoms"
+            },
+            "rings": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of rings"
+            },
+            "inchi": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "InChI string"
+            },
+            "inchikey": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "InChIKey hash"
+            },
+            "database": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Source database (zinc20 or zinc22)"
+            },
+            "n_catalogs": {
+              "type": "integer",
+              "description": "Number of vendor catalogs offering this compound"
             }
           },
           "required": [
-            "status",
-            "data"
+            "zinc_id"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }
@@ -179,115 +160,96 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "zinc_id": {
               "type": "string",
-              "enum": [
-                "success"
-              ]
+              "description": "ZINC compound identifier"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "zinc_id": {
-                  "type": "string",
-                  "description": "ZINC compound identifier"
-                },
-                "smiles": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Canonical SMILES structure"
-                },
-                "vendor_count": {
-                  "type": "integer",
-                  "description": "Number of vendor catalog entries"
-                },
-                "vendors": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "catalog_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Vendor/catalog name"
-                      },
-                      "supplier_code": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Vendor's internal product/supplier code"
-                      },
-                      "price": {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "description": "Quoted price"
-                      },
-                      "quantity": {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "description": "Quantity for the quoted price"
-                      },
-                      "unit": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Unit for the quantity (e.g., mg)"
-                      },
-                      "shipping": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Estimated shipping time"
-                      },
-                      "purchasable": {
-                        "type": "boolean",
-                        "description": "Whether this catalog entry is purchasable"
-                      },
-                      "url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Vendor order URL template (if available)"
-                      }
-                    }
+            "smiles": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Canonical SMILES structure"
+            },
+            "vendor_count": {
+              "type": "integer",
+              "description": "Number of vendor catalog entries"
+            },
+            "vendors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "catalog_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Vendor/catalog name"
                   },
-                  "description": "List of vendor/catalog entries offering this compound"
+                  "supplier_code": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Vendor's internal product/supplier code"
+                  },
+                  "price": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Quoted price"
+                  },
+                  "quantity": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Quantity for the quoted price"
+                  },
+                  "unit": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Unit for the quantity (e.g., mg)"
+                  },
+                  "shipping": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Estimated shipping time"
+                  },
+                  "purchasable": {
+                    "type": "boolean",
+                    "description": "Whether this catalog entry is purchasable"
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Vendor order URL template (if available)"
+                  }
                 }
-              }
+              },
+              "description": "List of vendor/catalog entries offering this compound"
             }
           },
           "required": [
-            "status",
-            "data"
+            "zinc_id"
           ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }
@@ -353,107 +315,81 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "zinc_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "ZINC compound identifier"
-                  },
-                  "smiles": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Canonical SMILES of the hit"
-                  },
-                  "matched_smiles": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "The matched substructure/query SMILES"
-                  },
-                  "formula": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Molecular formula"
-                  },
-                  "mwt": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Molecular weight (Da)"
-                  },
-                  "logp": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Calculated LogP"
-                  },
-                  "inchikey": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "InChIKey hash"
-                  },
-                  "database": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Source database (zinc20 or zinc22)"
-                  },
-                  "n_catalogs": {
-                    "type": "integer",
-                    "description": "Number of vendor catalogs offering this hit"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "zinc_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "ZINC compound identifier"
+              },
+              "smiles": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Canonical SMILES of the hit"
+              },
+              "matched_smiles": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The matched substructure/query SMILES"
+              },
+              "formula": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Molecular formula"
+              },
+              "mwt": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Molecular weight (Da)"
+              },
+              "logp": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Calculated LogP"
+              },
+              "inchikey": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "InChIKey hash"
+              },
+              "database": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Source database (zinc20 or zinc22)"
+              },
+              "n_catalogs": {
+                "type": "integer",
+                "description": "Number of vendor catalogs offering this hit"
               }
-            },
-            "count": {
-              "type": "integer",
-              "description": "Number of matches returned"
             }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }
@@ -495,32 +431,11 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array"
-            }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          "type": "array"
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             },
@@ -529,7 +444,6 @@
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }
@@ -587,32 +501,11 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array"
-            }
-          },
-          "required": [
-            "status",
-            "data"
-          ]
+          "type": "array"
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "error"
-              ]
-            },
             "error": {
               "type": "string"
             },
@@ -621,7 +514,6 @@
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }

--- a/src/tooluniverse/data/zooma_tools.json
+++ b/src/tooluniverse/data/zooma_tools.json
@@ -50,84 +50,73 @@
       "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "property_value": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "property_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "semantic_tags": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Ontology term IRIs (OBO/EFO PURLs) this text maps to."
-                  },
-                  "curies": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Compact CURIEs derived from the semantic-tag IRIs, e.g. 'MONDO:0004979', 'UBERON:0002371', 'EFO:0006842'."
-                  },
-                  "confidence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "HIGH, GOOD, MEDIUM, or LOW."
-                  },
-                  "source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Annotation source name, e.g. 'zooma', 'uberon', 'efo'."
-                  },
-                  "source_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "ONTOLOGY or DATABASE."
-                  },
-                  "evidence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Evidence type, e.g. ZOOMA_INFERRED_FROM_CURATED, OLS_TEXT_TAGGER, OLS_EMBEDDING."
-                  },
-                  "ols_links": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "OLS API URLs for each semantic tag."
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "property_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "property_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "semantic_tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Ontology term IRIs (OBO/EFO PURLs) this text maps to."
+              },
+              "curies": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Compact CURIEs derived from the semantic-tag IRIs, e.g. 'MONDO:0004979', 'UBERON:0002371', 'EFO:0006842'."
+              },
+              "confidence": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "HIGH, GOOD, MEDIUM, or LOW."
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Annotation source name, e.g. 'zooma', 'uberon', 'efo'."
+              },
+              "source_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "ONTOLOGY or DATABASE."
+              },
+              "evidence": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Evidence type, e.g. ZOOMA_INFERRED_FROM_CURATED, OLS_TEXT_TAGGER, OLS_EMBEDDING."
+              },
+              "ols_links": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "OLS API URLs for each semantic tag."
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -183,44 +172,33 @@
       "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Short datasource identifier, e.g. 'uniprot', 'eva-clinvar', 'atlas'."
-                  },
-                  "type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Datasource type: 'DATABASE' or 'ONTOLOGY'."
-                  },
-                  "uri": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Home URI of the datasource."
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Short datasource identifier, e.g. 'uniprot', 'eva-clinvar', 'atlas'."
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Datasource type: 'DATABASE' or 'ONTOLOGY'."
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Home URI of the datasource."
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/zooma_tools.json
+++ b/src/tooluniverse/data/zooma_tools.json
@@ -47,7 +47,6 @@
       "operation": "annotate"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "array",
@@ -169,7 +168,6 @@
       "operation": "list_datasources"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "array",


### PR DESCRIPTION
## Summary

Part 5 of 5 batches fixing #288 — 100 of the 552 tools with envelope-style `return_schema` beyond the 9 already fixed in #287 (one tool originally in this batch, `WAQI_get_air_quality`, turned out to be a detection false positive and was left unchanged — see below). Same root cause and fix recipe as batch 1 (#290); see that PR for the full write-up.

## Files in this batch (alphabetically R-Z)

`rnacentral`, `roc_analysis`, `ror`, `rxclass`, `rxn_chemistry`, `rxnorm_extended`, `sabdab`, `sasbdb`, `scanprosite`, `screen`, `scxa`, `semantic_scholar_ext`, `sgd_protein`, `signor`, `spredixcan`, `ssgsea`, `stitch`, `structure_annotation`, `sunrise_sunset`, `swiss_target`, `swisslipids`, `tark`, `tdc_dataset`, `tdc_oracle`, `therasabdab`, `togoid`, `tumorhope2`, `unibind`, `uniprot_idmapping`, `uniprot_locations`, `uniprot_proteomes`, `uniprot_ref`, `uniprot_taxonomy`, `uniprot`, `usda_plants`, `variant_fraction`, `vcf_stats`, `veupathdb`, `waqi`, `web_search`, `wikipathways`, `worms`, `zfin`, `zinc`, `zooma`.

## Two more real bugs this batch caught (beyond the mechanical fix)

1. **`UniBind_search_datasets` / `UniBind_list_tfs` (`unibind_tools.json`) and `ZOOMA_annotate_text` / `ZOOMA_list_datasources` (`zooma_tools.json`)** — the same stray root-level `type` sibling to `oneOf` found in batch 4's PanglaoDB/RGD fix (their success payload is an array, and the redundant root `"type": "object"` made the schema unsatisfiable). A full codebase sweep for this pattern (across all `src/tooluniverse/data/*_tools.json`, not just the 552 tools in #288) found 11 total instances: 5 already fixed in batch 4 (#293), 4 fixed here, and 2 in `LipidMaps_get_gene`/`LipidMaps_get_protein` (`lipidmaps_gene_tools.json`, batch 3) fixed as a follow-up commit already pushed to #292. All 11 confirmed live.
2. **`WAQI_get_air_quality`** was a genuine detection false positive. Its real `result["data"]` is shaped `{"status": "ok"/"error", "data": {...}}` because the tool passes through the raw upstream WAQI API response verbatim, which happens to use `status`/`data` as its own top-level keys — coincidentally matching the buggy envelope pattern's signature. The original schema already correctly described this shape (notably: no `required` was ever set on that branch, unlike every genuine envelope-bug tool). The mechanical fix incorrectly promoted the wrong nesting level, breaking a tool that was already passing `tu test`. Reverted this one tool's `return_schema` to its original form; confirmed live it still passes. A full sweep for this exact signature (branch with no `required` and properties exactly `{status, data}`, nothing else) across all 554 originally-flagged tools found this to be the only instance.

## Validation

- Every changed tool's `return_schema.oneOf` compiles under `jsonschema.Draft7Validator` and stays disjoint (synthetic error-payload check) — except `WAQI_get_air_quality`, intentionally left in its original (pre-#288) form; see above.
- `tu list` loads the full registry cleanly with this batch applied.
- Live-tested a broad sample against real APIs: `RNAcentral_get_xrefs_and_pubs`, `ROC_analysis`, `ROR_match_affiliation`, `ROR_get_organization`, `RxClass_get_drug_classes`, `RxNorm_get_ndc_properties`, `SemanticScholar_search_authors`, `SGD_get_protein_domains`, `SIGNOR_connect_proteins`, `STITCH_get_chemical_protein_interactions`, `SunriseSunset_get_times`, `SwissLipids_search`, `Tark_get_transcript`, `TogoID_convert`, `UniBind_search_datasets`, `UniBind_list_tfs`, `UniProtIDMap_convert_ids`, `UniProtLocations_get_location`, `UniProtRef_search_diseases`, `UniProtTaxonomy_get_taxon`, `UniProt_search`, `USDA_plants_get_profile`, `VEuPathDB_search_genes_by_organism`, `WAQI_get_air_quality`, `WikiPathways_search`, `WoRMS_get_classification`, `ZFIN_get_gene_expression`, `ZOOMA_annotate_text`, `ZOOMA_list_datasources` — all pass.
- A few sampled tools hit unrelated, pre-existing issues (not caused by this change): `SAbDab_get_structure_summary` and `VCF_summary_stats`/`VCF_count_variants`/`VCF_normalize` fail on stale test_examples (a missing local file path / a structure ID SAbDab no longer serves as tabular data), `ZINC_get_compound` and `ScanProsite_find_proteins_with_motif` hit slow/timing-out upstream APIs. None are return_schema-envelope issues.

## Test coverage

Schema-only change; correctness validated via the programmatic disjointness check plus the live `tu test` runs above.