### PR TITLE
Fix Round 20: Rhea reaction participants, UniProt/Orphanet/Pharos data-completeness bugs

### DIFF
--- a/src/tooluniverse/alphafold_tool.py
+++ b/src/tooluniverse/alphafold_tool.py
@@ -123,6 +123,25 @@ class AlphaFoldRESTTool(BaseTool):
 
         return {"response": resp}
 
+    @staticmethod
+    def _response_count(data: Any) -> int:
+        """Best-effort result count across this tool's many differently-
+        shaped AlphaFold endpoints. Several (e.g. /uniprot/summary, which
+        wraps its real payload as {"uniprot_entry": ..., "structures":
+        [...]}, or /annotations, which wraps it as {..., "annotation":
+        [...]}) return a dict whose only list-valued field is the actual
+        result list -- report that list's length instead of a hardcoded 1,
+        which was always wrong for these shapes (confirmed live: P69905's
+        /uniprot/summary carries 16 structures, not the 1 the old code
+        reported)."""
+        if isinstance(data, list):
+            return len(data)
+        if isinstance(data, dict):
+            for value in data.values():
+                if isinstance(value, list):
+                    return len(value)
+        return 1
+
     def run(self, arguments: Dict[str, Any]):
         """Execute the tool with provided arguments."""
         # Normalize uniprot_id / uniprot_accession → qualifier
@@ -172,7 +191,7 @@ class AlphaFoldRESTTool(BaseTool):
                     "status": "success",
                     "data": data,
                     "metadata": {
-                        "count": len(data) if isinstance(data, list) else 1,
+                        "count": self._response_count(data),
                         "source": "AlphaFold Protein Structure DB",
                         "endpoint": url,
                         "query": arguments,

--- a/src/tooluniverse/cli.py
+++ b/src/tooluniverse/cli.py
@@ -453,6 +453,38 @@ def _render_info(d: dict) -> str:
     return "\n".join(lines)
 
 
+def _extract_detail_hint(raw_detail: Any) -> str | None:
+    """Pull a human-readable hint out of an error envelope's `detail` field.
+
+    Different tools populate `detail` inconsistently: a dict with hint/
+    message keys, or (very commonly, since many tools just pass through
+    `resp.text`) a raw response-body string that is often itself a
+    JSON-encoded object, e.g. '{"code": "404", "status": "The Uniprot code
+    p00698 does not exist in the SASBDB"}'. The default (non---json) CLI
+    output previously dropped this entirely, showing only the generic
+    top-level error string and leaving the actually-useful upstream
+    message discoverable only via --json (confirmed live for SASBDB 404s
+    and AlphaFold 400s).
+    """
+    if isinstance(raw_detail, dict):
+        return raw_detail.get("hint") or raw_detail.get("message")
+    if isinstance(raw_detail, str) and raw_detail.strip():
+        try:
+            parsed = json.loads(raw_detail)
+        except (json.JSONDecodeError, TypeError):
+            parsed = None
+        if isinstance(parsed, dict):
+            for key in ("message", "error", "status", "detail", "reason"):
+                val = parsed.get(key)
+                if isinstance(val, str) and val.strip():
+                    return val
+        # Not JSON, or no usable field inside it -- fall back to the raw
+        # string, capped so a huge HTML error page doesn't flood the
+        # terminal.
+        return raw_detail if len(raw_detail) <= 300 else raw_detail[:297] + "..."
+    return None
+
+
 def _render_run(d: dict) -> str:
     """Feature-23B-02: human-friendly renderer for `tu run` errors.
 
@@ -507,6 +539,12 @@ def _render_run(d: dict) -> str:
         )
         if hint:
             cli_steps = [*cli_steps, hint]
+        raw_detail = d.get("detail") or (
+            nested.get("detail") if isinstance(nested, dict) else None
+        )
+        detail_hint = _extract_detail_hint(raw_detail)
+        if detail_hint and detail_hint != hint:
+            cli_steps = [*cli_steps, f"Upstream detail: {detail_hint}"]
         if cli_steps:
             lines.append("Tips:")
             for step in cli_steps:

--- a/src/tooluniverse/data/expression_atlas_tools.json
+++ b/src/tooluniverse/data/expression_atlas_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "ExpressionAtlas_get_baseline",
-    "description": "Get baseline gene expression experiments from EBI Expression Atlas. Shows which tissues/cell types express a gene under normal conditions. Complements GTEx and HPA. No API key needed. Query by gene symbol or Ensembl ID.",
+    "description": "List baseline (normal-condition) expression EXPERIMENTS in EBI Expression Atlas for a species, with any experiments whose description happens to mention the queried gene sorted first. Complements GTEx and HPA. No API key needed. Caveat: this does not return actual per-gene expression values, and the 'mentions the gene' tagging is a text-search coincidence that almost never matches for baseline experiments -- for real tissue-level expression values for a specific gene, use GTEx or HPA tools instead.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -138,7 +138,7 @@
   },
   {
     "name": "ExpressionAtlas_search_differential",
-    "description": "Search for differential expression experiments from EBI Expression Atlas. Find experiments where a gene is differentially expressed in disease vs. normal, treated vs. untreated, etc. Supports disease-context expression analysis.",
+    "description": "Search for differential expression EXPERIMENTS from EBI Expression Atlas by condition text and/or a gene mentioned in the experiment description. Supports disease-context expression analysis. Caveat: `condition` does real text filtering, but `gene` is a text-search coincidence (experiment descriptions rarely name individual genes) and does not return actual per-gene differential-expression values -- treat gene-tagged results as a starting point for manual review, not a validated gene-specific result set.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -275,7 +275,7 @@
   },
   {
     "name": "ExpressionAtlas_search_experiments",
-    "description": "Search all EBI Expression Atlas experiments (baseline + differential) by gene and/or condition. Returns experiment accessions, types, descriptions, and assay counts. Use to find relevant expression datasets.",
+    "description": "Search all EBI Expression Atlas experiments (baseline + differential) by condition text and/or a gene mentioned in the experiment description. Returns experiment accessions, types, descriptions, and assay counts. Caveat: `condition` does real text filtering, but `gene` is a text-search coincidence (experiment descriptions rarely name individual genes), so a gene-only query effectively returns the unfiltered catalog -- use to find relevant expression datasets, not as a validated per-gene result set.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -413,7 +413,7 @@
   },
   {
     "name": "ExpressionAtlas_get_experiment",
-    "description": "Get detailed metadata for a specific Expression Atlas experiment by accession (e.g., E-MTAB-2836). Returns experiment design, species, technology, contrasts, PubMed references, and number of assays.",
+    "description": "Get metadata for a specific Expression Atlas experiment by accession (e.g., E-MTAB-2836): accession, type, species, and description/URLs. Caveat: the underlying GXA API does not expose per-experiment design/technology/contrasts/PubMed/assay-count data through this endpoint (confirmed live: those fields are always empty) -- for that level of detail, visit the experiment's page on https://www.ebi.ac.uk/gxa directly.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/orphanet_tools.json
+++ b/src/tooluniverse/data/orphanet_tools.json
@@ -283,9 +283,17 @@
             "orpha_code": {
               "type": "string"
             },
-            "classification": {
+            "parent": {
+              "type": ["object", "null"],
+              "description": "Preferential parent disease/category in the rare disease taxonomy tree, or null if this is a top-level category."
+            },
+            "children": {
+              "type": "array",
+              "description": "Child diseases/categories in the rare disease taxonomy tree. Empty for leaf diseases."
+            },
+            "member_of_classifications": {
               "type": "object",
-              "description": "Hierarchical classification"
+              "description": "Which named Orphanet classification systems (e.g. 'Orphanet classification of rare respiratory diseases') this disease is filed under. This is classification-system MEMBERSHIP, not the parent/child taxonomy tree -- see parent/children for that."
             }
           }
         }

--- a/src/tooluniverse/data/rhea_reaction_tools.json
+++ b/src/tooluniverse/data/rhea_reaction_tools.json
@@ -60,10 +60,22 @@
                     "type": "object",
                     "properties": {
                       "chebi_id": {
-                        "type": "string"
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "ChEBI compound id, e.g. \"CHEBI:30616\". Null for generic/polymer participants (see rhea_comp_id)."
                       },
                       "name": {
                         "type": "string"
+                      },
+                      "is_generic": {
+                        "type": "boolean",
+                        "description": "True if this participant is a generic/polymer reactive part (e.g. a protein residue like \"L-tyrosyl-[protein]\") rather than a discrete ChEBI compound."
+                      },
+                      "rhea_comp_id": {
+                        "type": "string",
+                        "description": "Rhea generic-compound id, e.g. \"RHEA-COMP:10136\". Present only when is_generic is true."
                       }
                     }
                   }
@@ -74,10 +86,22 @@
                     "type": "object",
                     "properties": {
                       "chebi_id": {
-                        "type": "string"
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "ChEBI compound id, e.g. \"CHEBI:30616\". Null for generic/polymer participants (see rhea_comp_id)."
                       },
                       "name": {
                         "type": "string"
+                      },
+                      "is_generic": {
+                        "type": "boolean",
+                        "description": "True if this participant is a generic/polymer reactive part (e.g. a protein residue like \"L-tyrosyl-[protein]\") rather than a discrete ChEBI compound."
+                      },
+                      "rhea_comp_id": {
+                        "type": "string",
+                        "description": "Rhea generic-compound id, e.g. \"RHEA-COMP:10136\". Present only when is_generic is true."
                       }
                     }
                   }
@@ -206,10 +230,22 @@
                     "type": "object",
                     "properties": {
                       "chebi_id": {
-                        "type": "string"
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "ChEBI compound id, e.g. \"CHEBI:30616\". Null for generic/polymer participants (see rhea_comp_id)."
                       },
                       "name": {
                         "type": "string"
+                      },
+                      "is_generic": {
+                        "type": "boolean",
+                        "description": "True if this participant is a generic/polymer reactive part (e.g. a protein residue like \"L-tyrosyl-[protein]\") rather than a discrete ChEBI compound."
+                      },
+                      "rhea_comp_id": {
+                        "type": "string",
+                        "description": "Rhea generic-compound id, e.g. \"RHEA-COMP:10136\". Present only when is_generic is true."
                       }
                     }
                   }
@@ -220,10 +256,22 @@
                     "type": "object",
                     "properties": {
                       "chebi_id": {
-                        "type": "string"
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "description": "ChEBI compound id, e.g. \"CHEBI:30616\". Null for generic/polymer participants (see rhea_comp_id)."
                       },
                       "name": {
                         "type": "string"
+                      },
+                      "is_generic": {
+                        "type": "boolean",
+                        "description": "True if this participant is a generic/polymer reactive part (e.g. a protein residue like \"L-tyrosyl-[protein]\") rather than a discrete ChEBI compound."
+                      },
+                      "rhea_comp_id": {
+                        "type": "string",
+                        "description": "Rhea generic-compound id, e.g. \"RHEA-COMP:10136\". Present only when is_generic is true."
                       }
                     }
                   }

--- a/src/tooluniverse/data/sasbdb_tools.json
+++ b/src/tooluniverse/data/sasbdb_tools.json
@@ -9,6 +9,10 @@
         "query": {
           "type": "string",
           "description": "Search query: UniProt accession (e.g., 'P02769' for BSA) or free-text term. Note: SASBDB has no full-text search API; UniProt accessions are resolved directly."
+        },
+        "max_results": {
+          "type": ["integer", "null"],
+          "description": "Cap on entries returned when query is free-text and falls back to listing all published SASBDB entries (~5432). Default 50."
         }
       },
       "required": ["query"]

--- a/src/tooluniverse/data/uniprot_idmapping_tools.json
+++ b/src/tooluniverse/data/uniprot_idmapping_tools.json
@@ -88,6 +88,10 @@
                     }
                   }
                 },
+                "truncated": {
+                  "type": "boolean",
+                  "description": "True if more than 500 mapped results exist and were cut off from the results array (result_count still reflects the true total)."
+                },
                 "failed_ids": {
                   "type": "array"
                 }
@@ -179,6 +183,10 @@
                       }
                     }
                   }
+                },
+                "truncated": {
+                  "type": "boolean",
+                  "description": "True if more than 500 mapped results exist and were cut off from the results array (result_count still reflects the true total)."
                 }
               }
             },
@@ -289,6 +297,10 @@
                       }
                     }
                   }
+                },
+                "truncated": {
+                  "type": "boolean",
+                  "description": "True if more than 500 mapped results exist and were cut off from the results array (result_count still reflects the true total)."
                 }
               }
             },

--- a/src/tooluniverse/expression_atlas_tool.py
+++ b/src/tooluniverse/expression_atlas_tool.py
@@ -60,6 +60,38 @@ class ExpressionAtlasTool(BaseTool):
         else:
             return {"status": "error", "error": f"Unknown operation: {operation}"}
 
+    def _gene_experiment_ids(self, gene: str) -> set:
+        """Look up experiment accessions whose EBI Search description-index
+        entry happens to mention `gene`. Confirmed live: baseline-type
+        experiment descriptions (e.g. "The Genotype-Tissue Expression
+        (GTEx) project v8") almost never contain individual gene symbols
+        (0/4561 hits for HK1, 1/4561 for TP53), so this is a best-effort
+        text-coincidence tag, not real per-gene filtering -- callers must
+        not treat a non-empty result set as "this gene's expression data."
+        """
+        gene_experiment_ids: set = set()
+        search_resp = requests.get(
+            f"{EBI_SEARCH_BASE}/atlas-experiments",
+            params={"query": gene, "size": 100, "format": "json"},
+            timeout=self.timeout,
+        )
+        if search_resp.status_code == 200:
+            for entry in search_resp.json().get("entries", []):
+                gene_experiment_ids.add(entry.get("id"))
+        return gene_experiment_ids
+
+    @staticmethod
+    def _gene_filter_warning(gene: str) -> str:
+        return (
+            f"'gene_mentioned' only reflects a text-search coincidence "
+            f"against experiment descriptions, not real per-gene "
+            f"expression values -- this API has no working way to filter "
+            f"experiments by whether they actually studied '{gene}'. The "
+            f"experiment list below is effectively the full, unfiltered "
+            f"catalog for the given species/condition constraints, not a "
+            f"gene-specific result set."
+        )
+
     def _get_baseline_expression(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """
         Get baseline expression experiments for a gene.
@@ -95,23 +127,7 @@ class ExpressionAtlasTool(BaseTool):
             ]
 
             # Step 2: Search EBI Search for gene-specific experiments
-            search_url = f"{EBI_SEARCH_BASE}/atlas-experiments"
-            search_params = {
-                "query": gene,
-                "size": 100,
-                "format": "json",
-                "fields": "description",
-            }
-            search_resp = requests.get(
-                search_url,
-                params=search_params,
-                timeout=self.timeout,
-            )
-            gene_experiment_ids = set()
-            if search_resp.status_code == 200:
-                search_data = search_resp.json()
-                for entry in search_data.get("entries", []):
-                    gene_experiment_ids.add(entry.get("id"))
+            gene_experiment_ids = self._gene_experiment_ids(gene)
 
             # Combine: tag baseline experiments that mention the gene
             results = []
@@ -147,6 +163,7 @@ class ExpressionAtlasTool(BaseTool):
                     "gene_specific_count": len(
                         [r for r in results if r["gene_mentioned"]]
                     ),
+                    "warning": self._gene_filter_warning(gene),
                 },
                 "source": ("EBI Expression Atlas - Baseline Expression"),
             }
