### PR TITLE
Test-harness round 8: ClinVar, ClinicalTrials domain-sweep fixes

### DIFF
--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -188,7 +188,15 @@ class ClinVarSearchVariants(ClinVarRESTTool):
         query_parts = []
 
         if "gene" in arguments:
-            query_parts.append(f"{arguments['gene']}[gene]")
+            # Fix-R8B-1: HGNC gene symbols don't contain hyphens (modern
+            # nomenclature phased them out decades ago), but older
+            # literature/informal usage still writes them hyphenated (e.g.
+            # "BRCA-2", "HER-2") -- ClinVar's [gene] index only matches the
+            # canonical unhyphenated form, so a hyphenated query silently
+            # returned 0 results (confirmed live and via raw NCBI E-utils:
+            # "BRCA-2[gene]" -> 0 hits, "BRCA2[gene]" -> 21879 hits).
+            gene = arguments["gene"].strip().replace("-", "")
+            query_parts.append(f"{gene}[gene]")
 
         if "condition" in arguments:
             # Feature-70B-005: [disease/phenotype] is not a valid ClinVar eSearch field.
@@ -211,7 +219,41 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             clnsig = arguments["clinical_significance"].lower().replace("_", " ")
             query_parts.append(f'"clinsig {clnsig}"[Filter]')
 
+        # Fix-R5D-1/R8C-1: a caller-supplied param that doesn't match any
+        # recognized name/alias (e.g. "gene_name" instead of "gene", or
+        # "variant_name" -- there is no such parameter, only "variant_id")
+        # was silently dropped. When it's the ONLY param supplied, this
+        # produced a generic "at least one search parameter is required"
+        # error with no hint the parameter itself was misnamed. When OTHER
+        # valid params are also supplied, the query still runs but silently
+        # ignores the unrecognized one -- confirmed live that
+        # {"gene": "GJB2", "variant_name": "35delG"} returns all 739 GJB2
+        # variants with no indication the variant_name filter had zero
+        # effect. Name unrecognized parameter(s) in both cases.
+        recognized = {
+            "gene",
+            "gene_symbol",
+            "condition",
+            "query",
+            "variant_id",
+            "clinical_significance",
+            "significance",
+            "max_results",
+            "limit",
+        }
+        unrecognized = sorted(set(arguments) - recognized)
+
         if not query_parts:
+            if unrecognized:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"Unrecognized parameter(s): {', '.join(unrecognized)}. "
+                        "Valid search parameters: gene (or gene_symbol), "
+                        "condition (or query), variant_id, "
+                        "clinical_significance (or significance)."
+                    ),
+                }
             return {
                 "status": "error",
                 "error": "At least one search parameter is required",
@@ -257,16 +299,16 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             }.items()
             if v is not None
         }
-        return {
-            "status": "success",
-            "data": {
-                "total_count": count,
-                "variant_ids": ids,
-                "variants": variants,
-                "query_translation": esearch.get("querytranslation", ""),
-                "search_params": search_params,
-            },
+        response_data = {
+            "total_count": count,
+            "variant_ids": ids,
+            "variants": variants,
+            "query_translation": esearch.get("querytranslation", ""),
+            "search_params": search_params,
         }
+        if unrecognized:
+            response_data["ignored_parameters"] = unrecognized
+        return {"status": "success", "data": response_data}
 
 
 @register_tool("ClinVarGetVariantDetails")
@@ -304,6 +346,15 @@ class ClinVarGetVariantDetails(ClinVarRESTTool):
             **self._parse_variant_summary(variant_data),
             "raw_data": variant_data,
         }
+        # Fix-R8E-1/R6C-2: `result["data"]` (the full, unprocessed esummary
+        # envelope from _make_request) duplicates the same content already
+        # exposed at formatted_data["raw_data"] -- keeping both roughly
+        # tripled payload size for no informational gain and made this
+        # tool's output nearly indistinguishable from
+        # ClinVarGetClinicalSignificance's, which has the identical
+        # duplication. Drop the redundant top-level copy; raw access is
+        # still available via formatted_data.raw_data.
+        result.pop("data", None)
 
         return result
 
@@ -359,5 +410,8 @@ class ClinVarGetClinicalSignificance(ClinVarRESTTool):
             },
             "raw_data": variant_data,
         }
+        # Fix-R8E-1/R6C-2: see the matching fix in ClinVarGetVariantDetails
+        # -- result["data"] duplicates formatted_data["raw_data"].
+        result.pop("data", None)
 
         return result

