### PR TITLE
Test-harness round 7: DailyMed, PubMed guideline-search domain-sweep fixes

### DIFF
--- a/src/tooluniverse/dailymed_tool.py
+++ b/src/tooluniverse/dailymed_tool.py
@@ -337,27 +337,11 @@ class DailyMedSPLParserTool(BaseTool):
 
             adverse_reactions = []
             for section in sections:
-                # Extract text content
                 text_elements = section.xpath(".//hl7:text", namespaces=self.ns)
                 for text_el in text_elements:
-                    # Look for tables
-                    tables = text_el.xpath(".//hl7:table", namespaces=self.ns)
-                    for table in tables:
-                        table_data = self._extract_table_data(table)
-                        if table_data:
-                            adverse_reactions.extend(table_data)
-
-                    # If no tables, extract paragraph text
-                    if not tables:
-                        paragraphs = text_el.xpath(
-                            ".//hl7:paragraph", namespaces=self.ns
-                        )
-                        for para in paragraphs:
-                            text_content = "".join(para.itertext()).strip()
-                            if text_content and len(text_content) > 10:
-                                adverse_reactions.append(
-                                    {"type": "text", "content": text_content}
-                                )
+                    adverse_reactions.extend(
+                        self._extract_ordered_content(text_el, "text")
+                    )
 
             return {
                 "status": "success",
@@ -574,6 +558,34 @@ class DailyMedSPLParserTool(BaseTool):
                 "status": "error",
                 "error": f"Failed to parse clinical pharmacology: {str(e)}",
             }
+
+    def _extract_ordered_content(
+        self, text_el, text_type: str, min_len: int = 10
+    ) -> List[Dict[str, Any]]:
+        """Fix-R7A-1: walk a <text> element's direct children (paragraph/
+        list/table) in document order instead of the old "extract tables;
+        if no tables, extract paragraphs" logic, which had no handling for
+        <list>/<item> elements at all. Confirmed live that warfarin's
+        adverse-reactions section encodes its actual reaction list as
+        <list><item> blocks alongside intro <paragraph> sentences -- the
+        old code silently dropped every list item, leaving only the two
+        generic intro sentences and none of the clinically relevant
+        content."""
+        items: List[Dict[str, Any]] = []
+        for child in text_el.iterchildren():
+            tag = etree.QName(child).localname
+            if tag == "table":
+                items.extend(self._extract_table_data(child))
+            elif tag == "paragraph":
+                text_content = "".join(child.itertext()).strip()
+                if text_content and len(text_content) > min_len:
+                    items.append({"type": text_type, "content": text_content})
+            elif tag == "list":
+                for item_el in child.xpath(".//hl7:item", namespaces=self.ns):
+                    text_content = "".join(item_el.itertext()).strip()
+                    if text_content and len(text_content) > 5:
+                        items.append({"type": text_type, "content": text_content})
+        return items
 
     def _extract_table_data(self, table_element) -> List[Dict[str, Any]]:
         """Extract structured data from table element."""

--- a/src/tooluniverse/unified_guideline_tools.py
+++ b/src/tooluniverse/unified_guideline_tools.py
@@ -4,6 +4,7 @@ Unified Guideline Tools
 Consolidated clinical guidelines search tools from multiple sources.
 """
 
+import html
 import requests
 import time
 import re
@@ -340,7 +341,13 @@ class PubMedGuidelinesTool(BaseTool):
                 if abstract_match:
                     # Clean HTML tags from abstract
                     abstract = re.sub(r"<[^>]+>", "", abstract_match.group(1))
-                    abstracts[pmid] = abstract.strip()
+                    # Fix-R7B-2/R7E-1: this regex-based extraction never
+                    # actually parses the XML, so entity references like
+                    # "&#x2265;" (confirmed present verbatim in PubMed's raw
+                    # efetch XML for "&#x2265;" / "&#xe7;" etc.) were left
+                    # undecoded, unlike PubMed_search_articles which uses a
+                    # real XML parser that resolves them automatically.
+                    abstracts[pmid] = html.unescape(abstract).strip()
                 else:
                     abstracts[pmid] = ""
 

--- a/tests/unit/test_dailymed_adverse_reactions_lists.py
+++ b/tests/unit/test_dailymed_adverse_reactions_lists.py
@@ -1,0 +1,55 @@
+"""Regression guard for Fix-R7A-1: DailyMed_parse_adverse_reactions had no
+handling for <hl7:list>/<hl7:item> elements at all -- it only extracted
+<table> content, or (if no table) <paragraph> text. Confirmed live that
+warfarin's adverse-reactions section encodes its actual reaction list as
+<list><item> blocks alongside intro <paragraph> sentences, so every real
+reaction item (hemorrhage, tissue necrosis, calciphylaxis, ...) was
+silently dropped, leaving only the two generic intro sentences.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.dailymed_tool import DailyMedSPLParserTool
+
+pytestmark = pytest.mark.unit
+
+_ADVERSE_REACTIONS_WITH_LIST_XML = """<?xml version="1.0"?>
+<document xmlns="urn:hl7-org:v3">
+  <component><structuredBody>
+    <component><section>
+      <code code="34084-4"/>
+      <text>
+        <paragraph>The following serious adverse reactions are discussed elsewhere:</paragraph>
+        <list>
+          <item>Hemorrhage</item>
+          <item>Tissue Necrosis</item>
+          <item>Calciphylaxis</item>
+        </list>
+      </text>
+    </section></component>
+  </structuredBody></component>
+</document>
+"""
+
+
+def test_adverse_reactions_includes_list_items_not_just_intro_paragraph():
+    tool = DailyMedSPLParserTool(
+        {"name": "DailyMed_parse_adverse_reactions", "parameter": {"properties": {}}}
+    )
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = _ADVERSE_REACTIONS_WITH_LIST_XML
+
+    with patch("tooluniverse.dailymed_tool.requests.get", return_value=resp):
+        result = tool.run(
+            {"operation": "parse_adverse_reactions", "setid": "fake-setid"}
+        )
+
+    assert result["status"] == "success"
+    contents = [item["content"] for item in result["data"]["adverse_reactions"]]
+    assert "Hemorrhage" in contents
+    assert "Tissue Necrosis" in contents
+    assert "Calciphylaxis" in contents
+    assert result["data"]["count"] == 4

