### PR TITLE
Test-harness round 10: ClinVar, DrugBank/MeSH, PubMed guideline-search fixes

### DIFF
--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -5,6 +5,7 @@ This tool provides access to the ClinVar database for clinical variant informati
 disease associations, and clinical significance data.
 """
 
+import re
 import requests
 import time
 from typing import Dict, Any, Optional
@@ -188,7 +189,21 @@ class ClinVarSearchVariants(ClinVarRESTTool):
         query_parts = []
 
         if "gene" in arguments:
-            query_parts.append(f"{arguments['gene']}[gene]")
+            # Fix-R10D-1: ClinVar's [gene] index only matches a bare HGNC
+            # symbol, but a natural clinical phrasing like "NF2 gene" (used
+            # verbatim in real research questions -- e.g. "look up the NF2
+            # gene") silently returns 0 results, since the literal trailing
+            # word "gene" becomes part of the queried string (confirmed
+            # live and via raw NCBI E-utils curl: "Nf2 gene[gene]" -> 0
+            # hits, "NF2[gene]" -> 2612 hits). Strip a trailing/leading
+            # "gene"/"protein" qualifier word before querying.
+            gene = re.sub(
+                r"^\s*(?:gene|protein)\s+|\s+(?:gene|protein)\s*$",
+                "",
+                arguments["gene"],
+                flags=re.IGNORECASE,
+            ).strip()
+            query_parts.append(f"{gene}[gene]")
 
         if "condition" in arguments:
             # Feature-70B-005: [disease/phenotype] is not a valid ClinVar eSearch field.

--- a/src/tooluniverse/data/xml_tools.json
+++ b/src/tooluniverse/data/xml_tools.json
@@ -54,10 +54,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -229,10 +226,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -406,10 +400,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -581,10 +572,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -766,10 +754,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -957,10 +942,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -1130,10 +1112,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -1288,10 +1267,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -1479,10 +1455,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -1670,10 +1643,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -1872,10 +1842,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -2122,10 +2089,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -2307,10 +2271,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -2529,10 +2490,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -2699,10 +2657,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -2917,10 +2872,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -3131,10 +3083,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -3331,10 +3280,7 @@
         }
       },
       "required": [
-        "query",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "return_schema": {
@@ -3513,8 +3459,7 @@
       },
       "required": [
         "condition",
-        "value",
-        "limit"
+        "value"
       ]
     },
     "return_schema": {

--- a/src/tooluniverse/unified_guideline_tools.py
+++ b/src/tooluniverse/unified_guideline_tools.py
@@ -359,6 +359,18 @@ class PubMedGuidelinesTool(BaseTool):
                     author_str = ", ".join(authors)
                     if len(article.get("authors", [])) > 3:
                         author_str += ", et al."
+                    # Fix-R10E-3: NCBI Bookshelf-type records (e.g. WHO
+                    # monographs/guidelines, doctype="book") store their
+                    # title under `booktitle` instead of `title`, and have
+                    # no individual `authors` list -- confirmed live via
+                    # raw esummary for PMID 34787987 ("WHO guideline for
+                    # clinical management of exposure to lead"), whose
+                    # `title`/`authors` were both empty while `booktitle`
+                    # and `publishername` had the real values. Fall back to
+                    # those fields instead of silently returning blanks.
+                    title = article.get("title") or article.get("booktitle") or ""
+                    if not author_str:
+                        author_str = article.get("publishername", "")
 
                     # Check publication types
                     pub_types = article.get("pubtype", [])
@@ -366,11 +378,7 @@ class PubMedGuidelinesTool(BaseTool):
 
                     abstract_text = abstracts.get(pmid, "")
                     searchable_text = " ".join(
-                        [
-                            article.get("title", ""),
-                            abstract_text or "",
-                            " ".join(pub_types),
-                        ]
+                        [title, abstract_text or "", " ".join(pub_types)]
                     ).lower()
 
                     if query_terms and not any(
@@ -380,7 +388,7 @@ class PubMedGuidelinesTool(BaseTool):
 
                     result = {
                         "pmid": pmid,
-                        "title": article.get("title", ""),
+                        "title": title,
                         "abstract": abstract_text,
                         "content": abstract_text,  # Copy abstract to content field
                         "authors": author_str,

--- a/tests/unit/test_clinvar_gene_qualifier_words.py
+++ b/tests/unit/test_clinvar_gene_qualifier_words.py
@@ -1,0 +1,47 @@
+"""Regression guard for Fix-R10D-1: ClinVar's [gene] index only matches a
+bare HGNC symbol, but a natural clinical phrasing like "NF2 gene" (used
+verbatim in real research questions) silently returned 0 results, since
+the literal trailing word "gene" became part of the queried string
+(confirmed live and via raw NCBI E-utils curl: "Nf2 gene[gene]" -> 0
+hits, "NF2[gene]" -> 2612 hits). A trailing/leading "gene"/"protein"
+qualifier word is now stripped before querying.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import ClinVarSearchVariants
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ClinVarSearchVariants({"name": "ClinVar_search_variants"})
+
+
+def _term_for(gene_value):
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        tool.run({"gene": gene_value})
+    return mock_request.call_args[0][1]["term"]
+
+
+def test_trailing_gene_qualifier_is_stripped():
+    assert _term_for("Nf2 gene") == "Nf2[gene]"
+
+
+def test_leading_gene_qualifier_is_stripped():
+    assert _term_for("gene NF2") == "NF2[gene]"
+
+
+def test_trailing_protein_qualifier_is_stripped():
+    assert _term_for("NF2 protein") == "NF2[gene]"
+
+
+def test_plain_symbol_unaffected():
+    assert _term_for("NF2") == "NF2[gene]"