--- a/src/tooluniverse/data/clinicaltrials_gov_tools.json
+++ b/src/tooluniverse/data/clinicaltrials_gov_tools.json
@@ -978,6 +978,7 @@
     "description": "Search ClinicalTrials.gov for clinical trial studies by condition, intervention, sponsor, or other criteria. Returns NCT IDs, titles, status, phase, enrollment, and key trial metadata. Example: search for 'breast cancer' trials with 'pembrolizumab' that are RECRUITING in Phase 3.",
     "parameter": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "query_cond": {
           "type": [

--- a/tests/unit/test_clinicaltrials_search_studies_schema.py
+++ b/tests/unit/test_clinicaltrials_search_studies_schema.py
@@ -1,0 +1,35 @@
+"""Regression guard for Fix-R8C-2: ClinicalTrials_search_studies had no
+additionalProperties restriction, so an unrecognized parameter (e.g.
+"intervention" -- the real key is "query_intr") was silently ignored
+rather than rejected, and the query ran anyway using only the recognized
+params. Matches the same additionalProperties: false fix already applied
+to the sibling search_clinical_trials tool.
+"""
+
+import json
+
+import jsonschema
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _load_schema():
+    with open("src/tooluniverse/data/clinicaltrials_gov_tools.json") as f:
+        tools = json.load(f)
+    tool = next(t for t in tools if t["name"] == "ClinicalTrials_search_studies")
+    return tool["parameter"]
+
+
+def test_schema_rejects_unrecognized_key():
+    schema = _load_schema()
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            {"condition": "hearing loss", "intervention": "gene therapy"}, schema
+        )
+
+
+def test_schema_accepts_documented_alias_and_real_params():
+    schema = _load_schema()
+    jsonschema.validate({"condition": "hearing loss", "max_results": 5}, schema)
+    jsonschema.validate({"query_cond": "hearing loss", "query_intr": "gene therapy"}, schema)

--- a/tests/unit/test_clinvar_gene_hyphen_and_params.py
+++ b/tests/unit/test_clinvar_gene_hyphen_and_params.py
@@ -1,0 +1,101 @@
+"""Regression guard for two round-8 ClinVar_search_variants fixes:
+
+Fix-R8B-1: HGNC gene symbols don't contain hyphens, but informal usage
+still writes them hyphenated (e.g. "BRCA-2"). ClinVar's [gene] index only
+matches the canonical unhyphenated form, so a hyphenated query silently
+returned 0 results.
+
+Fix-R5D-1/R8C-1: an unrecognized parameter (e.g. "variant_name", which
+doesn't exist -- only "variant_id" does) was silently dropped. When it was
+the only param supplied, this produced a generic "at least one search
+parameter is required" error; when other valid params were also supplied,
+the query ran but silently ignored the unrecognized one with no
+indication the filter had zero effect.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import ClinVarSearchVariants
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ClinVarSearchVariants({"name": "ClinVar_search_variants"})
+
+
+def _patch_request():
+    return patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    )
+
+
+def test_hyphenated_gene_symbol_is_normalized():
+    tool = _tool()
+    with _patch_request() as mock_request:
+        tool.run({"gene": "BRCA-2"})
+
+    assert "BRCA2[gene]" in mock_request.call_args[0][1]["term"]
+    assert "BRCA-2" not in mock_request.call_args[0][1]["term"]
+
+
+def test_plain_gene_symbol_unaffected():
+    tool = _tool()
+    with _patch_request() as mock_request:
+        tool.run({"gene": "BRCA2"})
+
+    assert "BRCA2[gene]" in mock_request.call_args[0][1]["term"]
+
+
+def test_unrecognized_param_alone_names_itself_in_error():
+    tool = _tool()
+    result = tool.run({"variant_name": "35delG"})
+
+    assert result["status"] == "error"
+    assert "variant_name" in result["error"]
+    assert "Unrecognized parameter" in result["error"]
+
+
+def test_unrecognized_param_alongside_valid_param_is_noted_not_silently_dropped():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        side_effect=[
+            {
+                "status": "success",
+                "data": {
+                    "esearchresult": {
+                        "idlist": [],
+                        "count": "739",
+                        "querytranslation": "GJB2[gene]",
+                    }
+                },
+            },
+        ],
+    ):
+        result = tool.run({"gene": "GJB2", "variant_name": "35delG"})
+
+    assert result["status"] == "success"
+    assert result["data"]["ignored_parameters"] == ["variant_name"]
+    assert result["data"]["total_count"] == 739
+
+
+def test_all_valid_params_have_no_ignored_parameters_key():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={
+            "status": "success",
+            "data": {"esearchresult": {"idlist": [], "count": "1", "querytranslation": ""}},
+        },
+    ):
+        result = tool.run({"gene": "BRCA2"})
+
+    assert result["status"] == "success"
+    assert "ignored_parameters" not in result["data"]

--- a/tests/unit/test_clinvar_no_duplicate_raw_data.py
+++ b/tests/unit/test_clinvar_no_duplicate_raw_data.py
@@ -1,0 +1,68 @@
+"""Regression guard for Fix-R8E-1/R6C-2: ClinVarGetVariantDetails and
+ClinVarGetClinicalSignificance both returned the full raw esummary blob
+twice -- once as the top-level "data" key (from the underlying
+_make_request envelope) and again inside formatted_data["raw_data"] --
+roughly tripling payload size for no informational gain and making the
+two tools' outputs nearly indistinguishable from each other. The
+top-level duplicate is now dropped; raw access remains available via
+formatted_data.raw_data.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import (
+    ClinVarGetClinicalSignificance,
+    ClinVarGetVariantDetails,
+)
+
+pytestmark = pytest.mark.unit
+
+_VARIANT_DATA = {
+    "accession": "VCV000000009",
+    "obj_type": "single nucleotide variant",
+    "chr_sort": "13",
+    "variation_set": [{"variation_loc": [{"band": "13q13.1"}], "variation_name": "NM_007294.4(BRCA1):c.68_69delAG"}],
+    "title": "NM_007294.4(BRCA1):c.68_69delAG",
+    "genes": [{"symbol": "BRCA1"}],
+    "germline_classification": {"description": "Pathogenic", "review_status": "reviewed"},
+    "clinical_impact_classification": {},
+    "oncogenicity_classification": {},
+}
+
+_FETCH_RESULT = {
+    "status": "success",
+    "data": {"result": {"9": _VARIANT_DATA}},
+    "url": "https://example.com",
+}
+
+
+def _fetch_variant_patch():
+    return patch.object(
+        ClinVarGetVariantDetails.__bases__[0],
+        "_fetch_variant",
+        return_value={"variant_data": _VARIANT_DATA, "result": dict(_FETCH_RESULT)},
+    )
+
+
+def test_get_variant_details_has_no_duplicate_top_level_data():
+    tool = ClinVarGetVariantDetails({"name": "ClinVar_get_variant_details"})
+    with _fetch_variant_patch():
+        result = tool.run({"variant_id": "9"})
+
+    assert "data" not in result
+    assert result["formatted_data"]["raw_data"] == _VARIANT_DATA
+
+
+def test_get_clinical_significance_has_no_duplicate_top_level_data():
+    tool = ClinVarGetClinicalSignificance({"name": "ClinVar_get_clinical_significance"})
+    with patch.object(
+        ClinVarGetClinicalSignificance.__bases__[0],
+        "_fetch_variant",
+        return_value={"variant_data": _VARIANT_DATA, "result": dict(_FETCH_RESULT)},
+    ):
+        result = tool.run({"variant_id": "9"})
+
+    assert "data" not in result
+    assert result["formatted_data"]["raw_data"] == _VARIANT_DATA


### PR DESCRIPTION
## Summary

Round 8 of the ongoing test-harness sweep. Persona domains this round: dentistry/oral health, urology, otolaryngology, palliative care, anesthesiology. Every issue below was CLI-verified (`python3 -m tooluniverse.cli run <Tool> '<args>'`) before fixing, including raw NCBI E-utils curl checks.

## Verified bugs fixed

- **Fix-R8B-1** (`clinvar_tool.py`) — `ClinVar_search_variants`'s gene-symbol query passed the caller's string straight through to ClinVar's `[gene]` index, which only matches canonical unhyphenated HGNC symbols. Older literature/informal usage still hyphenates common gene names ("BRCA-2", "HER-2"), and a hyphenated query silently returned 0 results despite 21,879 real matches existing under the unhyphenated form (confirmed live and via raw NCBI E-utils curl). Hyphens are now stripped before building the query.

- **Fix-R5D-1/R8C-1** (`clinvar_tool.py`) — reimplements and extends an unrecognized-parameter check. A caller-supplied param that doesn't match any recognized name/alias (e.g. `variant_name` — the real param is `variant_id`) was silently dropped. When it was the only param supplied this produced a generic "at least one search parameter is required" error with no hint the parameter itself was misnamed; when other valid params were also supplied (confirmed live: `{"gene": "GJB2", "variant_name": "35delG"}`), the query still ran but silently ignored the unrecognized filter, with `total_count` reflecting all 739 GJB2 variants rather than the intended narrower search. Both cases now name the unrecognized parameter(s) — as an error when no valid params exist, and as a new `ignored_parameters` note in the success response when the query still runs on other valid params.

- **Fix-R8C-2** (`clinicaltrials_gov_tools.json`) — `ClinicalTrials_search_studies` had no `additionalProperties` restriction, so an unrecognized parameter (e.g. `intervention` — the real key is `query_intr`) was silently ignored rather than rejected, and the query ran anyway using only the recognized params (confirmed live). Added `"additionalProperties": false`, matching the same fix already applied to the sibling `search_clinical_trials` tool in an earlier round.

- **Fix-R8E-1/R6C-2** (`clinvar_tool.py`) — `ClinVarGetVariantDetails` and `ClinVarGetClinicalSignificance` both returned the full raw esummary blob twice — once as the top-level `data` key (from the underlying `_make_request` envelope) and again inside `formatted_data["raw_data"]` — roughly tripling payload size for no informational gain and making the two tools' outputs nearly indistinguishable from each other despite their differently-named, purpose-built `formatted_data` blocks. Dropped the redundant top-level copy from both; raw access remains available via `formatted_data.raw_data`.

## Confirmed duplicates of already-fixed-but-unmerged bugs (no new action needed)

These will resolve once earlier rounds' fixes merge (see #302, the consolidated PR for rounds 1–7):
- **R8B-2/R8D-2** — DailyMed table-cell text containing raw XML whitespace artifacts — already fixed by the `_cell_text()` helper from round 6 (Fix-R6E-2), applied to both header and data cells.
- **R8D-1** — `DailyMed_parse_contraindications`/`parse_dosing` returning duplicated content from overlapping SPL sections — already fixed by the `_dedupe_items()` helper from round 4 (Fix-R4C-1).

## False positives / deferred (not fixed)

- **R8A-1** — `DailyMed_parse_dosing` intermittent HTTP 500 with an empty error body — the error message already surfaces everything the upstream response provides (`f"HTTP {status}: {text[:200]}"`); a transient empty-bodied upstream 500 isn't something a better message can fix without adding retry logic, a bigger design change.
- **R8A-2** — `PubMed_Guidelines_Search` AND-combines all query terms literally with no relaxation/fallback, so a natural multi-concept clinical query underperforms a simpler one — a real UX gap, but fixing it needs query-relaxation logic, not a quick change.
- **R8C-3** — `ClinicalTrials_search_studies`'s condition+intervention filters don't strictly exclude an unrelated trial even with correct parameter names — likely an upstream ClinicalTrials.gov query-construction/matching looseness, consistent with previously-deferred relevance-ranking gaps in other search tools.

## A note on repeated rediscovery

3 of this round's ~11 raw findings turned out to be duplicates of bugs already fixed in rounds 4 and 6 (currently sitting in the still-open, not-yet-merged #302). This is the second round in a row where a meaningful fraction of persona findings re-discover already-fixed-but-unmerged bugs — worth prioritizing a merge of #302 to stop this pattern before round 9.

## Known session-local issue (not a code bug)

The MCP server in this development session holds a stale reference to a garbage-collected `uv` cache dir, causing TLS cert / "tool type not found" errors across `mcp__tooluniverse__*` calls. Every finding above was independently verified via the local CLI, which is unaffected. Documented for consistency with prior round PRs — not something this PR changes.

## Test plan

- [x] 3 new mocked unit test files (`test_clinvar_gene_hyphen_and_params.py`, `test_clinvar_no_duplicate_raw_data.py`, `test_clinicaltrials_search_studies_schema.py`) — 9 new tests, all passing
- [x] Existing `test_ctg_tool.py` and `test_round007_fixes.py` re-run to confirm no regression
- [x] Every fix re-verified live via `python3 -m tooluniverse.cli run` after the code change, plus raw NCBI E-utils curl checks confirming root cause
- [x] Auto-regen stub drift (`uv.lock`) reverted before commit — diff contains only intentional changes