### PR TITLE
Test-harness round 5: ClinVar, CPIC, DailyMed domain-sweep fixes

### DIFF
--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -212,6 +212,34 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             query_parts.append(f'"clinsig {clnsig}"[Filter]')
 
         if not query_parts:
+            # Fix-R5D-1: a caller-supplied param that doesn't match any
+            # recognized name/alias (e.g. "gene_name" instead of "gene" or
+            # "gene_symbol") was silently dropped, producing a generic
+            # "at least one search parameter is required" error that gave
+            # no hint the parameter itself was misnamed. Name the actual
+            # unrecognized keys so the caller can fix the typo directly.
+            recognized = {
+                "gene",
+                "gene_symbol",
+                "condition",
+                "query",
+                "variant_id",
+                "clinical_significance",
+                "significance",
+                "max_results",
+                "limit",
+            }
+            unrecognized = sorted(set(arguments) - recognized)
+            if unrecognized:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"Unrecognized parameter(s): {', '.join(unrecognized)}. "
+                        "Valid search parameters: gene (or gene_symbol), "
+                        "condition (or query), variant_id, "
+                        "clinical_significance (or significance)."
+                    ),
+                }
             return {
                 "status": "error",
                 "error": "At least one search parameter is required",

--- a/src/tooluniverse/cpic_search_pairs_tool.py
+++ b/src/tooluniverse/cpic_search_pairs_tool.py
@@ -67,11 +67,19 @@ class CPICGetRecommendationsTool(BaseTool):
                 }
             result = _resolve_drug_to_guideline_id(drug)
             if result is None:
+                # Fix-R5C-2: CPIC's /drug table only has generic names (no
+                # brand-name field), so a brand name like "zoloft" never
+                # matches. The old message sent callers to browse guideline
+                # IDs, which doesn't actually solve "I don't know the
+                # generic name" -- name the real constraint instead.
                 return {
                     "status": "error",
                     "error": (
                         f"No CPIC guideline found for drug '{drug}'. "
-                        "Use CPIC_list_guidelines to find valid guideline IDs."
+                        "CPIC only indexes generic drug names (e.g. "
+                        "'sertraline', not 'Zoloft') -- try the generic "
+                        "name, or use CPIC_list_guidelines to browse "
+                        "available guidelines."
                     ),
                 }
             guideline_id, rxnorm_id = result

--- a/src/tooluniverse/dailymed_tool.py
+++ b/src/tooluniverse/dailymed_tool.py
@@ -390,29 +390,9 @@ class DailyMedSPLParserTool(BaseTool):
             for section in sections:
                 text_elements = section.xpath(".//hl7:text", namespaces=self.ns)
                 for text_el in text_elements:
