### PR TITLE
Test-harness round 4: cBioPortal, GDC, USDA PLANTS, DailyMed domain-sweep fixes

### DIFF
--- a/src/tooluniverse/cbioportal_tool.py
+++ b/src/tooluniverse/cbioportal_tool.py
@@ -151,6 +151,21 @@ class CBioPortalRESTTool(BaseTool):
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         try:
+            # Fix-R4A-001: _build_url only substitutes {placeholder} for keys
+            # actually present in `arguments`, so an omitted optional param
+            # (e.g. `limit`) left its literal "{limit}" placeholder unfilled
+            # in the endpoint template, sending a broken query string to the
+            # live API instead of falling back to the schema's declared
+            # default value.
+            schema_props = self.tool_config.get("parameter", {}).get("properties", {})
+            defaults = {
+                name: prop["default"]
+                for name, prop in schema_props.items()
+                if "default" in prop and name not in arguments
+            }
+            if defaults:
+                arguments = {**arguments, **defaults}
+
             if "query" in arguments and "keyword" not in arguments:
                 arguments = {**arguments, "keyword": arguments["query"]}
             if (

--- a/src/tooluniverse/cli.py
+++ b/src/tooluniverse/cli.py
@@ -1703,6 +1703,15 @@ def main() -> None:
     p.add_argument(
         "--categories", nargs="+", metavar="CAT", help="Filter by category names"
     )
+    # Fix-R4E-2: users reflexively type grep's -i flag; accept it instead of
+    # an unrecognized-arguments error. text mode (the default) already does
+    # case-insensitive matching, so this is a no-op rather than a real toggle.
+    p.add_argument(
+        "-i",
+        "--ignore-case",
+        action="store_true",
+        help="No-op: text mode (the default) is already case-insensitive",
+    )
     p.set_defaults(func=cmd_grep)
 
     # ── info ──────────────────────────────────────────────────────────────────

--- a/src/tooluniverse/dailymed_tool.py
+++ b/src/tooluniverse/dailymed_tool.py
@@ -1,5 +1,6 @@
 # dailymed_tool.py
 
+import json
 import requests
 from typing import Dict, Any, List
 from .base_tool import BaseTool
@@ -193,6 +194,23 @@ class GetSPLBySetIDTool(BaseTool):
         return {"status": "success", "xml": resp.text}
 
 
+def _dedupe_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Fix-R4C-1: SPL documents often expose the same section content
+    through multiple matching <section> elements (e.g. a Highlights summary
+    plus the Full Prescribing Information), so a parser can walk the
+    identical paragraph/table text more than once. Dedupe by content,
+    preserving first-seen order, so the same statement never appears twice
+    in one response. A no-op when there's no duplication to begin with."""
+    seen = set()
+    deduped = []
+    for item in items:
+        key = json.dumps(item, sort_keys=True)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+    return deduped
+
+
 @register_tool("DailyMedSPLParserTool")
 class DailyMedSPLParserTool(BaseTool):
     """
@@ -238,6 +256,19 @@ class DailyMedSPLParserTool(BaseTool):
                     pass
 
         if not setid:
+            if arguments.get("drug_name"):
+                # Fix-R4C-2: drug_name WAS provided but the lookup above found
+                # no matching SPL (or the lookup call itself failed) -- the old
+                # generic "setid missing" message told the user to do exactly
+                # what they already did, instead of reporting the real problem.
+                return {
+                    "status": "error",
+                    "error": (
+                        f"No DailyMed SPL found for drug_name="
+                        f"'{arguments['drug_name']}'. Check the spelling, or "
+                        "supply an exact `setid` (DailyMed Set ID UUID) instead."
+                    ),
+                }
             return {
                 "status": "error",
                 "error": (
@@ -359,6 +390,8 @@ class DailyMedSPLParserTool(BaseTool):
                                     {"type": "text", "content": text_content}
                                 )
 
+            adverse_reactions = _dedupe_items(adverse_reactions)
+
             return {
                 "status": "success",
                 "adverse_reactions": adverse_reactions,
@@ -413,6 +446,8 @@ class DailyMedSPLParserTool(BaseTool):
                             dosing_info.append(
                                 {"type": "dosing_text", "content": text_content}
                             )
+
+            dosing_info = _dedupe_items(dosing_info)
 
             return {
                 "status": "success",
@@ -469,6 +504,8 @@ class DailyMedSPLParserTool(BaseTool):
                                     }
                                 )
 
+            contraindications = _dedupe_items(contraindications)
+
             return {
                 "status": "success",
                 "contraindications": contraindications,
@@ -516,6 +553,8 @@ class DailyMedSPLParserTool(BaseTool):
                                 {"type": "interaction_text", "content": text_content}
                             )
 
+            interactions = _dedupe_items(interactions)
+
             return {
                 "status": "success",
                 "interactions": interactions,
@@ -562,6 +601,8 @@ class DailyMedSPLParserTool(BaseTool):
                             pharmacology.append(
                                 {"type": "pharmacology_text", "content": text_content}
                             )
+
+            pharmacology = _dedupe_items(pharmacology)
 
             return {
                 "status": "success",

--- a/src/tooluniverse/gdc_tool.py
+++ b/src/tooluniverse/gdc_tool.py
@@ -753,15 +753,53 @@ class GDCMutationFreqByProjectTool:
             raw.get("aggregations", {}).get("projects", {}).get("buckets", []) or []
         )
 
+        # Fix-R4A-002: the analysis endpoint's nested `case_summary.doc_count`
+        # is NOT the project's total case count (confirmed against the raw
+        # API and cross-checked with GDC_search_cases/GDC_list_projects,
+        # e.g. it reports 2282 for TCGA-COAD when the real total is 461) —
+        # its sibling `case_summary.case_with_ssm.doc_count` is simply a
+        # duplicate of the mutated count. Fetch true per-project totals from
+        # the /projects endpoint's `summary.case_count` field instead, the
+        # same field GDC_list_projects uses.
+        project_ids = [b.get("key") for b in buckets if b.get("key")]
+        true_totals: Dict[str, int] = {}
+        if project_ids:
+            proj_filters = json.dumps(
+                {
+                    "op": "in",
+                    "content": {"field": "project_id", "value": project_ids},
+                }
+            )
+            proj_query = {
+                "filters": proj_filters,
+                "fields": "project_id,summary.case_count",
+                "size": len(project_ids),
+            }
+            proj_url = f"{base}/projects?{urlencode(proj_query)}"
+            try:
+                proj_raw = _http_get(
+                    proj_url, headers={"Accept": "application/json"}, timeout=timeout
+                )
+                for hit in proj_raw.get("data", {}).get("hits", []) or []:
+                    pid = hit.get("project_id")
+                    count = (hit.get("summary") or {}).get("case_count")
+                    if pid and count is not None:
+                        true_totals[pid] = count
+            except Exception:
+                pass  # fall back to the (less reliable) case_summary field below
+
         projects = []
         for b in buckets:
             mutated = b.get("doc_count", 0) or 0
+            project_id = b.get("key")
             case_summary = b.get("case_summary", {}) or {}
-            total = case_summary.get("doc_count", 0) or 0
+            total = true_totals.get(project_id)
+            if total is None:
+                total = case_summary.get("doc_count", 0) or 0
             freq = round(mutated / total, 4) if total else None
             projects.append(
                 {
-                    "project_id": b.get("key"),
+                    "project_id": project_id,
                     "mutated_case_count": mutated,
                     "total_case_count": total,
                     "frequency": freq,

--- a/src/tooluniverse/usda_plants_tool.py
+++ b/src/tooluniverse/usda_plants_tool.py
@@ -378,7 +378,14 @@ class USDAPlantsProfileTool(_USDAPlantsBase):
                 {
                     "symbol": plant.get("Symbol"),
                     "scientific_name": _strip_html(plant.get("ScientificName")),
-                    "common_name": plant.get("CommonName") or item.get("Text"),
+                    # Fix-R4E-4: when CommonName is empty, USDA's own
+                    # fallback autocomplete text re-renders the scientific
+                    # name wrapped in <i> tags — strip it the same way
+                    # scientific_name already is, instead of leaking raw
+                    # HTML markup into a field callers expect to be plain
+                    # text.
+                    "common_name": plant.get("CommonName")
+                    or _strip_html(item.get("Text")),
                     "rank": plant.get("Rank"),
                     "id": plant.get("Id"),
                 }

--- a/tests/tools/test_tu_cli.py
+++ b/tests/tools/test_tu_cli.py
@@ -4203,6 +4203,21 @@ class TestRound20Fixes:
         d = json.loads(out)
         assert "error" in d
 
+    # Fix-R4E-2: `tu grep -i` used to error with "unrecognized arguments: -i"
+    # since users reflexively type grep's -i flag even though text mode (the
+    # default) is already case-insensitive.
+    @pytest.mark.unit
+    def test_grep_accepts_ignore_case_flag(self, capsys):
+        """-i is accepted (as a no-op) instead of an argparse error."""
+        import sys as _sys
+        from tooluniverse.cli import main
+
+        _sys.argv = ["tu", "grep", "-i", "protein", "--json", "--limit", "3"]
+        main()
+        out = capsys.readouterr().out
+        d = json.loads(out)
+        assert "error" not in d
+
 
 class TestRound21PreFixes:
     """Tests for Feature-20A-07 and Feature-20A-08 fixed before Round 21 agents launched."""

--- a/tests/unit/test_cbioportal_tool.py
+++ b/tests/unit/test_cbioportal_tool.py
@@ -1,0 +1,59 @@
+"""Regression guard for Fix-R4A-001: CBioPortalRESTTool schema-default fill.
+
+_build_url only substitutes {placeholder} for keys present in the call
+arguments, so an omitted optional parameter (e.g. `limit`, which the JSON
+schema declares default=20) left its literal "{limit}" placeholder unfilled
+in the endpoint template -- sending a broken query string to the live API
+instead of falling back to the declared default.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.cbioportal_tool import CBioPortalRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return CBioPortalRESTTool(
+        {
+            "name": "cBioPortal_get_cancer_studies",
+            "parameter": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer", "default": 20},
+                },
+            },
+            "fields": {"endpoint": "https://www.cbioportal.org/api/studies?pageSize={limit}"},
+        }
+    )
+
+
+def test_omitted_param_uses_schema_default():
+    tool = _tool()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = [{"studyId": "x"}]
+
+    with patch.object(tool.session, "get", return_value=resp) as mock_get:
+        result = tool.run({})
+
+    assert result["status"] == "success"
+    called_url = mock_get.call_args.args[0]
+    assert "{limit}" not in called_url
+    assert "pageSize=20" in called_url
+
+
+def test_explicit_param_overrides_default():
+    tool = _tool()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = [{"studyId": "x"}]
+
+    with patch.object(tool.session, "get", return_value=resp) as mock_get:
+        tool.run({"limit": 5})
+
+    called_url = mock_get.call_args.args[0]
+    assert "pageSize=5" in called_url

