### PR TITLE
Fix Round 2: test-harness sweep across structural biology, pharmacovigilance, variant-annotation

### DIFF
--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -6,7 +6,7 @@ pathogenicity classification, population frequencies, and clinical evidence.
 """
 
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from .base_tool import BaseTool
 from .tool_registry import register_tool
@@ -104,7 +104,11 @@ class CompoundVariantAnnotationTool(BaseTool):
                         "arguments": {"query": clinvar_query, "limit": 20},
                     }
                 )
-                annotations["clinvar"] = self._parse_clinvar(r, variant_token)
+                error = self._sub_call_error(r)
+                if error:
+                    sources_failed.append(f"ClinVar: {error[:100]}")
+                else:
+                    annotations["clinvar"] = self._parse_clinvar(r, variant_token)
             except Exception as e:
                 sources_failed.append(f"ClinVar: {str(e)[:100]}")
 
@@ -117,7 +121,11 @@ class CompoundVariantAnnotationTool(BaseTool):
                         "arguments": {"gene_symbol": gene_for_gnomad},
                     }
                 )
-                annotations["gnomad"] = self._parse_gnomad(r)
+                error = self._sub_call_error(r)
+                if error:
+                    sources_failed.append(f"gnomAD: {error[:100]}")
+                else:
+                    annotations["gnomad"] = self._parse_gnomad(r)
             except Exception as e:
                 sources_failed.append(f"gnomAD: {str(e)[:100]}")
 
@@ -130,7 +138,11 @@ class CompoundVariantAnnotationTool(BaseTool):
                         "arguments": {"gene_symbol": gene_for_gnomad},
                     }
                 )
-                annotations["civic"] = self._parse_civic(r, variant_token)
+                error = self._sub_call_error(r)
+                if error:
+                    sources_failed.append(f"CIViC: {error[:100]}")
+                else:
+                    annotations["civic"] = self._parse_civic(r, variant_token)
             except Exception as e:
                 sources_failed.append(f"CIViC: {str(e)[:100]}")
 
@@ -147,7 +159,11 @@ class CompoundVariantAnnotationTool(BaseTool):
                         },
                     }
                 )
-                annotations["uniprot"] = self._parse_uniprot(r)
+                error = self._sub_call_error(r)
+                if error:
+                    sources_failed.append(f"UniProt: {error[:100]}")
+                else:
+                    annotations["uniprot"] = self._parse_uniprot(r)
             except Exception as e:
                 sources_failed.append(f"UniProt: {str(e)[:100]}")
 
@@ -164,6 +180,17 @@ class CompoundVariantAnnotationTool(BaseTool):
                 "annotations": annotations,
             },
         }
+
+    def _sub_call_error(self, result: Any) -> Optional[str]:
+        """Fix-R2B-003: sub-tool calls signal failure by returning a
+        {"status": "error", ...} dict, not by raising — the try/except around
+        each call only catches raised exceptions, so an upstream failure was
+        silently parsed as "zero variants found" instead of being recorded in
+        sources_failed. Detect that shape here so callers can distinguish a
+        genuine empty result from a failed call."""
+        if isinstance(result, dict) and result.get("status") == "error":
+            return str(result.get("error", "unknown error"))
+        return None
 
     def _parse_clinvar(self, result: Any, variant_token: str = None) -> Dict[str, Any]:
         if not isinstance(result, dict):

--- a/src/tooluniverse/data/fda_drug_adverse_event_detail_tools.json
+++ b/src/tooluniverse/data/fda_drug_adverse_event_detail_tools.json
@@ -71,7 +71,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "patientsex": [
           "patient.patientsex"
@@ -314,7 +315,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "reactionmeddrapt": [
           "patient.reaction.reactionmeddrapt"
@@ -445,7 +447,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "seriousnessdeath": [
           "seriousnessdeath"
@@ -578,7 +581,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "drugindication": [
           "patient.drug.drugindication"
@@ -696,7 +700,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "reactionoutcome": [
           "patient.reaction.reactionoutcome"

--- a/src/tooluniverse/data/fda_drug_adverse_event_tools.json
+++ b/src/tooluniverse/data/fda_drug_adverse_event_tools.json
@@ -62,7 +62,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "patientsex": [
           "patient.patientsex"
@@ -524,7 +525,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "patientsex": [
           "patient.patientsex"
@@ -610,7 +612,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "patientsex": [
           "patient.patientsex"
@@ -693,7 +696,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "patientsex": [
           "patient.patientsex"
@@ -894,7 +898,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "patientsex": [
           "patient.patientsex"
@@ -1076,7 +1081,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "serious": [
           "serious"
@@ -1197,7 +1203,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ]
       },
       "return_fields": [
@@ -1253,7 +1260,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "seriousnessdeath": [
           "seriousnessdeath"
@@ -2326,7 +2334,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "serious": [
           "serious"
@@ -2408,7 +2417,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "serious": [
           "serious"
@@ -2497,7 +2507,8 @@
     "fields": {
       "search_fields": {
         "medicinalproduct": [
-          "patient.drug.medicinalproduct"
+          "patient.drug.medicinalproduct",
+          "patient.drug.openfda.generic_name"
         ],
         "serious": [
           "serious"

--- a/src/tooluniverse/data/foldseek_tools.json
+++ b/src/tooluniverse/data/foldseek_tools.json
@@ -7,15 +7,15 @@
       "properties": {
         "pdb_id": {
           "type": "string",
-          "description": "PDB ID to search (e.g., '4HHB', '1CRN'). The structure will be fetched from RCSB PDB."
+          "description": "PDB ID to search (e.g., '4HHB', '1CRN'). The structure will be fetched from RCSB PDB. Required: this API only accepts structure-based (3D coordinate) search, not a raw sequence."
         },
         "sequence": {
           "type": "string",
-          "description": "Amino acid sequence to search (alternative to pdb_id). For sequence-based structure search. Alias: 'query'."
+          "description": "NOT SUPPORTED as a standalone input: the Foldseek search API requires a 3D structure, so submitting a raw sequence without pdb_id always fails. Provide pdb_id instead. Alias: 'query'."
         },
         "query": {
           "type": "string",
-          "description": "Amino acid sequence to search (alias for sequence)."
+          "description": "NOT SUPPORTED as a standalone input: see 'sequence'. Provide pdb_id instead."
         },
         "database": {
           "type": "string",
@@ -24,7 +24,7 @@
         },
         "mode": {
           "type": "string",
-          "description": "Search mode: 'tmalign' (fast 3Di+AA, default), 'tmalign' (TM-align, slower but more sensitive).",
+          "description": "Search mode: '3diaa' (fast 3Di+AA, default), 'tmalign' (TM-align, slower but more sensitive).",
           "default": "3diaa"
         },
         "max_results": {

--- a/src/tooluniverse/foldseek_tool.py
+++ b/src/tooluniverse/foldseek_tool.py
@@ -74,7 +74,11 @@ class FoldseekTool(BaseRESTTool):
         # Accept 'query' as alias for 'sequence'
         sequence = (arguments.get("sequence") or arguments.get("query") or "").strip()
         database = arguments.get("database", "afdb50")
-        mode = arguments.get("mode", "tmalign")
+        # Fix-R2A-008: must match the JSON schema's documented default
+        # ("3diaa", Foldseek's fast structural-alphabet mode). The prior
+        # "tmalign" fallback silently returned noise-level hits (e-value ~0.3,
+        # ~2-5% identity) for every query, including trivial control cases.
+        mode = arguments.get("mode", "3diaa")
         max_results = min(int(arguments.get("max_results", 10)), 50)
 
         if not pdb_id and not sequence:

--- a/src/tooluniverse/pdbe_ligands_tool.py
+++ b/src/tooluniverse/pdbe_ligands_tool.py
@@ -60,6 +60,16 @@ class PDBeLigandsTool(BaseTool):
         except Exception as e:
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}
 
+    def _entry_exists(self, pdb_id: str) -> bool:
+        """Check whether a PDB entry exists via the (near-universally populated) summary endpoint."""
+        try:
+            resp = requests.get(
+                f"{PDBE_API_BASE_URL}/summary/{pdb_id}", timeout=self.timeout
+            )
+            return resp.status_code == 200
+        except requests.exceptions.RequestException:
+            return False
+
     def _query(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Route to appropriate endpoint."""
         if self.endpoint == "ligand_monomers":