@@ -219,21 +236,7 @@ class ExpressionAtlasTool(BaseTool):
 
             # If gene specified, cross-reference with
             # EBI Search gene-experiment matches
-            gene_exp_ids = set()
-            if gene:
-                search_url = f"{EBI_SEARCH_BASE}/atlas-experiments"
-                search_resp = requests.get(
-                    search_url,
-                    params={
-                        "query": gene,
-                        "size": 100,
-                        "format": "json",
-                    },
-                    timeout=self.timeout,
-                )
-                if search_resp.status_code == 200:
-                    for entry in search_resp.json().get("entries", []):
-                        gene_exp_ids.add(entry.get("id"))
+            gene_exp_ids = self._gene_experiment_ids(gene) if gene else set()
 
             experiments = []
             for exp in diff_exps:
@@ -259,15 +262,19 @@ class ExpressionAtlasTool(BaseTool):
                     )
                 )
 
+            result_data = {
+                "gene": gene,
+                "condition": condition,
+                "species": species,
+                "experiments": experiments[:50],
+                "experiment_count": len(experiments),
+            }
+            if gene:
+                result_data["warning"] = self._gene_filter_warning(gene)
+
             return {
                 "status": "success",
-                "data": {
-                    "gene": gene,
-                    "condition": condition,
-                    "species": species,
-                    "experiments": experiments[:50],
-                    "experiment_count": len(experiments),
-                },
+                "data": result_data,
                 "source": ("EBI Expression Atlas - Differential Expression"),
             }
 
@@ -312,21 +319,7 @@ class ExpressionAtlasTool(BaseTool):
 
         try:
             # Get gene-specific experiment IDs from EBI Search
-            gene_exp_ids = set()
-            if gene:
-                search_url = f"{EBI_SEARCH_BASE}/atlas-experiments"
-                search_resp = requests.get(
-                    search_url,
-                    params={
-                        "query": gene,
-                        "size": 100,
-                        "format": "json",
-                    },
-                    timeout=self.timeout,
-                )
-                if search_resp.status_code == 200:
-                    for entry in search_resp.json().get("entries", []):
-                        gene_exp_ids.add(entry.get("id"))
+            gene_exp_ids = self._gene_experiment_ids(gene) if gene else set()
 
             # Get full experiment catalog
             url = f"{GXA_BASE}/json/experiments"
@@ -374,16 +367,20 @@ class ExpressionAtlasTool(BaseTool):
                     )
                 )
 
+            result_data = {
+                "gene": gene,
+                "condition": condition,
+                "species": species,
+                "experiments": experiments[:50],
+                "total_count": len(experiments),
+                "gene_specific_count": len(gene_exp_ids),
+            }
+            if gene:
+                result_data["warning"] = self._gene_filter_warning(gene)
+
             return {
                 "status": "success",
-                "data": {
-                    "gene": gene,
-                    "condition": condition,
-                    "species": species,
-                    "experiments": experiments[:50],
-                    "total_count": len(experiments),
-                    "gene_specific_count": len(gene_exp_ids),
-                },
+                "data": result_data,
                 "source": "EBI Expression Atlas",
             }
 

--- a/src/tooluniverse/massive_tool.py
+++ b/src/tooluniverse/massive_tool.py
@@ -182,6 +182,20 @@ class MassIVETool(BaseTool):
             )
             resp.raise_for_status()
             return {"ok": True, "data": resp.json()}
+        except requests.exceptions.HTTPError as e:
+            # ProXI 4xx/5xx responses carry a real, more useful reason in
+            # their JSON body (confirmed live:
+            # {"code":404,"title":"Not Found","message":"No data found for
+            # the specified parameters."}) that plain str(e) discards,
+            # leaving only the generic "404 Client Error: ..." text.
+            message = None
+            if e.response is not None:
+                try:
+                    message = e.response.json().get("message")
+                except ValueError:
+                    pass
+            base = f"MassIVE API error: {e}"
+            return {"ok": False, "error": f"{base} ({message})" if message else base}
         except requests.exceptions.RequestException as e:
             return {"ok": False, "error": f"MassIVE API error: {e}"}
         except ValueError:

--- a/src/tooluniverse/orphanet_tool.py
+++ b/src/tooluniverse/orphanet_tool.py
@@ -266,6 +266,33 @@ class OrphanetTool(BaseTool):
             },
         }
 
+    def _orpha_code_exists(self, orpha_code: str) -> bool:
+        """True unless the RDcode Name endpoint definitively 404s for this
+        ORPHA code -- i.e. the code itself doesn't exist, as opposed to a
+        real disease that simply has no records for the data type being
+        requested (genes/epidemiology/classification/etc. legitimately can
+        be empty for a valid code). Network errors don't block the caller;
+        they're treated as "can't tell, proceed" so a transient
+        existence-check failure doesn't mask an otherwise-working request.
+        """
+        try:
+            response = requests.get(
+                f"{RDCODE_API_URL}/EN/ClinicalEntity/orphacode/{orpha_code}/Name",
+                timeout=self.timeout,
+                headers=get_rdcode_headers(),
+            )
+        except requests.exceptions.RequestException:
+            return True
+        return response.status_code != 404
+
+    def _orpha_not_found_error(self, orpha_code: str) -> Optional[Dict[str, Any]]:
+        """Standard "Disease not found" error payload if `orpha_code`
+        doesn't exist, else None. Callers should `return` the result when
+        it's not None."""
+        if self._orpha_code_exists(orpha_code):
+            return None
+        return {"status": "error", "error": f"Disease not found: ORPHA:{orpha_code}"}
+
     def _extract_genes_from_associations(self, associations):
         """Extract gene info dicts from DisorderGeneAssociation list."""
         genes = []
@@ -352,7 +379,10 @@ class OrphanetTool(BaseTool):
         )
 
         try:
-            # Get disease name from RDcode API
+            # Get disease name from RDcode API. This also serves as the
+            # existence check: a 404 here means orpha_code itself is
+            # invalid (not just "no genes for this disease"), so surface a
+            # clear error instead of silently returning an empty gene list.
             disease_name = ""
             try:
                 name_response = requests.get(
@@ -360,14 +390,22 @@ class OrphanetTool(BaseTool):
                     timeout=self.timeout,
                     headers=get_rdcode_headers(),
                 )
-                name_response.raise_for_status()
-                name_data = name_response.json()
-                if isinstance(name_data, dict):
-                    disease_name = name_data.get(
-                        "Preferred term", name_data.get("Name", "")
-                    )
-            except Exception:
-                pass
+            except requests.exceptions.RequestException:
+                name_response = None
+            if name_response is not None and name_response.status_code == 404:
+                return {
+                    "status": "error",
+                    "error": f"Disease not found: ORPHA:{orpha_code}",
+                }
+            if name_response is not None and name_response.status_code == 200:
+                try:
+                    name_data = name_response.json()
+                    if isinstance(name_data, dict):
+                        disease_name = name_data.get(
+                            "Preferred term", name_data.get("Name", "")
+                        )
+                except ValueError:
+                    pass
 
             subtype_sources = []
             orphadata_headers = {
@@ -434,6 +472,29 @@ class OrphanetTool(BaseTool):
         except Exception as e:
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}
 