--- a/tests/unit/test_dailymed_dedup_and_errors.py
+++ b/tests/unit/test_dailymed_dedup_and_errors.py
@@ -1,0 +1,95 @@
+"""Regression guard for Fix-R4C-1 (duplicate SPL section dedup) and
+Fix-R4C-2 (misleading "missing setid" error when drug_name lookup fails).
+
+SPL XML documents often expose the same section content through multiple
+matching <section> elements (e.g. a Highlights summary plus the Full
+Prescribing Information), so naive parsers double-count identical
+paragraphs -- confirmed live against the apixaban SPL (20 drug-interaction
+items / 10 unique, 103 dosing items / 79 unique).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.dailymed_tool import DailyMedSPLParserTool, _dedupe_items
+
+pytestmark = pytest.mark.unit
+
+_DUPLICATED_INTERACTIONS_XML = """<?xml version="1.0"?>
+<document xmlns="urn:hl7-org:v3">
+  <component><structuredBody>
+    <component><section>
+      <code code="34073-7"/>
+      <text><paragraph>Coadministration with strong CYP3A4 inhibitors increases exposure.</paragraph></text>
+    </section></component>
+    <component><section>
+      <code code="34073-7"/>
+      <text><paragraph>Coadministration with strong CYP3A4 inhibitors increases exposure.</paragraph></text>
+    </section></component>
+  </structuredBody></component>
+</document>
+"""
+
+
+def _tool():
+    return DailyMedSPLParserTool(
+        {"name": "DailyMed_parse_drug_interactions", "parameter": {"properties": {}}}
+    )
+
+
+def test_dedupe_items_preserves_order_and_drops_exact_repeats():
+    items = [
+        {"type": "interaction_text", "content": "a"},
+        {"type": "interaction_text", "content": "b"},
+        {"type": "interaction_text", "content": "a"},
+    ]
+    assert _dedupe_items(items) == [
+        {"type": "interaction_text", "content": "a"},
+        {"type": "interaction_text", "content": "b"},
+    ]
+
+
+def test_dedupe_items_is_noop_when_no_duplication():
+    items = [{"type": "x", "content": "1"}, {"type": "x", "content": "2"}]
+    assert _dedupe_items(items) == items
+
+
+def test_parse_drug_interactions_dedupes_duplicated_spl_sections():
+    tool = _tool()
+    fetch_resp = MagicMock()
+    fetch_resp.status_code = 200
+    fetch_resp.text = _DUPLICATED_INTERACTIONS_XML
+
+    with patch("tooluniverse.dailymed_tool.requests.get", return_value=fetch_resp):
+        result = tool.run(
+            {"operation": "parse_drug_interactions", "setid": "fake-setid"}
+        )
+
+    assert result["status"] == "success"
+    assert result["data"]["count"] == 1
+    assert len(result["data"]["interactions"]) == 1
+
+
+def test_missing_setid_with_drug_name_gives_actionable_not_found_error():
+    tool = _tool()
+    lookup_resp = MagicMock()
+    lookup_resp.status_code = 200
+    lookup_resp.json.return_value = {"data": []}  # no SPL matched
+
+    with patch("tooluniverse.dailymed_tool.requests.get", return_value=lookup_resp):
+        result = tool.run(
+            {"operation": "parse_drug_interactions", "drug_name": "apixiban"}
+        )
+
+    assert result["status"] == "error"
+    assert "No DailyMed SPL found for drug_name='apixiban'" in result["error"]
+    assert "Missing required parameter: setid" not in result["error"]
+
+
+def test_missing_setid_and_drug_name_gives_original_generic_error():
+    tool = _tool()
+    result = tool.run({"operation": "parse_drug_interactions"})
+
+    assert result["status"] == "error"
+    assert "Missing required parameter: setid" in result["error"]

--- a/tests/unit/test_gdc_mutation_frequency.py
+++ b/tests/unit/test_gdc_mutation_frequency.py
@@ -1,0 +1,76 @@
+"""Regression guard for Fix-R4A-002: GDCMutationFreqByProjectTool denominator.
+
+The GDC analysis endpoint's nested `case_summary.doc_count` is NOT a
+project's total case count -- confirmed against the raw API and
+cross-checked with GDC_search_cases/GDC_list_projects (e.g. it reported
+2282 for TCGA-COAD when the real total is 461, understating KRAS mutation
+frequency in colorectal cancer by ~5x: 11% instead of the real ~54%).
+The fix looks up true per-project totals via the /projects endpoint's
+`summary.case_count` field, same as GDC_list_projects already does.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.gdc_tool import GDCMutationFreqByProjectTool
+
+pytestmark = pytest.mark.unit
+
+_ANALYSIS_RESPONSE = {
+    "aggregations": {
+        "projects": {
+            "buckets": [
+                {
+                    "key": "TCGA-COAD",
+                    "doc_count": 250,
+                    "case_summary": {
+                        "doc_count": 2282,  # wrong: not a real case total
+                        "case_with_ssm": {"doc_count": 250},
+                    },
+                }
+            ]
+        }
+    }
+}
+
+_PROJECTS_RESPONSE = {
+    "data": {
+        "hits": [
+            {"project_id": "TCGA-COAD", "summary": {"case_count": 461}},
+        ]
+    }
+}
+
+
+def test_uses_projects_endpoint_case_count_not_case_summary():
+    tool = GDCMutationFreqByProjectTool({})
+
+    with patch(
+        "tooluniverse.gdc_tool._http_get",
+        side_effect=[_ANALYSIS_RESPONSE, _PROJECTS_RESPONSE],
+    ):
+        result = tool.run({"gene_symbol": "KRAS"})
+
+    assert result["status"] == "success"
+    project = result["data"]["projects"][0]
+    assert project["project_id"] == "TCGA-COAD"
+    assert project["mutated_case_count"] == 250
+    assert project["total_case_count"] == 461
+    assert project["frequency"] == round(250 / 461, 4)
+
+
+def test_falls_back_to_case_summary_if_projects_lookup_fails():
+    """If the /projects lookup errors, still return a (less reliable)
+    result rather than failing the whole call."""
+    tool = GDCMutationFreqByProjectTool({})
+
+    with patch(
+        "tooluniverse.gdc_tool._http_get",
+        side_effect=[_ANALYSIS_RESPONSE, Exception("network error")],
+    ):
+        result = tool.run({"gene_symbol": "KRAS"})
+
+    assert result["status"] == "success"
+    project = result["data"]["projects"][0]
+    assert project["total_case_count"] == 2282  # fallback value

