### PR TITLE
Fix Round 17: TheraSAbDab target aliasing, SAbDab SPA-migration detection, Rfam operation fallback

### DIFF
--- a/src/tooluniverse/data/rfam_tools.json
+++ b/src/tooluniverse/data/rfam_tools.json
@@ -22,7 +22,7 @@
           "description": "Output format"
         }
       },
-      "required": ["operation", "family_id"]
+      "required": ["family_id"]
     },
     "return_schema": {
       "type": "object",
@@ -70,7 +70,7 @@
           "description": "Compress output with gzip"
         }
       },
-      "required": ["operation", "family_id"]
+      "required": ["family_id"]
     },
     "return_schema": {
       "type": "object",
@@ -108,7 +108,7 @@
           "description": "Required: Rfam accession or family name"
         }
       },
-      "required": ["operation", "family_id"]
+      "required": ["family_id"]
     },
     "return_schema": {
       "type": "object",
@@ -151,7 +151,7 @@
           "description": "Maximum time to wait for results (default: 120s). Job continues running if timeout reached."
         }
       },
-      "required": ["operation", "sequence"]
+      "required": ["sequence"]
     },
     "return_schema": {
       "type": "object",
@@ -195,7 +195,7 @@
           "description": "Required: Rfam accession or family name"
         }
       },
-      "required": ["operation", "family_id"]
+      "required": ["family_id"]
     },
     "return_schema": {
       "type": "object",
@@ -237,7 +237,7 @@
           "description": "Output format"
         }
       },
-      "required": ["operation", "family_id"]
+      "required": ["family_id"]
     },
     "return_schema": {
       "type": "object",
@@ -282,7 +282,7 @@
           "description": "Output format"
         }
       },
-      "required": ["operation", "family_id"]
+      "required": ["family_id"]
     },
     "return_schema": {
       "type": "object",
@@ -320,7 +320,7 @@
           "description": "Required: Rfam accession (e.g., RF00360)"
         }
       },
-      "required": ["operation", "accession"]
+      "required": ["accession"]
     },
     "return_schema": {
       "type": "object",
@@ -355,7 +355,7 @@
           "description": "Required: Family name (e.g., snoZ107_R87)"
         }
       },
-      "required": ["operation", "family_id"]
+      "required": ["family_id"]
     },
     "return_schema": {
       "type": "object",

--- a/src/tooluniverse/rfam_tool.py
+++ b/src/tooluniverse/rfam_tool.py
@@ -47,6 +47,19 @@ class RfamTool(BaseTool):
 
         operation = arguments.get("operation")
         if not operation:
+            # Fix-R17C-2: every Rfam_* tool config constrains `operation`
+            # to a single-value enum (each ToolUniverse tool name maps to
+            # exactly one Rfam operation) -- confirmed live this was still
+            # required on every call, forcing a caller to look up and pass
+            # back a fixed value the tool config itself already pins.
+            # Fall back to that sole enum value when omitted.
+            enum_values = (
+                self.parameter.get("properties", {}).get("operation", {}).get("enum")
+                or []
+            )
+            if len(enum_values) == 1:
+                operation = enum_values[0]
+        if not operation:
             return {"status": "error", "error": "Missing required parameter: operation"}
 
         # Route to appropriate operation handler

--- a/src/tooluniverse/sabdab_tool.py
+++ b/src/tooluniverse/sabdab_tool.py
@@ -148,8 +148,26 @@ class SAbDabTool(BaseTool):
 
             response.raise_for_status()
 
-            # Extract metadata from PDB REMARK lines
+            # Fix-R17D-2: SAbDab migrated to a new frontend ("SAbDab2", a
+            # React SPA) and its old download URL now redirects to an
+            # internal-only backend hostname (confirmed live: the new
+            # domain's /api/pdb/{id}/ route 307-redirects to
+            # "http://sabdab-backend:8000/...", not publicly resolvable) --
+            # so this request lands on the SPA shell instead of real PDB
+            # coordinate data, and used to be reported as a successful
+            # download of that HTML. Detect and report it honestly instead.
             pdb_content = response.text
+            if self._looks_like_html(pdb_content):
+                return {
+                    "status": "error",
+                    "error": (
+                        "SAbDab appears to have migrated to a new site "
+                        "(SAbDab2) with no public structure-download API "
+                        "currently reachable at this URL -- got an HTML "
+                        "page instead of PDB coordinate data. This is an "
+                        "upstream issue, not a query problem."
+                    ),
+                }
             metadata = {"pdb_id": pdb_id}
 
             # Parse REMARK 5 lines which contain SAbDab annotations
@@ -190,6 +208,12 @@ class SAbDabTool(BaseTool):
             return {"status": "error", "error": f"Request failed: {str(e)}"}
         except Exception as e:
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}
+
+    @staticmethod
+    def _looks_like_html(text: str) -> bool:
+        """True when the response body is an HTML page (the SAbDab2 SPA shell)
+        rather than the expected PDB/TSV data."""
+        return text.lstrip()[:20].lower().startswith(("<!doctype html", "<html"))
 
     @staticmethod
     def _coerce(value: str):