@@ -81,6 +91,30 @@ class PDBeLigandsTool(BaseTool):
         pdb_id = pdb_id.lower().strip()
         url = f"{PDBE_API_BASE_URL}/ligand_monomers/{pdb_id}"
         response = requests.get(url, timeout=self.timeout)
+        if response.status_code == 404:
+            # Fix-R2A-003: this endpoint 404s whenever an entry has no
+            # non-polymer ligand data — including well-known entries whose
+            # only "ligand" (e.g. a peptidomimetic inhibitor) is modeled as a
+            # polymer chain, not just when the entry itself doesn't exist.
+            # Disambiguate via the summary endpoint instead of reporting a
+            # real, well-known entry as "not found".
+            if self._entry_exists(pdb_id):
+                return {
+                    "status": "success",
+                    "data": {"pdb_id": pdb_id, "ligands": [], "total_ligands": 0},
+                    "metadata": {"source": "PDBe REST API (ebi.ac.uk/pdbe)"},
+                    "note": (
+                        f"PDB entry '{pdb_id}' exists but has no non-polymer "
+                        "ligand data. This commonly means the entry's "
+                        "inhibitor/ligand is modeled as a polymer or peptide "
+                        "chain rather than a discrete non-polymer ligand; "
+                        "check the entry's polymer entities instead."
+                    ),
+                }
+            return {
+                "status": "error",
+                "error": f"PDB entry '{pdb_id}' not found. Provide a valid 4-character PDB ID (e.g., '4hhb', '3ert').",
+            }
         response.raise_for_status()
         data = response.json()
 
