### PR TITLE
Fix Round 3: test-harness sweep across toxicology, nutrition, clinical genetics, environmental health, medical devices

### DIFF
--- a/src/tooluniverse/cli.py
+++ b/src/tooluniverse/cli.py
@@ -475,6 +475,14 @@ def _render_run(d: dict) -> str:
         or "unknown error"
     )
     lines = [f"Error: {short_err}"]
+    # Fix-R3B-007/R3E-002: BaseRESTTool-backed tools (openFDA, EPA, etc.) put
+    # the raw upstream HTTP response body in `detail` on non-2xx responses.
+    # That's often the only place the *actionable* explanation lives (e.g.
+    # openFDA's "use a .exact keyword field" hint) — short_err is usually
+    # just a generic "<Tool> API error". Surface it instead of dropping it.
+    detail = d.get("detail")
+    if isinstance(detail, str) and detail.strip() and detail.strip() not in short_err:
+        lines.append(f"Detail: {detail.strip()[:300]}")
     details = d.get("error_details") or {}
 
     # Feature-25B-02: for "tool not found" errors, replace generic network tips

--- a/src/tooluniverse/data/openfda_tools.json
+++ b/src/tooluniverse/data/openfda_tools.json
@@ -526,7 +526,7 @@
                         "string",
                         "null"
                     ],
-                    "description": "Field to count by for frequency analysis (e.g., 'classification', 'recalling_firm.exact', 'voluntary_mandated.exact')"
+                    "description": "Field to count by for frequency analysis. Must use the '.exact' keyword sub-field for text columns or openFDA rejects the request (e.g. 'classification.exact', 'recalling_firm.exact', 'voluntary_mandated.exact')."
                 }
             },
             "required": []
@@ -661,7 +661,7 @@
                         "string",
                         "null"
                     ],
-                    "description": "Field to count by (e.g., 'classification', 'status', 'recalling_firm.exact')"
+                    "description": "Field to count by. Must use the '.exact' keyword sub-field for text columns or openFDA rejects the request (e.g. 'classification.exact', 'status.exact', 'recalling_firm.exact')."
                 }
             },
             "required": []
@@ -879,7 +879,7 @@
                         "string",
                         "null"
                     ],
-                    "description": "Field to count by (e.g., 'classification', 'state', 'recalling_firm.exact')"
+                    "description": "Field to count by. Must use the '.exact' keyword sub-field for text columns or openFDA rejects the request (e.g. 'classification.exact', 'state.exact', 'recalling_firm.exact')."
                 }
             },
             "required": []

--- a/src/tooluniverse/epa_envirofacts_tool.py
+++ b/src/tooluniverse/epa_envirofacts_tool.py
@@ -196,8 +196,15 @@ class EPAFRSFacilitiesTool(_EnvirofactsBase):
             "facility_name": r.get("std_name") or r.get("std_base_name"),
             "address": r.get("std_full_address") or r.get("location_address"),
             "city": r.get("std_city_name") or r.get("city_name"),
-            "state": r.get("state_name"),
-            "registry_id": r.get("parent_registry_id"),
+            # Fix-R3D-002: state_name is a separate, unreliable column that
+            # frequently doesn't match the state a row was actually filtered
+            # on; state_code is the 2-letter field the query itself filters
+            # by (self.state_col), so it's the only field guaranteed to be
+            # consistent with the requested state. Likewise registry_id (not
+            # parent_registry_id, which is null for nearly every row) is the
+            # real FRS identifier confirmed present in live API responses.
+            "state": r.get("state_code"),
+            "registry_id": r.get("registry_id"),
             "federal_facility": r.get("federal_facility_code"),
             "tribal_land": r.get("tribal_land_name"),
         }

--- a/tests/tools/test_tu_cli.py
+++ b/tests/tools/test_tu_cli.py
@@ -4927,6 +4927,29 @@ class TestRound23BRemainingFixes:
         assert len(rendered) < 300
 
     @pytest.mark.unit
