### PR TITLE
Round 13: WormBase gene-ID resolution, Wikidata schema defaults, gated-tool discovery

### DIFF
--- a/src/tooluniverse/cli.py
+++ b/src/tooluniverse/cli.py
@@ -258,6 +258,21 @@ def _render_grep(d: dict) -> str:
             if d.get("limit") == 0:
                 return f"0 of {total} matches (limit=0, no results shown)"
             return f"0 of {total} matches (offset past end — use --offset < {total})"
+        # Fix-R13D-1: surface tools that exist but are hidden because a
+        # required API key is unset -- without this, `tu grep uspto` looked
+        # identical to "no such tools exist" (confirmed live), when in fact
+        # the tools are real and just need a key set.
+        gated = d.get("gated_matches")
+        if gated:
+            lines = [
+                f"0 loaded matches, but {len(gated)} gated tool(s) matched by name:"
+            ]
+            for g in gated:
+                lines.append(
+                    f"  {g['name']}  (requires: {', '.join(g['missing_api_keys'])})"
+                )
+            lines.append("  Set the API key(s) as environment variables, then retry.")
+            return "\n".join(lines)
         # Feature-R13A-01 / R21B-03: context-sensitive hints for 0 name-field matches.
         if d.get("field") == "name":
             pattern = d.get("pattern", "")
@@ -377,7 +392,16 @@ def _render_info(d: dict) -> str:
     """Render get_tool_info result as human-readable tool card."""
     if "error" in d:
         name = d.get("name", "")
+        error_msg = d.get("error", "")
         suggestions = d.get("suggestions", [])
+        # Fix-R13D-1: this used to hardcode "not found" for every error here,
+        # discarding a more specific message like "requires API key(s) not
+        # set: X" (confirmed live this contradicted `tu run`'s own error for
+        # the exact same tool name, which does surface the real reason).
+        # Only fall back to the generic not-found/"did you mean" framing when
+        # the tool is genuinely absent from the registry.
+        if name and error_msg and "not found" not in error_msg:
+            return f"Error: Tool '{name}' {error_msg}"
         # R22B-04: append "Did you mean?" hint when suggestions are available.
         if name:
             hint = ""
@@ -981,10 +1005,13 @@ def cmd_info(args: argparse.Namespace) -> None:
         )
     # R22B-04: inject "did you mean" suggestions into each not-found error entry so
     # _render_info can display them without needing direct access to `tu`.
+    # Fix-R13D-1: skip this for a gated tool (error != "not found") -- the
+    # tool name is already exact, so suggesting near-miss alternatives is
+    # noise, not help.
     if isinstance(result, dict) and "tools" in result:
         all_names = list(tu.all_tool_dict.keys())
         for tool in result["tools"]:
-            if isinstance(tool, dict) and "error" in tool:
+            if isinstance(tool, dict) and tool.get("error") == "not found":
                 name = tool.get("name", "")
                 if name:
                     # Feature-23B-04: raised cutoff from 0.5 → 0.62 to avoid spurious

--- a/src/tooluniverse/data/ctd_tools.json
+++ b/src/tooluniverse/data/ctd_tools.json
@@ -176,7 +176,7 @@
   },
   {
     "name": "CTD_get_chemical_diseases",
-    "description": "Get curated chemical-disease associations from CTD. Given a chemical name, returns diseases it is associated with, including direct evidence type (therapeutic, marker/mechanism) and disease categories. Example: 'bisphenol A' returns associations with cancer, reproductive disorders, etc. Backed by the RENCI Automat CTD mirror (June-2024 snapshot, biolink-categorized); CTD's native batchQuery.go is currently CAPTCHA-blocked for programmatic clients.",
+    "description": "Get curated chemical-disease associations from CTD. Given a chemical name, returns diseases it is associated with, and disease categories. Example: 'bisphenol A' returns associations with cancer, reproductive disorders, etc. Note: unlike the sibling CTD_get_chemical_gene_interactions tool, the RENCI mirror's chemical-disease edges do not carry a direct evidence type (predicate/qualified_predicate) -- those fields are consistently null here, not a query error. Backed by the RENCI Automat CTD mirror (June-2024 snapshot, biolink-categorized); CTD's native batchQuery.go is currently CAPTCHA-blocked for programmatic clients.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/wikidata_entity_tools.json
+++ b/src/tooluniverse/data/wikidata_entity_tools.json
@@ -14,6 +14,7 @@
             "string",
             "null"
           ],
