### PR TITLE
Round 12: PRIDE search, WHO GHO param mapping, Semantic Scholar bulk-sort, NCBI lineage names

### DIFF
--- a/src/tooluniverse/data/crossref_tools.json
+++ b/src/tooluniverse/data/crossref_tools.json
@@ -2,7 +2,7 @@
   {
     "type": "CrossrefRESTTool",
     "name": "Crossref_search_works",
-    "description": "Search Crossref Works API for scholarly articles, publications, and research outputs by keyword. Returns metadata including title, abstract, journal, authors, publication year, DOI, URL, citations, and publisher. Supports filtering by publication type (journal article, conference paper, etc.) and date range. Use this to discover academic literature, verify citations, or build bibliographies. Find DOIs to use with Crossref_get_work for complete metadata.",
+    "description": "Search Crossref Works API for scholarly articles, publications, and research outputs by keyword. Returns metadata including title, abstract, journal, authors, publication year, DOI, URL, citations, and publisher. Supports filtering by publication type (journal article, conference paper, etc.) and date range. Use this to discover academic literature, verify citations, or build bibliographies. Find DOIs to use with Crossref_get_work for complete metadata. Note: Crossref's own API weakens keyword relevance-matching whenever a non-default 'sort' query param is combined with 'query' (e.g. sort=is-referenced-by-count), returning globally top-cited works largely unrelated to the search term -- omit 'sort' (the default relevance ranking) unless you have separately verified the combination for your query.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/ncbi_datasets_tools.json
+++ b/src/tooluniverse/data/ncbi_datasets_tools.json
@@ -474,7 +474,7 @@
     },
     {
         "name": "NCBIDatasets_get_taxonomy",
-        "description": "Get detailed taxonomy information from NCBI by taxonomy ID. Returns organism name, rank, full lineage, counts of genes/assemblies/RNA types, and child taxa. Covers all organisms in NCBI Taxonomy including bacteria, archaea, eukaryotes, and viruses. Example: tax_id 9606 returns Homo sapiens with 20,625 protein-coding genes.",
+        "description": "Get detailed taxonomy information from NCBI by taxonomy ID. Returns organism name, rank, full lineage (as bare ancestor tax_ids in `lineage`, and as resolved organism_name/rank pairs in `lineage_names`), counts of genes/assemblies/RNA types, and child taxa. Covers all organisms in NCBI Taxonomy including bacteria, archaea, eukaryotes, and viruses. Example: tax_id 9606 returns Homo sapiens with 20,625 protein-coding genes.",
         "parameter": {
             "type": "object",
             "properties": {
@@ -541,6 +541,30 @@
                                     "type": "array",
                                     "items": {
                                         "type": "integer"
+                                    }
+                                },
+                                "lineage_names": {
+                                    "type": "array",
+                                    "description": "Ancestor tax_ids from `lineage`, resolved to organism_name/rank (root-first). Entries fall back to null names/ranks if the resolution lookup failed.",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "tax_id": {
+                                                "type": "integer"
+                                            },
+                                            "organism_name": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "rank": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
                                     }
                                 },
                                 "children": {

--- a/src/tooluniverse/data/pride_tools.json
+++ b/src/tooluniverse/data/pride_tools.json
@@ -21,8 +21,7 @@
       ]
     },
     "fields": {
-      "endpoint": "https://www.ebi.ac.uk/pride/ws/archive/v2/projects?query={query}",
-      "params": {"pageSize": "20"},
+      "endpoint": "https://www.ebi.ac.uk/pride/ws/archive/v2/search/projects?keyword={query}",
       "return_format": "JSON"
     },
     "return_schema": {

--- a/src/tooluniverse/data/who_gho_tools.json
+++ b/src/tooluniverse/data/who_gho_tools.json
@@ -119,6 +119,10 @@
       "endpoint": "https://ghoapi.azureedge.net/api/{indicator_code}",
       "params": {
         "$top": 20
+      },
+      "param_mapping": {
+        "filter": "$filter",
+        "top": "$top"
       }
     },
     "type": "BaseRESTTool",

--- a/src/tooluniverse/ncbi_datasets_tool.py
+++ b/src/tooluniverse/ncbi_datasets_tool.py
@@ -259,6 +259,7 @@ class NCBIDatasetsTool(BaseTool):
             }
 
         tax_data = nodes[0].get("taxonomy", {})
