### PR TITLE
Fix Round 25: genetics/cheminformatics/proteomics/omics tool fixes

### DIFF
--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -504,6 +504,7 @@ STATIC_LAZY_REGISTRY = {
     "OMIMTool": "omim_tool",
     "ORCIDTool": "orcid_tool",
     "OSFPreprintsTool": "osf_preprints_tool",
+    "OmicsDITool": "omicsdi_tool",
     "OmniPathTool": "omnipath_tool",
     "OncoKBTool": "oncokb_tool",
     "OncoTreeBaseTool": "oncotree_tool",

--- a/src/tooluniverse/data/medlineplus_tools.json
+++ b/src/tooluniverse/data/medlineplus_tools.json
@@ -185,7 +185,7 @@
   },
   {
     "name": "MedlinePlus_get_genetics_condition_by_name",
-    "description": "Get detailed information from MedlinePlus Genetics corresponding to genetic condition name. Returns XML data parsed into a dictionary with condition description, related genes, synonyms, and other details.",
+    "description": "Get detailed information from MedlinePlus Genetics corresponding to genetic condition name. Returns condition description, related genes, inheritance pattern, synonyms, and other details.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -236,6 +236,13 @@
             "type": "string"
           },
           "description": "List of related genes"
+        },
+        "inheritance": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Inheritance pattern(s) (e.g. 'Autosomal dominant')"
         },
         "synonyms": {
           "type": "array",

--- a/src/tooluniverse/data/molecule_2d_tools.json
+++ b/src/tooluniverse/data/molecule_2d_tools.json
@@ -55,12 +55,7 @@
           "default": true,
           "description": "Whether to include stereochemistry information"
         }
-      },
-      "required": [
-        "smiles",
-        "inchi",
-        "molecule_name"
-      ]
+      }
     },
     "default_width": 400,
     "default_height": 400,

--- a/src/tooluniverse/data/omicsdi_tools.json
+++ b/src/tooluniverse/data/omicsdi_tools.json
@@ -66,7 +66,7 @@
     "fields": {
       "endpoint": "https://www.omicsdi.org/ws/dataset/search"
     },
