### PR TITLE
Round 16: PubMed date-range filter, NHANES dataset resolution, HPO namespace leakage

### DIFF
--- a/src/tooluniverse/data/monarch_tools.json
+++ b/src/tooluniverse/data/monarch_tools.json
@@ -105,7 +105,7 @@
   },
   {
     "name": "get_HPO_ID_by_phenotype",
-    "description": "Retrieve the HPO ID of a phenotype or symptom.",
+    "description": "Retrieve the HPO ID of a phenotype or symptom. Results are restricted to the HP: namespace (Monarch's underlying search spans multiple ontologies -- e.g. MP: mouse phenotype, UPHENO: cross-species upper ontology -- for the same query term).",
     "parameter": {
       "type": "object",
       "properties": {
@@ -134,6 +134,7 @@
       "limit": 20,
       "offset": 0
     },
+    "result_id_prefix": "HP:",
     "label": [
       "Monarch",
       "Phenotype",

--- a/src/tooluniverse/mobidb_tool.py
+++ b/src/tooluniverse/mobidb_tool.py
@@ -12,7 +12,7 @@ No authentication required.
 """
 
 import requests
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
@@ -62,6 +62,43 @@ class MobiDBTool(BaseTool):
         except Exception as e:
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}
 
+    def _fetch_protein_json(self, accession: str) -> Optional[Dict[str, Any]]:
+        """GET the MobiDB download endpoint for an accession and parse JSON.
+
+        Returns None if MobiDB has no data for this accession.
+
+        Fix-R16C-1: for an unrecognized identifier MobiDB returns HTTP 200
+        with a completely empty body (confirmed live, e.g. a UniProt entry
+        name like "SNCA_HUMAN" instead of an accession like "P37840") rather
+        than a 404 -- so raise_for_status() never fires, and the previous
+        code called response.json() directly, letting a raw
+        json.JSONDecodeError ("Expecting value: line 1 column 1") leak
+        through as an opaque "Unexpected error" instead of an actionable
+        not-found message.
+        """
+        response = requests.get(
+            MOBIDB_BASE_URL,
+            params={"acc": accession, "format": "json"},
+            allow_redirects=True,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        if not response.text.strip():
+            return None
+        return response.json()
+
+    @staticmethod
+    def _not_found_error(accession: str) -> Dict[str, Any]:
+        """Standard error for an accession MobiDB has no data for."""
+        return {
+            "status": "error",
+            "error": (
+                f"No MobiDB data found for accession '{accession}'. "
+                "MobiDB expects a UniProt accession (e.g. 'P37840'), "
+                "not a UniProt entry name (e.g. 'SNCA_HUMAN')."
+            ),
+        }
+
     def _query(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Route to appropriate endpoint."""
         if self.endpoint == "get_protein":
@@ -80,13 +117,9 @@ class MobiDBTool(BaseTool):
                 "error": "accession is required (UniProt ID, e.g., 'P04637' for TP53).",
             }
 
-        url = MOBIDB_BASE_URL
-        params = {"acc": accession, "format": "json"}
-        response = requests.get(
-            url, params=params, allow_redirects=True, timeout=self.timeout
-        )
-        response.raise_for_status()
-        data = response.json()
+        data = self._fetch_protein_json(accession)
+        if data is None:
+            return self._not_found_error(accession)
 
         # Extract key disorder data
         prediction = data.get("prediction-disorder-mobidb_lite", {})
@@ -144,13 +177,9 @@ class MobiDBTool(BaseTool):
                 "error": "accession is required (UniProt ID, e.g., 'P04637' for TP53).",
             }
 
-        url = MOBIDB_BASE_URL
-        params = {"acc": accession, "format": "json"}
-        response = requests.get(
-            url, params=params, allow_redirects=True, timeout=self.timeout
-        )
-        response.raise_for_status()
-        data = response.json()
+        data = self._fetch_protein_json(accession)
+        if data is None:
+            return self._not_found_error(accession)
 
         # Extract consensus disorder data
         consensus_disorder = data.get("prediction-disorder-mobidb_lite", {})

--- a/src/tooluniverse/nhanes_tool.py
+++ b/src/tooluniverse/nhanes_tool.py
@@ -212,6 +212,13 @@ class NHANESTool(BaseTool):
                 return ""
 
         if dataset_name:
+            # Fix-R16B-2: nhanes_search_datasets' own results carry the
+            # cycle suffix already (e.g. file_name "BMX_J") -- confirmed
+            # live that passing that value straight through here appended
+            # the suffix a second time ("BMX_J" + "_J" -> 404 downloading
+            # BMX_J_J.XPT). Don't double it if it's already present.
+            if dataset_name.endswith(suffix):
+                return dataset_name
             return f"{dataset_name}{suffix}"
 
         prefix = self._COMPONENT_PREFIX.get(component)
@@ -306,6 +313,27 @@ class NHANESTool(BaseTool):
                 "error": (
                     "Laboratory component requires 'dataset_name' "
                     "(e.g., 'CBC', 'BIOPRO', 'GHB', 'GLU', 'TRIGLY', 'HDL', 'TCHOL'). "
+                    "Use nhanes_search_datasets to discover available dataset names."
+                ),
+            }
+        # Fix-R16B-1: Examination and Questionnaire, like Laboratory, each
+        # span many distinct files (Examination: BMX body measures, BPX
+        # blood pressure, AUX audiometry, OHXDEN oral health, ...). The old
+        # _COMPONENT_PREFIX fallback silently picked one arbitrary file
+        # (BPX for Examination) regardless of which `variables` were
+        # actually requested -- confirmed live that requesting BMXBMI/BMXWT
+        # without dataset_name silently downloaded the blood-pressure file
+        # instead and returned status:"success" with the requested
+        # variables missing. Require dataset_name here too, matching the
+        # precedent already set for Laboratory.
+        if component in ("Examination", "Questionnaire") and not dataset_name:
+            return {
+                "status": "error",
+                "error": (
+                    f"'{component}' component has multiple distinct files and "
+                    "requires 'dataset_name' to disambiguate which one to "
+                    "download (e.g., 'BMX' for body measures, 'BPX' for blood "
+                    "pressure under Examination). "
                     "Use nhanes_search_datasets to discover available dataset names."
                 ),
             }