--- a/tests/unit/test_pubmed_guidelines_entity_decoding.py
+++ b/tests/unit/test_pubmed_guidelines_entity_decoding.py
@@ -1,0 +1,59 @@
+"""Regression guard for Fix-R7B-2/R7E-1: PubMedGuidelinesTool extracted
+abstracts via regex on raw, unparsed efetch XML text, so entity references
+like "&#x2265;" (confirmed present verbatim in PubMed's real efetch XML,
+e.g. "NEWS/NEWS2 &#x2265; 5") were never resolved -- unlike
+PubMed_search_articles, which uses a real XML parser that decodes them
+automatically. html.unescape() now runs after the tag-strip regex.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.unified_guideline_tools import PubMedGuidelinesTool
+
+pytestmark = pytest.mark.unit
+
+_SEARCH_JSON = {"esearchresult": {"idlist": ["123"], "count": "1"}}
+_SUMMARY_JSON = {
+    "result": {
+        "123": {
+            "title": "Sepsis guideline",
+            "authors": [{"name": "Doe J"}],
+            "pubtype": ["Guideline"],
+            "source": "Crit Care Med",
+            "pubdate": "2026",
+            "elocationid": "",
+        }
+    }
+}
+_ABSTRACT_XML = (
+    "<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>123</PMID>"
+    "<Article><Abstract><AbstractText>"
+    "Criteria include NEWS/NEWS2 &#x2265; 5 and Shock Index &#x2265; 0.7."
+    "</AbstractText></Article></MedlineCitation></PubmedArticle></PubmedArticleSet>"
+)
+
+
+def test_abstract_entities_are_decoded():
+    tool = PubMedGuidelinesTool({"name": "PubMed_Guidelines_Search"})
+
+    search_resp = MagicMock()
+    search_resp.json.return_value = _SEARCH_JSON
+    summary_resp = MagicMock()
+    summary_resp.json.return_value = _SUMMARY_JSON
+    abstract_resp = MagicMock()
+    abstract_resp.text = _ABSTRACT_XML
+
+    with patch.object(
+        tool.session,
+        "get",
+        side_effect=[search_resp, summary_resp, abstract_resp],
+    ), patch("tooluniverse.unified_guideline_tools.time.sleep"):
+        results = tool.run({"query": "sepsis vasopressor"})
+
+    assert len(results) == 1
+    abstract = results[0]["abstract"]
+    assert "≥" in abstract
+    assert "&#x2265;" not in abstract
+    assert "&amp;" not in abstract


### PR DESCRIPTION
## Summary

Round 7 of the ongoing test-harness sweep. Persona domains this round: geriatrics, pediatrics, sports medicine/orthopedics, medical genetics counseling, critical care. Every issue below was CLI-verified (`python3 -m tooluniverse.cli run <Tool> '<args>'`) before fixing, including direct curl checks against the raw upstream APIs to confirm root cause.

## Verified bugs fixed

- **Fix-R7A-1** (`dailymed_tool.py`) — `DailyMed_parse_adverse_reactions` had no handling for `<hl7:list>/<hl7:item>` elements at all — it only extracted `<table>` content, or (if no table) `<paragraph>` text. Confirmed live and via raw SPL XML inspection that warfarin's adverse-reactions section encodes its actual reaction list as `<list><item>` blocks (Hemorrhage, Tissue Necrosis, Calciphylaxis, Acute Kidney Injury, etc.) alongside intro `<paragraph>` sentences — every real reaction item was silently dropped, leaving only 4 generic sentences where a clinician would expect the full FDA-labeled list. Added an `_extract_ordered_content()` helper (walks a `<text>` element's paragraph/list/table children in document order) and rewired `_parse_adverse_reactions` to use it, taking the reaction count for the verified case from 4 to 18. This is the same fix pattern already applied to `_parse_dosing`/`_parse_drug_interactions`/`_parse_clinical_pharmacology` in a separate, still-unmerged round-5 PR (#299) — reimplemented here since this round's worktree branched off `main` before #299 merged; the two will need a small conflict resolution at merge time, whichever lands second.

- **Fix-R7B-2/R7E-1** (`unified_guideline_tools.py`) — `PubMed_Guidelines_Search` extracted abstracts via regex directly on raw, unparsed efetch XML text, so entity references were never resolved — confirmed via raw curl against PubMed's efetch endpoint that the true source XML contains standard single-escaped numeric character references like `&#x2265;` (verified for PMID 42044523, the exact article both the critical-care and pediatrician personas independently hit), which the sibling `PubMed_search_articles` correctly decodes because it uses a real XML parser, but this tool's regex-based tag-stripping left as literal undecoded text. Added `html.unescape()` after the tag-strip regex.

## False positives / deferred (not fixed)

- **R7A-2/R7D-3** — `CPIC_get_gene_info` (wants `symbol` not `gene`/`gene_symbol`) and `tu grep -i` (already fixed in round 4, Fix-R4E-2, PR #298, not yet merged when this round's worktree was branched off main) — naming-intuition mismatches with already-actionable error messages.
- **R7B-1/R7D-2** — `PubMed_Guidelines_Search` returns a bare array/dict with no status/data envelope, inconsistent with sibling `PubMed_search_articles` — independently reported a 3rd time across rounds (also R5D-2 in round 5); a systemic envelope-consistency issue better handled as a dedicated audit (see the prior issue #288 envelope batch, PRs #290–294) than a per-round patch, consistent with the round-5 deferral of the same class of issue.
- **R7C-1** — DailyMed's `drug_name`→setid auto-lookup for "ibuprofen" resolved to a combination acetaminophen+ibuprofen product (COMBOGESIC) rather than a single-ingredient label, apparently picking the most-recently-published SPL rather than the best name match — a real data-attribution concern, but a "prefer exact/single-ingredient match" heuristic risks new misclassifications for other drugs and needs more design thought than a single round allows.
- **R7C-2** — `DailyMed_parse_contraindications` gives the same misleading "Missing required parameter: setid" message for a misspelled `drug_name` as for no `drug_name` at all — already fixed in round 4 (Fix-R4C-2, PR #298, not yet merged) for the shared setid-resolution code path used by all `DailyMedSPLParserTool` operations, including this one.
- **R7D-1** — `ClinVar_get_variant_details`'s `protein_change` field returns multiple concatenated stop-codon calls (e.g. "E634\*, E672\*, ..., E703\*") for what's presented as a single specific variant — confirmed via raw NCBI esummary curl that this is genuine upstream data (NCBI's own response literally contains this multi-value string, likely aggregating protein_change annotations across multiple transcript isoforms), not a ToolUniverse-side bug.
- **R7D-4** — `PubMed_Guidelines_Search`'s `tu info` example args use a generic non-clinical query — cosmetic documentation gap.

## Known session-local issue (not a code bug)

The MCP server in this development session holds a stale reference to a garbage-collected `uv` cache dir, causing TLS cert / "tool type not found" errors across `mcp__tooluniverse__*` calls. Every finding above was independently verified via the local CLI, which is unaffected. Documented for consistency with prior round PRs (#295–300) — not something this PR changes.

## Test plan

- [x] 2 new mocked unit test files (`test_dailymed_adverse_reactions_lists.py`, `test_pubmed_guidelines_entity_decoding.py`) — 2 new tests, both passing
- [x] Every fix re-verified live via `python3 -m tooluniverse.cli run` after the code change, plus raw upstream API curl checks confirming root cause (SPL XML structure for the DailyMed fix; efetch XML entity encoding for the PubMed fix)
- [x] Auto-regen stub drift (`uv.lock`) reverted before commit — diff contains only intentional changes