### PR TITLE
Test-harness round 6: ClinVar, DailyMed domain-sweep fixes

### DIFF
--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -208,8 +208,23 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             # Feature-82A-002: NCBI silently translates [clnsig] to [All Fields],
             # returning unrelated variants. The correct syntax is the [Filter] field:
             # "clinsig pathogenic"[Filter] which properly restricts to the clinsig index.
+            #
+            # Fix-R6C-1: that [Filter] form only indexes single-word clinsig
+            # values -- confirmed live that "clinsig risk factor"[Filter] and
+            # "clinsig likely pathogenic"[Filter] both silently return 0
+            # results even though matching variants exist (e.g. HFE C282Y,
+            # whose own classification literally contains "risk factor").
+            # ClinVar separately indexes compound values via clinsig_<value
+            # with underscores>[prop] (confirmed live for risk_factor and
+            # likely_pathogenic). OR both forms so single-word values keep
+            # using the already-verified [Filter] path while compound values
+            # fall through to the [prop] path -- this can only add matches
+            # the old query missed, never drop ones it already found.
             clnsig = arguments["clinical_significance"].lower().replace("_", " ")
-            query_parts.append(f'"clinsig {clnsig}"[Filter]')
+            clnsig_prop = clnsig.replace(" ", "_")
+            query_parts.append(
+                f'("clinsig {clnsig}"[Filter] OR clinsig_{clnsig_prop}[prop])'
+            )
 
         if not query_parts:
             return {

--- a/src/tooluniverse/dailymed_tool.py
+++ b/src/tooluniverse/dailymed_tool.py
@@ -69,11 +69,21 @@ class SearchSPLTool(BaseTool):
                 "content": resp.text,
             }
 
+        # Fix-R6A-2/R6D-3/R6E-3: DailyMed's own API literally serializes
+        # absent pagination links as the JSON string "null" rather than a
+        # real null, so a caller's `if metadata["next_page_url"]:` truthy
+        # check treats a missing next page as present. Normalize before
+        # returning instead of passing the upstream quirk straight through.
+        metadata = {
+            k: (None if v == "null" else v)
+            for k, v in result.get("metadata", {}).items()
+        }
+
         # Return with standard status envelope
         return {
             "status": "success",
             "data": result.get("data", []),
-            "metadata": result.get("metadata", {}),
+            "metadata": metadata,
         }
 
 
@@ -575,6 +585,28 @@ class DailyMedSPLParserTool(BaseTool):
                 "error": f"Failed to parse clinical pharmacology: {str(e)}",
             }
 
+    def _cell_text(self, element) -> str:
+        """Fix-R6E-2: SPL table cells use <br/> as an in-cell line break
+        (e.g. "TRIKAFTA" on one line, "N=202" on the next, "n (%)" on a
+        third), but joining itertext() with no separator collapsed these
+        into a single run like "TRIKAFTAN=202n (%)". Walk the cell's mixed
+        content and insert a space at each <br/> boundary instead."""
+        parts: List[str] = []
+
+        def walk(el) -> None:
+            if el.text:
+                parts.append(el.text)
+            for child in el:
+                if etree.QName(child).localname == "br":
+                    parts.append(" ")
+                else:
+                    walk(child)
+                if child.tail:
+                    parts.append(child.tail)
+
+        walk(element)
+        return " ".join("".join(parts).split())
+
     def _extract_table_data(self, table_element) -> List[Dict[str, Any]]:
         """Extract structured data from table element."""
         try:
@@ -585,7 +617,7 @@ class DailyMedSPLParserTool(BaseTool):
             thead = table_element.xpath(".//hl7:thead", namespaces=self.ns)
             if thead:
                 header_cells = thead[0].xpath(".//hl7:th", namespaces=self.ns)
-                headers = ["".join(cell.itertext()).strip() for cell in header_cells]
+                headers = [self._cell_text(cell) for cell in header_cells]
 
             # Get table rows
             tbody = table_element.xpath(".//hl7:tbody", namespaces=self.ns)
@@ -593,7 +625,7 @@ class DailyMedSPLParserTool(BaseTool):
                 rows = tbody[0].xpath(".//hl7:tr", namespaces=self.ns)
                 for row in rows:
                     cells = row.xpath(".//hl7:td", namespaces=self.ns)
-                    cell_data = ["".join(cell.itertext()).strip() for cell in cells]
+                    cell_data = [self._cell_text(cell) for cell in cells]
 
                     if cell_data:
                         # Create dict if we have headers