--- a/src/tooluniverse/pubmed_tool.py
+++ b/src/tooluniverse/pubmed_tool.py
@@ -97,10 +97,26 @@ class PubMedRESTTool(BaseRESTTool):
         if limit_val is not None:
             params["retmax"] = max(0, int(limit_val))
 
-        # Forward date-range parameters for esearch
+        # Forward date-range parameters for esearch.
+        # Fix-R16E-1: NCBI's esearch silently ignores mindate/maxdate
+        # entirely unless BOTH are present -- confirmed live that
+        # mindate alone (an open-ended "from this date on" range, the
+        # natural way a caller would use it) returns the exact same
+        # unfiltered count as no date params at all, while mindate+maxdate
+        # together correctly filters. Backfill whichever bound is missing
+        # with a placeholder outside PubMed's real date range so an
+        # open-ended query still filters as the caller intends. Also
+        # confirmed omitting datetype (even with both dates set) silently
+        # changes NCBI's filter basis from publication date to Entrez
+        # date, so default it to "pdat" per this tool's own documented
+        # default whenever any date bound is supplied.
         for date_key in ("mindate", "maxdate", "datetype"):
             if date_key in args and args[date_key]:
                 params[date_key] = args[date_key]
+        if "mindate" in params or "maxdate" in params:
+            params.setdefault("mindate", "1000")
+            params.setdefault("maxdate", "3000")
+            params.setdefault("datetype", "pdat")
 
         # Forward sort parameter for esearch
         # Valid values: pub_date, Author, JournalName, relevance

--- a/src/tooluniverse/restful_tool.py
+++ b/src/tooluniverse/restful_tool.py
@@ -63,6 +63,14 @@ class MonarchTool(RESTfulTool):
                 query_schema_runtime["q"] = query_schema_runtime[
                     "query"
                 ]  # match with the api
+        result_id_prefix = self.tool_config.get("result_id_prefix")
+        requested_limit = query_schema_runtime.get("limit")
+        if result_id_prefix and isinstance(requested_limit, int):
+            # Over-fetch since client-side filtering below removes
+            # cross-ontology matches; still truncated back to
+            # requested_limit after filtering so the returned count
+            # matches what the caller asked for.
+            query_schema_runtime["limit"] = requested_limit * 3
         response = execute_RESTful_query(
             endpoint_url=formatted_endpoint_url, variables=query_schema_runtime
         )