@@ -270,6 +294,24 @@ class SAbDabTool(BaseTool):
 
             # Expect a TSV with a header row + one row per antibody chain pairing.
             if "tab-separated" not in content_type and "\t" not in text:
+                # Fix-R17D-3: see the matching detection in _get_structure
+                # -- SAbDab's new site returns its SPA shell HTML instead
+                # of TSV data at this URL now, which the old message here
+                # ("may not be an antibody complex") misleadingly blamed on
+                # the structure itself rather than the actual cause
+                # (upstream site migration), confirmed live even for
+                # verified real antibody-antigen complexes.
+                if self._looks_like_html(text):
+                    return {
+                        "status": "error",
+                        "error": (
+                            "SAbDab appears to have migrated to a new site "
+                            "(SAbDab2) with no public summary-data API "
+                            "currently reachable at this URL -- got an "
+                            "HTML page instead of TSV data. This is an "
+                            "upstream issue, not a query problem."
+                        ),
+                    }
                 return {
                     "status": "error",
                     "error": (

--- a/src/tooluniverse/therasabdab_tool.py
+++ b/src/tooluniverse/therasabdab_tool.py
@@ -374,15 +374,34 @@ class TheraSAbDabTool(BaseTool):
             # Load all therapeutics and filter by target
             all_therapeutics = self._load_all_therapeutics()
 
-            # Filter by target (case-insensitive, hyphen-normalized)
-            # TheraSAbDab stores targets as "PDCD1/CD279/PD1" (no hyphens)
+            # Filter by target (case-insensitive, hyphen-normalized, exact
+            # alias match).
+            # Fix-R17D-1: TheraSAbDab stores targets as e.g.
+            # "PDCD1/CD279/PD1" (multiple aliases, "/"-joined) or, for
+            # bispecifics, "LAG3/CD223;PDCD1/CD279/PD1" (";"-joined target
+            # groups) -- confirmed live that plain substring containment
+            # matched "pd1" inside "entpd1" (ENTPD1/CD39, an unrelated
+            # target), silently polluting a PD-1 search with CD39
+            # antibodies. Split the stored target string into individual
+            # alias tokens and require an exact (not substring) match
+            # against one of them.
             target_lower = target.lower()
             target_nohyphen = target_lower.replace("-", "")
+
+            def _target_aliases(raw_target: Optional[str]) -> set:
+                aliases = set()
+                for part in re.split(r"[;/]", raw_target or ""):
+                    part = part.strip().lower()
+                    if part:
+                        aliases.add(part)
+                        aliases.add(part.replace("-", ""))
+                return aliases
+
+            query_aliases = {target_lower, target_nohyphen}
             filtered = [
                 t
                 for t in all_therapeutics
-                if target_lower in (t.get("target") or "").lower()
-                or target_nohyphen in (t.get("target") or "").lower().replace("-", "")
+                if query_aliases & _target_aliases(t.get("target"))
             ]
 
             return {

--- a/tests/unit/test_rfam_operation_fallback.py
+++ b/tests/unit/test_rfam_operation_fallback.py
@@ -1,0 +1,83 @@
+"""Regression guard for Fix-R17C-2: every Rfam_* tool config constrains
+`operation` to a single-value enum (each ToolUniverse tool name maps to
+exactly one Rfam operation, e.g. Rfam_get_family -> "get_family"), yet
+`operation` was still required on every call -- forcing a caller to look
+up and pass back a fixed value the tool config itself already pins.
+RfamTool.run() now falls back to that sole enum value when the caller
+omits `operation`, and the JSON configs no longer list it in `required`.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.rfam_tool import RfamTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(operation_enum, required):
+    return RfamTool(
+        {
+            "name": "Rfam_get_family",
+            "parameter": {
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string", "enum": operation_enum},
+                    "family_id": {"type": "string"},
+                },
+                "required": required,
+            },
+        }
+    )
+
+
+def test_operation_omitted_falls_back_to_sole_enum_value(monkeypatch):
+    tool = _tool(["get_family"], ["family_id"])
+    captured = {"called": False}
+
+    def fake_get_family(arguments):
+        captured["called"] = True
+        return {"status": "success"}
+
+    monkeypatch.setattr(tool, "_get_family", fake_get_family)
+
+    result = tool.run({"family_id": "RF01871"})
+
+    assert result["status"] == "success"
+    assert captured["called"] is True
+
+
+def test_operation_explicitly_provided_still_works(monkeypatch):
+    tool = _tool(["get_family"], ["family_id"])
+    monkeypatch.setattr(
+        tool, "_get_family", lambda arguments: {"status": "success"}
+    )
+
+    result = tool.run({"operation": "get_family", "family_id": "RF01871"})
+
+    assert result["status"] == "success"
+
+
+def test_missing_family_id_still_rejected():
+    tool = _tool(["get_family"], ["family_id"])
+
+    result = tool.run({})
+
+    assert result["status"] == "error"
+    assert "family_id" in result["error"]
+
+
+def test_multi_value_enum_does_not_fall_back():
+    # A hypothetical tool with more than one legal operation value should
+    # not silently guess -- fallback only applies when there's exactly one
+    # possible value.
+    tool = _tool(["get_family", "get_alignment"], ["family_id"])
+
+    result = tool.run({"family_id": "RF01871"})
+
+    assert result["status"] == "error"
+    assert "operation" in result["error"]

--- a/tests/unit/test_sabdab_spa_migration_detection.py
+++ b/tests/unit/test_sabdab_spa_migration_detection.py
@@ -1,0 +1,94 @@
+"""Regression guard for Fix-R17D-2 and Fix-R17D-3: SAbDab migrated to a new
+frontend ("SAbDab2", a React SPA), and its old download/summary URLs now
+return an HTTP-200 SPA HTML shell instead of the real PDB/TSV data
+(confirmed live: the new domain's /api/pdb/{id}/ route 307-redirects to an
+internal-only "sabdab-backend:8000" hostname, not publicly resolvable).
+Before this fix, SAbDab_get_structure reported the HTML as a successful PDB
+download, and SAbDab_get_structure_summary blamed the HTML on the
+structure "may not be an antibody complex" -- both misleading. Both now
+detect the SPA shell and report the real, upstream cause honestly.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.sabdab_tool import SAbDabTool
+
+pytestmark = pytest.mark.unit
+
+SPA_HTML = (
+    '<!doctype html>\n<html lang="en"><head><title>SAbDab2</title></head>'
+    "<body><div id=\"root\"></div></body></html>"
+)
+
+
+class _FakeResponse:
+    def __init__(self, text, status_code=200, headers=None):
+        self.text = text
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        pass
+
+
+def _tool():
+    return SAbDabTool({"name": "SAbDab_get_structure"})
+
+
+def test_get_structure_detects_spa_html(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(
+        "tooluniverse.sabdab_tool.requests.get",
+        lambda *a, **k: _FakeResponse(SPA_HTML),
+    )
+
+    result = tool._get_structure({"pdb_id": "5jxe"})
+
+    assert result["status"] == "error"
+    assert "migrated" in result["error"]
+    assert "SAbDab2" in result["error"]
+
+
+def test_get_structure_still_parses_real_pdb_content(monkeypatch):
+    tool = _tool()
+    real_pdb = "REMARK   5 PAIRED_HL=A_B\nATOM      1  N   ALA A   1\n"
+    monkeypatch.setattr(
+        "tooluniverse.sabdab_tool.requests.get",
+        lambda *a, **k: _FakeResponse(real_pdb),
+    )
+
+    result = tool._get_structure({"pdb_id": "5jxe"})
+
+    assert result["status"] == "success"
+    assert result["data"]["pdb_id"] == "5jxe"
+
+
+def test_get_structure_summary_detects_spa_html(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(
+        "tooluniverse.sabdab_tool.requests.get",
+        lambda *a, **k: _FakeResponse(SPA_HTML, headers={"Content-Type": "text/html"}),
+    )
+
+    result = tool._get_structure_summary({"pdb_id": "5jxe"})
+
+    assert result["status"] == "error"
+    assert "migrated" in result["error"]
+
+
+def test_get_structure_summary_non_html_non_tabular_keeps_original_message(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(
+        "tooluniverse.sabdab_tool.requests.get",
+        lambda *a, **k: _FakeResponse("not tabular and not html either"),
+    )
+
+    result = tool._get_structure_summary({"pdb_id": "5jxe"})
+
+    assert result["status"] == "error"
+    assert "may not be an antibody complex" in result["error"]

--- a/tests/unit/test_therasabdab_target_matching.py
+++ b/tests/unit/test_therasabdab_target_matching.py
@@ -1,0 +1,63 @@
+"""Regression guard for Fix-R17D-1: TheraSAbDab_search_by_target used plain
+substring containment against the stored target string (e.g.
+"PDCD1/CD279/PD1", or for bispecifics "LAG3/CD223;PDCD1/CD279/PD1"), so a
+search for "PD-1" matched "pd1" inside "entpd1" (ENTPD1/CD39, an unrelated
+target) -- confirmed live this silently polluted a PD-1 search with CD39
+antibodies. The fix splits the stored target string into individual alias
+tokens and requires an exact match against one of them.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.therasabdab_tool import TheraSAbDabTool
+
+pytestmark = pytest.mark.unit
+
+THERAPEUTICS = [
+    {"inn_name": "pembrolizumab", "target": "PDCD1/CD279/PD1"},
+    {"inn_name": "eltivutabart", "target": "ENTPD1/CD39"},
+    {"inn_name": "ipilimumab", "target": "CTLA4/CD152"},
+    {"inn_name": "some-bispecific", "target": "LAG3/CD223;PDCD1/CD279/PD1"},
+    {"inn_name": "trastuzumab", "target": "ERBB2/CD340/HER2"},
+]
+
+
+def _tool():
+    return TheraSAbDabTool({"name": "TheraSAbDab_search_by_target"})
+
+
+def test_pd1_search_excludes_entpd1(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(tool, "_load_all_therapeutics", lambda: list(THERAPEUTICS))
+
+    result = tool._search_by_target({"target": "PD-1"})
+
+    names = [t["inn_name"] for t in result["data"]["therapeutics"]]
+    assert "eltivutabart" not in names
+    assert "pembrolizumab" in names
+    assert "some-bispecific" in names
+
+
+def test_cd39_search_only_matches_entpd1(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(tool, "_load_all_therapeutics", lambda: list(THERAPEUTICS))
+
+    result = tool._search_by_target({"target": "CD39"})
+
+    names = [t["inn_name"] for t in result["data"]["therapeutics"]]
+    assert names == ["eltivutabart"]
+
+
+def test_her2_search_still_matches(monkeypatch):
+    tool = _tool()
+    monkeypatch.setattr(tool, "_load_all_therapeutics", lambda: list(THERAPEUTICS))
+
+    result = tool._search_by_target({"target": "HER2"})
+
+    names = [t["inn_name"] for t in result["data"]["therapeutics"]]
+    assert names == ["trastuzumab"]


### PR DESCRIPTION
## Summary

Round 17 of the ongoing test-harness sweep: 5 role-play researcher persona agents targeted antibody-structure, ncRNA, and comparative-genomics domains not recently covered. Every reported issue was CLI-verified against live upstream APIs before fixing; only root-caused, reproducible bugs are fixed here (naming-intuition mismatches, ranking-quality gaps, and other upstream-only issues were reviewed and deliberately deferred).

- **Fix-R17D-1** — `TheraSAbDab_search_by_target` matched targets by plain substring containment against Rfam-style `"/"`- and `";"`-joined alias strings (e.g. `"PDCD1/CD279/PD1"`). Confirmed live that a search for `"PD-1"` matched `"pd1"` inside `"entpd1"` (ENTPD1/CD39, an unrelated target), silently polluting PD-1 results with CD39 antibodies. Now splits the stored target string into individual alias tokens and requires an exact match against one of them.
- **Fix-R17D-2/3** — SAbDab has migrated to a new React SPA ("SAbDab2"); its old structure-download and summary URLs now return an HTTP-200 HTML shell instead of real PDB/TSV data (confirmed via `curl -sI`: `/api/pdb/{id}/` 307-redirects to an internal-only, publicly-unreachable `sabdab-backend:8000` host). Before this fix, `SAbDab_get_structure` silently returned the HTML as if it were a successful PDB download, and `SAbDab_get_structure_summary` blamed the HTML on "structure may not be an antibody complex" — both misleading. Both now detect the SPA shell and report the real upstream cause honestly.
- **Fix-R17C-2** — Every `Rfam_*` tool config constrains `operation` to a single-value enum (each tool name maps to exactly one Rfam operation), yet `operation` was still marked `required`, forcing callers to look up and pass back a value the config already pins. `RfamTool.run()` now falls back to the sole enum value when `operation` is omitted, and the 9 Rfam tool configs no longer list it in `required`.

## Test plan

- [x] 11 new mocked unit tests (`tests/unit/test_therasabdab_target_matching.py`, `tests/unit/test_sabdab_spa_migration_detection.py`, `tests/unit/test_rfam_operation_fallback.py`) covering the fixed behavior plus adjacent non-regression cases (e.g. CD39/HER2 searches still work, real PDB/TSV content still parses, multi-value enums correctly still require `operation`).
- [x] Pre-existing `tests/tools/test_sabdab_tool.py` and `tests/tools/test_rfam_tool.py` pass unchanged.
- [x] `code-simplifier` pass applied (deduped alias-set lookup in TheraSAbDab, extracted shared `_looks_like_html` helper in SAbDab).
- [x] All three fixes independently verified live against the real upstream APIs before and after the change.