+        lineage_ids = tax_data.get("lineage", [])
         return {
             "status": "success",
             "data": {
@@ -267,7 +268,8 @@ class NCBIDatasetsTool(BaseTool):
                 "genbank_common_name": tax_data.get("genbank_common_name"),
                 "rank": tax_data.get("rank"),
                 "blast_name": tax_data.get("blast_name"),
-                "lineage": tax_data.get("lineage", []),
+                "lineage": lineage_ids,
+                "lineage_names": self._resolve_lineage_names(lineage_ids),
                 "children": tax_data.get("children", []),
                 "counts": tax_data.get("counts", []),
             },
@@ -277,6 +279,45 @@ class NCBIDatasetsTool(BaseTool):
                 "source": "NCBI Datasets API v2",
             },
         }
+
+    def _resolve_lineage_names(self, tax_ids):
+        """Fix-R12B-1: `lineage` is a bare list of ancestor tax_ids with no
+        names or ranks attached, despite the tool's own description promising
+        "full lineage" -- confirmed this is exactly what NCBI's own API
+        returns, not something dropped by this tool. NCBI's endpoint accepts
+        a comma-joined batch of tax_ids in one request (confirmed live), so
+        resolve the whole lineage's names/ranks in a single extra call rather
+        than one call per ancestor. Best-effort: any failure here just leaves
+        `lineage_names` empty, since the bare-id `lineage` field above already
+        succeeded and shouldn't be failed by this enrichment step.
+        """
+        if not tax_ids:
+            return []
+        try:
+            response = requests.get(
+                f"{NCBI_DATASETS_BASE}/taxonomy/taxon/{','.join(str(t) for t in tax_ids)}",
+                headers={"Accept": "application/json"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            nodes = response.json().get("taxonomy_nodes", [])
+        except requests.exceptions.RequestException:
+            return []
+
+        by_id = {}
+        for node in nodes:
+            node_tax = node.get("taxonomy", {})
+            node_tax_id = node_tax.get("tax_id")
+            if node_tax_id is not None:
+                by_id[node_tax_id] = {
+                    "tax_id": node_tax_id,
+                    "organism_name": node_tax.get("organism_name"),
+                    "rank": node_tax.get("rank"),
+                }
+        return [
+            by_id.get(tid, {"tax_id": tid, "organism_name": None, "rank": None})
+            for tid in tax_ids
+        ]
 
     def _get_taxonomy_suggest(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Suggest taxonomy names matching a query string."""

--- a/src/tooluniverse/pride_tool.py
+++ b/src/tooluniverse/pride_tool.py
@@ -18,6 +18,18 @@ class PRIDERESTTool(BaseTool):
         url = self.tool_config["fields"]["endpoint"]
         for k, v in args.items():
             url = url.replace(f"{{{k}}}", str(v))
+
+        # Fix-R12C-1: page_size is declared as a schema parameter but PRIDE's
+        # search endpoint takes it as the query-string `pageSize` arg, not a
+        # {page_size} placeholder in the endpoint template -- it was never
+        # substituted anywhere and silently dropped. Append it explicitly,
+        # falling back to the schema's own advertised default of 20 when the
+        # caller omits it (confirmed live: PRIDE defaults to 100/page
+        # otherwise, not the documented 20).
+        if "page_size" in self.tool_config.get("parameter", {}).get("properties", {}):
+            page_size = args.get("page_size", 20)
+            separator = "&" if "?" in url else "?"
+            url = f"{url}{separator}pageSize={page_size}"
         return url
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -28,9 +40,22 @@ class PRIDERESTTool(BaseTool):
                 self.session, "GET", url, timeout=self.timeout, max_attempts=3
             )
             if response.status_code != 200:
+                error = "PRIDE API error"
+                # Fix-R12C-3: PRIDE returns a bare HTTP 404 with an empty
+                # body for any unrecognized identifier (e.g. a gene symbol
+                # passed where a UniProt accession or PXD accession is
+                # expected), so there is no upstream detail to surface --
+                # the previous generic message gave no hint the identifier
+                # itself was the problem.
+                if response.status_code == 404:
+                    error = (
+                        "PRIDE API error: no record found for this identifier "
+                        "(HTTP 404) -- check that it matches the ID format "
+                        "this tool expects (see the tool's description)"
+                    )
                 return {
                     "status": "error",
-                    "error": "PRIDE API error",
+                    "error": error,
                     "url": url,
                     "status_code": response.status_code,
                     "detail": (response.text or "")[:500],

--- a/src/tooluniverse/semantic_scholar_tool.py
+++ b/src/tooluniverse/semantic_scholar_tool.py
@@ -111,28 +111,34 @@ class SemanticScholarTool(BaseTool):
     def _search(
         self, query, limit, *, year=None, sort=None, include_abstract: bool = False
     ):
+        # Include identifiers and lightweight impact signals for better downstream utility.
+        fields = [
+            "paperId",
+            "externalIds",
+            "title",
+            "abstract",
+            "tldr",
+            "year",
+            "venue",
+            "url",
+            "authors",
+            "citationCount",
+            "referenceCount",
+            "isOpenAccess",
+            "openAccessPdf",
+            "fieldsOfStudy",
+        ]
+        # Fix-R12A-1: /paper/search/bulk (used below whenever sort is set)
+        # rejects the "tldr" field with a 400 ("Unrecognized or unsupported
+        # fields: [tldr]") -- confirmed live via raw curl -- even though the
+        # regular /paper/search endpoint supports it fine. Drop it only for
+        # the bulk path rather than losing TLDR summaries on every search.
+        if sort:
+            fields = [f for f in fields if f != "tldr"]
         params = {
             "query": query,
             "limit": limit,
-            # Include identifiers and lightweight impact signals for better downstream utility.
-            "fields": ",".join(
-                [
-                    "paperId",
-                    "externalIds",
-                    "title",
-                    "abstract",
-                    "tldr",
-                    "year",
-                    "venue",
-                    "url",
-                    "authors",
-                    "citationCount",
-                    "referenceCount",
-                    "isOpenAccess",
-                    "openAccessPdf",
-                    "fieldsOfStudy",
-                ]
-            ),
+            "fields": ",".join(fields),
         }
         if year:
             params["year"] = str(year)
@@ -177,6 +183,14 @@ class SemanticScholarTool(BaseTool):
             ]
 
         results = payload.get("data", []) if isinstance(payload, dict) else []
+        if sort:
+            # /paper/search/bulk has no `limit` concept of its own (only
+            # token-based pagination over its full result set), so the
+            # `limit` param above is silently ignored server-side -- slice
+            # here instead of returning however many the page happened to
+            # contain (and instead of unnecessarily paying the N+1
+            # missing-abstract lookup cost below for rows beyond `limit`).
+            results = results[:limit]
         papers = []
         for p in results:
             # Extract basic information

--- a/tests/unit/test_crossref_sort_caveat.py
+++ b/tests/unit/test_crossref_sort_caveat.py
@@ -1,0 +1,28 @@
+"""Regression guard for Fix-R12A-2: Crossref_search_works accepts an
+undeclared `sort` passthrough param (BaseRESTTool forwards any caller arg
+straight through as a query param). Confirmed live and via raw curl to
+api.crossref.org that combining `query=` with `sort=is-referenced-by-count`
+makes Crossref return globally top-cited works with no relevance to the
+query -- this is genuine upstream Crossref API behavior, not a ToolUniverse
+bug, but the tool description previously gave no warning about it. Lock in
+the caveat so it can't be silently dropped in a future docs edit.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+CONFIG_PATH = (
+    Path(__file__).parent.parent.parent / "src/tooluniverse/data/crossref_tools.json"
+)
+
+
+def test_search_description_warns_about_sort_and_query_interaction():
+    configs = json.loads(CONFIG_PATH.read_text())
+    config = next(c for c in configs if c["name"] == "Crossref_search_works")
+    description = config["description"].lower()
+    assert "sort" in description
+    assert "relevance" in description

--- a/tests/unit/test_ncbi_datasets_lineage_names.py
+++ b/tests/unit/test_ncbi_datasets_lineage_names.py
@@ -1,0 +1,162 @@
+"""Regression guard for Fix-R12B-1: NCBIDatasets_get_taxonomy's `lineage`
+field is a bare list of ancestor tax_ids with no names or ranks attached --
+confirmed this is exactly what NCBI's own Datasets v2 API returns (not
+something dropped by this tool), and that NCBI's endpoint accepts a
+comma-joined batch of tax_ids in a single extra request. `lineage_names`
+resolves the whole lineage's organism_name/rank in one additional call
+rather than one call per ancestor, without changing the existing `lineage`
+field's shape (still bare ints, for backward compatibility).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.ncbi_datasets_tool import NCBIDatasetsTool
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def _tool():
+    return NCBIDatasetsTool(
+        {
+            "name": "NCBIDatasets_get_taxonomy",
+            "fields": {"endpoint_type": "taxonomy"},
+        }
+    )
+
+
+PRIMARY_NODE_RESPONSE = {
+    "taxonomy_nodes": [
+        {
+            "taxonomy": {
+                "tax_id": 9601,
+                "organism_name": "Pongo abelii",
+                "genbank_common_name": "Sumatran orangutan",
+                "rank": "SPECIES",
+                "blast_name": "primates",
+                "lineage": [9604, 9599],
+                "children": [],
+                "counts": [],
+            }
+        }
+    ]
+}
+
+LINEAGE_ENRICHMENT_RESPONSE = {
+    "taxonomy_nodes": [
+        {"taxonomy": {"tax_id": 9604, "organism_name": "Hominidae", "rank": "FAMILY"}},
+        {"taxonomy": {"tax_id": 9599, "organism_name": "Pongo", "rank": "GENUS"}},
+    ]
+}
+
+
+def test_lineage_names_enriched_in_root_first_order(monkeypatch):
+    tool = _tool()
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append(url)
+        if len(calls) == 1:
+            return _FakeResponse(200, PRIMARY_NODE_RESPONSE)
+        return _FakeResponse(200, LINEAGE_ENRICHMENT_RESPONSE)
+
+    monkeypatch.setattr("tooluniverse.ncbi_datasets_tool.requests.get", fake_get)
+
+    result = tool.run({"tax_id": "9601"})
+
+    assert result["status"] == "success"
+    assert result["data"]["lineage"] == [9604, 9599]
+    assert result["data"]["lineage_names"] == [
+        {"tax_id": 9604, "organism_name": "Hominidae", "rank": "FAMILY"},
+        {"tax_id": 9599, "organism_name": "Pongo", "rank": "GENUS"},
+    ]
+    # Enrichment call batches all ancestor tax_ids into one comma-joined request.
+    assert "9604,9599" in calls[1]
+
+
+def test_lineage_names_empty_for_root_with_no_ancestors(monkeypatch):
+    tool = _tool()
+    root_response = {
+        "taxonomy_nodes": [
+            {
+                "taxonomy": {
+                    "tax_id": 1,
+                    "organism_name": "root",
+                    "rank": "NO RANK",
+                    "lineage": [],
+                }
+            }
+        ]
+    }
+
+    def fake_get(url, **kwargs):
+        return _FakeResponse(200, root_response)
+
+    monkeypatch.setattr("tooluniverse.ncbi_datasets_tool.requests.get", fake_get)
+
+    result = tool.run({"tax_id": "1"})
+
+    assert result["data"]["lineage_names"] == []
+
+
+def test_lineage_names_degrades_gracefully_on_enrichment_failure(monkeypatch):
+    tool = _tool()
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append(url)
+        if len(calls) == 1:
+            return _FakeResponse(200, PRIMARY_NODE_RESPONSE)
+        raise __import__("requests").exceptions.ConnectionError("boom")
+
+    monkeypatch.setattr("tooluniverse.ncbi_datasets_tool.requests.get", fake_get)
+
+    result = tool.run({"tax_id": "9601"})
+
+    # The primary lookup already succeeded; enrichment failure must not
+    # fail the whole tool call, and the bare-id `lineage` stays intact.
+    assert result["status"] == "success"
+    assert result["data"]["lineage"] == [9604, 9599]
+    assert result["data"]["lineage_names"] == []
+
+
+def test_lineage_names_falls_back_per_id_when_partially_resolved(monkeypatch):
+    tool = _tool()
+    calls = []
+    partial_response = {
+        "taxonomy_nodes": [
+            {"taxonomy": {"tax_id": 9604, "organism_name": "Hominidae", "rank": "FAMILY"}}
+        ]
+    }
+
+    def fake_get(url, **kwargs):
+        calls.append(url)
+        if len(calls) == 1:
+            return _FakeResponse(200, PRIMARY_NODE_RESPONSE)
+        return _FakeResponse(200, partial_response)
+
+    monkeypatch.setattr("tooluniverse.ncbi_datasets_tool.requests.get", fake_get)
+
+    result = tool.run({"tax_id": "9601"})
+
+    assert result["data"]["lineage_names"] == [
+        {"tax_id": 9604, "organism_name": "Hominidae", "rank": "FAMILY"},
+        {"tax_id": 9599, "organism_name": None, "rank": None},
+    ]

--- a/tests/unit/test_pride_search_proteomics.py
+++ b/tests/unit/test_pride_search_proteomics.py
@@ -1,0 +1,141 @@
+"""Regression guard for Fix-R12C-1 and Fix-R12C-3.
+
+Fix-R12C-1: PRIDE_search_proteomics's `query` and `page_size` params were
+completely ignored -- confirmed live that a real query ("TP53") and a
+nonsense query returned byte-identical 100-row results. Root cause: the
+config pointed at PRIDE's `/projects?query={query}` endpoint, which (via raw
+curl) turns out to ignore `query` entirely; the real keyword-filtering
+endpoint is `/search/projects?keyword={query}&pageSize=N`. `page_size` was
+also never wired into any request param anywhere in the code.
+
+Fix-R12C-3: any PRIDE 404 (e.g. a gene symbol passed where a UniProt/PXD
+accession is expected) returned a bare "PRIDE API error" with no hint that
+the identifier itself was the problem, even though PRIDE's own 404 body is
+empty and has nothing more to surface.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.pride_tool import PRIDERESTTool
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else []
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def _search_tool():
+    return PRIDERESTTool(
+        {
+            "name": "PRIDE_search_proteomics",
+            "parameter": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "page_size": {"type": "integer", "default": 20},
+                },
+            },
+            "fields": {
+                "endpoint": "https://www.ebi.ac.uk/pride/ws/archive/v2/search/projects?keyword={query}",
+                "return_format": "JSON",
+            },
+        }
+    )
+
+
+def _protein_tool():
+    return PRIDERESTTool(
+        {
+            "name": "PRIDE_get_projects_for_protein",
+            "parameter": {
+                "type": "object",
+                "properties": {"accession": {"type": "string"}},
+            },
+            "fields": {
+                "endpoint": "https://www.ebi.ac.uk/pride/ws/archive/v2/proteins/{accession}",
+                "return_format": "JSON",
+            },
+        }
+    )
+
+
+def test_search_url_uses_keyword_search_endpoint():
+    tool = _search_tool()
+    url = tool._build_url({"query": "TP53", "page_size": 5})
+    assert url.startswith(
+        "https://www.ebi.ac.uk/pride/ws/archive/v2/search/projects?keyword=TP53"
+    )
+    assert "pageSize=5" in url
+
+
+def test_search_page_size_defaults_to_20_when_omitted():
+    tool = _search_tool()
+    url = tool._build_url({"query": "cancer"})
+    assert "pageSize=20" in url
+
+
+def test_search_run_returns_data_from_correct_endpoint(monkeypatch):
+    tool = _search_tool()
+    captured = {}
+
+    def fake_request(session, method, url, **kwargs):
+        captured["url"] = url
+        return _FakeResponse(200, [{"accession": "PXD073999"}])
+
+    monkeypatch.setattr("tooluniverse.pride_tool.request_with_retry", fake_request)
+
+    result = tool.run({"query": "TP53", "page_size": 5})
+
+    assert result["status"] == "success"
+    assert "search/projects?keyword=TP53" in captured["url"]
+    assert "pageSize=5" in captured["url"]
+
+
+def test_url_build_does_not_add_page_size_for_tools_without_that_param():
+    tool = _protein_tool()
+    url = tool._build_url({"accession": "P04637"})
+    assert url == "https://www.ebi.ac.uk/pride/ws/archive/v2/proteins/P04637"
+    assert "pageSize" not in url
+
+
+def test_404_error_message_hints_at_identifier_mismatch(monkeypatch):
+    tool = _protein_tool()
+
+    def fake_request(session, method, url, **kwargs):
+        return _FakeResponse(404, {}, text="")
+
+    monkeypatch.setattr("tooluniverse.pride_tool.request_with_retry", fake_request)
+
+    result = tool.run({"accession": "TP53"})
+
+    assert result["status"] == "error"
+    assert result["status_code"] == 404
+    assert "404" in result["error"]
+    assert "identifier" in result["error"]
+
+
+def test_non_404_errors_keep_generic_message(monkeypatch):
+    tool = _protein_tool()
+
+    def fake_request(session, method, url, **kwargs):
+        return _FakeResponse(500, {}, text="internal error")
+
+    monkeypatch.setattr("tooluniverse.pride_tool.request_with_retry", fake_request)
+
+    result = tool.run({"accession": "P04637"})
+
+    assert result["status"] == "error"
+    assert result["error"] == "PRIDE API error"
+    assert result["status_code"] == 500