-    "type": "BaseRESTTool",
+    "type": "OmicsDITool",
     "test_examples": [
       {
         "query": "Alzheimer brain transcriptomics",

--- a/src/tooluniverse/drugcentral_tool.py
+++ b/src/tooluniverse/drugcentral_tool.py
@@ -128,20 +128,27 @@ class DrugCentralTool(BaseTool):
 
         hits = data.get("hits", [])
         results = []
-        seen_inchikeys = set()
+        seen_ids = set()
         for hit in hits:
             dc = hit.get("drugcentral", {})
             if not dc:
                 continue
             structures = dc.get("structures", {})
-            inchikey = structures.get("inchikey") or hit.get("_id", "")
-            if inchikey in seen_inchikeys:
+            # Biologics (e.g. monoclonal antibodies like pembrolizumab) have
+            # no small-molecule structure and legitimately no InChIKey
+            # upstream -- falling back to MyChem's internal "_id" here
+            # silently mislabeled that unrelated identifier as "inchikey"
+            # (confirmed live: e.g. "DPT0O3T46P", not a valid InChIKey).
+            # Dedup on "_id" (always present, always unique per hit)
+            # instead, and only ever report a real InChIKey or None.
+            hit_id = hit.get("_id", "")
+            if hit_id in seen_ids:
                 continue
-            seen_inchikeys.add(inchikey)
+            seen_ids.add(hit_id)
             xrefs = dc.get("xrefs", {})
             results.append(
                 {
-                    "inchikey": inchikey,
+                    "inchikey": structures.get("inchikey"),
                     "name": structures.get("inn"),
                     "cas_rn": structures.get("cas_rn"),
                     "smiles": structures.get("smiles"),
@@ -226,7 +233,11 @@ class DrugCentralTool(BaseTool):
         return {
             "status": "success",
             "data": {
-                "inchikey": data.get("_id"),
+                # MyChem's internal "_id" is not an InChIKey (confirmed live)
+                # -- biologics with no small-molecule structure legitimately
+                # have no InChIKey upstream; report that as None rather than
+                # mislabeling _id as one.
+                "inchikey": structures.get("inchikey"),
                 "name": structures.get("inn"),
                 "cas_rn": structures.get("cas_rn"),
                 "smiles": structures.get("smiles"),

--- a/src/tooluniverse/medlineplus_tool.py
+++ b/src/tooluniverse/medlineplus_tool.py
@@ -23,6 +23,15 @@ class MedlinePlusRESTTool(BaseTool):
         self.endpoint_template = tool_config["fields"]["endpoint"]
         self.param_schema = tool_config["parameter"]["properties"]
 
+    # MedlinePlus's genetics download endpoints are case-sensitive on the
+    # identifier segment: an uppercase gene symbol (e.g. "FBN1.json") 200s
+    # but silently serves XML instead of the requested JSON, forcing a much
+    # buggier XML-fallback parse path (confirmed live). Lowercasing matches
+    # the convention already used for condition names (e.g.
+    # "marfan-syndrome") and routes both endpoints through the same
+    # reliably-correct real-JSON response shape.
+    _LOWERCASE_URL_PARAMS = {"gene", "condition"}
+
     def _build_url(self, arguments: dict) -> str:
         """Build complete URL"""
         url_path = self.endpoint_template
@@ -34,7 +43,10 @@ class MedlinePlusRESTTool(BaseTool):
                     "status": "error",
                     "error": f"Missing required parameter '{ph}'",
                 }
-            url_path = url_path.replace(f"{{{ph}}}", str(arguments[ph]))
+            value = str(arguments[ph])
+            if ph in self._LOWERCASE_URL_PARAMS:
+                value = value.lower()
+            url_path = url_path.replace(f"{{{ph}}}", value)
 
         return url_path
 
@@ -77,22 +89,38 @@ class MedlinePlusRESTTool(BaseTool):
                         return self._extract_text_content(item)
             return ""
 
-        # Extract list items
+        # MedlinePlus genetics list fields arrive in two shapes depending on
+        # the parse path (confirmed live): real JSON gives a top-level *list*
+        # of single-key wrapper dicts (e.g. [{"related-gene": {...}}, ...]),
+        # while the XML fallback (xmltodict) collapses the same data to a
+        # *dict* ({"related-gene": [...] or {...}}). Normalize both to a flat
+        # list of entries.
+        def unwrap_entries(data, list_key, item_key):
+            raw = data.get(list_key, [])
+            if isinstance(raw, dict):
+                entries = raw.get(item_key, [])
+                return entries if isinstance(entries, list) else [entries]
+            if isinstance(raw, list):
+                return [w.get(item_key) if isinstance(w, dict) else w for w in raw]
+            return []
+
         def get_list_items(
             data, list_key, item_key, name_key="name", url_key="ghr-page"
         ):
-            items = []
-            list_data = data.get(list_key, {})
-            if isinstance(list_data, dict):
-                items = list_data.get(item_key, [])
-                if not isinstance(items, list):
-                    items = [items]
-            for item in items:
+            formatted = []
+            for item in unwrap_entries(data, list_key, item_key):
                 if isinstance(item, dict):
                     name = item.get(name_key, "")
                     url = item.get(url_key, "")
-                    items.append(f"{name} ({url})" if url else name)
-            return items
+                    formatted.append(f"{name} ({url})" if url else name)
+            return formatted
+
+        def get_synonyms(data):
+            return [
+                s
+                for s in unwrap_entries(data, "synonym-list", "synonym")
+                if isinstance(s, str)
+            ]
 
         # Format response based on tool type
         if tool_name == "MedlinePlus_search_topics_by_keyword":
@@ -182,20 +210,31 @@ class MedlinePlusRESTTool(BaseTool):
             )
 
         elif tool_name == "MedlinePlus_get_genetics_condition_by_name":
+            inheritance = [
+                p.get("memo", "")
+                for p in unwrap_entries(
+                    response, "inheritance-pattern-list", "inheritance-pattern"
+                )
+                if isinstance(p, dict)
+            ]
+
             return {
                 "name": response.get("name", ""),
                 "description": get_text_content(response, "description"),
                 "genes": get_list_items(
                     response, "related-gene-list", "related-gene", "gene-symbol"
                 ),
-                "synonyms": [
-                    s.get("synonym", "") for s in response.get("synonym-list", [])
-                ],
+                "inheritance": inheritance,
+                "synonyms": get_synonyms(response),
                 "ghr_page": response.get("ghr_page", ""),
             }
 
         elif tool_name == "MedlinePlus_get_genetics_gene_by_name":
-            gene_summary = response.get("gene-summary", {})
+            # Real JSON responses have the gene's fields at the top level
+            # (no "gene-summary" wrapper) -- that wrapper only exists in the
+            # XML-parsed shape. Fall back to `response` itself so both
+            # shapes work.
+            gene_summary = response.get("gene-summary", response)
             return {
                 "name": gene_summary.get("name", ""),
                 "function": get_text_content(gene_summary, "function"),
@@ -204,7 +243,7 @@ class MedlinePlusRESTTool(BaseTool):
                     "related-health-condition-list",
                     "related-health-condition",
                 ),
-                "synonyms": gene_summary.get("synonym-list", {}).get("synonym", []),
+                "synonyms": get_synonyms(gene_summary),
                 "ghr_page": gene_summary.get("ghr-page", ""),
             }
 

--- a/src/tooluniverse/omicsdi_tool.py
+++ b/src/tooluniverse/omicsdi_tool.py
@@ -1,0 +1,32 @@
+# omicsdi_tool.py
+"""OmicsDI dataset search tool for ToolUniverse.
+
+OmicsDI's search endpoint silently ignores omics_type/organism/tissue when
+sent as separate query params -- confirmed live (e.g. requesting
+omics_type=Proteomics still returns Transcriptomics-dominated results).
+The upstream API only respects these as Lucene clauses folded into the
+`query` string itself (e.g. `query AND omics_type:"Proteomics"`), so this
+tool builds that composite query before delegating to BaseRESTTool.
+"""
+
+from typing import Any, Dict
+
+from .base_rest_tool import BaseRESTTool
+from .tool_registry import register_tool
+
+_FILTER_FIELDS = ("omics_type", "organism", "tissue")
+
+
+@register_tool("OmicsDITool")
+class OmicsDITool(BaseRESTTool):
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        arguments = dict(arguments)
+        query = arguments.get("query", "")
+        clauses = [query] if query else []
+        for field in _FILTER_FIELDS:
+            value = arguments.pop(field, None)
+            if value:
+                clauses.append(f'{field}:"{value}"')
+        if clauses:
+            arguments["query"] = " AND ".join(clauses)
+        return super().run(arguments)

--- a/tests/unit/test_drugcentral_inchikey.py
+++ b/tests/unit/test_drugcentral_inchikey.py
@@ -1,0 +1,115 @@
+"""Regression guard for Fix-R25E-1: DrugCentralTool's "inchikey" field
+silently fell back to MyChem.info's internal "_id" whenever the real
+drugcentral.structures.inchikey was absent -- confirmed live for
+pembrolizumab (a monoclonal antibody with no small-molecule structure,
+hence no InChIKey upstream), which returned "DPT0O3T46P" and
+"CHEMBL3137343" as "inchikey" for two different records, neither a valid
+InChIKey. Fixed by reporting None instead of a mislabeled internal ID,
+and (for the search path) deduplicating on "_id" directly rather than on
+the now-frequently-None inchikey value.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.drugcentral_tool import DrugCentralTool
+
+pytestmark = pytest.mark.unit
+
+_BIOLOGIC_SEARCH_RESPONSE = {
+    "total": 2,
+    "hits": [
+        {
+            "_id": "CHEMBL3137343",
+            "drugcentral": {
+                "structures": {"inn": "pembrolizumab"},
+                "xrefs": {"chembl_id": "CHEMBL3137343"},
+                "approval": ["FDA"],
+            },
+        },
+        {
+            "_id": "DPT0O3T46P",
+            "drugcentral": {
+                "structures": {"inn": "pembrolizumab"},
+                "xrefs": {"chembl_id": "CHEMBL3137343"},
+                "approval": ["FDA"],
+            },
+        },
+    ],
+}
+
+_SMALL_MOLECULE_SEARCH_RESPONSE = {
+    "total": 1,
+    "hits": [
+        {
+            "_id": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+            "drugcentral": {
+                "structures": {
+                    "inn": "acetylsalicylic acid",
+                    "inchikey": "BSYNRYMUTXBXSQ-UHFFFAOYSA-N",
+                },
+                "xrefs": {},
+                "approval": ["FDA"],
+            },
+        }
+    ],
+}
+
+_GET_DRUG_RESPONSE = {
+    "_id": "DPT0O3T46P",
+    "drugcentral": {
+        "structures": {"inn": "pembrolizumab"},
+        "drug_use": {},
+        "approval": ["FDA"],
+    },
+}
+
+
+def _tool(operation):
+    return DrugCentralTool(
+        {"name": "drugcentral_test", "fields": {"operation": operation}}
+    )
+
+
+def _resp(json_body, status_code=200):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body
+    r.raise_for_status = MagicMock()
+    return r
+
+
+class TestSearchInchikey:
+    def test_biologic_reports_none_not_internal_id(self):
+        tool = _tool("search")
+        resp = _resp(_BIOLOGIC_SEARCH_RESPONSE)
+
+        with patch("tooluniverse.drugcentral_tool.requests.get", return_value=resp):
+            result = tool.run({"query": "pembrolizumab"})
+
+        assert result["status"] == "success"
+        inchikeys = [r["inchikey"] for r in result["data"]]
+        assert inchikeys == [None, None]
+        assert len(result["data"]) == 2  # dedup by _id, not by (now-None) inchikey
+
+    def test_small_molecule_still_returns_real_inchikey(self):
+        tool = _tool("search")
+        resp = _resp(_SMALL_MOLECULE_SEARCH_RESPONSE)
+
+        with patch("tooluniverse.drugcentral_tool.requests.get", return_value=resp):
+            result = tool.run({"query": "aspirin"})
+
+        assert result["data"][0]["inchikey"] == "BSYNRYMUTXBXSQ-UHFFFAOYSA-N"
+
+
+class TestGetDrugInchikey:
+    def test_get_drug_biologic_reports_none(self):
+        tool = _tool("get_drug")
+        resp = _resp(_GET_DRUG_RESPONSE)
+
+        with patch("tooluniverse.drugcentral_tool.requests.get", return_value=resp):
+            result = tool.run({"chem_id": "DPT0O3T46P"})
+
+        assert result["status"] == "success"
+        assert result["data"]["inchikey"] is None

--- a/tests/unit/test_medlineplus_genetics_parsing.py
+++ b/tests/unit/test_medlineplus_genetics_parsing.py
@@ -1,0 +1,171 @@
+"""Regression guard for Fix-R25A-1 (three compounding bugs) in
+MedlinePlusRESTTool's genetics condition/gene lookups.
+
+1. Case-sensitive URL: MedlinePlus's gene download endpoint serves real
+   JSON for a lowercase gene symbol ("fbn1.json") but silently serves XML
+   for an uppercase one ("FBN1.json") despite the .json extension --
+   confirmed live. Gene symbols are naturally uppercase (FBN1), so every
+   gene lookup was silently forced down a much buggier XML-fallback path.
+   Fixed by lowercasing gene/condition values before building the URL.
+
+2. get_list_items() only handled the XML-parsed dict shape ({item_key:
+   [...]}), not the real-JSON list-of-wrapper-dicts shape ([{item_key:
+   {...}}, ...]) -- so "genes" was always [] for condition lookups.
+   Separately it mutated the list it was iterating, duplicating every
+   entry once the XML-dict shape was hit.
+
+3. The gene handler read `response.get("gene-summary", {})`, but real
+   JSON gene responses have no "gene-summary" wrapper -- their fields are
+   at the top level, same as condition responses. That always evaluated
+   to {}, so every field was silently empty once the case-sensitivity fix
+   routed gene lookups through real JSON.
+
+Also added the "inheritance" field to the condition response, which was
+present in the raw upstream JSON but never extracted at all.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.medlineplus_tool import MedlinePlusRESTTool
+
+pytestmark = pytest.mark.unit
+
+_CONDITION_JSON = {
+    "name": "Marfan syndrome",
+    "ghr_page": "https://medlineplus.gov/genetics/condition/marfan-syndrome",
+    "text-list": [
+        {
+            "text": {
+                "text-role": "description",
+                "html": "<p>A connective tissue disorder.</p>",
+            }
+        }
+    ],
+    "inheritance-pattern-list": [
+        {"inheritance-pattern": {"code": "ad", "memo": "Autosomal dominant"}}
+    ],
+    "related-gene-list": [
+        {
+            "related-gene": {
+                "gene-symbol": "FBN1",
+                "ghr-page": "https://medlineplus.gov/genetics/gene/fbn1",
+            }
+        }
+    ],
+    "synonym-list": [{"synonym": "Marfan's syndrome"}, {"synonym": "MFS"}],
+}
+
+_GENE_JSON = {
+    "gene-symbol": "FBN1",
+    "name": "fibrillin 1",
+    "ghr-page": "https://medlineplus.gov/genetics/gene/fbn1",
+    "text-list": [
+        {"text": {"text-role": "function", "html": "<p>Makes fibrillin-1.</p>"}}
+    ],
+    "related-health-condition-list": [
+        {
+            "related-health-condition": {
+                "name": "Marfan syndrome",
+                "ghr-page": "https://medlineplus.gov/genetics/condition/marfan-syndrome",
+            }
+        },
+        {
+            "related-health-condition": {
+                "name": "Weill-Marchesani syndrome",
+                "ghr-page": "https://medlineplus.gov/genetics/condition/weill-marchesani-syndrome",
+            }
+        },
+    ],
+    "synonym-list": [{"synonym": "asprosin"}, {"synonym": "MASS"}],
+}
+
+
+def _tool_config(name):
+    return {
+        "name": name,
+        "fields": {
+            "endpoint": "https://medlineplus.gov/download/genetics/x/{gene_or_condition}.json"
+        },
+        "parameter": {"properties": {}},
+    }
+
+
+def _resp(json_body, text="{}"):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = json_body
+    r.text = text
+    return r
+
+
+class TestConditionLookup:
+    def test_genes_and_inheritance_extracted_from_real_json_list_shape(self):
+        tool = MedlinePlusRESTTool(
+            {
+                "name": "MedlinePlus_get_genetics_condition_by_name",
+                "fields": {
+                    "endpoint": "https://medlineplus.gov/download/genetics/condition/{condition}.{format}"
+                },
+                "parameter": {"properties": {"format": {"default": "json"}}},
+            }
+        )
+        resp = _resp(_CONDITION_JSON)
+
+        with patch(
+            "tooluniverse.medlineplus_tool.requests.get", return_value=resp
+        ) as mock_get:
+            result = tool.run({"condition": "Marfan-Syndrome"})
+
+        called_url = mock_get.call_args[0][0]
+        assert "marfan-syndrome" in called_url
+        assert "Marfan-Syndrome" not in called_url
+        assert result["genes"] == ["FBN1 (https://medlineplus.gov/genetics/gene/fbn1)"]
+        assert result["inheritance"] == ["Autosomal dominant"]
+        assert result["synonyms"] == ["Marfan's syndrome", "MFS"]
+
+
+class TestGeneLookup:
+    def test_gene_symbol_lowercased_in_url(self):
+        tool = MedlinePlusRESTTool(
+            {
+                "name": "MedlinePlus_get_genetics_gene_by_name",
+                "fields": {
+                    "endpoint": "https://medlineplus.gov/download/genetics/gene/{gene}.{format}"
+                },
+                "parameter": {"properties": {"format": {"default": "json"}}},
+            }
+        )
+        resp = _resp(_GENE_JSON)
+
+        with patch(
+            "tooluniverse.medlineplus_tool.requests.get", return_value=resp
+        ) as mock_get:
+            result = tool.run({"gene": "FBN1"})
+
+        called_url = mock_get.call_args[0][0]
+        assert called_url.endswith("gene/fbn1.json")
+        assert result["name"] == "fibrillin 1"
+        assert result["function"] != ""
+
+    def test_health_conditions_not_duplicated(self):
+        tool = MedlinePlusRESTTool(
+            {
+                "name": "MedlinePlus_get_genetics_gene_by_name",
+                "fields": {
+                    "endpoint": "https://medlineplus.gov/download/genetics/gene/{gene}.{format}"
+                },
+                "parameter": {"properties": {"format": {"default": "json"}}},
+            }
+        )
+        resp = _resp(_GENE_JSON)
+
+        with patch("tooluniverse.medlineplus_tool.requests.get", return_value=resp):
+            result = tool.run({"gene": "FBN1"})
+
+        assert result["health_conditions"] == [
+            "Marfan syndrome (https://medlineplus.gov/genetics/condition/marfan-syndrome)",
+            "Weill-Marchesani syndrome (https://medlineplus.gov/genetics/condition/weill-marchesani-syndrome)",
+        ]
+        assert result["synonyms"] == ["asprosin", "MASS"]

--- a/tests/unit/test_omicsdi_filter_folding.py
+++ b/tests/unit/test_omicsdi_filter_folding.py
@@ -1,0 +1,87 @@
+"""Regression guard for Fix-R25C-1: OmicsDI_search_datasets's
+omics_type/organism/tissue filters were sent as separate query params,
+which the upstream API silently ignores -- confirmed live that
+`?query=KLK3&omics_type=Proteomics` still returned Transcriptomics-
+dominated results identical to an unfiltered search, while folding the
+filter into the Lucene query string (`query AND omics_type:"Proteomics"`)
+correctly narrowed results (58182 -> 62 total hits for an organism
+filter, verified separately). Fixed by building the composite query
+string in Python before delegating to BaseRESTTool.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.omicsdi_tool import OmicsDITool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return OmicsDITool(
+        {
+            "name": "OmicsDI_search_datasets",
+            "fields": {"endpoint": "https://www.omicsdi.org/ws/dataset/search"},
+            "parameter": {"properties": {}},
+        }
+    )
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = json_body
+    r.headers = {"content-type": "application/json"}
+    return r
+
+
+class TestFilterFolding:
+    def test_omics_type_folded_into_query_string(self):
+        tool = _tool()
+        resp = _resp({"count": 1, "datasets": [], "facets": []})
+
+        with patch(
+            "tooluniverse.base_rest_tool.request_with_retry", return_value=resp
+        ) as mock_request:
+            tool.run({"query": "KLK3", "omics_type": "Proteomics", "size": 5})
+
+        sent_params = mock_request.call_args.kwargs["params"]
+        assert sent_params["query"] == 'KLK3 AND omics_type:"Proteomics"'
+        assert "omics_type" not in sent_params
+
+    def test_all_three_filters_folded_together(self):
+        tool = _tool()
+        resp = _resp({"count": 1, "datasets": [], "facets": []})
+
+        with patch(
+            "tooluniverse.base_rest_tool.request_with_retry", return_value=resp
+        ) as mock_request:
+            tool.run(
+                {
+                    "query": "insulin",
+                    "omics_type": "Proteomics",
+                    "organism": "Mus musculus",
+                    "tissue": "liver",
+                }
+            )
+
+        sent_params = mock_request.call_args.kwargs["params"]
+        assert sent_params["query"] == (
+            'insulin AND omics_type:"Proteomics" AND organism:"Mus musculus" '
+            'AND tissue:"liver"'
+        )
+        assert "organism" not in sent_params
+        assert "tissue" not in sent_params
+
+    def test_no_filters_leaves_query_unchanged(self):
+        tool = _tool()
+        resp = _resp({"count": 1, "datasets": [], "facets": []})
+
+        with patch(
+            "tooluniverse.base_rest_tool.request_with_retry", return_value=resp
+        ) as mock_request:
+            tool.run({"query": "Alzheimer brain"})
+
+        sent_params = mock_request.call_args.kwargs["params"]
+        assert sent_params["query"] == "Alzheimer brain"

--- a/tests/unit/test_visualize_molecule_2d_schema.py
+++ b/tests/unit/test_visualize_molecule_2d_schema.py
@@ -1,0 +1,48 @@
+"""visualize_molecule_2d's parameter schema must not require all three
+mutually-alternative identifier params at once.
+
+Regression (Fix-R25B-1): the JSON schema had
+`"required": ["smiles", "inchi", "molecule_name"]`, forcing every one of
+the three params even though the tool's own implementation
+(molecule_2d_tool.py) explicitly supports providing just one of them via
+an if/elif/elif chain, with its own clear
+"Either smiles, inchi, or molecule_name must be provided" error when none
+are given. The sibling tool visualize_molecule_3d has no `required` key
+at all for the same three-way-alternative param set -- that's the correct
+shape. Confirmed live: passing only `smiles` previously failed parameter
+validation before ever reaching the tool's own logic.
+"""
+
+import json
+import os
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_CONFIG = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "src",
+    "tooluniverse",
+    "data",
+    "molecule_2d_tools.json",
+)
+
+
+def _tool(name):
+    with open(_CONFIG) as fh:
+        for t in json.load(fh):
+            if isinstance(t, dict) and t.get("name") == name:
+                return t
+    raise AssertionError(f"{name} not found in molecule_2d_tools.json")
+
+
+def test_visualize_molecule_2d_does_not_require_all_three_identifiers():
+    tool = _tool("visualize_molecule_2d")
+    required = tool["parameter"].get("required")
+    assert not required, (
+        f"visualize_molecule_2d should not force smiles+inchi+molecule_name "
+        f"together, but required={required!r}"
+    )


### PR DESCRIPTION
## Summary

Round 25 of the ongoing test-harness campaign. 5 role-play research personas (rare disease genetics/genetic counseling, cheminformatics/medicinal chemistry, proteomics/mass spectrometry, virology/infectious disease genomics, clinical trials/regulatory affairs) exercised ~145 tool calls across 6+ domains; every finding was CLI-verified against live upstream APIs before fixing.

## Fixes

- **MedlinePlus_get_genetics_condition_by_name / MedlinePlus_get_genetics_gene_by_name**: three compounding bugs fixed together. MedlinePlus's genetics download endpoints are case-sensitive on the identifier segment — an uppercase gene symbol like `FBN1.json` silently serves XML instead of the requested JSON despite the `.json` extension, forcing gene lookups down a much buggier fallback path. Lowercasing routes both condition and gene lookups through the reliable real-JSON response shape. Separately, the list-parsing helper only handled one of the two possible list shapes (real JSON vs. XML-parsed), so `genes` was always empty for conditions and `health_conditions` was duplicated for genes; and the gene handler read a `gene-summary` wrapper key that doesn't exist in real JSON responses, silently emptying every field. Also added the `inheritance` field, present in the raw upstream data but never extracted at all.
- **visualize_molecule_2d**: the parameter schema required `smiles`, `inchi`, AND `molecule_name` together, even though the tool's own implementation explicitly supports providing just one (with its own clear error when none are given) — the sibling tool `visualize_molecule_3d` correctly has no such requirement for the same three-way-alternative param set.
- **OmicsDI_search_datasets**: `omics_type`/`organism`/`tissue` filters were sent as separate query params, which the upstream API silently ignores — confirmed live that a Proteomics-filtered query still returned Transcriptomics-dominated results identical to an unfiltered search. OmicsDI only respects these as Lucene clauses folded into the query string itself; added a small custom tool class to build that composite query before delegating to the shared REST-tool request logic.
- **DrugCentral_search / DrugCentral_get_drug**: the `inchikey` field silently fell back to MyChem.info's internal record ID whenever the real InChIKey was absent — confirmed live for pembrolizumab (a monoclonal antibody with no small-molecule structure, hence legitimately no InChIKey upstream), which returned two different non-InChIKey identifiers as `inchikey` for the same drug. Fixed to report `None` instead of mislabeling an unrelated ID, and to deduplicate search results on the internal ID directly rather than on the now-frequently-None inchikey value.

## Deferred (documented, not fixed)

A persona-D report on virology tools triggered an unrelated safety review; its concrete tool-bug findings (BV-BRC `host_group` enum documentation, ChEMBL target-filter schema mismatch, an MCP TLS-cert environment issue already seen in prior rounds) are left for a future round's more careful pass, and its "no systematic viral drug-resistance-mutation database" coverage-gap finding is deliberately not pursued.

Several other lower-confidence findings need further investigation before a confident fix: `Enamine_search_smiles`'s description overstating real API integration, `Metabolite_get_info`'s silent autocomplete substitution to an isotopologue compound, EBIProteins 404 handling losing upstream diagnostic detail, `UniProt_get_ptm_processing_by_accession`'s narrow PTM feature-type filter, and the MCP `find_tools`/`grep_tools` truncated-tool-name discovery-index issue seen recurringly across rounds.

## Test plan

- 4 new mocked unit test files, all passing
- Full `pytest tests/unit` suite passes (only pre-existing unrelated skips)
- Every fix verified live against the real upstream API before and after the change