@@ -70,6 +78,32 @@ class MonarchTool(RESTfulTool):
             del response["facet_fields"]
 
         response = remove_none_and_empty_values(response)
+        # Fix-R16A-2: Monarch's search endpoint has no server-side namespace
+        # filter (confirmed live: a "prefix" query param is silently
+        # ignored) and its "category" filter (e.g. biolink:PhenotypicFeature)
+        # matches equivalent terms across multiple ontologies (HP, MP,
+        # UPHENO, ...) -- so a tool promising a specific ontology's IDs (like
+        # get_HPO_ID_by_phenotype) could return a non-HPO term as its
+        # top-ranked hit. Opt-in, config-driven client-side filter: a tool
+        # config may declare `result_id_prefix` to restrict returned items
+        # to IDs starting with that prefix, without hardcoding any ontology
+        # into this shared class used by other Monarch tools. Combined with
+        # the over-fetch above, the returned count still matches what the
+        # caller asked for.
+        if (
+            result_id_prefix
+            and isinstance(response, dict)
+            and isinstance(response.get("items"), list)
+        ):
+            filtered = [
+                item
+                for item in response["items"]
+                if isinstance(item, dict)
+                and str(item.get("id", "")).startswith(result_id_prefix)
+            ]
+            if isinstance(requested_limit, int):
+                filtered = filtered[:requested_limit]
+            response["items"] = filtered
         if isinstance(response, dict) and "status" not in response:
             return {"status": "success", "data": response}
         return response