+    def _fetch_hierarchy_relation(self, orpha_code: str, relation: str) -> Any:
+        """Fetch PreferentialParent or PreferentialChildren for an ORPHA
+        code. The API returns a plain string message (not a dict/list) for
+        "no such relation" cases (e.g. a leaf disease has no children, a
+        top-level category has no parent) on both 200 and 404 responses --
+        normalize all of those to None so callers don't have to special-
+        case string payloads."""
+        try:
+            response = requests.get(
+                f"{RDCODE_API_URL}/EN/ClinicalEntity/orphacode/{orpha_code}/{relation}",
+                timeout=self.timeout,
+                headers=get_rdcode_headers(),
+            )
+        except requests.exceptions.RequestException:
+            return None
+        if response.status_code not in (200, 404):
+            return None
+        try:
+            payload = response.json()
+        except ValueError:
+            return None
+        return payload if isinstance(payload, (dict, list)) else None
+
     def _get_classification(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """
         Get disease classification hierarchy.
@@ -455,8 +516,20 @@ class OrphanetTool(BaseTool):
         )
         lang = normalize_lang(arguments.get("lang", "en"))
 
+        not_found = self._orpha_not_found_error(orpha_code)
+        if not_found:
+            return not_found
+
         try:
             # Use RDcode API: /{lang}/ClinicalEntity/orphacode/{orphacode}/Classification
+            # This endpoint only lists which Orphanet classification SYSTEMS
+            # the disease is filed under (e.g. "Orphanet classification of
+            # rare respiratory diseases") -- it is NOT the parent/child
+            # taxonomy tree the tool's own description promises. The real
+            # hierarchy lives on two separate RDcode endpoints (confirmed
+            # live via its OpenAPI spec: PreferentialParent /
+            # PreferentialChildren), fetched here too so parent/child
+            # relationships are actually returned.
             response = requests.get(
                 f"{RDCODE_API_URL}/{lang}/ClinicalEntity/orphacode/{orpha_code}/Classification",
                 timeout=self.timeout,
@@ -465,11 +538,18 @@ class OrphanetTool(BaseTool):
             response.raise_for_status()
             data = response.json()
 
+            parent = self._fetch_hierarchy_relation(orpha_code, "PreferentialParent")
+            children = self._fetch_hierarchy_relation(
+                orpha_code, "PreferentialChildren"
+            )
+
             return {
                 "status": "success",
                 "data": {
                     "orpha_code": orpha_code,
-                    "classification": data,
+                    "parent": parent,
+                    "children": children if isinstance(children, list) else [],
+                    "member_of_classifications": data,
                 },
                 "metadata": {
                     "source": "Orphanet RDcode API",
@@ -481,7 +561,12 @@ class OrphanetTool(BaseTool):
             if e.response.status_code == 404:
                 return {
                     "status": "success",
-                    "data": {"orpha_code": orpha_code, "classification": []},
+                    "data": {
+                        "orpha_code": orpha_code,
+                        "parent": None,
+                        "children": [],
+                        "member_of_classifications": [],
+                    },
                     "metadata": {"note": "No classification found"},
                 }
             return {"status": "error", "error": f"HTTP error: {e.response.status_code}"}
@@ -674,6 +759,10 @@ class OrphanetTool(BaseTool):
             str(orpha_code).replace("ORPHA:", "").replace("Orphanet:", "").strip()
         )
 
+        not_found = self._orpha_not_found_error(orpha_code)
+        if not_found:
+            return not_found
+
         try:
             response = requests.get(
                 f"{ORPHADATA_API_URL}/rd-epidemiology/orphacodes/{orpha_code}",
@@ -753,6 +842,10 @@ class OrphanetTool(BaseTool):
         orpha_code = (
             str(orpha_code).replace("ORPHA:", "").replace("Orphanet:", "").strip()
         )
+
+        not_found = self._orpha_not_found_error(orpha_code)
+        if not_found:
+            return not_found
 
         try:
             response = requests.get(
@@ -985,6 +1078,10 @@ class OrphanetTool(BaseTool):
                 "status": "error",
                 "error": f"Unknown coding_system: {coding_system}. Supported: all, icd10, icd11, omim, snomed",
             }
+
+        not_found = self._orpha_not_found_error(orpha_code)
+        if not_found:
+            return not_found
 
         for system in systems_to_query:
             try:

--- a/src/tooluniverse/pharos_tool.py
+++ b/src/tooluniverse/pharos_tool.py
@@ -173,14 +173,21 @@ class PharosTool(BaseTool):
         """
         query_term = arguments.get("query")
         top = arguments.get("top", 10)
+        tdl = arguments.get("tdl")
 
         if not query_term:
             return {"status": "error", "error": "query parameter is required"}
 
-        # Simple term-based search
+        # Simple term-based search. Pharos' IFilter input has no direct
+        # "tdl" scalar field -- TDL filtering is expressed through its
+        # generic facets mechanism instead (confirmed live via GraphQL
+        # introspection: IFilter.facets: [IFilterFacet], and the "Target
+        # Development Level" facet on the targets query returns exactly
+        # Tclin/Tchem/Tbio/Tdark). Passing tdl straight into the filter
+        # object (or ignoring it, as before) both silently fail to filter.
         query = """
-        query SearchTargets($term: String!, $top: Int!) {
-            targets(filter: {term: $term}, top: $top) {
+        query SearchTargets($term: String!, $top: Int!, $facets: [IFilterFacet!]) {
+            targets(filter: {term: $term, facets: $facets}, top: $top) {
                 count
                 targets {
                     name
@@ -195,9 +202,13 @@ class PharosTool(BaseTool):
         }
         """
 
+        facets = (
+            [{"facet": "Target Development Level", "values": [tdl]}] if tdl else None
+        )
         variables = {
             "term": query_term,
             "top": min(top, 100),  # Cap at 100
+            "facets": facets,
         }
 
         result = self._execute_graphql(query, variables)
@@ -221,17 +232,37 @@ class PharosTool(BaseTool):
         - Tbio: Targets with biological annotations
         - Tdark: Understudied targets with minimal information
         """
-        # Return a static description since aggregation queries are slow
-        # We can query individual TDL counts if needed
+        # An unfiltered targets query's own facet breakdown gives exact,
+        # whole-proteome TDL counts in a single request (confirmed live:
+        # {Tbio: 12303, Tdark: 5501, Tchem: 1904, Tclin: 704}). Pharos'
+        # IFilter has no way to request only the "Target Development
+        # Level" facet, so a minimal top:1 targets query is used purely to
+        # reach its facets field -- the single returned target itself is
+        # discarded.
         query = """
         query {
             dbVersion
+            targets(top: 1) {
+                facets {
+                    facet
+                    values { name value }
+                }
+            }
         }
         """
 
         result = self._execute_graphql(query)
 
         if result["status"] == "success":
+            counts = {"Tclin": 0, "Tchem": 0, "Tbio": 0, "Tdark": 0}
+            facets = result["data"].get("targets", {}).get("facets", [])
+            for facet in facets:
+                if facet.get("facet") == "Target Development Level":
+                    for v in facet.get("values", []):
+                        if v.get("name") in counts:
+                            counts[v["name"]] = v.get("value", 0)
+                    break
+
             result["data"] = {
                 "tdl_levels": ["Tclin", "Tchem", "Tbio", "Tdark"],
                 "description": {
@@ -240,8 +271,9 @@ class PharosTool(BaseTool):
                     "Tbio": "Targets with GO annotations, OMIM phenotypes, or publications",
                     "Tdark": "Understudied targets with minimal information",
                 },
+                "counts": counts,
+                "total_targets": sum(counts.values()),
                 "db_version": result["data"].get("dbVersion"),
-                "note": "For target counts by TDL, use search_targets with specific TDL filter or visit https://pharos.nih.gov",
             }
 
         return result

--- a/src/tooluniverse/rhea_reaction_tool.py
+++ b/src/tooluniverse/rhea_reaction_tool.py
@@ -35,8 +35,15 @@ from .tool_registry import register_tool
 RHEA_BASE_URL = "https://www.rhea-db.org/rhea"
 
 # Pull "<a data-molid="chebi:25858">1,7-dimethylxanthine</a>" out of htmlequation.
+# Generic/polymer participants (e.g. protein-linked residues consumed or
+# produced by the reaction, like "L-tyrosyl-[protein]") aren't real ChEBI
+# compounds -- Rhea gives them a "rhea-comp:" id instead of a "chebi:" one.
+# Both namespaces must be matched or those participants are silently dropped
+# even though they appear in the plain-text `equation` string (confirmed
+# live for RHEA:10596, whose htmlequation carries "rhea-comp:10136" and
+# "rhea-comp:20101" for its two protein-residue participants).
 _PARTICIPANT_RE = re.compile(
-    r'data-molid="chebi:(?P<chebi>\d+)"[^>]*>(?P<name>.*?)</a>',
+    r'data-molid="(?P<ns>chebi|rhea-comp):(?P<molid>\d+)"[^>]*>(?P<name>.*?)</a>',
     re.IGNORECASE | re.DOTALL,
 )
 # Strip residual inline HTML tags (<i>, <small>, <sup>, <sub>) from names.
@@ -119,12 +126,15 @@ class RheaReactionTool(BaseTool):
 
         for side_html, bucket in ((left, reactants), (right, products)):
             for m in _PARTICIPANT_RE.finditer(side_html):
-                bucket.append(
-                    {
-                        "chebi_id": f"CHEBI:{m.group('chebi')}",
-                        "name": self._clean_name(m.group("name")),
-                    }
-                )
+                is_generic = m.group("ns").lower() == "rhea-comp"
+                participant = {
+                    "chebi_id": None if is_generic else f"CHEBI:{m.group('molid')}",
+                    "name": self._clean_name(m.group("name")),
+                    "is_generic": is_generic,
+                }
+                if is_generic:
+                    participant["rhea_comp_id"] = f"RHEA-COMP:{m.group('molid')}"
+                bucket.append(participant)
         return {"reactants": reactants, "products": products}
 
     @staticmethod

--- a/src/tooluniverse/sasbdb_tool.py
+++ b/src/tooluniverse/sasbdb_tool.py
@@ -86,12 +86,22 @@ class SASBDBTextSearchTool(BaseTool):
                     "error": f"SASBDB API error: HTTP {resp.status_code}",
                 }
             entries = resp.json()
+            # This "list everything" fallback previously returned all
+            # ~5432 entries unbounded (~350KB) with no way to cap it --
+            # confirmed live. Apply the same client-side cap pattern used
+            # elsewhere in the project (e.g. HPA_search_genes_by_query).
+            max_results = arguments.get("max_results") or 50
+            total = len(entries)
+            truncated_entries = entries[:max_results]
             return {
                 "status": "success",
-                "data": entries,
+                "data": truncated_entries,
+                "total_entries": total,
+                "truncated": total > len(truncated_entries),
                 "note": (
                     f"SASBDB does not support free-text search. "
-                    f"Returned all {len(entries)} published entries. "
+                    f"Returned {len(truncated_entries)} of {total} published entries "
+                    f"(pass max_results to change the cap). "
                     f"To search by protein, provide a UniProt accession (e.g., 'P02769' for BSA). "
                     f"Use SASBDB_get_entry with a specific code (e.g., 'SASDCZ9') for details."
                 ),

--- a/src/tooluniverse/uniprot_idmapping_tool.py
+++ b/src/tooluniverse/uniprot_idmapping_tool.py
@@ -109,7 +109,15 @@ class UniProtIDMappingTool(BaseTool):
                 "error": "Failed to get job ID from UniProt ID Mapping",
             }
 
-        # Poll for completion (max 60 seconds)
+        # Poll for completion (max 60 seconds). The status endpoint sometimes
+        # 303-redirects straight into a results page instead of ever
+        # reporting jobStatus=="FINISHED" -- that redirected page uses its
+        # own default page size (25), not the size=500 this tool needs, so
+        # treat its presence as "job done" and always re-fetch the full,
+        # paginated result set via _fetch_all_results() below rather than
+        # returning that first small page directly. Confirmed live:
+        # P00533 -> PDB has 354 real mappings, but the redirected status
+        # response only ever carries the first 25 of them.
         max_polls = 20
         for _ in range(max_polls):
             status_resp = requests.get(
@@ -118,11 +126,8 @@ class UniProtIDMappingTool(BaseTool):
             )
             status_data = status_resp.json()
 
-            if status_data.get("jobStatus") == "FINISHED":
+            if status_data.get("jobStatus") == "FINISHED" or "results" in status_data:
                 break
-            if "results" in status_data:
-                # Some responses include results directly
-                return {"results": status_data["results"], "job_id": job_id}
             if status_data.get("jobStatus") == "ERROR":
                 msg = status_data.get("errorMessage", "Unknown error")
                 return {
@@ -137,22 +142,46 @@ class UniProtIDMappingTool(BaseTool):
                 "error": "UniProt ID mapping job did not complete within timeout",
             }
 
-        # Get results
-        results_resp = requests.get(
-            f"{UNIPROT_BASE_URL}/idmapping/results/{job_id}",
-            params={"size": 500},
-            timeout=self.timeout,
-        )
-        results_resp.raise_for_status()
-        results_data = results_resp.json()
-
-        # Feature-68B-003: extract failedIds so callers can detect unmapped input IDs
+        results, failed_ids = self._fetch_all_results(job_id)
         return {
             "status": "success",
-            "results": results_data.get("results", []),
+            "results": results,
             "job_id": job_id,
-            "failed_ids": results_data.get("failedIds", []),
+            "failed_ids": failed_ids,
         }
+
+    def _fetch_all_results(self, job_id: str, max_pages: int = 20):
+        """Fetch every page of a completed mapping job's results, following
+        the Link header's rel="next" URL so large result sets (e.g. a
+        heavily-studied protein with hundreds of PDB structures) aren't
+        silently truncated to a single page."""
+        results = []
+        failed_ids = []
+        url = f"{UNIPROT_BASE_URL}/idmapping/results/{job_id}"
+        params = {"size": 500}
+        for _ in range(max_pages):
+            resp = requests.get(url, params=params, timeout=self.timeout)
+            resp.raise_for_status()
+            page = resp.json()
+            results.extend(page.get("results", []))
+            failed_ids.extend(page.get("failedIds", []))
+
+            next_url = self._parse_next_link(resp.headers.get("Link"))
+            if not next_url:
+                break
+            url, params = next_url, None
+        return results, failed_ids
+
+    @staticmethod
+    def _parse_next_link(link_header):
+        """Extract the rel="next" URL from an RFC 5988 Link header."""
+        if not link_header:
+            return None
+        for part in link_header.split(","):
+            segments = part.split(";")
+            if len(segments) >= 2 and 'rel="next"' in segments[1]:
+                return segments[0].strip().strip("<>")
+        return None
 
     def _convert(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Generic ID conversion between any supported databases."""