-                    # Extract tables
-                    tables = text_el.xpath(".//hl7:table", namespaces=self.ns)
-                    for table in tables:
-                        table_data = self._extract_table_data(table)
-                        if table_data:
-                            dosing_info.extend(table_data)
-
-                    # Extract paragraphs
-                    paragraphs = text_el.xpath(".//hl7:paragraph", namespaces=self.ns)
-                    for para in paragraphs:
-                        text_content = "".join(para.itertext()).strip()
-                        if text_content and len(text_content) > 10:
-                            dosing_info.append(
-                                {"type": "dosing_text", "content": text_content}
-                            )
-
-                    # Extract list items (some drugs encode dosing as <list><item> elements)
-                    for item in text_el.xpath(".//hl7:item", namespaces=self.ns):
-                        text_content = "".join(item.itertext()).strip()
-                        if text_content and len(text_content) > 5:
-                            dosing_info.append(
-                                {"type": "dosing_text", "content": text_content}
-                            )
+                    dosing_info.extend(
+                        self._extract_ordered_content(text_el, "dosing_text")
+                    )
 
             return {
                 "status": "success",
@@ -500,21 +480,9 @@ class DailyMedSPLParserTool(BaseTool):
             for section in sections:
                 text_elements = section.xpath(".//hl7:text", namespaces=self.ns)
                 for text_el in text_elements:
-                    # Extract tables
-                    tables = text_el.xpath(".//hl7:table", namespaces=self.ns)
-                    for table in tables:
-                        table_data = self._extract_table_data(table)
-                        if table_data:
-                            interactions.extend(table_data)
-
-                    # Extract paragraphs
-                    paragraphs = text_el.xpath(".//hl7:paragraph", namespaces=self.ns)
-                    for para in paragraphs:
-                        text_content = "".join(para.itertext()).strip()
-                        if text_content and len(text_content) > 10:
-                            interactions.append(
-                                {"type": "interaction_text", "content": text_content}
-                            )
+                    interactions.extend(
+                        self._extract_ordered_content(text_el, "interaction_text")
+                    )
 
             return {
                 "status": "success",
@@ -547,21 +515,9 @@ class DailyMedSPLParserTool(BaseTool):
             for section in sections:
                 text_elements = section.xpath(".//hl7:text", namespaces=self.ns)
                 for text_el in text_elements:
-                    # Extract tables
-                    tables = text_el.xpath(".//hl7:table", namespaces=self.ns)
-                    for table in tables:
-                        table_data = self._extract_table_data(table)
-                        if table_data:
-                            pharmacology.extend(table_data)
-
-                    # Extract paragraphs
-                    paragraphs = text_el.xpath(".//hl7:paragraph", namespaces=self.ns)
-                    for para in paragraphs:
-                        text_content = "".join(para.itertext()).strip()
-                        if text_content and len(text_content) > 10:
-                            pharmacology.append(
-                                {"type": "pharmacology_text", "content": text_content}
-                            )
+                    pharmacology.extend(
+                        self._extract_ordered_content(text_el, "pharmacology_text")
+                    )
 
             return {
                 "status": "success",
@@ -574,6 +530,36 @@ class DailyMedSPLParserTool(BaseTool):
                 "status": "error",
                 "error": f"Failed to parse clinical pharmacology: {str(e)}",
             }
+
+    def _extract_ordered_content(
+        self, text_el, text_type: str, min_len: int = 10
+    ) -> List[Dict[str, Any]]:
+        """Fix-R5B-1: walk a <text> element's direct children (paragraph/
+        list/table) in document order instead of the old approach of
+        extracting all tables, then all paragraphs, then all list items in
+        three separate passes. SPL sections routinely interleave a heading
+        paragraph immediately before the table or list it introduces (e.g.
+        "Juvenile Idiopathic Arthritis (2.3):" followed by its dosing
+        table), and the three-pass extraction destroyed that association by
+        grouping every table before every paragraph regardless of where
+        each actually appeared in the source document."""
+        items: List[Dict[str, Any]] = []
+        for child in text_el.iterchildren():
+            tag = etree.QName(child).localname
+            if tag == "table":
+                # _extract_table_data always returns a list, so extend()
+                # handles the empty case without a separate guard.
+                items.extend(self._extract_table_data(child))
+            elif tag == "paragraph":
+                text_content = "".join(child.itertext()).strip()
+                if text_content and len(text_content) > min_len:
+                    items.append({"type": text_type, "content": text_content})
+            elif tag == "list":
+                for item_el in child.xpath(".//hl7:item", namespaces=self.ns):
+                    text_content = "".join(item_el.itertext()).strip()
+                    if text_content and len(text_content) > 5:
+                        items.append({"type": text_type, "content": text_content})
+        return items
 
     def _extract_table_data(self, table_element) -> List[Dict[str, Any]]:
         """Extract structured data from table element."""

--- a/tests/unit/test_clinvar_unrecognized_param.py
+++ b/tests/unit/test_clinvar_unrecognized_param.py
@@ -1,0 +1,62 @@
+"""Regression guard for Fix-R5D-1: ClinVar_search_variants used to silently
+drop any caller-supplied parameter that didn't match a recognized name or
+alias (e.g. "gene_name" instead of "gene"/"gene_symbol"), producing a
+generic "at least one search parameter is required" error with no hint the
+parameter itself was misnamed.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import ClinVarSearchVariants
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ClinVarSearchVariants({"name": "ClinVar_search_variants"})
+
+
+def test_unrecognized_param_names_itself_in_error():
+    tool = _tool()
+    result = tool.run({"gene_name": "BRCA1"})
+
+    assert result["status"] == "error"
+    assert "gene_name" in result["error"]
+    assert "Unrecognized parameter" in result["error"]
+
+
+def test_truly_empty_args_keeps_original_generic_error():
+    tool = _tool()
+    result = tool.run({})
+
+    assert result["status"] == "error"
+    assert result["error"] == "At least one search parameter is required"
+
+
+def test_recognized_gene_param_still_dispatches_request():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        result = tool.run({"gene": "BRCA1"})
+
+    assert result["status"] == "success"
+    mock_request.assert_called_once()
+    assert "BRCA1[gene]" in mock_request.call_args[0][1]["term"]
+
+
+def test_gene_symbol_alias_still_works():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        result = tool.run({"gene_symbol": "BRCA1"})
+
+    assert result["status"] == "success"
+    assert "BRCA1[gene]" in mock_request.call_args[0][1]["term"]

--- a/tests/unit/test_cpic_brand_name_error.py
+++ b/tests/unit/test_cpic_brand_name_error.py
@@ -1,0 +1,45 @@
+"""Regression guard for Fix-R5C-2: CPIC_get_recommendations returned
+"Use CPIC_list_guidelines to find valid guideline IDs" when a brand name
+(e.g. "zoloft") failed to resolve to a guideline -- CPIC's own /drug table
+only indexes generic names, so that suggestion doesn't actually solve a
+caller's "I don't know the generic name" problem. The error now names the
+real constraint and suggests trying the generic name instead.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.cpic_search_pairs_tool import CPICGetRecommendationsTool
+
+pytestmark = pytest.mark.unit
+
+
+def _empty_drug_lookup_response():
+    resp = MagicMock()
+    resp.json.return_value = []
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_brand_name_error_suggests_generic_name():
+    tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+
+    with patch(
+        "tooluniverse.cpic_search_pairs_tool.requests.get",
+        return_value=_empty_drug_lookup_response(),
+    ):
+        result = tool.run({"drug": "zoloft"})
+
+    assert result["status"] == "error"
+    assert "zoloft" in result["error"]
+    assert "generic drug names" in result["error"]
+    assert "sertraline" in result["error"]
+
+
+def test_missing_drug_and_guideline_id_keeps_original_error():
+    tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+    result = tool.run({})
+
+    assert result["status"] == "error"
+    assert "Either guideline_id or drug name is required" in result["error"]

--- a/tests/unit/test_dailymed_ordered_content.py
+++ b/tests/unit/test_dailymed_ordered_content.py
@@ -1,0 +1,80 @@
+"""Regression guard for Fix-R5B-1: DailyMed dosing/interactions/pharmacology
+parsers used to extract all <table> elements first, then all <paragraph>
+elements, then all <list><item> elements, in three separate passes -- this
+destroyed document order and separated a heading paragraph (e.g.
+"Juvenile Idiopathic Arthritis (2.3):") from the table it introduces.
+_extract_ordered_content walks a <text> element's direct children in
+document order instead, so heading text and its table/list stay adjacent.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.dailymed_tool import DailyMedSPLParserTool
+
+pytestmark = pytest.mark.unit
+
+_INTERLEAVED_DOSING_XML = """<?xml version="1.0"?>
+<document xmlns="urn:hl7-org:v3">
+  <component><structuredBody>
+    <component><section>
+      <code code="34068-7"/>
+      <text>
+        <paragraph>Adult Dosing (2.1):</paragraph>
+        <table>
+          <tbody>
+            <tr><td>Adults</td><td>40 mg every other week</td></tr>
+          </tbody>
+        </table>
+        <paragraph>Pediatric Dosing (2.2):</paragraph>
+        <list>
+          <item>10 kg to less than 15 kg: 10 mg every other week</item>
+        </list>
+      </text>
+    </section></component>
+  </structuredBody></component>
+</document>
+"""
+
+
+def _tool():
+    return DailyMedSPLParserTool(
+        {"name": "DailyMed_parse_dosing", "parameter": {"properties": {}}}
+    )
+
+
+def test_dosing_preserves_document_order_across_heading_table_and_list():
+    tool = _tool()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = _INTERLEAVED_DOSING_XML
+
+    with patch("tooluniverse.dailymed_tool.requests.get", return_value=resp):
+        result = tool.run({"operation": "parse_dosing", "setid": "fake-setid"})
+
+    assert result["status"] == "success"
+    items = result["data"]["dosing_info"]
+
+    # The heading immediately before a table/list must stay immediately
+    # before it in the output -- not grouped away into a separate block.
+    contents = [item.get("content") or item.get("data") for item in items]
+    assert contents[0] == "Adult Dosing (2.1):"
+    assert contents[1] == ["Adults", "40 mg every other week"]
+    assert contents[2] == "Pediatric Dosing (2.2):"
+    assert contents[3] == "10 kg to less than 15 kg: 10 mg every other week"
+
+
+def test_dosing_no_section_returns_empty_list():
+    tool = _tool()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = (
+        '<?xml version="1.0"?><document xmlns="urn:hl7-org:v3"></document>'
+    )
+
+    with patch("tooluniverse.dailymed_tool.requests.get", return_value=resp):
+        result = tool.run({"operation": "parse_dosing", "setid": "fake-setid"})
+
+    assert result["status"] == "success"
+    assert result["data"]["dosing_info"] == []


### PR DESCRIPTION
## Summary

Round 5 of the ongoing test-harness sweep. Persona domains this round: neurology, dermatology, psychiatry, OB-GYN/reproductive health, veterinary/comparative oncology. Every issue below was CLI-verified (`python3 -m tooluniverse.cli run <Tool> '<args>'`) before fixing.

## Verified bugs fixed

- **Fix-R5D-1** (`clinvar_tool.py`) — `ClinVar_search_variants` already has an alias convention (`gene_symbol`→`gene`, `significance`→`clinical_significance`, `query`→`condition`), but any other unrecognized key (e.g. `gene_name`) was silently dropped, producing a generic "at least one search parameter is required" error that gave no hint the parameter itself was misnamed. Rather than adding yet another one-off alias, the error now names any unrecognized parameter(s) directly so a caller can fix the typo without guessing.

- **Fix-R5C-2** (`cpic_search_pairs_tool.py`) — `CPIC_get_recommendations` resolves a drug name to a guideline via CPIC's own `/drug` table, which only indexes generic names (confirmed via raw API query — no brand-name field exists). A brand name like "zoloft" failed to resolve and returned "Use CPIC_list_guidelines to find valid guideline IDs", which doesn't solve the actual problem (not knowing the generic name). The error now names the real constraint and suggests the generic name instead.

- **Fix-R5B-1** (`dailymed_tool.py`) — `_parse_dosing`, `_parse_drug_interactions`, and `_parse_clinical_pharmacology` each extracted all `<table>` elements first, then all `<paragraph>` elements, then all `<list><item>` elements, in three separate xpath passes — destroying document order. SPL sections routinely interleave a heading paragraph immediately before the table/list it introduces (e.g. "Juvenile Idiopathic Arthritis (2.3):" followed by its pediatric dosing table, confirmed via raw XML inspection), and the three-pass extraction grouped every table before every paragraph regardless of where each actually appeared in the source document. Added a shared `_extract_ordered_content()` helper that walks a `<text>` element's direct children in true document order, applied to the three affected methods. `_parse_adverse_reactions` and `_parse_contraindications` were deliberately left untouched — they have different (mutually-exclusive table-or-paragraph) branching logic that a mechanical order fix would silently alter beyond just reordering, and no ordering issue was reported/verified for them this round.

## False positives / deferred (not fixed)

- **R5A-1** — `NCBIGene_get_summary` expects `id` not `gene_id`; error message already names the correct field clearly (naming-intuition mismatch, not a functional bug).
- **R5A-2** — `tu grep -i` unrecognized-argument error — already fixed in round 4 (Fix-R4E-2, PR #298, not yet merged when this round's worktree was branched off main).
- **R5A-3** — `OpenTargets_get_associated_drugs_by_disease_efoId` has two similarly-named clinical-stage fields (`drug.maximumClinicalStage` vs. top-level `maxClinicalStage`) with different values and no disambiguating documentation — likely a legitimate disease-specific vs. global-stage distinction passed through from OpenTargets' GraphQL schema rather than a ToolUniverse-side bug.
- **R5B-2** — `ClinicalTrials_search_studies`'s `query_intr` performs literal text matching rather than mechanism-of-action class expansion (a class-name query like "IL-17 inhibitor" underperforms a specific drug name) — tool description already models correct usage with a specific drug name example; arguably working as documented.
- **R5C-1** — `CPIC_get_gene_info` expects `symbol` not `gene_symbol`; error message already names the correct field clearly.
- **R5D-2** — `FDA_get_pregnancy_effects_info_by_drug_name` and `PubMed_Guidelines_Search` return raw passthrough envelopes without a `status` key, inconsistent with the `{status, data}` convention used by sibling tools — a systemic envelope-consistency issue better handled as a dedicated audit (see the prior issue #288 envelope batch, PRs #290-294) rather than a two-tool patch in this round.
- **R5E-1** — `ensembl_get_taxonomy`'s returned lineage excludes the queried taxon's own record — confirmed faithful to the real upstream Ensembl REST endpoint via direct curl, not a ToolUniverse-side bug (though the tool description doesn't warn about this, which is a documentation gap rather than a functional one).

## Note on file overlap with #298

This PR and round 4's PR (#298, not yet merged) both touch `dailymed_tool.py`, on different methods/fixes (round 4: dedup duplicated SPL sections; round 5: document-order preservation). Whichever merges second may need a small conflict resolution — both changes are independent and compose cleanly.

## Known session-local issue (not a code bug)

The MCP server in this development session holds a stale reference to a garbage-collected `uv` cache dir, causing TLS cert / "tool type not found" errors across `mcp__tooluniverse__*` calls. Every finding above was independently verified via the local CLI, which is unaffected. Documented for consistency with prior round PRs (#295–298) — not something this PR changes.

## Test plan

- [x] 3 new mocked unit test files (`test_dailymed_ordered_content.py`, `test_clinvar_unrecognized_param.py`, `test_cpic_brand_name_error.py`) — 8 new tests, all passing
- [x] Every fix re-verified live via `python3 -m tooluniverse.cli run` after the code change
- [x] Confirmed the 5 pre-existing failures in `tests/tools/test_dailymed_parser.py` (stale envelope-shape assumptions) pre-date this round's changes — not touched
- [x] Auto-regen stub drift (`uv.lock`) reverted before commit — diff contains only intentional changes