### PR TITLE
Fix Round 24: structural biology/epidemiology/plant/single-cell tool fixes

### DIFF
--- a/src/tooluniverse/data/cpic_tools.json
+++ b/src/tooluniverse/data/cpic_tools.json
@@ -1078,7 +1078,8 @@
             "integer",
             "null"
           ],
-          "description": "Maximum number of alleles to return (default 50)"
+          "description": "Maximum number of alleles to return (default 50)",
+          "default": 50
         }
       },
       "required": [

--- a/src/tooluniverse/data/disease_sh_ext_tools.json
+++ b/src/tooluniverse/data/disease_sh_ext_tools.json
@@ -10,7 +10,8 @@
             "string",
             "null"
           ],
-          "description": "Country name or ISO code. Use 'all' for global data. Examples: 'usa', 'china', 'india', 'uk', 'germany', 'all'"
+          "description": "Country name or ISO code. Use 'all' for global data. Examples: 'usa', 'china', 'india', 'uk', 'germany', 'all'",
+          "default": "all"
         },
         "lastdays": {
           "type": [
@@ -103,16 +104,13 @@
   },
   {
     "name": "DiseaseSH_get_vaccine_coverage",
-    "description": "Get COVID-19 vaccine coverage data for a country or globally using the Disease.sh API. Returns timeline of total vaccination doses administered and percentage of population vaccinated. No authentication required.",
+    "description": "Get COVID-19 vaccine coverage data for a specific country using the Disease.sh API. Returns timeline of total vaccination doses administered and percentage of population vaccinated. Global data is not available through this tool -- the upstream API serves it from a differently-shaped endpoint this tool does not call; pass a real country name/ISO code. No authentication required.",
     "parameter": {
       "type": "object",
       "properties": {
         "country": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Country name or 'all' for global. Examples: 'usa', 'uk', 'germany', 'india', 'all'"
+          "type": "string",
+          "description": "Country name or ISO code (a real one -- 'all' is not supported by this endpoint and 404s). Examples: 'usa', 'uk', 'germany', 'india'"
         },
         "lastdays": {
           "type": [
@@ -122,7 +120,7 @@
           "description": "Number of past days to include. Default: 30. Examples: 7, 30, 90"
         }
       },
-      "required": []
+      "required": ["country"]
     },
     "fields": {
       "endpoint": "https://disease.sh/v3/covid-19/vaccine/coverage/countries/{country}",

--- a/src/tooluniverse/data/diseasesh_tools.json
+++ b/src/tooluniverse/data/diseasesh_tools.json
@@ -266,7 +266,8 @@
             "string",
             "null"
           ],
-          "description": "Country name or 'all' for global data. Examples: 'USA', 'India', 'all'. If omitted, returns global data."
+          "description": "Country name or 'all' for global data. Examples: 'USA', 'India', 'all'. If omitted, returns global data.",
+          "default": "all"
         },
         "lastdays": {
           "type": [

--- a/src/tooluniverse/data/expression_atlas_tools.json
+++ b/src/tooluniverse/data/expression_atlas_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "ExpressionAtlas_get_baseline",
-    "description": "Get baseline gene expression experiments from EBI Expression Atlas. Shows which tissues/cell types express a gene under normal conditions. Complements GTEx and HPA. No API key needed. Query by gene symbol or Ensembl ID.",
+    "description": "List baseline gene expression experiments in EBI Expression Atlas for a given species. The `gene` argument is used to label the request and suggest a follow-up call, but does NOT filter the returned experiment list (the underlying API has no reliable way to filter experiments by gene) -- use GxA_get_experiment_expression with an experiment_accession from the results and gene_id=<gene> to check whether a specific experiment actually has data for that gene. Complements GTEx and HPA. No API key needed.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -75,9 +75,6 @@
                           "number"
                         ]
                       },
-                      "gene_mentioned": {
-                        "type": "boolean"
-                      },
                       "last_update": {
                         "type": "string"
                       }
@@ -89,14 +86,12 @@
                     "integer",
                     "number"
                   ]
-                },
-                "gene_specific_count": {
-                  "type": [
-                    "integer",
-                    "number"
-                  ]
                 }
               }