@@ -146,6 +180,24 @@ class PDBeLigandsTool(BaseTool):
             url = f"{PDBE_API_BASE_URL}/residue_listing/{pdb_id}"
 
         response = requests.get(url, timeout=self.timeout)
+        if response.status_code == 404:
+            # Fix-R2A-003: see _get_ligand_monomers — a 404 here can mean "no
+            # data for this specific chain/entry at this endpoint" rather than
+            # "entry does not exist". Disambiguate via the summary endpoint.
+            if self._entry_exists(pdb_id):
+                return {
+                    "status": "success",
+                    "data": {"pdb_id": pdb_id, "molecules": []},
+                    "metadata": {"source": "PDBe REST API (ebi.ac.uk/pdbe)"},
+                    "note": (
+                        f"PDB entry '{pdb_id}' exists but has no residue data "
+                        f"at this endpoint{f' for chain {chain_id}' if chain_id else ''}."
+                    ),
+                }
+            return {
+                "status": "error",
+                "error": f"PDB entry '{pdb_id}' not found. Provide a valid 4-character PDB ID (e.g., '4hhb', '3ert').",
+            }
         response.raise_for_status()
         data = response.json()
 

--- a/tests/tools/test_faers_analytics_tool.py
+++ b/tests/tools/test_faers_analytics_tool.py
@@ -40,15 +40,16 @@ class TestFAERSAnalyticsTool:
         assert result.get("status") in ["success", "error"]
         
         if result.get("status") == "success":
-            assert "metrics" in result
-            assert "ROR" in result["metrics"]
-            assert "PRR" in result["metrics"]
-            assert "IC" in result["metrics"]
-            assert "signal_detection" in result
-            
-            print(f"\n✅ ROR: {result['metrics']['ROR']['value']} "
-                  f"[{result['metrics']['ROR']['ci_95_lower']}-{result['metrics']['ROR']['ci_95_upper']}]")
-            print(f"   Signal: {result['signal_detection']['signal_strength']}")
+            data = result["data"]
+            assert "metrics" in data
+            assert "ROR" in data["metrics"]
+            assert "PRR" in data["metrics"]
+            assert "IC" in data["metrics"]
+            assert "signal_detection" in data
+
+            print(f"\n✅ ROR: {data['metrics']['ROR']['value']} "
+                  f"[{data['metrics']['ROR']['ci_95_lower']}-{data['metrics']['ROR']['ci_95_upper']}]")
+            print(f"   Signal: {data['signal_detection']['signal_strength']}")
         else:
             print(f"\n⚠️  API error (expected for some queries): {result.get('error')}")
     