@@ -194,6 +223,7 @@ class UniProtIDMappingTool(BaseTool):
                 "to_db": to_db,
                 "result_count": len(parsed),
                 "results": parsed[:500],
+                "truncated": len(parsed) > 500,
                 "failed_ids": result.get("failed_ids", []),
             },
             "metadata": {
@@ -228,6 +258,7 @@ class UniProtIDMappingTool(BaseTool):
                 "query_ids": uniprot_ids,
                 "result_count": len(parsed),
                 "results": parsed[:500],
+                "truncated": len(parsed) > 500,
             },
             "metadata": {
                 "source": "UniProt ID Mapping Service",
@@ -268,6 +299,7 @@ class UniProtIDMappingTool(BaseTool):
                 "species_taxid": tax_id,
                 "result_count": len(parsed),
                 "results": parsed[:500],
+                "truncated": len(parsed) > 500,
             },
             "metadata": {
                 "source": "UniProt ID Mapping Service",

--- a/src/tooluniverse/uniprot_tool.py
+++ b/src/tooluniverse/uniprot_tool.py
@@ -591,8 +591,28 @@ class UniProtRESTTool(BaseTool):
                 "retryable": True,
             }
 
-        # If extract_path is configured, extract the corresponding subset
+        # If extract_path is configured, extract the corresponding subset.
+        # Inactive/deleted entries (confirmed live for Q9ZZZ9: entryType
+        # "Inactive") carry none of the normal fields a JSONPath extractor
+        # looks for, which previously surfaced as a confusing raw
+        # "No data found for JSONPath: ..." error instead of explaining
+        # *why* -- give the same clear reason _compact_entry already does.
         if self.extract_path:
+            if str(data.get("entryType", "")).lower().startswith("inactive"):
+                reason = data.get("inactiveReason", {}) or {}
+                detail = (
+                    reason.get("deletedReason")
+                    or reason.get("mergeDemergeTo", [None])[0]
+                )
+                reason_type = reason.get("inactiveReasonType", "unknown reason")
+                reason_text = f"{reason_type}: {detail}" if detail else reason_type
+                return {
+                    "status": "error",
+                    "error": (
+                        f"UniProt entry {arguments.get('accession', '')} is "
+                        f"inactive/deleted ({reason_text})."
+                    ),
+                }
             result = self._extract_data(data, self.extract_path)
 
             # Handle empty results

--- a/tests/tools/test_pharos_tool.py
+++ b/tests/tools/test_pharos_tool.py
@@ -87,12 +87,13 @@ class TestPharosToolDirect:
         config = tool_config["Pharos_search_targets"]
         tool = PharosTool(config)
         result = tool.run({"query": "GPCR", "tdl": "Tdark", "top": 5})
-        
+
         assert result["status"] == "success"
-        # Results should be Tdark targets
+        # Fix-R20E-2: the tdl filter is applied via Pharos' facets
+        # mechanism; every returned target must actually be Tdark.
+        assert len(result["data"]["targets"]) > 0
         for target in result["data"]["targets"]:
-            if "idgTDL" in target:
-                assert target["idgTDL"] == "Tdark"
+            assert target["tdl"] == "Tdark"
 
     def test_search_targets_missing_query(self, tool_config):
         """Test error when query is missing."""
@@ -121,6 +122,11 @@ class TestPharosToolDirect:
         assert "Tchem" in result["data"]["tdl_levels"]
         assert "Tbio" in result["data"]["tdl_levels"]
         assert "Tdark" in result["data"]["tdl_levels"]
+        # Fix-R20E-3: the tool's own description promises real counts by
+        # TDL -- verify they're actually populated, not just static labels.
+        counts = result["data"]["counts"]
+        assert all(counts[level] > 0 for level in result["data"]["tdl_levels"])
+        assert result["data"]["total_targets"] == sum(counts.values())
 
     def test_get_disease_targets(self, tool_config):
         """Test getting targets for a disease."""

--- a/tests/tools/test_tu_cli.py
+++ b/tests/tools/test_tu_cli.py
@@ -1895,6 +1895,88 @@ class TestRenderFunctions:
         out = _render_run({"status": "error", "data": {"error": "HTTP Error: 500"}})
         assert "Tips:" not in out
 
+    @pytest.mark.unit
+    def test_render_run_surfaces_json_string_detail_as_tip(self):
+        """Fix-R20B-2: many tools set detail to a raw (often JSON-encoded)
+        response-body string rather than a dict -- confirmed live for
+        SASBDB 404s. The useful nested message must reach default output,
+        not just --json."""
+        from tooluniverse.cli import _render_run
+
+        out = _render_run(
+            {
+                "status": "error",
+                "error": "SASBDB API error",
+                "detail": '{"code": "404", "status": "The Uniprot code p00698 does not exist in the SASBDB"}',
+            }
+        )
+        assert "Tips:" in out
+        assert "The Uniprot code p00698 does not exist in the SASBDB" in out
+
+    @pytest.mark.unit
+    def test_render_run_surfaces_json_string_detail_error_key(self):
+        """A JSON-string detail using an "error" key (not "status") is also
+        extracted -- confirmed live for AlphaFold 400s."""
+        from tooluniverse.cli import _render_run
+
+        out = _render_run(
+            {
+                "status": "error",
+                "error": "AlphaFold API returned 400",
+                "detail": '{"error":"Invalid identifier format. Please use a UniProt accession."}',
+            }
+        )
+        assert "Tips:" in out
+        assert "Invalid identifier format" in out
+
+    @pytest.mark.unit
+    def test_render_run_non_json_string_detail_shown_raw(self):
+        """A plain-text (non-JSON) detail string still surfaces as-is
+        rather than being silently dropped."""
+        from tooluniverse.cli import _render_run
+
+        out = _render_run(
+            {
+                "status": "error",
+                "error": "Upstream error",
+                "detail": "Service temporarily unavailable, try again later",
+            }
+        )
+        assert "Tips:" in out
+        assert "Service temporarily unavailable, try again later" in out
+
+    @pytest.mark.unit
+    def test_render_run_dict_detail_hint_still_works(self):
+        """A dict-shaped detail with a hint/message key is still handled
+        (pre-existing shape, not a regression)."""
+        from tooluniverse.cli import _render_run
+
+        out = _render_run(
+            {
+                "status": "error",
+                "error": "boom",
+                "detail": {"message": "Retry with a smaller page size."},
+            }
+        )
+        assert "Tips:" in out
+        assert "Retry with a smaller page size." in out
+
+    @pytest.mark.unit
+    def test_render_run_no_duplicate_when_detail_matches_hint(self):
+        """If detail's extracted hint is identical to an existing hint,
+        it isn't repeated as a second, redundant Tips line."""
+        from tooluniverse.cli import _render_run
+
+        out = _render_run(
+            {
+                "status": "error",
+                "error": "boom",
+                "hint": "Do the thing.",
+                "detail": {"hint": "Do the thing."},
+            }
+        )
+        assert out.count("Do the thing.") == 1
+
 
 class TestResolveCategories:
     """Tests for _resolve_categories — case-insensitive category name mapping.

--- a/tests/unit/test_alphafold_response_count.py
+++ b/tests/unit/test_alphafold_response_count.py
@@ -1,0 +1,97 @@
+"""Regression guard for Fix-R20B-1: AlphaFoldRESTTool's metadata.count was
+hardcoded to 1 whenever the raw API response was a dict, since the
+computation only checked `len(data) if isinstance(data, list) else 1`.
+Several AlphaFold endpoints legitimately return a dict wrapping the real
+result list (e.g. /uniprot/summary/{qualifier}.json returns
+{"uniprot_entry": {...}, "structures": [...]} -- AlphaFold DB now serves
+proteome-wide complex predictions, so a single query can have many
+structures), so metadata.count was silently wrong for those endpoints
+while the actual data (data.structures) was correct all along.
+
+Confirmed live for P69905 (hemoglobin subunit alpha): 16 real structures
+in data.structures, but metadata.count reported 1. Fixed by scanning a
+dict response for its first list-valued field and reporting that list's
+length instead.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.alphafold_tool import AlphaFoldRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(endpoint):
+    return AlphaFoldRESTTool(
+        {
+            "name": "alphafold_test",
+            "fields": {"endpoint": endpoint},
+            "parameter": {"required": ["qualifier"]},
+        }
+    )
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = json_body
+    return r
+
+
+def test_dict_response_with_nested_list_reports_real_count():
+    tool = _tool("/uniprot/summary/{qualifier}.json")
+    payload = {
+        "uniprot_entry": {"ac": "P69905"},
+        "structures": [{"summary": {"model_identifier": f"model{i}"}} for i in range(16)],
+    }
+
+    with patch("tooluniverse.alphafold_tool.requests.get", return_value=_resp(payload)):
+        result = tool.run({"qualifier": "P69905"})
+
+    assert result["status"] == "success"
+    assert result["metadata"]["count"] == 16
+    assert len(result["data"]["structures"]) == 16
+
+
+def test_top_level_list_response_unaffected():
+    tool = _tool("/prediction/{qualifier}")
+    payload = [{"entryId": "AF-P61626-F1", "confidenceScore": 94.06}]
+
+    with patch("tooluniverse.alphafold_tool.requests.get", return_value=_resp(payload)):
+        result = tool.run({"qualifier": "P61626"})
+
+    assert result["status"] == "success"
+    assert result["metadata"]["count"] == 1
+
+
+def test_dict_response_with_scalar_fields_only_falls_back_to_one():
+    tool = _tool("/uniprot/summary/{qualifier}.json")
+    payload = {"uniprot_entry": {"ac": "X"}, "note": "no list field here"}
+
+    with patch("tooluniverse.alphafold_tool.requests.get", return_value=_resp(payload)):
+        result = tool.run({"qualifier": "X"})
+
+    assert result["status"] == "success"
+    assert result["metadata"]["count"] == 1
+
+
+def test_annotations_endpoint_dict_with_list_field():
+    tool = _tool("/annotations/{qualifier}.json")
+    payload = {
+        "accession": "P69905",
+        "id": "HBA_HUMAN",
+        "sequence": "MVLSPADKTN",
+        "annotation": [{"start": 10, "end": 10, "description": "mutagenesis"}],
+    }
+
+    with patch("tooluniverse.alphafold_tool.requests.get", return_value=_resp(payload)):
+        result = tool.run({"qualifier": "P69905"})
+
+    assert result["status"] == "success"
+    assert result["metadata"]["count"] == 1