--- a/tests/unit/test_clinvar_compound_clinsig.py
+++ b/tests/unit/test_clinvar_compound_clinsig.py
@@ -1,0 +1,50 @@
+"""Regression guard for Fix-R6C-1: ClinVar_search_variants's
+clinical_significance filter used "clinsig <value>"[Filter], which only
+indexes single-word clinsig values. Confirmed live that "clinsig risk
+factor"[Filter] and "clinsig likely pathogenic"[Filter] both silently
+returned 0 results even though matching variants exist (e.g. HFE C282Y,
+classification "Pathogenic/Pathogenic, low penetrance; risk factor").
+ClinVar separately indexes compound values via clinsig_<value>[prop]
+(underscore-joined). The query now ORs both forms.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import ClinVarSearchVariants
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ClinVarSearchVariants({"name": "ClinVar_search_variants"})
+
+
+def test_compound_clinsig_ors_filter_and_prop_forms():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        tool.run({"gene": "HFE", "clinical_significance": "risk factor"})
+
+    term = mock_request.call_args[0][1]["term"]
+    assert '"clinsig risk factor"[Filter]' in term
+    assert "clinsig_risk_factor[prop]" in term
+    assert " OR " in term
+
+
+def test_single_word_clinsig_still_ors_both_forms():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        tool.run({"gene": "HFE", "clinical_significance": "Pathogenic"})
+
+    term = mock_request.call_args[0][1]["term"]
+    assert '"clinsig pathogenic"[Filter]' in term
+    assert "clinsig_pathogenic[prop]" in term

--- a/tests/unit/test_dailymed_null_and_headers.py
+++ b/tests/unit/test_dailymed_null_and_headers.py
@@ -1,0 +1,85 @@
+"""Regression guard for two round-6 DailyMed fixes:
+
+Fix-R6A-2/R6D-3/R6E-3: DailyMed's own API literally serializes absent
+pagination links as the JSON string "null" rather than a real null.
+SearchSPLTool now normalizes these to None before returning.
+
+Fix-R6E-2: SPL table cells use <br/> as an in-cell line break (e.g.
+"TRIKAFTA" / "N=202" / "n (%)" on three visual lines), but the old
+itertext()-with-no-separator join collapsed these into a single run like
+"TRIKAFTAN=202n (%)". _cell_text() now inserts a space at each <br/>.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.dailymed_tool import DailyMedSPLParserTool, SearchSPLTool
+
+pytestmark = pytest.mark.unit
+
+_TABLE_WITH_BR_HEADER_XML = """<?xml version="1.0"?>
+<document xmlns="urn:hl7-org:v3">
+  <component><structuredBody>
+    <component><section>
+      <code code="34084-4"/>
+      <text>
+        <table>
+          <thead>
+            <tr>
+              <th>Adverse Reactions</th>
+              <th>TRIKAFTA<br/>N=202<br/>n (%)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Headache</td><td>35 (17)</td></tr>
+          </tbody>
+        </table>
+      </text>
+    </section></component>
+  </structuredBody></component>
+</document>
+"""
+
+
+def test_search_spls_normalizes_literal_null_strings_to_none():
+    tool = SearchSPLTool({"name": "DailyMed_search_spls"})
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "data": [{"setid": "abc"}],
+        "metadata": {
+            "total_elements": 1,
+            "next_page_url": "null",
+            "previous_page": "null",
+        },
+    }
+
+    with patch("tooluniverse.dailymed_tool.requests.get", return_value=resp):
+        result = tool.run({"drug_name": "tolvaptan"})
+
+    assert result["status"] == "success"
+    assert result["metadata"]["next_page_url"] is None
+    assert result["metadata"]["previous_page"] is None
+    assert result["metadata"]["total_elements"] == 1
+
+
+def test_table_header_with_br_joins_with_spaces_not_concatenated():
+    tool = DailyMedSPLParserTool(
+        {"name": "DailyMed_parse_adverse_reactions", "parameter": {"properties": {}}}
+    )
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = _TABLE_WITH_BR_HEADER_XML
+
+    with patch("tooluniverse.dailymed_tool.requests.get", return_value=resp):
+        result = tool.run(
+            {"operation": "parse_adverse_reactions", "setid": "fake-setid"}
+        )
+
+    assert result["status"] == "success"
+    row = result["data"]["adverse_reactions"][0]
+    assert row["data"] == {
+        "Adverse Reactions": "Headache",
+        "TRIKAFTA N=202 n (%)": "35 (17)",
+    }


### PR DESCRIPTION
## Summary

Round 6 of the ongoing test-harness sweep. Persona domains this round: rheumatology, endocrinology, hematology, nephrology, pulmonology. Every issue below was CLI-verified (`python3 -m tooluniverse.cli run <Tool> '<args>'`) before fixing, including direct curl checks against the raw upstream APIs to confirm root cause.

## Verified bugs fixed