@@ -65,10 +66,11 @@ class TestFAERSAnalyticsTool:
         assert result.get("status") in ["success", "error"]
         
         if result.get("status") == "success":
-            assert "stratification" in result
-            assert isinstance(result["stratification"], list)
-            print(f"\n✅ Total reports: {result['total_reports']}")
-            for strata in result["stratification"][:3]:
+            data = result["data"]
+            assert "stratification" in data
+            assert isinstance(data["stratification"], list)
+            print(f"\n✅ Total reports: {data['total_reports']}")
+            for strata in data["stratification"][:3]:
                 print(f"   {strata['group']}: {strata['count']} ({strata['percentage']}%)")
         else:
             print(f"\n⚠️  Stratification error: {result.get('error')}")
@@ -85,10 +87,11 @@ class TestFAERSAnalyticsTool:
         assert result.get("status") in ["success", "error"]
         
         if result.get("status") == "success":
-            assert "total_serious_events" in result
-            assert "top_serious_reactions" in result
-            print(f"\n✅ Total serious events: {result['total_serious_events']}")
-            for reaction in result["top_serious_reactions"][:5]:
+            data = result["data"]
+            assert "total_serious_events" in data
+            assert "top_serious_reactions" in data
+            print(f"\n✅ Total serious events: {data['total_serious_events']}")
+            for reaction in data["top_serious_reactions"][:5]:
                 print(f"   {reaction['reaction']}: {reaction['count']}")
         else:
             print(f"\n⚠️  Serious event filtering error: {result.get('error')}")
@@ -106,14 +109,15 @@ class TestFAERSAnalyticsTool:
         assert result.get("status") in ["success", "error"]
         
         if result.get("status") == "success":
-            assert "drug1" in result
-            assert "drug2" in result
-            assert "comparison" in result
-            print(f"\n✅ Comparison: {result['comparison']}")
-            if result["drug1"].get("metrics"):
-                print(f"   {result['drug1']['name']} ROR: {result['drug1']['metrics']['ROR']['value']}")
-            if result["drug2"].get("metrics"):
-                print(f"   {result['drug2']['name']} ROR: {result['drug2']['metrics']['ROR']['value']}")
+            data = result["data"]
+            assert "drug1" in data
+            assert "drug2" in data
+            assert "comparison" in data
+            print(f"\n✅ Comparison: {data['comparison']}")
+            if data["drug1"].get("metrics"):
+                print(f"   {data['drug1']['name']} ROR: {data['drug1']['metrics']['ROR']['value']}")
+            if data["drug2"].get("metrics"):
+                print(f"   {data['drug2']['name']} ROR: {data['drug2']['metrics']['ROR']['value']}")
         else:
             print(f"\n⚠️  Drug comparison error: {result.get('error')}")
     
@@ -129,11 +133,12 @@ class TestFAERSAnalyticsTool:
         assert result.get("status") in ["success", "error"]
         
         if result.get("status") == "success":
-            assert "temporal_data" in result
-            assert "trend_analysis" in result
-            print(f"\n✅ Trend: {result['trend_analysis']['trend']}")
-            print(f"   Percent change: {result['trend_analysis']['percent_change']}%")
-            print(f"   Years analyzed: {result['trend_analysis']['years_analyzed']}")
+            data = result["data"]
+            assert "temporal_data" in data
+            assert "trend_analysis" in data
+            print(f"\n✅ Trend: {data['trend_analysis']['trend']}")
+            print(f"   Percent change: {data['trend_analysis']['percent_change']}%")
+            print(f"   Years analyzed: {data['trend_analysis']['years_analyzed']}")
         else:
             print(f"\n⚠️  Temporal analysis error: {result.get('error')}")
     
@@ -148,10 +153,11 @@ class TestFAERSAnalyticsTool:
         assert result.get("status") in ["success", "error"]
         
         if result.get("status") == "success":