+            },
+            "note": {
+              "type": "string",
+              "description": "Clarifies this list is not gene-filtered and how to check a specific experiment for the gene."
             },
             "metadata": {
               "type": "object"

--- a/src/tooluniverse/data/foldseek_tools.json
+++ b/src/tooluniverse/data/foldseek_tools.json
@@ -24,7 +24,7 @@
         },
         "mode": {
           "type": "string",
-          "description": "Search mode: 'tmalign' (fast 3Di+AA, default), 'tmalign' (TM-align, slower but more sensitive).",
+          "description": "Search mode: '3diaa' (fast 3Di+AA, default), 'tmalign' (TM-align, slower but more sensitive).",
           "default": "3diaa"
         },
         "max_results": {

--- a/src/tooluniverse/data/marine_regions_tools.json
+++ b/src/tooluniverse/data/marine_regions_tools.json
@@ -28,7 +28,8 @@
             "integer",
             "null"
           ],
-          "description": "Pagination offset. Default: 0 (first page)"
+          "description": "Pagination offset. Default: 0 (first page)",
+          "default": 0
         }
       },
       "required": [

--- a/src/tooluniverse/data/who_gho_tools.json
+++ b/src/tooluniverse/data/who_gho_tools.json
@@ -119,6 +119,10 @@
       "endpoint": "https://ghoapi.azureedge.net/api/{indicator_code}",
       "params": {
         "$top": 20
+      },
+      "param_mapping": {
+        "filter": "$filter",
+        "top": "$top"
       }
     },
     "type": "BaseRESTTool",

