### PR TITLE
Round 15: FoodDataCentral dead error branches, GTDB species chaining, EPA state validation

### DIFF
--- a/src/tooluniverse/data/gnomad_tools.json
+++ b/src/tooluniverse/data/gnomad_tools.json
@@ -2,7 +2,7 @@
   {
     "type": "gnomADGetGeneConstraints",
     "name": "gnomad_get_gene_constraints",
-    "description": "Get gene constraint metrics from gnomAD for a gene symbol (GRCh38). Returns constraint fields under `exac_constraint` and `gnomad_constraint` (e.g., pLI, oe_lof/oe_mis/oe_syn, exp/obs counts).",
+    "description": "Get gene constraint metrics from gnomAD for a gene symbol (GRCh38). Returns constraint fields under `exac_constraint` and `gnomad_constraint` (e.g., pLI, oe_lof/oe_mis/oe_syn, exp/obs counts). Note: does NOT include LOEUF, missense Z-score, or synonymous Z-score -- for the full constraint panel (pLI + LOEUF + mis_z + syn_z), use gnomad_get_constraint instead.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/epa_envirofacts_tool.py
+++ b/src/tooluniverse/epa_envirofacts_tool.py
@@ -77,6 +77,20 @@ class _EnvirofactsBase(BaseTool):
                 "status": "error",
                 "error": "'state' (2-letter code, e.g. 'CA') is required",
             }
+        # Fix-R15C-2: a full state name (e.g. "Louisiana") doesn't match
+        # any row in Envirofacts' 2-letter state_code column, so it
+        # silently returns an empty result set indistinguishable from "this
+        # state genuinely has zero facilities" -- confirmed live the same
+        # state has hundreds of real rows under its actual 2-letter code
+        # ("LA"). Reject non-2-letter input instead of querying it.
+        if len(state) != 2 or not state.isalpha():
+            return {
+                "status": "error",
+                "error": (
+                    f"'state' must be a 2-letter US state code (e.g. 'CA', 'TX'), "
+                    f"got {arguments.get('state')!r}"
+                ),
+            }
         city = (arguments.get("city") or "").strip()
         try:
             limit = max(1, min(int(arguments.get("limit") or 10), 100))

--- a/src/tooluniverse/fooddata_central_tool.py
+++ b/src/tooluniverse/fooddata_central_tool.py
@@ -69,7 +69,14 @@ class FoodDataCentralTool(BaseTool):
                 "error": "Failed to connect to FoodData Central API. Check network connectivity.",
             }
         except requests.exceptions.HTTPError as e:
-            status_code = e.response.status_code if e.response else "unknown"
+            # Fix-R15A-1: requests.Response overrides __bool__ to return
+            # self.ok, which is False for any 4xx/5xx status -- so
+            # `if e.response else "unknown"` was always false-y for a real
+            # HTTP error response (confirmed live), making the 403/429
+            # branches below unreachable dead code. Use `is not None`.
+            status_code = (
+                e.response.status_code if e.response is not None else "unknown"
+            )
             detail = ""
             if e.response is not None:
                 detail = e.response.text[:200]
@@ -79,9 +86,16 @@ class FoodDataCentralTool(BaseTool):
                     "error": "FoodData Central API key invalid or missing. Set FDC_API_KEY env variable.",
                 }
             elif status_code == 429:
+                key_hint = (
+                    " (using the shared DEMO_KEY -- get a free personal key at "
+                    "https://api.nal.usda.gov/signup/ and set FDC_API_KEY for a "
+                    "higher limit)"
+                    if self.api_key == "DEMO_KEY"
+                    else ""
+                )
                 return {
                     "status": "error",
-                    "error": "FoodData Central rate limit exceeded (1000 req/hr). Try again later.",
+                    "error": f"FoodData Central rate limit exceeded (1000 req/hr){key_hint}. Try again later.",
                 }
             return {
                 "status": "error",

--- a/src/tooluniverse/gtdb_tool.py
+++ b/src/tooluniverse/gtdb_tool.py
@@ -151,6 +151,17 @@ class GTDBTool(BaseTool):
         if not species:
             return {"status": "error", "error": "species parameter is required"}
 
+        # Fix-R15E-1: GTDB's own /species/search endpoint rejects the
+        # "s__" rank prefix outright (confirmed live: HTTP 400 "No genomes
+        # found for species s__..." with the prefix, HTTP 200 without it) --
+        # but GTDB_search_taxon, the natural upstream discovery tool for
+        # finding a species name, returns names WITH that exact prefix
+        # (e.g. "s__Faecalibacterium prausnitzii"), breaking the natural
+        # search -> get_species chaining workflow. Strip it here so output
+        # from the sibling tool can be passed straight in.
+        if species.startswith("s__"):
+            species = species[3:]
+
         result = self._make_request("species/search/{}".format(species))
         if not result["ok"]:
             return {"status": "error", "error": result["error"]}

--- a/tests/unit/test_epa_state_validation.py
+++ b/tests/unit/test_epa_state_validation.py
@@ -1,0 +1,77 @@
+"""Regression guard for Fix-R15C-2: EPA_search_tri_facilities and
+EPA_search_frs_facilities (both via the shared `_run_state_search` on
+`_EnvirofactsBase`) accepted any string as `state`, including a full state
+name like "Louisiana" -- which matches zero rows in Envirofacts' 2-letter
+state_code column, silently returning an empty result set indistinguishable
+from "this state genuinely has zero facilities" (confirmed live the same
+state has hundreds of real rows under its actual 2-letter code "LA").
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.epa_envirofacts_tool import EPATRIFacilitiesTool, EPAFRSFacilitiesTool
+
+pytestmark = pytest.mark.unit
+
+
+def test_full_state_name_is_rejected():
+    tool = EPATRIFacilitiesTool({"name": "EPA_search_tri_facilities"})
+
+    result = tool._run_state_search({"state": "Louisiana", "limit": 3})
+
+    assert result["status"] == "error"
+    assert "2-letter" in result["error"]
+
+
+def test_valid_2_letter_code_still_queries(monkeypatch):
+    tool = EPATRIFacilitiesTool({"name": "EPA_search_tri_facilities"})
+    captured = {}
+
+    def fake_fetch(path):
+        captured["path"] = path
+        return []
+
+    monkeypatch.setattr(tool, "_fetch", fake_fetch)
+
+    result = tool._run_state_search({"state": "LA", "limit": 3})
+
+    assert result["status"] == "success"
+    assert "LA" in captured["path"]
+
+
+def test_lowercase_2_letter_code_is_normalized(monkeypatch):
+    tool = EPATRIFacilitiesTool({"name": "EPA_search_tri_facilities"})
+    captured = {}
+
+    def fake_fetch(path):
+        captured["path"] = path
+        return []
+
+    monkeypatch.setattr(tool, "_fetch", fake_fetch)
+
+    result = tool._run_state_search({"state": "la", "limit": 3})
+
+    assert result["status"] == "success"
+    assert "LA" in captured["path"]
+
+
+def test_frs_facilities_tool_shares_the_same_validation():
+    tool = EPAFRSFacilitiesTool({"name": "EPA_search_frs_facilities"})
+
+    result = tool._run_state_search({"state": "California", "limit": 3})
+
+    assert result["status"] == "error"
+    assert "2-letter" in result["error"]
+
+
+def test_non_alpha_state_code_is_rejected():
+    tool = EPATRIFacilitiesTool({"name": "EPA_search_tri_facilities"})
+
+    result = tool._run_state_search({"state": "12", "limit": 3})
+
+    assert result["status"] == "error"

--- a/tests/unit/test_fooddata_central_error_status_codes.py
+++ b/tests/unit/test_fooddata_central_error_status_codes.py
@@ -1,0 +1,104 @@
+"""Regression guard for Fix-R15A-1: FoodDataCentralTool extracted the HTTP
+status code from a caught HTTPError with `if e.response else "unknown"`.
+`requests.Response` overrides `__bool__` to return `self.ok`, which is
+False for any 4xx/5xx status -- so this check was always false-y for a real
+HTTP error response (confirmed live and via a direct requests repro),
+making the 403/429-specific branches below it unreachable dead code. Every
+error surfaced as a generic "HTTP error unknown: <raw body>" instead of the
+specific, actionable message that branch was written to produce.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.fooddata_central_tool import FoodDataCentralTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return FoodDataCentralTool(
+        {"name": "FoodDataCentral_search_foods", "fields": {"operation": "search"}}
+    )
+
+
+def _http_error(status_code, body=""):
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = body
+    # __bool__ mirrors the real requests.Response quirk: False for any
+    # non-2xx status, even though the response object itself is real.
+    response.__bool__ = lambda self: 200 <= status_code < 400
+    error = requests.exceptions.HTTPError(response=response)
+    return error
+
+
+def test_429_status_reaches_the_rate_limit_branch(monkeypatch):
+    tool = _tool()
+
+    def fake_search(arguments):
+        raise _http_error(429, '{"error":{"code":"OVER_RATE_LIMIT"}}')
+
+    monkeypatch.setattr(tool, "_search_foods", fake_search)
+
+    result = tool.run({"query": "almonds"})
+
+    assert result["status"] == "error"
+    assert "rate limit" in result["error"].lower()
+    assert "unknown" not in result["error"]
+
+
+def test_429_with_demo_key_hints_at_personal_key(monkeypatch):
+    tool = _tool()
+    tool.api_key = "DEMO_KEY"
+
+    monkeypatch.setattr(
+        tool, "_search_foods", lambda arguments: (_ for _ in ()).throw(_http_error(429))
+    )
+
+    result = tool.run({"query": "almonds"})
+
+    assert "FDC_API_KEY" in result["error"]
+
+
+def test_429_with_personal_key_omits_demo_key_hint(monkeypatch):
+    tool = _tool()
+    tool.api_key = "some-real-personal-key"
+
+    monkeypatch.setattr(
+        tool, "_search_foods", lambda arguments: (_ for _ in ()).throw(_http_error(429))
+    )
+
+    result = tool.run({"query": "almonds"})
+
+    assert "FDC_API_KEY" not in result["error"]
+
+
+def test_403_status_reaches_the_invalid_key_branch(monkeypatch):
+    tool = _tool()
+
+    monkeypatch.setattr(
+        tool, "_search_foods", lambda arguments: (_ for _ in ()).throw(_http_error(403))
+    )
+
+    result = tool.run({"query": "almonds"})
+
+    assert "invalid or missing" in result["error"]
+
+
+def test_other_status_codes_still_report_the_real_code(monkeypatch):
+    tool = _tool()
+
+    monkeypatch.setattr(
+        tool, "_search_foods", lambda arguments: (_ for _ in ()).throw(_http_error(500, "boom"))
+    )
+
+    result = tool.run({"query": "almonds"})
+
+    assert "500" in result["error"]

--- a/tests/unit/test_gnomad_constraint_tool_docs.py
+++ b/tests/unit/test_gnomad_constraint_tool_docs.py
@@ -1,0 +1,27 @@
+"""Regression guard for Feature-R15B-1: gnomad_get_gene_constraints and
+gnomad_get_constraint have near-identical names and both live under
+gnomAD-constraint-sounding categories, but only gnomad_get_constraint
+returns the full panel (pLI + LOEUF + missense Z-score + synonymous
+Z-score) -- confirmed live that gnomad_get_gene_constraints omits mis_z,
+syn_z, and LOEUF entirely. A researcher grepping "gnomad" + "constraint"
+and picking the more generic-sounding name would silently get an
+incomplete answer. gnomad_get_gene_constraints' description now says so
+and points to the sibling tool.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+CONFIG_PATH = Path(__file__).parent.parent.parent / "src/tooluniverse/data/gnomad_tools.json"
+
+
+def test_gene_constraints_description_notes_missing_fields_and_alternative():
+    configs = json.loads(CONFIG_PATH.read_text())
+    config = next(c for c in configs if c["name"] == "gnomad_get_gene_constraints")
+    description = config["description"]
+    assert "LOEUF" in description
+    assert "gnomad_get_constraint" in description

--- a/tests/unit/test_gtdb_species_prefix.py
+++ b/tests/unit/test_gtdb_species_prefix.py
@@ -1,0 +1,53 @@
+"""Regression guard for Fix-R15E-1: GTDB's own /species/search endpoint
+rejects the "s__" rank prefix outright (confirmed live: HTTP 400 with the
+prefix, HTTP 200 without it), but GTDB_search_taxon -- the natural upstream
+discovery tool for finding a species name -- returns names WITH that exact
+prefix (e.g. "s__Faecalibacterium prausnitzii"), breaking the natural
+search -> get_species chaining workflow.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.gtdb_tool import GTDBTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return GTDBTool({"name": "GTDB_get_species", "fields": {"operation": "get_species"}})
+
+
+def test_strips_s_prefix_before_querying(monkeypatch):
+    tool = _tool()
+    captured = {}
+
+    def fake_make_request(path, params=None):
+        captured["path"] = path
+        return {"ok": True, "data": {"name": "Faecalibacterium prausnitzii", "genomes": []}}
+
+    monkeypatch.setattr(tool, "_make_request", fake_make_request)
+
+    result = tool._get_species({"species": "s__Faecalibacterium prausnitzii"})
+
+    assert result["status"] == "success"
+    assert captured["path"] == "species/search/Faecalibacterium prausnitzii"
+
+
+def test_unprefixed_species_name_unchanged(monkeypatch):
+    tool = _tool()
+    captured = {}
+
+    def fake_make_request(path, params=None):
+        captured["path"] = path
+        return {"ok": True, "data": {"name": "Faecalibacterium prausnitzii", "genomes": []}}
+
+    monkeypatch.setattr(tool, "_make_request", fake_make_request)
+
+    tool._get_species({"species": "Faecalibacterium prausnitzii"})
+
+    assert captured["path"] == "species/search/Faecalibacterium prausnitzii"


### PR DESCRIPTION
## Round 15: nutrition science, population genetics, environmental health, metabolomics, microbiome

Eighth round of the ongoing test-harness sweep (continues #302 → ... → #309). Five role-play researcher personas exercised fresh tool families — nutrition science (FoodData Central, FooDB), population genetics (GTEx, gnomAD constraint), environmental health (EPA Envirofacts), metabolomics mass-spec (GNPS), and microbiome research (GTDB, GMrepo). Most findings this round were genuine coverage gaps (no code bug) or upstream-behavior notes rather than fixable defects — but the ones that were real bugs included one particularly interesting root cause.

### Fixed

**Fix-R15A-1 — `FoodDataCentral_*` tools silently swallowed their own 403/429 error handling (MEDIUM, found while investigating a persona report)**
The persona reported a raw, unhelpful USDA rate-limit error passing straight through. Investigating turned up something more interesting than the surface report: `FoodDataCentralTool`'s HTTPError handler extracted the status code via `e.response.status_code if e.response else "unknown"`. `requests.Response` overrides `__bool__` to return `self.ok`, which is `False` for *any* 4xx/5xx status — so this check was always false-y for a genuine HTTP error response (confirmed live via both the actual tool and a standalone `requests` repro). That made the tool's own 403 ("invalid API key") and 429 ("rate limit exceeded") specific-message branches **unreachable dead code** — every real HTTP error surfaced as a generic `"HTTP error unknown: <raw JSON body>"`. Fixed the truthiness check to `is not None` (matching the correct pattern already used two lines below it), and enriched the 429 message to mention setting `FDC_API_KEY` when on the shared `DEMO_KEY` fallback.
`src/tooluniverse/fooddata_central_tool.py`

**Fix-R15E-1 — `GTDB_get_species` broke the natural `GTDB_search_taxon` → `GTDB_get_species` chaining workflow (MEDIUM)**
GTDB's own `/species/search` endpoint rejects a leading `"s__"` rank prefix outright (confirmed live: HTTP 400 with it, HTTP 200 without) — but the sibling discovery tool `GTDB_search_taxon` returns species names *with* that exact prefix (e.g. `"s__Faecalibacterium prausnitzii"`), so feeding its own output straight into `GTDB_get_species` failed every time. Added a one-line strip of a leading `"s__"` before the request.
`src/tooluniverse/gtdb_tool.py`

**Fix-R15C-2 — `EPA_search_tri_facilities`/`EPA_search_frs_facilities` silently returned zero results for a full state name (MEDIUM)**
Both tools (sharing `_run_state_search`) accepted any string as `state`, including `"Louisiana"` — which matches nothing in Envirofacts' 2-letter `state_code` column and silently returns an empty result set, indistinguishable from "this state genuinely has zero facilities" (confirmed live the same state has hundreds of rows under its real code `"LA"`). Added a length/alpha validation that rejects non-2-letter input with an actionable error before querying, applied to both sibling tools since the fix lives in their shared base method.
`src/tooluniverse/epa_envirofacts_tool.py`

**Feature-R15B-1 — `gnomad_get_gene_constraints` vs `gnomad_get_constraint` naming trap (docs-only)**
Two near-identically-named tools in adjacent categories; only `gnomad_get_constraint` returns the full constraint panel (pLI + LOEUF + missense Z-score + synonymous Z-score) — confirmed live that `gnomad_get_gene_constraints` omits `mis_z`/`syn_z`/LOEUF entirely, with no signal in its description that it's the less-complete option. A researcher who greps "gnomad" + "constraint" and picks the more generic-sounding name would silently get an incomplete answer to exactly the question this round's persona asked. Added a caveat pointing to the sibling tool.
`src/tooluniverse/data/gnomad_tools.json`

### Deferred (documented, not fixed)

- **R15A-2** — `FooDB_get_compound` has no name-search API (id-only), and no other tool bridges a food name to a FooDB compound ID. Genuine coverage gap — the tool's own description is already upfront about this limitation.
- **R15B-2** — `tu grep -i` fails with a raw argparse error rather than a friendlier "grep only takes plain text" hint. Minor rough edge on documented literal-text-search behavior.
- **R15C-1** — `EPA_get_tri_facility_chemical_releases` timed out at `limit:5` but succeeded at `limit:3` on retry. Consistent with previously-noted EPA Envirofacts upstream latency variance, not a client-side bug.
- **R15C-3** — `EPA_search_frs_facilities`'s `registry_id` field was null across a sample of 5 records. Possibly a genuine upstream data gap for those specific rows; not confirmed further (would need a broader sample to rule out a field-mapping bug).
- **R15D-1** — No GNPS tool supports name→USI search or querying molecular-networking job results; only lookup-by-known-USI/SMILES tools exist. Coverage gap.
- **R15D-2** — `GNPS_get_spectrum` on an invalid USI returns a generic `"GNPS API HTTP error: 404"` that doesn't distinguish malformed input from a genuinely nonexistent accession. Shared error-formatting pattern, low-priority.
- **R15D-3** / **R15C notes** — Query-precision observations (PubMed's "network pharmacology" vs. MS "molecular networking" term collision; long AND-of-terms queries silently zeroing out) — confirmed upstream search-engine behavior, not ToolUniverse defects.
- **R15E-2** — GMrepo's two tools only return aggregate counts (e.g. "84 phenotypes linked to this species"), with no way to retrieve the actual cross-reference (species × disease enrichment values). Coverage gap relative to what a microbiome researcher would want to ask.

### Testing

13 new unit tests across 4 files (all mocked, no network calls):
- `tests/unit/test_gtdb_species_prefix.py` (2)
- `tests/unit/test_epa_state_validation.py` (5)
- `tests/unit/test_fooddata_central_error_status_codes.py` (5)
- `tests/unit/test_gnomad_constraint_tool_docs.py` (1)

Every fix was also verified live against the real upstream API via the CLI before and after the change (see fix descriptions above for the specific before/after evidence, including a standalone `requests` repro isolating the `Response.__bool__` gotcha in the FoodDataCentral fix).