-            assert "meddra_hierarchy" in result
-            assert "PT_level" in result["meddra_hierarchy"]
-            print(f"\n✅ Unique PTs: {result['meddra_hierarchy']['total_unique_PTs']}")
-            for pt in result["meddra_hierarchy"]["PT_level"][:5]:
+            data = result["data"]
+            assert "meddra_hierarchy" in data
+            assert "PT_level" in data["meddra_hierarchy"]
+            print(f"\n✅ Unique PTs: {data['meddra_hierarchy']['total_unique_PTs']}")
+            for pt in data["meddra_hierarchy"]["PT_level"][:5]:
                 print(f"   {pt['preferred_term']}: {pt['count']}")
         else:
             print(f"\n⚠️  MedDRA rollup error: {result.get('error')}")

--- a/tests/unit/test_compound_variant_tool.py
+++ b/tests/unit/test_compound_variant_tool.py
@@ -5,6 +5,8 @@ Regression guard for Feature-KRAS-001: the parsers read the WRONG nested paths
 back empty, and sources_with_data falsely listed sources that returned nothing.
 """
 
+from unittest.mock import patch
+
 from tooluniverse.compound_variant_tool import (
     CompoundVariantAnnotationTool,
     _variant_match_forms,
@@ -62,6 +64,41 @@ def test_parse_clinvar_falls_back_to_gene_context_when_no_exact_match():
     assert out["matched"] == 0
     assert out["exact_match"] is False
     assert len(out["variants"]) == 2  # gene-level context, not empty
+
+
+def test_sub_call_error_detects_error_status_dict():
+    """Fix-R2B-003: sub-tools signal failure by returning
+    {"status": "error", ...}, not by raising."""
+    t = _tool()
+    assert t._sub_call_error({"status": "error", "error": "boom"}) == "boom"
+    assert t._sub_call_error({"status": "success", "data": {}}) is None
+    assert t._sub_call_error(None) is None
+
+
+def test_run_records_sub_call_failures_instead_of_empty_success():
+    """Fix-R2B-003: when every underlying source call fails (returns an
+    error dict, e.g. a network outage), the aggregator must report those
+    failures in sources_failed rather than silently treating them as
+    "gene has zero known variants" (a dangerous false negative for a
+    clinically significant gene like BRCA1)."""
+    t = _tool()
+
+    def fake_run_one_function(call):
+        return {"status": "error", "error": "Could not find a suitable TLS CA certificate bundle"}
+
+    with patch(
+        "tooluniverse.execute_function.ToolUniverse.run_one_function",
+        side_effect=fake_run_one_function,
+    ), patch(
+        "tooluniverse.execute_function.ToolUniverse.load_tools", return_value=None
+    ):
+        result = t.run({"gene": "BRCA1", "rsid": "rs80357906"})
+
+    data = result["data"]
+    assert data["annotations"] == {}
+    assert len(data["sources_failed"]) == 4
+    assert all("TLS" in msg for msg in data["sources_failed"])
+    assert data["sources_queried"] == []
 
 
 def test_sources_with_data_is_honest():

--- a/tests/unit/test_foldseek_tool.py
+++ b/tests/unit/test_foldseek_tool.py
@@ -1,0 +1,71 @@
+"""Regression guard for Fix-R2A-008: FoldseekTool's default search mode.
+
+The JSON schema documents 'mode' defaulting to '3diaa' (Foldseek's fast
+structural-alphabet search), but the Python code's own fallback was
+'tmalign' whenever the caller omitted the parameter. This silently returned
+noise-level hits (e-value ~0.3, ~2-5% identity) for every query, including
+trivial control cases (e.g. hemoglobin 4HHB against pdb100).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.foldseek_tool import FoldseekTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return FoldseekTool({"name": "Foldseek_search_structure", "fields": {"operation": "search"}})
+
+
+def _resp(status_code=200, json_data=None, text=""):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_data or {}
+    r.text = text
+    return r
+
+
+def test_default_mode_is_3diaa_not_tmalign():
+    """The outgoing Foldseek ticket submission must use mode=3diaa when the
+    caller doesn't specify one, matching the schema's documented default."""
+    tool = _tool()
+
+    pdb_file_resp = _resp(200, text="ATOM ...")
+    ticket_resp = _resp(200, {"id": "ticket123"})
+    status_resp = _resp(200, {"status": "COMPLETE"})
+    result_resp = _resp(200, {"results": []})
+
+    with patch("tooluniverse.foldseek_tool.requests.get") as mock_get, patch(
+        "tooluniverse.foldseek_tool.requests.post"
+    ) as mock_post, patch("tooluniverse.foldseek_tool.time.sleep"):
+        mock_get.side_effect = [pdb_file_resp, status_resp, result_resp]
+        mock_post.return_value = ticket_resp
+
+        result = tool.run({"pdb_id": "4HHB", "database": "pdb100"})
+
+    assert result["status"] == "success"
+    submitted_data = mock_post.call_args.kwargs["data"]
+    assert submitted_data["mode"] == "3diaa"
+
+
+def test_explicit_mode_is_respected():
+    tool = _tool()
+
+    pdb_file_resp = _resp(200, text="ATOM ...")
+    ticket_resp = _resp(200, {"id": "ticket123"})
+    status_resp = _resp(200, {"status": "COMPLETE"})
+    result_resp = _resp(200, {"results": []})
+
+    with patch("tooluniverse.foldseek_tool.requests.get") as mock_get, patch(
+        "tooluniverse.foldseek_tool.requests.post"
+    ) as mock_post, patch("tooluniverse.foldseek_tool.time.sleep"):
+        mock_get.side_effect = [pdb_file_resp, status_resp, result_resp]
+        mock_post.return_value = ticket_resp
+
+        tool.run({"pdb_id": "4HHB", "database": "pdb100", "mode": "tmalign"})
+
+    submitted_data = mock_post.call_args.kwargs["data"]
+    assert submitted_data["mode"] == "tmalign"