+    def test_render_run_surfaces_detail_field(self):
+        """Fix-R3B-007/R3E-002: BaseRESTTool errors put the actionable upstream
+        message in `detail`, not `error` — the CLI must not drop it."""
+        from tooluniverse.cli import _render_run
+
+        result = {
+            "status": "error",
+            "error": "OpenFDA_search_food_enforcement API error",
+            "status_code": 500,
+            "detail": '{"error": {"details": "use a .exact keyword field"}}',
+        }
+        rendered = _render_run(result)
+        assert "Detail:" in rendered
+        assert ".exact keyword field" in rendered
+
+    @pytest.mark.unit
+    def test_render_run_no_detail_line_when_absent(self):
+        from tooluniverse.cli import _render_run
+
+        rendered = _render_run({"status": "error", "error": "boom"})
+        assert "Detail:" not in rendered
+
+    @pytest.mark.unit
     def test_render_run_success_returns_json(self):
         """Feature-23B-02: _render_run passes through success results as JSON."""
         from tooluniverse.cli import _render_run

--- a/tests/unit/test_epa_envirofacts_tool.py
+++ b/tests/unit/test_epa_envirofacts_tool.py
@@ -1,0 +1,35 @@
+"""Regression guard for Fix-R3D-002: EPAFRSFacilitiesTool field mapping.
+
+The FRS facility_site table exposes both `state_code` (the 2-letter field
+the query actually filters on) and a separate, unreliable `state_name`
+column that frequently belongs to a different state than the one requested.
+Likewise `registry_id` (the real FRS identifier) is a distinct field from
+`parent_registry_id` (null for nearly every row). `_summarize` used to read
+the wrong field in both cases, silently returning facilities that looked
+like they were from the wrong state with no registry_id at all.
+"""
+
+import pytest
+
+from tooluniverse.epa_envirofacts_tool import EPAFRSFacilitiesTool
+
+pytestmark = pytest.mark.unit
+
+
+def test_summarize_reads_state_code_not_state_name():
+    row = {
+        "std_name": "SOME FACILITY",
+        "state_code": "TX",
+        "state_name": "CALIFORNIA",  # mismatched, as observed live
+        "registry_id": "110049814322",
+        "parent_registry_id": None,
+    }
+    out = EPAFRSFacilitiesTool._summarize(row)
+    assert out["state"] == "TX"
+    assert out["registry_id"] == "110049814322"
+
+
+def test_summarize_falls_back_gracefully_when_fields_missing():
+    out = EPAFRSFacilitiesTool._summarize({})
+    assert out["state"] is None
+    assert out["registry_id"] is None


### PR DESCRIPTION
## Summary