--- a/tests/unit/test_semantic_scholar_bulk_sort.py
+++ b/tests/unit/test_semantic_scholar_bulk_sort.py
@@ -1,0 +1,116 @@
+"""Regression guard for Fix-R12A-1: SemanticScholar_search_papers with a
+`sort` value switches to the /paper/search/bulk endpoint, which rejects the
+"tldr" field with a 400 ("Unrecognized or unsupported fields: [tldr]") --
+confirmed live via raw curl -- and has no server-side `limit` concept (only
+token-based pagination over its full result set, so results must be sliced
+client-side). Before the fix, every sorted search call failed outright.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.semantic_scholar_tool import SemanticScholarTool
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.reason = ""
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+
+def _tool():
+    tool = SemanticScholarTool({"name": "SemanticScholar_search_papers"})
+    return tool
+
+
+def test_sorted_search_omits_tldr_from_bulk_request(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(tool, "_enforce_rate_limit", lambda has_api_key: None)
+
+    captured = {}
+
+    def fake_request(session, method, url, **kwargs):
+        captured["url"] = url
+        captured["params"] = kwargs.get("params", {})
+        return _FakeResponse(200, {"data": []})
+
+    monkeypatch.setattr(
+        "tooluniverse.semantic_scholar_tool.request_with_retry", fake_request
+    )
+
+    tool.run({"query": "CRISPR", "limit": 5, "sort": "citationCount:desc"})
+
+    assert "/paper/search/bulk" in captured["url"]
+    assert "tldr" not in captured["params"]["fields"].split(",")
+
+
+def test_unsorted_search_still_requests_tldr(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(tool, "_enforce_rate_limit", lambda has_api_key: None)
+
+    captured = {}
+
+    def fake_request(session, method, url, **kwargs):
+        captured["url"] = url
+        captured["params"] = kwargs.get("params", {})
+        return _FakeResponse(200, {"data": []})
+
+    monkeypatch.setattr(
+        "tooluniverse.semantic_scholar_tool.request_with_retry", fake_request
+    )
+
+    tool.run({"query": "CRISPR", "limit": 5})
+
+    assert "/paper/search/bulk" not in captured["url"]
+    assert "tldr" in captured["params"]["fields"].split(",")
+
+
+def test_sorted_search_results_sliced_to_requested_limit(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(tool, "_enforce_rate_limit", lambda has_api_key: None)
+
+    bulk_papers = [
+        {"paperId": str(i), "title": f"Paper {i}", "citationCount": 100 - i}
+        for i in range(50)
+    ]
+
+    def fake_request(session, method, url, **kwargs):
+        return _FakeResponse(200, {"data": bulk_papers, "token": "next-page"})
+
+    monkeypatch.setattr(
+        "tooluniverse.semantic_scholar_tool.request_with_retry", fake_request
+    )
+
+    result = tool.run({"query": "CRISPR", "limit": 5, "sort": "citationCount:desc"})
+
+    assert result["status"] == "success"
+    assert len(result["data"]) == 5
+
+
+def test_bulk_400_error_still_surfaced(monkeypatch):
+    """If the bulk endpoint rejects the request for any other reason, the
+    tool must still report the error rather than swallowing it."""
+    tool = _tool()
+    monkeypatch.setattr(tool, "_enforce_rate_limit", lambda has_api_key: None)
+
+    def fake_request(session, method, url, **kwargs):
+        return _FakeResponse(400, {})
+
+    monkeypatch.setattr(
+        "tooluniverse.semantic_scholar_tool.request_with_retry", fake_request
+    )
+
+    result = tool.run({"query": "CRISPR", "limit": 5, "sort": "citationCount:desc"})
+    assert result["status"] == "error"
+    assert result["error"] == "Semantic Scholar API error 400"

--- a/tests/unit/test_who_gho_indicator_data_param_mapping.py
+++ b/tests/unit/test_who_gho_indicator_data_param_mapping.py
@@ -1,0 +1,92 @@
+"""Regression guard for Fix-R12D-1: WHOGHO_get_indicator_data's `filter` and
+`top` schema parameters were silently dropped -- the tool always returned
+the same unfiltered, 20-row page regardless of what was requested. Root
+cause: unlike its sibling WHOGHO_search_indicators, this tool's config had
+no `fields.param_mapping` block, so BaseRESTTool never translated the
+declared `filter`/`top` args into the OData `$filter`/`$top` query params
+the live GHO OData API actually expects (confirmed live and via raw curl to
+ghoapi.azureedge.net).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.base_rest_tool import BaseRESTTool
+
+pytestmark = pytest.mark.unit
+
+CONFIG_PATH = (
+    Path(__file__).parent.parent.parent / "src/tooluniverse/data/who_gho_tools.json"
+)
+
+
+def _tool_config(name):
+    configs = json.loads(CONFIG_PATH.read_text())
+    return next(c for c in configs if c["name"] == name)
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {"value": []}
+        self.text = json.dumps(self._payload)
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+
+def test_config_declares_param_mapping_for_filter_and_top():
+    config = _tool_config("WHOGHO_get_indicator_data")
+    mapping = config["fields"].get("param_mapping", {})
+    assert mapping.get("filter") == "$filter"
+    assert mapping.get("top") == "$top"
+
+
+def test_filter_and_top_are_translated_into_odata_query_params(monkeypatch):
+    config = _tool_config("WHOGHO_get_indicator_data")
+    tool = BaseRESTTool(config)
+
+    captured = {}
+
+    def fake_request(session, method, url, **kwargs):
+        captured["params"] = kwargs.get("params", {})
+        return _FakeResponse(200, {"value": []})
+
+    monkeypatch.setattr("tooluniverse.base_rest_tool.request_with_retry", fake_request)
+
+    tool.run(
+        {
+            "indicator_code": "NCDMORT3070",
+            "filter": "SpatialDim eq 'USA'",
+            "top": 3,
+        }
+    )
+
+    params = captured["params"]
+    assert params["$filter"] == "SpatialDim eq 'USA'"
+    assert params["$top"] == 3
+    assert "filter" not in params
+    assert "top" not in params
+
+
+def test_indicator_code_still_substituted_into_path(monkeypatch):
+    config = _tool_config("WHOGHO_get_indicator_data")
+    tool = BaseRESTTool(config)
+
+    captured = {}
+
+    def fake_request(session, method, url, **kwargs):
+        captured["url"] = url
+        return _FakeResponse(200, {"value": []})
+
+    monkeypatch.setattr("tooluniverse.base_rest_tool.request_with_retry", fake_request)
+
+    tool.run({"indicator_code": "NCDMORT3070", "top": 3})
+
+    assert captured["url"] == "https://ghoapi.azureedge.net/api/NCDMORT3070"