--- a/tests/unit/test_expression_atlas_gene_filter_warning.py
+++ b/tests/unit/test_expression_atlas_gene_filter_warning.py
@@ -1,0 +1,148 @@
+"""Regression guard for Fix-R20C-1/2: ExpressionAtlasTool's `gene`
+parameter across get_baseline_expression, search_differential_experiments,
+and search_experiments silently had no real filtering effect.
+
+Confirmed live: querying the same species/condition with a real,
+well-characterized gene (HK1, TP53) and a nonsense gene string
+("NOTAREALGENEXYZ123") returned byte-identical result sets (same
+total_baseline=123, same top experiments, gene_mentioned=false /
+gene_specific_count=0 for both). Root cause: "gene_mentioned" tagging
+relies on a literal-text match against EBI Search's atlas-experiments
+description index, which almost never contains individual gene symbols in
+generic baseline/differential dataset descriptions (confirmed live: 0/4561
+hits for HK1, 1/4561 for TP53). The tool never fetches actual per-gene
+expression values, so it structurally cannot filter by gene -- this is a
+genuine upstream/architectural limitation, not something fixable with a
+different query parameter (confirmed: GXA's /json/experiments endpoint's
+own geneQuery param is also silently ignored server-side).
+
+Rather than silently return the unfiltered catalog as if it were
+gene-specific (the original bug), every gene-querying response now
+includes an explicit `warning` field naming this limitation -- matching
+the project's established "honest warning over silent wrong data" pattern
+used for DepMap's ignored tissue/cancer_type filter in round 19.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.expression_atlas_tool import ExpressionAtlasTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(operation):
+    return ExpressionAtlasTool({"name": "gxa_test", "fields": {"operation": operation}})
+
+
+def _resp(json_body, status_code=200):
+    r = MagicMock()
+    r.status_code = status_code
+    r.raise_for_status = MagicMock()
+    r.json.return_value = json_body
+    return r
+
+
+_EXPERIMENTS = {
+    "experiments": [
+        {
+            "experimentAccession": "E-GTEX-8",
+            "rawExperimentType": "RNASEQ_MRNA_BASELINE",
+            "experimentDescription": "The Genotype-Tissue Expression (GTEx) project v8",
+            "species": "homo sapiens",
+            "numberOfAssays": 17382,
+            "lastUpdate": "2020-01-01",
+        }
+    ]
+}
+
+
+def _no_ebi_search_hits(url, params=None, **kwargs):
+    if "ebisearch" in url:
+        return _resp({"entries": []})
+    return _resp(_EXPERIMENTS)
+
+
+def test_get_baseline_gene_and_nonsense_gene_return_same_catalog_but_gene_warns():
+    tool = _tool("get_baseline_expression")
+
+    with patch(
+        "tooluniverse.expression_atlas_tool.requests.get", side_effect=_no_ebi_search_hits
+    ):
+        real_gene = tool.run({"gene": "HK1", "species": "homo sapiens"})
+        nonsense_gene = tool.run(
+            {"gene": "NOTAREALGENEXYZ123", "species": "homo sapiens"}
+        )
+
+    assert real_gene["status"] == "success"
+    assert real_gene["data"]["total_baseline"] == nonsense_gene["data"]["total_baseline"]
+    assert "warning" in real_gene["data"]
+    assert "text-search coincidence" in real_gene["data"]["warning"]
+    assert "HK1" in real_gene["data"]["warning"]
+
+
+def test_search_differential_gene_query_warns_but_condition_only_does_not():
+    tool = _tool("search_differential_experiments")
+    diff_experiments = {
+        "experiments": [
+            {
+                "experimentAccession": "E-MTAB-1",
+                "rawExperimentType": "RNASEQ_MRNA_DIFFERENTIAL",
+                "experimentDescription": "cancer vs normal study",
+                "species": "homo sapiens",
+                "numberOfAssays": 20,
+                "experimentalFactors": ["disease"],
+            }
+        ]
+    }
+
+    def fake_get(url, params=None, **kwargs):
+        if "ebisearch" in url:
+            return _resp({"entries": []})
+        return _resp(diff_experiments)
+
+    with patch(
+        "tooluniverse.expression_atlas_tool.requests.get", side_effect=fake_get
+    ):
+        with_gene = tool.run({"gene": "HK1", "condition": "cancer"})
+        condition_only = tool.run({"condition": "cancer"})
+
+    assert "warning" in with_gene["data"]
+    assert "warning" not in condition_only["data"]
+    # Condition text filtering genuinely works and is unaffected.
+    assert with_gene["data"]["experiment_count"] == 1
+    assert condition_only["data"]["experiment_count"] == 1
+
+
+def test_search_experiments_gene_only_query_warns():
+    tool = _tool("search_experiments")
+
+    with patch(
+        "tooluniverse.expression_atlas_tool.requests.get", side_effect=_no_ebi_search_hits
+    ):
+        result = tool.run({"gene": "HK1"})
+
+    assert result["status"] == "success"
+    assert "warning" in result["data"]
+    assert result["data"]["gene_specific_count"] == 0
+
+
+def test_gene_experiment_ids_helper_deduplicates_three_call_sites():
+    """The three operations now share one EBI Search helper instead of
+    duplicating the request/parsing logic three times."""
+    tool = _tool("get_baseline_expression")
+    assert hasattr(tool, "_gene_experiment_ids")
+
+    with patch(
+        "tooluniverse.expression_atlas_tool.requests.get",
+        return_value=_resp({"entries": [{"id": "E-GTEX-8"}]}),
+    ) as mock_get:
+        ids = tool._gene_experiment_ids("HK1")
+
+    assert ids == {"E-GTEX-8"}
+    mock_get.assert_called_once()

--- a/tests/unit/test_massive_error_detail.py
+++ b/tests/unit/test_massive_error_detail.py
@@ -1,0 +1,83 @@
+"""Regression guard for Fix-R20C-4: MassIVETool's ProXI error handler
+discarded the upstream API's own JSON error body, showing only requests'
+generic "404 Client Error: ..." string.
+
+Confirmed live for MassIVE_get_protein_identifications with a sparse/
+missing human protein accession: the real ProXI 404 body is
+{"code":404,"title":"Not Found","message":"No data found for the
+specified parameters."}, but the tool's error message dropped the
+"message" field entirely. Fixed by parsing the HTTPError response body
+and appending its "message" field when present.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.massive_tool import MassIVETool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return MassIVETool(
+        {"name": "massive_test", "fields": {"operation": "get_protein_identifications"}}
+    )
+
+
+def _http_error_resp(status_code, json_body):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body
+    err = requests.exceptions.HTTPError(response=r)
+    r.raise_for_status = MagicMock(side_effect=err)
+    return r
+
+
+def test_404_error_includes_upstream_message():
+    tool = _tool()
+    resp = _http_error_resp(
+        404, {"code": 404, "title": "Not Found", "message": "No data found for the specified parameters."}
+    )
+
+    with patch("tooluniverse.massive_tool.requests.get", return_value=resp):
+        result = tool.run({"protein_accession": "HXK1_HUMAN"})
+
+    assert result["status"] == "error"
+    assert "No data found for the specified parameters." in result["error"]
+
+
+def test_error_without_json_body_falls_back_gracefully():
+    tool = _tool()
+    r = MagicMock()
+    r.status_code = 500
+    r.json.side_effect = ValueError("not json")
+    err = requests.exceptions.HTTPError(response=r)
+    r.raise_for_status = MagicMock(side_effect=err)
+
+    with patch("tooluniverse.massive_tool.requests.get", return_value=r):
+        result = tool.run({"protein_accession": "HXK1_HUMAN"})
+
+    assert result["status"] == "error"
+    assert "MassIVE API error" in result["error"]
+
+
+def test_success_case_unaffected():
+    tool = _tool()
+    r = MagicMock()
+    r.status_code = 200
+    r.raise_for_status = MagicMock()
+    r.json.return_value = [
+        {"proteinAccession": "A2M_MOUSE", "countPSM": 146131, "countPeptides": 106}
+    ]
+
+    with patch("tooluniverse.massive_tool.requests.get", return_value=r):
+        result = tool.run({"protein_accession": "A2M_MOUSE"})
+
+    assert result["status"] == "success"
+    assert result["data"]["protein_accession"] == "A2M_MOUSE"

--- a/tests/unit/test_orphanet_classification_hierarchy.py
+++ b/tests/unit/test_orphanet_classification_hierarchy.py
@@ -1,0 +1,139 @@
+"""Regression guard for Fix-R20D-2: Orphanet_get_classification's own
+description promises "parent and child disease categories showing where a
+disease fits in the rare disease taxonomy," but the implementation only
+ever called the RDcode Classification endpoint, which returns a flat list
+of named classification SYSTEMS the disease is filed under (e.g. "Orphanet
+classification of rare respiratory diseases") -- membership, not a
+parent/child tree.
+
+Confirmed live via the RDcode API's own OpenAPI spec that a real hierarchy
+exists on two separate endpoints: PreferentialParent and
+PreferentialChildren (e.g. Cystic fibrosis's preferential parent is "Rare
+respiratory disease", and that parent has 82 real preferential children).
+Fixed by fetching both alongside the existing classification-systems list,
+which is kept (renamed to member_of_classifications for clarity) rather
+than dropped.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.orphanet_tool import OrphanetTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return OrphanetTool({"name": "orphanet_test"})
+
+
+def _resp(status_code, json_body=None, is_string_body=False):
+    r = MagicMock()
+    r.status_code = status_code
+    if is_string_body:
+        r.json.return_value = json_body
+    else:
+        r.json.return_value = json_body or {}
+    if status_code >= 400:
+        import requests
+
+        r.raise_for_status = MagicMock(
+            side_effect=requests.exceptions.HTTPError(response=r)
+        )
+    else:
+        r.raise_for_status = MagicMock()
+    return r
+
+
+_MEMBERSHIP = {
+    "ORPHAcode": 586,
+    "Preferred term": "Cystic fibrosis",
+    "Classification": [
+        {
+            "ID of the classification": 184,
+            "Name of the classification": "Orphanet classification of rare respiratory diseases",
+        }
+    ],
+}
+
+_PARENT = {
+    "ORPHAcode": 586,
+    "Preferred term": "Cystic fibrosis",
+    "Preferential parent": {"ORPHAcode": 97955, "Preferred term": "Rare respiratory disease"},
+}
+
+
+def test_leaf_disease_has_real_parent_and_empty_children():
+    tool = _tool()
+
+    def fake_get(url, **kwargs):
+        if url.endswith("/orphacode/586/Name"):
+            return _resp(200, {"Preferred term": "Cystic fibrosis"})
+        if url.endswith("/orphacode/586/Classification"):
+            return _resp(200, _MEMBERSHIP)
+        if url.endswith("/orphacode/586/PreferentialParent"):
+            return _resp(200, _PARENT)
+        if url.endswith("/orphacode/586/PreferentialChildren"):
+            # The API returns a plain string (not JSON dict/list) for
+            # "no such relation" -- confirmed live for a leaf disease.
+            return _resp(
+                200,
+                "Clinical entity does not exist or is not a preferential parent.",
+                is_string_body=True,
+            )
+        raise AssertionError(f"unexpected URL {url}")
+
+    with patch("tooluniverse.orphanet_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"operation": "get_classification", "orpha_code": "586"})
+
+    assert result["status"] == "success"
+    assert result["data"]["parent"]["Preferential parent"]["Preferred term"] == (
+        "Rare respiratory disease"
+    )
+    assert result["data"]["children"] == []
+    assert "member_of_classifications" in result["data"]
+
+
+def test_top_level_category_has_no_parent_but_has_children():
+    tool = _tool()
+    children_payload = [
+        {"ORPHAcode": 586, "Preferred term": "Cystic fibrosis"},
+        {"ORPHAcode": 60, "Preferred term": "Alpha-1-antitrypsin deficiency"},
+    ]
+
+    def fake_get(url, **kwargs):
+        if url.endswith("/orphacode/97955/Name"):
+            return _resp(200, {"Preferred term": "Rare respiratory disease"})
+        if url.endswith("/orphacode/97955/Classification"):
+            return _resp(200, {"Classification": []})
+        if url.endswith("/orphacode/97955/PreferentialParent"):
+            # 404 with a plain string body for "no parent" -- confirmed
+            # live for a root-level category.
+            return _resp(404, "Query not found", is_string_body=True)
+        if url.endswith("/orphacode/97955/PreferentialChildren"):
+            return _resp(200, children_payload)
+        raise AssertionError(f"unexpected URL {url}")
+
+    with patch("tooluniverse.orphanet_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"operation": "get_classification", "orpha_code": "97955"})
+
+    assert result["status"] == "success"
+    assert result["data"]["parent"] is None
+    assert len(result["data"]["children"]) == 2
+
+
+def test_fetch_hierarchy_relation_swallows_network_errors():
+    import requests
+
+    tool = _tool()
+
+    def fake_get(url, **kwargs):
+        raise requests.exceptions.ConnectionError("boom")
+
+    with patch("tooluniverse.orphanet_tool.requests.get", side_effect=fake_get):
+        assert tool._fetch_hierarchy_relation("586", "PreferentialParent") is None

--- a/tests/unit/test_orphanet_invalid_code_validation.py
+++ b/tests/unit/test_orphanet_invalid_code_validation.py
@@ -1,0 +1,139 @@
+"""Regression guard for Fix-R20D-1: 5 of 7 code-based OrphanetTool operations
+silently returned status:"success" with empty payloads for a nonexistent
+ORPHA code, instead of erroring like their siblings Orphanet_get_disease and
+Orphanet_get_phenotypes already correctly do.
+
+Confirmed live for ORPHA:999999999 (a nonexistent code): the affected
+operations (get_genes, get_epidemiology, get_natural_history,
+get_classification, get_icd_mapping) hit a data-specific Orphadata/RDcode
+endpoint that 404s both when the disease code itself doesn't exist AND when
+a real disease legitimately has no records of that data type -- the old
+code couldn't tell those two cases apart and always returned empty success.
+Fixed by adding an explicit existence check (the RDcode Name endpoint 404s
+only when the orpha_code itself is invalid) before the data fetch, reusing
+that endpoint from _get_genes' existing disease_name lookup for that tool
+and via a shared _orpha_code_exists() helper for the other four.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.orphanet_tool import OrphanetTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return OrphanetTool({"name": "orphanet_test"})
+
+
+def _resp(status_code, json_body=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body or {}
+    if status_code >= 400:
+        import requests
+
+        http_err = requests.exceptions.HTTPError(response=r)
+        r.raise_for_status = MagicMock(side_effect=http_err)
+    else:
+        r.raise_for_status = MagicMock()
+    return r
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "get_genes",
+        "get_epidemiology",
+        "get_natural_history",
+        "get_classification",
+        "get_icd_mapping",
+    ],
+)
+def test_invalid_orpha_code_returns_error_not_silent_success(operation):
+    tool = _tool()
+
+    def fake_get(url, **kwargs):
+        # Every endpoint 404s for this nonexistent code, including the
+        # RDcode Name existence-check endpoint.
+        return _resp(404)
+
+    with patch("tooluniverse.orphanet_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"operation": operation, "orpha_code": "999999999"})
+
+    assert result["status"] == "error"
+    assert "not found" in result["error"].lower()
+    assert "999999999" in result["error"]
+
+
+@pytest.mark.parametrize(
+    "operation,data_url_fragment",
+    [
+        ("get_genes", "rd-associated-genes/orphacodes/586"),
+        ("get_epidemiology", "rd-epidemiology/orphacodes/586"),
+        ("get_natural_history", "rd-natural_history/orphacodes/586"),
+        ("get_classification", "Classification"),
+        ("get_icd_mapping", "ICD10"),
+    ],
+)
+def test_valid_code_with_no_data_still_returns_success_empty(
+    operation, data_url_fragment
+):
+    """A real disease code that exists (Name endpoint returns 200) but
+    happens to have no records for this specific data type must still
+    return status:success with an empty payload -- not an error. This is
+    the pre-existing, correct behavior for genuinely-empty-but-valid
+    diseases and must not regress."""
+    tool = _tool()
+
+    def fake_get(url, **kwargs):
+        if url.endswith("/orphacode/586/Name"):
+            return _resp(200, {"Preferred term": "Test Disease"})
+        # The actual data endpoint has nothing for this disease.
+        return _resp(404)
+
+    with patch("tooluniverse.orphanet_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"operation": operation, "orpha_code": "586"})
+
+    assert result["status"] == "success"
+
+
+def test_get_disease_and_get_phenotypes_unaffected_by_new_helper():
+    """Sibling operations that already had correct not-found handling
+    before this fix keep working identically."""
+    tool = _tool()
+
+    def fake_get(url, **kwargs):
+        return _resp(404)
+
+    with patch("tooluniverse.orphanet_tool.requests.get", side_effect=fake_get):
+        disease_result = tool.run(
+            {"operation": "get_disease", "orpha_code": "999999999"}
+        )
+        phenotype_result = tool.run(
+            {"operation": "get_phenotypes", "orpha_code": "999999999"}
+        )
+
+    assert disease_result["status"] == "error"
+    assert phenotype_result["status"] == "error"
+
+
+def test_orpha_code_exists_helper_is_lenient_on_network_error():
+    """A transient network failure on the existence-check itself must not
+    block a request that would otherwise succeed -- treat "can't tell" as
+    "proceed", matching the tool's existing resilience pattern elsewhere."""
+    import requests
+
+    tool = _tool()
+
+    def fake_get(url, **kwargs):
+        raise requests.exceptions.ConnectionError("boom")
+
+    with patch("tooluniverse.orphanet_tool.requests.get", side_effect=fake_get):
+        assert tool._orpha_code_exists("586") is True

--- a/tests/unit/test_pharos_search_targets_tdl_filter.py
+++ b/tests/unit/test_pharos_search_targets_tdl_filter.py
@@ -1,0 +1,134 @@
+"""Regression guard for Fix-R20E-2: Pharos_search_targets' `tdl` parameter
+was declared in the tool's schema and accepted by the code, but never
+actually used -- the GraphQL query sent only `filter: {term: $term}`,
+completely ignoring tdl. Confirmed live: `tdl:"Tdark"` and `tdl:"Tclin"`
+returned byte-identical count/results for the same query.
+
+Root cause (confirmed via GraphQL introspection against
+pharos-api.ncats.io): Pharos' `IFilter` input type has no direct `tdl`
+scalar field at all -- TDL filtering must go through its generic `facets`
+list (`facet: "Target Development Level", values: [...]`). Fixed by
+building that facets argument whenever `tdl` is provided.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.pharos_tool import PharosTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return PharosTool({"name": "pharos_test", "fields": {"operation": "search_targets"}})
+
+
+def _graphql_resp(targets_payload):
+    r = MagicMock()
+    r.status_code = 200
+    r.raise_for_status = MagicMock()
+    r.json.return_value = {"data": {"targets": targets_payload}}
+    return r
+
+
+def test_tdl_filter_sent_as_facets_not_dropped():
+    tool = _tool()
+    captured = {}
+
+    def fake_post(url, json=None, **kwargs):
+        captured["variables"] = json.get("variables")
+        return _graphql_resp({"count": 1, "targets": [{"sym": "KNDC1", "tdl": "Tdark"}]})
+
+    with patch("tooluniverse.pharos_tool.requests.post", side_effect=fake_post):
+        result = tool.run({"query": "kinase", "tdl": "Tdark", "top": 5})
+
+    assert result["status"] == "success"
+    facets = captured["variables"]["facets"]
+    assert facets == [{"facet": "Target Development Level", "values": ["Tdark"]}]
+
+
+def test_no_tdl_sends_no_facets():
+    tool = _tool()
+    captured = {}
+
+    def fake_post(url, json=None, **kwargs):
+        captured["variables"] = json.get("variables")
+        return _graphql_resp({"count": 2, "targets": []})
+
+    with patch("tooluniverse.pharos_tool.requests.post", side_effect=fake_post):
+        result = tool.run({"query": "kinase", "top": 5})
+
+    assert result["status"] == "success"
+    assert captured["variables"]["facets"] is None
+
+
+def test_different_tdl_values_produce_different_facet_filters():
+    tool = _tool()
+    seen_facets = []
+
+    def fake_post(url, json=None, **kwargs):
+        seen_facets.append(json.get("variables")["facets"])
+        return _graphql_resp({"count": 1, "targets": []})
+
+    with patch("tooluniverse.pharos_tool.requests.post", side_effect=fake_post):
+        tool.run({"query": "kinase", "tdl": "Tdark", "top": 5})
+        tool.run({"query": "kinase", "tdl": "Tclin", "top": 5})
+
+    assert seen_facets[0] != seen_facets[1]
+    assert seen_facets[0] == [{"facet": "Target Development Level", "values": ["Tdark"]}]
+    assert seen_facets[1] == [{"facet": "Target Development Level", "values": ["Tclin"]}]
+
+
+def test_tdl_summary_returns_real_counts_from_facets():
+    """Regression guard for Fix-R20E-3: get_tdl_summary previously
+    returned only static TDL labels/descriptions plus a note telling the
+    caller to look elsewhere -- confirmed live it now runs a minimal
+    top:1 targets query whose facets field carries the real whole-proteome
+    TDL breakdown."""
+    tool = PharosTool({"name": "pharos_test", "fields": {"operation": "get_tdl_summary"}})
+
+    def fake_post(url, json=None, **kwargs):
+        return _graphql_resp_full(
+            {
+                "dbVersion": "pharos319",
+                "targets": {
+                    "facets": [
+                        {
+                            "facet": "Target Development Level",
+                            "values": [
+                                {"name": "Tbio", "value": 12303},
+                                {"name": "Tdark", "value": 5501},
+                                {"name": "Tchem", "value": 1904},
+                                {"name": "Tclin", "value": 704},
+                            ],
+                        }
+                    ]
+                },
+            }
+        )
+
+    with patch("tooluniverse.pharos_tool.requests.post", side_effect=fake_post):
+        result = tool.run({})
+
+    assert result["status"] == "success"
+    assert result["data"]["counts"] == {
+        "Tclin": 704,
+        "Tchem": 1904,
+        "Tbio": 12303,
+        "Tdark": 5501,
+    }
+    assert result["data"]["total_targets"] == 20412
+    assert result["data"]["db_version"] == "pharos319"
+
+
+def _graphql_resp_full(data):
+    r = MagicMock()
+    r.status_code = 200
+    r.raise_for_status = MagicMock()
+    r.json.return_value = {"data": data}
+    return r

--- a/tests/unit/test_rhea_reaction_generic_participants.py
+++ b/tests/unit/test_rhea_reaction_generic_participants.py
@@ -1,0 +1,183 @@
+"""Regression guard for Fix-R20E-1: RheaReactionTool's htmlequation parser
+silently dropped generic/polymer participants (e.g. protein-linked residues
+like "L-tyrosyl-[protein]") from reactants/products.
+
+Confirmed live for RHEA:10596 (protein-tyrosine kinase reaction): Rhea's
+htmlequation identifies these participants with a `data-molid="rhea-comp:..."`
+attribute instead of `data-molid="chebi:..."`, since they aren't discrete
+ChEBI compounds -- they're Rhea "generic compounds". The old regex only
+matched the `chebi:` namespace, so both protein-residue participants
+(visible in the plain-text `equation` string) were completely absent from
+the parsed reactants/products arrays, even though the upstream API returned
+them. Fixed by matching both namespaces and marking generic participants
+with `is_generic: true` + a `rhea_comp_id` field (with `chebi_id: null`,
+since they have no real ChEBI id) instead of silently dropping them.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.rhea_reaction_tool import RheaReactionTool
+
+pytestmark = pytest.mark.unit
+
+# Real htmlequation for RHEA:10596, captured live from the Rhea REST API.
+_KINASE_HTMLEQUATION = (
+    '<span class="participant"><span class="stoichiometry"> </span>'
+    '<a data-molid="rhea-comp:10136"><small>L</small>-tyrosyl-[protein]</a>'
+    '<span class="location"> </span></span> + '
+    '<span class="participant"><span class="stoichiometry"> </span>'
+    '<a data-molid="chebi:30616">ATP</a><span class="location"> </span></span>'
+    " = "
+    '<span class="participant"><span class="stoichiometry"> </span>'
+    '<a data-molid="rhea-comp:20101"><i>O</i>-phospho-<small>L</small>-tyrosyl-[protein]</a>'
+    '<span class="location"> </span></span> + '
+    '<span class="participant"><span class="stoichiometry"> </span>'
+    '<a data-molid="chebi:456216">ADP</a><span class="location"> </span></span> + '
+    '<span class="participant"><span class="stoichiometry"> </span>'
+    '<a data-molid="chebi:15378">H<small><sup>+</sup></small></a>'
+    '<span class="location"> </span></span>'
+)
+
+
+def _tool(endpoint):
+    return RheaReactionTool({"name": "rhea_test", "fields": {"endpoint": endpoint}})
+
+
+def _json_resp(payload):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = payload
+    return r
+
+
+def _tsv_resp(text):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.text = text
+    return r
+
+
+def _mock_get_for(rhea_id, htmlequation, equation):
+    """Build a requests.get side_effect handling both the JSON and TSV
+    sub-requests _get_reaction makes (dispatched by `format` param)."""
+
+    def fake_get(url, params=None, **kwargs):
+        if params.get("format") == "json":
+            return _json_resp(
+                {
+                    "results": [
+                        {
+                            "id": rhea_id,
+                            "equation": equation,
+                            "htmlequation": htmlequation,
+                            "status": "approved",
+                            "balanced": True,
+                            "transport": False,
+                            "comment": "",
+                        }
+                    ]
+                }
+            )
+        # TSV request (full get_reaction only).
+        headers = (
+            "Reaction identifier\tEquation\tEC number\tUniProt\tPubMed\t"
+            "Cross-reference (KEGG)\tCross-reference (MetaCyc)"
+        )
+        row = f"RHEA:{rhea_id}\t{equation}\tEC:2.7.10.1\t\t15504335\tKEGG:R02584\tMetaCyc:2.7.10.1-RXN"
+        return _tsv_resp(headers + "\n" + row)
+
+    return fake_get
+
+
+def test_get_reaction_participants_includes_generic_protein_residues():
+    tool = _tool("get_participants")
+    equation = "L-tyrosyl-[protein] + ATP = O-phospho-L-tyrosyl-[protein] + ADP + H(+)"
+    fake_get = _mock_get_for("10596", _KINASE_HTMLEQUATION, equation)
+
+    with patch("tooluniverse.rhea_reaction_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"rhea_id": "RHEA:10596"})
+
+    assert result["status"] == "success"
+    data = result["data"]
+    reactant_names = [p["name"] for p in data["reactants"]]
+    product_names = [p["name"] for p in data["products"]]
+    assert "L-tyrosyl-[protein]" in reactant_names
+    assert "O-phospho-L-tyrosyl-[protein]" in product_names
+    assert data["n_reactants"] == 2
+    assert data["n_products"] == 3
+
+
+def test_generic_participant_marked_and_carries_rhea_comp_id_not_chebi():
+    tool = _tool("get_participants")
+    equation = "L-tyrosyl-[protein] + ATP = O-phospho-L-tyrosyl-[protein] + ADP + H(+)"
+    fake_get = _mock_get_for("10596", _KINASE_HTMLEQUATION, equation)
+
+    with patch("tooluniverse.rhea_reaction_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"rhea_id": "RHEA:10596"})
+
+    generic = next(
+        p for p in result["data"]["reactants"] if p["name"] == "L-tyrosyl-[protein]"
+    )
+    assert generic["is_generic"] is True
+    assert generic["chebi_id"] is None
+    assert generic["rhea_comp_id"] == "RHEA-COMP:10136"
+
+
+def test_ordinary_chebi_participants_unaffected():
+    tool = _tool("get_participants")
+    equation = "L-tyrosyl-[protein] + ATP = O-phospho-L-tyrosyl-[protein] + ADP + H(+)"
+    fake_get = _mock_get_for("10596", _KINASE_HTMLEQUATION, equation)
+
+    with patch("tooluniverse.rhea_reaction_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"rhea_id": "RHEA:10596"})
+
+    atp = next(p for p in result["data"]["reactants"] if p["name"] == "ATP")
+    assert atp["is_generic"] is False
+    assert atp["chebi_id"] == "CHEBI:30616"
+    assert "rhea_comp_id" not in atp
+
+
+def test_get_reaction_full_record_also_includes_generic_participants():
+    tool = _tool("get_reaction")
+    equation = "L-tyrosyl-[protein] + ATP = O-phospho-L-tyrosyl-[protein] + ADP + H(+)"
+    fake_get = _mock_get_for("10596", _KINASE_HTMLEQUATION, equation)
+
+    with patch("tooluniverse.rhea_reaction_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"rhea_id": "RHEA:10596"})
+
+    assert result["status"] == "success"
+    data = result["data"]
+    assert len(data["reactants"]) == 2
+    assert len(data["products"]) == 3
+    assert data["ec_numbers"] == ["EC:2.7.10.1"]
+
+
+def test_reaction_with_no_generic_participants_has_no_regression():
+    """Small-molecule-only reaction (all chebi: namespace) parses identically
+    to before the fix -- no is_generic=True entries, no rhea_comp_id keys."""
+    tool = _tool("get_participants")
+    htmlequation = (
+        '<span class="participant"><a data-molid="chebi:17234">D-glucose</a></span>'
+        " = "
+        '<span class="participant"><a data-molid="chebi:4167">D-glucose 6-phosphate</a></span>'
+    )
+    equation = "D-glucose = D-glucose 6-phosphate"
+    fake_get = _mock_get_for("00001", htmlequation, equation)
+
+    with patch("tooluniverse.rhea_reaction_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"rhea_id": "1"})
+
+    assert result["status"] == "success"
+    data = result["data"]
+    assert len(data["reactants"]) == 1
+    assert len(data["products"]) == 1
+    for p in data["reactants"] + data["products"]:
+        assert p["is_generic"] is False
+        assert p["chebi_id"] is not None
+        assert "rhea_comp_id" not in p

--- a/tests/unit/test_sasbdb_search_result_cap.py
+++ b/tests/unit/test_sasbdb_search_result_cap.py
@@ -1,0 +1,90 @@
+"""Regression guard for Fix-R20B-3: SASBDB_search's free-text fallback (it
+correctly self-documents that SASBDB has no full-text search and lists all
+published entries instead) had no way to cap the response -- confirmed
+live it returned all ~5432 entries (~350KB) with no limit/offset
+parameter available, a large mostly-useless payload for an LLM-agent
+caller. Fixed by adding a `max_results` argument (default 50) that caps
+the returned list client-side, with total_entries/truncated fields so the
+caller can tell it was capped.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.sasbdb_tool import SASBDBTextSearchTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return SASBDBTextSearchTool({"name": "sasbdb_test"})
+
+
+def _resp(status_code, json_body):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body
+    return r
+
+
+def test_free_text_query_capped_at_default_50():
+    tool = _tool()
+    all_entries = [{"code": f"SASD{i:04d}"} for i in range(5432)]
+
+    with patch(
+        "tooluniverse.sasbdb_tool.request_with_retry",
+        return_value=_resp(200, all_entries),
+    ):
+        result = tool.run({"query": "lysozyme"})
+
+    assert result["status"] == "success"
+    assert len(result["data"]) == 50
+    assert result["total_entries"] == 5432
+    assert result["truncated"] is True
+
+
+def test_free_text_query_respects_custom_max_results():
+    tool = _tool()
+    all_entries = [{"code": f"SASD{i:04d}"} for i in range(5432)]
+
+    with patch(
+        "tooluniverse.sasbdb_tool.request_with_retry",
+        return_value=_resp(200, all_entries),
+    ):
+        result = tool.run({"query": "lysozyme", "max_results": 5})
+
+    assert len(result["data"]) == 5
+    assert result["truncated"] is True
+
+
+def test_small_catalog_not_marked_truncated():
+    tool = _tool()
+    all_entries = [{"code": "SASD0001"}]
+
+    with patch(
+        "tooluniverse.sasbdb_tool.request_with_retry",
+        return_value=_resp(200, all_entries),
+    ):
+        result = tool.run({"query": "lysozyme"})
+
+    assert result["truncated"] is False
+    assert len(result["data"]) == 1
+
+
+def test_uniprot_accession_path_unaffected_by_cap():
+    tool = _tool()
+    entry = {"code": "SASDAC2", "uniprot": "P00698"}
+
+    with patch(
+        "tooluniverse.sasbdb_tool.request_with_retry", return_value=_resp(200, entry)
+    ):
+        result = tool.run({"query": "P00698"})
+
+    assert result["status"] == "success"
+    assert result["data"] == entry
+    assert "total_entries" not in result

--- a/tests/unit/test_uniprot_idmapping_full_results.py
+++ b/tests/unit/test_uniprot_idmapping_full_results.py
@@ -1,0 +1,157 @@
+"""Regression guard for Fix-R20A-1: UniProtIDMappingTool silently truncated
+large mapping result sets.
+
+Confirmed live for P00533 (EGFR) -> PDB: the UniProt ID Mapping status
+endpoint sometimes 303-redirects straight into a results page instead of
+ever reporting jobStatus=="FINISHED" -- and that redirected page uses its
+own default page size (25 records), not the size=500 this tool asks for
+when explicitly fetching results. The old code treated "results" showing up
+in a status-poll response as the final answer and returned it directly,
+silently truncating true 354-record result sets down to 25 with no
+truncation indicator at all. Fixed by treating a status-poll response that
+contains "results" as merely "job done" (like jobStatus=="FINISHED"), then
+always re-fetching through _fetch_all_results(), which pages through with
+size=500 and follows the Link header's rel="next" URL for results beyond a
+single page.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.uniprot_idmapping_tool import UniProtIDMappingTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(endpoint_type):
+    return UniProtIDMappingTool(
+        {"name": "uniprot_idmap_test", "fields": {"endpoint_type": endpoint_type}}
+    )
+
+
+def _resp(json_body, headers=None):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = json_body
+    r.headers = headers or {}
+    return r
+
+
+def test_convert_ids_fetches_full_result_set_not_just_redirect_preview():
+    """The status poll's first response embeds a "results" key with only
+    25 records (mimicking the real, confirmed-live UniProt redirect
+    behavior) -- the tool must not treat that as final and must instead
+    fetch the full 354-record set from the results endpoint."""
+    tool = _tool("convert")
+
+    full_results = [{"from": "P00533", "to": f"PDB{i}"} for i in range(354)]
+
+    def fake_post(url, data=None, **kwargs):
+        return _resp({"jobId": "job123"})
+
+    def fake_get(url, params=None, **kwargs):
+        if url.endswith("/status/job123"):
+            # Redirect-style response: only the first 25, no jobStatus key.
+            return _resp({"results": full_results[:25]})
+        if url.endswith("/results/job123"):
+            return _resp({"results": full_results, "failedIds": []})
+        raise AssertionError(f"unexpected URL {url}")
+
+    with patch("tooluniverse.uniprot_idmapping_tool.requests.post", side_effect=fake_post):
+        with patch("tooluniverse.uniprot_idmapping_tool.requests.get", side_effect=fake_get):
+            result = tool.run(
+                {"ids": "P00533", "from_db": "UniProtKB_AC-ID", "to_db": "PDB"}
+            )
+
+    assert result["status"] == "success"
+    assert result["data"]["result_count"] == 354
+    assert len(result["data"]["results"]) == 354
+    assert result["data"]["truncated"] is False
+
+
+def test_convert_ids_follows_link_header_pagination():
+    """A results set spanning more than one page (Link: rel="next") is
+    fully accumulated, not just the first page."""
+    tool = _tool("convert")
+    page1 = [{"from": "P00533", "to": f"PDB{i}"} for i in range(500)]
+    page2 = [{"from": "P00533", "to": f"PDB{i}"} for i in range(500, 600)]
+
+    def fake_post(url, data=None, **kwargs):
+        return _resp({"jobId": "job456"})
+
+    def fake_get(url, params=None, **kwargs):
+        if url.endswith("/status/job456"):
+            return _resp({"jobStatus": "FINISHED"})
+        if url == "https://rest.uniprot.org/idmapping/results/job456":
+            return _resp(
+                {"results": page1, "failedIds": []},
+                headers={
+                    "Link": '<https://rest.uniprot.org/idmapping/results/job456?cursor=abc&size=500>; rel="next"'
+                },
+            )
+        if "cursor=abc" in url:
+            return _resp({"results": page2, "failedIds": []}, headers={})
+        raise AssertionError(f"unexpected URL {url}")
+
+    with patch("tooluniverse.uniprot_idmapping_tool.requests.post", side_effect=fake_post):
+        with patch("tooluniverse.uniprot_idmapping_tool.requests.get", side_effect=fake_get):
+            result = tool.run(
+                {"ids": "P00533", "from_db": "UniProtKB_AC-ID", "to_db": "PDB"}
+            )
+
+    assert result["status"] == "success"
+    assert result["data"]["result_count"] == 600
+    # Display array is still capped at 500 for context-size reasons, but the
+    # truncation is now honestly flagged instead of silent.
+    assert len(result["data"]["results"]) == 500
+    assert result["data"]["truncated"] is True
+
+
+def test_small_result_set_unaffected_no_regression():
+    """A genuinely small result set (fewer than the redirect's own default
+    page size) still round-trips correctly."""
+    tool = _tool("gene_to_uniprot")
+    small_results = [{"from": "TP53", "to": "P04637"}]
+
+    def fake_post(url, data=None, **kwargs):
+        return _resp({"jobId": "job789"})
+
+    def fake_get(url, params=None, **kwargs):
+        if url.endswith("/status/job789"):
+            return _resp({"jobStatus": "FINISHED"})
+        if url.endswith("/results/job789"):
+            return _resp({"results": small_results, "failedIds": []})
+        raise AssertionError(f"unexpected URL {url}")
+
+    with patch("tooluniverse.uniprot_idmapping_tool.requests.post", side_effect=fake_post):
+        with patch("tooluniverse.uniprot_idmapping_tool.requests.get", side_effect=fake_get):
+            result = tool.run({"gene_names": "TP53"})
+
+    assert result["status"] == "success"
+    assert result["data"]["result_count"] == 1
+    assert result["data"]["truncated"] is False
+    assert result["data"]["results"][0]["to"] == "P04637"
+
+
+def test_job_error_status_still_returns_error():
+    tool = _tool("convert")
+
+    def fake_post(url, data=None, **kwargs):
+        return _resp({"jobId": "jobErr"})
+
+    def fake_get(url, params=None, **kwargs):
+        return _resp({"jobStatus": "ERROR", "errorMessage": "bad request"})
+
+    with patch("tooluniverse.uniprot_idmapping_tool.requests.post", side_effect=fake_post):
+        with patch("tooluniverse.uniprot_idmapping_tool.requests.get", side_effect=fake_get):
+            result = tool.run(
+                {"ids": "BOGUS", "from_db": "UniProtKB_AC-ID", "to_db": "PDB"}
+            )
+
+    assert result["status"] == "error"
+    assert "bad request" in result["error"]

--- a/tests/unit/test_uniprot_inactive_accession_error.py
+++ b/tests/unit/test_uniprot_inactive_accession_error.py
@@ -1,0 +1,133 @@
+"""Regression guard for Fix-R20A-3: UniProtRESTTool's JSONPath-extraction
+endpoints (get_organism_by_accession, get_sequence_by_accession,
+get_function_by_accession, get_subcellular_location_by_accession, and
+siblings using extract_path) surfaced a confusing raw
+"No data found for JSONPath: ..." error for a real-but-inactive/deleted
+UniProt accession, instead of explaining *why* -- unlike
+UniProt_get_entry_by_accession, which already handles the same accession
+gracefully (returns status:success with entryType:"Inactive" and empty
+fields).
+
+Confirmed live for Q9ZZZ9 (a real, UniProt-deleted accession -- HTTP 200,
+entryType:"Inactive", inactiveReason: {inactiveReasonType: "DELETED",
+deletedReason: "Not part of a reference proteome"}). Fixed by checking
+entryType before running extract_path's JSONPath and returning a clear,
+actionable error citing the real inactive reason.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.uniprot_tool import UniProtRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(extract_path="organism.scientificName"):
+    return UniProtRESTTool(
+        {
+            "name": "uniprot_test",
+            "fields": {
+                "endpoint": "https://rest.uniprot.org/uniprotkb/{accession}.json",
+                "extract_path": extract_path,
+            },
+        }
+    )
+
+
+def _resp(json_body, status_code=200):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body
+    return r
+
+
+_INACTIVE_ENTRY = {
+    "entryType": "Inactive",
+    "primaryAccession": "Q9ZZZ9",
+    "inactiveReason": {
+        "inactiveReasonType": "DELETED",
+        "deletedReason": "Not part of a reference proteome",
+    },
+}
+
+
+def test_inactive_accession_gives_clear_reason_not_raw_jsonpath_error():
+    tool = _tool("organism.scientificName")
+
+    with patch(
+        "tooluniverse.uniprot_tool.requests.get", return_value=_resp(_INACTIVE_ENTRY)
+    ):
+        result = tool.run({"accession": "Q9ZZZ9"})
+
+    assert result["status"] == "error"
+    assert "inactive" in result["error"].lower()
+    assert "DELETED" in result["error"]
+    assert "Not part of a reference proteome" in result["error"]
+    assert "JSONPath" not in result["error"]
+
+
+@pytest.mark.parametrize(
+    "extract_path",
+    [
+        "organism.scientificName",
+        "sequence.value",
+        "comments[?(@.commentType=='FUNCTION')].texts[*].value",
+        (
+            "comments[?(@.commentType=="
+            "'SUBCELLULAR LOCATION')].subcellularLocations[*].location.value"
+        ),
+    ],
+)
+def test_all_extract_path_variants_handle_inactive_entry(extract_path):
+    tool = _tool(extract_path)
+
+    with patch(
+        "tooluniverse.uniprot_tool.requests.get", return_value=_resp(_INACTIVE_ENTRY)
+    ):
+        result = tool.run({"accession": "Q9ZZZ9"})
+
+    assert result["status"] == "error"
+    assert "inactive" in result["error"].lower()
+
+
+def test_active_accession_extraction_unaffected():
+    tool = _tool("organism.scientificName")
+    active_entry = {
+        "entryType": "UniProtKB reviewed (Swiss-Prot)",
+        "organism": {"scientificName": "Homo sapiens"},
+    }
+
+    with patch(
+        "tooluniverse.uniprot_tool.requests.get", return_value=_resp(active_entry)
+    ):
+        result = tool.run({"accession": "P00533"})
+
+    assert result == "Homo sapiens"
+
+
+def test_merged_inactive_reason_without_deleted_detail():
+    """Some inactive entries are MERGED (not DELETED) and carry a
+    mergeDemergeTo list instead of deletedReason -- make sure that shape is
+    also handled without crashing."""
+    tool = _tool("organism.scientificName")
+    merged_entry = {
+        "entryType": "Inactive",
+        "inactiveReason": {
+            "inactiveReasonType": "MERGED",
+            "mergeDemergeTo": ["P12345"],
+        },
+    }
+
+    with patch(
+        "tooluniverse.uniprot_tool.requests.get", return_value=_resp(merged_entry)
+    ):
+        result = tool.run({"accession": "Q0OLD1"})
+
+    assert result["status"] == "error"
+    assert "MERGED" in result["error"]


### PR DESCRIPTION
## Summary

Round 20 of the ongoing test-harness sweep: 5 role-play researcher personas exercised protein biology (UniProt), structural biology (AlphaFold/SASBDB), proteomics (MassIVE/Expression Atlas/PeptideAtlas/BioSamples), rare disease genetics (Orphanet), and signal transduction/pharmacology (Pharos/SIGNOR/Rhea) — domains not previously covered. 18 findings were CLI-verified against live upstream APIs; 12 confirmed root-caused and fixed here.

## Fixed

- **Fix-R20E-1** — `Rhea_get_reaction`/`Rhea_get_reaction_participants` silently dropped generic/polymer ChEBI "residue" participants (e.g. the protein-tyrosine substrate of a kinase reaction, confirmed live for RHEA:10596) because Rhea identifies them with a `rhea-comp:` id in the htmlequation instead of `chebi:`, which the parser's regex only matched for the latter. Now captured with `is_generic`/`rhea_comp_id` fields instead of vanishing entirely.
- **Fix-R20A-1** — `UniProtIDMap_convert_ids`/`_to_pdb`/`gene_to_uniprot` silently truncated large result sets to 25 records (confirmed live: EGFR→PDB has 354 real xrefs, not 25) — the polling loop treated a status-endpoint redirect's small default-page-size preview as the final answer instead of always fetching the full, paginated result set via `size=500` + Link-header pagination.
- **Fix-R20D-1** — 5 of 7 code-based Orphanet operations (`get_genes`, `get_epidemiology`, `get_natural_history`, `get_classification`, `get_icd_mapping`) silently returned `status:success` with empty data for a nonexistent ORPHA code, instead of erroring like their siblings `get_disease`/`get_phenotypes` already did — a materially misleading result in a clinical-genetics context.
- **Fix-R20D-2** — `Orphanet_get_classification`'s own description promises "parent and child disease categories," but the implementation only ever returned a flat list of named classification *systems* the disease is filed under (membership, not hierarchy). Now fetches the real parent/children tree via the RDcode API's `PreferentialParent`/`PreferentialChildren` endpoints (confirmed live: Cystic fibrosis's parent is "Rare respiratory disease," which itself has 82 real children), keeping the systems-membership list too (renamed `member_of_classifications`).
- **Fix-R20E-2** — `Pharos_search_targets`'s `tdl` filter was accepted by the schema but never read by the code — confirmed live that `tdl:"Tdark"` and `tdl:"Tclin"` returned byte-identical results. Pharos' GraphQL `IFilter` has no direct `tdl` field; fixed by expressing it through Pharos' generic `facets` mechanism (confirmed via GraphQL introspection).
- **Fix-R20E-3** — `Pharos_get_tdl_summary` returned only static TDL labels/descriptions plus a note telling the caller to look elsewhere, despite its own description promising real counts. Now returns real whole-proteome TDL counts (Tclin: 704, Tchem: 1904, Tbio: 12303, Tdark: 5501) from a single minimal `facets` query.
- **Fix-R20A-3** — UniProt's JSONPath-extraction tools (`get_organism_by_accession`, `get_sequence_by_accession`, `get_function_by_accession`, `get_subcellular_location_by_accession`) surfaced a cryptic raw `"No data found for JSONPath: ..."` error for a real but inactive/deleted accession (confirmed live for Q9ZZZ9) instead of explaining why — unlike `get_entry_by_accession`, which already handles the same case gracefully.
- **Fix-R20B-1** — `alphafold_get_summary`'s `metadata.count` was hardcoded to 1 whenever the API returned a dict rather than a top-level list — silently wrong for `/uniprot/summary`, which wraps its real payload as `{"uniprot_entry": ..., "structures": [...]}` (confirmed live: P69905 has 16 real structures, reported as 1).
- **Fix-R20B-2** — CLI default (non-`--json`) error output dropped a tool's `detail` field whenever it was a JSON-encoded string rather than a dict with `hint`/`message` keys (confirmed live for SASBDB 404s and AlphaFold 400s), hiding the actually-useful upstream message behind `--json`.
- **Fix-R20C-1/2** — `ExpressionAtlas`'s `gene` parameter across `get_baseline_expression`/`search_differential_experiments`/`search_experiments` had no real filtering effect (confirmed live: a real gene and a nonsense gene string returned byte-identical results) — it relies on a literal-text match against EBI Search's description index, which almost never contains individual gene symbols. Rather than a full re-architecture (would need per-gene expression-value lookups the API doesn't cheaply expose), every gene-querying response now surfaces an explicit `warning` instead of silently implying the unfiltered catalog is gene-specific.
- **Fix-R20C-4** — MassIVE's ProXI error handler discarded the upstream JSON error body's actual reason (confirmed live: `{"message":"No data found for the specified parameters."}`), showing only a generic `"404 Client Error: ..."` string.
- **Fix-R20B-3** — `SASBDB_search`'s free-text fallback (correctly self-documents that SASBDB has no full-text search) returned all ~5432 published entries unbounded (~350KB) with no way to cap it. Added a `max_results` argument (default 50) with `total_entries`/`truncated` fields.

## Deferred (documented, not fixed)

- UniProt's two sibling proteome-count tools (`UniProt_get_proteome` vs `UniProtRef_get_proteome`) disagree by 14 proteins (147506 vs 147520) — likely a snapshot-timing or counting-method difference between two independently-maintained endpoints, not a client-side bug.
- `ExpressionAtlas_get_experiment`'s promised `factors`/`technology`/`contrasts`/`assay_count`/`pubmed_ids` fields are always empty (confirmed live for the tool's own documented test example) because the upstream GXA `/json/experiments/{accession}` endpoint's `experiment` sub-object genuinely doesn't carry those keys — no richer endpoint found after probing several candidates. Tool description corrected to stop overpromising.
- `Pharos_get_target`'s `status:"success"` + `data:null` combination on a no-match is a minor envelope-consistency nit (arguably valid REST semantics: request succeeded, no match found), not incorrect behavior — left as-is.
- Feature-20D-003 (misleading CLI "check tool name spelling" tips on an Orphanet not-found error) is a duplicate of the already-fixed-but-not-yet-merged Fix-R18A-2/R18C-6 from round 18's PR — not re-fixed here to avoid redundant work.

## Test plan

- [x] 26 new mocked unit tests across 10 files covering every fix plus adjacent non-regression cases (e.g. small/ordinary ChEBI participants still parse correctly, active UniProt accessions still extract fine, condition-only Expression Atlas queries are unaffected by the gene-filter warning, network-error resilience in the new Orphanet existence-check helper).
- [x] 2 existing test files strengthened: `tests/tools/test_pharos_tool.py` (fixed a vacuous assertion checking a nonexistent `idgTDL` key instead of the real `tdl` key, which let the tdl-filter bug ship unnoticed; also strengthened the tdl_summary test to check real counts), `tests/tools/test_tu_cli.py` (added coverage for the new detail-string CLI surfacing).
- [x] Full non-live-API suite (2568 tests) passes clean; the only failures are pre-existing live-API flakiness in files this PR never touches (BindingDB, ComplexPortal, DailyMed) and one pre-existing embedding-search relevance test, both independently confirmed to fail identically on unmodified `main`.
- [x] `code-simplifier` pass applied — extracted a shared `_orpha_not_found_error` helper deduplicating 4 repeated existence-check call sites in `orphanet_tool.py`; everything else in the diff was already clean.
- [x] All 12 fixes independently verified live against the real upstream APIs before and after the change.
