### PR TITLE
Round 14: dbSNP not-found detection, BRENDA SABIO-RK failure visibility, ArrayExpress sample extraction

### DIFF
--- a/src/tooluniverse/arrayexpress_tool.py
+++ b/src/tooluniverse/arrayexpress_tool.py
@@ -235,9 +235,19 @@ class ArrayExpressRESTTool(BaseTool):
         """Extract sample information from a BioStudies section"""
         samples = []
 
-        # Check if current section is a sample
+        # Fix-R14C-2: the literal "Samples" section is just a wrapper
+        # carrying aggregate summary attributes (e.g. "Sample count", plus
+        # one "Experimental Factors" attribute per factor -- which the dict
+        # build below collapses to just the last one on name collision) --
+        # not per-sample data. Confirmed live via the raw BioStudies API
+        # (E-GEOD-33447) that the actual per-sample-group records live one
+        # level deeper, under a "Source Characteristics" subsection, as
+        # "Characteristics Table" entries (one per distinct combination of
+        # characteristics, e.g. age/tissue). Match those instead of the
+        # aggregate wrapper; "sample" (singular) is kept for any submission
+        # that uses that type directly on an individual record.
         section_type = section.get("type", "")
-        if section_type.lower() in ["samples", "sample"]:
+        if section_type.lower() in ["sample", "characteristics table"]:
             # Extract sample attributes
             if "attributes" in section and isinstance(section["attributes"], list):
                 sample_data = {}

--- a/src/tooluniverse/brenda_tool.py
+++ b/src/tooluniverse/brenda_tool.py
@@ -466,6 +466,7 @@ class BRENDATool(BaseTool):
 
         sources_used = []
         result: Dict[str, Any] = {"ec_number": ec_number}
+        sabiork_error: Optional[str] = None
 
         # 1. ExPASy ENZYME: enzyme identity and catalytic activity
         try:
@@ -480,6 +481,13 @@ class BRENDATool(BaseTool):
             pass  # Non-fatal, continue with kinetics
 
         # 2. SABIO-RK: kinetic parameters (Km, kcat, Ki, Vmax)
+        # Fix-R14D-1: this whole block used to be one bare `except Exception:
+        # pass`, so any failure here (confirmed live: sabiork.h-its.org
+        # connection timeouts) silently dropped "kinetic_parameters" from
+        # the response entirely -- the tool's own headline capability --
+        # while still returning status:"success" with no indication that
+        # SABIO-RK was even attempted, let alone that it failed. Record the
+        # failure instead of erasing all trace of it.
         try:
             sabio = self._fetch_sabiork_kinetics(ec_number, organism, limit)
             result["kinetic_parameters"] = sabio.get("kinetic_laws", [])
@@ -516,8 +524,14 @@ class BRENDATool(BaseTool):
                     summary[ptype] = entry
                 if summary:
                     result["parameter_summary"] = summary
-        except Exception:
-            pass  # Non-fatal
+        except Exception as e:
+            result.setdefault("kinetic_parameters", [])
+            result.setdefault("sabiork_total_entries", 0)
+            sabiork_error = (
+                "SABIO-RK kinetics fetch timed out"
+                if isinstance(e, requests.exceptions.Timeout)
+                else f"SABIO-RK kinetics fetch failed: {type(e).__name__}: {e}"
+            )
 
         # 3. Optional BRENDA SOAP enrichment (if credentials available)
         creds = self._credentials()
@@ -621,15 +635,18 @@ class BRENDATool(BaseTool):
                 "error": f"No data found for EC {ec_number}. Verify the EC number is correct.",
             }
 
+        metadata: Dict[str, Any] = {
+            "sources": sources_used,
+            "note": (
+                "ExPASy ENZYME and SABIO-RK data require no authentication. "
+                "Set BRENDA_EMAIL/BRENDA_PASSWORD for additional pH, temperature, "
+                "and specific activity data from BRENDA."
+            ),
+        }
+        if sabiork_error:
+            metadata["sabiork_error"] = sabiork_error
         return {
             "status": "success",
             "data": result,
-            "metadata": {
-                "sources": sources_used,
-                "note": (
-                    "ExPASy ENZYME and SABIO-RK data require no authentication. "
-                    "Set BRENDA_EMAIL/BRENDA_PASSWORD for additional pH, temperature, "
-                    "and specific activity data from BRENDA."
-                ),
-            },
+            "metadata": metadata,
         }