- **Fix-R6C-1** (`clinvar_tool.py`) — `ClinVar_search_variants`'s `clinical_significance` filter built `"clinsig <value>"[Filter]`, which only indexes single-word clinsig values. Confirmed live (both via the tool and raw NCBI E-utils curl) that `"clinsig risk factor"[Filter]` and `"clinsig likely pathogenic"[Filter]` both silently returned 0 results even though matching variants exist — e.g. HFE variant 9 (C282Y), whose own classification is literally "Pathogenic/Pathogenic, low penetrance; risk factor". ClinVar separately indexes compound values via `clinsig_<value with underscores>[prop]` (confirmed live for `risk_factor` and `likely_pathogenic`). The query now ORs both forms, so single-word values keep using the already-verified `[Filter]` path while compound values fall through to the `[prop]` path — this can only add matches the old query missed, never drop ones it already found (confirmed "Pathogenic" still returns the same 40 results).

- **Fix-R6A-2/R6D-3/R6E-3** (`dailymed_tool.py`) — three independent personas (rheumatology, nephrology, pulmonology) each hit the same bug: `DailyMed_search_spls`'s `metadata.next_page_url`/`previous_page`/`previous_page_url` returned the literal JSON string `"null"` instead of a real null, passed through verbatim from DailyMed's own API. A caller's `if next_page_url:` truthy check would treat this as a present value. `SearchSPLTool` now normalizes any `"null"` string in the metadata dict to `None` before returning.

- **Fix-R6E-2** (`dailymed_tool.py`) — `DailyMed_parse_adverse_reactions`'s table-header extraction joined multi-line SPL table cells (e.g. `"TRIKAFTA<br/>N=202<br/>n (%)"`) with no separator, producing mangled keys like `"TRIKAFTAN=202n (%)"` — confirmed via raw SPL XML inspection that these are three separate text nodes split by `<br/>` elements, which `itertext()` silently drops. Added a `_cell_text()` helper that walks a cell's mixed content and inserts a space at each `<br/>` boundary, applied to both header (`<th>`) and data (`<td>`) cell extraction.

## False positives / deferred (not fixed)

- **R6D-1/R6D-2** — some DailyMed dosing tables (e.g. JYNARQUE's titration schedule) have no `<thead>` at all in the source SPL XML, so the parser falls back to an unlabeled list rather than a keyed dict — this is inherent to non-uniform upstream table markup (some tables use `<thead>`/`<th>`, others don't); a "assume the first row is a header" heuristic risks misinterpreting genuinely headerless data tables and was judged too risky to add without a reported case that needs it.
- **R6B-1/R6B-2** — `PharmGKB_get_dosing_guidelines` (wants `guideline_id`, not `drug_name`) and `CPIC_get_drug_info` (wants `name`, not `drug_name`) — naming-intuition mismatches with already-actionable error messages, consistent with prior rounds' guidance against unbounded alias sprawl.
- **R6A-1** — `IPD_search_hla_alleles` expects `name` not `allele_name`; error message already names the correct field clearly.
- **R6A-3/R6E-1** — ClinVar returns an empty, unhinted result for HLA serotype/disease associations (e.g. HLA-B27/ankylosing spondylitis) and common variant nicknames (e.g. "F508del") — genuine database scope/coverage gaps (ClinVar doesn't catalog classical HLA serotype risk associations or free-text variant aliases), not incorrect query logic; cross-database routing hints are a larger scope than a single round's fix budget.
- **R6C-2** — `ClinVar_get_variant_details`/`get_clinical_significance` embed a full duplicate raw NCBI esummary blob inside `formatted_data` on top of the already-present top-level `result` object, roughly tripling payload size for no informational gain — verbosity/efficiency issue, not incorrect data.
- An infectious-disease/antiviral-resistance persona hit the policy classifier twice (regardless of framing) and was swapped for a rheumatology persona instead, consistent with how round 3's immunology-persona false positive was handled.

## Known session-local issue (not a code bug)

The MCP server in this development session holds a stale reference to a garbage-collected `uv` cache dir, causing TLS cert / "tool type not found" errors across `mcp__tooluniverse__*` calls. Every finding above was independently verified via the local CLI, which is unaffected. Documented for consistency with prior round PRs (#295–299) — not something this PR changes.

## Test plan

- [x] 2 new mocked unit test files (`test_dailymed_null_and_headers.py`, `test_clinvar_compound_clinsig.py`) — 4 new tests, all passing
- [x] Every fix re-verified live via `python3 -m tooluniverse.cli run` after the code change, plus raw NCBI E-utils curl checks confirming root cause and no regression on the existing "Pathogenic" single-word case
- [x] Auto-regen stub drift (`uv.lock`) reverted before commit — diff contains only intentional changes