### PR TITLE
Fix Round 26: ProtParam MW, OpenGenes diseases, FooDB redirects, MedlinePlus parsing, PanelApp search, EnsemblCompara trees, OrthoDB, OpenTargets GWAS/pagination

### DIFF
--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -533,6 +533,7 @@ STATIC_LAZY_REGISTRY = {
     "OrthoDBTool": "orthodb_tool",
     "OxOTool": "oxo_tool",
     "PANTHERTool": "panther_tool",
+    "PanelAppSearchTool": "panelapp_tool",
     "PDBECompoundTool": "pdbe_compound_tool",
     "PDBeAPIRESTTool": "pdbe_api_tool",
     "PDBeLigandsTool": "pdbe_ligands_tool",

--- a/src/tooluniverse/data/metaboanalyst_tools.json
+++ b/src/tooluniverse/data/metaboanalyst_tools.json
@@ -53,7 +53,7 @@
   {
     "name": "MetaboAnalyst_name_to_id",
     "type": "MetaboAnalystTool",
-    "description": "Map metabolite common names to database identifiers (KEGG, HMDB, PubChem, ChEBI). Resolves metabolite names against the KEGG compound database and retrieves cross-references to HMDB, PubChem, and ChEBI. Returns matched name, molecular formula, and exact mass for each metabolite. Use for: converting metabolite lists to standardized IDs before pathway or enrichment analysis.",
+    "description": "Map metabolite common names to database identifiers (KEGG, PubChem, ChEBI). Resolves metabolite names against the KEGG compound database and retrieves cross-references to PubChem and ChEBI. Returns matched name, molecular formula, and exact mass for each metabolite. Note: hmdb_id is almost always null -- KEGG discontinued HMDB cross-references in its DBLINKS data years ago, so this field is populated only for the rare legacy entry that still carries one; use a dedicated HMDB lookup tool to resolve HMDB IDs. Use for: converting metabolite lists to standardized IDs before pathway or enrichment analysis.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -83,14 +83,15 @@
     },
     {
         "name": "OpenTargets_get_diseases_phenotypes_by_target_ensembl",
-        "description": "Find diseases or phenotypes associated with a specific target using ensemblId.",
+        "description": "Find diseases or phenotypes associated with a specific target using ensemblId. `associatedDiseases.count` is the total number of associations; `rows` returns only one page of them (25 by default) -- pass `page` to retrieve more (e.g. page 2 of a target with thousands of associations like SIRT1's 3432).",
         "label": [
             "Target",
             "Disease",
             "Phenotype",
             "Association",
             "OpenTarget",
-            "GraphQL"
+            "GraphQL",
+            "Pagination"
         ],
         "parameter": {
             "type": "object",
@@ -98,17 +99,38 @@
                 "ensemblId": {
                     "type": "string",
                     "description": "The ensemblId of a target."
+                },
+                "page": {
+                    "type": "object",
+                    "properties": {
+                        "index": {
+                            "type": "integer",
+                            "description": "The index of the page to retrieve (0-based)."
+                        },
+                        "size": {
+                            "type": "integer",
+                            "description": "The number of associations per page."
+                        }
+                    },
+                    "description": "Pagination parameters. `count` in the response is the total across all pages; omit this to get the first page only."
                 }
             },
             "required": [
                 "ensemblId"
             ]
         },
-        "query_schema": "\nquery associatedDiseases($ensemblId: String!) {\n  target(ensemblId: $ensemblId) {\n    id\n    approvedSymbol\n    associatedDiseases {\n      count\n      rows {\n        disease {\n          id\n          name\n        }\n        datasourceScores {\n          id\n          score\n        }\n      }\n    }\n  }\n}\n",
+        "query_schema": "\nquery associatedDiseases($ensemblId: String!, $page: Pagination) {\n  target(ensemblId: $ensemblId) {\n    id\n    approvedSymbol\n    associatedDiseases(page: $page) {\n      count\n      rows {\n        disease {\n          id\n          name\n        }\n        datasourceScores {\n          id\n          score\n        }\n      }\n    }\n  }\n}\n",
         "type": "OpenTarget",
         "test_examples": [
             {
                 "ensemblId": "ENSG00000141510"
+            },
+            {
+                "ensemblId": "ENSG00000141510",
+                "page": {
+                    "index": 1,
+                    "size": 25
+                }
             }
         ],
         "return_schema": {

--- a/src/tooluniverse/data/panelapp_tools.json
+++ b/src/tooluniverse/data/panelapp_tools.json
@@ -20,7 +20,7 @@
         "format": "json"
       }
     },
