### PR TITLE
Fix Round 23: immunology/microbiome/cardiology/genomics tool fixes

### DIFF
--- a/src/tooluniverse/aopwiki_tool.py
+++ b/src/tooluniverse/aopwiki_tool.py
@@ -20,6 +20,19 @@ def _get_json(url: str, timeout: int = 30) -> Any:
         return json.loads(resp.read().decode("utf-8", errors="ignore"))
 
 
+def _aopwiki_not_found(result: Any) -> bool:
+    """AOP-Wiki returns HTTP 200 with a body like
+    {"message": "This AOP does not exist.", "status": "unprocessable_entity"}
+    for an invalid id (confirmed live for both /aops and /events) -- there is
+    no HTTP error to catch. Detect that string status, not a numeric one.
+    """
+    return isinstance(result, dict) and result.get("status") in (
+        404,
+        500,
+        "unprocessable_entity",
+    )
+
+
 @register_tool(
     "AOPWikiListTool",
     config={
@@ -131,7 +144,7 @@ class AOPWikiDetailTool:
         except Exception as e:
             return {"status": "error", "error": f"AOPWiki API error: {e}"}
 
-        if not isinstance(result, dict) or result.get("status") in (404, 500):
+        if not isinstance(result, dict) or _aopwiki_not_found(result):
             return {
                 "status": "error",
                 "error": f"Key Event {event_id} not found or server error",
@@ -178,7 +191,7 @@ class AOPWikiDetailTool:
         except Exception as e:
             return {"status": "error", "error": f"AOPWiki API error: {e}"}
 
-        if isinstance(result, dict) and result.get("status") in (404, 500):
+        if _aopwiki_not_found(result):
             return {
                 "status": "error",
                 "error": f"AOP {aop_id} not found or server error",

--- a/src/tooluniverse/clinical_society_tools.py
+++ b/src/tooluniverse/clinical_society_tools.py
@@ -398,9 +398,19 @@ class AHAACCGuidelineTool(BaseTool):
                 f' AND ("{year_from}"[Date - Publication] : "3000"[Date - Publication])'
             )
 
+        # Many recent AHA/ACC joint-committee guidelines (e.g. the 2024 HCM
+        # guideline, PMID 38718139) carry no Corporate Author field at all --
+        # confirmed live via PubMed E-utilities -- only named individual
+        # authors, with the sponsoring societies appearing solely in the
+        # title ("... A Report of the American Heart Association/American
+        # College of Cardiology Joint Committee..."). Also match on title
+        # text so the Corporate Author-only filter doesn't silently exclude
+        # current guidelines that follow this newer authorship convention.
         pubmed_query = (
             f'(("American Heart Association"[Corporate Author] OR '
-            f'"American College of Cardiology"[Corporate Author]) AND '
+            f'"American College of Cardiology"[Corporate Author] OR '
+            f'"American Heart Association"[Title] OR '
+            f'"American College of Cardiology"[Title]) AND '
             f'("guideline"[Title] OR "practice guideline"[Publication Type])) '
             f"AND ({query_text}){date_filter}"
         )

--- a/src/tooluniverse/data/gtdb_tools.json
+++ b/src/tooluniverse/data/gtdb_tools.json
@@ -255,7 +255,7 @@
   },
   {
     "name": "GTDB_search_genomes",
-    "description": "Search for prokaryotic genomes in GTDB by organism name. Returns genome accessions with both NCBI and GTDB taxonomy classifications, allowing comparison between the two taxonomic systems. Each result shows the genome accession (GCA/GCF), NCBI organism name, NCBI taxonomy, GTDB taxonomy, and whether the genome is a GTDB species representative. Supports pagination. Useful for finding genome accessions, exploring taxonomic reclassifications, and linking genomes to the GTDB taxonomy.",
+    "description": "Search for prokaryotic genomes in GTDB by organism name. This matches against the whole taxonomic clade, not just the organism-name text, so results can include other members of the same family/genus alongside genomes whose own name matches the query (exact/prefix name matches are ranked first). Returns genome accessions with both NCBI and GTDB taxonomy classifications, allowing comparison between the two taxonomic systems. Each result shows the genome accession (GCA/GCF), NCBI organism name, NCBI taxonomy, GTDB taxonomy, and whether the genome is a GTDB species representative. Supports pagination. Useful for finding genome accessions, exploring taxonomic reclassifications, and linking genomes to the GTDB taxonomy.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -5151,7 +5151,7 @@
     },
     {
         "name": "OpenTargets_get_target_expression_by_ensemblID",
-        "description": "Retrieve baseline RNA and protein expression for a target across ~119 tissues and cell types (Human Protein Atlas / GTEx / FANTOM5 consensus) by Ensembl gene ID. Each record gives the tissue (label + parent organs), RNA value/zscore/level, and protein level. Levels of -1 mean no data. Use to profile where a target is normally expressed.",
+        "description": "Retrieve baseline expression for a target across tissues and cell types (GTEx, Human Protein Atlas, Tabula Sapiens, and other data sources) by Ensembl gene ID. Each record gives the source tissue/biosample, the originating datasource, and median/min/max expression values in that datasource's native unit (e.g. TPM for GTEx, PPB/iBAQ for PRIDE proteomics). Use to profile where a target is normally expressed.",
         "parameter": {
             "type": "object",
             "properties": {
@@ -5164,7 +5164,7 @@
                 "ensemblId"
             ]
         },
-        "query_schema": "\n      query targetExpression($ensemblId: String!) {\n        target(ensemblId: $ensemblId) {\n          id\n          approvedSymbol\n          expressions {\n            tissue { label organs anatomicalSystems }\n            rna { value zscore level unit }\n            protein { level reliability }\n          }\n        }\n      }\n    ",
+        "query_schema": "\n      query targetExpression($ensemblId: String!) {\n        target(ensemblId: $ensemblId) {\n          id\n          approvedSymbol\n          baselineExpression {\n            count\n            rows {\n              datasourceId\n              tissueBiosample { biosampleId biosampleName }\n              median\n              min\n              max\n              unit\n            }\n          }\n        }\n      }\n    ",
         "label": [
             "Target",
             "Expression",
@@ -5202,19 +5202,45 @@
                                         "approvedSymbol": {
                                             "type": "string"
                                         },
-                                        "expressions": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "tissue": {
-                                                        "type": "object"
-                                                    },
-                                                    "rna": {
-                                                        "type": "object"
-                                                    },
-                                                    "protein": {
-                                                        "type": "object"
+                                        "baselineExpression": {
+                                            "type": "object",
+                                            "properties": {
+                                                "count": {
+                                                    "type": "integer"
+                                                },
+                                                "rows": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "datasourceId": {
+                                                                "type": "string"
+                                                            },
+                                                            "tissueBiosample": {
+                                                                "type": "object"
+                                                            },
+                                                            "median": {
+                                                                "type": [
+                                                                    "number",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "min": {
+                                                                "type": [
+                                                                    "number",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "max": {
+                                                                "type": [
+                                                                    "number",
+                                                                    "null"
+                                                                ]
+                                                            },
+                                                            "unit": {
+                                                                "type": "string"
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }

--- a/src/tooluniverse/data/pgs_catalog_tools.json
+++ b/src/tooluniverse/data/pgs_catalog_tools.json
@@ -9,7 +9,7 @@
       "properties": {
         "query": {
           "type": "string",
-          "description": "Trait or phenotype term, e.g. 'coronary artery disease', 'type 2 diabetes', 'breast cancer'."
+          "description": "Trait or phenotype term, e.g. 'coronary artery disease', 'type 2 diabetes', 'breast cancer'. PGS Catalog's own search can return zero results for some multi-word phrases that don't exactly match an indexed label even when a near-identical trait exists (e.g. 'familial hypercholesterolemia' finds nothing while 'hypercholesterolemia' alone does) -- if a natural-language query returns no results, retry with a shorter or more generic core term."
         }
       },
       "required": ["query"]

--- a/src/tooluniverse/ebi_proteins_epitope_tool.py
+++ b/src/tooluniverse/ebi_proteins_epitope_tool.py
@@ -90,6 +90,14 @@ class EBIProteinsEpitopeTool(BaseTool):
                     pmids.append(src.get("id"))
                 if src.get("name") == "IEDB":
                     iedb_ids.append(src.get("id"))
+            # The IEDB epitope ID actually lives under "xrefs", not
+            # "evidences.source" (confirmed live: every EPITOPE feature's
+            # own description names an epitope ID, e.g. "epitope ID 1220",
+            # sourced from an xrefs entry {"name": "IEDB", "id": "1220"}),
+            # so the evidences-only check above never matched anything.
+            for xref in f.get("xrefs", []) or []:
+                if xref.get("name") == "IEDB" and xref.get("id"):
+                    iedb_ids.append(xref.get("id"))
 
             begin_val = f.get("begin")
             end_val = f.get("end")

--- a/src/tooluniverse/gtdb_tool.py
+++ b/src/tooluniverse/gtdb_tool.py
@@ -151,6 +151,18 @@ class GTDBTool(BaseTool):
         if not species:
             return {"status": "error", "error": "species parameter is required"}
 
+        # GTDB's species/search endpoint is case-sensitive on binomial
+        # capitalization (confirmed live: lowercase "akkermansia muciniphila"
+        # 404s while "Akkermansia muciniphila" succeeds), unlike the sibling
+        # genomes/search endpoint which is case-insensitive. Normalize to the
+        # standard Genus-capitalized/species-lowercase convention so callers
+        # aren't tripped up by an inconsistency within this same tool family.
+        parts = species.split()
+        if parts:
+            parts[0] = parts[0].capitalize()
+            parts[1:] = [p.lower() for p in parts[1:]]
+            species = " ".join(parts)
+
         result = self._make_request("species/search/{}".format(species))
         if not result["ok"]:
             return {"status": "error", "error": result["error"]}
@@ -238,6 +250,24 @@ class GTDBTool(BaseTool):
         data = result["data"]
         rows = data.get("rows", [])
         total = data.get("totalRows", len(rows))
+
+        # GTDB's search matches against the whole taxonomic clade, not just
+        # organism-name substrings (confirmed live: querying "Akkermansia
+        # muciniphila" returns unrelated family-mates like "Roseibacillus sp.
+        # TMED18" ranked above the exact species) -- boost rows whose own
+        # ncbiOrgName actually matches the query so the requested organism
+        # isn't buried under broader clade results within this page.
+        query_lower = query.strip().lower()
+
+        def _relevance(row):
+            name = (row.get("ncbiOrgName") or "").lower()
+            if name == query_lower:
+                return 0
+            if name.startswith(query_lower):
+                return 1
+            return 2
+
+        rows = sorted(rows, key=_relevance)
 
         return {
             "status": "success",

--- a/src/tooluniverse/iedb_prediction_tool.py
+++ b/src/tooluniverse/iedb_prediction_tool.py
@@ -61,6 +61,22 @@ class IEDBPredictionTool(BaseTool):
         reader = csv.DictReader(io.StringIO(text.strip()), delimiter="\t")
         return [dict(row) for row in reader]
 
+    @staticmethod
+    def _iedb_error_response(text: str) -> Dict[str, Any] | None:
+        """Detect IEDB's plain-text error responses (e.g. an invalid allele
+        name), which return HTTP 200 with prose instead of a TSV table --
+        parsing that as TSV silently produces bogus rows keyed on the error
+        message itself. Returns an error dict if `text` isn't real TSV data,
+        else None.
+        """
+        first_line = text.strip().split("\n", 1)[0]
+        if "\t" in first_line:
+            return None
+        return {
+            "status": "error",
+            "error": f"IEDB API error: {first_line}",
+        }
+
     def _predict_bcell(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Predict linear B-cell epitopes along a protein sequence.
 
@@ -78,6 +94,9 @@ class IEDBPredictionTool(BaseTool):
             timeout=self.timeout,
         )
         resp.raise_for_status()
+        err = self._iedb_error_response(resp.text)
+        if err:
+            return err
         rows = self._parse_tsv(resp.text)
 
         residues = []
@@ -174,6 +193,9 @@ class IEDBPredictionTool(BaseTool):
         )
         resp.raise_for_status()
 
+        err = self._iedb_error_response(resp.text)
+        if err:
+            return err
         results = self._parse_tsv(resp.text)
 
         # Cast numeric columns; sort by total_score descending (higher = more
@@ -243,6 +265,9 @@ class IEDBPredictionTool(BaseTool):
         )
         resp.raise_for_status()
 
+        err = self._iedb_error_response(resp.text)
+        if err:
+            return err
         results = self._parse_tsv(resp.text)
 
         # Sort by score (descending for EL, ascending for BA)
@@ -292,10 +317,18 @@ class IEDBPredictionTool(BaseTool):
         )
         resp.raise_for_status()
 
+        err = self._iedb_error_response(resp.text)
+        if err:
+            return err
         results = self._parse_tsv(resp.text)
+        # The mhcii/ endpoint's TSV column is "rank", not "percentile_rank"
+        # (confirmed live) -- reading the wrong key silently defaulted every
+        # result to 100.0, masking real binder rankings.
         for r in results:
             try:
-                r["percentile_rank"] = float(r.get("percentile_rank", 100))
+                r["percentile_rank"] = float(
+                    r.get("rank", r.get("percentile_rank", 100))
+                )
             except (ValueError, TypeError):
                 pass
 
@@ -309,5 +342,9 @@ class IEDBPredictionTool(BaseTool):
                 "allele": allele,
                 "n_peptides": len(results),
                 "source": "IEDB Analysis Resource",
+                "interpretation": (
+                    "percentile_rank < 2% = strong binder, "
+                    "2-10% = weak binder, >10% = non-binder (NetMHCIIpan convention)"
+                ),
             },
         }

--- a/src/tooluniverse/impc_tool.py
+++ b/src/tooluniverse/impc_tool.py
@@ -155,6 +155,26 @@ class IMPCTool(BaseTool):
             }
 
         gene_data = docs[0]
+
+        # The 'gene' core's phenotype-summary fields (imits_phenotype_complete,
+        # mp_id, ...) are inconsistently populated -- confirmed live that App
+        # (MGI:88059) has none of them set here despite having 9 real
+        # significant phenotype calls in the 'genotype-phenotype' core. A
+        # cheap rows=0 existence check against that core catches what the
+        # 'gene' core's summary fields silently miss.
+        resolved_mgi_id = gene_data.get("mgi_accession_id") or mgi_id
+        has_real_phenotype_calls = False
+        if resolved_mgi_id:
+            gp_check = self._solr_query(
+                core="genotype-phenotype",
+                query=f'marker_accession_id:"{resolved_mgi_id}"',
+                rows=0,
+            )
+            has_real_phenotype_calls = (
+                gp_check.get("status") == "success"
+                and gp_check["response"].get("numFound", 0) > 0
+            )
+
         return {
             "status": "success",
             "data": {
@@ -168,7 +188,8 @@ class IMPCTool(BaseTool):
                 "production_status": gene_data.get("latest_production_status"),
                 "phenotyping_centre": gene_data.get("latest_phenotyping_centre"),
                 "production_centre": gene_data.get("latest_production_centre"),
-                "has_phenotype_data": gene_data.get("imits_phenotype_complete") == "1"
+                "has_phenotype_data": has_real_phenotype_calls
+                or gene_data.get("imits_phenotype_complete") == "1"
                 or bool(gene_data.get("mp_id")),
                 "mp_terms": gene_data.get("mp_term", []),
                 "mp_ids": gene_data.get("mp_id", []),
@@ -291,8 +312,12 @@ class IMPCTool(BaseTool):
         if not query_str:
             return {"status": "error", "error": "query parameter is required"}
 
-        # Search across multiple fields
+        # Search across multiple fields. Without an exact-match boost, Solr's
+        # default relevance scoring can rank an exact gene-symbol match well
+        # below unrelated fuzzy/substring matches (confirmed live: querying
+        # "App" put the exact match 12th out of 20) -- boost it to the front.
         query = (
+            f'marker_symbol:"{query_str}"^100 OR '
             f"marker_symbol:{query_str}* OR "
             f"marker_name:*{query_str}* OR "
             f"marker_synonym:*{query_str}* OR "

--- a/src/tooluniverse/kegg_tool.py
+++ b/src/tooluniverse/kegg_tool.py
@@ -206,27 +206,32 @@ class KEGGListOrganisms(KEGGRESTTool):
 
     def __init__(self, tool_config):
         super().__init__(tool_config)
-        self.endpoint = "/list/organism"
+        # KEGG retired /list/organism (confirmed live: HTTP 400) -- /list/genome
+        # returns the same organism catalog under a "T-number\tcode; description"
+        # format instead of the old 3-column layout.
+        self.endpoint = "/list/genome"
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """List organisms."""
         result = self._make_request(self.endpoint)
 
-        # Parse organism list
+        # Parse organism list: each line is "T01001\thsa; Homo sapiens (human)".
         if result.get("status") == "success" and isinstance(result.get("data"), str):
             lines = result["data"].split("\n")
             organisms = []
             for line in lines:
-                if "\t" in line:
-                    parts = line.split("\t")
-                    if len(parts) >= 3:
-                        organisms.append(
-                            {
-                                "organism_code": parts[0],
-                                "organism_name": parts[1],
-                                "description": parts[2] if len(parts) > 2 else "",
-                            }
-                        )
+                if "\t" not in line:
+                    continue
+                genome_id, rest = line.split("\t", 1)
+                organism_code, _, description = rest.partition("; ")
+                organisms.append(
+                    {
+                        "organism_code": organism_code,
+                        "organism_name": description or organism_code,
+                        "description": description,
+                        "kegg_genome_id": genome_id,
+                    }
+                )
             result["data"] = organisms
             result["count"] = len(organisms)
 

--- a/tests/unit/test_aha_acc_guideline_query.py
+++ b/tests/unit/test_aha_acc_guideline_query.py
@@ -1,0 +1,44 @@
+"""Regression guard for Fix-R23E-1: AHA_ACC_search_guidelines's PubMed
+query hard-required a Corporate Author tag ("American Heart
+Association"[Corporate Author] OR "American College of
+Cardiology"[Corporate Author]) -- confirmed live via PubMed E-utilities
+that recent joint-committee guidelines (e.g. the 2024 HCM guideline, PMID
+38718139) carry no Corporate Author field at all, only named individual
+authors, with the sponsoring societies appearing solely in the title. The
+Corporate-Author-only filter silently excluded these, making a
+year_from-scoped search return zero results even though a current,
+directly relevant guideline exists. Fixed by also matching on title text.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinical_society_tools import AHAACCGuidelineTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return AHAACCGuidelineTool(
+        {"name": "aha_acc_test", "fields": {"operation": "search"}}
+    )
+
+
+class TestGuidelineQueryBroadening:
+    def test_query_matches_title_not_just_corporate_author(self):
+        tool = _tool()
+
+        with patch(
+            "tooluniverse.clinical_society_tools._search_and_fetch",
+            return_value={"status": "success", "result": []},
+        ) as mock_fetch:
+            tool.run(
+                {"query": "hypertrophic cardiomyopathy", "limit": 5, "year_from": 2020}
+            )
+
+        query_arg = mock_fetch.call_args[0][0]
+        assert '"American Heart Association"[Corporate Author]' in query_arg
+        assert '"American Heart Association"[Title]' in query_arg
+        assert '"American College of Cardiology"[Title]' in query_arg
+        assert '"guideline"[Title]' in query_arg or "practice guideline" in query_arg

--- a/tests/unit/test_aopwiki_not_found.py
+++ b/tests/unit/test_aopwiki_not_found.py
@@ -1,0 +1,71 @@
+"""Regression guard for Fix-R23C-1: AOPWiki's /aops and /events endpoints
+return HTTP 200 with a body like
+{"message": "This AOP does not exist.", "status": "unprocessable_entity"}
+for an invalid id -- confirmed live for both endpoints. The existing
+not-found check only matched numeric status codes (404, 500), which never
+appear in this API's error body, so an invalid id silently produced a
+status:"success" response with every field null/empty instead of an error.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.aopwiki_tool import AOPWikiDetailTool
+
+pytestmark = pytest.mark.unit
+
+_NOT_FOUND_BODY = {
+    "message": "This AOP does not exist.",
+    "status": "unprocessable_entity",
+}
+_EVENT_NOT_FOUND_BODY = {
+    "message": "This event does not exist.",
+    "status": "unprocessable_entity",
+}
+
+_REAL_AOP = {
+    "id": 1,
+    "title": "Uncharacterized liver damage leading to hepatocellular carcinoma",
+    "short_name": "Liver damage and hepatocellular carcinoma",
+    "created_at": "2016-11-29T18:41:15.000-05:00",
+    "updated_at": "2023-04-29T16:02:54.000-04:00",
+    "aop_stressors": [],
+    "aop_mies": [],
+    "aop_kes": [],
+    "aop_aos": [],
+}
+
+
+class TestAopNotFound:
+    def test_invalid_aop_id_returns_error_not_empty_success(self):
+        tool = AOPWikiDetailTool({"settings": {}})
+
+        with patch("tooluniverse.aopwiki_tool._get_json", return_value=_NOT_FOUND_BODY):
+            result = tool.run({"aop_id": 999999})
+
+        assert result["status"] == "error"
+        assert "999999" in result["error"]
+
+    def test_valid_aop_id_still_succeeds(self):
+        tool = AOPWikiDetailTool({"settings": {}})
+
+        with patch("tooluniverse.aopwiki_tool._get_json", return_value=_REAL_AOP):
+            result = tool.run({"aop_id": 1})
+
+        assert result["status"] == "success"
+        assert result["data"]["id"] == 1
+        assert result["data"]["title"].startswith("Uncharacterized liver damage")
+
+
+class TestEventNotFound:
+    def test_invalid_event_id_returns_error_not_empty_success(self):
+        tool = AOPWikiDetailTool({"settings": {"endpoint_kind": "event"}})
+
+        with patch(
+            "tooluniverse.aopwiki_tool._get_json", return_value=_EVENT_NOT_FOUND_BODY
+        ):
+            result = tool.run({"event_id": 9999999})
+
+        assert result["status"] == "error"
+        assert "9999999" in result["error"]

--- a/tests/unit/test_ebi_proteins_epitope_iedb_ids.py
+++ b/tests/unit/test_ebi_proteins_epitope_iedb_ids.py
@@ -1,0 +1,79 @@
+"""Regression guard for Fix-R23B-3: EBIProteinsEpitopeTool's `iedb_ids`
+field was always empty. Confirmed live for P0DTC2 (SARS-CoV-2 spike): the
+IEDB epitope ID actually lives under a feature's top-level "xrefs" array
+({"name": "IEDB", "id": "1220"}), not under "evidences.source" (which only
+ever carries PubMed references) -- the code only checked the latter. Every
+one of 1143 EPITOPE features for P0DTC2 has its own description naming a
+specific epitope ID (e.g. "epitope ID 1220") that the field should have
+surfaced.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.ebi_proteins_epitope_tool import EBIProteinsEpitopeTool
+
+pytestmark = pytest.mark.unit
+
+_RAW_FEATURE = {
+    "type": "EPITOPE",
+    "description": "AEVQIDRLI is a linear peptidic epitope (epitope ID 1220) tested in 5 T cell assays and 7 MHC ligand assays.",
+    "begin": "989",
+    "end": "997",
+    "xrefs": [
+        {
+            "name": "IEDB",
+            "id": "1220",
+            "url": "https://www.iedb.org/epitope/1220",
+        }
+    ],
+    "evidences": [
+        {
+            "code": "ECO:0000213",
+            "source": {"name": "PubMed", "id": "35383307"},
+        }
+    ],
+    "epitopeSequence": "AEVQIDRLI",
+    "matchScore": 100,
+}
+
+
+def _tool():
+    return EBIProteinsEpitopeTool({"name": "ebi_epitope_test"})
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.json.return_value = json_body
+    r.raise_for_status = MagicMock()
+    return r
+
+
+class TestIedbIdsFromXrefs:
+    def test_iedb_id_extracted_from_xrefs(self):
+        tool = _tool()
+        resp = _resp({"accession": "P0DTC2", "features": [_RAW_FEATURE]})
+
+        with patch(
+            "tooluniverse.ebi_proteins_epitope_tool.requests.get", return_value=resp
+        ):
+            result = tool.run({"accession": "P0DTC2"})
+
+        assert result["status"] == "success"
+        epitope = result["data"]["epitopes"][0]
+        assert epitope["iedb_ids"] == ["1220"]
+        assert epitope["pmids"] == ["35383307"]
+
+    def test_feature_with_no_xrefs_gets_empty_iedb_ids(self):
+        tool = _tool()
+        feature = dict(_RAW_FEATURE)
+        feature["xrefs"] = []
+        resp = _resp({"accession": "P0DTC2", "features": [feature]})
+
+        with patch(
+            "tooluniverse.ebi_proteins_epitope_tool.requests.get", return_value=resp
+        ):
+            result = tool.run({"accession": "P0DTC2"})
+
+        assert result["data"]["epitopes"][0]["iedb_ids"] == []

--- a/tests/unit/test_gtdb_search_relevance.py
+++ b/tests/unit/test_gtdb_search_relevance.py
@@ -1,0 +1,69 @@
+"""Regression guard for Fix-R23D-3: GTDB_search_genomes matches against the
+whole taxonomic clade, not just organism-name text -- confirmed live that
+querying "Akkermansia muciniphila" returned unrelated family-mates like
+"Roseibacillus sp. TMED18" ranked ahead of genomes whose own name actually
+matches. Fixed by boosting exact/prefix ncbiOrgName matches to the front of
+the fetched page.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.gtdb_tool import GTDBTool
+
+pytestmark = pytest.mark.unit
+
+_UNSORTED_ROWS = [
+    {"accession": "GCA_002168145.2", "ncbiOrgName": "Roseibacillus sp. TMED18"},
+    {"accession": "GCA_000436395.1", "ncbiOrgName": "Akkermansia muciniphila CAG:154"},
+    {
+        "accession": "GCA_002170085.1",
+        "ncbiOrgName": "Verrucomicrobiaceae bacterium TMED137",
+    },
+    {"accession": "GCA_000723745.2", "ncbiOrgName": "Akkermansia muciniphila"},
+]
+
+
+def _tool():
+    return GTDBTool({"name": "gtdb_test", "parameter": {}})
+
+
+def _resp(status_code, json_body):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body
+    return r
+
+
+class TestSearchGenomesRelevance:
+    def test_exact_name_match_ranked_first(self):
+        tool = _tool()
+        resp = _resp(200, {"rows": _UNSORTED_ROWS, "totalRows": 3599})
+
+        with patch.object(tool.session, "get", return_value=resp):
+            result = tool.run(
+                {"operation": "search_genomes", "query": "Akkermansia muciniphila"}
+            )
+
+        assert result["status"] == "success"
+        names = [r["ncbiOrgName"] for r in result["data"]["results"]]
+        assert names[0] == "Akkermansia muciniphila"
+        assert names[1] == "Akkermansia muciniphila CAG:154"
+        assert set(names[2:]) == {
+            "Roseibacillus sp. TMED18",
+            "Verrucomicrobiaceae bacterium TMED137",
+        }
+
+    def test_no_relevant_match_preserves_original_order(self):
+        tool = _tool()
+        rows = _UNSORTED_ROWS[:2]  # neither is an exact/prefix match for this query
+        resp = _resp(200, {"rows": rows, "totalRows": 2})
+
+        with patch.object(tool.session, "get", return_value=resp):
+            result = tool.run(
+                {"operation": "search_genomes", "query": "Faecalibacterium prausnitzii"}
+            )
+
+        names = [r["ncbiOrgName"] for r in result["data"]["results"]]
+        assert names == [r["ncbiOrgName"] for r in rows]

--- a/tests/unit/test_gtdb_species_case_normalization.py
+++ b/tests/unit/test_gtdb_species_case_normalization.py
@@ -1,0 +1,75 @@
+"""Regression guard for Fix-R23D-2: GTDB_get_species's species/search
+endpoint is case-sensitive on binomial capitalization (confirmed live:
+lowercase "akkermansia muciniphila" 404s with a misleading "no genomes
+found" error while "Akkermansia muciniphila" succeeds), unlike the sibling
+GTDB_search_genomes endpoint which matches case-insensitively. Fixed by
+normalizing input to Genus-capitalized/species-lowercase before querying.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.gtdb_tool import GTDBTool
+
+pytestmark = pytest.mark.unit
+
+_SPECIES_RESPONSE = {
+    "name": "Akkermansia muciniphila",
+    "genomes": [
+        {"accession": "GCA_000723745.2", "ncbi_org_name": "Akkermansia muciniphila"}
+    ],
+}
+
+
+def _tool():
+    return GTDBTool({"name": "gtdb_test", "parameter": {}})
+
+
+def _resp(status_code, json_body):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body
+    r.headers = {"content-type": "application/json"}
+    return r
+
+
+class TestSpeciesCaseNormalization:
+    def test_lowercase_input_still_resolves(self):
+        tool = _tool()
+        resp = _resp(200, _SPECIES_RESPONSE)
+
+        with patch.object(tool.session, "get", return_value=resp) as mock_get:
+            result = tool.run(
+                {"operation": "get_species", "species": "akkermansia muciniphila"}
+            )
+
+        assert result["status"] == "success"
+        assert result["data"]["species_name"] == "Akkermansia muciniphila"
+        called_url = mock_get.call_args[0][0]
+        assert (
+            "Akkermansia%20muciniphila" in called_url
+            or "Akkermansia muciniphila" in called_url
+        )
+
+    def test_already_proper_case_unaffected(self):
+        tool = _tool()
+        resp = _resp(200, _SPECIES_RESPONSE)
+
+        with patch.object(tool.session, "get", return_value=resp):
+            result = tool.run(
+                {"operation": "get_species", "species": "Akkermansia muciniphila"}
+            )
+
+        assert result["status"] == "success"
+        assert result["data"]["total_genomes"] == 1
+
+    def test_all_uppercase_input_normalized(self):
+        tool = _tool()
+        resp = _resp(200, _SPECIES_RESPONSE)
+
+        with patch.object(tool.session, "get", return_value=resp) as mock_get:
+            tool.run({"operation": "get_species", "species": "AKKERMANSIA MUCINIPHILA"})
+
+        called_url = mock_get.call_args[0][0]
+        assert "MUCINIPHILA" not in called_url

--- a/tests/unit/test_iedb_prediction_tool.py
+++ b/tests/unit/test_iedb_prediction_tool.py
@@ -1,0 +1,98 @@
+"""Regression guard for two Fix-R23B bugs in IEDBPredictionTool.
+
+Fix-R23B-1 (percentile_rank): the mhcii/ endpoint's real TSV column is
+"rank", not "percentile_rank" (confirmed live) -- _predict_mhcii read the
+wrong key, so every result silently defaulted to percentile_rank=100.0
+regardless of true binding strength, hiding real strong binders from any
+caller filtering on the documented convention.
+
+Fix-R23B-2 (invalid-allele silent success): IEDB's tools_api endpoints
+return HTTP 200 with a plain-text error message (not a TSV table) for
+invalid input like an unrecognized HLA allele name -- confirmed live for
+mhci/. Naively parsing that as TSV produced bogus single-column "rows"
+keyed on the error prose itself, with status:"success" and fabricated
+score/percentile_rank of 0.0/100.0. Fixed by detecting non-tabular
+responses before parsing and returning a clear error instead.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.iedb_prediction_tool import IEDBPredictionTool
+
+pytestmark = pytest.mark.unit
+
+_MHCII_TSV = (
+    "allele\tseq_num\tstart\tend\tlength\tcore_peptide\tpeptide\tscore\trank\n"
+    "HLA-DRB1*01:01\t1\t194\t208\t15\tFELLHAPAT\tVLSFELLHAPATVCG\t0.8447\t0.67\n"
+    "HLA-DRB1*01:01\t1\t192\t206\t15\tFELLHAPAT\tVVVLSFELLHAPATV\t0.8119\t0.86\n"
+)
+
+_MHCI_INVALID_ALLELE_TEXT = (
+    "Invalid allele name HLA-A*99:99 found.\n\n"
+    "* Please go to the link below for more usage info:\n"
+    "http://tools.iedb.org/main/html/tools_api.html"
+)
+
+_MHCI_VALID_TSV = (
+    "allele\tseq_num\tstart\tend\tlength\tpeptide\tcore\ticore\tscore\tpercentile_rank\n"
+    "HLA-A*02:01\t1\t1\t9\t9\tKIADYNYKL\tKIADYNYKL\tKIADYNYKL\t0.865\t0.05\n"
+)
+
+
+def _tool(endpoint_type):
+    return IEDBPredictionTool(
+        {"name": "iedb_test", "fields": {"endpoint_type": endpoint_type}}
+    )
+
+
+def _resp(text):
+    r = MagicMock()
+    r.text = text
+    r.raise_for_status = MagicMock()
+    return r
+
+
+class TestMhciiPercentileRank:
+    def test_reads_rank_column_not_hardcoded_100(self):
+        tool = _tool("predict_mhcii")
+        resp = _resp(_MHCII_TSV)
+
+        with patch(
+            "tooluniverse.iedb_prediction_tool.requests.post", return_value=resp
+        ):
+            result = tool.run({"sequence": "X" * 20, "allele": "HLA-DRB1*01:01"})
+
+        assert result["status"] == "success"
+        ranks = [r["percentile_rank"] for r in result["data"]]
+        assert ranks == [0.67, 0.86]
+        assert all(r != 100.0 for r in ranks)
+
+
+class TestInvalidAlleleErrorDetection:
+    def test_mhci_plain_text_error_returns_status_error(self):
+        tool = _tool("predict_mhci")
+        resp = _resp(_MHCI_INVALID_ALLELE_TEXT)
+
+        with patch(
+            "tooluniverse.iedb_prediction_tool.requests.post", return_value=resp
+        ):
+            result = tool.run({"sequence": "KIADYNYKLPDDFTGC", "allele": "HLA-A*99:99"})
+
+        assert result["status"] == "error"
+        assert "Invalid allele name HLA-A*99:99" in result["error"]
+        assert "data" not in result
+
+    def test_mhci_valid_tsv_still_succeeds(self):
+        tool = _tool("predict_mhci")
+        resp = _resp(_MHCI_VALID_TSV)
+
+        with patch(
+            "tooluniverse.iedb_prediction_tool.requests.post", return_value=resp
+        ):
+            result = tool.run({"sequence": "KIADYNYKLPDDFTGC", "allele": "HLA-A*02:01"})
+
+        assert result["status"] == "success"
+        assert result["data"][0]["peptide"] == "KIADYNYKL"
+        assert result["data"][0]["percentile_rank"] == 0.05

--- a/tests/unit/test_impc_tool_fixes.py
+++ b/tests/unit/test_impc_tool_fixes.py
@@ -1,0 +1,109 @@
+"""Regression guard for two Fix-R23A bugs in IMPCTool.
+
+Fix-R23A-1 (search relevance): IMPC_search_genes's Solr query had no
+exact-match boost, so a real gene symbol could rank well outside the
+default rows=20 window -- confirmed live that querying "App" put the exact
+match 12th, behind unrelated genes like Hydin/Nfrkb/Ikbke. Fixed by boosting
+an exact marker_symbol match to the front of Solr's own relevance ranking.
+
+Fix-R23A-2 (gene summary has_phenotype_data): IMPC_get_gene_summary derives
+has_phenotype_data purely from the 'gene' Solr core's own summary fields
+(imits_phenotype_complete, mp_id), which are inconsistently populated --
+confirmed live that App (MGI:88059) has none of them set in the 'gene' core
+despite having 9 real significant phenotype calls in the separate
+'genotype-phenotype' core (used by the sibling get_phenotypes_by_gene
+tool). Fixed by cross-checking that core before deciding has_phenotype_data.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.impc_tool import IMPCTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(operation):
+    return IMPCTool({"name": "impc_test", "fields": {"operation": operation}})
+
+
+def _solr_resp(docs, num_found=None):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = {
+        "response": {
+            "docs": docs,
+            "numFound": num_found if num_found is not None else len(docs),
+        }
+    }
+    return r
+
+
+class TestSearchGenesExactMatchBoost:
+    def test_query_boosts_exact_marker_symbol_match(self):
+        tool = _tool("search_genes")
+        resp = _solr_resp([{"mgi_accession_id": "MGI:88059", "marker_symbol": "App"}])
+
+        with patch(
+            "tooluniverse.impc_tool.requests.get", return_value=resp
+        ) as mock_get:
+            tool.run({"query": "App"})
+
+        query_param = mock_get.call_args.kwargs["params"]["q"]
+        assert 'marker_symbol:"App"^100' in query_param
+
+
+class TestGeneSummaryPhenotypeCrossCheck:
+    def test_falls_back_to_genotype_phenotype_core_when_gene_core_empty(self):
+        tool = _tool("get_gene_summary")
+        gene_resp = _solr_resp(
+            [{"mgi_accession_id": "MGI:88059", "marker_symbol": "App"}]
+        )
+        gp_resp = _solr_resp([], num_found=9)
+
+        with patch(
+            "tooluniverse.impc_tool.requests.get",
+            side_effect=[gene_resp, gp_resp],
+        ):
+            result = tool.run({"gene_symbol": "App"})
+
+        assert result["status"] == "success"
+        assert result["data"]["has_phenotype_data"] is True
+
+    def test_no_genotype_phenotype_hits_and_no_gene_core_fields_is_false(self):
+        tool = _tool("get_gene_summary")
+        gene_resp = _solr_resp(
+            [{"mgi_accession_id": "MGI:99999", "marker_symbol": "Xyz"}]
+        )
+        gp_resp = _solr_resp([], num_found=0)
+
+        with patch(
+            "tooluniverse.impc_tool.requests.get",
+            side_effect=[gene_resp, gp_resp],
+        ):
+            result = tool.run({"gene_symbol": "Xyz"})
+
+        assert result["status"] == "success"
+        assert result["data"]["has_phenotype_data"] is False
+
+    def test_gene_core_fields_alone_still_count(self):
+        tool = _tool("get_gene_summary")
+        gene_resp = _solr_resp(
+            [
+                {
+                    "mgi_accession_id": "MGI:12345",
+                    "marker_symbol": "Trp53",
+                    "imits_phenotype_complete": "1",
+                }
+            ]
+        )
+        gp_resp = _solr_resp([], num_found=0)
+
+        with patch(
+            "tooluniverse.impc_tool.requests.get",
+            side_effect=[gene_resp, gp_resp],
+        ):
+            result = tool.run({"gene_symbol": "Trp53"})
+
+        assert result["data"]["has_phenotype_data"] is True

--- a/tests/unit/test_kegg_list_organisms.py
+++ b/tests/unit/test_kegg_list_organisms.py
@@ -1,0 +1,51 @@
+"""Regression guard for Fix-R23D-1: KEGGListOrganisms hit KEGG's retired
+/list/organism endpoint, which now returns HTTP 400 (confirmed live) --
+the tool was completely non-functional. /list/genome serves the same
+organism catalog but in a different line format ("T01001\thsa; Homo
+sapiens (human)" instead of the old 3-column layout), so parsing had to
+change along with the endpoint.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.kegg_tool import KEGGListOrganisms
+
+pytestmark = pytest.mark.unit
+
+_GENOME_LIST_TEXT = (
+    "T01001\thsa; Homo sapiens (human)\nT01005\tptr; Pan troglodytes (chimpanzee)\n"
+)
+
+
+def _tool():
+    return KEGGListOrganisms({"name": "kegg_test", "fields": {}})
+
+
+def _resp(text):
+    r = MagicMock()
+    r.text = text
+    r.raise_for_status = MagicMock()
+    r.headers = {"content-type": "text/plain"}
+    return r
+
+
+class TestListOrganisms:
+    def test_uses_list_genome_endpoint(self):
+        tool = _tool()
+        assert tool.endpoint == "/list/genome"
+
+    def test_parses_code_and_description_from_genome_format(self):
+        tool = _tool()
+        resp = _resp(_GENOME_LIST_TEXT)
+
+        with patch.object(tool.session, "get", return_value=resp):
+            result = tool.run({})
+
+        assert result["status"] == "success"
+        assert result["count"] == 2
+        hsa = result["data"][0]
+        assert hsa["organism_code"] == "hsa"
+        assert hsa["organism_name"] == "Homo sapiens (human)"
+        assert hsa["kegg_genome_id"] == "T01001"

--- a/tests/unit/test_opentargets_expression_query.py
+++ b/tests/unit/test_opentargets_expression_query.py
@@ -1,0 +1,64 @@
+"""OpenTargets_get_target_expression_by_ensemblID must not request fields
+removed from the schema.
+
+Regression (Fix-R23A-1): OpenTargets removed the `Target.expressions` field
+entirely (confirmed live via GraphQL introspection: querying it now errors
+"Cannot query field 'expressions' on type 'Target'"). The replacement is
+`baselineExpression { count rows { datasourceId tissueBiosample { ... }
+median min max unit } }`, a differently-shaped biosample/datasource model
+rather than the old tissue/rna/protein triple. The query must use the
+current field names.
+"""
+
+import json
+import os
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_CONFIG = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "src",
+    "tooluniverse",
+    "data",
+    "opentarget_tools.json",
+)
+
+
+def _tool(name):
+    with open(_CONFIG) as fh:
+        for t in json.load(fh):
+            if isinstance(t, dict) and t.get("name") == name:
+                return t
+    raise AssertionError(f"{name} not found in opentarget_tools.json")
+
+
+def test_expression_query_uses_current_fields():
+    tool = _tool("OpenTargets_get_target_expression_by_ensemblID")
+    query = tool.get("query_schema", "")
+    assert "expressions" not in query
+    assert "baselineExpression" in query
+    assert "tissueBiosample" in query
+
+
+def test_expression_return_schema_matches_query_shape():
+    tool = _tool("OpenTargets_get_target_expression_by_ensemblID")
+    target_props = tool["return_schema"]["oneOf"][0]["properties"]["data"][
+        "properties"
+    ]["target"]["properties"]
+    assert "baselineExpression" in target_props
+    assert "expressions" not in target_props
+    row_props = target_props["baselineExpression"]["properties"]["rows"]["items"][
+        "properties"
+    ]
+    assert "datasourceId" in row_props
+    assert "tissueBiosample" in row_props
+
+
+def test_expression_has_real_example():
+    tool = _tool("OpenTargets_get_target_expression_by_ensemblID")
+    examples = tool.get("test_examples", [])
+    assert examples and examples[0].get("ensemblId")


### PR DESCRIPTION
## Summary

Round 23 of the ongoing test-harness campaign. 5 role-play research personas (neuroscience/CNS drug discovery, immunology/vaccine design, environmental toxicology, microbiome/metagenomics, cardiology/precision-medicine) exercised ~100 tool calls across 6+ domains; every finding was CLI-verified against live upstream APIs before fixing.

## Fixes

- **IEDB_predict_mhcii_binding**: reads the `mhcii/` endpoint's real `rank` column instead of the nonexistent `percentile_rank` column, which silently defaulted every result to 100.0 regardless of true binding strength
- **IEDB_predict_mhci/mhcii_binding, predict_bcell_epitopes, predict_antigen_processing**: detect IEDB's plain-text error responses (e.g. an invalid HLA allele name) before parsing them as TSV, which previously produced bogus single-column rows keyed on the error message itself with a fabricated `status:"success"`
- **kegg_list_organisms**: switched off KEGG's retired `/list/organism` endpoint (HTTP 400) to `/list/genome`, with matching line-format parsing
- **GTDB_get_species**: normalize species-name capitalization before querying (the endpoint is case-sensitive, unlike its sibling search endpoint)
- **GTDB_search_genomes**: boost exact/prefix organism-name matches to the front, since the endpoint matches on whole taxonomic clades and can bury the actually-requested organism under unrelated family members
- **OpenTargets_get_target_expression_by_ensemblID**: updated the GraphQL query off the removed `expressions` field to the current `baselineExpression` biosample/datasource model
- **AOPWiki_get_aop / get_key_event**: detect AOP-Wiki's string `"unprocessable_entity"` not-found status (the existing check only matched numeric HTTP-style codes), which previously returned a silent `status:"success"` with every field null for an invalid id
- **IMPC_search_genes**: boost an exact marker-symbol match in the Solr query so it doesn't get buried outside the default result window
- **IMPC_get_gene_summary**: cross-check the genotype-phenotype core for `has_phenotype_data`, since the gene core's own phenotype-summary fields are inconsistently populated and can silently under-report real data
- **AHA_ACC_search_guidelines**: broadened the PubMed query to also match guideline titles, since recent joint-committee guidelines (e.g. the 2024 hypertrophic cardiomyopathy guideline) carry no Corporate Author field
- **EBIProteins_get_epitopes**: extract `iedb_ids` from the `xrefs` array instead of `evidences.source`, where the IEDB epitope ID actually lives
- **PGSCatalog_search_traits**: doc-only caveat that multi-word trait phrases can silently zero out upstream even when a near-identical trait exists

## Deferred (documented, not fixed)

- MCP `find_tools`/`grep_tools` returning truncated/incomplete tool names, and `mcp__tooluniverse__execute_tool` failing session-wide — MCP-interface-layer issues, not tool code bugs
- OpenTargets known-drugs' null `disease` entries — confirmed genuine raw upstream GraphQL data (verified via direct API query), not a ToolUniverse transformation bug
- ADMET-AI's raw-torch-error message on invalid SMILES — needs the optional `[ml]` extra installed to safely verify a fix; current behavior is caught (not an unhandled crash), just a technical error message
- Several lower-severity findings needing further investigation before a confident fix: CTD name-resolution brittleness (BPA/hyphenation), ChEMBL structural-alert filter parameter apparently ignored server-side, CTD missing organism/PMID fields, NCBIDatasets taxonomy lineage returning unresolved numeric IDs, `grep_tools` regex-mode case sensitivity, NCBIDatasets silent-empty results for strain-qualified organism names, BVBRC fragmented synonym names (unverified against raw API)

## Test plan

- 9 new mocked unit test files, all passing
- Full `pytest tests/unit` suite passes (only pre-existing unrelated skips)
- Every fix verified live against the real upstream API before and after the change