--- a/src/tooluniverse/expression_atlas_tool.py
+++ b/src/tooluniverse/expression_atlas_tool.py
@@ -62,11 +62,13 @@ class ExpressionAtlasTool(BaseTool):
 
     def _get_baseline_expression(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Get baseline expression experiments for a gene.
+        List baseline expression experiments for a species.
 
-        Uses EBI Search to find experiments mentioning the gene,
-        then filters the Expression Atlas experiment catalog for
-        baseline experiments in the specified species.
+        Fetches the Expression Atlas experiment catalog and returns its
+        baseline experiments for the requested species. The list is not
+        filtered by gene -- the underlying API has no reliable way to do so
+        (see the inline note below), so ``gene`` only labels the request and
+        drives the follow-up suggestion.
         """
         gene = arguments.get("gene", "")
         species = arguments.get("species", "homo sapiens")
@@ -94,48 +96,34 @@ class ExpressionAtlasTool(BaseTool):
                 and e.get("species", "").lower() == species_lower
             ]
 
-            # Step 2: Search EBI Search for gene-specific experiments
-            search_url = f"{EBI_SEARCH_BASE}/atlas-experiments"
-            search_params = {
-                "query": gene,
-                "size": 100,
-                "format": "json",
-                "fields": "description",
-            }
-            search_resp = requests.get(
-                search_url,
-                params=search_params,
-                timeout=self.timeout,
-            )
-            gene_experiment_ids = set()
-            if search_resp.status_code == 200:
-                search_data = search_resp.json()
-                for entry in search_data.get("entries", []):
-                    gene_experiment_ids.add(entry.get("id"))
-
-            # Combine: tag baseline experiments that mention the gene
-            results = []
-            for exp in baseline_exps:
-                acc = exp.get("experimentAccession", "")
-                results.append(
-                    {
-                        "experiment_accession": acc,
-                        "experiment_type": exp.get("rawExperimentType"),
-                        "experiment_description": exp.get("experimentDescription"),
-                        "species": exp.get("species"),
-                        "num_assays": exp.get("numberOfAssays"),
-                        "gene_mentioned": acc in gene_experiment_ids,
-                        "last_update": exp.get("lastUpdate"),
-                    }
-                )
-
-            # Sort: gene-mentioned first, then by assay count
-            results.sort(
-                key=lambda x: (
-                    not x.get("gene_mentioned", False),
-                    -(x.get("num_assays") or 0),
-                )
-            )
+            # NOTE: this used to also tag each experiment with a
+            # "gene_mentioned" flag by full-text-searching EBI Search's
+            # experiment *description* field for the gene symbol. Confirmed
+            # live that this never works as intended: descriptions are
+            # one-line study summaries that essentially never contain a bare
+            # gene symbol, so gene_mentioned was false for every real gene
+            # (and could false-positive on short symbols that happen to
+            # substring-match unrelated words). The GXA API itself also
+            # silently ignores a geneQuery filter on /json/experiments
+            # (confirmed live: identical result count with and without it),
+            # so there's no cheap way to filter this list by gene. Listing
+            # species-level baseline experiments honestly, without a broken
+            # per-gene relevance signal, and pointing to
+            # GxA_get_experiment_expression (which does support per-gene
+            # filtering, against one already-known experiment) for the
+            # actual per-gene lookup.
+            results = [
+                {
+                    "experiment_accession": exp.get("experimentAccession", ""),
+                    "experiment_type": exp.get("rawExperimentType"),
+                    "experiment_description": exp.get("experimentDescription"),
+                    "species": exp.get("species"),
+                    "num_assays": exp.get("numberOfAssays"),
+                    "last_update": exp.get("lastUpdate"),
+                }
+                for exp in baseline_exps
+            ]
+            results.sort(key=lambda x: -(x.get("num_assays") or 0))
 
             return {
                 "status": "success",
@@ -144,10 +132,15 @@ class ExpressionAtlasTool(BaseTool):
                     "species": species,
                     "baseline_experiments": results[:50],
                     "total_baseline": len(baseline_exps),
-                    "gene_specific_count": len(
-                        [r for r in results if r["gene_mentioned"]]
-                    ),
                 },
+                "note": (
+                    f"This lists baseline experiments for '{species}'; it does "
+                    "not filter by gene (the underlying API has no reliable way "
+                    "to do so). Use GxA_get_experiment_expression with an "
+                    "experiment_accession from this list and gene_id="
+                    f"'{gene}' to check whether that specific experiment has "
+                    "data for the gene."
+                ),
                 "source": ("EBI Expression Atlas - Baseline Expression"),
             }
 

--- a/src/tooluniverse/foldseek_tool.py
+++ b/src/tooluniverse/foldseek_tool.py
@@ -74,7 +74,11 @@ class FoldseekTool(BaseRESTTool):
         # Accept 'query' as alias for 'sequence'
         sequence = (arguments.get("sequence") or arguments.get("query") or "").strip()
         database = arguments.get("database", "afdb50")
-        mode = arguments.get("mode", "tmalign")
+        # Match the JSON schema's documented default -- this previously
+        # disagreed with it ("tmalign" here vs "3diaa" in the schema),
+        # so an omitted mode silently ran the slower TM-align mode instead
+        # of the documented fast 3diaa default.
+        mode = arguments.get("mode", "3diaa")
         max_results = min(int(arguments.get("max_results", 10)), 50)
 
         if not pdb_id and not sequence:

--- a/src/tooluniverse/hca_tool.py
+++ b/src/tooluniverse/hca_tool.py
@@ -62,7 +62,10 @@ class HCATool(BaseTool):
             filters["organ"] = {"is": [organ]}
 
         if disease:
-            filters["disease"] = {"is": [disease]}
+            # Azul's facet is "donorDisease", not "disease" -- the latter is
+            # rejected outright with a 400 "Additional properties are not
+            # allowed" error (confirmed live).
+            filters["donorDisease"] = {"is": [disease]}
 
         params = {"size": limit, "filters": json.dumps(filters) if filters else "{}"}
 
@@ -73,17 +76,21 @@ class HCATool(BaseTool):
 
             projects = []
             for hit in data.get("hits", []):
-                # Extract relevant info to make it cleaner
+                # organ/disease live under the nested specimens/donorOrganisms
+                # arrays as plain string lists, not top-level "modelOrgan"/
+                # "donorDisease" dict keys (confirmed live) -- those top-level
+                # keys don't exist in the hit at all, so reading them always
+                # silently returned None.
+                specimens = hit.get("specimens") or [{}]
+                donors = hit.get("donorOrganisms") or [{}]
                 projects.append(
                     {
                         "entryId": hit.get("entryId"),
                         "projectTitle": hit.get("projects", [{}])[0].get(
                             "projectTitle"
                         ),
-                        "organ": hit.get("modelOrgan", {}).get(
-                            "terms"
-                        ),  # Inspect structure showed modelOrgan
-                        "donorDisease": hit.get("donorDisease", {}).get("terms"),
+                        "organ": specimens[0].get("organ"),
+                        "donorDisease": donors[0].get("disease"),
                     }
                 )
 

--- a/src/tooluniverse/uniprot_idmapping_tool.py
+++ b/src/tooluniverse/uniprot_idmapping_tool.py
@@ -118,11 +118,15 @@ class UniProtIDMappingTool(BaseTool):
             )
             status_data = status_resp.json()
 
-            if status_data.get("jobStatus") == "FINISHED":
+            # For jobs that complete almost instantly, the status endpoint can
+            # return results embedded directly instead of a "FINISHED"
+            # jobStatus (confirmed live) -- either way, treat it as done and
+            # fall through to the paginated results fetch below (size=500).
+            # Returning this embedded copy directly previously silently
+            # truncated to UniProt's unpaginated default page size (25),
+            # even when the job actually had hundreds of matches.
+            if status_data.get("jobStatus") == "FINISHED" or "results" in status_data:
                 break
-            if "results" in status_data:
-                # Some responses include results directly
-                return {"results": status_data["results"], "job_id": job_id}
             if status_data.get("jobStatus") == "ERROR":
                 msg = status_data.get("errorMessage", "Unknown error")
                 return {

--- a/tests/unit/test_expression_atlas_baseline_honesty.py
+++ b/tests/unit/test_expression_atlas_baseline_honesty.py
@@ -1,0 +1,123 @@
+"""Regression guard for Fix-R24E-1/24C-1: ExpressionAtlas_get_baseline's
+per-gene "gene_mentioned"/"gene_specific_count" fields were computed by
+full-text-searching EBI Search's experiment *description* field for the
+gene symbol. Confirmed live (independently, by two different queries) this
+essentially never matches -- descriptions are one-line study summaries
+that don't contain bare gene symbols -- so gene_mentioned was false for
+every real gene tested, including well-known housekeeping genes, while
+status stayed "success". Also confirmed live that GXA's own /json/experiments
+endpoint silently ignores a geneQuery filter (identical result count with
+or without it), so there is no cheap correct way to filter server-side
+either. Fixed by dropping the broken fields and being explicit that this
+call lists species-level baseline experiments, not gene-filtered ones.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.expression_atlas_tool import ExpressionAtlasTool
+
+pytestmark = pytest.mark.unit
+
+_ALL_EXPERIMENTS = {
+    "experiments": [
+        {
+            "experimentAccession": "E-GTEX-8",
+            "rawExperimentType": "RNASEQ_MRNA_BASELINE",
+            "experimentDescription": "The Genotype-Tissue Expression (GTEx) project v8",
+            "species": "Homo sapiens",
+            "numberOfAssays": 17350,
+            "lastUpdate": "20-12-2024",
+        },
+        {
+            "experimentAccession": "E-MTAB-5214",
+            "rawExperimentType": "RNASEQ_MRNA_BASELINE",
+            "experimentDescription": "Baseline RNA-seq of 53 human tissues",
+            "species": "Homo sapiens",
+            "numberOfAssays": 927,
+            "lastUpdate": "01-01-2023",
+        },
+        {
+            "experimentAccession": "E-MTAB-1234",
+            "rawExperimentType": "RNASEQ_MRNA_DIFFERENTIAL",
+            "experimentDescription": "Differential experiment, should be excluded",
+            "species": "Homo sapiens",
+            "numberOfAssays": 10,
+            "lastUpdate": "01-01-2023",
+        },
+    ]
+}
+
+
+def _tool():
+    return ExpressionAtlasTool(
+        {"name": "expr_atlas_test", "fields": {"operation": "get_baseline_expression"}}
+    )
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = json_body
+    return r
+
+
+class TestBaselineListingIsHonest:
+    def test_no_gene_mentioned_field_and_note_present(self):
+        tool = _tool()
+        resp = _resp(_ALL_EXPERIMENTS)
+
+        with patch(
+            "tooluniverse.expression_atlas_tool.requests.get", return_value=resp
+        ):
+            result = tool.run({"gene": "INS", "species": "homo sapiens"})
+
+        assert result["status"] == "success"
+        assert "gene_specific_count" not in result["data"]
+        for exp in result["data"]["baseline_experiments"]:
+            assert "gene_mentioned" not in exp
+        assert "GxA_get_experiment_expression" in result["note"]
+
+    def test_only_baseline_experiments_returned_for_species(self):
+        tool = _tool()
+        resp = _resp(_ALL_EXPERIMENTS)
+
+        with patch(
+            "tooluniverse.expression_atlas_tool.requests.get", return_value=resp
+        ):
+            result = tool.run({"gene": "INS", "species": "homo sapiens"})
+
+        accessions = {
+            e["experiment_accession"] for e in result["data"]["baseline_experiments"]
+        }
+        assert accessions == {"E-GTEX-8", "E-MTAB-5214"}
+        assert result["data"]["total_baseline"] == 2
+
+    def test_sorted_by_assay_count_descending(self):
+        tool = _tool()
+        resp = _resp(_ALL_EXPERIMENTS)
+
+        with patch(
+            "tooluniverse.expression_atlas_tool.requests.get", return_value=resp
+        ):
+            result = tool.run({"gene": "INS", "species": "homo sapiens"})
+
+        accessions = [
+            e["experiment_accession"] for e in result["data"]["baseline_experiments"]
+        ]
+        assert accessions == ["E-GTEX-8", "E-MTAB-5214"]
+
+    def test_only_one_http_call_made_no_ebi_search_call(self):
+        """The old implementation made a second HTTP call to EBI Search's
+        atlas-experiments index; that call is gone now that gene_mentioned
+        isn't computed."""
+        tool = _tool()
+        resp = _resp(_ALL_EXPERIMENTS)
+
+        with patch(
+            "tooluniverse.expression_atlas_tool.requests.get", return_value=resp
+        ) as mock_get:
+            tool.run({"gene": "INS", "species": "homo sapiens"})
+
+        assert mock_get.call_count == 1

--- a/tests/unit/test_foldseek_mode_default.py
+++ b/tests/unit/test_foldseek_mode_default.py
@@ -1,0 +1,78 @@
+"""Regression guard for Fix-R24A-1: Foldseek_search_structure's `mode`
+parameter had two disagreeing defaults -- the JSON schema declared
+"3diaa" but the Python code's own fallback was `arguments.get("mode",
+"tmalign")`. Confirmed live: with the corrected "3diaa" default, searching
+1M17 (EGFR kinase domain) against pdb100 correctly returns other EGFR
+mutant structures at ~99% identity; with "tmalign" it returns unrelated,
+weakly-scoring hits. An omitted `mode` argument was silently running the
+wrong (slower, less specific) search mode. The schema description also had
+a copy-paste typo labeling both options "tmalign"; fixed to name the fast
+default "3diaa".
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.foldseek_tool import FoldseekTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return FoldseekTool({"name": "foldseek_test", "fields": {"operation": "search"}})
+
+
+def _mock_flow():
+    """requests.post -> ticket submit; requests.get -> [status, result]."""
+    post_resp = MagicMock()
+    post_resp.status_code = 200
+    post_resp.json.return_value = {"id": "ticket123"}
+
+    status_resp = MagicMock()
+    status_resp.status_code = 200
+    status_resp.json.return_value = {"status": "COMPLETE"}
+
+    result_resp = MagicMock()
+    result_resp.status_code = 200
+    result_resp.json.return_value = {"results": [{"alignments": [[]]}]}
+
+    return post_resp, status_resp, result_resp
+
+
+class TestModeDefault:
+    def test_omitted_mode_submits_3diaa(self):
+        tool = _tool()
+        post_resp, status_resp, result_resp = _mock_flow()
+
+        with (
+            patch(
+                "tooluniverse.foldseek_tool.requests.post", return_value=post_resp
+            ) as mock_post,
+            patch(
+                "tooluniverse.foldseek_tool.requests.get",
+                side_effect=[status_resp, result_resp],
+            ),
+        ):
+            tool.run({"sequence": "MKV", "database": "pdb100"})
+
+        submitted_data = mock_post.call_args.kwargs["data"]
+        assert submitted_data["mode"] == "3diaa"
+
+    def test_explicit_mode_still_forwarded(self):
+        tool = _tool()
+        post_resp, status_resp, result_resp = _mock_flow()
+
+        with (
+            patch(
+                "tooluniverse.foldseek_tool.requests.post", return_value=post_resp
+            ) as mock_post,
+            patch(
+                "tooluniverse.foldseek_tool.requests.get",
+                side_effect=[status_resp, result_resp],
+            ),
+        ):
+            tool.run({"sequence": "MKV", "database": "pdb100", "mode": "tmalign"})
+
+        submitted_data = mock_post.call_args.kwargs["data"]
+        assert submitted_data["mode"] == "tmalign"

--- a/tests/unit/test_hca_search_projects.py
+++ b/tests/unit/test_hca_search_projects.py
@@ -1,0 +1,75 @@
+"""Regression guard for two Fix-R24E bugs in HCATool.search_projects.
+
+Fix-R24E-1 (disease filter facet name): the Azul HCA API rejects a
+"disease" filter facet outright with a 400 "Additional properties are not
+allowed ('disease' was unexpected)" error -- confirmed live. The real facet
+name is "donorDisease". Every call passing `disease` previously errored.
+
+Fix-R24E-2 (organ/donorDisease extraction): each hit's organ and disease
+values live under nested "specimens"/"donorOrganisms" array fields, not
+top-level "modelOrgan"/"donorDisease" dict keys -- confirmed live those
+top-level keys don't exist at all, so reading them always silently
+returned None regardless of the real data.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.hca_tool import HCATool
+
+pytestmark = pytest.mark.unit
+
+_HIT = {
+    "entryId": "894ae6ac-5b48-41a8-a72f-315a9b60a62e",
+    "projects": [
+        {"projectTitle": "A Single-Cell Transcriptome Atlas of the Human Pancreas."}
+    ],
+    "specimens": [{"organ": ["pancreas"], "disease": ["normal"]}],
+    "donorOrganisms": [{"disease": ["normal"]}],
+}
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = json_body
+    return r
+
+
+class TestDiseaseFilterFacetName:
+    def test_disease_arg_uses_donor_disease_facet(self):
+        tool = HCATool({"name": "hca_test"})
+        resp = _resp({"hits": [_HIT], "pagination": {"total": 1}})
+
+        with patch("tooluniverse.hca_tool.requests.get", return_value=resp) as mock_get:
+            tool.search_projects(organ="pancreas", disease="normal", limit=3)
+
+        filters_param = mock_get.call_args.kwargs["params"]["filters"]
+        assert '"donorDisease"' in filters_param
+        assert '"disease": {"is"' not in filters_param.replace(" ", "")
+
+
+class TestOrganAndDiseaseExtraction:
+    def test_organ_and_disease_populated_from_nested_fields(self):
+        tool = HCATool({"name": "hca_test"})
+        resp = _resp({"hits": [_HIT], "pagination": {"total": 1}})
+
+        with patch("tooluniverse.hca_tool.requests.get", return_value=resp):
+            result = tool.search_projects(organ="pancreas", limit=3)
+
+        project = result["projects"][0]
+        assert project["organ"] == ["pancreas"]
+        assert project["donorDisease"] == ["normal"]
+
+    def test_missing_specimens_or_donors_does_not_crash(self):
+        tool = HCATool({"name": "hca_test"})
+        bare_hit = {"entryId": "x", "projects": [{}]}
+        resp = _resp({"hits": [bare_hit], "pagination": {"total": 1}})
+
+        with patch("tooluniverse.hca_tool.requests.get", return_value=resp):
+            result = tool.search_projects(organ="pancreas", limit=3)
+
+        project = result["projects"][0]
+        assert project["organ"] is None
+        assert project["donorDisease"] is None

--- a/tests/unit/test_uniprot_idmapping_pagination.py
+++ b/tests/unit/test_uniprot_idmapping_pagination.py
@@ -1,0 +1,87 @@
+"""Regression guard for Fix-R24A-2: UniProtIDMappingTool._submit_and_poll
+silently truncated results to UniProt's unpaginated default page size (25)
+for jobs that complete almost instantly.
+
+Confirmed live (instrumented poll loop against the real API): for a job
+that finishes fast, UniProt's /idmapping/status/{job_id} endpoint can
+return the results embedded directly in the status response instead of
+{"jobStatus": "FINISHED"} -- e.g. P00533 (EGFR) -> PDB genuinely has 354
+matches, but the embedded status-response copy only had 25 (UniProt's
+default page size when no `size` param is set). The old code treated that
+embedded copy as authoritative and returned it immediately, bypassing the
+already-correct paginated fetch (`size=500`) a few lines below. Fixed by
+treating an embedded "results" key the same as "FINISHED" -- fall through
+to the paginated fetch either way instead of returning early.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.uniprot_idmapping_tool import UniProtIDMappingTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return UniProtIDMappingTool(
+        {"name": "uniprot_idmap_test", "fields": {"endpoint_type": "to_pdb"}}
+    )
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = json_body
+    return r
+
+
+class TestFastJobDoesNotTruncate:
+    def test_embedded_status_results_are_not_returned_directly(self):
+        tool = _tool()
+        submit_resp = _resp({"jobId": "job123"})
+        # Status response for a near-instant job: no "jobStatus", just a
+        # small embedded (unpaginated) results preview -- confirmed live.
+        status_resp = _resp({"results": [{"from": "P00533", "to": "1M17"}] * 25})
+        paginated_resp = _resp(
+            {"results": [{"from": "P00533", "to": f"PDB{i}"} for i in range(354)]}
+        )
+
+        with (
+            patch(
+                "tooluniverse.uniprot_idmapping_tool.requests.post",
+                return_value=submit_resp,
+            ),
+            patch(
+                "tooluniverse.uniprot_idmapping_tool.requests.get",
+                side_effect=[status_resp, paginated_resp],
+            ) as mock_get,
+        ):
+            result = tool.run({"uniprot_ids": "P00533"})
+
+        assert result["status"] == "success"
+        assert result["data"]["result_count"] == 354
+        # The second GET call must be the paginated results fetch with size=500.
+        second_call = mock_get.call_args_list[1]
+        assert second_call.kwargs["params"] == {"size": 500}
+
+    def test_normal_finished_status_still_works(self):
+        tool = _tool()
+        submit_resp = _resp({"jobId": "job456"})
+        status_resp = _resp({"jobStatus": "FINISHED"})
+        paginated_resp = _resp({"results": [{"from": "P00533", "to": "1M17"}]})
+
+        with (
+            patch(
+                "tooluniverse.uniprot_idmapping_tool.requests.post",
+                return_value=submit_resp,
+            ),
+            patch(
+                "tooluniverse.uniprot_idmapping_tool.requests.get",
+                side_effect=[status_resp, paginated_resp],
+            ),
+        ):
+            result = tool.run({"uniprot_ids": "P00533"})
+
+        assert result["status"] == "success"
+        assert result["data"]["result_count"] == 1

--- a/tests/unit/test_who_gho_indicator_data_params.py
+++ b/tests/unit/test_who_gho_indicator_data_params.py
@@ -1,0 +1,52 @@
+"""WHOGHO_get_indicator_data must map filter/top args to WHO GHO's OData
+query params.
+
+Regression (Fix-R24B-1): the config had no `fields.param_mapping`, so
+BaseRESTTool sent the caller's `filter`/`top` arguments as literal
+unprefixed query params (`filter=...`, `top=...`). WHO GHO's OData API
+silently ignores unrecognized params, so every call fell back to the
+hardcoded default `$top=20` with no filter applied at all -- confirmed
+live that a country-scoped query returned 20 rows from unrelated
+countries. The sibling tool WHOGHO_search_indicators already carries the
+correct `{"filter": "$filter", "top": "$top"}` mapping; this tool was
+missing it.
+"""
+
+import json
+import os
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_CONFIG = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "src",
+    "tooluniverse",
+    "data",
+    "who_gho_tools.json",
+)
+
+
+def _tool(name):
+    with open(_CONFIG) as fh:
+        for t in json.load(fh):
+            if isinstance(t, dict) and t.get("name") == name:
+                return t
+    raise AssertionError(f"{name} not found in who_gho_tools.json")
+
+
+def test_get_indicator_data_maps_filter_and_top_to_odata_params():
+    tool = _tool("WHOGHO_get_indicator_data")
+    mapping = tool.get("fields", {}).get("param_mapping", {})
+    assert mapping.get("filter") == "$filter"
+    assert mapping.get("top") == "$top"
+
+
+def test_search_indicators_mapping_unaffected():
+    tool = _tool("WHOGHO_search_indicators")
+    mapping = tool.get("fields", {}).get("param_mapping", {})
+    assert mapping.get("filter") == "$filter"
+    assert mapping.get("top") == "$top"


### PR DESCRIPTION
## Summary

Round 24 of the ongoing test-harness campaign. 5 role-play research personas (structural biology/crystallography, epidemiology/public health, plant/agricultural genomics, pharmacogenomics/drug safety, single-cell genomics) exercised ~130 tool calls across 6+ domains; every finding was CLI-verified against live upstream APIs before fixing.

## Fixes

- **CPIC_get_alleles**: the `limit` URL template placeholder was never substituted when omitted (no schema default), sending a literal `limit={limit}` to the API and returning all alleles unbounded instead of the documented default of 50
- **MarineRegions_search_by_name**: same missing-default pattern for `offset`
- **DiseaseSH_get_covid_historical / DiseaseSh_get_historical**: same pattern for `country`, which broke the documented "omit for global data" behavior with a 404
- **DiseaseSH_get_vaccine_coverage**: `country` is now required, since the upstream vaccine-coverage-by-country endpoint has no `all` global variant (confirmed live it 404s even with `country=all`, unlike the historical-cases endpoint)
- **hca_search_projects**: fixed the `disease` filter facet name (Azul rejects `disease` with a 400; the real facet is `donorDisease`) and fixed organ/donorDisease extraction, which read nonexistent top-level dict keys instead of the real nested `specimens`/`donorOrganisms` array fields
- **WHOGHO_get_indicator_data**: added the missing `$filter`/`$top` OData param mapping (the sibling tool `WHOGHO_search_indicators` already had it) so a country/year filter and row limit actually reach the API instead of being silently dropped
- **ExpressionAtlas_get_baseline**: removed the broken `gene_mentioned`/`gene_specific_count` fields, which were computed by full-text-searching experiment descriptions for a bare gene symbol — confirmed live this never matches real data, always reporting false. Now lists species-level baseline experiments honestly and points to `GxA_get_experiment_expression` for actual per-gene checks
- **Foldseek_search_structure**: the Python code's inline default (`tmalign`) disagreed with the documented JSON schema default (`3diaa`), so an omitted `mode` silently ran the slower, less specific TM-align search — confirmed live this explains implausible top hits for well-characterized folds (e.g. no EGFR-family structures in the top 10 for an EGFR kinase domain query); also fixed a copy-paste typo in the mode description
- **UniProtIDMap_to_pdb** (and its siblings via shared `_submit_and_poll`): jobs that complete almost instantly get results embedded directly in the status-check response instead of a `FINISHED` status, and the code returned that embedded copy immediately instead of falling through to the properly paginated results fetch — silently truncating to UniProt's unpaginated default page size (25) even when hundreds of matches exist (confirmed live: P00533→PDB has 354 matches, not 25)

## Deferred (documented, not fixed)

Several findings need further investigation or are architecturally larger in scope: `CxGDisc_search_datasets`'s strict Cell-Ontology-label-only substring matching (no synonym/plural support), `PlantReactome_search_pathways`'s species filter 404ing for all but one species, `USDA_plants_search_by_name`'s broken single-word common-name ranking, and `EpiGraphDB_get_drugs_for_trait`'s possibly-noisy drug-repurposing results for some traits (may be inherent to the underlying loose-threshold GWAS gene-mapping data rather than a ToolUniverse bug).

One reported finding (`GxA_get_experiment_expression`'s `gene_id` filter) was re-verified live and found to work correctly — the original report tested genes genuinely absent from that specific experiment's row subset, a false positive.

## Test plan

- 5 new mocked unit test files, all passing
- Full `pytest tests/unit` suite passes (only pre-existing unrelated skips)
- Every fix verified live against the real upstream API before and after the change