--- a/tests/unit/test_pubmed_guidelines_book_records.py
+++ b/tests/unit/test_pubmed_guidelines_book_records.py
@@ -1,0 +1,90 @@
+"""Regression guard for Fix-R10E-3: NCBI Bookshelf-type records (e.g. WHO
+monographs/guidelines, doctype="book") store their title under
+`booktitle` instead of `title`, and have no individual `authors` list --
+confirmed live via raw esummary for PMID 34787987 ("WHO guideline for
+clinical management of exposure to lead"), whose `title`/`authors` were
+both empty while `booktitle` and `publishername` had the real values.
+PubMedGuidelinesTool now falls back to those fields instead of silently
+returning blanks.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.unified_guideline_tools import PubMedGuidelinesTool
+
+pytestmark = pytest.mark.unit
+
+_SEARCH_JSON = {"esearchresult": {"idlist": ["34787987"], "count": "1"}}
+_SUMMARY_JSON = {
+    "result": {
+        "34787987": {
+            "title": "",
+            "authors": [],
+            "booktitle": "WHO guideline for clinical management of exposure to lead",
+            "publishername": "World Health Organization",
+            "pubtype": ["Book"],
+            "source": "",
+            "pubdate": "2021",
+            "elocationid": "",
+        }
+    }
+}
+_ABSTRACT_XML = (
+    "<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>34787987</PMID>"
+    "<Article><Abstract><AbstractText>Guidance on managing lead exposure."
+    "</AbstractText></Article></MedlineCitation></PubmedArticle></PubmedArticleSet>"
+)
+
+
+def test_book_record_falls_back_to_booktitle_and_publishername():
+    tool = PubMedGuidelinesTool({"name": "PubMed_Guidelines_Search"})
+
+    search_resp = MagicMock()
+    search_resp.json.return_value = _SEARCH_JSON
+    summary_resp = MagicMock()
+    summary_resp.json.return_value = _SUMMARY_JSON
+    abstract_resp = MagicMock()
+    abstract_resp.text = _ABSTRACT_XML
+
+    with patch.object(
+        tool.session, "get", side_effect=[search_resp, summary_resp, abstract_resp]
+    ), patch("tooluniverse.unified_guideline_tools.time.sleep"):
+        result = tool.run({"query": "lead exposure"})
+
+    assert len(result) == 1
+    record = result[0]
+    assert record["title"] == "WHO guideline for clinical management of exposure to lead"
+    assert record["authors"] == "World Health Organization"
+
+
+def test_regular_article_authors_unaffected():
+    tool = PubMedGuidelinesTool({"name": "PubMed_Guidelines_Search"})
+    summary = {
+        "result": {
+            "123": {
+                "title": "A normal article",
+                "authors": [{"name": "Doe J"}, {"name": "Smith A"}],
+                "pubtype": ["Journal Article"],
+                "source": "J Med",
+                "pubdate": "2024",
+                "elocationid": "",
+            }
+        }
+    }
+    search_resp = MagicMock()
+    search_resp.json.return_value = {"esearchresult": {"idlist": ["123"], "count": "1"}}
+    summary_resp = MagicMock()
+    summary_resp.json.return_value = summary
+    abstract_resp = MagicMock()
+    abstract_resp.text = ""
+
+    with patch.object(
+        tool.session, "get", side_effect=[search_resp, summary_resp, abstract_resp]
+    ), patch("tooluniverse.unified_guideline_tools.time.sleep"):
+        result = tool.run({"query": "normal article"})
+
+    record = result[0]
+    assert record["title"] == "A normal article"
+    assert record["authors"] == "Doe J, Smith A"

--- a/tests/unit/test_xml_tools_required_defaults.py
+++ b/tests/unit/test_xml_tools_required_defaults.py
@@ -1,0 +1,56 @@
+"""Regression guard for Fix-R10C-2: 19 XMLTool-family tools (drugbank_*,
+mesh_*) declared `default` values for case_sensitive/exact_match/limit but
+ALSO listed those same params in `required`, making the declared defaults
+completely unusable -- every caller had to always pass all 4 params
+explicitly, defeating the point of having defaults at all (confirmed live:
+{"query": "clopidogrel"} alone errored with
+"'case_sensitive' is a required property" before the fix). Removed the
+defaulted params from `required`, keeping only the genuinely-required
+search field.
+"""
+
+import json
+
+import jsonschema
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _load_tools():
+    with open("src/tooluniverse/data/xml_tools.json") as f:
+        return json.load(f)
+
+
+AFFECTED_TOOLS = [
+    "drugbank_get_drug_interactions_by_drug_name_or_id",
+    "drugbank_get_drug_basic_info_by_drug_name_or_id",
+    "mesh_get_subjects_by_subject_name",
+]
+
+
+@pytest.mark.parametrize("tool_name", AFFECTED_TOOLS)
+def test_query_alone_satisfies_schema(tool_name):
+    tools = _load_tools()
+    schema = next(t for t in tools if t["name"] == tool_name)["parameter"]
+    jsonschema.validate({"query": "clopidogrel"}, schema)
+
+
+@pytest.mark.parametrize("tool_name", AFFECTED_TOOLS)
+def test_only_query_remains_required(tool_name):
+    tools = _load_tools()
+    schema = next(t for t in tools if t["name"] == tool_name)["parameter"]
+    assert schema["required"] == ["query"]
+
+
+def test_no_xml_tool_has_a_defaulted_required_param():
+    """No tool in the file should still have this anti-pattern anywhere."""
+    tools = _load_tools()
+    for t in tools:
+        param = t.get("parameter", {})
+        props = param.get("properties", {})
+        required = set(param.get("required", []))
+        offenders = [
+            k for k in required if k in props and "default" in props[k]
+        ]
+        assert not offenders, f"{t['name']} still requires defaulted param(s) {offenders}"


### PR DESCRIPTION
## Summary

Round 10 of the ongoing test-harness sweep. Persona domains this round: hepatology, gastroenterology, vascular surgery, neurosurgery, occupational medicine. Every issue below was CLI-verified (`python3 -m tooluniverse.cli run <Tool> '<args>'`) before fixing, including raw upstream API curl checks to confirm root cause.

## Verified bugs fixed

- **Fix-R10D-1** (`clinvar_tool.py`) — ClinVar's `[gene]` index only matches a bare HGNC symbol, but a natural clinical phrasing like "NF2 gene" (used verbatim in real research questions, e.g. "look up the NF2 gene") silently returned 0 results, since the literal trailing word "gene" became part of the queried string — confirmed live and via raw NCBI E-utils curl: `"Nf2 gene[gene]"` → 0 hits, `"NF2[gene]"` → 2612 hits. A trailing/leading "gene"/"protein" qualifier word is now stripped before querying (verified across 4 phrasing variants, all now returning the same 2612 matches).

- **Fix-R10C-2** (`xml_tools.json`) — 19 XMLTool-family tools (`drugbank_*`, `mesh_*`) declared `default` values for `case_sensitive`/`exact_match`/`limit` but ALSO listed those same params in `required`, making the declared defaults completely unusable — every caller had to always pass all 4 params explicitly, defeating the point of having defaults at all (confirmed live: `{"query": "clopidogrel"}` alone errored with `"'case_sensitive' is a required property"` before the fix, on the exact tool a vascular surgeon persona hit while investigating clopidogrel interactions). This was a uniform copy-paste pattern across the whole file (confirmed by scanning all tool configs), fixed uniformly across all 19 affected tools by removing the defaulted params from `required`; removing items from `required` can only make validation more permissive, so no previously-working call (passing all 4 params explicitly) regresses.

- **Fix-R10E-3** (`unified_guideline_tools.py`) — `PubMedGuidelinesTool`'s title/authors extraction only ever read `title`/`authors`, but NCBI Bookshelf-type records (`doctype="book"`, e.g. WHO monographs and guideline documents) store their title under `booktitle` and have no individual author list — confirmed via raw esummary curl for PMID 34787987 ("WHO guideline for clinical management of exposure to lead"), whose `title`/`authors` were both empty while `booktitle` and `publishername` ("World Health Organization") had the real values. Falls back to those fields; verified a second book-type record with genuinely no `publishername` anywhere in NCBI's own data correctly still shows an empty author string (nothing left to fall back to), and that regular journal-article records are unaffected.

## Confirmed duplicates of already-fixed-but-unmerged bugs (no new action needed)

Will resolve once earlier rounds' PRs merge (see #302 for rounds 1–7, #303 for round 8, #304 for round 9):
- **R10D-3/R10A-2** — `ClinVar_get_variant_details`/`get_clinical_significance` duplicate `raw_data` payload — already fixed in round 8 (Fix-R8E-1/R6C-2).
- **R10E-2/R10A-2** — `PubMed_Guidelines_Search` missing status/data envelope — already fixed in round 9 (Fix-R9E-1).
- **R10E-4** — `DailyMed_search_spls` pagination `"null"` strings — already fixed in round 6 (Fix-R6A-2/R6D-3/R6E-3).

## False positives / deferred (not fixed)

- **R10D-2** — ClinVar `protein_change` field returning multiple concatenated stop-codon calls for a single variant — confirmed in round 7 (Fix-R7D-1 investigation) as genuine upstream NCBI multi-transcript data, not a ToolUniverse-side bug.
- **R10C-1** — `drugbank_get_drug_interactions_by_drug_name_or_id` expects `query` not `drug_name_or_id` despite the tool's own name — error message already names the correct field clearly, consistent with prior rounds' guidance against unbounded alias sprawl.
- **R10B-1/R10A-1** — `DailyMed_parse_adverse_reactions`/`parse_drug_interactions` table rows sometimes lack column headers or have inconsistent dict-vs-list shapes for sub-rows under merged/rowspan cells — same class of "no `<thead>` present in this specific source table" issue deliberately deferred in round 6 (R6D-1/R6D-2): a "assume the first row is a header" heuristic risks misinterpreting genuinely headerless data tables.
- **R10E-1** — `PubMed_search_articles` silently returns 0 results for a long (8-term) multi-concept AND query even though shorter subsets of the same terms return real results — same class of query-relaxation gap deferred in round 8 (R8A-2); needs fallback/relaxation logic, not a quick fix.

## Known session-local issue (not a code bug)

The MCP server in this development session holds a stale reference to a garbage-collected `uv` cache dir, causing TLS cert / "tool type not found" errors across `mcp__tooluniverse__*` calls. Every finding above was independently verified via the local CLI, which is unaffected. Documented for consistency with prior round PRs — not something this PR changes.

## Test plan

- [x] 3 new test files (`test_clinvar_gene_qualifier_words.py`, `test_xml_tools_required_defaults.py`, `test_pubmed_guidelines_book_records.py`) — 13 new tests, all passing
- [x] Existing `test_round007_fixes.py` re-run to confirm no regression
- [x] Every fix re-verified live via `python3 -m tooluniverse.cli run` after the code change, plus raw upstream API curl checks confirming root cause
- [x] The 19-tool `xml_tools.json` fix's diff was manually inspected to confirm it touches only `required` arrays and nothing else was reformatted/reordered
- [x] Auto-regen stub drift (`uv.lock`) reverted before commit — diff contains only intentional changes