--- a/tests/unit/test_mobidb_empty_response.py
+++ b/tests/unit/test_mobidb_empty_response.py
@@ -1,0 +1,80 @@
+"""Regression guard for Fix-R16C-1: MobiDB returns HTTP 200 with a
+completely empty body for an unrecognized identifier (confirmed live, e.g.
+a UniProt entry name like "SNCA_HUMAN" instead of an accession like
+"P37840") rather than a 404 -- so raise_for_status() never fires, and the
+previous code called response.json() directly, letting a raw
+json.JSONDecodeError ("Expecting value: line 1 column 1") leak through as
+an opaque "Unexpected error" instead of an actionable not-found message.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.mobidb_tool import MobiDBTool
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeResponse:
+    def __init__(self, text="", status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        import json
+
+        return json.loads(self.text)
+
+
+def _tool(endpoint):
+    return MobiDBTool({"name": "MobiDB_test", "fields": {"endpoint": endpoint}})
+
+
+def test_get_protein_empty_body_gives_actionable_error(monkeypatch):
+    tool = _tool("get_protein")
+    monkeypatch.setattr(
+        "tooluniverse.mobidb_tool.requests.get", lambda *a, **k: _FakeResponse("")
+    )
+
+    result = tool.run({"accession": "SNCA_HUMAN"})
+
+    assert result["status"] == "error"
+    assert "SNCA_HUMAN" in result["error"]
+    assert "UniProt accession" in result["error"]
+
+
+def test_get_consensus_empty_body_gives_actionable_error(monkeypatch):
+    tool = _tool("get_consensus")
+    monkeypatch.setattr(
+        "tooluniverse.mobidb_tool.requests.get", lambda *a, **k: _FakeResponse("")
+    )
+
+    result = tool.run({"accession": "SNCA_HUMAN"})
+
+    assert result["status"] == "error"
+    assert "SNCA_HUMAN" in result["error"]
+
+
+def test_get_protein_valid_response_still_parses(monkeypatch):
+    tool = _tool("get_protein")
+    body = (
+        '{"acc": "P37840", "gene": "SNCA", "name": "Alpha-synuclein", '
+        '"organism": "Homo sapiens", "length": 140, "sequence": "M...", '
+        '"prediction-disorder-mobidb_lite": {}, "curated-disorder-disprot": {}, '
+        '"curated-lip-disprot": {}, "reviewed": true}'
+    )
+    monkeypatch.setattr(
+        "tooluniverse.mobidb_tool.requests.get", lambda *a, **k: _FakeResponse(body)
+    )
+
+    result = tool.run({"accession": "P37840"})
+
+    assert result["status"] == "success"
+    assert result["data"]["accession"] == "P37840"

--- a/tests/unit/test_monarch_result_id_prefix.py
+++ b/tests/unit/test_monarch_result_id_prefix.py
@@ -1,0 +1,122 @@
+"""Regression guard for Fix-R16A-2: Monarch's search endpoint has no
+server-side namespace filter (confirmed live: a "prefix" query param is
+silently ignored) and its "category" filter matches equivalent terms
+across multiple ontologies (HP, MP, UPHENO, ...) -- so
+get_HPO_ID_by_phenotype could return a non-HPO term as its top-ranked hit
+despite its name promising HPO IDs. `MonarchTool.run()` now supports an
+opt-in `result_id_prefix` config key that client-side filters `items` by ID
+prefix, over-fetching first so the returned count still matches what the
+caller requested. The filter must stay opt-in so it doesn't affect other
+Monarch-type tools (e.g. gene/disease search) that don't declare it.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.restful_tool import MonarchTool
+
+pytestmark = pytest.mark.unit
+
+MIXED_NAMESPACE_RESPONSE = {
+    "limit": 30,
+    "offset": 0,
+    "total": 386,
+    "items": [
+        {"id": "MP:0002064", "name": "seizures"},
+        {"id": "HP:0001250", "name": "Seizure"},
+        {"id": "UPHENO:7000475", "name": "focal seizures"},
+        {"id": "HP:0011145", "name": "Symptomatic seizures"},
+        {"id": "HP:0031165", "name": "Multifocal seizures"},
+        {"id": "HP:0002173", "name": "Hypoglycemic seizures"},
+        {"id": "HP:0002199", "name": "Hypocalcemic seizures"},
+        {"id": "HP:0010819", "name": "Atonic seizure"},
+        {"id": "HP:0020219", "name": "Motor seizure"},
+        {"id": "HP:0031951", "name": "Nocturnal seizures"},
+    ],
+}
+
+
+def _hpo_tool():
+    return MonarchTool(
+        {
+            "name": "get_HPO_ID_by_phenotype",
+            "tool_url": "/search",
+            "parameter": {"properties": {}},
+            "query_schema": {
+                "query": None,
+                "category": ["biolink:PhenotypicFeature"],
+                "limit": 20,
+                "offset": 0,
+            },
+            "result_id_prefix": "HP:",
+        }
+    )
+
+
+def _generic_tool():
+    return MonarchTool(
+        {
+            "name": "Monarch_search_gene",
+            "tool_url": "/search",
+            "parameter": {"properties": {}},
+            "query_schema": {"query": None, "limit": 20, "offset": 0},
+        }
+    )
+
+
+def test_result_id_prefix_filters_out_other_namespaces():
+    tool = _hpo_tool()
+    with patch(
+        "tooluniverse.restful_tool.execute_RESTful_query",
+        return_value=dict(MIXED_NAMESPACE_RESPONSE),
+    ):
+        result = tool.run({"query": "seizures", "limit": 10})
+
+    ids = [item["id"] for item in result["data"]["items"]]
+    assert all(i.startswith("HP:") for i in ids)
+    assert "MP:0002064" not in ids
+    assert "UPHENO:7000475" not in ids
+
+
+def test_result_id_prefix_preserves_requested_count():
+    tool = _hpo_tool()
+    with patch(
+        "tooluniverse.restful_tool.execute_RESTful_query",
+        return_value=dict(MIXED_NAMESPACE_RESPONSE),
+    ):
+        result = tool.run({"query": "seizures", "limit": 8})
+
+    assert len(result["data"]["items"]) == 8
+
+
+def test_overfetch_requests_a_larger_limit_from_the_api():
+    tool = _hpo_tool()
+    captured = {}
+
+    def fake_query(endpoint_url, variables=None):
+        captured["variables"] = variables
+        return dict(MIXED_NAMESPACE_RESPONSE)
+
+    with patch(
+        "tooluniverse.restful_tool.execute_RESTful_query", side_effect=fake_query
+    ):
+        tool.run({"query": "seizures", "limit": 10})
+
+    assert captured["variables"]["limit"] == 30
+
+
+def test_tools_without_result_id_prefix_are_unaffected():
+    tool = _generic_tool()
+    with patch(
+        "tooluniverse.restful_tool.execute_RESTful_query",
+        return_value=dict(MIXED_NAMESPACE_RESPONSE),
+    ):
+        result = tool.run({"query": "SCN2A", "limit": 10})
+
+    ids = [item["id"] for item in result["data"]["items"]]
+    assert ids == [item["id"] for item in MIXED_NAMESPACE_RESPONSE["items"]]

