### PR TITLE
Fix Round 27: DepMap cell-line lookup, IMPC crash, Metabolite/CTD pubmed_ids, JASPAR validation, MGnify biome, ClinVar summary safety

### DIFF
--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -286,7 +286,15 @@ class CompoundVariantAnnotationTool(BaseTool):
                 summary["sources_with_data"].append(source)
 
         clinvar = annotations.get("clinvar", {})
-        if clinvar.get("variants"):
+        # _parse_clinvar's "variants" list falls back to unrelated top-10
+        # gene-level context variants when the specific change isn't found
+        # (exact_match: False) rather than being empty -- confirmed live
+        # this previously let clinvar_classification silently report an
+        # unrelated variant's classification (e.g. EGFR L858R -- a
+        # ClinVar-Oncogenic, Tier I-Strong variant -- summarized as
+        # "Uncertain significance" from an unrelated p.Leu828Ser record)
+        # whenever exact_match was False. Only derive it from a real match.
+        if clinvar.get("exact_match") and clinvar.get("variants"):
             classifications = [
                 v["classification"]
                 for v in clinvar["variants"]

--- a/src/tooluniverse/data/jaspar_tools.json
+++ b/src/tooluniverse/data/jaspar_tools.json
@@ -609,7 +609,8 @@
           "default": 20,
           "description": "Results per page."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "fields": {
       "endpoint": "https://jaspar.elixir.no/api/v1/matrix/",

--- a/src/tooluniverse/data/metabolite_tools.json
+++ b/src/tooluniverse/data/metabolite_tools.json
@@ -134,7 +134,7 @@
   },
   {
     "name": "Metabolite_get_diseases",
-    "description": "Get curated disease associations for a metabolite using CTD (Comparative Toxicogenomics Database). Accepts HMDB ID, compound name, or PubChem CID. Resolves the identifier to PubChem to get the canonical compound name, then queries CTD for chemical-disease associations with direct evidence. Returns disease name, disease ID (MeSH), disease categories, direct evidence type (marker/mechanism), and supporting PubMed IDs.",
+    "description": "Get curated disease associations for a metabolite using CTD (Comparative Toxicogenomics Database), served via the RENCI Automat CTD mirror since CTD's own batchQuery.go endpoint is CAPTCHA-blocked. Accepts HMDB ID, compound name, or PubChem CID. Resolves the identifier to PubChem to get the canonical compound name, then queries the mirror for chemical-disease associations. Returns disease name, disease ID (MONDO), and supporting PubMed IDs. Note: direct_evidence (CTD's own therapeutic/marker-mechanism classification) and disease_categories are always null -- the mirror's edge data does not carry either field, only the disease link and its citations.",
     "type": "MetaboliteTool",
     "parameter": {
       "type": "object",

--- a/src/tooluniverse/depmap_tool.py
+++ b/src/tooluniverse/depmap_tool.py
@@ -64,6 +64,21 @@ class DepMapTool(BaseTool):
         else:
             return {"status": "error", "error": f"Unknown operation: {operation}"}
 
+    @staticmethod
+    def _parse_model_list(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Map a JSON:API /models response's ``data`` array to
+        [{model_id, model_name}] rows (model_name is ``names[0]``, a list)."""
+        models = []
+        for item in data.get("data", []):
+            names = item.get("attributes", {}).get("names")
+            models.append(
+                {
+                    "model_id": item.get("id"),
+                    "model_name": names[0] if names else None,
+                }
+            )
+        return models
+
     def _get_cell_lines(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """
         Get list of cancer cell lines with metadata.
@@ -77,45 +92,43 @@ class DepMapTool(BaseTool):
         try:
             url = f"{DEPMAP_BASE_URL}/models"
             params = {"page[size]": min(page_size, 100)}
-
-            # Add filters if provided
-            filters = []
-            if tissue:
-                filters.append(f"tissue:{tissue}")
-            if cancer_type:
-                filters.append(f"cancer_type:{cancer_type}")
-
-            if filters:
-                params["filter[model]"] = ",".join(filters)
-
             response = requests.get(url, params=params, timeout=self.timeout)
             response.raise_for_status()
             data = response.json()
 
-            # Parse cell line data
-            cell_lines = []
-            for item in data.get("data", []):
-                attrs = item.get("attributes", {})
-                cell_lines.append(
-                    {
-                        "model_id": item.get("id"),
-                        "model_name": attrs.get("model_name"),
-                        "tissue": attrs.get("tissue"),
-                        "cancer_type": attrs.get("cancer_type"),
-                        "sample_site": attrs.get("sample_site"),
-                        "gender": attrs.get("gender"),
-                        "ethnicity": attrs.get("ethnicity"),
-                    }
-                )
+            # Parse cell line data. tissue/cancer_type/sample_site/gender/
+            # ethnicity are not attributes on /models list items at all
+            # (they live on each item's related sample/patient resources,
+            # only resolvable one model at a time via DepMap_get_cell_line)
+            # -- left unset here rather than reading nonexistent keys.
+            cell_lines = self._parse_model_list(data)
 
-            return {
+            result = {
                 "status": "success",
                 "data": {
                     "cell_lines": cell_lines,
                     "count": len(cell_lines),
-                    "total": data.get("meta", {}).get("total", len(cell_lines)),
+                    "total": data.get("meta", {}).get("count", len(cell_lines)),
                 },
             }
+            # The Cell Model Passports /models endpoint does not support
+            # server-side tissue/cancer_type filtering (confirmed live:
+            # every filter[...] syntax tried -- filter[model], filter[
+            # tissue.name], filter[sample.tissue.name], bare tissue=/
+            # cancer_type= -- returned the identical unfiltered page).
+            # Say so explicitly instead of silently ignoring the filter.
+            if tissue or cancer_type:
+                result["metadata"] = {
+                    "note": (
+                        "The upstream API does not support server-side "
+                        "tissue/cancer_type filtering on this endpoint; "
+                        "results above are unfiltered. Use "
+                        "DepMap_search_cell_lines by name, or "
+                        "DepMap_get_cell_line per model_id to check its "
+                        "tissue/cancer_type."
+                    )
+                }
+            return result
         except requests.exceptions.Timeout:
             return {
                 "status": "error",
@@ -159,7 +172,17 @@ class DepMapTool(BaseTool):
                 model_id = search_result["data"]["cell_lines"][0]["model_id"]
                 url = f"{DEPMAP_BASE_URL}/models/{model_id}"
 
-            response = requests.get(url, timeout=self.timeout)
+            # tissue/cancer_type/sample_site/tissue_status/age_at_sampling/
+            # gender/ethnicity/msi_status are not attributes on the model
+            # resource itself -- they live on related sample/patient/
+            # model_msi_status resources (confirmed live via the API's own
+            # /models/{id} response, which has none of these fields).
+            # `include` pulls all of them in with this one request instead
+            # of a separate round-trip per relationship.
+            params = {
+                "include": "sample,sample.tissue,sample.cancer_type,sample.patient,model_msi_status"
+            }
+            response = requests.get(url, params=params, timeout=self.timeout)
 
             if response.status_code == 404:
                 return {
@@ -173,23 +196,50 @@ class DepMapTool(BaseTool):
 
             item = data.get("data", {})
             attrs = item.get("attributes", {})
+            # `id` comes back as a string for most included types (e.g.
+            # sample, patient) but as an int for lookup-table types like
+            # tissue/cancer_type (confirmed live) -- normalize to str so
+            # the two sides of the (type, id) key always match.
+            included_by_key = {
+                (inc.get("type"), str(inc.get("id"))): inc
+                for inc in data.get("included", [])
+                if isinstance(inc, dict)
+            }
+
+            def _resolve(node: Dict[str, Any], rel_name: str) -> Dict[str, Any]:
+                """Follow a to-one relationship from a JSON:API resource
+                object to its included resource object (or {} if absent)."""
+                rel = (node.get("relationships") or {}).get(rel_name, {}).get("data")
+                if isinstance(rel, list):
+                    rel = rel[0] if rel else None
+                if not isinstance(rel, dict):
+                    return {}
+                return included_by_key.get((rel.get("type"), str(rel.get("id"))), {})
+
+            sample = _resolve(item, "sample")
+            sample_attrs = sample.get("attributes", {})
+            tissue_attrs = _resolve(sample, "tissue").get("attributes", {})
+            cancer_type_attrs = _resolve(sample, "cancer_type").get("attributes", {})
+            patient_attrs = _resolve(sample, "patient").get("attributes", {})
+            msi_attrs = _resolve(item, "model_msi_status").get("attributes", {})
+            names = attrs.get("names")
 
             return {
                 "status": "success",
                 "data": {
                     "model_id": item.get("id"),
-                    "model_name": attrs.get("model_name"),
-                    "tissue": attrs.get("tissue"),
-                    "cancer_type": attrs.get("cancer_type"),
-                    "tissue_status": attrs.get("tissue_status"),
-                    "sample_site": attrs.get("sample_site"),
-                    "gender": attrs.get("gender"),
-                    "ethnicity": attrs.get("ethnicity"),
-                    "age_at_sampling": attrs.get("age_at_sampling"),
+                    "model_name": names[0] if names else None,
+                    "tissue": tissue_attrs.get("name"),
+                    "cancer_type": cancer_type_attrs.get("name"),
+                    "tissue_status": sample_attrs.get("tissue_status"),
+                    "sample_site": sample_attrs.get("sample_site"),
+                    "gender": patient_attrs.get("gender"),
+                    "ethnicity": patient_attrs.get("ethnicity"),
+                    "age_at_sampling": sample_attrs.get("age_at_sampling"),
                     "growth_properties": attrs.get("growth_properties"),
-                    "msi_status": attrs.get("msi_status"),
+                    "msi_status": msi_attrs.get("msi_status"),
                     "ploidy": attrs.get("ploidy"),
-                    "mutational_burden": attrs.get("mutational_burden"),
+                    "mutational_burden": attrs.get("mutations_per_mb"),
                 },
             }
         except requests.exceptions.Timeout:
@@ -212,24 +262,18 @@ class DepMapTool(BaseTool):
             return {"status": "error", "error": "query parameter is required"}
 
         try:
-            url = f"{DEPMAP_BASE_URL}/models"
-            params = {"filter[model]": f"model_name:{query}", "page[size]": 20}
+            # The Cell Model Passports API silently ignores filter[model]
+            # on /models (confirmed live: any query, including nonsense
+            # strings, returned the same unfiltered first page). The real
+            # name-search endpoint is /search/models?q=... .
+            url = f"{DEPMAP_BASE_URL}/search/models"
+            params = {"q": query, "page[size]": 20}
 
             response = requests.get(url, params=params, timeout=self.timeout)
             response.raise_for_status()
             data = response.json()
 
-            cell_lines = []
-            for item in data.get("data", []):
-                attrs = item.get("attributes", {})
-                cell_lines.append(
-                    {
-                        "model_id": item.get("id"),
-                        "model_name": attrs.get("model_name"),
-                        "tissue": attrs.get("tissue"),
-                        "cancer_type": attrs.get("cancer_type"),
-                    }
-                )
+            cell_lines = self._parse_model_list(data)
 
             return {
                 "status": "success",

--- a/src/tooluniverse/impc_tool.py
+++ b/src/tooluniverse/impc_tool.py
@@ -266,7 +266,8 @@ class IMPCTool(BaseTool):
         return {
             "status": "success",
             "data": {
-                "gene_symbol": gene_symbol or docs[0].get("marker_symbol", ""),
+                "gene_symbol": gene_symbol
+                or (docs[0].get("marker_symbol", "") if docs else ""),
                 "mgi_id": mgi_id
                 or (docs[0].get("marker_accession_id", "") if docs else ""),
                 "total_phenotype_calls": num_found,

--- a/src/tooluniverse/metabolite_tool.py
+++ b/src/tooluniverse/metabolite_tool.py
@@ -208,7 +208,15 @@ class MetaboliteTool(BaseTool):
         if not isinstance(edges, list):
             return []
 
-        # 3) Flatten [source, edge_props, target] back to CTD-style rows
+        # 3) Flatten [source, edge_props, target] back to CTD-style rows.
+        # Confirmed live (automat.renci.org/ctd chemical-disease edges):
+        # edge_props only ever carries agent_type/knowledge_level/
+        # primary_knowledge_source/publications -- there is no predicate/
+        # qualified_predicate field, so DirectEvidence (CTD's own
+        # "therapeutic"/"marker/mechanism" classification) is genuinely
+        # unavailable from this mirror, not a parsing bug. publications
+        # (PMID:xxxxx strings) IS present but was previously hardcoded to
+        # [] instead of being read.
         rows = []
         for edge in edges:
             if not isinstance(edge, list) or len(edge) < 3:
@@ -218,13 +226,17 @@ class MetaboliteTool(BaseTool):
             disease_name = tgt.get("name")
             if not disease_name:
                 continue
+            pubmed_ids = [
+                p.split(":", 1)[-1]
+                for p in props.get("publications") or []
+                if isinstance(p, str)
+            ]
             rows.append(
                 {
                     "DiseaseName": disease_name,
                     "DiseaseID": tgt.get("id"),
-                    "DirectEvidence": props.get("qualified_predicate")
-                    or props.get("predicate"),
-                    "PubMedIDs": [],
+                    "DirectEvidence": None,
+                    "PubMedIDs": pubmed_ids,
                 }
             )
         return rows
@@ -424,7 +436,9 @@ class MetaboliteTool(BaseTool):
                     "disease_categories": r.get("DiseaseCategories"),
                     "direct_evidence": r.get("DirectEvidence"),
                     "pubmed_ids": (
-                        r["PubMedIDs"].split("|") if r.get("PubMedIDs") else []
+                        r["PubMedIDs"].split("|")
+                        if isinstance(r.get("PubMedIDs"), str)
+                        else (r.get("PubMedIDs") or [])
                     ),
                 }
                 for r in rows

--- a/src/tooluniverse/mgnify_expanded_tool.py
+++ b/src/tooluniverse/mgnify_expanded_tool.py
@@ -336,6 +336,17 @@ class MGnifyExpandedTool(BaseTool):
     def _format_sample(item: Dict[str, Any]) -> Dict[str, Any]:
         """Flatten a MGnify sample JSON:API record into a metadata row."""
         attrs = item.get("attributes", {}) if isinstance(item, dict) else {}
+        # attributes["environment-biome"] is null for most samples (confirmed
+        # live); the real per-sample biome path lives in the sample's own
+        # "biome" relationship instead (e.g. "root:Host-associated:Human:
+        # Digestive system:Large intestine"), which the list endpoint already
+        # includes per item -- fall back to it rather than dropping the tag
+        # entirely.
+        biome_rel = (
+            (item.get("relationships") or {}).get("biome", {}).get("data") or {}
+            if isinstance(item, dict)
+            else {}
+        )
         return {
             "sample_accession": item.get("id"),
             "biosample": attrs.get("biosample"),
@@ -348,7 +359,7 @@ class MGnifyExpandedTool(BaseTool):
             "collection_date": attrs.get("collection-date"),
             "host_tax_id": attrs.get("host-tax-id"),
             "species": attrs.get("species"),
-            "environment_biome": attrs.get("environment-biome"),
+            "environment_biome": attrs.get("environment-biome") or biome_rel.get("id"),
             "environment_feature": attrs.get("environment-feature"),
             "environment_material": attrs.get("environment-material"),
             "last_update": attrs.get("last-update"),

--- a/tests/unit/test_compound_variant_tool.py
+++ b/tests/unit/test_compound_variant_tool.py
@@ -77,3 +77,41 @@ def test_sources_with_data_is_honest():
     assert set(s["sources_with_data"]) == {"gnomad", "civic"}  # NOT clinvar/uniprot
     assert s["gnomad_gene_id"] == "ENSG00000157764"
     assert s["civic_variants_matched"] == 1
+
+
+def test_clinvar_classification_not_derived_from_unmatched_fallback():
+    # Fix-R27A-1: confirmed live for EGFR L858R -- _parse_clinvar's
+    # fallback context list (returned when exact_match is False) was
+    # being blindly summarized as clinvar_classification, e.g. reporting
+    # "Uncertain significance" (an unrelated p.Leu828Ser record) for a
+    # variant that is actually ClinVar Oncogenic/Tier I-Strong. When
+    # exact_match is False, clinvar_classification must not be set at all.
+    t = _tool()
+    annotations = {
+        "clinvar": {
+            "total_gene_variants": 3167,
+            "matched": 0,
+            "exact_match": False,
+            "variants": [
+                {"name": "p.Leu828Ser", "classification": "Uncertain significance"},
+            ],
+        },
+    }
+    s = t._build_summary(annotations, variant="L858R", gene="EGFR")
+    assert "clinvar_classification" not in s
+
+
+def test_clinvar_classification_set_when_exact_match_true():
+    t = _tool()
+    annotations = {
+        "clinvar": {
+            "total_gene_variants": 3167,
+            "matched": 1,
+            "exact_match": True,
+            "variants": [
+                {"name": "p.Leu858Arg", "classification": "Pathogenic"},
+            ],
+        },
+    }
+    s = t._build_summary(annotations, variant="L858R", gene="EGFR")
+    assert s["clinvar_classification"] == "Pathogenic"

--- a/tests/unit/test_depmap_cell_line_lookup.py
+++ b/tests/unit/test_depmap_cell_line_lookup.py
@@ -1,0 +1,203 @@
+"""Regression guard for two Fix-R27A bugs in DepMapTool (depmap_tool.py).
+
+Fix-R27A-1 (search always returns the same hardcoded result): the Cell
+Model Passports API silently ignores `filter[model]=model_name:...` on
+/models -- confirmed live that A549, HeLa, MCF7, and even a nonsense
+string all returned the API's identical unfiltered first page
+(model_id SIDM01774 every time). The real name-search endpoint is
+/search/models?q=... . Fixed by switching endpoints.
+
+Fix-R27A-2 (wrong/missing field mapping): even with a correctly-resolved
+model_id, most fields came back null -- confirmed live that tissue,
+cancer_type, sample_site, gender, ethnicity, age_at_sampling,
+tissue_status, and msi_status are not attributes on the /models/{id}
+resource at all (they live on related sample/patient/model_msi_status
+resources reachable only via JSON:API `include`), and
+`mutational_burden`/`model_name` were read from nonexistent attribute
+keys (real keys are `mutations_per_mb` and `names`, a list). Fixed by
+requesting `include=sample,sample.tissue,sample.cancer_type,sample.
+patient,model_msi_status` and resolving the relationship chain (also
+normalizing id types to str, since tissue/cancer_type ids come back as
+int while the relationship pointer's id is a str -- confirmed live).
+
+Fix-R27A-3 (get_cell_lines list endpoint): the same broken filter[model]
+pattern affects the plural list endpoint too -- confirmed live that
+tissue="Lung" and tissue="Breast" returned identical results (every
+filter[...] syntax tried was silently ignored), model_name read a
+nonexistent attribute key, and meta.total read a nonexistent key (the
+real key is meta.count). Fixed the field mapping and added an explicit
+note when a tissue/cancer_type filter is passed, since the API can't
+honor it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.depmap_tool import DepMapTool
+
+pytestmark = pytest.mark.unit
+
+_A549_GET_RESPONSE = {
+    "data": {
+        "id": "SIDM00903",
+        "attributes": {
+            "names": ["A549", "NCI-A549", "A549/ATCC", "hA549"],
+            "growth_properties": "Adherent",
+            "ploidy": 2.76,
+            "mutations_per_mb": 39.18,
+        },
+        "relationships": {
+            "sample": {"data": {"type": "sample", "id": "SIDS00075"}},
+            "model_msi_status": {"data": {"type": "model_msi_status", "id": "754"}},
+        },
+    },
+    "included": [
+        {
+            "type": "sample",
+            "id": "SIDS00075",
+            "attributes": {
+                "sample_site": "Unknown",
+                "tissue_status": "Tumour",
+                "age_at_sampling": 58.0,
+            },
+            "relationships": {
+                "tissue": {"data": {"type": "tissue", "id": "10"}},
+                "cancer_type": {"data": {"type": "cancer_type", "id": "14"}},
+                "patient": {"data": {"type": "patient", "id": "SIDP00060"}},
+            },
+        },
+        # tissue/cancer_type ids come back as ints, unlike the string id
+        # in the relationship pointer above -- this is the exact live
+        # mismatch that broke resolution before normalizing to str.
+        {"type": "tissue", "id": 10, "attributes": {"name": "Lung"}},
+        {
+            "type": "cancer_type",
+            "id": 14,
+            "attributes": {"name": "Non-Small Cell Lung Carcinoma"},
+        },
+        {
+            "type": "patient",
+            "id": "SIDP00060",
+            "attributes": {"gender": "Male", "ethnicity": "White"},
+        },
+        {
+            "type": "model_msi_status",
+            "id": "754",
+            "attributes": {"msi_status": "MSS"},
+        },
+    ],
+}
+
+_SEARCH_RESPONSE = {
+    "data": [
+        {"id": "SIDM00903", "attributes": {"names": ["A549", "NCI-A549"]}},
+    ]
+}
+
+
+def _resp(payload):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = payload
+    return r
+
+
+def _tool():
+    return DepMapTool({"fields": {"operation": "get_cell_line"}})
+
+
+class TestSearchUsesRealEndpoint:
+    def test_search_hits_search_models_not_broken_filter(self):
+        tool = DepMapTool({"fields": {"operation": "search_cell_lines"}})
+        with patch(
+            "tooluniverse.depmap_tool.requests.get", return_value=_resp(_SEARCH_RESPONSE)
+        ) as mock_get:
+            result = tool.run({"query": "A549"})
+
+        called_url = mock_get.call_args.args[0]
+        assert called_url == "https://api.cellmodelpassports.sanger.ac.uk/search/models"
+        called_params = mock_get.call_args.kwargs["params"]
+        assert called_params["q"] == "A549"
+        assert "filter[model]" not in called_params
+        assert result["data"]["cell_lines"][0]["model_id"] == "SIDM00903"
+        assert result["data"]["cell_lines"][0]["model_name"] == "A549"
+
+
+class TestGetCellLineFieldMapping:
+    def test_resolves_related_fields_via_include(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.depmap_tool.requests.get",
+            return_value=_resp(_A549_GET_RESPONSE),
+        ):
+            result = tool.run({"model_id": "SIDM00903"})
+
+        assert result["status"] == "success"
+        data = result["data"]
+        assert data["model_name"] == "A549"
+        assert data["tissue"] == "Lung"
+        assert data["cancer_type"] == "Non-Small Cell Lung Carcinoma"
+        assert data["sample_site"] == "Unknown"
+        assert data["tissue_status"] == "Tumour"
+        assert data["age_at_sampling"] == 58.0
+        assert data["gender"] == "Male"
+        assert data["ethnicity"] == "White"
+        assert data["msi_status"] == "MSS"
+        assert data["mutational_burden"] == 39.18
+
+    def test_missing_relationships_do_not_crash(self):
+        tool = _tool()
+        bare_response = {
+            "data": {
+                "id": "SIDM00001",
+                "attributes": {"names": ["X"], "mutations_per_mb": None},
+            }
+        }
+        with patch(
+            "tooluniverse.depmap_tool.requests.get", return_value=_resp(bare_response)
+        ):
+            result = tool.run({"model_id": "SIDM00001"})
+
+        assert result["status"] == "success"
+        assert result["data"]["tissue"] is None
+        assert result["data"]["cancer_type"] is None
+
+
+class TestGetCellLinesListEndpoint:
+    def test_model_name_and_total_use_real_keys(self):
+        tool = DepMapTool({"fields": {"operation": "get_cell_lines"}})
+        payload = {
+            "data": [{"id": "SIDM01774", "attributes": {"names": ["PK-59"]}}],
+            "meta": {"count": 2266},
+        }
+        with patch(
+            "tooluniverse.depmap_tool.requests.get", return_value=_resp(payload)
+        ):
+            result = tool.run({"page_size": 1})
+
+        assert result["data"]["cell_lines"][0]["model_name"] == "PK-59"
+        assert result["data"]["total"] == 2266
+
+    def test_tissue_filter_gets_honest_note_not_silent_no_op(self):
+        # The upstream API silently ignores every filter[...] syntax on
+        # this endpoint (confirmed live) -- a tissue/cancer_type filter
+        # must surface a note, not pretend it was applied.
+        tool = DepMapTool({"fields": {"operation": "get_cell_lines"}})
+        payload = {"data": [], "meta": {"count": 0}}
+        with patch(
+            "tooluniverse.depmap_tool.requests.get", return_value=_resp(payload)
+        ):
+            result = tool.run({"tissue": "Lung"})
+
+        assert "does not support server-side" in result["metadata"]["note"]
+
+    def test_no_filter_gets_no_note(self):
+        tool = DepMapTool({"fields": {"operation": "get_cell_lines"}})
+        payload = {"data": [], "meta": {"count": 0}}
+        with patch(
+            "tooluniverse.depmap_tool.requests.get", return_value=_resp(payload)
+        ):
+            result = tool.run({})
+
+        assert "metadata" not in result

--- a/tests/unit/test_impc_phenotypes_by_gene_empty_docs.py
+++ b/tests/unit/test_impc_phenotypes_by_gene_empty_docs.py
@@ -1,0 +1,78 @@
+"""Regression guard for Fix-R27B-1: IMPC_get_phenotypes_by_gene crashed
+with "list index out of range" whenever a valid mgi_id query matched zero
+records in the genotype-phenotype core -- confirmed live for Lrrk2
+(MGI:1913975) and Brca1 (MGI:104537), both real, resolvable mouse genes
+that simply have no significant phenotype calls in this core. Root cause:
+`docs[0].get("marker_symbol", "")` was unguarded for an empty `docs` list,
+unlike the very next line (`mgi_id`) which correctly guarded with
+`if docs else ""`.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.impc_tool import IMPCTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return IMPCTool({"name": "impc_test", "fields": {"operation": "get_phenotypes_by_gene"}})
+
+
+def _solr_resp(docs, num_found=None):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = {
+        "response": {
+            "docs": docs,
+            "numFound": num_found if num_found is not None else len(docs),
+        }
+    }
+    return r
+
+
+class TestEmptyDocsDoesNotCrash:
+    def test_mgi_id_with_zero_phenotype_calls_returns_success_not_crash(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.impc_tool.requests.get", return_value=_solr_resp([])
+        ):
+            result = tool.run({"mgi_id": "MGI:1913975"})
+
+        assert result["status"] == "success"
+        assert result["data"]["mgi_id"] == "MGI:1913975"
+        assert result["data"]["gene_symbol"] == ""
+        assert result["data"]["total_phenotype_calls"] == 0
+        assert result["data"]["phenotypes"] == []
+
+    def test_gene_symbol_query_with_zero_calls_also_does_not_crash(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.impc_tool.requests.get", return_value=_solr_resp([])
+        ):
+            result = tool.run({"gene_symbol": "Lrrk2"})
+
+        assert result["status"] == "success"
+        assert result["data"]["gene_symbol"] == "Lrrk2"
+        assert result["data"]["mgi_id"] == ""
+
+    def test_non_empty_docs_still_populate_gene_symbol(self):
+        tool = _tool()
+        docs = [
+            {
+                "marker_symbol": "Trp53",
+                "marker_accession_id": "MGI:98834",
+                "mp_term_id": "MP:0001",
+                "mp_term_name": "abnormal retina morphology",
+            }
+        ]
+        with patch(
+            "tooluniverse.impc_tool.requests.get", return_value=_solr_resp(docs)
+        ):
+            result = tool.run({"mgi_id": "MGI:98834"})
+
+        assert result["status"] == "success"
+        assert result["data"]["gene_symbol"] == "Trp53"
+        assert result["data"]["total_phenotype_calls"] == 1

--- a/tests/unit/test_jaspar_additional_properties.py
+++ b/tests/unit/test_jaspar_additional_properties.py
@@ -1,0 +1,63 @@
+"""Regression guard for Fix-R27E-1: jaspar_search_matrices silently
+ignored unrecognized query parameters instead of rejecting them.
+Confirmed live: `{"tf_name": "SP1"}` (a very natural guess, matching the
+naming convention of the sibling tool UniBind_search_datasets) returned
+`count: 5935` -- essentially JASPAR's entire unfiltered matrix database,
+with zero indication the param was ignored -- while the documented
+`{"name": "SP1"}` correctly returns 6 SP1 matrices. JASPARRESTTool
+extends BaseTool, whose validate_parameters() already enforces
+`additionalProperties: false` via jsonschema when the schema declares it;
+the schema previously omitted that flag entirely. Fixed with a
+config-only change (no Python code touched).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.jaspar_tool import JASPARRESTTool
+
+pytestmark = pytest.mark.unit
+
+_CONFIG_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "tooluniverse"
+    / "data"
+    / "jaspar_tools.json"
+)
+
+
+def _load_tool_config():
+    configs = json.loads(_CONFIG_PATH.read_text())
+    for cfg in configs:
+        if cfg["name"] == "jaspar_search_matrices":
+            return cfg
+    raise AssertionError("tool config not found")
+
+
+def _tool():
+    return JASPARRESTTool(_load_tool_config())
+
+
+class TestAdditionalPropertiesEnforced:
+    def test_schema_declares_additional_properties_false(self):
+        cfg = _load_tool_config()
+        assert cfg["parameter"]["additionalProperties"] is False
+
+    def test_unrecognized_param_is_rejected(self):
+        tool = _tool()
+        error = tool.validate_parameters({"tf_name": "SP1"})
+        assert error is not None
+        assert "tf_name" in str(error)
+
+    def test_documented_param_is_accepted(self):
+        tool = _tool()
+        error = tool.validate_parameters({"name": "SP1"})
+        assert error is None
+
+    def test_no_params_is_accepted(self):
+        tool = _tool()
+        error = tool.validate_parameters({})
+        assert error is None

--- a/tests/unit/test_metabolite_ctd_pubmed_ids.py
+++ b/tests/unit/test_metabolite_ctd_pubmed_ids.py
@@ -1,0 +1,150 @@
+"""Regression guard for Fix-R27D-1 in metabolite_tool.py's `_ctd_diseases`
+(the RENCI Automat CTD-mirror fallback used since CTD's native
+batchQuery.go became CAPTCHA-blocked).
+
+Confirmed live (automat.renci.org/ctd chemical-disease edges for
+cholesterol/CHEBI:16113): edge_props only ever carries agent_type/
+knowledge_level/primary_knowledge_source/publications -- there is no
+predicate/qualified_predicate field, so `direct_evidence` is genuinely
+unavailable from this source (not a bug to "fix" further, now documented
+honestly). `publications` (PMID:xxxxx strings) IS present but was
+previously hardcoded to an empty list instead of being read, so
+`pubmed_ids` came back [] for every single result (100% of associations
+for both cholesterol and lutein in the original report).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.metabolite_tool import MetaboliteTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return MetaboliteTool({"name": "metabolite_test", "fields": {}})
+
+
+def _cypher_resp(curie):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = {"results": [{"data": [{"row": [curie]}]}]}
+    return r
+
+
+def _edges_resp(edges):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = edges
+    return r
+
+
+class TestCtdDiseasesPubmedExtraction:
+    def test_publications_extracted_and_pmid_prefix_stripped(self):
+        tool = _tool()
+        edges = [
+            [
+                {"name": "cholesterol", "id": "CHEBI:16113"},
+                {
+                    "agent_type": "manual_agent",
+                    "knowledge_level": "knowledge_assertion",
+                    "primary_knowledge_source": "infores:ctd",
+                    "publications": ["PMID:29486218", "PMID:20557099"],
+                },
+                {
+                    "name": "metabolic dysfunction-associated steatotic liver disease",
+                    "id": "MONDO:0013209",
+                },
+            ]
+        ]
+        with patch(
+            "tooluniverse.metabolite_tool.requests.post",
+            return_value=_cypher_resp("CHEBI:16113"),
+        ), patch(
+            "tooluniverse.metabolite_tool.requests.get",
+            return_value=_edges_resp(edges),
+        ):
+            rows = tool._ctd_diseases("cholesterol")
+
+        assert len(rows) == 1
+        assert rows[0]["PubMedIDs"] == ["29486218", "20557099"]
+        assert rows[0]["DirectEvidence"] is None
+
+    def test_edge_with_no_publications_gets_empty_list_not_crash(self):
+        tool = _tool()
+        edges = [
+            [
+                {"name": "cholesterol", "id": "CHEBI:16113"},
+                {"agent_type": "manual_agent"},
+                {"name": "some disease", "id": "MONDO:0000001"},
+            ]
+        ]
+        with patch(
+            "tooluniverse.metabolite_tool.requests.post",
+            return_value=_cypher_resp("CHEBI:16113"),
+        ), patch(
+            "tooluniverse.metabolite_tool.requests.get",
+            return_value=_edges_resp(edges),
+        ):
+            rows = tool._ctd_diseases("cholesterol")
+
+        assert rows[0]["PubMedIDs"] == []
+
+
+class TestGetDiseasesPubmedIdsFormat:
+    def test_list_format_pubmed_ids_passed_through(self):
+        # PubMedIDs is now always a list (from _ctd_diseases), not the
+        # legacy pipe-delimited string -- both shapes must work.
+        tool = _tool()
+        with patch.object(
+            tool,
+            "_resolve_ctd_term",
+            return_value=(
+                "cholesterol",
+                [
+                    {
+                        "DiseaseName": "atherosclerosis",
+                        "DiseaseID": "MONDO:0005311",
+                        "DirectEvidence": None,
+                        "PubMedIDs": ["111", "222"],
+                    }
+                ],
+            ),
+        ), patch.object(
+            tool, "_get_properties", return_value={"Title": "cholesterol"}
+        ), patch.object(
+            tool, "_get_synonyms", return_value=[]
+        ), patch.object(
+            tool, "_resolve_to_cid", return_value=5997
+        ):
+            result = tool._get_diseases({"compound_name": "cholesterol"})
+
+        assert result["data"]["diseases"][0]["pubmed_ids"] == ["111", "222"]
+
+    def test_legacy_pipe_string_format_still_works(self):
+        tool = _tool()
+        with patch.object(
+            tool,
+            "_resolve_ctd_term",
+            return_value=(
+                "cholesterol",
+                [
+                    {
+                        "DiseaseName": "atherosclerosis",
+                        "DiseaseID": "MONDO:0005311",
+                        "DirectEvidence": "marker/mechanism",
+                        "PubMedIDs": "111|222",
+                    }
+                ],
+            ),
+        ), patch.object(
+            tool, "_get_properties", return_value={"Title": "cholesterol"}
+        ), patch.object(
+            tool, "_get_synonyms", return_value=[]
+        ), patch.object(
+            tool, "_resolve_to_cid", return_value=5997
+        ):
+            result = tool._get_diseases({"compound_name": "cholesterol"})
+
+        assert result["data"]["diseases"][0]["pubmed_ids"] == ["111", "222"]

--- a/tests/unit/test_microbiology_pathogen_depth.py
+++ b/tests/unit/test_microbiology_pathogen_depth.py
@@ -260,6 +260,42 @@ class TestMGnifySamples(unittest.TestCase):
         self.assertEqual(result["metadata"]["total_results"], 435812)
         self.assertIn("/samples", get.call_args[0][0])
 
+    def test_environment_biome_falls_back_to_relationship(self):
+        """Fix-R27D-2: attributes["environment-biome"] is null for most
+        samples (confirmed live); the real per-sample biome path lives in
+        the sample's own "biome" relationship instead, which the list
+        endpoint already includes per item."""
+        tool = _mgnify_samples_tool()
+        payload = {
+            "data": [
+                {
+                    "id": "SRS10016928",
+                    "attributes": {
+                        "biosample": "SAMN21216480",
+                        "environment-biome": None,
+                    },
+                    "relationships": {
+                        "biome": {
+                            "data": {
+                                "type": "biomes",
+                                "id": "root:Host-associated:Human:Digestive system:Large intestine",
+                            }
+                        }
+                    },
+                }
+            ],
+            "meta": {"pagination": {"count": 1, "page": 1, "pages": 1}},
+        }
+        resp = MagicMock()
+        resp.json.return_value = payload
+        resp.raise_for_status.return_value = None
+        with patch("tooluniverse.mgnify_expanded_tool.requests.get", return_value=resp):
+            result = tool.run({"page_size": 1})
+        self.assertEqual(
+            result["data"][0]["environment_biome"],
+            "root:Host-associated:Human:Digestive system:Large intestine",
+        )
+
     def test_single_sample_detail_path(self):
         """A sample_accession routes to the single-sample detail endpoint."""
         tool = _mgnify_samples_tool()


### PR DESCRIPTION
## Summary

Round 27 of the ongoing test-harness campaign. 5 role-play researcher personas (oncology/precision cancer medicine, neuroscience/neurodegeneration, endocrinology/metabolic disease, microbiome/gut-health, RNA biology/epigenetics) surfaced 30 findings; every finding below was CLI-verified against the live upstream API before and after the fix.

## Fixes

- **DepMap_get_cell_line / DepMap_search_cell_lines / DepMap_get_cell_lines** (`depmap_tool.py`): the Cell Model Passports API silently ignores `filter[model]=model_name:X` on `/models` (confirmed live: A549, HeLa, and a nonsense string all returned the identical unfiltered first page, `model_id SIDM01774` every time). Switched to the real `/search/models?q=...` endpoint. Separately, even with a correctly resolved `model_id` most fields came back null: `tissue`/`cancer_type`/`sample_site`/`gender`/`ethnicity`/`age_at_sampling`/`tissue_status`/`msi_status` are not attributes on the model resource at all — they live on related sample/patient/model_msi_status resources — and `mutational_burden`/`model_name` were read from nonexistent attribute keys (real keys are `mutations_per_mb` and `names`, a list). Fixed by requesting `include=sample,sample.tissue,sample.cancer_type,sample.patient,model_msi_status` and resolving the relationship chain (including a live id-type mismatch — tissue/cancer_type ids come back as `int` while relationship pointers use `str`). The plural list endpoint had the same field-mapping bugs plus a nonexistent `meta.total` key (real key is `meta.count`); since the API has no working tissue/cancer_type filter under any syntax tried (5 variants tested), callers now get an explicit note instead of silently-ignored results.
- **IMPC_get_phenotypes_by_gene** (`impc_tool.py`): crashed with `"list index out of range"` whenever a valid `mgi_id` query matched zero records in the genotype-phenotype core — confirmed live for Lrrk2 (MGI:1913975) and Brca1 (MGI:104537), both real, resolvable genes that simply have no significant phenotype calls in this core. One line was unguarded for an empty `docs` list, unlike the adjacent line for `mgi_id`.
- **Metabolite_get_diseases / HMDB_get_diseases** (`metabolite_tool.py`): the RENCI Automat CTD-mirror fallback (used since CTD's native `batchQuery.go` became CAPTCHA-blocked) hardcoded `pubmed_ids` to an empty list for every result, even though the mirror's edge data does carry `publications`. `direct_evidence` is genuinely unavailable from this source (confirmed via live API introspection — no predicate field exists at all in the mirror's edge schema), now documented honestly in the tool description instead of silently returning null.
- **jaspar_search_matrices** (`jaspar_tools.json`): the parameter schema lacked `additionalProperties: false`, so an unrecognized param like `tf_name` (a very natural guess, matching the sibling tool `UniBind_search_datasets`'s naming convention) was silently forwarded to and ignored by JASPAR's API, returning the entire 5935-matrix unfiltered database with no indication anything was wrong.
- **MGnify_get_samples** (`mgnify_expanded_tool.py`): `environment_biome` was always null in list results because `attributes["environment-biome"]` is null for most samples upstream; the real per-sample biome path lives in the sample's own `biome` relationship instead, which the list endpoint already includes per item.
- **annotate_variant_multi_source** (`compound_variant_tool.py`): the summary block derived `clinvar_classification` from ClinVar's deliberate gene-context fallback list (returned when no exact match exists) without checking `exact_match` first — confirmed live that EGFR L858R, a ClinVar Oncogenic/Tier I-Strong variant, was being summarized as "Uncertain significance" from an unrelated p.Leu828Ser record. This was a real clinical-safety-relevant bug. Now only derives the classification from a real match.

## Deferred (documented, not fixed this round)

- MCP `execute_tool` TLS-cert-path and tool-registry-lookup failures, and OpenTargets abbreviated-name/full-name mismatches via MCP discovery — environment/deployment issues outside this repo, recurring across rounds 22-27.
- OncoKB demo-mode `geneExist:false` messaging, CIViC/ClinVar variant-name search ergonomics (3-letter codes, protein-change search), ClinGen/GenCC alias resolution (PARK8), PathwayCommons `limit`-vs-depth param naming, `MGI_get_gene` `cross_references` duplication, `NCBIDatasets_get_taxonomy`'s unresolved numeric lineage, `MyDisease_get_disease`'s undelivered `disgenet` field, `ChIPAtlas_enrichment_analysis` returning a submission URL instead of computed results, APPRIS SSL flakiness, and several OpenTargets camelCase-vs-snake_case parameter mismatches — lower-severity, larger-scope, or environment-dependent items left for a future round.

## Test plan

- [x] 4 new mocked unit test files + 2 updated existing test files covering every fix above
- [x] `uv run pytest tests/unit -q --no-cov` — 2189 passed, 11 skipped (all environmental: scanpy not installed, no-tools-loaded fixtures, one resource-exhaustion deselect)
- [x] Every fix CLI-verified live against the real upstream API before and after the change
- [x] code-simplifier pass applied (deduplicated the model-list parsing logic shared by `_get_cell_lines`/`_search_cell_lines` in `depmap_tool.py`; removed a redundant default in `metabolite_tool.py`)