### PR TITLE
Fix Round 21: HTTP-status truthiness bug, BVBRC/IPD/VDJDB/GWAS data-completeness bugs

### DIFF
--- a/src/tooluniverse/allen_brain_tool.py
+++ b/src/tooluniverse/allen_brain_tool.py
@@ -55,7 +55,12 @@ class AllenBrainTool(BaseTool):
                 "error": "Failed to connect to Allen Brain Atlas API.",
             }
         except requests.exceptions.HTTPError as e:
-            status = e.response.status_code if e.response else "unknown"
+            # `bool(e.response)` is `requests.Response.ok`, which is False for
+            # every 4xx/5xx response -- so `e.response else "unknown"` always
+            # discarded the real status code on an actual HTTP error (same bug
+            # confirmed live in the sibling NeuroMorpho tool). Use an explicit
+            # None check instead.
+            status = e.response.status_code if e.response is not None else "unknown"
             return {
                 "status": "error",
                 "error": f"Allen Brain Atlas API HTTP error: {status}",

--- a/src/tooluniverse/bvbrc_tool.py
+++ b/src/tooluniverse/bvbrc_tool.py
@@ -663,6 +663,18 @@ class BVBRCTool(BaseTool):
             "ec_number",
             "ec_description",
             "taxon_id",
+            # BV-BRC's pathway index has one row per gene/annotation-source
+            # per pathway/EC pair (e.g. the same EC number annotated once
+            # by RefSeq and once by PATRIC, or matched by multiple distinct
+            # genes). Without these fields selected, those genuinely
+            # distinct records collapse into what looks like exact
+            # duplicate rows (confirmed live for M. tuberculosis
+            # "Fatty acid metabolism": 10/10 rows identical without these
+            # fields, vs. fadD15/fadD19/fadD35 etc. once selected).
+            "gene",
+            "feature_id",
+            "product",
+            "annotation",
         ]
 
         query = self._build_query_string(

--- a/src/tooluniverse/data/bvbrc_tools.json
+++ b/src/tooluniverse/data/bvbrc_tools.json
@@ -1717,6 +1717,34 @@
                       "integer",
                       "null"
                     ]
+                  },
+                  "gene": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Gene symbol for this pathway/EC record, e.g. \"fadD15\". Distinguishes genuinely different genes sharing the same EC number/pathway from true duplicate rows."
+                  },
+                  "feature_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "BV-BRC feature id for this record, e.g. \"RefSeq.83332.12.NC_000962.CDS.2448160.2449962.fwd\"."
+                  },
+                  "product": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Gene product/protein description."
+                  },
+                  "annotation": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Annotation source, e.g. \"RefSeq\" or \"PATRIC\" -- the same EC/pathway is often independently annotated by multiple sources."
                   }
                 }
               }

--- a/src/tooluniverse/data/neurovault_tools.json
+++ b/src/tooluniverse/data/neurovault_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "NeuroVault_list_collections",
-    "description": "List and browse neuroimaging statistical map collections from NeuroVault. Returns collections of brain images (fMRI, PET, EEG) contributed by researchers worldwide. Each collection contains metadata about the study, DOI, authors, and imaging parameters. NeuroVault hosts over 16,000 collections with 650,000+ brain images. Use limit and offset for pagination. Use this to discover available neuroimaging datasets for meta-analysis or to find specific studies.",
+    "description": "List and browse neuroimaging statistical map collections from NeuroVault. Returns collections of brain images (fMRI, PET, EEG) contributed by researchers worldwide. Each collection contains metadata about the study, DOI, authors, and imaging parameters. NeuroVault hosts over 16,000 collections with 650,000+ brain images. Use limit and offset for pagination. Caveat: NeuroVault's public API has no working keyword/name search or filter parameter (confirmed live -- name/search/q/keywords all return the full unfiltered catalog) -- this only returns pages of the full, unfiltered collection catalog, which must be paged through client-side to find specific studies.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/gwas_sumstats_tool.py
+++ b/src/tooluniverse/gwas_sumstats_tool.py
@@ -113,10 +113,21 @@ class GWASSumStatsTool(BaseTool):
         url = f"{GWAS_SS_BASE_URL}/traits/{trait_id}/studies"
         resp = requests.get(url, timeout=self.timeout)
         if resp.status_code == 404:
-            return {
-                "status": "error",
-                "error": f"No summary statistics found for trait '{trait_id}'",
-            }
+            error = f"No summary statistics found for trait '{trait_id}'"
+            # This API only recognizes EFO ids. A disease looked up in a
+            # different ontology (e.g. PGS Catalog's MONDO/HP ids) 404s
+            # identically to a genuinely nonexistent EFO id, which silently
+            # sends the caller down the wrong path -- confirmed live for
+            # MONDO_0004975 (Alzheimer disease's MONDO id; EFO_0000249
+            # works for the same disease). Name the likely cause when the
+            # id doesn't look like an EFO id.
+            if not trait_id.upper().startswith("EFO_"):
+                error += (
+                    ". This API only accepts EFO trait ids -- if this id "
+                    "came from another ontology (e.g. MONDO, HP, DOID), "
+                    "look up the equivalent EFO id instead."
+                )
+            return {"status": "error", "error": error}
         resp.raise_for_status()
         data = resp.json()
 

--- a/src/tooluniverse/ipd_imgt_hla_tool.py
+++ b/src/tooluniverse/ipd_imgt_hla_tool.py
@@ -113,6 +113,15 @@ class IPDIMGTHLATool(BaseTool):
         if not name:
             return {"status": "error", "error": "name parameter is required"}
 