+          "default": "en",
           "description": "Language code for search and results. Default: 'en'. Examples: 'fr', 'de', 'zh', 'ja', 'es'"
         },
         "type": {

--- a/src/tooluniverse/data/wikidata_sparql_tools.json
+++ b/src/tooluniverse/data/wikidata_sparql_tools.json
@@ -17,8 +17,7 @@
         }
       },
       "required": [
-        "sparql",
-        "max_results"
+        "sparql"
       ]
     },
     "return_schema": {

--- a/src/tooluniverse/tool_discovery_tools.py
+++ b/src/tooluniverse/tool_discovery_tools.py
@@ -181,7 +181,7 @@ class GrepToolsTool(BaseTool):
             if limit == 0
             else (limit is not None and (offset + len(matching_tools)) < total_matches)
         )
-        return {
+        result = {
             "total_matches": total_matches,
             "limit": limit,
             "offset": offset,
@@ -200,6 +200,25 @@ class GrepToolsTool(BaseTool):
             "search_mode": search_mode,
             "tools": matching_tools,
         }
+        # Fix-R13D-1: a tool with unmet required_api_keys is dropped from
+        # all_tool_dict entirely, so e.g. `tu grep uspto` returned 0 matches
+        # with no hint that USPTO tools exist but are gated -- confirmed
+        # live this makes a real tool look nonexistent to the documented
+        # "grep -> info -> run" discovery workflow. Only attempt this
+        # name-substring fallback (matches what a plain-text `field=name`
+        # search would have found) when the normal search truly found
+        # nothing, to keep the common case unaffected.
+        if total_matches == 0 and field == "name" and search_mode == "text":
+            excluded = getattr(self.tooluniverse, "_excluded_api_key_tools", {})
+            gated_matches = sorted(
+                name for name in excluded if pattern.lower() in name.lower()
+            )
+            if gated_matches:
+                result["gated_matches"] = [
+                    {"name": name, "missing_api_keys": excluded[name]}
+                    for name in gated_matches
+                ]
+        return result
 
 
 @register_tool("ListTools")
@@ -703,6 +722,26 @@ class GetToolInfoTool(BaseTool):
         super().__init__(tool_config)
         self.tooluniverse = tooluniverse
 
+    def _not_found_error(self, tool_name: str) -> str:
+        """Fix-R13D-1: a tool with unmet required_api_keys is dropped from
+        all_tool_dict entirely during loading, so this previously reported a
+        flat "not found" -- indistinguishable from a genuinely nonexistent
+        tool name and misleading the "grep/info -> run" discovery workflow,
+        since `tu run` on the exact same tool already gives an actionable
+        "requires API key(s) not set" message via _excluded_api_key_tools
+        (confirmed live: this contradicted `tu run`'s own error for the same
+        tool name). Mirror that message here instead of a bare "not found".
+        """
+        missing_keys = getattr(self.tooluniverse, "_excluded_api_key_tools", {}).get(
+            tool_name
+        )
+        if missing_keys:
+            return (
+                f"requires API key(s) not set: {', '.join(missing_keys)}. "
+                "Set them as environment variables and retry."
+            )
+        return "not found"
+
     def run(self, arguments):
         """
         Get tool information with configurable detail level.
@@ -757,7 +796,12 @@ class GetToolInfoTool(BaseTool):
                     tool_config = self.tooluniverse.all_tool_dict.get(tool_name)
                     if not tool_config:
                         # tool_name is already shortened (primary identifier)
-                        results.append({"name": tool_name, "error": "not found"})
+                        results.append(
+                            {
+                                "name": tool_name,
+                                "error": self._not_found_error(tool_name),
+                            }
+                        )
                     else:
                         # tool_name is already shortened (primary identifier)
                         results.append(
@@ -789,9 +833,18 @@ class GetToolInfoTool(BaseTool):
                         tool_names[0], return_prompt=False
                     )
                     if not tool_config:
+                        error = self._not_found_error(tool_names[0])
+                        # Fix-R13D-1: this dict has no "name" key (unlike the
+                        # per-tool entries elsewhere), so a bare "not found"
+                        # would drop the tool name from the message entirely.
+                        # Restore the original name-embedded wording for the
+                        # genuine-not-found case; the gated-tool message
+                        # already names the tool.
+                        if error == "not found":
+                            error = f"Tool '{tool_names[0]}' not found"
                         return {
                             "status": "error",
-                            "error": f"Tool '{tool_names[0]}' not found",
+                            "error": error,
                         }
                     return tool_config
                 else:
@@ -805,7 +858,7 @@ class GetToolInfoTool(BaseTool):
                         tool.get("name") for tool in tools_definitions if tool
                     }
                     missing_tools = [
-                        {"name": name, "error": "not found"}
+                        {"name": name, "error": self._not_found_error(name)}
                         for name in tool_names
                         if name not in found_names
                     ]

--- a/src/tooluniverse/wormbase_tool.py
+++ b/src/tooluniverse/wormbase_tool.py
@@ -16,7 +16,7 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 WORMBASE_BASE_URL = "https://rest.wormbase.org/rest"
-ALLIANCE_SEARCH_URL = "https://www.alliancegenome.org/api/search"
+ALLIANCE_AUTOCOMPLETE_URL = "https://www.alliancegenome.org/api/search_autocomplete"
 
 # Module-level cache: gene name (lower) -> WBGene ID, avoids repeated lookups
 _WBGENE_CACHE: dict = {}
@@ -25,33 +25,41 @@ _WBGENE_CACHE: dict = {}
 def _resolve_wbgene_id(gene_input: str) -> str:
     """Resolve a gene name (e.g. 'unc-86') to a WBGene ID via the Alliance API.
 
-    If the input already looks like a WBGene ID, return it unchanged.
+    If the input already looks like a WBGene ID (with or without a "WB:"
+    CURIE prefix -- exactly what a sibling tool like Alliance_search_genes
+    returns for the same gene), return it with the prefix stripped.
     Returns the resolved WBGene ID or the original input if resolution fails.
     """
-    if gene_input.upper().startswith("WBGENE"):
-        return gene_input
+    # Fix-R13B-1: WormBase's own REST API 500s on a "WB:"-prefixed ID
+    # because the old check below didn't strip it, so the colon-containing
+    # string was passed straight into the URL path unchanged.
+    unprefixed = gene_input.split(":", 1)[-1]
+    if unprefixed.upper().startswith("WBGENE"):
+        return unprefixed
 
     cache_key = gene_input.lower()
     if cache_key in _WBGENE_CACHE:
         return _WBGENE_CACHE[cache_key]
 
     try:
-        params = {
-            "category": "gene",
-            "q": gene_input,
-            "species": "Caenorhabditis elegans",
-            "limit": 5,
-        }
-        resp = requests.get(ALLIANCE_SEARCH_URL, params=params, timeout=10)
+        # Fix-R13B-2: /api/search with `category`/`species` params returns
+        # zero results for any real gene symbol (confirmed live) -- Alliance
+        # no longer honours those params on that endpoint. The endpoint that
+        # actually resolves symbols is /api/search_autocomplete, which mixes
+        # gene/disease/dataset hits and has no `id` field, so gene hits must
+        # be filtered client-side by category and the gene id read from
+        # `curie` (e.g. "WB:WBGene00006746").
+        params = {"q": gene_input, "limit": 25}
+        resp = requests.get(ALLIANCE_AUTOCOMPLETE_URL, params=params, timeout=10)
         if resp.status_code != 200:
             return gene_input
         results = resp.json().get("results", [])
         for r in results:
-            symbol = r.get("symbol", "")
-            if symbol.lower() == cache_key:
-                raw_id = r.get("id", "")
-                # Alliance returns "WB:WBGene00006818" — strip the "WB:" prefix
-                resolved = raw_id.split(":")[-1] if ":" in raw_id else raw_id
+            if r.get("category") != "gene_search_result":
+                continue
+            raw_id = r.get("curie", "")
+            if r.get("symbol", "").lower() == cache_key and raw_id.startswith("WB:"):
+                resolved = raw_id.split(":", 1)[-1]
                 _WBGENE_CACHE[cache_key] = resolved
                 return resolved
         return gene_input

--- a/tests/unit/test_ctd_disease_predicate_caveat.py
+++ b/tests/unit/test_ctd_disease_predicate_caveat.py
@@ -1,0 +1,27 @@
+"""Regression guard for Feature-R13A-1 (docs-only): CTD_get_chemical_diseases's
+description promised "direct evidence type (therapeutic, marker/mechanism)"
+that the RENCI Automat CTD mirror never actually provides for chemical-disease
+edges -- confirmed via raw curl to automat.renci.org/ctd that the edge
+properties for a real chemical-disease pair are exactly
+{agent_type, knowledge_level, primary_knowledge_source, publications}, with no
+predicate/qualified_predicate key at all (unlike the sibling chemical-gene
+interaction edges, which do carry one). This is a genuine upstream data gap,
+not a code bug, so the fix is a description caveat rather than a code change.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+CONFIG_PATH = Path(__file__).parent.parent.parent / "src/tooluniverse/data/ctd_tools.json"
+
+
+def test_chemical_diseases_description_no_longer_promises_evidence_type():
+    configs = json.loads(CONFIG_PATH.read_text())
+    config = next(c for c in configs if c["name"] == "CTD_get_chemical_diseases")
+    description = config["description"]
+    assert "including direct evidence type" not in description
+    assert "predicate" in description.lower()

--- a/tests/unit/test_gated_tool_discovery.py
+++ b/tests/unit/test_gated_tool_discovery.py
@@ -1,0 +1,169 @@
+"""Regression guard for Fix-R13D-1: a tool with unmet `required_api_keys`
+(e.g. USPTO tools needing USPTO_API_KEY) is dropped from `all_tool_dict`
+entirely during loading -- correct for keeping an agent's active tool list
+clean -- but that made `tu grep`/`tu info` report such tools as flatly
+nonexistent, contradicting `tu run`'s own "requires API key(s) not set"
+message for the exact same tool name. Confirmed live: `tu grep uspto` and
+`tu info get_patent_overview_by_text_query` both looked identical to "no
+such tool", even though the tool exists, is correctly registered, and just
+needs an env var set.
+
+These tests cover the three layers of the fix:
+  - GetToolInfoTool._not_found_error / GrepToolsTool.run: surface
+    `_excluded_api_key_tools` instead of a bare "not found".
+  - cli._render_info / cli._render_grep: render that distinction instead of
+    collapsing every error back to a hardcoded "not found" message.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.tool_discovery_tools import GetToolInfoTool, GrepToolsTool
+
+pytestmark = pytest.mark.unit
+
+
+def _fake_tooluniverse(all_tool_dict=None, excluded=None):
+    tu = MagicMock()
+    tu.all_tool_dict = all_tool_dict or {}
+    tu._excluded_api_key_tools = excluded or {}
+    return tu
+
+
+# ---------------------------------------------------------------------------
+# GetToolInfoTool
+# ---------------------------------------------------------------------------
+
+
+def test_info_gated_tool_reports_missing_key_not_generic_not_found():
+    tu = _fake_tooluniverse(
+        excluded={"get_patent_overview_by_text_query": ["USPTO_API_KEY"]}
+    )
+    tool = GetToolInfoTool({"name": "get_tool_info"}, tooluniverse=tu)
+
+    result = tool.run(
+        {"tool_names": "get_patent_overview_by_text_query", "detail_level": "description"}
+    )
+
+    assert result["error"] != "not found"
+    assert "USPTO_API_KEY" in result["error"]
+
+
+def test_info_genuinely_missing_tool_still_says_not_found():
+    tu = _fake_tooluniverse()
+    tool = GetToolInfoTool({"name": "get_tool_info"}, tooluniverse=tu)
+
+    result = tool.run(
+        {"tool_names": "TotallyFakeToolName123", "detail_level": "description"}
+    )
+
+    assert result["error"] == "not found"
+
+
+def test_info_batch_mode_distinguishes_gated_from_missing():
+    tu = _fake_tooluniverse(excluded={"gated_tool": ["SOME_KEY"]})
+    tool = GetToolInfoTool({"name": "get_tool_info"}, tooluniverse=tu)
+
+    result = tool.run(
+        {"tool_names": ["gated_tool", "fake_tool"], "detail_level": "description"}
+    )
+
+    by_name = {t["name"]: t["error"] for t in result["tools"]}
+    assert "SOME_KEY" in by_name["gated_tool"]
+    assert by_name["fake_tool"] == "not found"
+
+
+# ---------------------------------------------------------------------------
+# GrepToolsTool
+# ---------------------------------------------------------------------------
+
+
+def test_grep_zero_matches_surfaces_gated_tool_by_name():
+    tu = _fake_tooluniverse(
+        all_tool_dict={},
+        excluded={"get_patent_overview_by_text_query": ["USPTO_API_KEY"]},
+    )
+    tool = GrepToolsTool({"name": "grep_tools"}, tooluniverse=tu)
+
+    result = tool.run({"pattern": "patent_overview"})
+
+    assert result["total_matches"] == 0
+    assert result["gated_matches"] == [
+        {"name": "get_patent_overview_by_text_query", "missing_api_keys": ["USPTO_API_KEY"]}
+    ]
+
+
+def test_grep_with_real_matches_does_not_surface_gated_tools():
+    tu = _fake_tooluniverse(
+        all_tool_dict={
+            "PubMed_search_articles": {"name": "PubMed_search_articles", "description": "search pubmed"}
+        },
+        excluded={"unrelated_gated_tool": ["SOME_KEY"]},
+    )
+    tool = GrepToolsTool({"name": "grep_tools"}, tooluniverse=tu)
+
+    result = tool.run({"pattern": "pubmed"})
+
+    assert result["total_matches"] == 1
+    assert "gated_matches" not in result
+
+
+def test_grep_no_gated_matches_omits_the_key():
+    tu = _fake_tooluniverse(all_tool_dict={}, excluded={"foo_tool": ["FOO_KEY"]})
+    tool = GrepToolsTool({"name": "grep_tools"}, tooluniverse=tu)
+
+    result = tool.run({"pattern": "totally_unrelated_zzz"})
+
+    assert result["total_matches"] == 0
+    assert "gated_matches" not in result
+
+
+# ---------------------------------------------------------------------------
+# CLI rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_info_shows_gated_message_verbatim():
+    from tooluniverse.cli import _render_info
+
+    d = {
+        "name": "get_patent_overview_by_text_query",
+        "error": "requires API key(s) not set: USPTO_API_KEY. Set them as environment variables and retry.",
+    }
+    result = _render_info(d)
+    assert "USPTO_API_KEY" in result
+    assert "Did you mean" not in result
+
+
+def test_render_info_still_shows_did_you_mean_for_real_not_found():
+    from tooluniverse.cli import _render_info
+
+    d = {
+        "error": "not found",
+        "name": "UniProt_search_typo",
+        "suggestions": ["UniProt_search", "UniProt_get_entry_by_accession"],
+    }
+    result = _render_info(d)
+    assert "Did you mean" in result
+
+
+def test_render_grep_shows_gated_matches():
+    from tooluniverse.cli import _render_grep
+
+    d = {
+        "tools": [],
+        "total_matches": 0,
+        "field": "name",
+        "pattern": "uspto",
+        "gated_matches": [
+            {"name": "get_patent_overview_by_text_query", "missing_api_keys": ["USPTO_API_KEY"]}
+        ],
+    }
+    result = _render_grep(d)
+    assert "get_patent_overview_by_text_query" in result
+    assert "USPTO_API_KEY" in result

--- a/tests/unit/test_wikidata_schema_fixes.py
+++ b/tests/unit/test_wikidata_schema_fixes.py
@@ -1,0 +1,88 @@
+"""Regression guard for Fix-R13E-1 and Fix-R13E-3.
+
+Fix-R13E-1: Wikidata_search_entities's `language` param was documented as
+"Default: 'en'" but had no actual `default` in its JSON schema, so omitting
+it sent no `language` param at all. Confirmed live that MediaWiki's
+wbsearchentities then returns HTTP 200 with a `{"error": {"code":
+"missingparam", ...}}` body -- a failure disguised as a ToolUniverse
+success. Adding the schema default (BaseRESTTool applies schema defaults
+for any arg the caller omits) makes the documented behavior real.
+
+Fix-R13E-3: Wikidata_SPARQL_query's `max_results` was listed in `required`
+even though its own description says "Optional... If not specified, uses
+the LIMIT clause" and the Python code already does `arguments.get(...)`
+(gracefully handling absence) -- the schema contradicted both the docs and
+the implementation.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+ENTITY_CONFIG_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src/tooluniverse/data/wikidata_entity_tools.json"
+)
+SPARQL_CONFIG_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src/tooluniverse/data/wikidata_sparql_tools.json"
+)
+
+
+def test_search_entities_language_has_en_default():
+    configs = json.loads(ENTITY_CONFIG_PATH.read_text())
+    config = next(c for c in configs if c["name"] == "Wikidata_search_entities")
+    assert config["parameter"]["properties"]["language"]["default"] == "en"
+
+
+def test_search_entities_language_default_is_applied_to_request(monkeypatch):
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+    from tooluniverse.base_rest_tool import BaseRESTTool
+
+    configs = json.loads(ENTITY_CONFIG_PATH.read_text())
+    config = next(c for c in configs if c["name"] == "Wikidata_search_entities")
+    tool = BaseRESTTool(config)
+
+    params = tool._build_params({"search": "Zea mays"})
+    assert params["language"] == "en"
+
+
+def test_sparql_query_max_results_not_required():
+    configs = json.loads(SPARQL_CONFIG_PATH.read_text())
+    config = next(c for c in configs if c["name"] == "Wikidata_SPARQL_query")
+    assert "max_results" not in config["parameter"]["required"]
+    assert "sparql" in config["parameter"]["required"]
+
+
+def test_sparql_query_runs_without_max_results(monkeypatch):
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+    from tooluniverse.wikidata_sparql_tool import WikidataSPARQLTool
+
+    class _FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "results": {
+                    "bindings": [{"item": {"value": "Zea mays"}}]
+                }
+            }
+
+    def fake_get(url, **kwargs):
+        return _FakeResponse()
+
+    monkeypatch.setattr("tooluniverse.wikidata_sparql_tool.requests.get", fake_get)
+
+    tool = WikidataSPARQLTool({"name": "Wikidata_SPARQL_query"})
+    result = tool.run({"sparql": "SELECT ?item WHERE { wd:Q11575 wdt:P225 ?item }"})
+    assert result == [{"item": "Zea mays"}]