--- a/tests/unit/test_nhanes_dataset_resolution.py
+++ b/tests/unit/test_nhanes_dataset_resolution.py
@@ -1,0 +1,84 @@
+"""Regression guard for Fix-R16B-1 and Fix-R16B-2.
+
+Fix-R16B-1: Examination and Questionnaire, like Laboratory, each span many
+distinct files (Examination: BMX body measures, BPX blood pressure, AUX
+audiometry, ...). The old _COMPONENT_PREFIX fallback silently picked one
+arbitrary file (BPX for Examination) regardless of which `variables` were
+actually requested, returning status:"success" with the requested variables
+silently missing. Now requires `dataset_name` for these components too,
+matching the existing Laboratory precedent.
+
+Fix-R16B-2: nhanes_search_datasets' own results carry the cycle suffix
+already (e.g. file_name "BMX_J"). Passing that value straight into
+NHANES_download_and_parse's `dataset_name` used to append the suffix a
+second time ("BMX_J" + "_J" -> 404 downloading BMX_J_J.XPT).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.nhanes_tool import NHANESTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return NHANESTool(
+        {
+            "name": "NHANES_download_and_parse",
+            "fields": {"endpoint": "download_and_parse"},
+        }
+    )
+
+
+def test_examination_without_dataset_name_is_rejected():
+    tool = _tool()
+    result = tool._download_and_parse(
+        {"component": "Examination", "cycle": "2017-2018", "variables": ["SEQN", "BMXBMI"]}
+    )
+    assert result["status"] == "error"
+    assert "dataset_name" in result["error"]
+
+
+def test_questionnaire_without_dataset_name_is_rejected():
+    tool = _tool()
+    result = tool._download_and_parse(
+        {"component": "Questionnaire", "cycle": "2017-2018", "variables": ["SEQN"]}
+    )
+    assert result["status"] == "error"
+    assert "dataset_name" in result["error"]
+
+
+def test_laboratory_still_requires_dataset_name():
+    tool = _tool()
+    result = tool._download_and_parse(
+        {"component": "Laboratory", "cycle": "2017-2018", "variables": ["SEQN"]}
+    )
+    assert result["status"] == "error"
+    assert "dataset_name" in result["error"]
+
+
+def test_dataset_name_already_carrying_suffix_is_not_doubled():
+    tool = _tool()
+    filename = tool._resolve_filename("Examination", "2017-2018", dataset_name="BMX_J")
+    assert filename == "BMX_J"
+
+
+def test_dataset_name_without_suffix_gets_it_appended():
+    tool = _tool()
+    filename = tool._resolve_filename("Examination", "2017-2018", dataset_name="BMX")
+    assert filename == "BMX_J"
+
+
+def test_dataset_name_with_a_different_cycles_suffix_still_gets_current_appended():
+    # A dataset_name ending in a DIFFERENT cycle's suffix than the one being
+    # requested should not be mistaken for "already suffixed" -- only an
+    # exact match against the requested cycle's own suffix should skip
+    # appending.
+    tool = _tool()
+    filename = tool._resolve_filename("Examination", "2017-2018", dataset_name="BMX_H")
+    assert filename == "BMX_H_J"

--- a/tests/unit/test_pubmed_date_range_filter.py
+++ b/tests/unit/test_pubmed_date_range_filter.py
@@ -1,0 +1,76 @@
+"""Regression guard for Fix-R16E-1: NCBI's esearch silently ignores
+mindate/maxdate entirely unless BOTH are present -- confirmed live that
+mindate alone (an open-ended "from this date on" range) returned the exact
+same unfiltered count as no date params at all, while mindate+maxdate
+together correctly filtered. Also confirmed omitting datetype (even with
+both dates set) silently changes NCBI's filter basis from publication date
+to Entrez date. _build_params now backfills whichever bound is missing and
+defaults datetype whenever any date bound is supplied.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.pubmed_tool import PubMedRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return PubMedRESTTool(
+        {
+            "name": "PubMed_search_articles",
+            "fields": {
+                "db": "pubmed",
+                "retmode": "json",
+                "endpoint": "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi",
+            },
+        }
+    )
+
+
+def test_mindate_alone_backfills_maxdate_and_datetype():
+    tool = _tool()
+    params = tool._build_params({"query": "diabetes", "mindate": "2024/01/01"})
+
+    assert params["mindate"] == "2024/01/01"
+    assert params["maxdate"] == "3000"
+    assert params["datetype"] == "pdat"
+
+
+def test_maxdate_alone_backfills_mindate_and_datetype():
+    tool = _tool()
+    params = tool._build_params({"query": "diabetes", "maxdate": "2010/12/31"})
+
+    assert params["maxdate"] == "2010/12/31"
+    assert params["mindate"] == "1000"
+    assert params["datetype"] == "pdat"
+
+
+def test_both_dates_present_are_not_overwritten():
+    tool = _tool()
+    params = tool._build_params(
+        {
+            "query": "diabetes",
+            "mindate": "2020/01/01",
+            "maxdate": "2022/01/01",
+            "datetype": "edat",
+        }
+    )
+
+    assert params["mindate"] == "2020/01/01"
+    assert params["maxdate"] == "2022/01/01"
+    assert params["datetype"] == "edat"
+
+
+def test_no_date_params_means_no_date_params_added():
+    tool = _tool()
+    params = tool._build_params({"query": "diabetes"})
+
+    assert "mindate" not in params
+    assert "maxdate" not in params
+    assert "datetype" not in params


