### PR TITLE
Fix Round 18: PDBe/EMDB, Reactome, CTD, IEDB, and KEGG bugs

### DIFF
--- a/src/tooluniverse/cli.py
+++ b/src/tooluniverse/cli.py
@@ -479,7 +479,15 @@ def _render_run(d: dict) -> str:
 
     # Feature-25B-02: for "tool not found" errors, replace generic network tips
     # with tool-discovery tips and include fuzzy suggestions when available.
-    is_not_found = "not found" in short_err.lower()
+    # Fix-R18A-2/R18C-6: a plain "not found" substring match also fires on a
+    # tool's own HTTP-404-shaped error message (e.g. "PDBe API error: 404
+    # Client Error: Not Found for url: ..." or CTD's "'cadmium' was not found
+    # in the RENCI CTD mirror") -- confirmed live these produced misleading
+    # "check tool name spelling" tips for a perfectly valid tool call with a
+    # bad parameter VALUE, not a bad tool name. A genuine unknown-tool-name
+    # error is reliably tagged error_details.type == "ToolUnavailableError"
+    # (confirmed live); use that structured signal instead of the message text.
+    is_not_found = details.get("type") == "ToolUnavailableError"
     is_api_key_error = "requires api key" in short_err.lower()
     suggestions = d.get("suggestions") or details.get("suggestions") or []
     if is_api_key_error:
@@ -507,6 +515,24 @@ def _render_run(d: dict) -> str:
         )
         if hint:
             cli_steps = [*cli_steps, hint]
+        # Fix-R18C-1: some tools put a single actionable redirect at the
+        # top-level "suggestion" key (e.g. CTD_get_gene_diseases pointing
+        # callers at OpenTargets) -- confirmed live this was silently
+        # dropped since only the plural "suggestions" (fuzzy tool-name
+        # matches) and error_details.next_steps were ever surfaced.
+        suggestion = d.get("suggestion")
+        if suggestion:
+            cli_steps = [*cli_steps, suggestion]
+        # Fix-R18D-3: BaseRESTTool-backed tools put the actionable upstream
+        # error in a top-level "detail" dict (PostgREST-style hint/message,
+        # e.g. IEDB's shared query tool), distinct from error_details --
+        # confirmed live this was silently dropped, leaving only the generic
+        # "Error: HTTP request failed" with no indication of the real cause.
+        raw_detail = d.get("detail")
+        if isinstance(raw_detail, dict):
+            detail_hint = raw_detail.get("hint") or raw_detail.get("message")
+            if detail_hint:
+                cli_steps = [*cli_steps, detail_hint]
         if cli_steps:
             lines.append("Tips:")
             for step in cli_steps:

--- a/src/tooluniverse/ctd_tool.py
+++ b/src/tooluniverse/ctd_tool.py
@@ -10,8 +10,9 @@ chemical↔disease cleanly, but does NOT contain CTD's gene-disease inferred
 edges. Gene→disease queries return an honest error pointing at OpenTargets.
 """
 
+import re
 import requests
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from .base_tool import BaseTool
 from .tool_registry import register_tool
@@ -19,6 +20,42 @@ from .tool_registry import register_tool
 RENCI_BASE = "https://automat.renci.org/ctd"
 RENCI_HEADERS = {"Accept": "application/json", "User-Agent": "ToolUniverse CTDTool"}
 DATA_AS_OF = "2024-06"  # RENCI snapshot version
+
+_MESH_ID_RE = re.compile(r"^[CD]\d{6,9}$")  # D=descriptor, C=supplementary concept
+_CAS_RN_RE = re.compile(r"^\d{1,7}-\d{2}-\d$")
+_ALL_DIGITS_RE = re.compile(r"^\d+$")
+
+# Per input_type, the (pattern, CURIE prefix) pairs to try in order when the
+# bare term looks like a well-known, unambiguous ID format.
+_CURIE_RULES = {
+    "chem": ((_MESH_ID_RE, "MESH"), (_CAS_RN_RE, "CAS")),
+    "gene": ((_ALL_DIGITS_RE, "NCBIGene"),),
+    "disease": ((_MESH_ID_RE, "MESH"),),
+}
+
+
+def _candidate_curies(term: str, input_type: str) -> List[str]:
+    """Fix-R18C-2/4: CTD's own tool descriptions promise bare CAS RN, bare
+    MeSH ID, and bare NCBI Gene ID as valid input_terms formats, but the
+    RENCI mirror's equivalent_identifiers only ever store the CURIE-prefixed
+    form -- confirmed live that "D000082" (bare MeSH ID) and "80-05-7" (bare
+    CAS RN) both fail to resolve while "MESH:D000082" and "CAS:80-05-7"
+    succeed, and likewise a bare NCBI Gene ID needs "NCBIGene:" prepended.
+    When input_terms matches one of these well-known, unambiguous ID
+    formats and isn't already a CURIE, try the correctly-prefixed form
+    first; the original string is always tried too so a name/CURIE that
+    already works keeps working.
+    """
+    if ":" in term:
+        return [term]
+    candidates = [
+        f"{prefix}:{term}"
+        for pattern, prefix in _CURIE_RULES.get(input_type, ())
+        if pattern.match(term)
+    ]
+    candidates.append(term)
+    return candidates
+
 
 # Maps the existing tool configs' (input_type, report_type) to RENCI
 # (source_category, target_category). The gene→disease entry is None
@@ -121,7 +158,11 @@ class CTDTool(BaseTool):
             }
         source_cat, target_cat = mapping
 
-        canonical = self._resolve_curie(input_terms)
+        canonical = None
+        for candidate in _candidate_curies(input_terms, input_type):
+            canonical = self._resolve_curie(candidate)
+            if canonical:
+                break
         if not canonical:
             return {
                 "status": "error",

--- a/src/tooluniverse/data/ctd_tools.json
+++ b/src/tooluniverse/data/ctd_tools.json
@@ -1,13 +1,13 @@
 [
   {
     "name": "CTD_get_chemical_gene_interactions",
-    "description": "Get curated chemical-gene interactions from CTD (Comparative Toxicogenomics Database). Given a chemical name, returns genes it interacts with, including organism, PubMed references, and interaction types. Example: 'bisphenol A' returns thousands of gene interactions across species. Backed by the RENCI Automat CTD mirror (June-2024 snapshot, biolink-categorized); CTD's native batchQuery.go is currently CAPTCHA-blocked for programmatic clients.",
+    "description": "Get curated chemical-gene interactions from CTD (Comparative Toxicogenomics Database). Given a chemical name, returns genes it interacts with, including organism, PubMed references, and interaction types. Example: 'bisphenol A' returns thousands of gene interactions across species. Note: the result's top-level 'predicate' field is always null for this edge type -- the real interaction-type signal is in 'qualified_predicate' (e.g. 'biolink:causes') and 'object_direction_qualifier'. Backed by the RENCI Automat CTD mirror (June-2024 snapshot, biolink-categorized); CTD's native batchQuery.go is currently CAPTCHA-blocked for programmatic clients.",
     "parameter": {
       "type": "object",
       "properties": {
         "input_terms": {
           "type": "string",
-          "description": "Chemical name, MeSH name, synonym, CAS RN, or MeSH ID. Examples: 'bisphenol A', 'acetaminophen', 'D000082' (MeSH ID for acetaminophen)."
+          "description": "Chemical name, CAS RN, or MeSH ID. Examples: 'bisphenol A', 'paracetamol' (the RENCI mirror's canonical name -- common synonyms like 'acetaminophen' may not resolve), 'D000082' (MeSH ID, prefix optional). CAS RN and MeSH/NCBI Gene IDs are matched by exact string against the graph's canonical name/synonym list, not fuzzy-matched, so an uncommon synonym can fail even when the substance is covered."
         }
       },
       "required": [
@@ -700,13 +700,13 @@
   },
   {
     "name": "CTD_get_disease_chemicals",
-    "description": "Get curated disease-chemical associations from CTD. Given a disease name, returns chemicals associated with it, including evidence type. Example: 'Breast Neoplasms' returns chemicals linked to breast cancer including both therapeutic agents and toxicants. Backed by the RENCI Automat CTD mirror (June-2024 snapshot, biolink-categorized); CTD's native batchQuery.go is currently CAPTCHA-blocked for programmatic clients.",
+    "description": "Get curated disease-chemical associations from CTD. Given a disease name, returns chemicals associated with it, including evidence type. Example: 'breast neoplasm' returns chemicals linked to breast cancer including both therapeutic agents and toxicants. Backed by the RENCI Automat CTD mirror (June-2024 snapshot, biolink-categorized); CTD's native batchQuery.go is currently CAPTCHA-blocked for programmatic clients.",
     "parameter": {
       "type": "object",
       "properties": {
         "input_terms": {
           "type": "string",
-          "description": "Disease name, MeSH name, synonym, or MeSH/OMIM ID. Examples: 'Breast Neoplasms', 'asthma', 'MESH:D001249'."
+          "description": "Disease name, MeSH/OMIM ID. Examples: 'breast neoplasm' (singular -- the plural 'Breast Neoplasms' does not resolve), 'asthma', 'MESH:D001249'. Matched by exact string against the graph's canonical name, not fuzzy-matched, so an uncommon phrasing can fail even when the disease is covered."
         }
       },
       "required": [

--- a/src/tooluniverse/emdb_tool.py
+++ b/src/tooluniverse/emdb_tool.py
@@ -1,5 +1,5 @@
 import requests
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 from .base_tool import BaseTool
 from .http_utils import request_with_retry
 from .tool_registry import register_tool
@@ -14,18 +14,38 @@ class EMDBRESTTool(BaseTool):
         self.session.headers.update({"Accept": "application/json"})
         self.timeout = 30
 
-    def _build_url(self, args: Dict[str, Any]) -> str:
+    def _build_url(self, args: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+        """Substitute `{placeholder}` tokens in the endpoint template.
+
+        Fix-R18A-1: args with no matching `{placeholder}` (e.g.
+        EMDB_search_structures's `rows`) were silently dropped -- there was
+        no query-string fallback, so `rows` had zero effect on the request
+        regardless of value (confirmed live: rows=2 and rows=10 both
+        returned the same 10 results; the raw EMDB API honors `?rows=N` as
+        a query param). Return them separately so the caller can pass them
+        through as query params instead.
+        """
         url = self.tool_config["fields"]["endpoint"]
+        query_params = {}
         for k, v in args.items():
-            url = url.replace(f"{{{k}}}", str(v))
-        return url
+            token = f"{{{k}}}"
+            if token in url:
+                url = url.replace(token, str(v))
+            else:
+                query_params[k] = v
+        return url, query_params
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         url = None
         try:
-            url = self._build_url(arguments)
+            url, query_params = self._build_url(arguments)
             response = request_with_retry(
-                self.session, "GET", url, timeout=self.timeout, max_attempts=3
+                self.session,
+                "GET",
+                url,
+                params=query_params,
+                timeout=self.timeout,
+                max_attempts=3,
             )
             if response.status_code != 200:
                 return {

--- a/src/tooluniverse/iedb_prediction_tool.py
+++ b/src/tooluniverse/iedb_prediction_tool.py
@@ -58,7 +58,24 @@ class IEDBPredictionTool(BaseTool):
             return {"status": "error", "error": f"IEDB prediction error: {str(e)}"}
 
     def _parse_tsv(self, text: str) -> List[Dict[str, str]]:
-        reader = csv.DictReader(io.StringIO(text.strip()), delimiter="\t")
+        text = text.strip()
+        # Fix-R18D-1: IEDB's prediction endpoints return HTTP 200 with a
+        # plain-text validation error (e.g. "The length of input sequence
+        # is less than the input/default length 15.") instead of TSV data
+        # for invalid input like a too-short sequence -- confirmed live.
+        # csv.DictReader silently treated the error's first line as a
+        # single-column header and the second as one data row, and the
+        # caller's `.get("percentile_rank", 100)` fallback then made this
+        # look like a real (if suspicious) successful prediction. Detect
+        # the non-tabular response before parsing and raise instead, so
+        # `run()`'s exception handler reports it as the error it is.
+        if not text or "\t" not in text.splitlines()[0]:
+            raise ValueError(
+                f"IEDB tool returned a non-tabular response, likely an "
+                f"input validation error rather than prediction data: "
+                f"{text[:300]!r}"
+            )
+        reader = csv.DictReader(io.StringIO(text), delimiter="\t")
         return [dict(row) for row in reader]
 
     def _predict_bcell(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -294,8 +311,14 @@ class IEDBPredictionTool(BaseTool):
 
         results = self._parse_tsv(resp.text)
         for r in results:
+            # Fix-R18D-2: the mhcii endpoint's real TSV column is named
+            # "rank", not "percentile_rank" (unlike the mhci endpoint,
+            # confirmed live to genuinely have a "percentile_rank" column)
+            # -- so this always hit the `100` default, making the field
+            # silently and completely wrong for every successful call
+            # regardless of the actual binding rank.
             try:
-                r["percentile_rank"] = float(r.get("percentile_rank", 100))
+                r["percentile_rank"] = float(r.get("rank", 100))
             except (ValueError, TypeError):
                 pass
 

--- a/src/tooluniverse/kegg_ext_tool.py
+++ b/src/tooluniverse/kegg_ext_tool.py
@@ -19,6 +19,30 @@ from .base_tool import BaseTool
 
 KEGG_BASE_URL = "https://rest.kegg.jp"
 
+# Cross-reference line prefixes recognized inside a KEGG variant's VARIATION
+# block, mapped to the result field they populate. COSF (COSMIC Fusion) and
+# OmimVar were added in Fix-R18E-5 (confirmed live in the raw record for
+# BCR-ABL, hsa_var:25v1); previously only ClinVar/dbSNP/COSM were captured.
+_VARIANT_XREF_FIELDS = {
+    "ClinVar:": "clinvar",
+    "dbSNP:": "dbsnp",
+    "COSM:": "cosmic",
+    "COSF:": "cosmic_fusion",
+    "OmimVar:": "omim_variant",
+}
+
+
+def _new_kegg_variation(mutation: str) -> Dict[str, Any]:
+    """A fresh KEGG variant record with all cross-reference lists empty."""
+    return {
+        "mutation": mutation,
+        "clinvar": [],
+        "dbsnp": [],
+        "cosmic": [],
+        "cosmic_fusion": [],
+        "omim_variant": [],
+    }
+
 
 def _parse_tsv_column(text: str, column: int = 0) -> list:
     """Extract a single column from KEGG tab-separated text output."""
@@ -72,7 +96,29 @@ class KEGGExtTool(BaseTool):
         except requests.exceptions.HTTPError as e:
             code = e.response.status_code if e.response is not None else "unknown"
             if code == 404:
-                return {"status": "error", "error": f"KEGG entry not found"}
+                if self.endpoint == "get_brite_hierarchy":
+                    # Fix-R18E-4: some BRITE files are KEGG's "(table)"-type
+                    # hierarchies (e.g. br08341, Pharmacogenomic
+                    # biomarkers), published only as flat text/HTML
+                    # upstream with no JSON tree representation -- their
+                    # /get/br:{id}/json endpoint 404s even though the
+                    # hierarchy itself exists and KEGG_list_brite_hierarchies
+                    # happily lists it (confirmed live via curl). A bare
+                    # "not found" wrongly implies the hierarchy_id itself
+                    # is wrong.
+                    hid = arguments.get("hierarchy_id", "")
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"KEGG BRITE hierarchy '{hid}' has no JSON tree "
+                            "representation (HTTP 404). This is common for "
+                            "KEGG's table-type BRITE files, which are only "
+                            "published as flat text/HTML upstream -- it "
+                            "does not necessarily mean hierarchy_id is "
+                            "wrong."
+                        ),
+                    }
+                return {"status": "error", "error": "KEGG entry not found"}
             return {"status": "error", "error": f"KEGG API HTTP error: {code}"}
         except Exception as e:
             return {
@@ -625,7 +671,12 @@ class KEGGExtTool(BaseTool):
                 gene_line = line[12:].strip()
                 if gene_line:
                     result["genes"].append(gene_line)
-            elif line.startswith("PATHWAY"):
+            elif line.startswith(("PATHWAY", "DIS_PATHWAY")):
+                # Fix-R18E-2: a KEGG disease flat file uses the field name
+                # DIS_PATHWAY (not PATHWAY) for its associated pathways --
+                # confirmed live via raw curl for H00004 (chronic myeloid
+                # leukemia), whose real DIS_PATHWAY entry was silently
+                # unrecognized and dropped entirely.
                 current_field = "PATHWAY"
                 parts = line[12:].strip().split("  ", 1)
                 if len(parts) >= 2:
@@ -812,12 +863,23 @@ class KEGGExtTool(BaseTool):
                 target_line = line[12:].strip()
                 if target_line:
                     result["targets"].append(target_line)
-            elif line.startswith("PATHWAY"):
+            elif line.startswith(("PATHWAY", "  PATHWAY")):
+                # Fix-R18E-1: in a KEGG drug flat file, PATHWAY is nested
+                # 2 spaces under TARGET (not a top-level 0-indent field
+                # like every other field this parser recognizes) --
+                # confirmed live via raw curl for D01441 (imatinib), whose
+                # 3 real pathways were silently dropped entirely, along
+                # with their continuation lines (current_field was reset
+                # to None on the unrecognized "  PATHWAY   ..." line, so
+                # even the follow-on indented rows never attributed).
+                # Content still starts at column 12 in both cases.
                 current_field = "PATHWAY"
                 parts = line[12:].strip().split("  ", 1)
                 if len(parts) >= 2:
                     result["pathways"][parts[0].strip()] = parts[1].strip()
-            elif line.startswith("DISEASE"):
+            elif line.startswith(("DISEASE", "  DISEASE")):
+                # Fix-R18E-1: DISEASE is likewise nested 2 spaces under
+                # EFFICACY in a KEGG drug flat file.
                 current_field = "DISEASE"
                 disease_line = line[12:].strip()
                 if disease_line:
@@ -941,7 +1003,19 @@ class KEGGExtTool(BaseTool):
                 "error": "network_id is required (e.g., 'N00001')",
             }
 
-        url = f"{KEGG_BASE_URL}/get/{network_id}"
+        # Fix-R18E-6: KEGG's REST API accepts a bare "N00001"-style
+        # perturbed-network ID directly, but 404s on a bare "nt06276"-style
+        # disease/map network ID -- it requires a "network:" prefix for
+        # that ID family (confirmed live: GET /get/nt06276 -> 404, GET
+        # /get/network:nt06276 -> 200). This nt###### format is exactly
+        # what this same tool family's other outputs surface (e.g.
+        # KEGG_get_disease's NETWORK field, KEGG_get_variant's networks
+        # list), making it a natural, undocumented chaining trap.
+        lookup_id = network_id
+        if lookup_id.lower().startswith("nt") and ":" not in lookup_id:
+            lookup_id = f"network:{lookup_id}"
+
+        url = f"{KEGG_BASE_URL}/get/{lookup_id}"
         response = requests.get(url, timeout=self.timeout)
         response.raise_for_status()
 
@@ -982,7 +1056,14 @@ class KEGGExtTool(BaseTool):
                 drug_line = line[12:].strip()
                 if drug_line:
                     result["drugs"].append(drug_line)
-            elif line.startswith("ELEMENT"):
+            elif line.startswith(("ELEMENT", "MEMBER")):
+                # Fix-R18E-7: KEGG's Map-type network entries (nt######
+                # IDs) list their child networks under MEMBER, not ELEMENT
+                # (that field name is only used by N#####-style perturbed
+                # networks) -- confirmed live for nt06276, whose 9 real
+                # MEMBER entries were silently dropped entirely. Both
+                # represent the same concept (child network elements) so
+                # they're merged into the one "elements" output field.
                 current_field = "ELEMENT"
                 result["elements"].append(line[12:].strip())
             elif line.startswith("///"):
@@ -1097,12 +1178,7 @@ class KEGGExtTool(BaseTool):
             elif line.startswith("VARIATION"):
                 current_field = "VARIATION"
                 content = line[12:].strip()
-                current_variation = {
-                    "mutation": content,
-                    "clinvar": [],
-                    "dbsnp": [],
-                    "cosmic": [],
-                }
+                current_variation = _new_kegg_variation(content)
                 result["variations"].append(current_variation)
             elif line.startswith("NETWORK"):
                 current_field = "NETWORK"
@@ -1119,25 +1195,20 @@ class KEGGExtTool(BaseTool):
                 content = line[12:].strip()
                 if current_field == "VARIATION" and current_variation:
                     if content.startswith("mutation "):
-                        current_variation = {
-                            "mutation": content.replace("mutation ", ""),
-                            "clinvar": [],
-                            "dbsnp": [],
-                            "cosmic": [],
-                        }
+                        current_variation = _new_kegg_variation(
+                            content.replace("mutation ", "")
+                        )
                         result["variations"].append(current_variation)
-                    elif content.startswith("ClinVar:"):
-                        current_variation["clinvar"] = content.replace(
-                            "ClinVar: ", ""
-                        ).split()
-                    elif content.startswith("dbSNP:"):
-                        current_variation["dbsnp"] = content.replace(
-                            "dbSNP: ", ""
-                        ).split()
-                    elif content.startswith("COSM:"):
-                        current_variation["cosmic"] = content.replace(
-                            "COSM: ", ""
-                        ).split()
+                    else:
+                        # Capture any recognized cross-reference line (ClinVar,
+                        # dbSNP, COSM, and -- per Fix-R18E-5 -- COSF/OmimVar)
+                        # into its result field; unrecognized lines are ignored.
+                        for prefix, key in _VARIANT_XREF_FIELDS.items():
+                            if content.startswith(prefix):
+                                current_variation[key] = content.replace(
+                                    f"{prefix} ", ""
+                                ).split()
+                                break
                 elif current_field == "NETWORK":
                     result["networks"].append(content)
                 elif current_field == "DISEASE":

--- a/src/tooluniverse/pdbe_sifts_tool.py
+++ b/src/tooluniverse/pdbe_sifts_tool.py
@@ -47,9 +47,26 @@ class PDBeSIFTSTool(BaseTool):
         except requests.exceptions.ConnectionError:
             return {"status": "error", "error": "Failed to connect to PDBe SIFTS API"}
         except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else None
+            if status_code == 404:
+                # Fix-R18A-3: a bare "HTTP error: 404" doesn't distinguish
+                # a genuinely broken request from PDBe simply having no
+                # mapping data of this type for an otherwise-valid entry
+                # (confirmed live: PDBeSIFTS_get_scop_mapping 404s for
+                # 3k34, which has real PDB/ligand data elsewhere -- SCOP
+                # classification just doesn't cover it).
+                return {
+                    "status": "error",
+                    "error": (
+                        f"PDBe SIFTS API returned no {self.endpoint} mapping "
+                        "for this entry (HTTP 404). This usually means the "
+                        "entry exists but has no data of this specific type "
+                        "in SIFTS, not that the request itself is invalid."
+                    ),
+                }
             return {
                 "status": "error",
-                "error": f"PDBe SIFTS API HTTP error: {e.response.status_code}",
+                "error": f"PDBe SIFTS API HTTP error: {status_code}",
             }
         except Exception as e:
             return {

--- a/src/tooluniverse/reactome_content_tool.py
+++ b/src/tooluniverse/reactome_content_tool.py
@@ -161,12 +161,40 @@ class ReactomeContentTool(BaseTool):
         response.raise_for_status()
         events = response.json()
 
-        # Count event types (some elements may be plain integer DB IDs, skip those)
+        # Fix-R18B-1: Reactome's containedEvents endpoint mixes full event
+        # dicts with plain integer DB IDs for some sub-pathways -- confirmed
+        # live for R-HSA-2219528 ("PI3K/AKT Signaling in Cancer"), where 2 of
+        # its 3 real sub-pathways (R-HSA-5674400, R-HSA-2219530) came back as
+        # bare ints. Silently skipping them (as before) both dropped real
+        # sub-pathways from the hierarchy and made total_events disagree with
+        # pathway_count + reaction_count. Batch-resolve any bare IDs via the
+        # /data/query/ids endpoint (confirmed live it accepts a comma-joined
+        # list and returns full records with schemaClass) instead of
+        # discarding them.
+        bare_ids = [e for e in events if not isinstance(e, dict)]
+        resolved_by_id = {}
+        if bare_ids:
+            ids_response = requests.post(
+                f"{REACTOME_CS_BASE_URL}/data/query/ids",
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "text/plain",
+                },
+                data=",".join(str(i) for i in bare_ids),
+                timeout=self.timeout,
+            )
+            if ids_response.ok:
+                for item in ids_response.json():
+                    if isinstance(item, dict) and item.get("dbId") is not None:
+                        resolved_by_id[item["dbId"]] = item
+
         pathways = []
         reactions = []
         for e in events:
             if not isinstance(e, dict):
-                continue
+                e = resolved_by_id.get(e)
+                if e is None:
+                    continue
             schema = e.get("schemaClass", "")
             entry = {
                 "stId": e.get("stId"),

--- a/src/tooluniverse/reactome_interactors_tool.py
+++ b/src/tooluniverse/reactome_interactors_tool.py
@@ -84,7 +84,12 @@ class ReactomeInteractorsTool(BaseTool):
         page_size = arguments.get("page_size") or 20
 
         url = f"{REACTOME_BASE_URL}/interactors/static/molecule/{accession}/details"
-        params = {"page": -1, "pageSize": min(page_size, 100)}
+        # Fix-R18B-2: page=-1 tells Reactome's interactors API to ignore
+        # pagination and return every interactor regardless of pageSize --
+        # confirmed live (page=-1&pageSize=10 returned all 153 interactors
+        # for P31749; page=1&pageSize=10 correctly returned 10), directly
+        # contradicting this tool's own documented page_size contract.
+        params = {"page": 1, "pageSize": min(page_size, 100)}
 
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()

--- a/tests/unit/test_cli_error_rendering_fixes.py
+++ b/tests/unit/test_cli_error_rendering_fixes.py
@@ -1,0 +1,97 @@
+"""Regression guard for Fix-R18A-2/R18C-6 and Fix-R18C-1/R18D-3: `tu run`'s
+human-readable error renderer (`_render_run`) had two related gaps --
+
+1. `is_not_found` matched a plain "not found" substring anywhere in the
+   error message, so a tool's own HTTP-404-shaped error (e.g. PDBe's
+   "404 Client Error: Not Found for url: ...", or CTD's "'cadmium' was not
+   found in the RENCI CTD mirror") triggered misleading "check tool name
+   spelling" / "run tu find" / "run tu grep" tips meant for a genuinely
+   unknown tool NAME, not a bad parameter value. A real unknown-tool-name
+   error is reliably tagged error_details.type == "ToolUnavailableError";
+   that's now the discriminator instead of message-text matching.
+2. Two other actionable fields were silently dropped from the rendered
+   Tips: section: the top-level "suggestion" string some tools use for a
+   single redirect hint (e.g. CTD_get_gene_diseases -> OpenTargets), and
+   the top-level "detail" dict some BaseRESTTool-backed tools use for
+   PostgREST-style upstream error detail (e.g. IEDB's shared query tool).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.cli import _render_run
+
+pytestmark = pytest.mark.unit
+
+
+def test_tool_http_404_does_not_trigger_tool_not_found_tips():
+    result = {
+        "status": "error",
+        "error": "PDBe API error: 404 Client Error: Not Found for url: https://example/zzzz",
+    }
+
+    rendered = _render_run(result)
+
+    assert "Check tool name spelling" not in rendered
+    assert "tu find" not in rendered
+    assert "tu grep" not in rendered
+
+
+def test_genuine_tool_unavailable_error_still_triggers_tool_not_found_tips():
+    result = {
+        "status": "error",
+        "error": "Tool 'NonexistentToolXYZ' not found even after loading tools",
+        "error_details": {"type": "ToolUnavailableError"},
+    }
+
+    rendered = _render_run(result)
+
+    assert "Check tool name spelling" in rendered
+    assert "tu find" in rendered
+    assert "tu grep" in rendered
+
+
+def test_top_level_suggestion_field_is_surfaced():
+    result = {
+        "status": "error",
+        "error": "Gene→disease relationships are not available in the RENCI CTD mirror.",
+        "suggestion": "Use OpenTargets_get_associated_diseases instead.",
+    }
+
+    rendered = _render_run(result)
+
+    assert "Tips:" in rendered
+    assert "Use OpenTargets_get_associated_diseases instead." in rendered
+
+
+def test_top_level_detail_dict_hint_is_surfaced():
+    result = {
+        "status": "error",
+        "error": "HTTP request failed",
+        "detail": {
+            "code": "42883",
+            "hint": "You might need to add explicit type casts.",
+            "message": "operator does not exist: character varying[] ~~* unknown",
+        },
+    }
+
+    rendered = _render_run(result)
+
+    assert "Tips:" in rendered
+    assert "You might need to add explicit type casts." in rendered
+
+
+def test_detail_dict_falls_back_to_message_when_no_hint():
+    result = {
+        "status": "error",
+        "error": "HTTP request failed",
+        "detail": {"message": "some upstream error message", "hint": None},
+    }
+
+    rendered = _render_run(result)
+
+    assert "some upstream error message" in rendered

--- a/tests/unit/test_ctd_id_normalization.py
+++ b/tests/unit/test_ctd_id_normalization.py
@@ -1,0 +1,62 @@
+"""Regression guard for Fix-R18C-2/4: CTD's own tool descriptions promise
+bare CAS RN, bare MeSH ID, and bare NCBI Gene ID as valid input_terms
+formats, but the RENCI Automat mirror's equivalent_identifiers only ever
+store the CURIE-prefixed form -- confirmed live that "D000082" (bare MeSH
+descriptor ID), "C006780" (bare MeSH supplementary-concept ID), "80-05-7"
+(bare CAS RN), and "7157" (bare NCBI Gene ID) all failed to resolve while
+their "MESH:"/"CAS:"/"NCBIGene:"-prefixed forms succeeded.
+_candidate_curies() now tries the correctly-prefixed form first for
+recognizable ID patterns, always falling back to the original string so a
+name or already-prefixed CURIE keeps working unchanged.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.ctd_tool import _candidate_curies
+
+pytestmark = pytest.mark.unit
+
+
+def test_bare_mesh_descriptor_id_gets_prefixed_for_chem():
+    assert _candidate_curies("D000082", "chem") == ["MESH:D000082", "D000082"]
+
+
+def test_bare_mesh_supplementary_concept_id_gets_prefixed_for_chem():
+    assert _candidate_curies("C006780", "chem") == ["MESH:C006780", "C006780"]
+
+
+def test_bare_cas_rn_gets_prefixed_for_chem():
+    assert _candidate_curies("80-05-7", "chem") == ["CAS:80-05-7", "80-05-7"]
+
+
+def test_bare_ncbi_gene_id_gets_prefixed_for_gene():
+    assert _candidate_curies("7157", "gene") == ["NCBIGene:7157", "7157"]
+
+
+def test_bare_mesh_id_gets_prefixed_for_disease():
+    assert _candidate_curies("D001943", "disease") == ["MESH:D001943", "D001943"]
+
+
+def test_already_prefixed_curie_is_passed_through_unchanged():
+    assert _candidate_curies("MESH:D000082", "chem") == ["MESH:D000082"]
+    assert _candidate_curies("CAS:80-05-7", "chem") == ["CAS:80-05-7"]
+
+
+def test_plain_name_has_no_id_candidates_generated():
+    assert _candidate_curies("bisphenol A", "chem") == ["bisphenol A"]
+    assert _candidate_curies("paracetamol", "chem") == ["paracetamol"]
+
+
+def test_gene_symbol_is_not_treated_as_a_gene_id():
+    assert _candidate_curies("TP53", "gene") == ["TP53"]
+
+
+def test_all_digit_string_is_not_treated_as_gene_id_for_chem_type():
+    # A bare numeric string only means "NCBI Gene ID" when input_type is
+    # "gene" -- for chemical tools it's not auto-prefixed as anything.
+    assert _candidate_curies("7157", "chem") == ["7157"]

--- a/tests/unit/test_emdb_query_params.py
+++ b/tests/unit/test_emdb_query_params.py
@@ -1,0 +1,69 @@
+"""Regression guard for Fix-R18A-1: EMDBRESTTool._build_url only substituted
+`{placeholder}` tokens present in the endpoint template, so a declared
+parameter with no matching placeholder (e.g. EMDB_search_structures's
+`rows`, whose template is "https://.../search/{query}" with no `{rows}`
+token) was silently dropped -- confirmed live that rows=2 and rows=10 both
+returned the same 10 results, since the raw EMDB API honors `?rows=N` as a
+query string parameter but the tool never sent one. _build_url now returns
+unmatched args separately so they can be passed through as query params.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.emdb_tool import EMDBRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(endpoint):
+    return EMDBRESTTool(
+        {"name": "EMDB_search_structures", "fields": {"endpoint": endpoint}}
+    )
+
+
+def test_build_url_returns_unmatched_args_as_query_params():
+    tool = _tool("https://www.ebi.ac.uk/emdb/api/search/{query}")
+
+    url, params = tool._build_url({"query": "ribosome", "rows": 2})
+
+    assert url == "https://www.ebi.ac.uk/emdb/api/search/ribosome"
+    assert params == {"rows": 2}
+
+
+def test_build_url_no_leftover_params_when_all_args_match_placeholders():
+    tool = _tool("https://www.ebi.ac.uk/emdb/api/entry/{emdb_id}")
+
+    url, params = tool._build_url({"emdb_id": "EMD-53925"})
+
+    assert url == "https://www.ebi.ac.uk/emdb/api/entry/EMD-53925"
+    assert params == {}
+
+
+def test_run_passes_leftover_args_as_query_params():
+    tool = _tool("https://www.ebi.ac.uk/emdb/api/search/{query}")
+
+    captured = {}
+
+    def fake_request_with_retry(session, method, url, **kwargs):
+        captured["url"] = url
+        captured["params"] = kwargs.get("params")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = [{"id": "EMD-1"}, {"id": "EMD-2"}]
+        return resp
+
+    with patch(
+        "tooluniverse.emdb_tool.request_with_retry",
+        side_effect=fake_request_with_retry,
+    ):
+        result = tool.run({"query": "ribosome", "rows": 2})
+
+    assert result["status"] == "success"
+    assert captured["params"] == {"rows": 2}
+    assert "rows" not in captured["url"]

--- a/tests/unit/test_iedb_mhcii_fixes.py
+++ b/tests/unit/test_iedb_mhcii_fixes.py
@@ -1,0 +1,114 @@
+"""Regression guard for Fix-R18D-1/R18D-2: IEDB's MHC-II prediction endpoint
+had two bugs, both confirmed live --
+
+1. A too-short input sequence gets a plain-text validation error back with
+   HTTP 200 (not real TSV data). csv.DictReader silently misparsed the
+   error's first line as a single-column header, producing a fabricated
+   "successful" result with `percentile_rank: 100.0`. _parse_tsv now
+   detects a non-tabular response (no tab in the first line) and raises,
+   so it surfaces as a real error instead.
+2. Even on a genuine successful response, the real TSV column is named
+   "rank" (unlike the sibling MHC-I endpoint, which really does use
+   "percentile_rank"), so `r.get("percentile_rank", 100)` always hit the
+   default -- every result silently reported rank 100 regardless of the
+   real value.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.iedb_prediction_tool import IEDBPredictionTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(endpoint_type):
+    return IEDBPredictionTool(
+        {"name": "IEDB_predict", "fields": {"endpoint_type": endpoint_type}}
+    )
+
+
+def _resp(text):
+    r = MagicMock()
+    r.text = text
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def test_short_sequence_error_text_is_reported_as_error_not_success():
+    tool = _tool("predict_mhcii")
+    error_text = (
+        "The length of input sequence is less than the input/default length 15.\n"
+        "* Please go to the link below for usage info:\n"
+        "http://tools.iedb.org/main/html/tools_api.html"
+    )
+
+    with patch(
+        "tooluniverse.iedb_prediction_tool.requests.post",
+        return_value=_resp(error_text),
+    ):
+        result = tool.run({"sequence": "PKYVKQNTLKLAT", "allele": "HLA-DRB1*01:01"})
+
+    assert result["status"] == "error"
+    assert "non-tabular" in result["error"]
+
+
+def test_percentile_rank_reads_from_real_rank_column():
+    tool = _tool("predict_mhcii")
+    tsv = (
+        "allele\tseq_num\tstart\tend\tlength\tcore_peptide\tpeptide\tscore\trank\n"
+        "HLA-DRB1*01:01\t1\t15\t29\t15\tYAGSYPYDV\tVPDYAGSYPYDVPDY\t0.2922\t6.4\n"
+        "HLA-DRB1*01:01\t1\t14\t28\t15\tYAGSYPYDV\tDVPDYAGSYPYDVPD\t0.2454\t7.4\n"
+    )
+
+    with patch(
+        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp(tsv)
+    ):
+        result = tool.run(
+            {
+                "sequence": "YPYDVPDYAGYPYDVPDYAGSYPYDVPDYA",
+                "allele": "HLA-DRB1*01:01",
+            }
+        )
+
+    assert result["status"] == "success"
+    ranks = [r["percentile_rank"] for r in result["data"]]
+    assert ranks == [6.4, 7.4]
+
+
+def test_mhci_percentile_rank_column_unaffected():
+    tool = _tool("predict_mhci")
+    tsv = (
+        "allele\tseq_num\tstart\tend\tlength\tpeptide\tcore\ticore\tscore\tpercentile_rank\n"
+        "HLA-A*02:01\t1\t18\t26\t9\tYAGSYPYDV\tYAGSYPYDV\tYAGSYPYDV\t0.0512\t2.1\n"
+    )
+
+    with patch(
+        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp(tsv)
+    ):
+        result = tool.run(
+            {
+                "sequence": "YPYDVPDYAGYPYDVPDYAGSYPYDVPDYA",
+                "allele": "HLA-A*02:01",
+                "length": 9,
+            }
+        )
+
+    assert result["status"] == "success"
+    assert result["data"][0]["percentile_rank"] == 2.1
+
+
+def test_empty_response_is_reported_as_error():
+    tool = _tool("predict_mhcii")
+
+    with patch(
+        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp("")
+    ):
+        result = tool.run({"sequence": "A" * 20, "allele": "HLA-DRB1*01:01"})
+
+    assert result["status"] == "error"

--- a/tests/unit/test_kegg_ext_tool_fixes.py
+++ b/tests/unit/test_kegg_ext_tool_fixes.py
@@ -1,0 +1,219 @@
+"""Regression guard for round-18 KEGG fixes (Fix-R18E-1 through R18E-7), all
+confirmed live via raw curl against rest.kegg.jp:
+
+- R18E-1: KEGG_get_drug's PATHWAY/DISEASE fields are nested 2 spaces under
+  TARGET/EFFICACY (not top-level, 0-indent fields like every other field
+  this parser recognized), so they -- and their continuation lines -- were
+  silently dropped entirely (confirmed for D01441/imatinib: 3 real
+  pathways, 7 real diseases, all lost).
+- R18E-2: KEGG_get_disease uses the field name DIS_PATHWAY (not PATHWAY)
+  for its pathway associations (confirmed for H00004/CML).
+- R18E-4: KEGG_get_brite_hierarchy 404s uninformatively for "(table)"-type
+  BRITE files that have no JSON representation upstream (confirmed for
+  br08341, Pharmacogenomic biomarkers).
+- R18E-5: KEGG_get_variant drops COSF (COSMIC Fusion) and OmimVar
+  cross-refs -- the parser only recognized ClinVar/dbSNP/COSM keys
+  (confirmed for hsa_var:25v1, BCR-ABL).
+- R18E-6/7: KEGG_get_network 404s on a bare "nt######"-style network ID
+  unless "network:" is prepended (confirmed for nt06276), and its child
+  elements are listed under MEMBER (not ELEMENT) for that ID family
+  (confirmed 9 real entries silently dropped).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.kegg_ext_tool import KEGGExtTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(endpoint):
+    return KEGGExtTool({"name": "kegg_test", "fields": {"endpoint": endpoint}})
+
+
+def _resp(text):
+    r = MagicMock()
+    r.text = text
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def _http_error(status_code):
+    resp = MagicMock()
+    resp.status_code = status_code
+    return requests.exceptions.HTTPError(response=resp)
+
+
+DRUG_FLAT_FILE = """ENTRY       D01441                      Drug
+NAME        Imatinib mesylate (USAN)
+FORMULA     C29H31N7O. CH4SO3
+TARGET      BCR-ABL [HSA_VAR:25v1] [HSA:25] [KO:K06619]
+            FIP1L1-PDGFRA [HSA:5156] [KO:K04363]
+  PATHWAY   hsa04010(3815+5156)  MAPK signaling pathway
+            hsa05200(25+3815+5156)  Pathways in cancer
+            hsa05220(25)  Chronic myeloid leukemia
+  NETWORK   nt06276  Chronic myeloid leukemia
+EFFICACY    Antineoplastic, Tyrosine kinase inhibitor
+  DISEASE   Chronic myeloid leukemia (Philadelphia chromosome positive) [DS:H00004]
+            Acute lymphoblastic leukemia (Philadelphia chromosome positive) [DS:H00001]
+///
+"""
+
+DISEASE_FLAT_FILE = """ENTRY       H00004                      Disease
+NAME        Chronic myeloid leukemia
+CATEGORY    Cancer
+DIS_PATHWAY hsa05220  Chronic myeloid leukemia
+NETWORK     nt06276 Chronic myeloid leukemia
+///
+"""
+
+VARIANT_FLAT_FILE = """ENTRY       hsa_var:25v1
+NAME        BCR-ABL
+VARIATION   translocation t(9;22)(q34;q11)
+            COSF: 1756 1758 1783
+            mutation T315I
+            OmimVar: 189980
+///
+"""
+
+NETWORK_FLAT_FILE = """ENTRY       nt06276           Map       Network
+NAME        Chronic myeloid leukemia
+MEMBER      N00001  EGF-EGFR-RAS-ERK signaling pathway
+            N00002  BCR-ABL fusion kinase to RAS-ERK signaling pathway
+///
+"""
+
+
+def test_get_drug_captures_nested_pathway_and_disease():
+    tool = _tool("get_drug")
+
+    with patch(
+        "tooluniverse.kegg_ext_tool.requests.get",
+        return_value=_resp(DRUG_FLAT_FILE),
+    ):
+        result = tool._get_drug({"drug_id": "D01441"})
+
+    data = result["data"]
+    assert data["pathways"] == {
+        "hsa04010(3815+5156)": "MAPK signaling pathway",
+        "hsa05200(25+3815+5156)": "Pathways in cancer",
+        "hsa05220(25)": "Chronic myeloid leukemia",
+    }
+    assert data["diseases"] == [
+        "Chronic myeloid leukemia (Philadelphia chromosome positive) [DS:H00004]",
+        "Acute lymphoblastic leukemia (Philadelphia chromosome positive) [DS:H00001]",
+    ]
+    # TARGET (top-level, 0-indent) still parses correctly alongside the
+    # newly-recognized nested fields.
+    assert len(data["targets"]) == 2
+
+
+def test_get_disease_captures_dis_pathway_field():
+    tool = _tool("get_disease")
+
+    with patch(
+        "tooluniverse.kegg_ext_tool.requests.get",
+        return_value=_resp(DISEASE_FLAT_FILE),
+    ):
+        result = tool._get_disease({"disease_id": "H00004"})
+
+    assert result["data"]["pathways"] == {"hsa05220": "Chronic myeloid leukemia"}
+
+
+def test_get_variant_captures_cosf_and_omimvar():
+    tool = _tool("get_variant")
+
+    with patch(
+        "tooluniverse.kegg_ext_tool.requests.get",
+        return_value=_resp(VARIANT_FLAT_FILE),
+    ):
+        result = tool._get_variant({"variant_id": "hsa_var:25v1"})
+
+    variations = result["data"]["variations"]
+    assert variations[0]["mutation"] == "translocation t(9;22)(q34;q11)"
+    assert variations[0]["cosmic_fusion"] == ["1756", "1758", "1783"]
+    assert variations[1]["mutation"] == "T315I"
+    assert variations[1]["omim_variant"] == ["189980"]
+
+
+def test_get_network_prepends_network_prefix_for_nt_ids():
+    tool = _tool("get_network")
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        return _resp(NETWORK_FLAT_FILE)
+
+    with patch("tooluniverse.kegg_ext_tool.requests.get", side_effect=fake_get):
+        result = tool._get_network({"network_id": "nt06276"})
+
+    assert captured["url"].endswith("/get/network:nt06276")
+    assert result["data"]["elements"] == [
+        "N00001  EGF-EGFR-RAS-ERK signaling pathway",
+        "N00002  BCR-ABL fusion kinase to RAS-ERK signaling pathway",
+    ]
+    # The output still reports the caller's original (unprefixed) ID.
+    assert result["data"]["network_id"] == "nt06276"
+
+
+def test_get_network_does_not_prefix_n_style_ids():
+    tool = _tool("get_network")
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        return _resp("ENTRY       N00001\nNAME        Test\n///\n")
+
+    with patch("tooluniverse.kegg_ext_tool.requests.get", side_effect=fake_get):
+        tool._get_network({"network_id": "N00001"})
+
+    assert captured["url"].endswith("/get/N00001")
+
+
+def test_get_network_does_not_double_prefix_already_prefixed_id():
+    tool = _tool("get_network")
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        return _resp(NETWORK_FLAT_FILE)
+
+    with patch("tooluniverse.kegg_ext_tool.requests.get", side_effect=fake_get):
+        tool._get_network({"network_id": "network:nt06276"})
+
+    assert captured["url"].endswith("/get/network:nt06276")
+    assert "network:network:" not in captured["url"]
+
+
+def test_brite_hierarchy_404_gives_table_type_hint():
+    tool = _tool("get_brite_hierarchy")
+
+    def fake_get(*a, **k):
+        raise _http_error(404)
+
+    with patch("tooluniverse.kegg_ext_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"hierarchy_id": "br08341"})
+
+    assert result["status"] == "error"
+    assert "br08341" in result["error"]
+    assert "table-type" in result["error"]
+
+
+def test_other_endpoint_404_keeps_generic_message():
+    tool = _tool("get_drug")
+
+    def fake_get(*a, **k):
+        raise _http_error(404)
+
+    with patch("tooluniverse.kegg_ext_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"drug_id": "D99999"})
+
+    assert result["status"] == "error"
+    assert result["error"] == "KEGG entry not found"

--- a/tests/unit/test_pdbe_sifts_404_message.py
+++ b/tests/unit/test_pdbe_sifts_404_message.py
@@ -1,0 +1,64 @@
+"""Regression guard for Fix-R18A-3: PDBeSIFTSTool's shared HTTPError handler
+gave a bare "PDBe SIFTS API HTTP error: 404" for every 404, regardless of
+cause -- confirmed live for PDBeSIFTS_get_scop_mapping on PDB 3k34 (a real,
+valid entry that simply has no SCOP classification), which gave no way to
+tell "no mapping data for this entry" apart from "the request itself is
+broken." 404s now get an endpoint-aware message clarifying this; other
+status codes and successful responses are unaffected.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.pdbe_sifts_tool import PDBeSIFTSTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(endpoint):
+    return PDBeSIFTSTool(
+        {"name": "PDBeSIFTS_get_scop_mapping", "fields": {"endpoint": endpoint}}
+    )
+
+
+def _http_error(status_code):
+    resp = MagicMock()
+    resp.status_code = status_code
+    err = requests.exceptions.HTTPError(response=resp)
+    return err
+
+
+def test_404_gives_data_gap_message_not_bare_status_code(monkeypatch):
+    tool = _tool("scop")
+
+    def fake_get(*a, **k):
+        raise _http_error(404)
+
+    monkeypatch.setattr("tooluniverse.pdbe_sifts_tool.requests.get", fake_get)
+
+    result = tool.run({"pdb_id": "3k34"})
+
+    assert result["status"] == "error"
+    assert "404" in result["error"]
+    assert "scop" in result["error"]
+    assert "no data of this specific type" in result["error"]
+
+
+def test_non_404_http_error_keeps_bare_status_code(monkeypatch):
+    tool = _tool("scop")
+
+    def fake_get(*a, **k):
+        raise _http_error(500)
+
+    monkeypatch.setattr("tooluniverse.pdbe_sifts_tool.requests.get", fake_get)
+
+    result = tool.run({"pdb_id": "3k34"})
+
+    assert result["status"] == "error"
+    assert result["error"] == "PDBe SIFTS API HTTP error: 500"

--- a/tests/unit/test_reactome_content_bare_ids.py
+++ b/tests/unit/test_reactome_content_bare_ids.py
@@ -1,0 +1,133 @@
+"""Regression guard for Fix-R18B-1: Reactome's containedEvents endpoint mixes
+full event dicts with plain integer DB IDs for some sub-pathways -- confirmed
+live for R-HSA-2219528 ("PI3K/AKT Signaling in Cancer"), where 2 of its 3
+real sub-pathways came back as bare ints and were silently skipped, both
+dropping them from the hierarchy and making total_events disagree with
+pathway_count + reaction_count. Bare IDs are now batch-resolved via
+Reactome's /data/query/ids endpoint instead of discarded.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.reactome_content_tool import ReactomeContentTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ReactomeContentTool(
+        {"name": "ReactomeContent_get_contained_events", "fields": {}}
+    )
+
+
+def _resp(json_body, ok=True):
+    r = MagicMock()
+    r.ok = ok
+    r.json.return_value = json_body
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def test_bare_int_ids_are_resolved_not_dropped():
+    tool = _tool()
+    contained_events = [
+        {
+            "stId": "R-HSA-5674404",
+            "displayName": "PTEN Loss of Function in Cancer",
+            "schemaClass": "Pathway",
+            "isInDisease": True,
+        },
+        5674400,
+        2219530,
+    ] + [
+        {
+            "stId": f"R-HSA-{i}",
+            "displayName": f"Reaction {i}",
+            "schemaClass": "Reaction",
+            "isInDisease": False,
+        }
+        for i in range(21)
+    ]
+    ids_response = [
+        {
+            "dbId": 5674400,
+            "stId": "R-HSA-5674400",
+            "displayName": "Constitutive Signaling by AKT1 E17K in Cancer",
+            "schemaClass": "Pathway",
+            "isInDisease": True,
+        },
+        {
+            "dbId": 2219530,
+            "stId": "R-HSA-2219530",
+            "displayName": "Constitutive Signaling by Aberrant PI3K in Cancer",
+            "schemaClass": "Pathway",
+            "isInDisease": True,
+        },
+    ]
+
+    def fake_get(url, **kwargs):
+        return _resp(contained_events)
+
+    def fake_post(url, **kwargs):
+        return _resp(ids_response)
+
+    with patch("tooluniverse.reactome_content_tool.requests.get", side_effect=fake_get), \
+         patch("tooluniverse.reactome_content_tool.requests.post", side_effect=fake_post):
+        result = tool._get_contained_events({"identifier": "R-HSA-2219528"})
+
+    data = result["data"]
+    assert data["total_events"] == 24
+    assert data["pathway_count"] == 3
+    assert data["reaction_count"] == 21
+    assert data["pathway_count"] + data["reaction_count"] == data["total_events"]
+    stids = {p["stId"] for p in data["pathways"]}
+    assert stids == {"R-HSA-5674404", "R-HSA-5674400", "R-HSA-2219530"}
+
+
+def test_no_extra_request_when_all_events_are_dicts():
+    tool = _tool()
+    contained_events = [
+        {
+            "stId": "R-HSA-1",
+            "displayName": "Reaction 1",
+            "schemaClass": "Reaction",
+            "isInDisease": False,
+        }
+    ]
+
+    def fake_get(url, **kwargs):
+        return _resp(contained_events)
+
+    with patch("tooluniverse.reactome_content_tool.requests.get", side_effect=fake_get), \
+         patch("tooluniverse.reactome_content_tool.requests.post") as mock_post:
+        result = tool._get_contained_events({"identifier": "R-HSA-1"})
+
+    mock_post.assert_not_called()
+    assert result["data"]["total_events"] == 1
+    assert result["data"]["reaction_count"] == 1
+
+
+def test_unresolvable_bare_id_is_dropped_gracefully():
+    tool = _tool()
+    contained_events = [999999999]
+
+    def fake_get(url, **kwargs):
+        return _resp(contained_events)
+
+    def fake_post(url, **kwargs):
+        return _resp([])
+
+    with patch("tooluniverse.reactome_content_tool.requests.get", side_effect=fake_get), \
+         patch("tooluniverse.reactome_content_tool.requests.post", side_effect=fake_post):
+        result = tool._get_contained_events({"identifier": "R-HSA-X"})
+
+    data = result["data"]
+    assert data["total_events"] == 1
+    assert data["pathway_count"] == 0
+    assert data["reaction_count"] == 0

--- a/tests/unit/test_reactome_interactors_pagination.py
+++ b/tests/unit/test_reactome_interactors_pagination.py
@@ -1,0 +1,57 @@
+"""Regression guard for Fix-R18B-2: ReactomeInteractorsTool sent
+page=-1 (a Reactome-specific "ignore pagination, return everything"
+signal), so the tool's own documented page_size parameter had zero effect
+-- confirmed live that page=-1&pageSize=10 returned all 153 interactors for
+P31749, while page=1&pageSize=10 correctly returned 10.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.reactome_interactors_tool import ReactomeInteractorsTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ReactomeInteractorsTool(
+        {"name": "ReactomeInteractors_get_protein_interactors", "fields": {}}
+    )
+
+
+def test_page_size_is_honored_via_correct_page_param():
+    tool = _tool()
+    captured = {}
+
+    def fake_get(url, params=None, **kwargs):
+        captured["params"] = params
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "resource": "IntAct",
+            "entities": [
+                {
+                    "acc": "P31749",
+                    "count": 10,
+                    "interactors": [
+                        {"acc": f"P{i}", "alias": None, "score": 0.5, "evidences": []}
+                        for i in range(10)
+                    ],
+                }
+            ],
+        }
+        return resp
+
+    with patch(
+        "tooluniverse.reactome_interactors_tool.requests.get", side_effect=fake_get
+    ):
+        result = tool._get_interactors({"accession": "P31749", "page_size": 10})
+
+    assert captured["params"]["page"] == 1
+    assert captured["params"]["pageSize"] == 10
+    assert len(result["data"]["interactors"]) == 10


### PR DESCRIPTION
## Summary

Round 18 of the ongoing test-harness sweep: 5 role-play researcher personas exercised structural biology (PDBe/EMDB), pathway/network biology (Reactome), toxicology (CTD), immunology (IEDB), and pharmacogenomics (KEGG) — domains not previously covered. 27 findings were CLI-verified against live upstream APIs; 12 confirmed root-caused and fixed here (the rest were deliberately deferred: genuine coverage gaps, upstream data-model nuances, or STRING/IEDB behavior inherited from those APIs — not ToolUniverse bugs).

## Fixed

- **Fix-R18A-1** — `EMDB_search_structures`'s `rows` parameter had no matching `{placeholder}` in its endpoint template and was silently dropped (confirmed live: `rows=2` and `rows=10` both returned the same 10 results). Unmatched args are now passed through as query params.
- **Fix-R18A-2 / Fix-R18C-6** — `tu run`'s human-readable error renderer matched a bare `"not found"` substring to decide whether to show "check tool name spelling" tips, so a tool's own HTTP-404-shaped error (e.g. a bad PDB ID, or CTD's `"'cadmium' was not found in the RENCI CTD mirror"`) produced misleading tool-discovery guidance for what was actually a bad parameter *value*. Switched to the structured `error_details.type == "ToolUnavailableError"` signal, which reliably discriminates a genuine unknown tool name.
- **Fix-R18A-3** — PDBe SIFTS 404s (e.g. `PDBeSIFTS_get_scop_mapping`) now clarify that the entry likely just lacks data of that specific mapping type, instead of a bare, ambiguous status code.
- **Fix-R18B-1** — Reactome's `containedEvents` endpoint mixes full event dicts with bare integer DB IDs for some sub-pathways (confirmed live for R-HSA-2219528: 2 of 3 real sub-pathways came back as bare ints). These were silently dropped instead of resolved, both losing real hierarchy data and making `total_events` disagree with `pathway_count + reaction_count`. Bare IDs are now batch-resolved via one extra call to Reactome's `/data/query/ids`.
- **Fix-R18B-2** — `ReactomeInteractors_get_protein_interactors` sent `page=-1` (a Reactome-specific "ignore pagination, return everything" signal), making its own documented `page_size` parameter have zero effect (confirmed live: returned all 153 interactors regardless of `page_size=10`).
- **Fix-R18C-1 / Fix-R18D-3** — two more actionable fields silently dropped by the CLI's error renderer: a top-level `"suggestion"` string some tools use for a single redirect hint (e.g. `CTD_get_gene_diseases` → OpenTargets), and a top-level `"detail"` dict some `BaseRESTTool`-backed tools use for PostgREST-style upstream error detail (e.g. IEDB's shared query tool).
- **Fix-R18C-2/4** — CTD's RENCI backend only indexes CURIE-prefixed IDs (`MESH:`, `CAS:`, `NCBIGene:`) in `equivalent_identifiers`, but the tool's own parameter docs promise bare CAS RN / MeSH ID / NCBI Gene ID work (confirmed live: `"D000082"`, `"80-05-7"`, `"7157"` all failed bare, succeeded prefixed). Recognizable bare ID formats now try the correctly-prefixed CURIE first, falling back to the original string so name-based and already-prefixed lookups are unaffected.
- **Fix-R18D-1/2** — IEDB's MHC-II prediction endpoint returns a plain-text validation error (not TSV) with HTTP 200 for invalid input (e.g. a too-short sequence), which was silently misparsed by `csv.DictReader` as a fake successful prediction with a fabricated rank. Separately, even genuine successful responses were affected: the real TSV column is named `"rank"`, not `"percentile_rank"` (unlike the sibling MHC-I endpoint, which really does use that name), so every real MHC-II result silently reported a hardcoded rank of 100 regardless of the true binding rank.
- **Fix-R18E-1/2** — `KEGG_get_drug`'s `PATHWAY`/`DISEASE` fields are nested 2 spaces under `TARGET`/`EFFICACY` in KEGG's flat-file format (not top-level like every other field this parser recognized), and `KEGG_get_disease` uses the field name `DIS_PATHWAY` (not `PATHWAY`) — both silently unrecognized, dropping all pathway/disease associations (confirmed live: 3 real pathways and 7 real diseases lost for imatinib/D01441; 1 real pathway lost for CML/H00004).
- **Fix-R18E-4** — `KEGG_get_brite_hierarchy` 404s uninformatively for KEGG's "table-type" BRITE files, which have no JSON tree representation upstream even though they're real, listed hierarchies (confirmed live for `br08341`, Pharmacogenomic biomarkers).
- **Fix-R18E-5** — `KEGG_get_variant` silently dropped `COSF` (COSMIC Fusion) and `OmimVar` cross-reference lines — the parser only recognized `ClinVar`/`dbSNP`/`COSM` keys.
- **Fix-R18E-6/7** — `KEGG_get_network` 404s on a bare `"nt######"`-style network ID unless a `"network:"` prefix is prepended (confirmed live), and its child elements are listed under `MEMBER` (not `ELEMENT`) for that same ID family — both silently broke the natural chaining path from sibling tools that surface `nt######` IDs.

## Deferred (documented, not fixed)

Genuine coverage gaps or upstream-API-inherited behavior, not ToolUniverse code bugs: Reactome's enrichment-vs-found-entities count mismatch (AKT1's dual UniProt mapping, a real upstream data-model nuance) and STRING's silent resolution of an ambiguous gene symbol like "AKT"; CTD's lack of a chemical-pathway tool and one disease query returning genuinely sparse results in the June-2024 snapshot; IEDB's organism-name search not matching common pathogen abbreviations (correct `ilike` behavior, just a documentation gap).

## Test plan

- [x] 35 new mocked unit tests across 8 files covering the fixed behavior plus adjacent non-regression cases (e.g. name-based CTD lookups still work, MHC-I prediction unaffected by the shared TSV-parsing change, `N#####`-style KEGG network IDs aren't double-prefixed).
- [x] Pre-existing `test_ctd_tool.py` and `test_iedb_bcell_prediction.py` pass unchanged.
- [x] Full `tests/unit` suite (the standard CI scope) run clean — 0 failures.
- [x] `code-simplifier` pass applied (deduped KEGG variant-record construction into a shared helper, collapsed a 5-branch cross-ref elif-chain into a table-driven loop, and refactored CTD's CURIE-candidate generation into a small rules table).
- [x] All 12 fixes independently verified live against the real upstream APIs before and after the change.