+        # The IPD-IMGT/HLA `name` field is stored without the "HLA-" locus
+        # prefix (e.g. "A*02:01:01:01"), but that prefixed form is exactly
+        # what sibling HLA tools like VDJDB return (mhc.a: "HLA-A*02:01")
+        # -- confirmed live that passing it straight through silently
+        # matched zero alleles. Strip it so a natural cross-tool chain
+        # (VDJDB output -> this tool's input) works.
+        if name.upper().startswith("HLA-"):
+            name = name[4:]
+
         match = self._resolve_match(arguments, "startsWith")
         if self._is_api_error(match):
             return match

--- a/src/tooluniverse/mhcmotifatlas_tool.py
+++ b/src/tooluniverse/mhcmotifatlas_tool.py
@@ -45,7 +45,12 @@ class MHCMotifAtlasTool(BaseTool):
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         try:
-            allele = (arguments.get("allele") or "").strip()
+            # Atlas allele codes are conventionally uppercase (e.g. "A0101",
+            # "DRB1_01_01") and matched by exact string equality below, so a
+            # case-different but otherwise well-formed input (e.g. "a0201")
+            # previously matched nothing -- confirmed live. Normalize case
+            # here, matching the existing mhc_class normalization pattern.
+            allele = (arguments.get("allele") or "").strip().upper()
             if not allele:
                 return {
                     "status": "error",

--- a/src/tooluniverse/neuromorpho_tool.py
+++ b/src/tooluniverse/neuromorpho_tool.py
@@ -77,8 +77,23 @@ class NeuroMorphoTool(BaseTool):
                 "error": "Failed to connect to NeuroMorpho API. Check network connectivity.",
             }
         except requests.exceptions.HTTPError as e:
-            status = e.response.status_code if e.response else "unknown"
-            return {"status": "error", "error": f"NeuroMorpho API HTTP error: {status}"}
+            # `bool(e.response)` is `requests.Response.ok`, which is False for
+            # every 4xx/5xx response -- so `e.response else "unknown"` always
+            # discarded the real status code on an actual HTTP error. Use an
+            # explicit None check, and surface the upstream JSON body's own
+            # "message" field (e.g. "Requested neuron not found") when present.
+            status = e.response.status_code if e.response is not None else "unknown"
+            detail = None
+            if e.response is not None:
+                try:
+                    detail = e.response.json().get("message")
+                except ValueError:
+                    pass
+            base = f"NeuroMorpho API HTTP error: {status}"
+            return {
+                "status": "error",
+                "error": f"{base} ({detail})" if detail else base,
+            }
         except Exception as e:
             return {
                 "status": "error",

--- a/src/tooluniverse/pathoplexus_tool.py
+++ b/src/tooluniverse/pathoplexus_tool.py
@@ -19,6 +19,12 @@ from .tool_registry import register_tool
 
 LAPIS_BASE = "https://lapis.pathoplexus.org"
 
+# Confirmed live: an unsupported organism slug 404s with a bare LAPIS error
+# that doesn't name the actual valid slugs, forcing the caller back to the
+# tool description. Surface this list directly in the error message too.
+KNOWN_ORGANISMS = ["west-nile", "ebola-zaire", "ebola-sudan", "cchf", "mpox"]
+_ORGS = ", ".join(KNOWN_ORGANISMS)
+
 
 def _organism(arguments: Dict[str, Any]) -> str:
     return (arguments.get("organism") or "").strip().lower()
@@ -52,6 +58,15 @@ class _PathoplexusBase(BaseTool):
         )
         resp.raise_for_status()
         return resp.text
+
+    @staticmethod
+    def _http_error_response(
+        e: requests.exceptions.HTTPError, hint: str
+    ) -> Dict[str, Any]:
+        return {
+            "status": "error",
+            "error": f"Pathoplexus HTTP {e.response.status_code} — check the organism slug (known organisms: {_ORGS}) and {hint}",
+        }
 
     @staticmethod
     def _common_filters(arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -109,10 +124,7 @@ class PathoplexusCountTool(_PathoplexusBase):
                 "error": f"Pathoplexus request timed out after {self.timeout}s",
             }
         except requests.exceptions.HTTPError as e:
-            return {
-                "status": "error",
-                "error": f"Pathoplexus HTTP {e.response.status_code} — check the organism slug and filter fields",
-            }
+            return self._http_error_response(e, "filter fields")
         except requests.exceptions.RequestException as e:
             return {"status": "error", "error": f"Pathoplexus request failed: {e}"}
         except ValueError:
@@ -167,10 +179,7 @@ class PathoplexusCountTool(_PathoplexusBase):
                 "error": f"Pathoplexus request timed out after {self.timeout}s",
             }
         except requests.exceptions.HTTPError as e:
-            return {
-                "status": "error",
-                "error": f"Pathoplexus HTTP {e.response.status_code} — check the organism slug and field names",
-            }
+            return self._http_error_response(e, "field names")
         except requests.exceptions.RequestException as e:
             return {"status": "error", "error": f"Pathoplexus request failed: {e}"}
         except ValueError:
@@ -231,10 +240,7 @@ class PathoplexusCountTool(_PathoplexusBase):
                 "error": f"Pathoplexus request timed out after {self.timeout}s",
             }
         except requests.exceptions.HTTPError as e:
-            return {
-                "status": "error",
-                "error": f"Pathoplexus HTTP {e.response.status_code} — check the organism slug and filter fields",
-            }
+            return self._http_error_response(e, "filter fields")
         except requests.exceptions.RequestException as e:
             return {"status": "error", "error": f"Pathoplexus request failed: {e}"}
 