### PR DESCRIPTION
## Round 12: bibliometrics, biodiversity/taxonomy, proteomics, public health, metabolomics

Fifth round of the ongoing test-harness sweep (continues #302 → #303 → #304 → #305 → #306). Five role-play researcher personas exercised tool families not covered by earlier rounds — bibliometrics (Semantic Scholar / OpenAlex / Crossref), biodiversity/taxonomy (GBIF / NCBI Taxonomy / IUCN), proteomics (PRIDE / UniProt PTM), public health surveillance (WHO GHO), and metabolomics (KEGG / Reactome / Metabolite DB) — chosen specifically to avoid re-discovering bugs already fixed but not yet merged in earlier rounds. Every finding below was CLI-verified and root-caused against the live upstream API (raw `curl`) before any fix.

### Fixed

**Fix-R12C-1 — `PRIDE_search_proteomics` ignored `query` and `page_size` entirely (HIGH)**
The tool's config pointed at `GET /projects?query={query}`. Raw curl confirmed PRIDE's `/projects` endpoint ignores `query` completely — a real query (`TP53`) and a nonsense string (`xyzzyzzynonexistentquery12345`) both returned the identical unfiltered 100 projects. The actual keyword-search endpoint is `/search/projects?keyword={query}&pageSize=N`, confirmed live to filter correctly (0 results for the nonsense query, TP53-relevant hits for `TP53`). `page_size` was also dead — the static `fields.params: {"pageSize": "20"}` in the JSON config was never read by any code path. Fixed by pointing the config at the real endpoint and wiring `page_size` into `_build_url` (falls back to the schema's advertised default of 20; confirmed live PRIDE otherwise defaults to 100/page).
`src/tooluniverse/pride_tool.py`, `src/tooluniverse/data/pride_tools.json`

**Fix-R12C-3 — `PRIDE_get_projects_for_protein` gave an unactionable error for wrong identifier type (MEDIUM)**
Passing a gene symbol (`TP53`) instead of a UniProt accession (`P04637`) returned a bare "PRIDE API error" — confirmed PRIDE returns an empty-body HTTP 404 for any unrecognized identifier, so there's no upstream detail to surface. Added a 404-specific message hinting the identifier format is the likely problem, without guessing a specific resource type (shared code path across all PRIDE tools).
`src/tooluniverse/pride_tool.py`

**Fix-R12B-1 — `NCBIDatasets_get_taxonomy`'s `lineage` was unusable ancestor IDs with no names (MEDIUM)**
`lineage` returned 30 bare numeric tax_ids with zero names/ranks, despite the tool's description promising "full lineage" — confirmed this is exactly what NCBI's own Datasets v2 API returns unmodified, not something dropped by the tool. NCBI's endpoint accepts a comma-joined batch of tax_ids in one request (confirmed live), so added a `lineage_names` field that resolves the whole lineage's `organism_name`/`rank` in a single extra batched call rather than one call per ancestor. The original `lineage` field is untouched (still bare ints) for backward compatibility; enrichment degrades gracefully to `[]` on failure rather than failing the whole call.
`src/tooluniverse/ncbi_datasets_tool.py`, `src/tooluniverse/data/ncbi_datasets_tools.json`

**Fix-R12D-1 — `WHOGHO_get_indicator_data`'s `filter`/`top` params were silently dropped (HIGH)**
Requesting `{"filter":"SpatialDim eq 'USA'","top":3}` returned the same unfiltered 20-row page every time (verified with 3 different filter/top combinations, and cross-checked that the raw WHO GHO OData API honors `$filter`/`$top` fine). Root cause: unlike its sibling `WHOGHO_search_indicators`, this tool's config had no `fields.param_mapping` block, so the generic `BaseRESTTool` never translated `filter`/`top` into the OData `$filter`/`$top` query params. Silent — no error, just wrong (unfiltered) data, which is the worst failure mode for a "compare across countries" workflow. Pure JSON config fix: added the missing `param_mapping` block, identical to the working sibling tool's.
`src/tooluniverse/data/who_gho_tools.json`

**Fix-R12A-1 — `SemanticScholar_search_papers` with `sort` failed with a deterministic 400 (HIGH)**
Any `sort` value (e.g. `citationCount:desc`) switches the tool to Semantic Scholar's `/paper/search/bulk` endpoint (needed because the plain `/paper/search` endpoint silently ignores `sort`). Raw curl isolated the exact cause: the bulk endpoint rejects the `tldr` field with `400 {"error": "Unrecognized or unsupported fields: [tldr]"}`, even though `/paper/search` supports it fine. The bulk endpoint also has no `limit` concept (only token-based pagination over its full result set), so `limit` was being silently ignored server-side too. Fixed by dropping `tldr` from the fields list only on the bulk path (kept on the normal path), and slicing results to the requested `limit` client-side when sorting.
`src/tooluniverse/semantic_scholar_tool.py`

**Fix-R12A-2 — `Crossref_search_works` + `sort` silently discards query relevance (MEDIUM, docs-only)**
`{"query":"CRISPR Cas9 genome editing","sort":"is-referenced-by-count","order":"desc"}` returned globally top-cited works (DESeq2, SAMtools, GSEA...) with zero relevance to the query. Confirmed via identical raw curl to `api.crossref.org` that this is genuine upstream Crossref behavior — combining `sort` with `query` weakens/discards the BM25 relevance matching — not a ToolUniverse bug. Added a caveat to the tool description warning about this known combination pitfall.
`src/tooluniverse/data/crossref_tools.json`

### Deferred (documented, not fixed)

- **R12C-2** — `PRIDE_get_projects_for_protein` rejects `protein` as a param name with a generic jsonschema "'accession' is a required property" error rather than naming the unrecognized key. Error is already actionable (states the correct key); this is a naming-intuition mismatch, not a broken tool — consistent with prior rounds' treatment of similar cases.
- **R12D-2** — `WHOGHO_get_indicator_data` on an invalid indicator code returns a generic `"{api_name} API error"` (no status code/detail surfaced by the CLI's default rendering). Confirmed WHO GHO returns an empty-body 404, so there's genuinely nothing more to surface for this case; the message itself comes from `base_rest_tool.py`, shared by many unrelated tool families — broadening it needs a dedicated audit (same precedent as the prior envelope-consistency batch, issue #288), not a one-off tweak here.
- **R12D-3** — `WHS2_161` (a cardiovascular indicator surfaced by `WHOGHO_search_indicators`) returns zero data rows. Confirmed via raw curl this is a genuine upstream WHO GHO data gap (stale/retired indicator still listed in the catalog), not a tool bug.
- **R11 carryover items** (UniProt bare-envelope, GWAS error/empty-success inconsistency, STRING type mismatch, CxGDisc relevance ranking, ChEMBL nested output, ZINC22 timeout) — unchanged from round 11, still deferred for the same reasons documented there.

### Testing

18 new unit tests across 5 files (all mocked, no network calls):
- `tests/unit/test_pride_search_proteomics.py` (6)
- `tests/unit/test_ncbi_datasets_lineage_names.py` (4)
- `tests/unit/test_who_gho_indicator_data_param_mapping.py` (3)
- `tests/unit/test_semantic_scholar_bulk_sort.py` (4)
- `tests/unit/test_crossref_sort_caveat.py` (1)

Every fix was also verified live against the real upstream API via the CLI before and after the change (see fix descriptions above for the specific before/after evidence).