Third internal test-harness round (see #295 round 1, #296 round 2), covering domains not previously exercised: toxicology, nutrition/food science, clinical genetics (rare disease diagnosis, substituted for an immunology persona that hit a policy-classifier false positive twice on epitope/MHC-binding framing), environmental health, and medical devices. Ran 5 role-play researcher-persona agents, then CLI-verified every reported issue before touching code.

### Verified and fixed

- **`EPA_search_frs_facilities`** — `_summarize`'s field mapping read `state_name` and `parent_registry_id`, two columns in EPA's FRS facility table that are either unreliable/mismatched (`state_name`) or almost always null (`parent_registry_id`), instead of `state_code` (the field the query itself filters on) and `registry_id` (the real, populated identifier). **Independently reproduced by two personas** (environmental health, toxicology) on the same tool with different queries: `state=TX` correctly filtered server-side, but every result displayed a wrong state ("CALIFORNIA", "COLORADO", "FLORIDA"...) with `registry_id: null`. Confirmed against the raw EPA Envirofacts API that both correct columns are present and populated on the same records. Fixed the two-line mapping bug; added regression tests.
- **`OpenFDA_search_drug_enforcement` / `_device_enforcement` / `_food_enforcement`** — each tool's own `count` parameter description gave example field values (`'classification'`, `'status'`, `'state'`) that openFDA's Elasticsearch backend always rejects with a 500 — text fields need the `.exact` keyword sub-field for aggregation. **Independently reproduced by two personas** (medical devices, nutrition) copying the exact broken examples straight from each tool's own docs. Fixed all three descriptions to give working examples (`'classification.exact'`, `'status.exact'`/`'state.exact'`).
- **CLI `tu run` error rendering** — `BaseRESTTool`-backed tools (openFDA, EPA, and others) put the actual actionable upstream error in a `detail` field on non-2xx HTTP responses (e.g. the openFDA message explaining the `.exact` requirement above), but `_render_run`'s human-readable error path only ever surfaced the generic top-level `error` string (`"<Tool> API error"`) and silently dropped `detail` — hiding the one piece of information a CLI user needs to self-correct. Now surfaced as a `Detail:` line whenever present and not already redundant with the short summary. This is a general fix (benefits any `BaseRESTTool`-based tool that populates `detail`), not scoped to the three tools above.

### False positives (CLI/API-verified, not fixed)

- **`AOPWiki_list_aops`** and **`EPA_search_tri_facilities`** were both reported as "referenced by a broken description cross-link to a tool that doesn't exist." Both tools actually exist and work correctly (verified live via CLI) — the persona's own tool-discovery calls (`grep_tools`/`get_tool_info`) failed to find them, most likely the same session-local MCP staleness described below also affecting search/discovery, not just execution.
- **`Orphanet_search_by_name`** was reported as silently ignoring a misspelled disease-name query, returning the same total count (3527) as the correctly-spelled query along with allegedly unrelated top results (Turner/Rett/Angelman syndrome instead of Noonan). The `total` count *is* genuinely identical for both queries — confirmed directly against Orphanet's raw upstream API, so this part is real — but it turns out to be a cosmetic quirk of their `ApproximateName` endpoint (it appears to always report a fixed corpus-scan size rather than a true match count). The part that actually matters — which results the tool surfaces up to `limit` — is correctly relevance-ranked with the real disease first for *both* the correct and misspelled query, reproduced directly. The persona's specific claim about which diseases appear in the top results did not reproduce.

### Verified-real but deferred this round

- **`OpenFoodFacts_filter_products_by_tags`** — passing an allergen tag value that's real English but doesn't exist in OpenFoodFacts' *allergen* taxonomy specifically (e.g. `'en:almonds'`, which only exists as a *category* tag, not an *allergen* tag — almonds are only tagged generically as `en:nuts`) returns `count: 94659` with products whose `allergens_tags` don't contain the requested tag at all, instead of an empty/filtered result. Reproduced live and confirmed the tool sends the documented, correct query parameter — the odd fallback-to-unfiltered behavior appears to originate in OpenFoodFacts' own search API. `OpenFoodFacts_filter_products_by_tags` is a generic config-driven `BaseRESTTool` passthrough with no OpenFoodFacts-specific logic; a proper fix needs either client-side allergen-taxonomy validation or response post-filtering — a bigger, riskier change than this round's scope. Flagging for a dedicated pass.

### A recurring session-local environment issue (not fixed here)

As in rounds 1 and 2, nearly every persona's initial tool calls through the MCP interface failed with either a stale TLS certificate-bundle path or "tool type not found in registry" — both traced to the same session's MCP server process holding a reference to a `uv` cache directory that's since been garbage-collected. Every finding in this PR was cross-checked via the local `tu`/`python3 -m tooluniverse.cli` (a fresh process each time), which worked correctly throughout, confirming this is an environment/process-lifecycle issue specific to this session, not a code defect.

### Verification

- All 4 touched/new files have unit test coverage: `test_epa_envirofacts_tool.py` (new, 2 tests), `test_tu_cli.py` (2 new tests for the `Detail:` line, plus the full existing 369-test suite re-run to confirm no regressions — 3 pre-existing, unrelated failures confirmed present with or without this branch's changes via a stash/pop comparison).
- Every fix was reproduced live via `python3 -m tooluniverse.cli run <ToolName> '<args>'` (or direct Python `ToolUniverse.run_one_function`) before the change and re-verified after.
- JSON config validated with `python3 -c "import json; json.load(...)"`.

Branch created fresh off `origin/main` (not building on the still-open #295/#296) via an isolated worktree, per project convention.