### PR DESCRIPTION
## Round 16: clinical genetics, epidemiology, structural bioinformatics, pharmacology, immunogenetics

Ninth round of the ongoing test-harness sweep (continues #302 → ... → #310). Five role-play researcher personas exercised fresh tool families — clinical genetics (HPO, Monarch), epidemiology (NHANES), structural bioinformatics (MobiDB, IUPred3), pharmacology (Guide to Pharmacology), and immunogenetics (IPD-IMGT/HLA, HLA Ligand Atlas). This was an unusually high-value round: four confirmed HIGH-severity bugs, one of them (PubMed date filtering) in a tool used constantly across the entire campaign.

### Fixed

**Fix-R16E-1 — `PubMed_search_articles`'s `mindate`/`maxdate` silently had zero effect when used alone (HIGH — largest blast radius of any fix in this campaign)**
Confirmed via multiple raw curl tests against NCBI's `esearch.fcgi`: an open-ended date range (`mindate` supplied without `maxdate`, or vice versa — the natural way a caller would ask "articles from 2024 onward") returns the **exact same unfiltered result count** as no date filter at all. Only when both bounds are present together does NCBI actually apply the filter. Separately confirmed that omitting `datetype` (even with both dates set) silently shifts the filter basis from publication date to Entrez date. `_build_params` now backfills whichever bound is missing with an out-of-PubMed's-real-range placeholder (`"1000"`/`"3000"`) and defaults `datetype` to `"pdat"` whenever either date bound is supplied. Verified live: a query that previously always included a 2017 article regardless of `mindate:"2024/01/01"` now correctly excludes it, and the symmetric `maxdate`-only case works too.
`src/tooluniverse/pubmed_tool.py`

**Fix-R16B-1 / Fix-R16B-2 — `NHANES_download_and_parse` had two bugs breaking the discover→fetch workflow (HIGH)**
- Requesting the `Examination` component without `dataset_name` silently downloaded the wrong file (`BPX_J`, blood pressure) instead of the one implied by the requested `variables` (`BMXBMI`/`BMXWT`, body measures) — returning `status: "success"` with the requested variables silently missing. `Examination` and `Questionnaire` each span many distinct files, exactly like the already-guarded `Laboratory` component; extended that same "requires `dataset_name`" guard to both.
- Passing `dataset_name` with the cycle suffix already included (exactly what the sibling tool `nhanes_search_datasets` returns, e.g. `"BMX_J"`) caused the suffix to be appended a second time, producing a 404 downloading `BMX_J_J.XPT`. Fixed with an `endswith(suffix)` check before appending.
`src/tooluniverse/nhanes_tool.py`

**Fix-R16A-2 — `get_HPO_ID_by_phenotype` could return a non-HPO term as its top hit (HIGH)**
Monarch's search API has no server-side namespace filter (confirmed live: a `prefix` query param is silently ignored), and its `category` filter (`biolink:PhenotypicFeature`) matches equivalent terms across multiple ontologies — for `"seizures"`, the top-ranked result was `MP:0002064` (Mouse Phenotype ontology), not an HPO term, despite the tool's name promising HPO IDs. Added an opt-in `result_id_prefix` config key to the shared `MonarchTool` class, which client-side filters results by ID prefix — opt-in specifically so it doesn't affect other Monarch-type tools (e.g. gene/disease search) that don't declare it. Also over-fetches before filtering so the returned count still matches what the caller requested.
`src/tooluniverse/restful_tool.py`, `src/tooluniverse/data/monarch_tools.json`

**Fix-R16C-1 — `MobiDB_get_protein`/`MobiDB_get_consensus` leaked a raw JSON-decode exception (MEDIUM)**
MobiDB returns HTTP 200 with a completely empty body for an unrecognized identifier (confirmed live, e.g. a UniProt entry name like `"SNCA_HUMAN"` instead of an accession) rather than a 404 — so `raise_for_status()` never fired, and the old code's direct `response.json()` call let a raw `json.JSONDecodeError` ("Expecting value: line 1 column 1") leak through as an opaque "Unexpected error." Added a shared fetch helper that detects the empty body and returns a clean, actionable error instead.
`src/tooluniverse/mobidb_tool.py`

### Deferred (documented, not fixed)

- **R16A-1 / R16A-3 / R16A-4 / R16A-5** — Several HPO/Monarch tools reject a natural-first-guess param name (`phenotype`→`query`, `hpo_id`→`term_id`, `gene_symbol`→`query`/`subject`) with an already-actionable jsonschema error. Naming-intuition mismatch, matches the established defer pattern from many earlier rounds.
- **R16D-1** — `GtoPdb_search_targets` doesn't match the standard HGNC gene symbol (`"ADRB2"`) or a multi-word phrase, and the first-failure hint misleadingly suggests trying the ligands tool instead. Worth a future look, but out of scope for this round's budget.
- **R16D-2** — `GtoPdb_get_disease_associations` requires `disease_id`, not the `targetId` a sibling tool (`get_interactions`) accepts — error is already actionable (names the missing param), just doesn't cross-reference the sibling tool.
- **R16E-2** — `HLALigandAtlas_get_benign_peptides`'s metadata reports `rows_scanned` (the full unfiltered table size) but not the actual filtered-match count, making it hard to gauge result completeness. Metadata-completeness UX gap, not incorrect data.
- **R16B-3 / R16B-4** — `nhanes_get_dataset_info` returns a generic category landing-page URL rather than a per-file listing (the sibling `nhanes_search_datasets` already does this better); `nhanes_search_datasets` with a plain-English term like `"obesity"` returns zero hits since it only matches literal CDC variable-name/label text. Both are real UX rough edges but not incorrect-data bugs.

### Testing

17 new unit tests across 4 files (all mocked, no network calls):
- `tests/unit/test_pubmed_date_range_filter.py` (4)
- `tests/unit/test_nhanes_dataset_resolution.py` (6)
- `tests/unit/test_monarch_result_id_prefix.py` (4)
- `tests/unit/test_mobidb_empty_response.py` (3)

Also re-checked existing PubMed test coverage (`tests/tools/test_pubmed_search_include_abstract.py`) since the date-filter fix touches shared, heavily-used code — 2 failures there are pre-existing and unrelated (confirmed via `git stash` to fail identically against a clean `origin/main` baseline before this round's changes).

Every fix was also verified live against the real upstream API via the CLI before and after the change (see fix descriptions above for the specific before/after evidence, including multiple isolating raw-curl comparisons for the PubMed date-range bug).