-    "type": "BaseRESTTool",
+    "type": "PanelAppSearchTool",
     "test_examples": [
       {
         "search": "breast cancer"

--- a/src/tooluniverse/data/sequence_analyze_tools.json
+++ b/src/tooluniverse/data/sequence_analyze_tools.json
@@ -164,7 +164,7 @@
   {
     "name": "Sequence_stats",
     "type": "SequenceAnalyzeTool",
-    "description": "Compute basic statistics for a DNA, RNA, or protein sequence. Auto-detects sequence type, reports length, full composition, and type-specific metrics (GC% for nucleotides, estimated molecular weight for proteins). Accepts sequence string or UniProt accession.",
+    "description": "Compute basic statistics for a DNA, RNA, or protein sequence. Auto-detects sequence type, reports length, full composition, and type-specific metrics (GC% for nucleotides, estimated monoisotopic molecular weight for proteins -- for the conventional average mass reported by ExPASy ProtParam/UniProt, use ProtParam_calculate instead). Accepts sequence string or UniProt accession.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/ensembl_compara_tool.py
+++ b/src/tooluniverse/ensembl_compara_tool.py
@@ -195,9 +195,12 @@ class EnsemblComparaTool(BaseTool):
 
         species = arguments.get("species", "human")
 
-        # Gene tree uses /genetree/member/id or /genetree/member/symbol
+        # Gene tree uses /genetree/member/id or /genetree/member/symbol --
+        # confirmed live that the id form 404s without a {species} path
+        # segment (e.g. /genetree/member/id/ENSG00000141510 alone 404s;
+        # /genetree/member/id/human/ENSG00000141510 works).
         if gene.startswith("ENS"):
-            url = f"{ENSEMBL_BASE_URL}/genetree/member/id/{gene}"
+            url = f"{ENSEMBL_BASE_URL}/genetree/member/id/{species}/{gene}"
         else:
             url = f"{ENSEMBL_BASE_URL}/genetree/member/symbol/{species}/{gene}"
 
@@ -210,19 +213,30 @@ class EnsemblComparaTool(BaseTool):
         response.raise_for_status()
         data = response.json()
 
-        # Extract tree info
-        tree_id = (
-            data.get("tree", {}).get("id")
-            if isinstance(data.get("tree"), dict)
-            else data.get("id")
-        )
+        # Extract tree info. The tree's own id is a top-level field, not
+        # nested under "tree" (confirmed live: {"type", "rooted", "tree",
+        # "id"} -- "tree" itself carries no "id" key).
+        tree_id = data.get("id")
         rooted = data.get("rooted", True)
-
-        # Get Newick tree from the response if available
-        newick = None
         tree_data = data.get("tree", data)
-        if isinstance(tree_data, dict):
-            newick = tree_data.get("newick")
+
+        # Ensembl's JSON genetree response never embeds a "newick" field
+        # regardless of nh_format -- Newick text is only served as a
+        # separate plain-text response via the "text/x-nh" content type.
+        # Fetch it as a best-effort second call; a failure here shouldn't
+        # fail the whole tool.
+        newick = None
+        try:
+            nh_resp = requests.get(
+                url,
+                params=params,
+                headers={**ENSEMBL_HEADERS, "Content-Type": "text/x-nh"},
+                timeout=self.timeout,
+            )
+            if nh_resp.status_code == 200 and nh_resp.text.strip():
+                newick = nh_resp.text.strip()
+        except requests.exceptions.RequestException:
+            pass
 
         # Count members in the tree
         members = []
@@ -248,17 +262,21 @@ class EnsemblComparaTool(BaseTool):
         if len(members) >= max_members:
             return
         if isinstance(node, dict):
-            # Leaf node has 'id' and 'species'
-            if "id" in node and "species" in node:
+            # Leaf nodes carry a gene "id" and have no "children"; internal
+            # (ancestral) nodes have "taxonomy" too but no "id". Confirmed
+            # live: leaves have no "species" key at all -- species info
+            # lives under "taxonomy", which the previous check never read.
+            if "id" in node and not node.get("children"):
                 gene_id = node.get("id", {})
                 if isinstance(gene_id, dict):
                     gene_id = gene_id.get("accession", "")
+                taxonomy = node.get("taxonomy", {})
                 members.append(
                     {
                         "gene_id": str(gene_id),
-                        "species": node.get("species", {}).get("scientific_name", "")
-                        if isinstance(node.get("species"), dict)
-                        else str(node.get("species", "")),
+                        "species": taxonomy.get("scientific_name", "")
+                        if isinstance(taxonomy, dict)
+                        else str(taxonomy),
                     }
                 )
             # Traverse children

--- a/src/tooluniverse/foodb_tool.py
+++ b/src/tooluniverse/foodb_tool.py
@@ -54,6 +54,27 @@ class FooDBCompoundTool(BaseTool):
                 }
             resp.raise_for_status()
             c = resp.json()
+
+            # Retired/renumbered FDB ids 302-redirect to a *different*
+            # compound's current page instead of 404ing (confirmed live:
+            # FDB012199 -> FDB004133, an unrelated compound). `requests`
+            # follows redirects transparently, so without this check the
+            # substituted compound's data would silently be returned as
+            # if it were the one requested.
+            if resp.history and isinstance(c, dict) and c.get("public_id") != fdb_id:
+                return {
+                    "status": "success",
+                    "data": {},
+                    "metadata": {
+                        "query_fdb_id": fdb_id,
+                        "note": (
+                            f"'{fdb_id}' is not a current FooDB compound id "
+                            f"(it redirects to unrelated compound '{c.get('public_id')}', "
+                            "likely a retired/renumbered id). Not returning that "
+                            "compound's data since it does not match the request."
+                        ),
+                    },
+                }
         except requests.exceptions.Timeout:
             return {
                 "status": "error",

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -44,11 +44,18 @@ def remove_none_and_empty_values(json_obj):
             if v is not None and v != []
         }
     elif isinstance(json_obj, list):
-        return [
+        # Filter on the *recursed* item, not the original: a list entry
+        # like {"disease": None} isn't empty pre-recursion, but stripping
+        # its null "disease" key turns it into {} -- confirmed live in
+        # OpenTargets_get_associated_drugs_by_target_ensemblID's "diseases"
+        # list, which was leaving bare {} placeholders interleaved with
+        # real entries instead of dropping them like every other null.
+        cleaned = [
             remove_none_and_empty_values(item)
             for item in json_obj
             if item is not None and item != []
         ]
+        return [item for item in cleaned if item != {}]
     else:
         return json_obj
 
@@ -248,6 +255,27 @@ class OpentargetTool(GraphQLTool):
                     "it has no data for non-cancer diseases or non-driver genes. "
                     "For non-oncology phenotypes, use OpenTargets_get_evidence_by_datasource instead."
                 )
+
+        # A diseaseIds-filtered list query (e.g. studies(diseaseIds: ...))
+        # has no single entity to resolve to null, so the EFO->MONDO
+        # not-found detection above never fires for it -- it just returns a
+        # normal, misleadingly-empty count: 0 (confirmed live: EFO_0000676
+        # for psoriasis silently returns 0 studies, while the current
+        # MONDO_0005083 ID returns 79). Flag legacy EFO IDs specifically.
+        if result.get("status") == "success":
+            disease_ids = arguments.get("diseaseIds")
+            if isinstance(disease_ids, list) and any(
+                isinstance(d, str) and d.upper().startswith("EFO_") for d in disease_ids
+            ):
+                studies = result.get("data", {}).get("studies")
+                if isinstance(studies, dict) and studies.get("count") == 0:
+                    result.setdefault("metadata", {})["note"] = (
+                        "0 studies found for a legacy EFO disease ID. OpenTargets "
+                        "migrated most disease IDs from EFO to MONDO, so this may "
+                        "be a stale ID rather than a genuine zero-studies result. "
+                        "Look up the current MONDO ID with "
+                        "OpenTargets_multi_entity_search_by_query_string."
+                    )
 
         # If no results AND an argument contains '-', retry once with '-'
         # replaced by ' ' (rescues hyphenated names). The hyphen guard keeps a

--- a/src/tooluniverse/medlineplus_tool.py
+++ b/src/tooluniverse/medlineplus_tool.py
@@ -9,6 +9,8 @@ import json
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
 
 @register_tool("MedlinePlusRESTTool")
 class MedlinePlusRESTTool(BaseTool):
@@ -38,6 +40,26 @@ class MedlinePlusRESTTool(BaseTool):
 
         return url_path
 
+    @staticmethod
+    def _paragraph_text(p) -> str:
+        """A <html:p> paragraph from xmltodict is a bare string when it has
+        no nested inline tag, or a dict when it does (e.g. <html:i>FMR1</html:i>
+        splits into {"html:i": "FMR1", "#text": "The  gene provides..."} --
+        xmltodict keeps the surrounding text but drops the inline tag's own
+        text from "#text", leaving a double-space gap where it belongs).
+        Reinsert the inline text into that gap instead of losing the word."""
+        if isinstance(p, str):
+            return p
+        if not isinstance(p, dict):
+            return ""
+        text = p.get("#text", "")
+        inline = next(
+            (v for k, v in p.items() if k != "#text" and isinstance(v, str)), None
+        )
+        if inline and "  " in text:
+            text = text.replace("  ", f" {inline} ", 1)
+        return text
+
     def _extract_text_content(self, text_item: dict) -> str:
         """Extract content from text item"""
         if not isinstance(text_item, dict):
@@ -50,15 +72,16 @@ class MedlinePlusRESTTool(BaseTool):
         html = text.get("html", "")
         if isinstance(html, dict) and "html:p" in html:
             paragraphs = html["html:p"]
-            if isinstance(paragraphs, list):
-                return "\n".join(
-                    [
-                        p.get("#text", "")
-                        for p in paragraphs
-                        if isinstance(p, dict) and "#text" in p
-                    ]
-                )
-        return html.replace("<p>", "").replace("</p>", "\n")
+            if not isinstance(paragraphs, list):
+                paragraphs = [paragraphs]
+            # Confirmed live: paragraphs without a nested inline tag parse as
+            # bare strings, not dicts -- the previous `isinstance(p, dict)`
+            # filter silently dropped every such paragraph (e.g. lost the
+            # entire middle paragraph of FMR1's "function" description).
+            return "\n".join(self._paragraph_text(p) for p in paragraphs)
+        if isinstance(html, str):
+            return _HTML_TAG_RE.sub("", html.replace("</p>", "\n")).strip()
+        return ""
 
     def _format_response(self, response: Any, tool_name: str) -> Dict[str, Any]:
         """Format response content"""

--- a/src/tooluniverse/open_genes_tool.py
+++ b/src/tooluniverse/open_genes_tool.py
@@ -19,9 +19,9 @@ from .tool_registry import register_tool
 OPEN_GENES_BASE = "https://open-genes.com/api"
 
 
-def _names(items: Any) -> List[str]:
+def _names(items: Any, key: str = "name") -> List[str]:
     return (
-        [i.get("name") for i in items if isinstance(i, dict) and i.get("name")]
+        [i.get(key) for i in items if isinstance(i, dict) and i.get(key)]
         if isinstance(items, list)
         else []
     )
@@ -69,7 +69,14 @@ def _summarize(g: Dict[str, Any]) -> Dict[str, Any]:
         "ensembl": g.get("ensembl"),
         "aging_mechanisms": _names(g.get("agingMechanisms")),
         "functional_clusters": _names(g.get("functionalClusters")),
-        "disease_categories": _names(g.get("diseaseCategories")),
+        # diseaseCategories entries key their label as "icdCategoryName", not
+        # "name" (confirmed live), so pass that key explicitly.
+        "disease_categories": _names(g.get("diseaseCategories"), "icdCategoryName"),
+        # Specific named disease associations (e.g. "Progeria", "Dilated
+        # cardiomyopathy") -- a separate, more specific field from
+        # diseaseCategories's broad ICD chapter groupings, and previously
+        # not surfaced at all.
+        "diseases": _names(g.get("diseases")),
         "confidence_level": conf.get("name") if isinstance(conf, dict) else conf,
         "expression_change": g.get("expressionChange"),
     }

--- a/src/tooluniverse/orthodb_tool.py
+++ b/src/tooluniverse/orthodb_tool.py
@@ -96,30 +96,31 @@ class OrthoDBTool(BaseTool):
 
         group_ids = data.get("data", [])
 
-        # Get basic info for top groups via tab endpoint
+        # /search only returns bare group ids -- name/level_taxid require a
+        # separate per-group /tab lookup (confirmed live: OrthoDB has no
+        # batch/comma-separated id support for /tab). Enrich every returned
+        # group, not just the first -- confirmed live this previously left
+        # 9 of 10 results as bare {"group_id": ...} with no way to tell
+        # them apart without a follow-up call per group.
         groups = []
         for gid in group_ids[:limit]:
-            groups.append({"group_id": gid})
-
-        # Enrich with group names using the tab endpoint for first few
-        if group_ids:
+            group = {"group_id": gid}
             try:
-                tab_url = f"{ORTHODB_BASE_URL}/tab"
-                tab_params = {"id": group_ids[0], "limit": 1}
                 tab_resp = requests.get(
-                    tab_url, params=tab_params, timeout=self.timeout
+                    f"{ORTHODB_BASE_URL}/tab",
+                    params={"id": gid, "limit": 1},
+                    timeout=self.timeout,
                 )
                 if tab_resp.status_code == 200:
                     lines = tab_resp.text.strip().split("\n")
                     if len(lines) > 1:
                         cols = lines[1].split("\t")
                         if len(cols) >= 2:
-                            groups[0]["name"] = cols[1]
-                            groups[0]["level_taxid"] = (
-                                cols[2] if len(cols) > 2 else None
-                            )
+                            group["name"] = cols[1]
+                            group["level_taxid"] = cols[2] if len(cols) > 2 else None
             except Exception:
                 pass
+            groups.append(group)
 
         return {
             "status": "success",

--- a/src/tooluniverse/panelapp_tool.py
+++ b/src/tooluniverse/panelapp_tool.py
@@ -1,0 +1,71 @@
+# panelapp_tool.py
+"""PanelApp panel search tool for ToolUniverse.
+
+PanelApp's `/panels/` endpoint silently ignores substring search params --
+confirmed live: `search=`, `q=`, and `name__icontains=` all return the
+unfiltered, unranked list of all 434 panels regardless of value; only an
+exact full-string `name=` match filters anything (its OpenAPI schema
+documents no search param at all, only `type` and `page`). Since the API
+can't filter server-side, this fetches every panel (paginating the
+API's fixed page_size=100) and filters client-side by substring match
+against name/disease_group/disease_sub_group.
+"""
+
+from typing import Any, Dict
+
+from .base_rest_tool import BaseRESTTool
+from .tool_registry import register_tool
+
+PANELS_URL = "https://panelapp.genomicsengland.co.uk/api/v1/panels/"
+_MAX_PAGES = 10  # safety cap; ~434 panels / 100 per page = 5 pages today
+
+
+@register_tool("PanelAppSearchTool")
+class PanelAppSearchTool(BaseRESTTool):
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        search = (arguments.get("search") or "").strip().lower()
+        if not search:
+            return {"status": "error", "error": "'search' is required"}
+
+        panels = []
+        url = PANELS_URL
+        params = {"format": "json"}
+        for _ in range(_MAX_PAGES):
+            try:
+                resp = self.session.get(url, params=params, timeout=self.timeout)
+                resp.raise_for_status()
+                page = resp.json()
+            except Exception as e:
+                return {"status": "error", "error": f"PanelApp API error: {e}"}
+            panels.extend(page.get("results", []))
+            url = page.get("next")
+            params = None  # `next` already includes all query params
+            if not url:
+                break
+
+        def matches(p: Dict[str, Any]) -> bool:
+            haystack = " ".join(
+                str(p.get(k) or "")
+                for k in ("name", "disease_group", "disease_sub_group")
+            ).lower()
+            return search in haystack
+
+        results = [p for p in panels if matches(p)]
+        return {
+            "status": "success",
+            "data": {
+                "count": len(results),
+                "next": None,
+                "previous": None,
+                "results": results,
+            },
+            "metadata": {
+                "query": arguments.get("search"),
+                "total_panels_searched": len(panels),
+                "note": (
+                    "PanelApp's API has no server-side search filter, so this "
+                    "matches client-side against name/disease_group/"
+                    "disease_sub_group across all panels."
+                ),
+            },
+        }

--- a/src/tooluniverse/protparam_tool.py
+++ b/src/tooluniverse/protparam_tool.py
@@ -134,11 +134,20 @@ def _count_aa(seq: str) -> Dict[str, int]:
 
 
 def _calc_mw(seq: str) -> float:
-    """Calculate molecular weight using average isotopic masses."""
+    """Calculate molecular weight using average isotopic masses.
+
+    _MW_AVG holds free-amino-acid masses; each peptide bond formed loses
+    one water, so an n-residue chain loses (n-1) waters relative to the
+    sum of free residues. Starting the accumulator at _WATER_MW and then
+    subtracting it once per residue implements exactly that (the loop
+    subtracts n waters, the initial term adds one back = -(n-1) net).
+    A stray trailing `total += _WATER_MW` here previously added a second,
+    unwanted water, overshooting every result by 18.02 Da regardless of
+    sequence length (confirmed live).
+    """
     total = _WATER_MW
     for ch in seq.upper():
         total += _MW_AVG.get(ch, 0) - _WATER_MW
-    total += _WATER_MW
     return round(total, 2)
 
 

--- a/src/tooluniverse/sequence_analyze_tool.py
+++ b/src/tooluniverse/sequence_analyze_tool.py
@@ -220,7 +220,12 @@ class SequenceAnalyzeTool(BaseTool):
         else:
             seq_type = "Protein"
             mw = _WATER_MASS + sum(_AA_MASS.get(aa, 111.1) for aa in seq)
-            extra = {"estimated_mw_da": round(mw, 2)}
+            # Monoisotopic, not average mass -- confirmed live this was
+            # previously reported as unlabeled "estimated_mw_da" and silently
+            # mismatched the average mass most tools (ExPASy ProtParam,
+            # UniProt) report by default (off by ~11-18 Da, more for larger
+            # proteins). Use ProtParam_calculate for average mass.
+            extra = {"estimated_mw_monoisotopic_da": round(mw, 2)}
 
         data = {
             "sequence_type": seq_type,

--- a/tests/unit/test_discovery_resource_tools_batch11.py
+++ b/tests/unit/test_discovery_resource_tools_batch11.py
@@ -5,11 +5,12 @@ from unittest.mock import MagicMock, patch
 from tooluniverse.foodb_tool import FooDBCompoundTool
 
 
-def _resp(status=200, json_body=None):
+def _resp(status=200, json_body=None, history=None):
     r = MagicMock()
     r.status_code = status
     r.json.return_value = json_body
     r.raise_for_status.return_value = None
+    r.history = history if history is not None else []
     return r
 
 
@@ -52,3 +53,29 @@ def test_foodb_non_compound_body_empty():
         out = FooDBCompoundTool(_cfg()).run({"fdb_id": "FDB000004"})
     assert out["status"] == "success"
     assert out["data"] == {}
+
+
+def test_foodb_retired_id_redirect_not_returned_as_match():
+    # Fix-R26A-1: FDB012199 is retired and 302-redirects to unrelated
+    # compound FDB004133 (confirmed live). `requests` follows redirects
+    # transparently, so without a history/public_id check the substituted
+    # compound would silently be returned as if it matched the request.
+    body = {"public_id": "FDB004133", "name": "3-Benzylisothiocyanate"}
+    resp = _resp(200, body, history=[_resp(302)])
+    with patch("tooluniverse.foodb_tool.requests.get", return_value=resp):
+        out = FooDBCompoundTool(_cfg()).run({"fdb_id": "FDB012199"})
+    assert out["status"] == "success"
+    assert out["data"] == {}
+    assert "FDB004133" in out["metadata"]["note"]
+    assert out["metadata"]["query_fdb_id"] == "FDB012199"
+
+
+def test_foodb_redirect_to_same_id_still_returns_data():
+    # A redirect that lands on the *same* public_id (e.g. http->https,
+    # case-normalization) should still return the compound normally.
+    body = {"public_id": "FDB000004", "name": "Cyanidin 3-galactoside"}
+    resp = _resp(200, body, history=[_resp(301)])
+    with patch("tooluniverse.foodb_tool.requests.get", return_value=resp):
+        out = FooDBCompoundTool(_cfg()).run({"fdb_id": "FDB000004"})
+    assert out["status"] == "success"
+    assert out["data"]["fdb_id"] == "FDB000004"

--- a/tests/unit/test_ensembl_compara_gene_tree.py
+++ b/tests/unit/test_ensembl_compara_gene_tree.py
@@ -1,0 +1,118 @@
+"""Regression guard for Fix-R26E-2: EnsemblCompara_get_gene_tree
+(EnsemblComparaTool, endpoint "gene_tree") never returned usable data in
+any input form, confirmed live for TP53 (the tool's own documented
+example) and LYZ:
+
+1. tree_id was read from the nonexistent data["tree"]["id"] instead of
+   the real top-level data["id"] -- always null.
+2. Leaf members were detected via `"species" in node`, but leaf nodes
+   carry taxonomy info under "taxonomy", never "species" -- members was
+   always empty.
+3. `newick` was read from a "newick" JSON field that Ensembl's genetree
+   endpoint never returns in JSON mode; real Newick text is only served
+   via a separate request with a "text/x-nh" Content-Type header.
+4. The Ensembl-gene-ID path form (`/genetree/member/id/{gene}`) 404d
+   because it's missing a required {species} path segment
+   (`/genetree/member/id/{species}/{gene}`).
+
+All four are fixed in ensembl_compara_tool.py. Network mocked.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.ensembl_compara_tool import EnsemblComparaTool
+
+pytestmark = pytest.mark.unit
+
+_TREE_JSON = {
+    "type": "gene tree",
+    "rooted": 1,
+    "id": "ENSGT00950000183153",
+    "tree": {
+        "taxonomy": {"scientific_name": "Bilateria"},
+        "children": [
+            {
+                "id": {"source": "EnsEMBL", "accession": "ENSG00000141510"},
+                "taxonomy": {"scientific_name": "Homo sapiens"},
+                "branch_length": 0.01,
+            },
+            {
+                "id": {"source": "EnsEMBL", "accession": "ENSMUSG00000059552"},
+                "taxonomy": {"scientific_name": "Mus musculus"},
+                "branch_length": 0.02,
+            },
+        ],
+    },
+}
+_NEWICK_TEXT = "(ENSG00000141510:0.01,ENSMUSG00000059552:0.02);"
+
+
+def _json_resp(payload):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = payload
+    r.raise_for_status.return_value = None
+    return r
+
+
+def _text_resp(text, status_code=200):
+    r = MagicMock()
+    r.status_code = status_code
+    r.text = text
+    r.raise_for_status.return_value = None
+    return r
+
+
+def _tool():
+    return EnsemblComparaTool({"fields": {"endpoint": "gene_tree"}, "timeout": 30})
+
+
+class TestGeneTreeParsing:
+    def test_symbol_lookup_populates_tree_id_members_and_newick(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.ensembl_compara_tool.requests.get",
+            side_effect=[_json_resp(_TREE_JSON), _text_resp(_NEWICK_TEXT)],
+        ):
+            result = tool.run({"gene": "TP53", "species": "human"})
+
+        assert result["status"] == "success"
+        data = result["data"]
+        assert data["tree_id"] == "ENSGT00950000183153"
+        assert data["newick"] == _NEWICK_TEXT
+        assert data["total_members"] == 2
+        assert {m["gene_id"] for m in data["members"]} == {
+            "ENSG00000141510",
+            "ENSMUSG00000059552",
+        }
+        assert {m["species"] for m in data["members"]} == {
+            "Homo sapiens",
+            "Mus musculus",
+        }
+
+    def test_ensembl_id_lookup_includes_species_in_path(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.ensembl_compara_tool.requests.get",
+            side_effect=[_json_resp(_TREE_JSON), _text_resp(_NEWICK_TEXT)],
+        ) as mock_get:
+            tool.run({"gene": "ENSG00000090382", "species": "human"})
+
+        first_call_url = mock_get.call_args_list[0].args[0]
+        assert first_call_url == (
+            "https://rest.ensembl.org/genetree/member/id/human/ENSG00000090382"
+        )
+
+    def test_newick_fetch_failure_does_not_fail_whole_call(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.ensembl_compara_tool.requests.get",
+            side_effect=[_json_resp(_TREE_JSON), _text_resp("", status_code=500)],
+        ):
+            result = tool.run({"gene": "TP53", "species": "human"})
+
+        assert result["status"] == "success"
+        assert result["data"]["newick"] is None
+        assert result["data"]["total_members"] == 2

--- a/tests/unit/test_graphql_tool_round26_fixes.py
+++ b/tests/unit/test_graphql_tool_round26_fixes.py
@@ -1,0 +1,90 @@
+"""Regression guards for two Fix-R26B bugs in graphql_tool.py.
+
+Fix-R26B-1 (empty dict remnants in lists): remove_none_and_empty_values()
+stripped a null "disease" key from a list entry like {"disease": None},
+turning it into {}, but only filtered list items on their *pre-recursion*
+value -- so the resulting {} survived instead of being dropped like every
+other null. Confirmed live in OpenTargets_get_associated_drugs_by_target_
+ensemblID's "diseases" list (bare {} interleaved with real disease entries
+for BRODALUMAB). Fixed by filtering on the recursed result.
+
+Fix-R26B-2 (silent empty result for legacy EFO disease IDs):
+OpenTargets_search_gwas_studies_by_disease's studies(diseaseIds: ...) query
+returns a normal, non-null {"count": 0} for a stale EFO_* disease id
+instead of a null entity, so the existing EFO->MONDO not-found detection
+(which only fires on a null entity) never caught it. Confirmed live:
+EFO_0000676 (psoriasis) silently returned 0 studies while the current
+MONDO_0005083 id returns 79. Fixed by flagging legacy EFO ids specifically
+when the studies count comes back 0.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.graphql_tool import OpentargetTool, remove_none_and_empty_values
+
+pytestmark = pytest.mark.unit
+
+
+class TestRemoveNoneAndEmptyValues:
+    def test_dict_with_null_key_in_list_is_dropped_not_left_empty(self):
+        data = {
+            "diseases": [
+                {"disease": {"id": "MONDO_1", "name": "psoriasis"}},
+                {"disease": None},
+                {"disease": {"id": "MONDO_2", "name": "asthma"}},
+            ]
+        }
+        cleaned = remove_none_and_empty_values(data)
+        assert cleaned["diseases"] == [
+            {"disease": {"id": "MONDO_1", "name": "psoriasis"}},
+            {"disease": {"id": "MONDO_2", "name": "asthma"}},
+        ]
+
+    def test_plain_none_and_empty_list_still_dropped(self):
+        data = {"a": None, "b": [], "c": "keep", "d": [1, None, 2]}
+        cleaned = remove_none_and_empty_values(data)
+        assert cleaned == {"c": "keep", "d": [1, 2]}
+
+
+def _tool():
+    tool = OpentargetTool.__new__(OpentargetTool)
+    tool.endpoint_url = "https://api.platform.opentargets.org/api/v4/graphql"
+    tool.query_schema = "query searchStudies($diseaseIds: [String!]) { studies { count } }"
+    return tool
+
+
+class TestLegacyEfoStudiesNote:
+    def test_legacy_efo_id_with_zero_studies_gets_note(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.graphql_tool.GraphQLTool.run",
+            return_value={"status": "success", "data": {"studies": {"count": 0}}},
+        ):
+            result = tool.run({"diseaseIds": ["EFO_0000676"]})
+
+        assert result["status"] == "success"
+        assert "EFO to MONDO" in result["metadata"]["note"]
+
+    def test_current_mondo_id_with_results_gets_no_note(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.graphql_tool.GraphQLTool.run",
+            return_value={"status": "success", "data": {"studies": {"count": 79}}},
+        ):
+            result = tool.run({"diseaseIds": ["MONDO_0005083"]})
+
+        assert "metadata" not in result or "note" not in result.get("metadata", {})
+
+    def test_mondo_id_with_zero_studies_gets_no_note(self):
+        # A genuine current MONDO id with zero studies is a real answer,
+        # not a stale-id symptom -- only EFO_-prefixed ids should get the note.
+        tool = _tool()
+        with patch(
+            "tooluniverse.graphql_tool.GraphQLTool.run",
+            return_value={"status": "success", "data": {"studies": {"count": 0}}},
+        ):
+            result = tool.run({"diseaseIds": ["MONDO_9999999"]})
+
+        assert "metadata" not in result or "note" not in result.get("metadata", {})

--- a/tests/unit/test_medlineplus_paragraph_extraction.py
+++ b/tests/unit/test_medlineplus_paragraph_extraction.py
@@ -1,0 +1,83 @@
+"""Regression guard for Fix-R26C-1 in MedlinePlusRESTTool._extract_text_content.
+
+Confirmed live against MedlinePlus's XML-fallback response for FMR1.json
+(xmltodict-parsed): a <html:p> paragraph containing a nested inline tag
+(e.g. <html:i>FMR1</html:i>) parses to a dict whose "#text" has the tag's
+own text dropped, leaving a double-space gap ("The  gene provides...").
+A paragraph WITHOUT any nested tag parses as a bare string instead of a
+dict, and the previous `isinstance(p, dict)` filter silently discarded it
+entirely -- for FMR1 this dropped the whole middle paragraph of the
+"function" description. Also covers the real-JSON path, where "html" is
+a raw HTML string (e.g. "<p>The <i>FMR1</i> gene...</p>") and the previous
+code only stripped <p>/</p>, leaving <i>/</i> as literal text.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.medlineplus_tool import MedlinePlusRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return MedlinePlusRESTTool.__new__(MedlinePlusRESTTool)
+
+
+class TestXmlFallbackParagraphExtraction:
+    def test_inline_tag_text_reinserted_not_dropped(self):
+        text_item = {
+            "text": {
+                "html": {
+                    "html:p": [
+                        {"html:i": "FMR1", "#text": "The  gene provides instructions."}
+                    ]
+                }
+            }
+        }
+        result = _tool()._extract_text_content(text_item)
+        assert result == "The FMR1 gene provides instructions."
+
+    def test_bare_string_paragraph_not_dropped(self):
+        # A paragraph with no nested inline tag parses as a plain string,
+        # not a dict -- the old `isinstance(p, dict)` filter silently
+        # discarded these entirely.
+        text_item = {
+            "text": {
+                "html": {
+                    "html:p": [
+                        {"html:i": "FMR1", "#text": "The  gene provides FMRP."},
+                        "Researchers believe FMRP acts as a shuttle.",
+                    ]
+                }
+            }
+        }
+        result = _tool()._extract_text_content(text_item)
+        assert "Researchers believe FMRP acts as a shuttle." in result
+        assert result == (
+            "The FMR1 gene provides FMRP.\nResearchers believe FMRP acts as a shuttle."
+        )
+
+    def test_single_paragraph_not_wrapped_in_list_still_works(self):
+        text_item = {"text": {"html": {"html:p": "Just one paragraph."}}}
+        result = _tool()._extract_text_content(text_item)
+        assert result == "Just one paragraph."
+
+
+class TestRealJsonHtmlStringExtraction:
+    def test_inline_tags_stripped_not_left_literal(self):
+        html = "<p>The <i>FMR1</i> gene provides instructions for making FMRP.</p>"
+        text_item = {"text": {"html": html}}
+        result = _tool()._extract_text_content(text_item)
+        assert result == "The FMR1 gene provides instructions for making FMRP."
+        assert "<i>" not in result
+
+    def test_multiple_paragraphs_join_with_newline(self):
+        html = "<p>First paragraph.</p><p>Second paragraph.</p>"
+        text_item = {"text": {"html": html}}
+        result = _tool()._extract_text_content(text_item)
+        assert result == "First paragraph.\nSecond paragraph."

--- a/tests/unit/test_open_genes_disease_fields.py
+++ b/tests/unit/test_open_genes_disease_fields.py
@@ -1,0 +1,93 @@
+"""Regression guard for Fix-R26D-1: OpenGenesGeneTool's "disease_categories"
+field was always empty for every gene tested. Confirmed live (curl to
+open-genes.com/api/gene/LMNA): diseaseCategories entries key their label
+as "icdCategoryName", not "name" -- the shared _names() helper (which
+looks for "name") never matched, silently discarding real curated disease
+evidence (e.g. LMNA/progeria, confirmed present via
+evidence_counts.geneAssociatedWithProgeriaSyndromes: 3). Also added a new
+"diseases" field surfacing the separate, more specific named-disease list
+(e.g. "Progeria", "Dilated cardiomyopathy") that the raw API already
+provides under "diseases" but the tool never read at all.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.open_genes_tool import OpenGenesGeneTool
+
+pytestmark = pytest.mark.unit
+
+_LMNA_RESPONSE = {
+    "symbol": "LMNA",
+    "name": "lamin A/C",
+    "ncbiId": 4000,
+    "diseaseCategories": [
+        {"id": 336, "icdCode": "I30-I52", "icdCategoryName": "Other forms of heart disease"},
+        {"id": 772, "icdCode": "G60-G64", "icdCategoryName": "Polyneuropathies and other disorders of the peripheral nervous system"},
+    ],
+    "diseases": [
+        {"id": 33, "icdCode": "I42.0", "name": "Dilated cardiomyopathy"},
+        {"id": 37, "icdCode": "Q87.5", "name": "Mandibuloacral dysplasia with lipodystrophy"},
+        {"id": 40, "icdCode": "E34.8", "name": "Progeria"},
+    ],
+    "agingMechanisms": [],
+    "functionalClusters": [],
+    "researches": {},
+}
+
+
+def _tool():
+    return OpenGenesGeneTool({"name": "opengenes_test", "fields": {}})
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = json_body
+    return r
+
+
+class TestDiseaseFieldExtraction:
+    def test_disease_categories_extracted_from_icd_category_name(self):
+        tool = _tool()
+        resp = _resp(_LMNA_RESPONSE)
+
+        with patch("tooluniverse.open_genes_tool.requests.get", return_value=resp):
+            result = tool.run({"symbol": "LMNA"})
+
+        assert result["status"] == "success"
+        assert result["data"]["disease_categories"] == [
+            "Other forms of heart disease",
+            "Polyneuropathies and other disorders of the peripheral nervous system",
+        ]
+
+    def test_diseases_field_populated(self):
+        tool = _tool()
+        resp = _resp(_LMNA_RESPONSE)
+
+        with patch("tooluniverse.open_genes_tool.requests.get", return_value=resp):
+            result = tool.run({"symbol": "LMNA"})
+
+        assert result["data"]["diseases"] == [
+            "Dilated cardiomyopathy",
+            "Mandibuloacral dysplasia with lipodystrophy",
+            "Progeria",
+        ]
+
+    def test_empty_disease_lists_do_not_crash(self):
+        tool = _tool()
+        response = dict(_LMNA_RESPONSE)
+        response["diseaseCategories"] = []
+        response["diseases"] = []
+        resp = _resp(response)
+
+        with patch("tooluniverse.open_genes_tool.requests.get", return_value=resp):
+            result = tool.run({"symbol": "LMNA"})
+
+        assert result["data"]["disease_categories"] == []
+        assert result["data"]["diseases"] == []

--- a/tests/unit/test_opentargets_disease_pagination.py
+++ b/tests/unit/test_opentargets_disease_pagination.py
@@ -1,0 +1,84 @@
+"""Regression guard for Fix-R26D-2: OpenTargets_get_diseases_phenotypes_by_
+target_ensembl's associatedDiseases query had no `page` argument, so Open
+Targets silently applied its default page size (25 rows) regardless of how
+many associations actually existed -- confirmed live for SIRT1
+(ENSG00000096717): count: 3432 but only 25 rows returned, with no way to
+retrieve the other 3407. OpenTargets' associatedDiseases field does accept
+a `page: Pagination` argument (confirmed via GraphQL introspection), matching
+the same `page: {index, size}` convention already used by several sibling
+OpenTarget tools (e.g. OpenTargets_get_target_interactions_by_ensemblID).
+Fixed by exposing that argument through the query_schema and parameter
+schema instead of silently truncating with no way to page further.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.graphql_tool import OpentargetTool
+
+pytestmark = pytest.mark.unit
+
+_CONFIG_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "tooluniverse"
+    / "data"
+    / "opentarget_tools.json"
+)
+
+
+def _load_tool_config():
+    configs = json.loads(_CONFIG_PATH.read_text())
+    for cfg in configs:
+        if cfg["name"] == "OpenTargets_get_diseases_phenotypes_by_target_ensembl":
+            return cfg
+    raise AssertionError("tool config not found")
+
+
+def _tool():
+    cfg = _load_tool_config()
+    return OpentargetTool(cfg), cfg
+
+
+class TestQuerySchemaExposesPagination:
+    def test_query_schema_declares_page_variable(self):
+        _, cfg = _tool()
+        assert "$page: Pagination" in cfg["query_schema"]
+        assert "associatedDiseases(page: $page)" in cfg["query_schema"]
+
+    def test_parameter_schema_has_page_object(self):
+        _, cfg = _tool()
+        page_param = cfg["parameter"]["properties"]["page"]
+        assert set(page_param["properties"].keys()) == {"index", "size"}
+        assert "ensemblId" in cfg["parameter"]["required"]
+        assert "page" not in cfg["parameter"]["required"]
+
+
+class TestPageArgumentForwarded:
+    def test_page_argument_passed_through_as_graphql_variable(self):
+        tool, _ = _tool()
+        response = MagicMock()
+        response.ok = True
+        response.json.return_value = {
+            "data": {
+                "target": {
+                    "id": "ENSG00000096717",
+                    "associatedDiseases": {"count": 3432, "rows": []},
+                }
+            }
+        }
+        with patch(
+            "tooluniverse.graphql_tool.requests.post", return_value=response
+        ) as mock_post:
+            tool.run(
+                {
+                    "ensemblId": "ENSG00000096717",
+                    "page": {"index": 1, "size": 25},
+                }
+            )
+
+        sent_variables = mock_post.call_args.kwargs["json"]["variables"]
+        assert sent_variables["page"] == {"index": 1, "size": 25}

--- a/tests/unit/test_orthodb_search_groups_enrichment.py
+++ b/tests/unit/test_orthodb_search_groups_enrichment.py
@@ -1,0 +1,76 @@
+"""Regression guard for Fix-R26E-3: OrthoDB_search_groups
+(OrthoDBTool, endpoint "search") only enriched the *first* returned group
+with name/level_taxid via the /tab endpoint -- confirmed live querying
+"lysozyme": 9 of 10 returned groups were bare {"group_id": ...} with no
+name or taxid, even though that data is retrievable per-group via /tab
+(there is no batch/comma-separated id support on OrthoDB's /tab endpoint).
+Fixed by enriching every returned group, not just groups[0]. Network mocked.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.orthodb_tool import OrthoDBTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return OrthoDBTool({"fields": {"endpoint": "search"}, "timeout": 30})
+
+
+def _json_resp(payload):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = payload
+    r.raise_for_status.return_value = None
+    return r
+
+
+def _tab_resp(name, level_taxid):
+    r = MagicMock()
+    r.status_code = 200
+    r.text = f"pub_og_id\tog_name\tlevel_taxid\n" f"x\t{name}\t{level_taxid}\n"
+    return r
+
+
+class TestSearchGroupsEnrichment:
+    def test_all_returned_groups_are_enriched_not_just_first(self):
+        tool = _tool()
+        search_resp = _json_resp({"data": ["1at2759", "2at33208", "3at7742"]})
+        tab_responses = [
+            _tab_resp("Lysozyme", "2759"),
+            _tab_resp("lysozyme g-like", "33208"),
+            _tab_resp("lysozyme G-like", "7742"),
+        ]
+        with patch(
+            "tooluniverse.orthodb_tool.requests.get",
+            side_effect=[search_resp] + tab_responses,
+        ):
+            result = tool.run({"query": "lysozyme", "limit": 3})
+
+        assert result["status"] == "success"
+        groups = result["data"]["groups"]
+        assert len(groups) == 3
+        for g in groups:
+            assert "name" in g
+            assert "level_taxid" in g
+        assert groups[0]["name"] == "Lysozyme"
+        assert groups[1]["name"] == "lysozyme g-like"
+        assert groups[2]["name"] == "lysozyme G-like"
+
+    def test_per_group_tab_failure_leaves_that_group_bare_not_fatal(self):
+        tool = _tool()
+        search_resp = _json_resp({"data": ["1at2759", "2at33208"]})
+        with patch(
+            "tooluniverse.orthodb_tool.requests.get",
+            side_effect=[search_resp, Exception("network error"), _tab_resp("ok", "1")],
+        ):
+            result = tool.run({"query": "lysozyme", "limit": 2})
+
+        assert result["status"] == "success"
+        groups = result["data"]["groups"]
+        assert len(groups) == 2
+        assert "name" not in groups[0]
+        assert groups[1]["name"] == "ok"

--- a/tests/unit/test_panelapp_client_side_search.py
+++ b/tests/unit/test_panelapp_client_side_search.py
@@ -1,0 +1,82 @@
+"""Regression guard for Fix-R26C-2: PanelApp_search_panels's `search` param
+was a complete no-op server-side. Confirmed live: `search=`, `q=`, and
+`name__icontains=` all returned PanelApp's full unfiltered 434-panel list
+regardless of value (only an exact full-string `name=` match filters
+anything, and its OpenAPI schema documents no search param at all).
+PanelAppSearchTool now fetches every panel (paginating the API's fixed
+page_size=100) and filters client-side by substring match against
+name/disease_group/disease_sub_group.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.panelapp_tool import PanelAppSearchTool
+
+pytestmark = pytest.mark.unit
+
+_PANELS = [
+    {"id": 1, "name": "Acute intermittent porphyria", "disease_group": "Gastrohepatology", "disease_sub_group": ""},
+    {"id": 2, "name": "Familial breast cancer", "disease_group": "Inherited cancer", "disease_sub_group": ""},
+    {"id": 3, "name": "Primary ovarian insufficiency", "disease_group": "Reproductive", "disease_sub_group": ""},
+]
+
+
+def _tool():
+    return PanelAppSearchTool({"name": "panelapp_test", "fields": {}, "parameter": {}})
+
+
+def _resp(results, next_url=None):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = {"count": len(results), "next": next_url, "results": results}
+    return r
+
+
+class TestClientSideSearchFiltering:
+    def test_filters_by_name_substring(self):
+        tool = _tool()
+        with patch.object(tool.session, "get", return_value=_resp(_PANELS)):
+            result = tool.run({"search": "breast cancer"})
+
+        assert result["status"] == "success"
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["name"] == "Familial breast cancer"
+
+    def test_no_match_returns_empty_not_full_list(self):
+        # The old behavior (server-side no-op) would have returned all 3
+        # panels here; the fix must return zero for a genuine non-match.
+        tool = _tool()
+        with patch.object(tool.session, "get", return_value=_resp(_PANELS)):
+            result = tool.run({"search": "xyzzyqqqnonexistentterm"})
+
+        assert result["data"]["count"] == 0
+        assert result["data"]["results"] == []
+
+    def test_matches_disease_group_not_just_name(self):
+        tool = _tool()
+        with patch.object(tool.session, "get", return_value=_resp(_PANELS)):
+            result = tool.run({"search": "reproductive"})
+
+        assert result["data"]["count"] == 1
+        assert result["data"]["results"][0]["name"] == "Primary ovarian insufficiency"
+
+    def test_paginates_through_next_url(self):
+        tool = _tool()
+        page1 = _resp([_PANELS[0]], next_url="https://panelapp.../?page=2")
+        page2 = _resp([_PANELS[1]])
+        with patch.object(tool.session, "get", side_effect=[page1, page2]):
+            result = tool.run({"search": "cancer"})
+
+        assert result["metadata"]["total_panels_searched"] == 2
+        assert result["data"]["count"] == 1
+
+    def test_requires_search_param(self):
+        tool = _tool()
+        result = tool.run({})
+        assert result["status"] == "error"

--- a/tests/unit/test_protparam_molecular_weight.py
+++ b/tests/unit/test_protparam_molecular_weight.py
@@ -1,0 +1,59 @@
+"""Regression guard for Fix-R26E-1: ProtParam_calculate's molecular_weight_da
+was systematically 18.02 Da too high for every sequence -- exactly one
+water molecule's mass, regardless of sequence length. Root cause: _calc_mw
+added _WATER_MW once before the per-residue loop (correct, to convert the
+loop's per-residue "free amino acid mass minus water" terms into a proper
+peptide-bond-aware sum) but then added it again after the loop, a second,
+unwanted water. Confirmed live against known references: ACDEFGHIK should
+be 1019.14 Da (was 1037.15) and human lysozyme C (148 aa) should be
+~16537 Da (was 16554.97).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.protparam_tool import ProtParamTool
+
+pytestmark = pytest.mark.unit
+
+_LYSOZYME = (
+    "MKALIVLGLVLLSVTVQGKVFERCELARTLKRLGMDGYRGISLANWMCLAKWESGYNTRATNYNAGDRST"
+    "DYGIFQINSRYWCNDGKTPGAVNACHLSCSALLQDNIADAVACAKRVVRDPQGIRAWVAWRNRCQNRDVR"
+    "QYVQGCGV"
+)
+
+
+def _tool():
+    return ProtParamTool()
+
+
+class TestMolecularWeight:
+    def test_short_peptide_matches_known_reference(self):
+        tool = _tool()
+        result = tool.run({"sequence": "ACDEFGHIK"})
+
+        assert result["status"] == "success"
+        assert result["data"]["molecular_weight_da"] == pytest.approx(1019.14, abs=0.05)
+
+    def test_lysozyme_matches_uniprot_reference_mass(self):
+        tool = _tool()
+        result = tool.run({"sequence": _LYSOZYME})
+
+        assert result["status"] == "success"
+        # UniProt P61626 records 16537 Da for this sequence.
+        assert result["data"]["molecular_weight_da"] == pytest.approx(16537, abs=0.5)
+
+    def test_dipeptide_equals_two_free_masses_minus_one_water(self):
+        tool = _tool()
+        result = tool.run({"sequence": "AA"})
+
+        # One peptide bond forms between the two alanines, losing exactly
+        # one water relative to the sum of the two free amino acid masses
+        # (89.0935 * 2 - 18.01524 = 160.17176). The double-water bug would
+        # instead have subtracted zero waters (or added one back), landing
+        # on 178.19 or 196.20 instead.
+        assert result["data"]["molecular_weight_da"] == pytest.approx(160.17, abs=0.01)

--- a/tests/unit/test_sequence_stats_monoisotopic_label.py
+++ b/tests/unit/test_sequence_stats_monoisotopic_label.py
@@ -1,0 +1,37 @@
+"""Regression guard for Fix-R26E-4: Sequence_stats's molecular-weight field
+was named "estimated_mw_da" with no indication it's monoisotopic mass, not
+the conventional average mass ExPASy ProtParam/UniProt report by default.
+Confirmed live: for ACDEFGHIK it returned 1018.45 (monoisotopic), matching
+PepCalc's `molecularWeight` monoisotopic field exactly, while
+ProtParam_calculate's average mass for the same sequence is 1019.14 --
+a silent, unlabeled mismatch. Renamed to "estimated_mw_monoisotopic_da"
+so the value is self-documenting; the underlying computation is unchanged.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.sequence_analyze_tool import SequenceAnalyzeTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return SequenceAnalyzeTool({"name": "sequence_stats_test", "fields": {}})
+
+
+class TestMonoisotopicLabel:
+    def test_field_is_labeled_monoisotopic(self):
+        tool = _tool()
+        result = tool.run({"operation": "stats", "sequence": "ACDEFGHIK"})
+
+        assert result["status"] == "success"
+        assert "estimated_mw_monoisotopic_da" in result["data"]
+        assert "estimated_mw_da" not in result["data"]
+        assert result["data"]["estimated_mw_monoisotopic_da"] == pytest.approx(
+            1018.45, abs=0.01
+        )


### PR DESCRIPTION
## Summary

Round 26 of the ongoing test-harness campaign. 5 role-play researcher personas (nutrition/food science, dermatology/skin genetics, reproductive biology/fertility, aging/geroscience, bioinformatics/sequence analysis) surfaced 39 findings; every finding below was CLI-verified against the live upstream API before and after the fix.

## Fixes

- **ProtParam_calculate** (`protparam_tool.py`): `_calc_mw()` added a water molecule's mass twice — once before the residue-summation loop, once after — overshooting every molecular weight by 18.02 Da regardless of sequence length. Verified: `ACDEFGHIK` now correctly returns 1019.14 Da (was 1037.15); 148-aa lysozyme now returns 16536.95 Da (was 16554.97), matching UniProt P61626's reference mass.
- **OpenGenes_get_gene** (`open_genes_tool.py`): `disease_categories` was always empty — `diseaseCategories` entries key their label as `icdCategoryName`, not `name` (confirmed via raw API curl to `open-genes.com/api/gene/LMNA`). Also surfaces a new `diseases` field (specific named disease associations like "Progeria") that was present in the raw API but never read at all.
- **FooDB_get_compound** (`foodb_tool.py`): retired/renumbered FDB ids 302-redirect to a completely unrelated compound's current page instead of 404ing (confirmed live: `FDB012199` → `FDB004133`, an unrelated compound). The tool silently followed the redirect via `requests`' default behavior and returned the wrong compound's data labeled with the originally-requested id. Now detects the redirect and reports "not a current id" instead.
- **MedlinePlusRESTTool._extract_text_content** (`medlineplus_tool.py`): a `<html:p>` paragraph containing a nested inline tag (e.g. `<html:i>FMR1</html:i>`) lost the tag's own text entirely ("The  gene provides instructions..." — double space), and a paragraph with *no* nested tag parsed as a bare string rather than a dict and was silently dropped by the old `isinstance(p, dict)` filter (lost the entire middle paragraph of FMR1's function description). The real-JSON html-string code path also only stripped `<p>`/`</p>`, leaving other inline tags like `<i>` literal in the output text.
- **PanelApp_search_panels** (new `panelapp_tool.py`): PanelApp's `search`/`q`/`name__icontains` query params are all silent no-ops server-side (confirmed via introspection — only an exact full-string `name=` match filters anything; the endpoint's own OpenAPI schema documents no search param at all). Every query previously returned the same unfiltered 434-panel list. New `PanelAppSearchTool` paginates the full panel list and filters client-side by name/disease_group/disease_sub_group.
- **Sequence_stats** (`sequence_analyze_tool.py`): `estimated_mw_da` was unlabeled monoisotopic mass, silently mismatched against the average mass most tools (ExPASy ProtParam, UniProt) report by default (off by ~11-18 Da). Renamed to `estimated_mw_monoisotopic_da`; description now points to `ProtParam_calculate` for average mass.
- **EnsemblCompara_get_gene_tree** (`ensembl_compara_tool.py`): four compounding bugs, confirmed live for TP53 (the tool's own documented example) and LYZ — `tree_id` was read from a nonexistent nested `tree.id` field instead of the real top-level `id`; leaf-member detection required a `species` key that leaf nodes never carry (species info lives under `taxonomy`), so `members` was always empty; `newick` was never populated since Ensembl's JSON response has no `newick` field in any mode (now fetched via a second request with a `text/x-nh` Content-Type header); and the Ensembl-gene-ID path form 404d because it was missing a required `{species}` path segment.
- **OrthoDB_search_groups** (`orthodb_tool.py`): only the first of up to 50 returned groups was enriched with `name`/`level_taxid` via the `/tab` endpoint (confirmed live: 9 of 10 results for "lysozyme" were bare `{group_id}` objects). Now enriches every returned group.
- **graphql_tool.remove_none_and_empty_values** (`graphql_tool.py`): a list entry like `{"disease": null}` recursed to `{}` after its null key was stripped, but the emptiness filter only checked the item's *pre-recursion* value, so the resulting `{}` survived. Confirmed live in `OpenTargets_get_associated_drugs_by_target_ensemblID`'s `diseases` array (bare `{}` interleaved with real entries for BRODALUMAB). Now filters on the recursed result.
- **OpenTargets_search_gwas_studies_by_disease** (`graphql_tool.py`): a legacy `EFO_` disease id silently returns `{"count": 0}` (a normal empty list, not a null entity), so the existing EFO→MONDO not-found detection — which only fires on a null entity — never caught it (confirmed live: `EFO_0000676` for psoriasis silently returns 0 studies while the current `MONDO_0005083` id returns 79). Now flags legacy EFO ids specifically when the studies count is 0.
- **OpenTargets_get_diseases_phenotypes_by_target_ensembl** (`opentarget_tools.json`): no `page` argument on `associatedDiseases`, so Open Targets silently applied its default page size regardless of the true count (confirmed live: SIRT1 has `count: 3432` but only 25 rows were ever returned, with no way to retrieve the rest). Added the same `page: Pagination` support already used by sibling OpenTarget tools (e.g. `OpenTargets_get_target_interactions_by_ensemblID`).

## Deferred (documented, not fixed this round)

- MCP `execute_tool` TLS-cert-path and tool-registry-lookup failures — environment/deployment issue outside this repo, recurring across rounds 22-26.
- OpenTargets `Target.expressions` → `baselineExpression` GraphQL schema drift — duplicate of round 23's fix (unmerged).
- MedlinePlus genes-always-empty / health_conditions-duplicated — duplicate of round 25's fix (unmerged).
- `IMPC_get_gene_summary` `has_phenotype_data` and `IMPC_search_genes` relevance ranking — duplicates of round 23's fixes (unmerged).
- ChEMBL/GtoPdb gene-symbol-aware target search, ClinGen `gene_symbol` alias, MetaboAnalyst evidence-count fields, `disease_target_score` timeout-vs-pageSize semantics, OpenGenes `expression_change` legend — lower-severity or larger-scope items left for a future round.

## Test plan

- [x] 12 new/updated mocked unit test files covering every fix above
- [x] `uv run pytest tests/unit -q --no-cov` — 2201 passed, 11 skipped (all environmental: scanpy not installed, no-tools-loaded fixtures, one resource-exhaustion deselect)
- [x] Every fix CLI-verified live against the real upstream API before and after the change
- [x] code-simplifier pass applied (deduplicated a near-identical helper in `open_genes_tool.py`)