--- a/tests/unit/test_pdbe_ligands_tool.py
+++ b/tests/unit/test_pdbe_ligands_tool.py
@@ -1,0 +1,68 @@
+"""Regression guard for Fix-R2A-003: PDBeLigandsTool 404 disambiguation.
+
+The ligand_monomers/residue_listing PDBe endpoints 404 whenever an entry has
+no data there (e.g. an entry whose only "ligand" is modeled as a polymer
+chain, like SARS-CoV-2 Mpro 6LU7's N3 inhibitor) -- not only when the entry
+genuinely doesn't exist. The tool used to report every such 404 as "PDB
+entry not found", which is false for real, well-known entries.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.pdbe_ligands_tool import PDBeLigandsTool
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(status_code):
+    r = MagicMock()
+    r.status_code = status_code
+    return r
+
+
+def _ligands_tool():
+    return PDBeLigandsTool(
+        {
+            "name": "PDBe_get_structure_ligands",
+            "fields": {"endpoint": "ligand_monomers"},
+        }
+    )
+
+
+def test_404_with_existing_entry_returns_empty_success_not_error():
+    tool = _ligands_tool()
+    with patch("tooluniverse.pdbe_ligands_tool.requests.get") as mock_get:
+        mock_get.side_effect = [_resp(404), _resp(200)]  # ligand_monomers 404, summary 200
+        result = tool.run({"pdb_id": "6lu7"})
+
+    assert result["status"] == "success"
+    assert result["data"]["ligands"] == []
+    assert "note" in result
+    assert "6lu7" in result["note"]
+
+
+def test_404_with_nonexistent_entry_still_returns_error():
+    tool = _ligands_tool()
+    with patch("tooluniverse.pdbe_ligands_tool.requests.get") as mock_get:
+        mock_get.side_effect = [_resp(404), _resp(404)]  # ligand_monomers 404, summary 404 too
+        result = tool.run({"pdb_id": "9zzz"})
+
+    assert result["status"] == "error"
+    assert "not found" in result["error"].lower()
+
+
+def test_real_ligand_data_unaffected():
+    tool = _ligands_tool()
+    ok_resp = MagicMock()
+    ok_resp.status_code = 200
+    ok_resp.json.return_value = {
+        "4hhb": [{"chem_comp_id": "HEM", "chem_comp_name": "HEME", "weight": 616.5}]
+    }
+    with patch("tooluniverse.pdbe_ligands_tool.requests.get", return_value=ok_resp):
+        result = tool.run({"pdb_id": "4hhb"})
+
+    assert result["status"] == "success"
+    assert result["data"]["ligands"][0]["chem_comp_id"] == "HEM"
+    assert "note" not in result


### PR DESCRIPTION
## Summary

Second internal test-harness round (see #295 for round 1), covering domains not exercised previously: structural biology/PDB, genomics/variant-calling, epidemiology, drug safety/pharmacovigilance, and imaging. Ran 5 role-play researcher-persona agents against ~85 tool calls across ~40 distinct tools, then CLI-verified every reported issue before touching code.

### A note on a session-local environment issue

Several persona reports were dominated by a stale MCP server process in this session, holding a reference to a `uv` cache directory (`~/.cache/uv/archive-v0/...`) that had since been garbage-collected. This caused two consistent symptoms across almost every network-calling tool call made *through the MCP interface*: a "Could not find a suitable TLS CA certificate bundle" error, and/or "Tool type 'X' not found in registry" for more recently-added tool families. This is an environment/process-lifecycle issue specific to this session (the MCP server needs a restart against a fresh install), **not a ToolUniverse code defect** — confirmed by re-running the exact same tool calls via the local `tu`/`python3 -m tooluniverse.cli` (a fresh process each time), which worked correctly. All findings below were verified via that CLI path, not the broken MCP session.

### Verified and fixed

- **`Foldseek_search_structure`** — the code's own default search `mode` (`"tmalign"`) didn't match the JSON schema's documented default (`"3diaa"`), so any call that omitted `mode` (the common case) silently ran the wrong Foldseek search mode and returned noise-level hits: e-value ≈0.3 (not significant), 2–5% sequence identity, structurally unrelated proteins. Reproduced on both the persona's real query (SARS-CoV-2 Mpro, PDB 6LU7) and a trivial control case (hemoglobin, PDB 4HHB) — the same garbage-result pattern on both confirmed this was systemic, not query-specific. After the fix, 4HHB correctly returns other hemoglobin structures at e-value 4.985e-18 / 100% identity, and 6LU7 correctly returns other SARS-CoV-2 Mpro structures at e-value ~1e-60 / ~99% identity. Also fixed a copy-paste typo in the `mode` parameter description that named `'tmalign'` twice instead of `'3diaa'` and `'tmalign'`, and clarified that the `sequence`/`query` parameters (documented as an alternative to `pdb_id`) always fail server-side, since Foldseek's public ticket API requires an actual 3D structure.
- **`PDBe_get_structure_ligands` / `PDBe_get_bound_molecules`** (`ligand_monomers` and `residue_listing` PDBe endpoints) — these endpoints return HTTP 404 whenever an entry simply has no data there (e.g. its bound inhibitor is modeled as a polymer/peptide chain rather than a discrete non-polymer ligand), which the tool unconditionally reported as `"PDB entry '{id}' not found"` — including for real, extremely well-known entries. Reproduced on SARS-CoV-2 Mpro (6LU7, N3 inhibitor) and 3 other Mpro structures with peptidomimetic inhibitors (7BQY, 6M03, 6Y2E). Added a lightweight follow-up check against PDBe's summary endpoint to disambiguate "entry doesn't exist" from "entry exists but has no data at this specific endpoint"; the latter now returns a clean empty success with an explanatory note instead of a false error.
- **`FAERS_search_reports_by_drug_and_reaction`** and 15 sibling `FAERS_search_*`/`FAERS_count_*` tools — `medicinalproduct` only matched openFDA's raw, literal `patient.drug.medicinalproduct` free-text field, not the FDA-normalized `patient.drug.openfda.generic_name` field. Reproduced with semaglutide: searching the generic name returned zero gastroparesis reports, while searching a brand name (Ozempic) found the same real report — since ~92% of FAERS reports for this drug are filed under brand names (Ozempic/Wegovy/Rybelsus), not the generic name. Fixed by adding the normalized field as an OR-matched alternative, reusing the multi-field search-mapping mechanism the same tool classes already support and use elsewhere (no new code paths). This also resolves a related, previously-noted-but-unfixed inconsistency from round 1 (rivaroxaban generic-name vs. brand-name FAERS death counts no longer diverge for the wrong reason).
- **`annotate_variant_multi_source`** — the four sub-source calls (ClinVar, gnomAD, CIViC, UniProt) signal failure by returning a `{"status": "error", ...}` dict, which is the normal way tools in this framework report failure — but the aggregator's `try/except` only catches *raised* exceptions, so a failed sub-call was silently parsed as if it were valid (empty) data and never recorded in `sources_failed`. Reproduced independently of the session's environment issue via a clean mock: with every sub-call failing, the tool returned `"status": "success"` with an empty result set for BRCA1 — a gene with thousands of real ClinVar entries — giving no indication anything had gone wrong. Now correctly reports each failed source in `sources_failed` and leaves `annotations` empty for it, rather than fabricating an empty-but-successful result.

### Regression suite hygiene

While working in the FAERS tool family for the `medicinalproduct` fix, found `tests/tools/test_faers_analytics_tool.py` (6 tests) failing due to the same class of stale test debt already cleaned up in round 1 — assertions written against a flat/duplicate-top-level response shape from before an earlier return-schema envelope migration, when the tools now correctly nest everything under `data`. Fixed the assertions to match current (correct) tool behavior.

### Known false positives / environment noise (not fixed, not real code bugs)

- The MCP-server TLS/registry staleness described above — confirmed environment-specific via CLI cross-check, not reproducible in a fresh process.
- `HPA_get_protein_interactions_by_gene`-style "already handled correctly" cases were not re-flagged this round.

### Verified-real but out of scope this round (lower value / bigger design changes, deferred)

- PDBe/RCSB free-text search tools (`RCSBAdvSearch_search_structures`, `PDBeSearch_search_structures`) rank results by resolution/deposition date rather than textual relevance, so a query like "nirmatrelvir" without an organism filter surfaces unrelated 2010-era HIV protease structures above the real SARS-CoV-2 hits. Same class of issue as ClinVar's ranking gap noted in round 1 — needs a relevance-sort option, not a quick fix.
- `RCSBData_get_nonpolymer_entity` reports "entry not found" for an entity that exists but is polymer-typed (same root cause family as the PDBe fix above, but in a different tool with a different response shape).
- `NeuroVault_list_collections`/`list_atlases` have no keyword/tag search parameter (17,586 total collections, no practical way to filter) — a coverage gap, not a bug.
- TCIA's `TCGA-GBM` example in tool descriptions silently returns empty results — confirmed via direct upstream API check to be a real NBIA v1 API limitation (the collection isn't served there anymore), not a ToolUniverse bug; the example should be swapped for a currently-live collection (e.g. `UPENN-GBM`) in a docs-focused pass.
- `TCIA_get_body_part_values` returns one spurious empty `{}` row alongside real data — cosmetic, low severity.
- `get_cellpose_info` reports PyPI's latest published version rather than checking whether the package is actually installed locally, which can mislead a user into thinking segmentation is ready to run.

### Verification

- All 4 fixed/touched source files have new or updated unit tests (10 files total changed/added), all passing: `test_compound_variant_tool.py` (2 new + 5 existing), `test_foldseek_tool.py` (new, 2 tests), `test_pdbe_ligands_tool.py` (new, 3 tests), `test_faers_analytics_tool.py` (11, all fixed).
- Every fix was reproduced live via `python3 -m tooluniverse.cli run <ToolName> '<args>'` before the change and re-verified after; the Foldseek and FAERS fixes were also cross-checked against their originally-broken real-world queries (6LU7, 4HHB, semaglutide/gastroparesis).
- JSON configs validated with `python3 -c "import json; json.load(...)"`.

Branch created fresh off `origin/main` (not building on the still-open #295) via an isolated worktree, per project convention.