### PR TITLE
Test-harness round 11: RCSB PDB search, GWAS Catalog fixes

### DIFF
--- a/src/tooluniverse/data/rcsb_advanced_search_tools.json
+++ b/src/tooluniverse/data/rcsb_advanced_search_tools.json
@@ -56,7 +56,7 @@
             "string",
             "null"
           ],
-          "description": "Sort results by: 'resolution' (best resolution first, default), 'date' (newest first), 'weight' (smallest first)."
+          "description": "Sort results by: 'resolution' (best resolution first, default), 'date' (newest first), 'weight' (smallest first), 'score' (best full-text relevance match first)."
         }
       },
       "required": []

--- a/src/tooluniverse/gwas_tool.py
+++ b/src/tooluniverse/gwas_tool.py
@@ -142,10 +142,23 @@ class GWASRESTTool(BaseTool):
     @staticmethod
     def _empty_result_note(efo_id: str) -> str:
         """Return a suggestion note when no associations are found for an EFO ID."""
+        # Fix-R11B-2: this note previously suggested retrying with a
+        # different disease_trait text query, using a hardcoded, unrelated
+        # example ("colorectal cancer") that didn't adapt to the caller's
+        # actual query. Confirmed live that for a real empty-result case
+        # (LCT/lactase persistence), the trait itself was resolvable but
+        # simply had no directly-tagged associations -- the associations
+        # existed under other EFO terms, and the tool that actually found
+        # them was GWAS_search_associations_by_gene/gwas_get_snps_for_gene
+        # (gene-based lookup), not a reworded trait string. Point to that
+        # real fallback instead of a generic, non-adaptive example.
         return (
             f"No associations found for EFO ID '{efo_id}'. "
-            "GWAS Catalog may use a broader parent term — try disease_trait "
-            "with a text query (e.g., 'colorectal cancer') to find related associations."
+            "GWAS Catalog may tag related associations under a different "
+            "EFO/MONDO term, or under pleiotropic traits rather than this "
+            "specific one. If you know the gene of interest, try "
+            "GWAS_search_associations_by_gene or gwas_get_snps_for_gene "
+            "instead, which search by gene rather than by trait term."
         )
 
     def _add_empty_result_note(

--- a/src/tooluniverse/rcsb_advanced_search_tool.py
+++ b/src/tooluniverse/rcsb_advanced_search_tool.py
@@ -171,13 +171,22 @@ class RCSBAdvancedSearchTool(BaseTool):
             query = {"type": "group", "logical_operator": "and", "nodes": nodes}
 
         # Sort mapping
+        # Fix-R11A-1: "score" (RCSB's own full-text relevance score) was
+        # missing from this map entirely, so there was no way to request
+        # relevance-sorted results even though every hit already carries a
+        # `score` field in the response -- confirmed live and via raw RCSB
+        # Search API curl that "score" is a valid sort_by value and sorts
+        # correctly descending. Without it, results default to
+        # resolution-sorted order, so the highest-relevance hit for a
+        # text query could be buried well past the first page.
         sort_map = {
             "resolution": "rcsb_entry_info.resolution_combined",
             "date": "rcsb_accession_info.deposit_date",
             "weight": "rcsb_entry_info.molecular_weight",
+            "score": "score",
         }
         sort_field = sort_map.get(sort_by, sort_map["resolution"])
-        sort_direction = "desc" if sort_by == "date" else "asc"
+        sort_direction = "desc" if sort_by in ("date", "score") else "asc"
 
         request_body = {
             "query": query,

--- a/tests/unit/test_gwas_empty_result_note.py
+++ b/tests/unit/test_gwas_empty_result_note.py
@@ -1,0 +1,33 @@
+"""Regression guard for Fix-R11B-2: GWASRESTTool._empty_result_note
+previously suggested retrying with a different disease_trait text query,
+using a hardcoded, unrelated example ("colorectal cancer") that didn't
+adapt to the caller's actual query. Confirmed live that for a real
+empty-result case (LCT/lactase persistence), the trait itself was
+resolvable but simply had no directly-tagged associations -- the
+associations existed under other EFO terms, and the tool that actually
+found them was GWAS_search_associations_by_gene/gwas_get_snps_for_gene
+(gene-based lookup), not a reworded trait string. The note now points to
+that real fallback.
+"""
+
+import pytest
+
+from tooluniverse.gwas_tool import GWASRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def test_note_no_longer_uses_generic_hardcoded_example():
+    note = GWASRESTTool._empty_result_note("MONDO_0100345")
+    assert "colorectal cancer" not in note
+
+
+def test_note_points_to_gene_based_search_fallback():
+    note = GWASRESTTool._empty_result_note("MONDO_0100345")
+    assert "GWAS_search_associations_by_gene" in note
+    assert "gwas_get_snps_for_gene" in note
+
+
+def test_note_includes_the_efo_id():
+    note = GWASRESTTool._empty_result_note("MONDO_0100345")
+    assert "MONDO_0100345" in note

--- a/tests/unit/test_rcsb_score_sort.py
+++ b/tests/unit/test_rcsb_score_sort.py
@@ -1,0 +1,64 @@
+"""Regression guard for Fix-R11A-1: RCSBAdvSearch_search_structures had no
+way to request relevance-sorted results, even though every hit already
+carries a `score` field in the response -- the sort_map only had
+resolution/date/weight. Confirmed live and via raw RCSB Search API curl
+that "score" is a valid sort_by value and sorts correctly descending.
+Without it, results defaulted to resolution-sorted order, so the
+highest-relevance hit for a text query could be buried well past the
+first page.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.rcsb_advanced_search_tool import RCSBAdvancedSearchTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return RCSBAdvancedSearchTool(
+        {
+            "name": "RCSBAdvSearch_search_structures",
+            "fields": {"endpoint": "advanced_search"},
+        }
+    )
+
+
+def _mock_response():
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"result_set": [], "total_count": 0}
+    return resp
+
+
+def test_score_sort_by_maps_to_score_field_descending():
+    tool = _tool()
+    with patch("requests.post", return_value=_mock_response()) as mock_post:
+        tool.run({"query": "KRAS G12C", "sort_by": "score"})
+
+    body = mock_post.call_args.kwargs["json"]
+    sort_clause = body["request_options"]["sort"][0]
+    assert sort_clause["sort_by"] == "score"
+    assert sort_clause["direction"] == "desc"
+
+
+def test_default_sort_is_still_resolution_ascending():
+    tool = _tool()
+    with patch("requests.post", return_value=_mock_response()) as mock_post:
+        tool.run({"query": "KRAS G12C"})
+
+    body = mock_post.call_args.kwargs["json"]
+    sort_clause = body["request_options"]["sort"][0]
+    assert sort_clause["sort_by"] == "rcsb_entry_info.resolution_combined"
+    assert sort_clause["direction"] == "asc"
+
+
+def test_date_sort_still_descending():
+    tool = _tool()
+    with patch("requests.post", return_value=_mock_response()) as mock_post:
+        tool.run({"query": "KRAS G12C", "sort_by": "date"})
+
+    sort_clause = mock_post.call_args.kwargs["json"]["request_options"]["sort"][0]
+    assert sort_clause["direction"] == "desc"


### PR DESCRIPTION
## Summary

Round 11 of the ongoing test-harness sweep. Persona domains this round deliberately pivoted away from clinical specialties — DailyMed/ClinVar/PubMed have been increasingly re-discovering already-fixed-but-unmerged bugs across rounds 8–10 — toward computational/bioinformatics tool families not yet exercised: structural biology (AlphaFold/PDB/UniProt), population genetics (GWAS Catalog/gnomAD), systems biology (Reactome/KEGG/STRING), single-cell genomics (CellxGene), and cheminformatics (PubChem/ChEMBL/ZINC). Every issue below was CLI-verified (`python3 -m tooluniverse.cli run <Tool> '<args>'`) before fixing, including raw upstream API curl checks to confirm root cause.

## Verified bugs fixed

- **Fix-R11A-1** (`rcsb_advanced_search_tool.py`) — `RCSBAdvSearch_search_structures` had no way to request relevance-sorted results, even though every hit already carries a `score` field in the response — the `sort_map` only had resolution/date/weight. Confirmed live that scores in the default response were not descending-ordered (e.g. the highest-scoring hit, 0.947, was buried 8th of 10), and via raw RCSB Search API curl that `"score"` is a valid `sort_by` value that correctly sorts descending. Added it as a fourth `sort_by` option; default behavior (resolution) unaffected.

- **Fix-R11B-2** (`gwas_tool.py`) — `GWASRESTTool._empty_result_note`'s suggestion text for an empty-result trait search always recommended retrying with a hardcoded, unrelated example ("try disease_trait with a text query (e.g., 'colorectal cancer')") that never adapted to the caller's actual query. Confirmed live on a real empty-result case (LCT/lactase persistence, EFO resolved successfully but had no directly-tagged associations) that the actually-effective fallback was gene-based search (`GWAS_search_associations_by_gene`/`gwas_get_snps_for_gene`), not a reworded `disease_trait` string. The note now points to that real fallback instead of a generic, non-adaptive example.

## False positives / deferred (not fixed)

- **R11A-2** — `UniProt_get_function_by_accession`/`get_features_by_accession` return a bare `{"result": [...]}` envelope with no `status` key, unlike every other tool in the same session — same class of envelope-consistency gap already deferred/fixed elsewhere for other tool families; first report for UniProt specifically, not yet independently confirmed enough times to prioritize over this round's other findings.
- **R11B-1** — `gwas_get_associations_for_trait` hard-errors on an unresolvable `disease_trait` while sibling tool `gwas_search_studies` silently returns an empty success for the identical input — a real inconsistency, but unifying error-vs-empty-success semantics across two tools with different underlying resolution strategies risks behavior changes for existing callers; needs more design thought than a single round allows.
- **R11C-1/R11C-2** — `STRING_get_network` rejects list input for `identifiers` (JSON-schema-level type mismatch, string vs array) and `STRING_get_interaction_partners` gives a generic, non-diagnostic error for an unresolved identifier — both real, but properly fixing the schema/type handling requires coordinating a JSON schema change with Python-side list-joining logic across multiple STRING_* tool configs; deferred pending deeper investigation.
- **R11D-1** — `CxGDisc_search_datasets` sorts disease-only queries purely by `cell_count` with no relevance weighting toward how central the disease match is, surfacing cross-tissue comorbidity noise above on-topic datasets — same class of relevance-ranking gap already deferred for PDBe/RCSB free-text search (round 2) and ClinicalTrials.gov (round 9); needs a real ranking redesign, not a quick fix.
- **R11E-1** — `ChEMBL_search_similar_molecules` returns a nested anchor-group/`similar_molecules` structure that's confusing to consume and diverges sharply from the flat list the near-identically-named `ChEMBL_search_similarity` (SMILES-input) returns — a real usability gap, but restructuring the output risks breaking existing consumers of the current shape; needs design work.
- **R11E-2** — `ZINC_search_by_smiles` ("ZINC22 (CartBlanche)") timed out on both attempts of a well-formed query — per the tool's own description this endpoint polls an async job "within 30s"; most likely upstream infrastructure availability rather than a ToolUniverse-side defect, not reproduced against a definitively-broken code path.

## Known session-local issue (not a code bug)

The MCP server in this development session holds a stale reference to a garbage-collected `uv` cache dir, causing TLS cert / "tool type not found" errors across `mcp__tooluniverse__*` calls. Every finding above was independently verified via the local CLI, which is unaffected. Documented for consistency with prior round PRs — not something this PR changes.

## Test plan

- [x] 2 new test files (`test_rcsb_score_sort.py`, `test_gwas_empty_result_note.py`) — 6 new tests, all passing
- [x] Existing `test_gwas_population_depth.py`, `test_gwas_tool_params.py`, `test_rcsb_entry_id_alias.py` re-run to confirm no regression
- [x] Every fix re-verified live via `python3 -m tooluniverse.cli run` after the code change, plus raw upstream API curl checks confirming root cause
- [x] Auto-regen stub drift (`uv.lock`) reverted before commit — diff contains only intentional changes