--- a/tests/unit/test_usda_plants_tool.py
+++ b/tests/unit/test_usda_plants_tool.py
@@ -1,0 +1,68 @@
+"""Regression guard for Fix-R4E-4: USDA_plants_search_by_name common_name HTML leak.
+
+When USDA's PlantSearch API has no true common name for a result, the tool
+fell back to the raw autocomplete `Text` field, which USDA wraps in <i>
+tags around the scientific name (e.g. "<i>Holcus sorghum</i> L.") -- the
+same markup `scientific_name` already strips via `_strip_html`, but the
+common_name fallback didn't.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.usda_plants_tool import USDAPlantsProfileTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return USDAPlantsProfileTool(
+        {"name": "USDA_plants_search_by_name", "fields": {"action": "search"}}
+    )
+
+
+def test_common_name_fallback_strips_html():
+    tool = _tool()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = [
+        {
+            "Text": "<i>Holcus sorghum</i> L.",
+            "Plant": {
+                "Symbol": "HOSO",
+                "ScientificName": "Holcus sorghum L.",
+                "CommonName": "",
+                "Rank": "Species",
+                "Id": 25717,
+            },
+        }
+    ]
+    with patch("tooluniverse.usda_plants_tool.requests.get", return_value=resp):
+        result = tool.run({"searchText": "sorghum"})
+
+    entry = result["data"][0]
+    assert entry["common_name"] == "Holcus sorghum L."
+    assert "<i>" not in entry["common_name"]
+
+
+def test_real_common_name_unaffected():
+    tool = _tool()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = [
+        {
+            "Text": "sorghum",
+            "Plant": {
+                "Symbol": "SORGH2",
+                "ScientificName": "Sorghum Moench",
+                "CommonName": "sorghum",
+                "Rank": "Genus",
+                "Id": 25704,
+            },
+        }
+    ]
+    with patch("tooluniverse.usda_plants_tool.requests.get", return_value=resp):
+        result = tool.run({"searchText": "sorghum"})
+
+    assert result["data"][0]["common_name"] == "sorghum"


### PR DESCRIPTION
## Summary

Round 4 of the ongoing test-harness sweep. Persona domains this round: oncology, microbiome, cardiology, ophthalmology, agricultural science. Every issue below was CLI-verified (`python3 -m tooluniverse.cli run <Tool> '<args>'`) before fixing — roughly half of raw persona reports turned out to be false positives, consistent with prior rounds.

## Verified bugs fixed

- **Fix-R4A-001** (`cbioportal_tool.py`) — `_build_url` only substitutes `{placeholder}` tokens for keys present in the call `arguments`, so an omitted optional param (e.g. `limit`, schema default=20) left its literal `{limit}` unfilled in the endpoint template, sending a broken query string and causing a live 400 on `cBioPortal_get_cancer_studies`. Now fills in schema-declared defaults for any omitted param before building the URL.

- **Fix-R4A-002** (`gdc_tool.py`) — `GDCMutationFreqByProjectTool` read `case_summary.doc_count` from the GDC analysis endpoint as a project's total case count, but that field is not reliable (confirmed against the raw API and cross-checked with `GDC_search_cases`/`GDC_list_projects` — it reported 2282 for TCGA-COAD when the real total is 461, understating KRAS mutation frequency in colorectal cancer as 11% instead of the correct ~54%). Now fetches true per-project totals from the `/projects` endpoint's `summary.case_count` field, the same field `GDC_list_projects` already uses, falling back to the old value only if that lookup fails.

- **Fix-R4C-1** (`dailymed_tool.py`) — SPL XML documents expose the same section content through multiple matching `<section>` elements (a Highlights summary plus the Full Prescribing Information), so `DailyMed_parse_drug_interactions` and `DailyMed_parse_dosing` returned exact duplicates (20 items/10 unique, and 103/79 respectively, for apixaban). Added a shared `_dedupe_items()` helper applied consistently across all 5 SPL parser operations (safe no-op where there's no duplication).

- **Fix-R4C-2** (`dailymed_tool.py`) — when `drug_name` was provided but the automatic setid lookup found no match (e.g. a misspelled drug name), the tool returned `"Missing required parameter: setid"` — telling the caller to do exactly what they'd already done. Now returns a distinct `"No DailyMed SPL found for drug_name=X"` message naming the actual problem, while the truly-missing-both-params case keeps its original message.

- **Fix-R4E-4** (`usda_plants_tool.py`) — `USDA_plants_search_by_name`'s `common_name` fallback (used when `CommonName` is empty) left raw HTML markup un-stripped, e.g. `"<i>Holcus sorghum</i> L."` — the sibling `scientific_name` field already stripped this via `_strip_html`, but the fallback didn't.

- **Fix-R4E-2** (`cli.py`) — `tu grep -i` errored with `"unrecognized arguments: -i"` since users reflexively type grep's `-i` flag. Accepted as a no-op flag (text mode, the default, is already case-insensitive).

## False positives / deferred (not fixed)

- **R4E-1** — `tu`/pip package mismatch hit by a persona's fresh environment (stale pip install lacking `cli.py`) — local onboarding friction, not a code bug.
- **R4E-3** — `USDA_plants_search_by_name` expects `searchText` not `name`; the error message already names the correct field clearly, and renaming/aliasing risks the param-alias anti-pattern for a cosmetic naming mismatch.
- **R4E-5** — `GBIF_search_species` free-text ranking puts an unrelated virus above *Zea mays* for query "maize" — `GBIF_match_name` (scientific name) works correctly; likely upstream relevance ranking, not ToolUniverse-side.
- **R4B-1** — `MGnify_get_taxonomy` param naming (`analysis_id` vs a sibling tool's `study_accession`) — low severity, error message already actionable.

## Known session-local issue (not a code bug)

The MCP server in this development session holds a stale reference to a garbage-collected `uv` cache dir, causing TLS cert / "tool type not found" errors across `mcp__tooluniverse__*` calls. Every finding above was independently verified via the local CLI, which is unaffected. This is documented for consistency with prior round PRs (#295, #296, #297) — not something this PR changes.

## Test plan

- [x] 4 new mocked unit test files (`tests/unit/test_cbioportal_tool.py`, `test_gdc_mutation_frequency.py`, `test_usda_plants_tool.py`, `test_dailymed_dedup_and_errors.py`) — 11 new tests, all passing
- [x] 1 new CLI test (`test_grep_accepts_ignore_case_flag` in `tests/tools/test_tu_cli.py`) — passing, plus all 66 existing `grep`-related CLI tests still pass
- [x] Every fix re-verified live via `python3 -m tooluniverse.cli run` after the code change
- [x] Auto-regen stub drift (`uv.lock`, `_lazy_registry_static.py`) reverted before commit — diff contains only intentional changes