--- a/src/tooluniverse/data/allen_cell_types_tools.json
+++ b/src/tooluniverse/data/allen_cell_types_tools.json
@@ -6,7 +6,7 @@
             "species": {"type": ["string", "null"], "description": "Donor species: 'Homo Sapiens' or 'Mus musculus'."},
             "structure": {"type": ["string", "null"], "description": "Brain structure name substring, e.g. 'frontal gyrus', 'visual cortex'."},
             "limit": {"type": ["integer", "null"], "description": "Max specimens (default 20, max 100)."}
-        }, "required": []},
+        }, "required": [], "additionalProperties": false},
         "fields": {"timeout": 30},
         "type": "AllenCellTypesSpecimensTool",
         "test_examples": [{"species": "Homo Sapiens", "limit": 5}, {"species": "Mus musculus", "limit": 3}, {"structure": "frontal gyrus", "limit": 3}],

--- a/src/tooluniverse/data/biostudies_tools.json
+++ b/src/tooluniverse/data/biostudies_tools.json
@@ -2,7 +2,7 @@
   {
     "type": "BioStudiesRESTTool",
     "name": "biostudies_search",
-    "description": "Search BioStudies repository for biological studies across all collections. BioStudies is a comprehensive repository at EMBL-EBI that hosts diverse study types including genomics, transcriptomics, proteomics, imaging data, and more. Supports full-text search with pagination and sorting. HTML responses are automatically converted to Markdown using markitdown.",
+    "description": "Search BioStudies repository for biological studies across all collections. BioStudies is a comprehensive repository at EMBL-EBI that hosts diverse study types including genomics, transcriptomics, proteomics, imaging data, and more. Supports full-text search with pagination and sorting. HTML responses are automatically converted to Markdown using markitdown. Note: common biomedical phrases are frequently dominated by 'S-EPMC*' hits (full-text literature indexed via the EuropePMC collection) rather than actual datasets -- to search datasets specifically (e.g. ArrayExpress expression data), use biostudies_search_by_collection with collection='arrayexpress' instead.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/cath_tools.json
+++ b/src/tooluniverse/data/cath_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "CATH_get_superfamily",
-    "description": "Get CATH protein structure superfamily information by CATH ID. CATH classifies protein domain structures into a four-level hierarchy: Class, Architecture, Topology, Homologous superfamily. Superfamilies group evolutionarily related domains. Returns classification name, number of families, and domain counts. Example: 2.40.50.140 returns 'Nucleic acid-binding proteins' with 227 S35 families and 2,879 total domains.",
+    "description": "Get CATH protein structure superfamily information by CATH ID. CATH classifies protein domain structures into a four-level hierarchy: Class, Architecture, Topology, Homologous superfamily. Superfamilies group evolutionarily related domains. Returns classification name, number of families, and domain counts. Example: 2.40.50.140 returns 'Nucleic acid-binding proteins' with 227 S35 families and 2,879 total domains. Note: 'classification_name'/'classification_description' are null for some superfamilies (e.g. 1.10.530.10, the lysozyme-like fold) -- this is missing curation in CATH's own API, not a query error; family/domain counts and example_domain_id are still populated in that case.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/dbsnp_tool.py
+++ b/src/tooluniverse/dbsnp_tool.py
@@ -41,9 +41,18 @@ class dbSNPGetVariantByRsID(dbSNPRESTTool):
             data = result.get("data", {})
             if isinstance(data, dict) and "result" in data:
                 result_data = data["result"]
-                if rsid in result_data:
-                    variant_data = result_data[rsid]
-
+                variant_data = result_data.get(rsid)
+                # Fix-R14E-1: NCBI's esummary.fcgi doesn't 404 or omit the ID
+                # for a nonexistent rsID -- it returns a per-ID entry shaped
+                # {"uid": "...", "error": "cannot get document summary"}
+                # (confirmed live). The old check only tested key presence,
+                # so this error-shaped entry was treated as a real record and
+                # every field below silently defaulted to null/empty,
+                # returning status:"success" for a variant that doesn't
+                # exist. `.get()` already makes the isinstance check below
+                # False for a missing key (returns None), so no separate
+                # membership check is needed.
+                if isinstance(variant_data, dict) and "error" not in variant_data:
                     # Extract key information
                     parsed_data = {
                         "refsnp_id": f"rs{rsid}",
@@ -161,9 +170,12 @@ class dbSNPGetFrequencies(dbSNPRESTTool):
             data = result.get("data", {})
             if isinstance(data, dict) and "result" in data:
                 result_data = data["result"]
-                if rsid in result_data:
-                    variant_data = result_data[rsid]
-
+                variant_data = result_data.get(rsid)
+                # Fix-R14E-1: see dbSNPGetVariantByRsID.run() -- the same
+                # error-shaped entry (no "error" key check) causes a
+                # nonexistent rsID to silently return an empty-but-"success"
+                # frequencies list here too.
+                if isinstance(variant_data, dict) and "error" not in variant_data:
                     # Extract allele frequency data
                     frequencies = []
                     global_mafs = variant_data.get("global_mafs", [])

--- a/tests/unit/test_allen_cell_types_schema.py
+++ b/tests/unit/test_allen_cell_types_schema.py
@@ -1,0 +1,56 @@
+"""Regression guard for Feature-R14A-2: AllenCellTypes_search_specimens
+silently ignored an unrecognized `gene` parameter (this tool has no
+gene-expression filter -- it wraps electrophysiology/morphology specimen
+search, not transcriptomics) and returned unrelated specimens as if the
+request had been fully satisfied, with nothing indicating the key was
+dropped. AllenCellTypesSpecimensTool is a BaseTool subclass whose run()
+only ever reads species/structure/limit, so adding `additionalProperties:
+false` is safe and makes the rejection explicit instead of silent.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.allen_cell_types_tool import AllenCellTypesSpecimensTool
+
+pytestmark = pytest.mark.unit
+
+CONFIG_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src/tooluniverse/data/allen_cell_types_tools.json"
+)
+
+
+def _tool_config():
+    configs = json.loads(CONFIG_PATH.read_text())
+    return next(c for c in configs if c["name"] == "AllenCellTypes_search_specimens")
+
+
+def test_schema_rejects_additional_properties():
+    config = _tool_config()
+    assert config["parameter"]["additionalProperties"] is False
+
+
+def test_unrecognized_gene_param_is_rejected_by_validation():
+    config = _tool_config()
+    tool = AllenCellTypesSpecimensTool(config)
+
+    error = tool.validate_parameters(
+        {"species": "Mus musculus", "gene": "Bdnf", "limit": 5}
+    )
+
+    assert error is not None
+
+
+def test_declared_params_still_validate_cleanly():
+    config = _tool_config()
+    tool = AllenCellTypesSpecimensTool(config)
+
+    error = tool.validate_parameters({"species": "Mus musculus", "limit": 5})
+
+    assert error is None

--- a/tests/unit/test_arrayexpress_samples_extraction.py
+++ b/tests/unit/test_arrayexpress_samples_extraction.py
@@ -1,0 +1,91 @@
+"""Regression guard for Fix-R14C-2: arrayexpress_get_experiment_samples
+extracted the wrong level of a BioStudies study's section tree. Confirmed
+live (raw curl to the BioStudies API for E-GEOD-33447) that the literal
+"Samples" section is just a wrapper carrying aggregate summary attributes
+("Sample count", one "Experimental Factors" attribute per factor -- which
+the old dict-build collapsed to just the last one on name collision), not
+per-sample data. The real per-sample-group records live one level deeper,
+under a "Source Characteristics" subsection, as "Characteristics Table"
+entries (one per distinct combination of characteristics, e.g. age/tissue).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.arrayexpress_tool import ArrayExpressRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+# Trimmed version of the real BioStudies section tree for E-GEOD-33447,
+# preserving the exact nesting shape that caused the bug.
+STUDY_SECTION = {
+    "accno": "s-E-GEOD-33447",
+    "type": "Study",
+    "attributes": [],
+    "subsections": [
+        {
+            "accno": "s-samples-factors-E-GEOD-33447",
+            "type": "Samples",
+            "attributes": [
+                {"name": "Sample count", "value": "16"},
+                {"name": "Experimental Factors", "value": "TISSUE"},
+                {"name": "Experimental Factors", "value": "AGE"},
+            ],
+            "subsections": [
+                {
+                    "accno": "source_chars-E-GEOD-33447",
+                    "type": "Source Characteristics",
+                    "subsections": [
+                        [
+                            {
+                                "accno": "source_0",
+                                "type": "Characteristics Table",
+                                "attributes": [
+                                    {"name": "age", "value": "39 years"},
+                                    {"name": "tissue", "value": "normal breast"},
+                                    {"name": "No. of Samples", "value": "1"},
+                                ],
+                            },
+                            {
+                                "accno": "source_1",
+                                "type": "Characteristics Table",
+                                "attributes": [
+                                    {"name": "age", "value": "49 years"},
+                                    {"name": "tissue", "value": "breast cancer"},
+                                    {"name": "No. of Samples", "value": "2"},
+                                ],
+                            },
+                        ]
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+def _tool():
+    return ArrayExpressRESTTool({"name": "arrayexpress_get_experiment_samples"})
+
+
+def test_extracts_real_per_sample_group_records_not_the_wrapper():
+    tool = _tool()
+    samples = tool._extract_samples_from_section(STUDY_SECTION)
+
+    assert samples == [
+        {"age": "39 years", "tissue": "normal breast", "No. of Samples": "1"},
+        {"age": "49 years", "tissue": "breast cancer", "No. of Samples": "2"},
+    ]
+
+
+def test_does_not_return_the_aggregate_samples_wrapper_record():
+    tool = _tool()
+    samples = tool._extract_samples_from_section(STUDY_SECTION)
+
+    assert not any("Sample count" in s for s in samples)
+    assert not any("Experimental Factors" in s for s in samples)

--- a/tests/unit/test_brenda_sabiork_failure_visibility.py
+++ b/tests/unit/test_brenda_sabiork_failure_visibility.py
@@ -1,0 +1,106 @@
+"""Regression guard for Fix-R14D-1: BRENDA_get_enzyme_kinetics wrapped its
+entire SABIO-RK section in one bare `except Exception: pass`, so any failure
+there (confirmed live: sabiork.h-its.org connection timeouts from this
+network) silently dropped "kinetic_parameters" -- the tool's headline
+capability -- from the response entirely, with status:"success" and no
+indication SABIO-RK was even attempted. The fix records the failure in
+metadata and always includes kinetic_parameters/sabiork_total_entries keys
+(empty on failure) instead of omitting them.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.brenda_tool import BRENDATool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return BRENDATool({"name": "BRENDA_get_enzyme_kinetics"})
+
+
+def test_sabiork_timeout_is_surfaced_not_swallowed(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(
+        tool,
+        "_fetch_expasy_enzyme",
+        lambda ec: {
+            "name": "hexokinase",
+            "alternative_names": [],
+            "catalytic_activity": [],
+            "comments": [],
+        },
+    )
+
+    def fake_sabiork(ec_number, organism, limit):
+        raise requests.exceptions.ConnectTimeout("connection timed out")
+
+    monkeypatch.setattr(tool, "_fetch_sabiork_kinetics", fake_sabiork)
+
+    result = tool._get_enzyme_kinetics({"ec_number": "2.7.1.1"})
+
+    assert result["status"] == "success"
+    assert result["data"]["kinetic_parameters"] == []
+    assert result["data"]["sabiork_total_entries"] == 0
+    assert "timed out" in result["metadata"]["sabiork_error"]
+    assert "SABIO-RK" not in result["metadata"]["sources"]
+
+
+def test_sabiork_success_reports_no_error(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(
+        tool,
+        "_fetch_expasy_enzyme",
+        lambda ec: {
+            "name": "hexokinase",
+            "alternative_names": [],
+            "catalytic_activity": [],
+            "comments": [],
+        },
+    )
+    monkeypatch.setattr(
+        tool,
+        "_fetch_sabiork_kinetics",
+        lambda ec_number, organism, limit: {
+            "kinetic_laws": [{"parameters": [{"type": "Km", "value": 0.1}]}],
+            "total_count": 1,
+        },
+    )
+
+    result = tool._get_enzyme_kinetics({"ec_number": "2.7.1.1"})
+
+    assert result["status"] == "success"
+    assert result["data"]["sabiork_total_entries"] == 1
+    assert "SABIO-RK" in result["metadata"]["sources"]
+    assert "sabiork_error" not in result["metadata"]
+
+
+def test_sabiork_generic_exception_still_records_error(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(
+        tool,
+        "_fetch_expasy_enzyme",
+        lambda ec: {
+            "name": "hexokinase",
+            "alternative_names": [],
+            "catalytic_activity": [],
+            "comments": [],
+        },
+    )
+
+    def fake_sabiork(ec_number, organism, limit):
+        raise ValueError("unexpected SBML shape")
+
+    monkeypatch.setattr(tool, "_fetch_sabiork_kinetics", fake_sabiork)
+
+    result = tool._get_enzyme_kinetics({"ec_number": "2.7.1.1"})
+
+    assert result["status"] == "success"
+    assert result["data"]["kinetic_parameters"] == []
+    assert "ValueError" in result["metadata"]["sabiork_error"]

--- a/tests/unit/test_dbsnp_nonexistent_rsid.py
+++ b/tests/unit/test_dbsnp_nonexistent_rsid.py
@@ -1,0 +1,104 @@
+"""Regression guard for Fix-R14E-1: dbSNP's esummary.fcgi doesn't 404 or
+omit the ID for a nonexistent rsID -- it returns a per-ID entry shaped
+{"uid": "...", "error": "cannot get document summary"} (confirmed live via
+raw curl to eutils.ncbi.nlm.nih.gov). The old code only checked whether the
+rsid was a key in the result dict, so this error-shaped entry was treated as
+a real record and every field defaulted to null/empty, silently returning
+status:"success" for a variant that doesn't exist. Both
+dbSNPGetVariantByRsID and dbSNPGetFrequencies shared this bug.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.dbsnp_tool import dbSNPGetVariantByRsID, dbSNPGetFrequencies
+
+pytestmark = pytest.mark.unit
+
+NOT_FOUND_RESPONSE = {
+    "status": "success",
+    "data": {
+        "result": {
+            "uids": ["99999999999999"],
+            "99999999999999": {
+                "uid": "99999999999999",
+                "error": "cannot get document summary",
+            },
+        }
+    },
+}
+
+FOUND_RESPONSE = {
+    "status": "success",
+    "data": {
+        "result": {
+            "uids": ["429358"],
+            "429358": {
+                "snp_id": 429358,
+                "chr": "19",
+                "chrpos": "19:44908684",
+                "allele": "Y",
+                "snp_class": "snv",
+                "clinical_significance": "risk-factor",
+                "genes": [{"name": "APOE"}],
+                "global_mafs": [],
+                "docsum": "",
+                "spdi": "",
+                "fxn_class": "missense_variant",
+                "validated": "by-cluster",
+                "createdate": "2000-01-01",
+                "updatedate": "2020-01-01",
+            },
+        }
+    },
+}
+
+
+def test_variant_by_rsid_reports_error_for_nonexistent_id(monkeypatch):
+    tool = dbSNPGetVariantByRsID({"name": "dbsnp_get_variant_by_rsid"})
+    monkeypatch.setattr(tool, "_make_request", lambda *a, **k: dict(NOT_FOUND_RESPONSE))
+
+    result = tool.run({"rsid": "rs99999999999999"})
+
+    assert result["status"] == "error"
+    assert "not found" in result["error"]
+
+
+def test_variant_by_rsid_still_succeeds_for_real_variant(monkeypatch):
+    tool = dbSNPGetVariantByRsID({"name": "dbsnp_get_variant_by_rsid"})
+    monkeypatch.setattr(tool, "_make_request", lambda *a, **k: dict(FOUND_RESPONSE))
+
+    result = tool.run({"rsid": "rs429358"})
+
+    assert result["status"] == "success"
+    assert result["data"]["chromosome"] == "19"
+    assert result["data"]["genes"] == ["APOE"]
+
+
+def test_frequencies_reports_error_for_nonexistent_id(monkeypatch):
+    tool = dbSNPGetFrequencies({"name": "dbsnp_get_frequencies"})
+    monkeypatch.setattr(tool, "_make_request", lambda *a, **k: dict(NOT_FOUND_RESPONSE))
+
+    result = tool.run({"rsid": "rs99999999999999"})
+
+    assert result["status"] == "error"
+    assert "not found" in result["error"]
+
+
+def test_frequencies_still_succeeds_for_real_variant(monkeypatch):
+    tool = dbSNPGetFrequencies({"name": "dbsnp_get_frequencies"})
+    response = dict(FOUND_RESPONSE)
+    response["data"]["result"]["429358"] = {
+        **FOUND_RESPONSE["data"]["result"]["429358"],
+        "global_mafs": [{"study": "1000Genomes", "freq": "C=0.15/754"}],
+    }
+    monkeypatch.setattr(tool, "_make_request", lambda *a, **k: response)
+
+    result = tool.run({"rsid": "rs429358"})
+
+    assert result["status"] == "success"
+    assert result["data"]["total_studies"] == 1

--- a/tests/unit/test_round14_docs_caveats.py
+++ b/tests/unit/test_round14_docs_caveats.py
@@ -1,0 +1,44 @@
+"""Regression guard for two docs-only fixes in round 14.
+
+Feature-R14B-1: CATH_get_superfamily's description unconditionally promised
+a classification name/description. Confirmed via raw curl to cathdb.info
+that classification_name/classification_description are genuinely null in
+CATH's own API for some superfamilies (e.g. 1.10.530.10, the lysozyme-like
+fold) -- a real upstream curation gap, not a ToolUniverse extraction bug
+(the same code correctly returns the name for other superfamilies, e.g.
+2.40.50.140).
+
+Feature-R14C-1: biostudies_search's description didn't warn that common
+biomedical phrases are frequently dominated by 'S-EPMC*' literature hits
+(EuropePMC-collection entries) rather than actual datasets -- confirmed live
+that the top 5 hits for "breast cancer transcriptomics" were literature, not
+datasets.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+CATH_CONFIG_PATH = Path(__file__).parent.parent.parent / "src/tooluniverse/data/cath_tools.json"
+BIOSTUDIES_CONFIG_PATH = (
+    Path(__file__).parent.parent.parent / "src/tooluniverse/data/biostudies_tools.json"
+)
+
+
+def test_cath_superfamily_description_notes_possible_null_classification():
+    configs = json.loads(CATH_CONFIG_PATH.read_text())
+    config = next(c for c in configs if c["name"] == "CATH_get_superfamily")
+    description = config["description"]
+    assert "null" in description
+    assert "1.10.530.10" in description
+
+
+def test_biostudies_search_description_warns_about_literature_dominance():
+    configs = json.loads(BIOSTUDIES_CONFIG_PATH.read_text())
+    config = next(c for c in configs if c["name"] == "biostudies_search")
+    description = config["description"]
+    assert "S-EPMC" in description
+    assert "biostudies_search_by_collection" in description


### PR DESCRIPTION
## Round 14: neuroscience, structural biology, functional genomics, enzymology, clinical genomics

Seventh round of the ongoing test-harness sweep (continues #302 → ... → #308). Five role-play researcher personas exercised entirely fresh tool families — neuroscience (Allen Brain Atlas, Allen Cell Types), structural biology (CATH, ClusPro/docking coverage), functional genomics (ArrayExpress, BioStudies), enzymology (BRENDA), and clinical genomics (dbSNP, CADD) — continuing the domain-diversification strategy that's kept every round since 11 free of duplicate rediscoveries.

### Fixed

**Fix-R14E-1 — `dbsnp_get_variant_by_rsid`/`dbsnp_get_frequencies` silently "succeeded" on a nonexistent rsID (HIGH)**
NCBI's `esummary.fcgi` doesn't 404 for a bad rsID — it returns a per-ID entry shaped `{"uid": "...", "error": "cannot get document summary"}` (confirmed live via raw curl). Both tools only checked whether the rsid was a key in the response dict, not whether that entry itself carried an error marker, so a nonexistent variant silently returned `status: "success"` with every field null/empty — a caller checking only `status` would proceed with a garbage record. Both methods now check for the embedded error marker and return an actionable "not found" error instead.
`src/tooluniverse/dbsnp_tool.py`

**Fix-R14D-1 — `BRENDA_get_enzyme_kinetics` silently dropped its headline capability on any SABIO-RK failure (HIGH)**
The entire SABIO-RK section (kinetic parameter fetching — the tool's own advertised primary purpose) was wrapped in one bare `except Exception: pass`. A connection timeout to `sabiork.h-its.org` (confirmed live, reproducible from this network) caused `kinetic_parameters`/`sabiork_total_entries` to be omitted from the response entirely, with `status: "success"` and zero indication that kinetics data was even attempted. Split into a `Timeout`-specific branch and a generic-exception branch, both of which now populate empty defaults for those keys and record a `sabiork_error` message in `metadata` — the caller can now tell "checked SABIO-RK, zero real entries" apart from "SABIO-RK fetch failed."
`src/tooluniverse/brenda_tool.py`

**Fix-R14C-2 — `arrayexpress_get_experiment_samples` returned the wrong section entirely (MEDIUM)**
`_extract_samples_from_section` matched on section `type in ["samples", "sample"]`, which matched the "Samples" *wrapper* section — aggregate summary attributes only (`"Sample count"`, plus one `"Experimental Factors"` attribute per factor that a dict-build silently collapsed to just the last one on a name collision). The real per-sample-group records live one level deeper, as `"Characteristics Table"` entries under a `"Source Characteristics"` subsection (confirmed via raw BioStudies API for `E-GEOD-33447`). Fixed the match to target the real per-record level; verified the fix generalizes correctly against a second, structurally-different accession (`E-GEOD-48162`, a ChIP-seq study with a completely different characteristics schema).
`src/tooluniverse/arrayexpress_tool.py`

**Feature-R14A-2 — `AllenCellTypes_search_specimens` silently ignored an unrecognized `gene` param (MEDIUM)**
This tool wraps electrophysiology/morphology specimen data, not transcriptomics — but passing `gene` (a natural first guess) was silently dropped instead of rejected, returning unrelated specimens as if the request had been fully satisfied. Verified `AllenCellTypesSpecimensTool.run()` only ever reads its three declared params, so added `"additionalProperties": false` to the schema — unknown params are now rejected with a clear jsonschema error.
`src/tooluniverse/data/allen_cell_types_tools.json`

**Feature-R14B-1 / Feature-R14C-1 — two description caveats for confirmed upstream data gaps (docs-only)**
- `CATH_get_superfamily`'s description unconditionally promised a classification name. Confirmed via raw curl to `cathdb.info` that `classification_name`/`classification_description` are genuinely `null` in CATH's own API for some superfamilies (e.g. `1.10.530.10`, the lysozyme-like fold) — the same extraction code correctly returns the name for other superfamilies (e.g. `2.40.50.140`), so this is upstream curation, not a ToolUniverse bug.
- `biostudies_search`'s description didn't warn that common biomedical phrases are dominated by `S-EPMC*` (EuropePMC-collection literature) hits rather than actual datasets. Confirmed live for `"breast cancer transcriptomics"`. Added a caveat pointing to `biostudies_search_by_collection` for dataset-only searches.
`src/tooluniverse/data/cath_tools.json`, `src/tooluniverse/data/biostudies_tools.json`

### Deferred (documented, not fixed)

- **R14A-1** — `AllenBrain_search_genes`'s description says "by gene symbol" but the actual param is `gene_acronym`. Error message already names the correct param; wording drift, not a broken tool.
- **R14A-3** — No ToolUniverse tool wraps Allen Institute's cell-type *transcriptomic* API (only the electrophysiology/morphology one exists) — a genuine coverage gap, not a bug in an existing tool.
- **R14B-2** — `CATH_get_domain_summary` returns a raw HTTP 400 for an invalid domain suffix (e.g. `1lyzA01` when only `1lyzA00` exists) with no hint about CATH's domain-numbering convention. Correct rejection, just an unhelpful message on a fairly rare edge case.
- **R14B-3** — No ToolUniverse tool wraps ClusPro or any protein-protein docking service (only protein-*ligand* docking exists). Coverage gap, confirmed via 5 independent `tu grep` queries before concluding absence.
- **R14D-2** — `UniProt_get_function_by_accession` returns a bare `{"result": [...]}` envelope inconsistent with the `status`/`data`/`metadata` convention used elsewhere. Matches the long-documented, systemic envelope-consistency issue (same class as the prior issue #288 batch) — needs a dedicated audit, not a one-off fix here.

### Testing

14 new unit tests across 5 files (all mocked, no network calls):
- `tests/unit/test_dbsnp_nonexistent_rsid.py` (4)
- `tests/unit/test_brenda_sabiork_failure_visibility.py` (3)
- `tests/unit/test_arrayexpress_samples_extraction.py` (2)
- `tests/unit/test_allen_cell_types_schema.py` (3)
- `tests/unit/test_round14_docs_caveats.py` (2)

Every fix was also verified live against the real upstream API via the CLI before and after the change (see fix descriptions above for the specific before/after evidence, including cross-checking the ArrayExpress fix against a second, structurally-different real accession).
