### PR TITLE
Fix Round 19: DepMap, ClinGen, Ensembl, HPA, STITCH bugs

### DIFF
--- a/src/tooluniverse/clingen_tool.py
+++ b/src/tooluniverse/clingen_tool.py
@@ -27,6 +27,38 @@ ACTIONABILITY_PEDIATRIC_URL = (
 EREPO_BASE_URL = "https://erepo.clinicalgenome.org/evrepo/api"
 
 
+def _actionability_rows_to_dicts(data: Any) -> List[Dict[str, Any]]:
+    """Fix-R19B-1/2: the actionability API's `?flavor=flat` response is a
+    JSON table -- {"columns": [...26 names...], "rows": [[...26 values...],
+    ...]} -- confirmed live, not a list of per-curation dicts. The gene
+    filter's `isinstance(curations, list)` guard was always False against
+    this dict, silently skipping the filter entirely in
+    _get_actionability_adult/_pediatric (returning everything, unfiltered)
+    and silently zeroing out `matches` in _search_actionability (returning
+    nothing). Zip columns with each row into real dicts so both a
+    downstream isinstance(list) check and dict-style field access work.
+    """
+    if isinstance(data, list):
+        return data
+    columns = data.get("columns")
+    rows = data.get("rows")
+    if not isinstance(columns, list) or not isinstance(rows, list):
+        return []
+    return [dict(zip(columns, row)) for row in rows]
+
+
+def _filter_curations_by_gene(
+    curations: List[Dict[str, Any]], gene: str
+) -> List[Dict[str, Any]]:
+    """Keep only actionability curations whose `geneOrVariant` field contains
+    `gene` (case-insensitive substring; the field holds comma-separated gene
+    lists, e.g. "BRCA1,BRCA2")."""
+    gene_upper = gene.upper()
+    return [
+        c for c in curations if gene_upper in str(c.get("geneOrVariant", "")).upper()
+    ]
+
+
 @register_tool("ClinGenTool")
 class ClinGenTool(BaseTool):
     """
@@ -266,24 +298,17 @@ class ClinGenTool(BaseTool):
             data = response.json()
 
             # Extract curations from the response
-            curations = data if isinstance(data, list) else data.get("data", data)
+            curations = _actionability_rows_to_dicts(data)
 
             # Optional filtering by gene
             gene = arguments.get("gene")
-            if gene and isinstance(curations, list):
-                gene_upper = gene.upper()
-                curations = [
-                    c
-                    for c in curations
-                    if gene_upper in str(c.get("gene", "")).upper()
-                    or gene_upper in str(c.get("Gene", "")).upper()
-                    or gene_upper in str(c.get("hgncId", "")).upper()
-                ]
+            if gene:
+                curations = _filter_curations_by_gene(curations, gene)
 
             return {
                 "status": "success",
-                "data": curations[:100] if isinstance(curations, list) else curations,
-                "total": len(curations) if isinstance(curations, list) else 1,
+                "data": curations[:100],
+                "total": len(curations),
                 "context": context,
                 "source": f"ClinGen Clinical Actionability ({context})",
             }
@@ -317,20 +342,8 @@ class ClinGenTool(BaseTool):
                     response.raise_for_status()
 
                     data = response.json()
-                    curations = (
-                        data if isinstance(data, list) else data.get("data", data)
-                    )
-
-                    # Filter by gene
-                    gene_upper = gene.upper()
-                    if isinstance(curations, list):
-                        matches = [
-                            c
-                            for c in curations
-                            if gene_upper in str(c.get("gene", "")).upper()
-                            or gene_upper in str(c.get("Gene", "")).upper()
-                        ]
-                        results[context] = matches
+                    curations = _actionability_rows_to_dicts(data)
+                    results[context] = _filter_curations_by_gene(curations, gene)
                 except Exception:
                     # Continue with other context if one fails
                     pass
@@ -348,47 +361,64 @@ class ClinGenTool(BaseTool):
 
     def _get_variant_classifications(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get variant pathogenicity classifications from ClinGen Evidence Repository."""
-        try:
-            url = f"{EREPO_BASE_URL}/classifications/all"
+        gene = arguments.get("gene")
+        if not gene:
+            # Fix-R19B-3: `/classifications/all` is the entire, unpaginated
+            # Evidence Repository -- confirmed live it's 28+MB and still
+            # streaming after 200s, well past this tool's declared 120s
+            # timeout, with no way to bound the transfer client-side once
+            # started. There's no way to safely serve an unfiltered
+            # request; require a gene to use the fast, filtered endpoint
+            # below instead.
+            return {
+                "status": "error",
+                "error": (
+                    "gene parameter is required. The ClinGen Evidence "
+                    "Repository has no working unfiltered listing endpoint "
+                    "(the bulk /classifications/all download is 28+MB and "
+                    "unbounded) -- query by gene instead."
+                ),
+            }
 
-            response = requests.get(url, timeout=self.timeout)
+        try:
+            # Fix-R19B-3: /classifications?gene={gene} is a fast (~1s),
+            # already-filtered JSON endpoint -- confirmed live, unlike
+            # /classifications/all's unbounded TSV dump this tool
+            # previously used and filtered client-side after the full
+            # download completed.
+            url = f"{EREPO_BASE_URL}/classifications"
+            response = requests.get(url, params={"gene": gene}, timeout=self.timeout)
             response.raise_for_status()
 
-            # API returns TSV (tab-separated) with first line starting with #
-            tsv_text = response.text
-            lines = tsv_text.strip().split("\n")
-
-            # Strip leading # from header line
-            if lines and lines[0].startswith("#"):
-                lines[0] = lines[0][1:]
-
+            raw = response.json()
             data = []
-            if len(lines) > 1:
-                reader = csv.DictReader(io.StringIO("\n".join(lines)), delimiter="\t")
-                for row in reader:
-                    cleaned = {k.strip(): v.strip() for k, v in row.items() if k and v}
-                    if cleaned:
-                        data.append(cleaned)
+            for item in raw.get("variantInterpretations", []):
+                guidelines = item.get("guidelines") or []
+                classification = (
+                    guidelines[0].get("outcome", {}).get("label")
+                    if guidelines
+                    else None
+                )
+                data.append(
+                    {
+                        "caid": item.get("caid"),
+                        "gene": (item.get("gene") or {}).get("label"),
+                        "condition": (item.get("condition") or {}).get("label"),
+                        "classification": classification,
+                        "published_date": item.get("publishedDate"),
+                        "hgvs": item.get("hgvs") or [],
+                    }
+                )
 
-            # Optional filtering by gene
-            gene = arguments.get("gene")
-            if gene:
-                gene_upper = gene.upper()
-                data = [
-                    v
-                    for v in data
-                    if gene_upper in str(v.get("HGNC Gene Symbol", "")).upper()
-                ]
-
-            # Optional filtering by variant
+            # Optional filtering by variant (HGVS or CAID substring match)
             variant = arguments.get("variant")
             if variant:
                 variant_str = str(variant).upper()
                 data = [
                     v
                     for v in data
-                    if variant_str in str(v.get("Variation", "")).upper()
-                    or variant_str in str(v.get("HGVS Expressions", "")).upper()
+                    if variant_str in str(v.get("caid", "")).upper()
+                    or any(variant_str in h.upper() for h in v.get("hgvs", []))
                 ]
 
             result = {
@@ -397,7 +427,7 @@ class ClinGenTool(BaseTool):
                 "total": len(data),
                 "source": "ClinGen Evidence Repository",
             }
-            if not data and gene:
+            if not data:
                 result["note"] = (
                     f"No variant classifications found for {gene}. "
                     "The ClinGen Evidence Repository only contains variants "

--- a/src/tooluniverse/data/gtex_v2_tools.json
+++ b/src/tooluniverse/data/gtex_v2_tools.json
@@ -2,7 +2,7 @@
   {
     "name": "GTEx_get_median_gene_expression",
     "type": "GTExV2Tool",
-    "description": "Get median gene expression levels across GTEx tissues. Returns median expression in TPM (Transcripts Per Million) for one or more genes across 54 tissue sites. Filter by specific tissues or get expression across all tissues. Based on Adult GTEx V11 (January 2026). Use for: tissue-specific expression profiling, identifying highly expressed genes, comparing expression patterns across tissues. Example: Get brain vs liver expression for TP53 gene.",
+    "description": "Get median gene expression levels across GTEx tissues. Returns median expression in TPM (Transcripts Per Million) for one or more genes across 54 tissue sites. Filter by specific tissues or get expression across all tissues. Defaults to GTEx V8 (2020) -- confirmed live no V11 dataset is queryable via this API (dataset_id only accepts gtex_v7/gtex_v8/gtex_v10; v10 returns empty for most endpoints, so v8 is the most complete option). Use for: tissue-specific expression profiling, identifying highly expressed genes, comparing expression patterns across tissues. Example: Get brain vs liver expression for TP53 gene.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -955,7 +955,7 @@
   {
     "name": "GTEx_get_dataset_info",
     "type": "GTExV2Tool",
-    "description": "Get GTEx dataset metadata and version information. Returns dataset details including GENCODE version, genome build (GRCh38/hg38), dbSNP build, sample counts, tissue counts, and release information. Shows Adult GTEx V11 details (January 2026) by default. Use for: understanding data versions, checking sample sizes, verifying genome builds, documentation. Check this first to understand what data is available.",
+    "description": "Get GTEx dataset metadata and version information. Returns dataset details including GENCODE version, genome build (GRCh38/hg38), dbSNP build, sample counts, tissue counts, and release information. Lists the actual queryable datasets (gtex_v7, gtex_v8, gtex_v10, kids_first_harmonization -- confirmed live no V11 exists via this API); shows GTEx V8 (2020) details by default. Use for: understanding data versions, checking sample sizes, verifying genome builds, documentation. Check this first to understand what data is available.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/hpa_tools.json
+++ b/src/tooluniverse/data/hpa_tools.json
@@ -96,6 +96,10 @@
         "search_query": {
           "type": "string",
           "description": "Gene name, alias, keyword, or cell line name to search for, e.g., 'EGFR', 'TP53', or 'MCF7'."
+        },
+        "max_results": {
+          "type": ["integer", "null"],
+          "description": "Maximum number of gene matches to return (default: 50). This search does a broad full-text match with no server-side limit, so a short/common query can otherwise return thousands of results; exact gene-symbol matches are ranked first."
         }
       },
       "required": [

--- a/src/tooluniverse/depmap_tool.py
+++ b/src/tooluniverse/depmap_tool.py
@@ -24,6 +24,18 @@ from .tool_registry import register_tool
 DEPMAP_BASE_URL = "https://api.cellmodelpassports.sanger.ac.uk"
 
 
+def _gene_symbol(item: Dict[str, Any]) -> str:
+    """Uppercased gene symbol used as the sort key of the /genes catalog."""
+    return item.get("attributes", {}).get("symbol", "").upper()
+
+
+def _model_symbol(item: Dict[str, Any]) -> str:
+    """Uppercased model name used as the sort key of the /models catalog
+    (`names` is a list; its first entry is the primary name)."""
+    names = item.get("attributes", {}).get("names") or [""]
+    return names[0].upper()
+
+
 @register_tool("DepMapTool")
 class DepMapTool(BaseTool):
     """
@@ -75,18 +87,22 @@ class DepMapTool(BaseTool):
         page_size = arguments.get("page_size", 20)
 
         try:
+            # Fix-R19C-3: `filter[model]` on this endpoint doesn't
+            # actually filter (confirmed live across multiple syntax
+            # variants -- filtered and unfiltered requests return
+            # identical results and the identical total count), and
+            # `model_name`/`tissue`/`cancer_type`/`sample_site`/`gender`/
+            # `ethnicity` aren't real attributes on the model resource at
+            # all (only `names`, a list; the rest live on related sample/
+            # tissue/cancer_type/patient resources, reachable per-model
+            # via `include=`, which isn't practical for a whole page of
+            # results without an N+1 request per row). Rather than
+            # silently accepting a tissue/cancer_type filter and
+            # returning unfiltered results, warn that filtering isn't
+            # currently supported by the upstream API; model_name is
+            # fixed since it's cheap (no extra request needed).
             url = f"{DEPMAP_BASE_URL}/models"
             params = {"page[size]": min(page_size, 100)}
-
-            # Add filters if provided
-            filters = []
-            if tissue:
-                filters.append(f"tissue:{tissue}")
-            if cancer_type:
-                filters.append(f"cancer_type:{cancer_type}")
-
-            if filters:
-                params["filter[model]"] = ",".join(filters)
 
             response = requests.get(url, params=params, timeout=self.timeout)
             response.raise_for_status()
@@ -96,26 +112,29 @@ class DepMapTool(BaseTool):
             cell_lines = []
             for item in data.get("data", []):
                 attrs = item.get("attributes", {})
+                names = attrs.get("names") or []
                 cell_lines.append(
                     {
                         "model_id": item.get("id"),
-                        "model_name": attrs.get("model_name"),
-                        "tissue": attrs.get("tissue"),
-                        "cancer_type": attrs.get("cancer_type"),
-                        "sample_site": attrs.get("sample_site"),
-                        "gender": attrs.get("gender"),
-                        "ethnicity": attrs.get("ethnicity"),
+                        "model_name": names[0] if names else None,
                     }
                 )
 
-            return {
-                "status": "success",
-                "data": {
-                    "cell_lines": cell_lines,
-                    "count": len(cell_lines),
-                    "total": data.get("meta", {}).get("total", len(cell_lines)),
-                },
+            result_data = {
+                "cell_lines": cell_lines,
+                "count": len(cell_lines),
+                "total": data.get("meta", {}).get("count", len(cell_lines)),
             }
+            if tissue or cancer_type:
+                result_data["warning"] = (
+                    "The tissue/cancer_type filter had no effect: the "
+                    "Sanger Cell Model Passports /models endpoint does not "
+                    "support server-side filtering by these fields. The "
+                    "results above are unfiltered. Use DepMap_get_cell_line "
+                    "on individual model_ids to retrieve their tissue/"
+                    "cancer_type."
+                )
+            return {"status": "success", "data": result_data}
         except requests.exceptions.Timeout:
             return {
                 "status": "error",
@@ -159,7 +178,19 @@ class DepMapTool(BaseTool):
                 model_id = search_result["data"]["cell_lines"][0]["model_id"]
                 url = f"{DEPMAP_BASE_URL}/models/{model_id}"
 
-            response = requests.get(url, timeout=self.timeout)
+            # Fix-R19C-3: the fields below (tissue, cancer_type, gender,
+            # ethnicity, msi_status, etc.) don't exist on the model
+            # resource's own `attributes` at all -- confirmed live the
+            # model only has fields like `names`/`growth_properties`/
+            # `mutations_per_mb`/`ploidy`. tissue/cancer_type/gender/
+            # ethnicity/msi_status are on separate related resources
+            # (sample -> tissue/cancer_type/patient, and a top-level
+            # model_msi_status relation), reachable in one request via
+            # the JSON:API `include` param.
+            params = {
+                "include": "sample.tissue,sample.cancer_type,sample.patient,model_msi_status"
+            }
+            response = requests.get(url, params=params, timeout=self.timeout)
 
             if response.status_code == 404:
                 return {
@@ -173,23 +204,38 @@ class DepMapTool(BaseTool):
 
             item = data.get("data", {})
             attrs = item.get("attributes", {})
+            included = {
+                (inc.get("type"), inc.get("id")): inc.get("attributes", {})
+                for inc in data.get("included", [])
+            }
+            sample = next((v for (t, _), v in included.items() if t == "sample"), {})
+            tissue = next((v for (t, _), v in included.items() if t == "tissue"), {})
+            cancer_type = next(
+                (v for (t, _), v in included.items() if t == "cancer_type"), {}
+            )
+            patient = next((v for (t, _), v in included.items() if t == "patient"), {})
+            msi = next(
+                (v for (t, _), v in included.items() if t == "model_msi_status"), {}
+            )
+
+            names = attrs.get("names") or []
 
             return {
                 "status": "success",
                 "data": {
                     "model_id": item.get("id"),
-                    "model_name": attrs.get("model_name"),
-                    "tissue": attrs.get("tissue"),
-                    "cancer_type": attrs.get("cancer_type"),
-                    "tissue_status": attrs.get("tissue_status"),
-                    "sample_site": attrs.get("sample_site"),
-                    "gender": attrs.get("gender"),
-                    "ethnicity": attrs.get("ethnicity"),
-                    "age_at_sampling": attrs.get("age_at_sampling"),
+                    "model_name": names[0] if names else None,
+                    "tissue": tissue.get("name"),
+                    "cancer_type": cancer_type.get("name"),
+                    "tissue_status": sample.get("tissue_status"),
+                    "sample_site": sample.get("sample_site"),
+                    "gender": patient.get("gender"),
+                    "ethnicity": patient.get("ethnicity"),
+                    "age_at_sampling": sample.get("age_at_sampling"),
                     "growth_properties": attrs.get("growth_properties"),
-                    "msi_status": attrs.get("msi_status"),
+                    "msi_status": msi.get("msi_status"),
                     "ploidy": attrs.get("ploidy"),
-                    "mutational_burden": attrs.get("mutational_burden"),
+                    "mutational_burden": attrs.get("mutations_per_mb"),
                 },
             }
         except requests.exceptions.Timeout:
@@ -202,6 +248,58 @@ class DepMapTool(BaseTool):
         except Exception as e:
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}
 
+    def _find_catalog_page(
+        self,
+        url: str,
+        params: Dict[str, Any],
+        query_upper: str,
+        symbol_of,
+        request_timeout: int,
+    ) -> List[Dict[str, Any]]:
+        """Binary-search a symbol-sorted, paginated JSON:API catalog for the
+        single page that could contain ``query_upper``.
+
+        ``params`` must already request page 1 (``page[number]=1``) with the
+        desired ``sort`` and ``page[size]``; it is mutated in place as pages
+        are visited. ``symbol_of(item)`` returns an item's uppercased sort
+        symbol. Returns that page's list of resource items, or ``[]`` if the
+        query sorts outside the whole catalog.
+
+        Comparing the query against each page's first/last symbol (rather
+        than scanning linearly from page 1) keeps the cost to
+        ~log2(total_pages) round-trips over the full catalog. ``fetched_page``
+        is tracked so re-examining the current page reuses the data already in
+        hand instead of refetching (which would also risk stale data).
+        """
+        page_size = params["page[size]"]
+        response = requests.get(url, params=params, timeout=request_timeout)
+        response.raise_for_status()
+        first_data = response.json()
+        total_count = first_data.get("meta", {}).get("count", 0)
+        total_pages = max(1, -(-total_count // page_size))  # ceil division
+
+        page_items = first_data.get("data", [])
+        fetched_page = 1
+        lo, hi = 1, total_pages
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            if mid != fetched_page:
+                params["page[number]"] = mid
+                response = requests.get(url, params=params, timeout=request_timeout)
+                response.raise_for_status()
+                page_items = response.json().get("data", [])
+                fetched_page = mid
+            if not page_items:
+                hi = mid - 1
+                continue
+            if query_upper < symbol_of(page_items[0]):
+                hi = mid - 1
+            elif query_upper > symbol_of(page_items[-1]):
+                lo = mid + 1
+            else:
+                return page_items
+        return []
+
     def _search_cell_lines(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """
         Search cell lines by name or identifier.
@@ -212,24 +310,38 @@ class DepMapTool(BaseTool):
             return {"status": "error", "error": "query parameter is required"}
 
         try:
+            # Fix-R19C-3: same root cause as _search_genes -- filter[model]
+            # doesn't work on this API (confirmed live: identical,
+            # unfiltered results regardless of filter value), and
+            # `model_name`/`tissue`/`cancer_type` aren't real attributes on
+            # the model resource (it only has `names`, a list). The
+            # `/models` endpoint DOES support `sort=names` though
+            # (confirmed live), so binary-search the ~2266-model catalog by
+            # name the same way _search_genes does for the gene catalog.
             url = f"{DEPMAP_BASE_URL}/models"
-            params = {"filter[model]": f"model_name:{query}", "page[size]": 20}
-
-            response = requests.get(url, params=params, timeout=self.timeout)
-            response.raise_for_status()
-            data = response.json()
+            params = {"sort": "names", "page[size]": 500, "page[number]": 1}
+            query_upper = query.upper()
+            # Several sequential round-trips; give each request more headroom
+            # than the tool's default (same rationale as _search_genes).
+            page_items = self._find_catalog_page(
+                url, params, query_upper, _model_symbol, max(self.timeout, 45)
+            )
 
             cell_lines = []
-            for item in data.get("data", []):
-                attrs = item.get("attributes", {})
-                cell_lines.append(
-                    {
-                        "model_id": item.get("id"),
-                        "model_name": attrs.get("model_name"),
-                        "tissue": attrs.get("tissue"),
-                        "cancer_type": attrs.get("cancer_type"),
-                    }
-                )
+            for item in page_items:
+                names = item.get("attributes", {}).get("names") or []
+                name = names[0] if names else None
+                if name and (
+                    name.upper() == query_upper or name.upper().startswith(query_upper)
+                ):
+                    cell_lines.append(
+                        {
+                            "model_id": item.get("id"),
+                            "model_name": name,
+                            "exact_match": name.upper() == query_upper,
+                        }
+                    )
+            cell_lines.sort(key=lambda c: (not c["exact_match"], c["model_name"]))
 
             return {
                 "status": "success",
@@ -339,52 +451,46 @@ class DepMapTool(BaseTool):
             return {"status": "error", "error": "query parameter is required"}
 
         try:
-            # The Sanger API's filter[gene] param doesn't work for
-            # exact symbol matching. Use sorted pagination + client filter.
+            # Fix-R19C-1: the Sanger API's filter[gene] param doesn't work
+            # for exact symbol matching (confirmed live: it silently
+            # returns an unrelated, seemingly-arbitrary page of genes
+            # regardless of the filter value). The catalog has ~45,751
+            # genes; the previous "scan up to 5 pages of 100" approach only
+            # ever covered the first ~1% alphabetically, so any gene not
+            # starting with A/B (e.g. KRAS, TP53, EGFR) was always
+            # reported "not found" -- confirmed live for all three.
+            # Results are sorted by symbol, so binary-search the pages by
+            # comparing the query against each page's first/last symbol
+            # instead of scanning linearly from page 1.
             url = f"{DEPMAP_BASE_URL}/genes"
-            params = {
-                "sort": "symbol",
-                "page[size]": 100,
-            }
-
-            # Scan through pages to find matching genes
-            # With sorted results, we search up to 5 pages (500 genes)
-            genes = []
+            params = {"sort": "symbol", "page[size]": 1000, "page[number]": 1}
             query_upper = query.upper()
-            for page_num in range(1, 6):
-                params["page[number]"] = page_num
-                response = requests.get(url, params=params, timeout=self.timeout)
-                response.raise_for_status()
-                data = response.json()
+            # Binary search makes several sequential round-trips (~6 for the
+            # full 45k-gene catalog); this API is occasionally slow on an
+            # individual request (confirmed live, one page took 22s), so
+            # give each request more headroom than the tool's default.
+            page_items = self._find_catalog_page(
+                url, params, query_upper, _gene_symbol, max(self.timeout, 45)
+            )
 
-                for item in data.get("data", []):
-                    attrs = item.get("attributes", {})
-                    symbol = attrs.get("symbol", "")
-                    # Check for exact or prefix match
-                    if symbol.upper() == query_upper or symbol.upper().startswith(
-                        query_upper
-                    ):
-                        genes.append(
-                            {
-                                "gene_id": item.get("id"),
-                                "symbol": symbol,
-                                "name": attrs.get("name"),
-                                "hgnc_id": attrs.get("hgnc_id"),
-                                "ensembl_id": attrs.get("ensembl_gene_id"),
-                                "exact_match": (symbol.upper() == query_upper),
-                            }
-                        )
-
-                # If we found exact match(es), no need for more pages
-                if any(g["exact_match"] for g in genes):
-                    break
-
-                # Check if we've gone past alphabetically
-                page_data = data.get("data", [])
-                if page_data:
-                    last_sym = page_data[-1].get("attributes", {}).get("symbol", "")
-                    if last_sym.upper() > query_upper + "Z":
-                        break
+            genes = []
+            for item in page_items:
+                attrs = item.get("attributes", {})
+                symbol = attrs.get("symbol", "")
+                # Check for exact or prefix match
+                if symbol.upper() == query_upper or symbol.upper().startswith(
+                    query_upper
+                ):
+                    genes.append(
+                        {
+                            "gene_id": item.get("id"),
+                            "symbol": symbol,
+                            "name": attrs.get("name"),
+                            "hgnc_id": attrs.get("hgnc_id"),
+                            "ensembl_id": attrs.get("ensembl_gene_id"),
+                            "exact_match": (symbol.upper() == query_upper),
+                        }
+                    )
 
             # Sort: exact matches first
             genes.sort(

--- a/src/tooluniverse/ensembl_archive_tool.py
+++ b/src/tooluniverse/ensembl_archive_tool.py
@@ -47,9 +47,25 @@ class EnsemblArchiveTool(BaseTool):
         except requests.exceptions.HTTPError as e:
             code = e.response.status_code if e.response is not None else "unknown"
             if code == 400:
+                # Fix-R19A-2: Ensembl's archive endpoint returns HTTP 400
+                # (not 404) for both a malformed ID AND a syntactically
+                # valid but nonexistent one -- confirmed live for
+                # ENSG00000999999 (correct ENSG + 11 digits, same shape as
+                # a real ID): HTTP 400 with body {"error": "No object
+                # found for ENSG00000999999"}. Blanket-mapping every 400
+                # to "Invalid format" discarded that real message and sent
+                # a user checking ID syntax instead of realizing the
+                # record simply doesn't exist. Surface the upstream
+                # message when present.
+                upstream_error = None
+                try:
+                    upstream_error = e.response.json().get("error")
+                except Exception:
+                    pass
                 return {
                     "status": "error",
-                    "error": f"Invalid Ensembl ID format: {arguments.get('ensembl_id', '')}",
+                    "error": upstream_error
+                    or f"Invalid Ensembl ID format: {arguments.get('ensembl_id', '')}",
                 }
             if code == 404:
                 return {

--- a/src/tooluniverse/ensembl_xrefs_tool.py
+++ b/src/tooluniverse/ensembl_xrefs_tool.py
@@ -113,17 +113,28 @@ class EnsemblXrefsTool(BaseTool):
                 }
             )
 
+        # Fix-R19A-1: xrefs was silently truncated to 100 while
+        # database_summary was computed from the full, untruncated list --
+        # confirmed live for ENSG00000141510 (TP53, 157 real xrefs): the
+        # per-database counts in database_summary didn't match what was
+        # actually present in the truncated xrefs array, and there was no
+        # flag indicating truncation happened at all. Raised the cap high
+        # enough that this essentially never triggers in practice, and
+        # made truncation explicit when it does.
+        limit = 500
+        truncated = len(xrefs) > limit
         return {
             "status": "success",
             "data": {
                 "ensembl_id": ensembl_id,
-                "xrefs": xrefs[:100],
+                "xrefs": xrefs[:limit],
                 "database_summary": by_db,
+                "truncated": truncated,
             },
             "metadata": {
                 "source": "Ensembl REST API (rest.ensembl.org)",
                 "total_xrefs": len(data),
-                "returned": min(len(xrefs), 100),
+                "returned": min(len(xrefs), limit),
                 "databases_found": len(by_db),
             },
         }

--- a/src/tooluniverse/hpa_tool.py
+++ b/src/tooluniverse/hpa_tool.py
@@ -664,12 +664,29 @@ class HPASearchGenesTool(HPASearchApiTool):
                 }
             )
 
+        # Fix-R19D-1: HPA's search_download.php does a broad full-text
+        # match with no server-side limit param (confirmed live: a
+        # "limit" query param has no effect) -- a short, valid gene
+        # symbol like "INS" returned 8,441 genes (1.4MB), many not even
+        # containing the query as a substring. Rank exact gene-symbol
+        # matches first and cap the response client-side; the caller can
+        # raise max_results for a deliberately broad search.
+        query_upper = search_query.upper()
+        formatted_results.sort(
+            key=lambda g: (g.get("gene_name") or "").upper() != query_upper
+        )
+        total_matches = len(formatted_results)
+        max_results = arguments.get("max_results") or 50
+        truncated_results = formatted_results[:max_results]
+
         return {
             "status": "success",
             "data": {
                 "search_query": search_query,
-                "match_count": len(formatted_results),
-                "genes": formatted_results,
+                "match_count": len(truncated_results),
+                "total_matches": total_matches,
+                "truncated": total_matches > len(truncated_results),
+                "genes": truncated_results,
             },
         }
 

--- a/src/tooluniverse/stitch_tool.py
+++ b/src/tooluniverse/stitch_tool.py
@@ -14,8 +14,38 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 # Base URL for STITCH REST API (chemical-protein interactions)
-# NOTE: stitch.embl.de API endpoints have moved to string-db.org (same API format)
-STITCH_BASE_URL = "https://string-db.org/api"
+# Fix-R19E-3: this previously pointed at string-db.org, STRING's own
+# PROTEIN-ONLY network API -- confirmed live it silently returns real but
+# entirely protein-protein data (e.g. resolving "aspirin" returned the gene
+# SLC17A4) with zero chemicals anywhere in the response, since STRING has
+# no concept of a chemical CID. stitch.embl.de (STITCH's real, historical
+# domain) 301-redirects to stitch-db.org, which correctly resolves
+# chemical names/CIDs to STITCH-format stringIds (confirmed live: aspirin
+# -> "-1.CID100002244"). Note: the network/interactions sub-endpoints
+# still 404 on the new domain even with a correctly-resolved identifier
+# (confirmed live) -- see the honest error messages in
+# _get_interactions/_get_interactors below.
+STITCH_BASE_URL = "https://stitch-db.org/api"
+
+
+def _endpoint_unavailable_error(endpoint_path: str, identifiers: Any) -> Dict[str, Any]:
+    """Fix-R19E-3: STITCH's /json interaction sub-endpoints 404 on the
+    migrated stitch-db.org site even for a correctly-resolved identifier
+    (confirmed live) -- the endpoint path itself appears unavailable, not a
+    bad identifier. Return an error saying so honestly instead of implying
+    the identifier format is the problem."""
+    return {
+        "status": "error",
+        "error": (
+            f"STITCH's {endpoint_path} endpoint returned 404 for "
+            f"{identifiers}. This endpoint appears unavailable on "
+            "STITCH's current site (stitch-db.org) even for a "
+            "correctly-resolved identifier -- not necessarily a bad "
+            "identifier. Use STITCH_resolve_identifier to confirm the "
+            "identifier resolves, or browse interactions directly at "
+            "https://stitch-db.org/."
+        ),
+    }
 
 
 @register_tool("STITCHTool")
@@ -100,12 +130,7 @@ class STITCHTool(BaseTool):
                 timeout=self.timeout,
             )
             if response.status_code == 404:
-                return {
-                    "status": "error",
-                    "error": f"No interactions found for {identifiers} in STITCH. "
-                    "Try using CID identifiers (e.g., 'CIDm00002244' for aspirin) "
-                    "or check compound names at http://stitch.embl.de/",
-                }
+                return _endpoint_unavailable_error("/json/interactions", identifiers)
             response.raise_for_status()
             return {"status": "success", "data": response.json()}
         except requests.RequestException as e:
@@ -138,11 +163,7 @@ class STITCHTool(BaseTool):
                 timeout=self.timeout,
             )
             if response.status_code == 404:
-                return {
-                    "status": "error",
-                    "error": f"No interactors found for {identifiers} in STITCH. "
-                    "Try using CID identifiers or check compound names at http://stitch.embl.de/",
-                }
+                return _endpoint_unavailable_error("/json/network", identifiers)
             response.raise_for_status()
             return {"status": "success", "data": response.json()}
         except requests.RequestException as e:

--- a/tests/unit/test_clingen_actionability_and_classifications.py
+++ b/tests/unit/test_clingen_actionability_and_classifications.py
@@ -1,0 +1,155 @@
+"""Regression guard for Fix-R19B-1/2/3: ClinGenTool's actionability and
+variant-classification methods had two related bugs, both confirmed live --
+
+1. The actionability API's `?flavor=flat` response is a JSON table --
+   {"columns": [...], "rows": [[...], ...]} -- not a list of per-curation
+   dicts. `_get_actionability`'s `isinstance(curations, list)` guard was
+   always False against this dict, so a gene filter was silently skipped
+   entirely (returning all 254 unfiltered rows for BRCA1). The identical
+   check in `_search_actionability` had the opposite symptom: `matches`
+   was never assigned, so it always returned {"Adult": [], "Pediatric":
+   []} even for BRCA1, which has real curated actionability data.
+2. `_get_variant_classifications` downloaded the ENTIRE, unpaginated
+   ClinGen Evidence Repository (confirmed live: 28+MB and still streaming
+   after 200s) and filtered client-side afterward. A fast, already
+   gene-filtered JSON endpoint exists (`/classifications?gene=X`,
+   confirmed live ~1s response) and is now used instead; a request with
+   no gene now errors immediately rather than hanging.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.clingen_tool import ClinGenTool, _actionability_rows_to_dicts
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(operation):
+    return ClinGenTool({"name": "clingen_test", "fields": {"operation": operation}})
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.json.return_value = json_body
+    r.raise_for_status = MagicMock()
+    return r
+
+
+TABLE_RESPONSE = {
+    "columns": ["docId", "geneOrVariant", "disease"],
+    "rows": [
+        ["AC001", "CYP27A1", "Cerebrotendinous xanthomatosis"],
+        ["AC002", "BRCA1,BRCA2", "Hereditary Breast and Ovarian Cancer"],
+        ["AC003", "MLH1,MSH2,MSH6,PMS2", "Lynch Syndrome"],
+    ],
+}
+
+
+def test_actionability_rows_to_dicts_converts_table_format():
+    result = _actionability_rows_to_dicts(TABLE_RESPONSE)
+    assert result == [
+        {"docId": "AC001", "geneOrVariant": "CYP27A1", "disease": "Cerebrotendinous xanthomatosis"},
+        {"docId": "AC002", "geneOrVariant": "BRCA1,BRCA2", "disease": "Hereditary Breast and Ovarian Cancer"},
+        {"docId": "AC003", "geneOrVariant": "MLH1,MSH2,MSH6,PMS2", "disease": "Lynch Syndrome"},
+    ]
+
+
+def test_actionability_rows_to_dicts_passes_through_existing_list():
+    already_list = [{"a": 1}]
+    assert _actionability_rows_to_dicts(already_list) is already_list
+
+
+def test_get_actionability_adult_filters_by_gene(monkeypatch):
+    tool = _tool("get_actionability_adult")
+
+    with patch("tooluniverse.clingen_tool.requests.get", return_value=_resp(TABLE_RESPONSE)):
+        result = tool.run({"gene": "BRCA1"})
+
+    assert result["status"] == "success"
+    assert result["total"] == 1
+    assert result["data"][0]["geneOrVariant"] == "BRCA1,BRCA2"
+
+
+def test_get_actionability_adult_no_filter_returns_all(monkeypatch):
+    tool = _tool("get_actionability_adult")
+
+    with patch("tooluniverse.clingen_tool.requests.get", return_value=_resp(TABLE_RESPONSE)):
+        result = tool.run({})
+
+    assert result["total"] == 3
+
+
+def test_search_actionability_returns_matches_for_both_contexts(monkeypatch):
+    tool = _tool("search_actionability")
+
+    with patch("tooluniverse.clingen_tool.requests.get", return_value=_resp(TABLE_RESPONSE)):
+        result = tool.run({"gene": "BRCA1"})
+
+    assert result["status"] == "success"
+    data = result["data"]
+    assert len(data["Adult"]) == 1
+    assert len(data["Pediatric"]) == 1
+    assert data["Adult"][0]["geneOrVariant"] == "BRCA1,BRCA2"
+
+
+def test_get_variant_classifications_requires_gene():
+    tool = _tool("get_variant_classifications")
+
+    result = tool.run({})
+
+    assert result["status"] == "error"
+    assert "gene" in result["error"]
+
+
+def test_get_variant_classifications_uses_fast_filtered_endpoint(monkeypatch):
+    tool = _tool("get_variant_classifications")
+    api_response = {
+        "variantInterpretations": [
+            {
+                "caid": "CAR:CA000895",
+                "gene": {"label": "BRCA1"},
+                "condition": {"label": "BRCA1-related cancer predisposition"},
+                "publishedDate": "2024-06-11",
+                "hgvs": ["NM_007294.4:c.135-1G>T"],
+                "guidelines": [{"outcome": {"label": "Pathogenic"}}],
+            }
+        ]
+    }
+    captured = {}
+
+    def fake_get(url, params=None, **kwargs):
+        captured["url"] = url
+        captured["params"] = params
+        return _resp(api_response)
+
+    with patch("tooluniverse.clingen_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"gene": "BRCA1"})
+
+    assert result["status"] == "success"
+    assert result["total"] == 1
+    assert result["data"][0]["classification"] == "Pathogenic"
+    assert result["data"][0]["caid"] == "CAR:CA000895"
+    assert "classifications/all" not in captured["url"]
+    assert captured["params"] == {"gene": "BRCA1"}
+
+
+def test_get_variant_classifications_variant_filter_matches_hgvs(monkeypatch):
+    tool = _tool("get_variant_classifications")
+    api_response = {
+        "variantInterpretations": [
+            {"caid": "CAR:CA1", "hgvs": ["NM_1:c.1A>T"], "guidelines": []},
+            {"caid": "CAR:CA2", "hgvs": ["NM_2:c.2A>T"], "guidelines": []},
+        ]
+    }
+
+    with patch("tooluniverse.clingen_tool.requests.get", return_value=_resp(api_response)):
+        result = tool.run({"gene": "BRCA1", "variant": "CA1"})
+
+    assert result["total"] == 1
+    assert result["data"][0]["caid"] == "CAR:CA1"

--- a/tests/unit/test_depmap_search_and_fields.py
+++ b/tests/unit/test_depmap_search_and_fields.py
@@ -1,0 +1,209 @@
+"""Regression guard for Fix-R19C-1/3: DepMapTool's search and detail methods
+had two related classes of bugs, both confirmed live --
+
+1. DepMap_search_genes/DepMap_search_cell_lines scanned only the first 5
+   pages (500 records) of a ~45,751-gene / ~2,266-model catalog looking for
+   an exact/prefix match, or relied on filter[gene]/filter[model] query
+   params that the Sanger Cell Model Passports API silently ignores
+   (confirmed live: filtered and unfiltered requests return identical
+   results). Any gene/cell-line not alphabetically within the first ~1%
+   was always reported "not found" -- confirmed for KRAS, EGFR, TP53, A549.
+   Both now binary-search the full, sorted (sort=symbol / sort=names)
+   catalog instead.
+2. DepMap_get_cell_line/DepMap_get_cell_lines read field names
+   (model_name, tissue, cancer_type, gender, ethnicity, sample_site) that
+   don't exist on the model resource's own `attributes` at all -- only
+   `names` (a list) does. The real data lives on related sample/tissue/
+   cancer_type/patient resources, reachable via the JSON:API `include`
+   param. get_cell_line now resolves all fields correctly via `include`;
+   get_cell_lines (a list endpoint, where per-row `include` isn't
+   practical) fixes model_name and stops silently ignoring a tissue/
+   cancer_type filter that has no effect server-side.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.depmap_tool import DepMapTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(operation):
+    return DepMapTool({"name": "depmap_test", "fields": {"operation": operation}})
+
+
+def _resp(json_body, status_code=200):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def _gene_item(symbol, gene_id="SIDGxxxxx"):
+    return {"id": gene_id, "attributes": {"symbol": symbol, "name": None, "hgnc_id": None}}
+
+
+def _gene_item_model(name, model_id):
+    return {"id": model_id, "attributes": {"names": [name]}}
+
+
+def test_search_genes_binary_search_finds_mid_alphabet_gene(monkeypatch):
+    """KRAS-like case: target isn't on page 1, must be found via search."""
+    tool = _tool("search_genes")
+
+    # Simulate a full sorted 26-page catalog, one page per letter of the
+    # alphabet (A on page 1, K on page 11, Z on page 26) -- large enough
+    # that the original "scan up to 5 pages" bug would never reach K, and
+    # that a truly-linear scan (not a real binary search) would take 11
+    # requests instead of ~5 (log2(26)).
+    letters = [chr(ord("A") + i) for i in range(26)]
+    pages = {
+        i + 1: [_gene_item(f"{letters[i]}AA1"), _gene_item(f"{letters[i]}ZZ9")]
+        for i in range(26)
+    }
+    # Page 11 ('K') deliberately contains the exact target plus a prefix match.
+    pages[11] = [_gene_item("KRAS"), _gene_item("KRASP1")]
+
+    call_log = []
+
+    def fake_get(url, params=None, **kwargs):
+        page_num = params["page[number]"]
+        call_log.append(page_num)
+        if page_num == 1:
+            # page_size in the implementation is 1000; 26000 -> 26 pages,
+            # matching the 26-page mock catalog above.
+            body = {"meta": {"count": 26000}, "data": pages[1]}
+        else:
+            body = {"data": pages[page_num]}
+        return _resp(body)
+
+    with patch("tooluniverse.depmap_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"query": "KRAS"})
+
+    assert result["status"] == "success"
+    symbols = [g["symbol"] for g in result["data"]["genes"]]
+    assert "KRAS" in symbols
+    assert "KRASP1" in symbols
+    exact = [g for g in result["data"]["genes"] if g["exact_match"]]
+    assert len(exact) == 1 and exact[0]["symbol"] == "KRAS"
+    # Confirms it landed on the exact right page (11) via genuine binary
+    # search, not a linear scan or a lucky guess.
+    assert call_log[-1] == 11
+    assert len(call_log) <= 8  # log2(26) ~= 5; generous upper bound
+
+
+def test_search_genes_no_match_returns_empty_not_stale_page(monkeypatch):
+    tool = _tool("search_genes")
+
+    def fake_get(url, params=None, **kwargs):
+        page_num = params["page[number]"]
+        if page_num == 1:
+            return _resp({"meta": {"count": 100}, "data": [_gene_item("AAAS")]})
+        return _resp({"data": [_gene_item("ZZZ1")]})
+
+    with patch("tooluniverse.depmap_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"query": "NOTAREALGENE"})
+
+    assert result["status"] == "success"
+    assert result["data"]["genes"] == []
+    assert result["data"]["count"] == 0
+
+
+def test_get_cell_line_resolves_tissue_cancer_type_gender_via_include(monkeypatch):
+    tool = _tool("get_cell_line")
+
+    body = {
+        "data": {
+            "id": "SIDM01774",
+            "attributes": {
+                "names": ["PK-59"],
+                "growth_properties": "Adherent",
+                "ploidy": None,
+                "mutations_per_mb": 24.79,
+            },
+        },
+        "included": [
+            {"type": "sample", "id": "SIDS01659", "attributes": {
+                "sample_site": "Liver", "tissue_status": "Metastasis", "age_at_sampling": None,
+            }},
+            {"type": "tissue", "id": "16", "attributes": {"name": "Pancreas"}},
+            {"type": "cancer_type", "id": "25", "attributes": {"name": "Pancreatic Carcinoma"}},
+            {"type": "patient", "id": "SIDP01578", "attributes": {"gender": "Unknown", "ethnicity": "Unknown"}},
+            {"type": "model_msi_status", "id": "1", "attributes": {"msi_status": "No Data"}},
+        ],
+    }
+    captured = {}
+
+    def fake_get(url, params=None, **kwargs):
+        captured["params"] = params
+        return _resp(body)
+
+    with patch("tooluniverse.depmap_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"model_id": "SIDM01774"})
+
+    assert result["status"] == "success"
+    data = result["data"]
+    assert data["model_name"] == "PK-59"
+    assert data["tissue"] == "Pancreas"
+    assert data["cancer_type"] == "Pancreatic Carcinoma"
+    assert data["gender"] == "Unknown"
+    assert data["sample_site"] == "Liver"
+    assert data["msi_status"] == "No Data"
+    assert data["mutational_burden"] == 24.79
+    assert "include" in captured["params"]
+
+
+def test_get_cell_lines_fixes_model_name_and_warns_on_ignored_filter(monkeypatch):
+    tool = _tool("get_cell_lines")
+
+    body = {
+        "meta": {"count": 2266},
+        "data": [_gene_item_model("PK-59", "SIDM01774")],
+    }
+
+    with patch("tooluniverse.depmap_tool.requests.get", return_value=_resp(body)):
+        result = tool.run({"tissue": "Lung", "page_size": 3})
+
+    data = result["data"]
+    assert data["cell_lines"][0]["model_name"] == "PK-59"
+    assert data["total"] == 2266
+    assert "no effect" in data["warning"]
+
+
+def test_get_cell_lines_no_warning_without_filter(monkeypatch):
+    tool = _tool("get_cell_lines")
+    body = {"meta": {"count": 1}, "data": [_gene_item_model("A549", "SIDM00903")]}
+
+    with patch("tooluniverse.depmap_tool.requests.get", return_value=_resp(body)):
+        result = tool.run({})
+
+    assert "warning" not in result["data"]
+
+
+def test_search_cell_lines_binary_search_finds_match(monkeypatch):
+    tool = _tool("search_cell_lines")
+
+    def fake_get(url, params=None, **kwargs):
+        page_num = params["page[number]"]
+        if page_num == 1:
+            return _resp(
+                {
+                    "meta": {"count": 2000},
+                    "data": [_gene_item_model("1181N1", "SIDM1"), _gene_item_model("293T", "SIDM2")],
+                }
+            )
+        return _resp({"data": [_gene_item_model("A549", "SIDM00903")]})
+
+    with patch("tooluniverse.depmap_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"query": "A549"})
+
+    assert result["status"] == "success"
+    names = [c["model_name"] for c in result["data"]["cell_lines"]]
+    assert "A549" in names

--- a/tests/unit/test_ensembl_xrefs_and_archive_fixes.py
+++ b/tests/unit/test_ensembl_xrefs_and_archive_fixes.py
@@ -1,0 +1,112 @@
+"""Regression guard for Fix-R19A-1/2:
+
+- EnsemblXrefsTool._get_xrefs silently truncated `xrefs` to 100 entries
+  while `database_summary` was computed from the full, untruncated list --
+  confirmed live for TP53 (ENSG00000141510, 157 real xrefs) that the
+  per-database counts didn't match what was actually present in the
+  truncated array, with no flag indicating truncation happened. The cap
+  is now high enough to essentially never trigger, and an explicit
+  `truncated` flag is set when it does.
+- EnsemblArchiveTool blanket-mapped every upstream HTTP 400 to "Invalid
+  Ensembl ID format", discarding the real message -- confirmed live for a
+  syntactically valid but nonexistent ID (ENSG00000999999), which
+  Ensembl's own archive endpoint returns as HTTP 400 with body
+  {"error": "No object found for ENSG00000999999"}, not a format problem.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.ensembl_xrefs_tool import EnsemblXrefsTool
+from tooluniverse.ensembl_archive_tool import EnsemblArchiveTool
+
+pytestmark = pytest.mark.unit
+
+
+def _xrefs_tool():
+    return EnsemblXrefsTool({"name": "xrefs_test", "fields": {"endpoint": "xrefs_by_id"}})
+
+
+def _archive_tool():
+    return EnsemblArchiveTool({"name": "archive_test", "fields": {"endpoint": "get_id_history"}})
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.json.return_value = json_body
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def test_xrefs_database_summary_matches_returned_xrefs_count():
+    tool = _xrefs_tool()
+    # 157 entries across a couple of databases, like the real TP53 response.
+    raw = [
+        {"dbname": "HGNC", "primary_id": f"HGNC:{i}", "display_id": "TP53"}
+        for i in range(100)
+    ] + [
+        {"dbname": "EntrezGene", "primary_id": f"{i}", "display_id": "TP53"}
+        for i in range(57)
+    ]
+
+    with patch("tooluniverse.ensembl_xrefs_tool.requests.get", return_value=_resp(raw)):
+        result = tool.run({"ensembl_id": "ENSG00000141510"})
+
+    data = result["data"]
+    assert len(data["xrefs"]) == 157
+    assert data["truncated"] is False
+    assert sum(data["database_summary"].values()) == len(data["xrefs"])
+    assert result["metadata"]["total_xrefs"] == 157
+
+
+def test_xrefs_truncation_flag_set_when_cap_exceeded():
+    tool = _xrefs_tool()
+    raw = [{"dbname": "HGNC", "primary_id": str(i)} for i in range(600)]
+
+    with patch("tooluniverse.ensembl_xrefs_tool.requests.get", return_value=_resp(raw)):
+        result = tool.run({"ensembl_id": "ENSG00000141510"})
+
+    data = result["data"]
+    assert len(data["xrefs"]) == 500
+    assert data["truncated"] is True
+
+
+def test_archive_400_surfaces_upstream_not_found_message(monkeypatch):
+    tool = _archive_tool()
+    resp = MagicMock()
+    resp.status_code = 400
+    resp.json.return_value = {"error": "No object found for ENSG00000999999"}
+    http_error = requests.exceptions.HTTPError(response=resp)
+
+    def fake_get(*a, **k):
+        raise http_error
+
+    with patch("tooluniverse.ensembl_archive_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"ensembl_id": "ENSG00000999999"})
+
+    assert result["status"] == "error"
+    assert result["error"] == "No object found for ENSG00000999999"
+    assert "Invalid Ensembl ID format" not in result["error"]
+
+
+def test_archive_400_falls_back_to_generic_message_when_no_body(monkeypatch):
+    tool = _archive_tool()
+    resp = MagicMock()
+    resp.status_code = 400
+    resp.json.side_effect = ValueError("not json")
+    http_error = requests.exceptions.HTTPError(response=resp)
+
+    def fake_get(*a, **k):
+        raise http_error
+
+    with patch("tooluniverse.ensembl_archive_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"ensembl_id": "not-even-an-id"})
+
+    assert result["status"] == "error"
+    assert "Invalid Ensembl ID format" in result["error"]

--- a/tests/unit/test_hpa_search_genes_cap.py
+++ b/tests/unit/test_hpa_search_genes_cap.py
@@ -1,0 +1,74 @@
+"""Regression guard for Fix-R19D-1: HPASearchGenesTool's underlying
+search_download.php call does a broad full-text match with no server-side
+limit param (confirmed live: a "limit" query param has no effect) -- a
+short, valid gene symbol like "INS" returned 8,441 genes (1.4MB), many not
+even containing the query as a substring. Exact gene-symbol matches are now
+ranked first and the response is capped client-side (default 50, overridable
+via max_results), with total_matches/truncated exposed for transparency.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.hpa_tool import HPASearchGenesTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return HPASearchGenesTool({"name": "HPA_search_genes_by_query", "fields": {}})
+
+
+def _many_genes(query, count):
+    genes = [
+        {"Gene": query, "Gene synonym": "", "Ensembl": "ENSG00000254647"}
+    ]
+    genes += [
+        {"Gene": f"NOISE{i}", "Gene synonym": "", "Ensembl": f"ENSG{i:011d}"}
+        for i in range(count - 1)
+    ]
+    return genes
+
+
+def test_exact_match_ranked_first_and_capped_at_default():
+    tool = _tool()
+    raw = _many_genes("INS", 8441)
+
+    with patch.object(tool, "_make_api_request", return_value=raw):
+        result = tool.run({"search_query": "INS"})
+
+    data = result["data"]
+    assert data["genes"][0]["gene_name"] == "INS"
+    assert data["match_count"] == 50
+    assert data["total_matches"] == 8441
+    assert data["truncated"] is True
+
+
+def test_max_results_override_returns_more():
+    tool = _tool()
+    raw = _many_genes("INS", 200)
+
+    with patch.object(tool, "_make_api_request", return_value=raw):
+        result = tool.run({"search_query": "INS", "max_results": 150})
+
+    data = result["data"]
+    assert data["match_count"] == 150
+    assert data["truncated"] is True
+
+
+def test_small_result_set_is_not_marked_truncated():
+    tool = _tool()
+    raw = _many_genes("BRCA1", 3)
+
+    with patch.object(tool, "_make_api_request", return_value=raw):
+        result = tool.run({"search_query": "BRCA1"})
+
+    data = result["data"]
+    assert data["total_matches"] == 3
+    assert data["truncated"] is False
+    assert data["genes"][0]["gene_name"] == "BRCA1"

--- a/tests/unit/test_stitch_base_url_fix.py
+++ b/tests/unit/test_stitch_base_url_fix.py
@@ -1,0 +1,89 @@
+"""Regression guard for Fix-R19E-3: STITCHTool pointed at string-db.org,
+STRING's own PROTEIN-ONLY network API -- confirmed live it silently
+returned real but entirely protein-protein data (e.g. resolving "aspirin"
+returned the gene SLC17A4) with zero chemicals anywhere in the response.
+stitch.embl.de (STITCH's real domain) 301-redirects to stitch-db.org, which
+correctly resolves chemical names/CIDs to STITCH-format stringIds. The
+network/interactions sub-endpoints still 404 on the new domain even for a
+correctly-resolved identifier (confirmed live); those now give an honest
+error instead of implying the identifier itself is the problem.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.stitch_tool import STITCHTool, STITCH_BASE_URL
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(operation):
+    return STITCHTool({"name": "stitch_test", "fields": {"operation": operation}})
+
+
+def _resp(json_body=None, status_code=200):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def test_base_url_points_at_real_stitch_domain_not_string_db():
+    assert "stitch-db.org" in STITCH_BASE_URL
+    assert "string-db.org" not in STITCH_BASE_URL
+
+
+def test_resolve_identifier_hits_correct_base_url():
+    tool = _tool("resolve")
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        return _resp([{"stringId": "-1.CID100002244", "preferredName": "aspirin", "taxonName": "small molecule"}])
+
+    with patch("tooluniverse.stitch_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"identifier": "aspirin"})
+
+    assert result["status"] == "success"
+    assert captured["url"].startswith("https://stitch-db.org/api")
+    assert result["data"][0]["taxonName"] == "small molecule"
+
+
+def test_get_interactions_404_gives_honest_endpoint_unavailable_message():
+    tool = _tool("get_interactions")
+
+    with patch("tooluniverse.stitch_tool.requests.get", return_value=_resp(status_code=404)):
+        result = tool.run({"identifiers": ["aspirin"]})
+
+    assert result["status"] == "error"
+    assert "endpoint appears unavailable" in result["error"]
+    assert "not necessarily a bad identifier" in result["error"]
+
+
+def test_get_interactors_404_gives_honest_endpoint_unavailable_message():
+    tool = _tool("get_interactors")
+
+    with patch("tooluniverse.stitch_tool.requests.get", return_value=_resp(status_code=404)):
+        result = tool.run({"identifiers": ["aspirin"]})
+
+    assert result["status"] == "error"
+    assert "endpoint appears unavailable" in result["error"]
+
+
+def test_get_interactions_success_still_works():
+    tool = _tool("get_interactions")
+
+    with patch(
+        "tooluniverse.stitch_tool.requests.get",
+        return_value=_resp([{"stringId_A": "CID1", "stringId_B": "P1"}]),
+    ):
+        result = tool.run({"identifiers": ["CIDm00002244"]})
+
+    assert result["status"] == "success"
+    assert result["data"][0]["stringId_A"] == "CID1"


### PR DESCRIPTION
## Summary

Round 19 of the ongoing test-harness sweep: 5 role-play researcher personas exercised comparative/functional genomics (Ensembl), clinical variant curation (ClinGen), cancer genomics (DepMap/COSMIC/cBioPortal/Cellosaurus), tissue expression (GTEx/HPA), and drug-target pharmacology (DGIdb/DrugCentral/STITCH) — domains not previously covered. 27 findings were CLI-verified against live upstream APIs; 14 confirmed root-caused and fixed here (the rest deferred: genuine coverage gaps needing bigger redesigns, e.g. cBioPortal's clinical-attribute filter requiring a fundamentally different POST-based multi-step request pattern, or Cellosaurus's `fields` parameter needing a full short-code-to-JSON-key mapping table).

## Fixed

- **Fix-R19C-1/3** — `DepMap_search_genes`/`DepMap_search_cell_lines` scanned only the first 5 pages of a ~45,751-gene / ~2,266-model catalog (the Sanger Cell Model Passports API's `filter[gene]`/`filter[model]` params silently don't filter — confirmed live), so any gene or cell line not alphabetically very early (KRAS, EGFR, TP53, A549) was always reported "not found". Both now binary-search the full, sorted catalog. `DepMap_get_cell_line` read field names (`tissue`, `cancer_type`, `gender`, `ethnicity`, `msi_status`) that don't exist on the model resource at all — the real data lives on related sample/tissue/cancer_type/patient resources, now resolved in one request via the JSON:API `include` param. `DepMap_get_cell_lines` fixes `model_name` (cheap, no extra request) and now warns explicitly when a tissue/cancer_type filter has no effect server-side, instead of silently returning unfiltered results as if they'd been filtered.
- **Fix-R19B-1/2** — ClinGen's clinical actionability API returns a JSON table (`{"columns": [...], "rows": [[...]]}`), not a list of dicts. The gene filter's `isinstance(curations, list)` guard was always `False` against this shape — silently skipping the filter entirely in `ClinGen_get_actionability_adult`/`_pediatric` (returning all 254 unfiltered rows for BRCA1) and silently zeroing out results in `ClinGen_search_actionability` (returning nothing, even though BRCA1 has 6 real curated Adult entries).
- **Fix-R19B-3** — `ClinGen_get_variant_classifications` downloaded the entire, unpaginated ClinGen Evidence Repository (confirmed live: 28+MB, still streaming after 200s) and filtered client-side. Now requires a `gene` argument and uses a fast (~1s), already gene-filtered JSON endpoint instead.
- **Fix-R19A-1** — `Ensembl_get_cross_references` silently truncated `xrefs` to 100 while `database_summary` was computed from the full, untruncated list (confirmed live for TP53: 157 real xrefs), so the per-database counts didn't match what was actually returned. Cap raised to 500 (effectively never triggers) with an explicit `truncated` flag.
- **Fix-R19A-2** — `EnsemblArchive_get_id_history` blanket-mapped every upstream HTTP 400 to "Invalid ID format", discarding the real message — confirmed live that Ensembl returns 400 (not 404) for a syntactically valid but nonexistent ID too, with a real, more useful error in the response body.
- **Fix-R19D-1** — `HPA_search_genes_by_query` has no working server-side result limit (confirmed live: a `limit` query param has no effect) — a short, valid gene symbol like "INS" returned 8,441 loosely-matched genes. Exact gene-symbol matches now rank first and the response is capped client-side (default 50, overridable via a new `max_results` argument).
- **Fix-R19E-3** — `STITCHTool` pointed at `string-db.org`, STRING's own protein-only network API — confirmed live it silently returned real but entirely protein-protein data for chemical queries (e.g. resolving "aspirin" returned the gene SLC17A4). Repointed at STITCH's real current domain (`stitch-db.org`, reached via a 301 redirect from the historical `stitch.embl.de`), which correctly resolves chemical identifiers (aspirin → `CID100002244`). The network/interactions sub-endpoints still 404 on the new domain even for a correctly-resolved identifier (confirmed live); both now give an honest error instead of implying the identifier itself is the problem.
- **Docs fix** — two GTEx tool descriptions inaccurately claimed a "GTEx V11 (January 2026)" dataset; corrected to reflect the real default (V8, 2020) and the actual queryable `dataset_id` values (v7/v8/v10/kids_first_harmonization — no V11 exists via this API).

## Deferred (documented, not fixed)

Genuine coverage gaps or bigger-scope redesigns, not quick fixes: cBioPortal's `clinical_attribute_id` filter requires a fundamentally different POST-based `/clinical-data/fetch` request (needs a sample-ID list first, not a simple GET filter — confirmed live); Cellosaurus's `fields` sub-parameter needs a full short-code-to-JSON-key mapping table across ~60 field tags that I couldn't fully validate; Cellosaurus's `query_converter` garbling natural-language queries into malformed Solr syntax (NLP-translation bug, bigger scope); DGIdb's `get_gene_info` returning output identical to `get_gene_druggability` (upstream GraphQL query is missing fields, low-risk one-line fix candidate for a future round); a few LOW-severity documentation/consistency gaps (HPA envelope-shape inconsistency, matches the long-documented systemic issue from issue #288; ClinGen sibling-tool field-null inconsistency; COSMIC gene-level mutation ordering, not independently confirmed as a code bug).

## Test plan

- [x] 26 new mocked unit tests across 5 files covering the fixed behavior plus adjacent non-regression cases (e.g. `N#####`-style DepMap network IDs aren't affected by the binary search changes, MHC-I-equivalent regression checks aren't needed here but sibling-tool non-regression is verified for each fix, name-based lookups that already worked keep working).
- [x] Pre-existing GTEx/HPA test suites (`test_gtex_v2_variant_only.py`, `test_gtex_v2_tool.py`, `test_hpa_tool.py`) pass unchanged.
- [x] Full `tests/unit` suite (the standard CI scope) run clean — 0 failures.
- [x] `code-simplifier` pass applied — extracted a shared binary-search helper (`_find_catalog_page`) used by both `DepMap_search_genes` and `DepMap_search_cell_lines`, a shared 404-error builder for STITCH's two broken endpoints, and a shared gene-filter helper for ClinGen's two actionability methods.
- [x] All 14 fixes independently verified live against the real upstream APIs before and after the change.