@@ -295,10 +301,7 @@ class PathoplexusMutationsTool(_PathoplexusBase):
                 "error": f"Pathoplexus request timed out after {self.timeout}s",
             }
         except requests.exceptions.HTTPError as e:
-            return {
-                "status": "error",
-                "error": f"Pathoplexus HTTP {e.response.status_code} — check the organism slug and filter fields",
-            }
+            return self._http_error_response(e, "filter fields")
         except requests.exceptions.RequestException as e:
             return {"status": "error", "error": f"Pathoplexus request failed: {e}"}
         except ValueError:

--- a/src/tooluniverse/pubchem_tox_tool.py
+++ b/src/tooluniverse/pubchem_tox_tool.py
@@ -98,6 +98,15 @@ class PubChemToxTool(BaseTool):
 
         url = f"{PUG_BASE_URL}/name/{compound_name}/cids/JSON"
         response = requests.get(url, timeout=self.timeout)
+        # PubChem's name->CID lookup itself 404s when the name doesn't
+        # resolve at all (confirmed live) -- raise that as a distinct
+        # ValueError here, before it can reach run()'s generic
+        # HTTPError(404) handler, which otherwise conflates "compound name
+        # never resolved" with "compound resolved fine but this specific
+        # toxicity heading is absent for it" into the identical misleading
+        # "This heading may not exist for this compound" message.
+        if response.status_code == 404:
+            raise ValueError(f"No compound found for name: {compound_name}")
         response.raise_for_status()
         data = response.json()
         cids = data.get("IdentifierList", {}).get("CID", [])

--- a/src/tooluniverse/vdjdb_tool.py
+++ b/src/tooluniverse/vdjdb_tool.py
@@ -43,6 +43,26 @@ COLUMN_NAMES = [
     "vdjdb.score",
 ]
 
+# VDJdb's `species` column is an exact-match filter restricted to these 3
+# CamelCase values -- common plain-language aliases (confirmed live:
+# "human" silently matched zero of the 20,139 real HomoSapiens records)
+# are normalized here rather than left to fail silently.
+_SPECIES_ALIASES = {
+    "human": "HomoSapiens",
+    "homosapiens": "HomoSapiens",
+    "mouse": "MusMusculus",
+    "musmusculus": "MusMusculus",
+    "macaque": "MacacaMulatta",
+    "monkey": "MacacaMulatta",
+    "macacamulatta": "MacacaMulatta",
+}
+
+
+def _normalize_species(species: Optional[str]) -> Optional[str]:
+    if not species:
+        return species
+    return _SPECIES_ALIASES.get(species.strip().lower(), species)
+
 
 def _parse_row(entries: List[str], metadata: Dict) -> Dict[str, Any]:
     """Parse a raw VDJdb search row into a structured dictionary."""
@@ -168,7 +188,7 @@ class VDJDBTool(BaseTool):
         if not cdr3:
             return {"status": "error", "error": "cdr3 parameter is required"}
 
-        species = arguments.get("species")
+        species = _normalize_species(arguments.get("species"))
         gene = arguments.get("gene")
         match_type = arguments.get("match_type", "exact")
         page = arguments.get("page", 0)
@@ -258,7 +278,7 @@ class VDJDBTool(BaseTool):
         if not epitope:
             return {"status": "error", "error": "epitope parameter is required"}
 
-        species = arguments.get("species")
+        species = _normalize_species(arguments.get("species"))
         gene = arguments.get("gene")
         mhc_class = arguments.get("mhc_class")
         min_score = arguments.get("min_score")