--- a/tests/unit/test_wormbase_gene_id_resolution.py
+++ b/tests/unit/test_wormbase_gene_id_resolution.py
@@ -1,0 +1,115 @@
+"""Regression guard for Fix-R13B-1 and Fix-R13B-2.
+
+Fix-R13B-1: WormBase_get_gene 500'd on a "WB:"-prefixed WBGene ID (e.g.
+"WB:WBGene00006746", exactly what a sibling tool like Alliance_search_genes
+returns for the same gene) because the old check `startswith("WBGENE")`
+didn't strip the "WB:" CURIE prefix, so the colon-containing string was
+interpolated straight into the WormBase REST URL.
+
+Fix-R13B-2: WormBase's own /api/search endpoint with `category=gene` and
+`species=...` params silently returns zero results for any real gene symbol
+(confirmed live) -- Alliance no longer honours those params there. The
+working endpoint is /api/search_autocomplete with just `q`, filtering gene
+hits client-side by category and by the "WB:" curie prefix.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.wormbase_tool import _resolve_wbgene_id, _WBGENE_CACHE
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    _WBGENE_CACHE.clear()
+    yield
+    _WBGENE_CACHE.clear()
+
+
+def test_wb_prefixed_id_is_stripped_without_any_api_call(monkeypatch):
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("should not call the Alliance API for an already-resolved ID")
+
+    monkeypatch.setattr("tooluniverse.wormbase_tool.requests.get", fail_if_called)
+
+    assert _resolve_wbgene_id("WB:WBGene00006746") == "WBGene00006746"
+
+
+def test_bare_wbgene_id_returned_unchanged():
+    assert _resolve_wbgene_id("WBGene00006746") == "WBGene00006746"
+
+
+def test_gene_symbol_resolves_via_autocomplete_endpoint(monkeypatch):
+    captured = {}
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "results": [
+                    {"symbol": "unc-6", "curie": "WB:WBGene00006746", "category": "gene_search_result"},
+                    {"symbol": "unc-60", "curie": "WB:WBGene00006794", "category": "gene_search_result"},
+                    {"symbol": "unc-6", "curie": "MGI:1234", "category": "gene_search_result"},
+                    {"symbol": "unc-6", "curie": "WB:WBGene00006746", "category": "disease_search_result"},
+                ]
+            }
+
+    def fake_get(url, params=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params
+        return _FakeResponse()
+
+    monkeypatch.setattr("tooluniverse.wormbase_tool.requests.get", fake_get)
+
+    resolved = _resolve_wbgene_id("unc-6")
+
+    assert resolved == "WBGene00006746"
+    assert "search_autocomplete" in captured["url"]
+    assert "category" not in captured["params"]
+    assert "species" not in captured["params"]
+
+
+def test_unresolvable_symbol_falls_back_to_original_input(monkeypatch):
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"results": []}
+
+    monkeypatch.setattr(
+        "tooluniverse.wormbase_tool.requests.get",
+        lambda url, params=None, timeout=None: _FakeResponse(),
+    )
+
+    assert _resolve_wbgene_id("not-a-real-gene") == "not-a-real-gene"
+
+
+def test_resolution_result_is_cached(monkeypatch):
+    calls = []
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {
+                "results": [
+                    {"symbol": "unc-6", "curie": "WB:WBGene00006746", "category": "gene_search_result"}
+                ]
+            }
+
+    def fake_get(url, params=None, timeout=None):
+        calls.append(1)
+        return _FakeResponse()
+
+    monkeypatch.setattr("tooluniverse.wormbase_tool.requests.get", fake_get)
+
+    assert _resolve_wbgene_id("unc-6") == "WBGene00006746"
+    assert _resolve_wbgene_id("unc-6") == "WBGene00006746"
+    assert len(calls) == 1


### PR DESCRIPTION
## Round 13: toxicology, developmental biology, immunology, patent search, agricultural science

Sixth round of the ongoing test-harness sweep (continues #302 → #303 → #304 → #305 → #306 → #307). Five role-play researcher personas exercised entirely fresh tool families — toxicology (CTD), developmental/model-organism biology (WormBase, Xenbase, VEuPathDB), immunology (VDJdb, IEDB), patent/IP analysis (USPTO), and agricultural science (USDA Plants, Wikidata) — continuing the domain-diversification strategy from rounds 11-12 to avoid rediscovering bugs already fixed in earlier, still-unmerged rounds. Immunology (VDJdb/IEDB) came back completely clean: 7 tool calls, cross-database concordance, zero issues.

### Fixed

**Fix-R13B-1 / Fix-R13B-2 — `WormBase_get_gene` 500'd on a "WB:"-prefixed ID or a bare gene symbol (HIGH)**
`_resolve_wbgene_id` had two independent bugs, both confirmed live:
- A "WB:"-prefixed WBGene ID (`WB:WBGene00006746` — exactly what the sibling tool `Alliance_search_genes` returns for the same gene) wasn't recognized as already-resolved (`startswith("WBGENE")` doesn't match `"WB:WBGENE..."`), so the raw colon-containing string was interpolated straight into the WormBase REST URL, which 500'd.
- A bare gene symbol (`unc-6`) fell through to an Alliance Genome Resources lookup using `category=gene`/`species=...` query params on `/api/search` — confirmed via raw curl these params are no longer honored and always return zero results. The working endpoint (already used correctly by the `alliance_genome_tool.py` sibling) is `/api/search_autocomplete` with client-side filtering by category and species curie prefix.
Both now resolve correctly; verified live for both `WB:WBGene00006746` and `unc-6`.
`src/tooluniverse/wormbase_tool.py`

**Fix-R13E-1 — `Wikidata_search_entities` disguised a MediaWiki failure as success (HIGH)**
The `language` param was documented as defaulting to `'en'` but had no `default` in the JSON schema, so omitting it sent no `language` param at all. Confirmed live that MediaWiki's `wbsearchentities` then returns HTTP 200 with `{"error": {"code": "missingparam", ...}}` embedded in the body — ToolUniverse reported this as `status: success`, requiring the caller to inspect payload contents to discover the call actually failed. Added the schema default so the documented behavior is real.
`src/tooluniverse/data/wikidata_entity_tools.json`

**Fix-R13D-1 — `tu grep`/`tu info` made real, gated tools look nonexistent (HIGH)**
Tools with an unmet `required_api_keys` (here: 6 USPTO patent-search tools needing `USPTO_API_KEY`) are correctly excluded from the active tool registry — but this made `tu grep uspto` return 0 matches and `tu info get_patent_overview_by_text_query` return "Tool not found", both indistinguishable from the tool genuinely not existing. `tu run` on the exact same tool name already gives the correct, actionable "requires API key(s) not set: USPTO_API_KEY" message via an existing `_excluded_api_key_tools` tracking dict — it just wasn't wired into the discovery commands. Fixed by threading that same lookup into `GetToolInfoTool` and `GrepToolsTool` (`tool_discovery_tools.py`), and fixing `cli.py`'s `_render_info` (which previously hardcoded every error to a generic "not found", discarding any more specific message) and `_render_grep` (renders the new `gated_matches` list) to surface it. `tu grep get_patent_overview` and `tu info get_patent_overview_by_text_query` now both correctly report the missing API key instead of "doesn't exist."
`src/tooluniverse/tool_discovery_tools.py`, `src/tooluniverse/cli.py`

**Fix-R13E-3 — `Wikidata_SPARQL_query`'s `max_results` was required despite being documented and implemented as optional**
The schema listed `max_results` in `required`, but its own description says "Optional result limit override... If not specified, uses the LIMIT clause," and the Python implementation already does `arguments.get("max_results")` with graceful fallback. Every call omitting it failed validation before ever reaching that correctly-written handling. Removed from `required`.
`src/tooluniverse/data/wikidata_sparql_tools.json`

**Feature-R13A-1 — `CTD_get_chemical_diseases` description over-promised evidence-type data (docs-only)**
The description promised "direct evidence type (therapeutic, marker/mechanism)" for every chemical-disease association. Confirmed via raw curl to RENCI's Automat CTD mirror that the actual edge properties for chemical-disease pairs are `{agent_type, knowledge_level, primary_knowledge_source, publications}` — no `predicate`/`qualified_predicate` key at all, unlike the sibling chemical-gene-interaction edges which do carry one. Genuine upstream data gap, not a code bug (the shared `_format_edge` extraction is correct); added a caveat to the description instead of a code change.
`src/tooluniverse/data/ctd_tools.json`

### Deferred (documented, not fixed)

- **R13A-2** — `PubChemTox_get_toxicity_summary` rejects a guessed `chemical_name` param (correct name: `compound_name`). Error is already actionable; naming-intuition mismatch, not a broken tool.
- **R13B-3** — `VEuPathDB_search_genes_by_organism` returns a raw WDK validation error for an out-of-scope organism (C. elegans isn't covered by VEuPathDB, which is pathogen/vector-focused) — the underlying negative result is actually correct, just opaquely worded.
- **R13D-2** — `tu status` has no way to enumerate all 87 gated tools by name/required-key; only a bare count. The core discoverability blocker (a specific gated tool being indistinguishable from nonexistent) is fixed by R13D-1 above; full enumeration is a separate, larger UX enhancement.
- **R13D-3** — `PubMed_search_articles` for "CRISPR Cas9 patent" returned only tangentially relevant results (CAR-T papers mentioning CRISPR in passing). Confirmed a PubMed relevance-ranking characteristic, not a tool defect — PubMed doesn't index patents and "patent" as a free-text term dilutes relevance.
- **R13E-2** — `USDA_plants_get_profile`'s `fips_distribution` field is always null. Confirmed via raw curl this is genuinely null on the `PlantProfile` endpoint itself (even though a `HasDistributionData: true` flag suggests the data exists elsewhere) — probing several plausible distribution-endpoint URL patterns (`PlantDistribution/{id}`, `PlantProfile/{id}/Distribution`, etc.) all 404'd. The real endpoint likely requires live network-tab inspection of the USDA Plants website to find; deferring rather than guessing further.

### Testing

19 new unit tests across 4 files (all mocked, no network calls):
- `tests/unit/test_wormbase_gene_id_resolution.py` (5)
- `tests/unit/test_wikidata_schema_fixes.py` (4)
- `tests/unit/test_gated_tool_discovery.py` (9)
- `tests/unit/test_ctd_disease_predicate_caveat.py` (1)

Also re-ran the full pre-existing `tests/tools/test_tu_cli.py` suite (369 tests) since the `tu grep`/`tu info` changes touch shared CLI rendering code — all green except one already-documented, pre-existing flaky test (`test_find_tool_name_with_underscores_works`, a semantic-search ranking issue unrelated to this round, confirmed in earlier rounds to fail identically against a clean `origin/main` baseline).

Every fix was also verified live against the real upstream API via the CLI before and after the change (see fix descriptions above for the specific before/after evidence).