--- a/tests/unit/test_bvbrc_pathways_distinguishing_fields.py
+++ b/tests/unit/test_bvbrc_pathways_distinguishing_fields.py
@@ -1,0 +1,80 @@
+"""Regression guard for Fix-R21C-1: BVBRC_search_pathways' select_fields
+list omitted gene/feature_id/product/annotation, so genuinely distinct
+BV-BRC pathway records (different genes, or the same EC/pathway annotated
+independently by RefSeq vs. PATRIC) collapsed into what looked like exact
+duplicate rows.
+
+Confirmed live for M. tuberculosis H37Rv (genome_id 83332.12) "Fatty acid
+metabolism": querying with the old select_fields returned 10 byte-for-byte
+identical rows; the same query against the raw BV-BRC Solr API with
+gene/feature_id/product/annotation added showed the true underlying
+records differ (fadD15 via RefSeq, fadD19/fadD35 via PATRIC, etc.). Fixed
+by adding those 4 fields to select_fields so the tool's own output can
+distinguish real duplicates from independently-annotated distinct records.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.bvbrc_tool import BVBRCTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return BVBRCTool(
+        {"name": "bvbrc_test", "fields": {"data_type": "pathway", "action": "search"}}
+    )
+
+
+def test_search_pathways_requests_distinguishing_fields():
+    tool = _tool()
+    captured = {}
+
+    def fake_get(url, headers=None, timeout=None, **kwargs):
+        captured["url"] = url
+        r = MagicMock()
+        r.raise_for_status = MagicMock()
+        r.json.return_value = [
+            {
+                "pathway_id": "00071",
+                "pathway_name": "Fatty acid metabolism",
+                "gene": "fadD15",
+                "feature_id": "RefSeq.83332.12.NC_000962.CDS.2448160.2449962.fwd",
+                "product": "long-chain-fatty-acid-CoA ligase fadD15",
+                "annotation": "RefSeq",
+            },
+            {
+                "pathway_id": "00071",
+                "pathway_name": "Fatty acid metabolism",
+                "gene": "fadD19",
+                "feature_id": "PATRIC.83332.12.NC_000962.CDS.3950824.3952464.rev",
+                "product": "Long-chain-fatty-acid--CoA ligase FadD19",
+                "annotation": "PATRIC",
+            },
+        ]
+        return r
+
+    with patch("tooluniverse.bvbrc_tool.requests.get", side_effect=fake_get):
+        result = tool.run(
+            {"genome_id": "83332.12", "pathway_name": "Fatty acid", "limit": 10}
+        )
+
+    assert result["status"] == "success"
+    for field in ("gene", "feature_id", "product", "annotation"):
+        assert f"select(" in captured["url"] and field in captured["url"]
+
+    genes = [row["gene"] for row in result["data"]]
+    assert genes == ["fadD15", "fadD19"]
+    assert len(set(genes)) == 2
+
+
+def test_search_pathways_still_requires_at_least_one_filter():
+    tool = _tool()
+    result = tool.run({})
+    assert result["status"] == "error"

--- a/tests/unit/test_gap_ipd_imgt_hla.py
+++ b/tests/unit/test_gap_ipd_imgt_hla.py
@@ -119,6 +119,28 @@ def test_search_alleles_invalid_match_mode_errors():
     assert "match" in result["error"].lower()
 
 
+def test_search_alleles_strips_hla_prefix():
+    """Fix-R21B-1: sibling HLA tools (e.g. VDJDB) return allele names with
+    an "HLA-" locus prefix (mhc.a: "HLA-A*02:01"), which the IPD-IMGT/HLA
+    `name` field itself doesn't carry -- confirmed live this silently
+    matched zero alleles before the prefix was stripped."""
+    tool = _make_tool("IPD_search_hla_alleles")
+    with patch("tooluniverse.ipd_imgt_hla_tool.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(json_data={"data": [], "meta": {}})
+        tool.run({"name": "HLA-A*02:01"})
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"]["query"] == 'startsWith(name,"A*02:01")'
+
+
+def test_search_alleles_hla_prefix_case_insensitive():
+    tool = _make_tool("IPD_search_hla_alleles")
+    with patch("tooluniverse.ipd_imgt_hla_tool.requests.get") as mock_get:
+        mock_get.return_value = _mock_response(json_data={"data": [], "meta": {}})
+        tool.run({"name": "hla-A*02:01"})
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"]["query"] == 'startsWith(name,"A*02:01")'
+
+
 def test_search_alleles_limit_clamped():
     tool = _make_tool("IPD_search_hla_alleles")
     with patch("tooluniverse.ipd_imgt_hla_tool.requests.get") as mock_get:

--- a/tests/unit/test_gwas_sumstats_trait_ontology_hint.py
+++ b/tests/unit/test_gwas_sumstats_trait_ontology_hint.py
@@ -1,0 +1,76 @@
+"""Regression guard for Fix-R21E-2: GWASSumStats_get_trait_studies's 404
+error for an unrecognized trait_id gave no hint about *why* -- a very
+natural trap since a sibling database (PGS Catalog) uses MONDO ids for
+the same diseases this API only recognizes by EFO id.
+
+Confirmed live: trait_id=MONDO_0004975 (Alzheimer disease's MONDO id, as
+returned by PGSCatalog_search_traits) 404s identically to a genuinely
+nonexistent EFO id, while EFO_0000249 (the same disease's real EFO id)
+works. Fixed by naming the likely cause when trait_id doesn't look like
+an EFO id.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.gwas_sumstats_tool import GWASSumStatsTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return GWASSumStatsTool(
+        {"name": "gwas_sumstats_test", "fields": {"endpoint_type": "get_trait_studies"}}
+    )
+
+
+def _resp(status_code, json_body=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.raise_for_status = MagicMock()
+    r.json.return_value = json_body or {}
+    return r
+
+
+def test_non_efo_trait_id_gets_ontology_hint():
+    tool = _tool()
+    with patch(
+        "tooluniverse.gwas_sumstats_tool.requests.get", return_value=_resp(404)
+    ):
+        result = tool.run({"trait_id": "MONDO_0004975"})
+
+    assert result["status"] == "error"
+    assert "MONDO_0004975" in result["error"]
+    assert "EFO" in result["error"]
+
+
+def test_efo_shaped_but_nonexistent_trait_id_no_hint():
+    """A trait_id that already looks like an EFO id but still 404s (a
+    genuinely nonexistent EFO id) doesn't need the ontology-mismatch
+    hint -- it's not a namespace problem."""
+    tool = _tool()
+    with patch(
+        "tooluniverse.gwas_sumstats_tool.requests.get", return_value=_resp(404)
+    ):
+        result = tool.run({"trait_id": "EFO_9999999"})
+
+    assert result["status"] == "error"
+    assert "EFO_9999999" in result["error"]
+    assert "another ontology" not in result["error"]
+
+
+def test_valid_efo_trait_id_succeeds():
+    tool = _tool()
+    body = {"_embedded": {"studies": [{"study_accession": "GCST002245"}]}}
+    with patch(
+        "tooluniverse.gwas_sumstats_tool.requests.get", return_value=_resp(200, body)
+    ):
+        result = tool.run({"trait_id": "EFO_0000249"})
+
+    assert result["status"] == "success"
+    assert result["data"][0]["study_accession"] == "GCST002245"

--- a/tests/unit/test_mhcmotifatlas_case_insensitive_allele.py
+++ b/tests/unit/test_mhcmotifatlas_case_insensitive_allele.py
@@ -1,0 +1,85 @@
+"""Regression guard for Fix-R21B-3: MHCMotifAtlasTool matched allele codes
+with exact, case-sensitive string equality against the atlas's own
+uppercase-only TSV files, so a well-formed but lowercase allele (e.g.
+"a0201") silently matched zero rows -- confirmed live -- even though the
+tool's own error message's example format doesn't mention case matters.
+
+Fixed by uppercasing the input allele before matching, consistent with how
+mhc_class is already normalized.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.mhcmotifatlas_tool import MHCMotifAtlasTool
+
+pytestmark = pytest.mark.unit
+
+_CLASS_I_TSV = "Allele\tPeptide\nA0201\tALFTKVLENV\nA0201\tGILGFVFTL\nB0702\tRANDOMPEP\n"
+_CLASS_II_TSV = "Allele\tPeptide\tCore\nDRB1_01_01\tAAAAAKAAKYGLVPGVGVAPG\tYGLVPGVGV\n"
+
+
+def _tool():
+    return MHCMotifAtlasTool({"name": "mhcmotif_test"})
+
+
+def _resp(text):
+    r = MagicMock()
+    r.status_code = 200
+    r.text = text
+    return r
+
+
+def test_lowercase_class_i_allele_matches():
+    tool = _tool()
+    with patch(
+        "tooluniverse.mhcmotifatlas_tool.request_with_retry",
+        return_value=_resp(_CLASS_I_TSV),
+    ):
+        result = tool.run({"allele": "a0201", "mhc_class": "I", "limit": 10})
+
+    assert result["status"] == "success"
+    assert result["data"]["allele"] == "A0201"
+    assert len(result["data"]["peptides"]) == 2
+
+
+def test_lowercase_class_ii_allele_matches():
+    tool = _tool()
+    with patch(
+        "tooluniverse.mhcmotifatlas_tool.request_with_retry",
+        return_value=_resp(_CLASS_II_TSV),
+    ):
+        result = tool.run({"allele": "drb1_01_01", "mhc_class": "II", "limit": 10})
+
+    assert result["status"] == "success"
+    assert result["data"]["allele"] == "DRB1_01_01"
+    assert result["data"]["peptides"][0]["core"] == "YGLVPGVGV"
+
+
+def test_uppercase_allele_still_works_no_regression():
+    tool = _tool()
+    with patch(
+        "tooluniverse.mhcmotifatlas_tool.request_with_retry",
+        return_value=_resp(_CLASS_I_TSV),
+    ):
+        result = tool.run({"allele": "B0702", "mhc_class": "I", "limit": 10})
+
+    assert result["status"] == "success"
+    assert len(result["data"]["peptides"]) == 1
+
+
+def test_genuinely_unknown_allele_still_errors():
+    tool = _tool()
+    with patch(
+        "tooluniverse.mhcmotifatlas_tool.request_with_retry",
+        return_value=_resp(_CLASS_I_TSV),
+    ):
+        result = tool.run({"allele": "Z9999", "mhc_class": "I", "limit": 10})
+
+    assert result["status"] == "error"
+    assert "No ligands found" in result["error"]

--- a/tests/unit/test_neuromorpho_allenbrain_http_error_status.py
+++ b/tests/unit/test_neuromorpho_allenbrain_http_error_status.py
@@ -1,0 +1,130 @@
+"""Regression guard for Fix-R21D-1/2: NeuroMorphoTool and AllenBrainTool's
+HTTPError handlers discarded the real upstream status code, always
+reporting "unknown" instead.
+
+Confirmed live for NeuroMorpho_get_neuron with a nonexistent neuron_id
+(999999999): the real upstream response is HTTP 404 with a JSON body
+{"status":404,"error":"Not Found","message":"Requested neuron not
+found"}, but the tool reported {"status":"error","error":"NeuroMorpho API
+HTTP error: unknown"}.
+
+Root cause: `requests.Response.__bool__` returns `self.ok` (True only for
+2xx/3xx), so `e.response.status_code if e.response else "unknown"` treats
+every 4xx/5xx Response object as falsy and always falls through to
+"unknown" -- the exact opposite of the intended check. The identical
+pattern existed in AllenBrainTool (confirmed via source inspection and a
+live 404 against a bad Allen Brain Atlas API path). Fixed by checking
+`e.response is not None` instead of truthiness, and (for NeuroMorpho,
+whose error responses are JSON) also surfacing the upstream "message"
+field.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.neuromorpho_tool import NeuroMorphoTool
+from tooluniverse.allen_brain_tool import AllenBrainTool
+
+pytestmark = pytest.mark.unit
+
+
+def _http_error_response(status_code, json_body=None, raise_on_json=False):
+    r = MagicMock()
+    r.status_code = status_code
+    if raise_on_json:
+        r.json.side_effect = ValueError("not json")
+    else:
+        r.json.return_value = json_body or {}
+    err = requests.exceptions.HTTPError(response=r)
+    r.raise_for_status = MagicMock(side_effect=err)
+    return r, err
+
+
+def test_neuromorpho_404_reports_real_status_and_message():
+    tool = NeuroMorphoTool(
+        {"name": "nm_test", "fields": {"endpoint_type": "neuron", "query_mode": "id"}}
+    )
+    resp, err = _http_error_response(
+        404, {"status": 404, "error": "Not Found", "message": "Requested neuron not found"}
+    )
+
+    def fake_get(url, **kwargs):
+        raise err
+
+    with patch("tooluniverse.neuromorpho_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"neuron_id": 999999999})
+
+    assert result["status"] == "error"
+    assert "404" in result["error"]
+    assert "unknown" not in result["error"]
+    assert "Requested neuron not found" in result["error"]
+
+
+def test_neuromorpho_http_error_without_json_body_still_reports_status():
+    tool = NeuroMorphoTool(
+        {"name": "nm_test", "fields": {"endpoint_type": "neuron", "query_mode": "id"}}
+    )
+    resp, err = _http_error_response(500, raise_on_json=True)
+
+    def fake_get(url, **kwargs):
+        raise err
+
+    with patch("tooluniverse.neuromorpho_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"neuron_id": 1})
+
+    assert result["status"] == "error"
+    assert "500" in result["error"]
+    assert "unknown" not in result["error"]
+
+
+def test_neuromorpho_no_response_object_falls_back_to_unknown():
+    """A genuine HTTPError with no response attached (e.response is None)
+    should still say 'unknown', not crash."""
+    tool = NeuroMorphoTool(
+        {"name": "nm_test", "fields": {"endpoint_type": "neuron", "query_mode": "id"}}
+    )
+    err = requests.exceptions.HTTPError("boom")
+    err.response = None
+
+    def fake_get(url, **kwargs):
+        raise err
+
+    with patch("tooluniverse.neuromorpho_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"neuron_id": 1})
+
+    assert result["status"] == "error"
+    assert "unknown" in result["error"]
+
+
+def test_allenbrain_http_error_reports_real_status():
+    tool = AllenBrainTool({"name": "allen_test", "fields": {"query_type": "gene_search"}})
+    resp, err = _http_error_response(404)
+
+    def fake_get(url, **kwargs):
+        raise err
+
+    with patch("tooluniverse.allen_brain_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"gene_acronym": "Bdnf"})
+
+    assert result["status"] == "error"
+    assert "404" in result["error"]
+    assert "unknown" not in result["error"]
+
+
+def test_allenbrain_success_case_unaffected():
+    tool = AllenBrainTool({"name": "allen_test", "fields": {"query_type": "gene_search"}})
+    r = MagicMock()
+    r.status_code = 200
+    r.raise_for_status = MagicMock()
+    r.json.return_value = {"success": True, "msg": [{"id": 11850, "acronym": "Bdnf"}]}
+
+    with patch("tooluniverse.allen_brain_tool.requests.get", return_value=r):
+        result = tool.run({"gene_acronym": "Bdnf"})
+
+    assert result["status"] == "success"

--- a/tests/unit/test_pathoplexus_organism_error_hint.py
+++ b/tests/unit/test_pathoplexus_organism_error_hint.py
@@ -1,0 +1,53 @@
+"""Regression guard for Fix-R21C-2: PathoplexusCountTool's HTTP-error
+messages told the caller to "check the organism slug" without ever naming
+the actual valid slugs, forcing a trip back to the tool description.
+Confirmed live for an unsupported organism (mycobacterium-tuberculosis):
+the LAPIS API 404s with a generic body, and the tool's own error text
+didn't help narrow down what a valid value looks like. Fixed by including
+the known-organism list directly in the error message.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.pathoplexus_tool import PathoplexusCountTool, KNOWN_ORGANISMS
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return PathoplexusCountTool({"name": "pathoplexus_test", "fields": {"timeout": 30}})
+
+
+def test_404_error_lists_known_organisms():
+    tool = _tool()
+    r = MagicMock()
+    r.status_code = 404
+    err = requests.exceptions.HTTPError(response=r)
+    r.raise_for_status = MagicMock(side_effect=err)
+
+    with patch("tooluniverse.pathoplexus_tool.requests.get", return_value=r):
+        result = tool.run({"organism": "mycobacterium-tuberculosis"})
+
+    assert result["status"] == "error"
+    for organism in KNOWN_ORGANISMS:
+        assert organism in result["error"]
+
+
+def test_valid_organism_unaffected():
+    tool = _tool()
+    r = MagicMock()
+    r.status_code = 200
+    r.raise_for_status = MagicMock()
+    r.json.return_value = {"data": [{"count": 42}]}
+
+    with patch("tooluniverse.pathoplexus_tool.requests.get", return_value=r):
+        result = tool.run({"organism": "west-nile"})
+
+    assert result["status"] == "success"

--- a/tests/unit/test_pubchem_tox_name_resolution_error.py
+++ b/tests/unit/test_pubchem_tox_name_resolution_error.py
@@ -1,0 +1,114 @@
+"""Regression guard for Fix-R21A-2: PubChemToxTool's name->CID resolution
+failure and its per-heading "no data" failure were both surfaced as the
+identical, misleading "No toxicity data found in PubChem for: X. This
+heading may not exist for this compound." message.
+
+Confirmed live: PubChem's own /pug/compound/name/{name}/cids/JSON endpoint
+returns HTTP 404 for a name that doesn't resolve at all, not just an empty
+CID list. That 404 was propagating out of _resolve_cid() as a generic
+requests.HTTPError, indistinguishable from a 404 on the actual toxicity
+PUG View lookup for a real, resolved compound missing a specific heading
+(e.g. caffeine has no "Target Organs" heading). A toxicologist debugging a
+typo would be misled into thinking the compound resolved fine. Fixed by
+checking status_code==404 inside _resolve_cid() and raising a distinct,
+clear ValueError before it reaches the generic HTTPError(404) handler.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.pubchem_tox_tool import PubChemToxTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return PubChemToxTool({"name": "pubchem_tox_test", "fields": {"endpoint": "target_organs"}})
+
+
+def _resp(status_code, json_body=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body or {}
+    return r
+
+
+def test_nonexistent_compound_name_gives_distinct_error():
+    tool = _tool()
+
+    def fake_get(url, timeout=None, **kwargs):
+        if "/cids/JSON" in url:
+            return _resp(404)
+        raise AssertionError("should not reach the PUG View lookup")
+
+    with patch("tooluniverse.pubchem_tox_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"compound_name": "Zzznonexistentdrugxyz123"})
+
+    assert result["status"] == "error"
+    assert "No compound found for name" in result["error"]
+    assert "This heading may not exist" not in result["error"]
+
+
+def test_resolved_compound_missing_heading_gives_original_message():
+    tool = _tool()
+
+    def fake_get(url, timeout=None, **kwargs):
+        if "/cids/JSON" in url:
+            return _resp(200, {"IdentifierList": {"CID": [2519]}})
+        # PUG View heading lookup 404s for a real, resolved compound.
+        r = MagicMock()
+        r.status_code = 404
+        import requests
+
+        r.raise_for_status = MagicMock(
+            side_effect=requests.exceptions.HTTPError(response=r)
+        )
+        return r
+
+    with patch("tooluniverse.pubchem_tox_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"compound_name": "caffeine"})
+
+    assert result["status"] == "error"
+    assert "This heading may not exist for this compound" in result["error"]
+    assert "No compound found for name" not in result["error"]
+
+
+def test_valid_compound_with_data_unaffected():
+    tool = _tool()
+    pug_view_body = {
+        "Record": {
+            "Section": [
+                {
+                    "TOCHeading": "Toxicity",
+                    "Section": [
+                        {
+                            "TOCHeading": "Target Organs",
+                            "Information": [
+                                {
+                                    "Value": {
+                                        "StringWithMarkup": [{"String": "Liver, kidneys"}]
+                                    }
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+
+    def fake_get(url, timeout=None, **kwargs):
+        if "/cids/JSON" in url:
+            return _resp(200, {"IdentifierList": {"CID": [5359596]}})
+        return _resp(200, pug_view_body)
+
+    with patch("tooluniverse.pubchem_tox_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"compound_name": "arsenic"})
+
+    assert result["status"] == "success"
+    assert result["data"]["cid"] == 5359596

--- a/tests/unit/test_vdjdb_species_alias_normalization.py
+++ b/tests/unit/test_vdjdb_species_alias_normalization.py
@@ -1,0 +1,122 @@
+"""Regression guard for Fix-R21B-2: VDJDBTool's `species` filter was typed
+as a free-text string in the schema but is actually an exact-match filter
+against a closed set of 3 CamelCase values (HomoSapiens/MusMusculus/
+MacacaMulatta). A plausible plain-language alias like "human" silently
+matched zero records instead of the real 20,139 HomoSapiens records for
+the same epitope (confirmed live for GILGFVFTL). Fixed by normalizing
+common aliases to the canonical VDJdb value before building the filter,
+in both _search_cdr3 and _get_antigen_specificity.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.vdjdb_tool import VDJDBTool, _normalize_species
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return VDJDBTool({"name": "vdjdb_test"})
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = json_body
+    return r
+
+
+def _empty_search_body():
+    return {"rows": [], "recordsFound": 0, "page": 0, "pageSize": 25, "pageCount": 0}
+
+
+@pytest.mark.parametrize(
+    "alias,canonical",
+    [
+        ("human", "HomoSapiens"),
+        ("HUMAN", "HomoSapiens"),
+        ("mouse", "MusMusculus"),
+        ("macaque", "MacacaMulatta"),
+        ("monkey", "MacacaMulatta"),
+    ],
+)
+def test_normalize_species_aliases(alias, canonical):
+    assert _normalize_species(alias) == canonical
+
+
+def test_normalize_species_canonical_value_passthrough():
+    assert _normalize_species("HomoSapiens") == "HomoSapiens"
+
+
+def test_normalize_species_none_passthrough():
+    assert _normalize_species(None) is None
+
+
+def test_get_antigen_specificity_normalizes_species_filter():
+    tool = _tool()
+    captured = {}
+
+    def fake_post(url, json=None, **kwargs):
+        captured["body"] = json
+        return _resp(_empty_search_body())
+
+    with patch.object(tool.session, "post", side_effect=fake_post):
+        tool.run(
+            {
+                "operation": "get_antigen_specificity",
+                "epitope": "GILGFVFTL",
+                "species": "human",
+            }
+        )
+
+    species_filters = [
+        f for f in captured["body"]["filters"] if f["column"] == "species"
+    ]
+    assert species_filters == [
+        {"column": "species", "value": "HomoSapiens", "filterType": "exact", "negative": False}
+    ]
+
+
+def test_search_cdr3_normalizes_species_filter():
+    tool = _tool()
+    captured = {}
+
+    def fake_post(url, json=None, **kwargs):
+        captured["body"] = json
+        return _resp(_empty_search_body())
+
+    with patch.object(tool.session, "post", side_effect=fake_post):
+        tool.run(
+            {
+                "operation": "search_cdr3",
+                "cdr3": "CASSIRSSYEQYF",
+                "species": "mouse",
+            }
+        )
+
+    species_filters = [
+        f for f in captured["body"]["filters"] if f["column"] == "species"
+    ]
+    assert species_filters == [
+        {"column": "species", "value": "MusMusculus", "filterType": "exact", "negative": False}
+    ]
+
+
+def test_no_species_filter_when_omitted():
+    tool = _tool()
+    captured = {}
+
+    def fake_post(url, json=None, **kwargs):
+        captured["body"] = json
+        return _resp(_empty_search_body())
+
+    with patch.object(tool.session, "post", side_effect=fake_post):
+        tool.run({"operation": "search_cdr3", "cdr3": "CASSIRSSYEQYF"})
+
+    assert not any(f["column"] == "species" for f in captured["body"]["filters"])


### PR DESCRIPTION
## Summary

Round 21 of the ongoing test-harness sweep: 5 role-play researcher personas exercised toxicology/pharmacovigilance (PubChemTox/FAERS), immunogenetics (IPD-IMGT/HLA, VDJDB, HLA Ligand Atlas, MHC Motif Atlas), microbiology (BV-BRC, Pathoplexus), neuroscience (NeuroMorpho, Allen Brain Atlas, NeuroVault), and population genetics (gnomAD, PGS Catalog, GWAS Catalog/SumStats) — domains not previously covered. 14 findings were CLI-verified against live upstream APIs; 9 confirmed root-caused and fixed here.

## Fixed

- **Fix-R21D-1/2** — `NeuroMorphoTool` and `AllenBrainTool`'s HTTPError handlers always reported "unknown" instead of the real HTTP status code, because `e.response else "unknown"` relies on `requests.Response.__bool__` (which is `False` for every 4xx/5xx response) instead of an explicit `is not None` check — the exact opposite of the intended fallback. Confirmed live for `NeuroMorpho_get_neuron` on a nonexistent id (real status: 404, reported: "unknown"). Fixed both; NeuroMorpho's handler also now surfaces the upstream JSON body's `message` field (e.g. "Requested neuron not found").
- **Fix-R21C-1** — `BVBRC_search_pathways`'s `select_fields` list omitted `gene`/`feature_id`/`product`/`annotation`, so genuinely distinct pathway records (different genes, or the same EC/pathway independently annotated by RefSeq vs. PATRIC) collapsed into what looked like exact duplicate rows (confirmed live: 10/10 identical rows for *M. tuberculosis* "Fatty acid metabolism"; direct API introspection showed the underlying records actually differ by gene: fadD15, fadD19, fadD35, etc.).
- **Fix-R21B-3** — `MHCMotifAtlas_get_allele_ligands` matched allele codes via exact, case-sensitive string equality against the atlas's all-uppercase TSV files, so a well-formed but lowercase allele (e.g. `"a0201"`) silently matched zero peptides.
- **Fix-R21A-2** — `PubChemToxTool` conflated two very different failure modes into the identical `"This heading may not exist for this compound"` message: a compound name that never resolved to a CID at all, and a real, resolved compound simply missing one specific toxicity heading. Confirmed live that PubChem's own name→CID endpoint itself 404s for unresolvable names (not just an empty CID list) — now distinguished with a clear, distinct error for each case.
- **Fix-R21B-1** — `IPD_search_hla_alleles` silently returned zero results for an `"HLA-"`-prefixed allele name — exactly the format sibling tool VDJDB itself returns (`mhc.a: "HLA-A*02:01"`) — since the underlying `name` field doesn't carry that locus prefix. Now strips it before searching.
- **Fix-R21B-2** — `VDJDBTool`'s `species` filter is an exact-match filter against exactly 3 CamelCase values (`HomoSapiens`/`MusMusculus`/`MacacaMulatta`) but was typed as free text, so a plausible alias like `"human"` silently matched zero of 20,139 real records for the same epitope (confirmed live). Added alias normalization shared by both `search_cdr3` and `get_antigen_specificity`.
- **Fix-R21C-2** — Pathoplexus's 4 HTTPError handlers said "check the organism slug" without ever naming the actual valid slugs, forcing a trip back to the tool description. Now lists them directly in the error message.
- **Fix-R21E-2** — `GWASSumStats_get_trait_studies`'s 404 for an unrecognized `trait_id` gave no hint that the API only accepts EFO ontology ids — a natural trap since a sibling database (PGS Catalog) returns MONDO ids for the same diseases (confirmed live: `MONDO_0004975` 404s identically to a genuinely nonexistent EFO id, while `EFO_0000249` for the same disease works). Now names the likely cause when `trait_id` isn't EFO-shaped.
- **Docs fix** — `NeuroVault_list_collections`'s description promised the ability to "find specific studies," but the public API has no working keyword/search/filter parameter at all (confirmed live against 5 candidate param names — `name`, `name__icontains`, `q`, `search`, `keywords` — all silent no-ops returning the full unfiltered 17,588-collection catalog). Corrected to stop overpromising.

## Deferred (documented, not fixed)

- FAERS/FDA free-text drug-name search pulls in combination products (e.g. searching "acetaminophen" surfaces opioid-acetaminophen combos), which skews aggregate adverse-event counts — a data-modeling tradeoff inherent to openFDA's free-text matching, not a clear client-side bug; fixing it well would need a fundamentally different exact-ingredient-match query path.
- FAERS silently returning an empty result for both "drug not recognized" and "drug recognized, zero events" is a low-value fix needing an extra existence-check request per call, with uncertain benefit given FAERS' free-text nature.
- A GWAS Summary Statistics region query returning duplicate records is confirmed (via direct curl against the raw EBI API) to originate from the upstream API itself, not from this package.
- Feature-21E-001 (CLI's generic "check tool name" tips firing on data-level "not found" errors, e.g. a mistyped gene symbol) is a duplicate of the already-fixed-but-not-yet-merged Fix-R18A-2/R18C-6 from round 18's PR (#314) — not re-fixed here to avoid redundant/conflicting work.

## Test plan

- [x] 24 new mocked unit tests across 7 new files, plus 2 tests added to the existing IPD-IMGT/HLA test file covering the new HLA-prefix-stripping behavior.
- [x] Full `tests/unit` suite (the standard, fully-mocked CI scope) passes clean — 0 failures.
- [x] `code-simplifier` pass applied — consolidated Pathoplexus's 4 near-identical HTTPError handlers into one shared `_http_error_response()` helper (carefully preserving the module-level `_ORGS` string constant, required since this project targets Python ≥3.10 and nested identical quotes inside an f-string only became legal in 3.12/PEP 701); fixed one line-length formatting issue. Everything else in the diff was already clean.
- [x] All 9 fixes independently verified live against the real upstream APIs before and after the change.
