### PR TITLE
Fix Round 28: CTD CAS/MeSH resolution, STITCH wrong database, UniProt protein names, PubChem image crash, ClinGen actionability parsing

### DIFF
--- a/src/tooluniverse/clingen_tool.py
+++ b/src/tooluniverse/clingen_tool.py
@@ -245,6 +245,28 @@ class ClinGenTool(BaseTool):
         """Get clinical actionability curations for pediatric context."""
         return self._get_actionability(arguments, "Pediatric")
 
+    @staticmethod
+    def _actionability_rows_to_dicts(data: Any) -> list:
+        """The ?flavor=flat actionability API returns a columnar table --
+        {"columns": [...], "rows": [[...], ...]} -- not a list of record
+        dicts (confirmed live). Neither older code path recognized this
+        shape (isinstance(data, list) is False and there's no "data" key),
+        so the gene filter silently matched nothing and the raw un-parsed
+        table was returned as-is. Zip columns with each row into dicts.
+        """
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict) and isinstance(data.get("columns"), list):
+            columns = data["columns"]
+            return [
+                dict(zip(columns, row))
+                for row in data.get("rows", [])
+                if isinstance(row, list)
+            ]
+        if isinstance(data, dict) and isinstance(data.get("data"), list):
+            return data["data"]
+        return []
+
     def _get_actionability(
         self, arguments: Dict[str, Any], context: str
     ) -> Dict[str, Any]:
@@ -263,27 +285,27 @@ class ClinGenTool(BaseTool):
             response = requests.get(url, headers=headers, timeout=self.timeout)
             response.raise_for_status()
 
-            data = response.json()
+            curations = self._actionability_rows_to_dicts(response.json())
 
-            # Extract curations from the response
-            curations = data if isinstance(data, list) else data.get("data", data)
-
-            # Optional filtering by gene
+            # Optional filtering by gene. geneOrVariant is a comma-joined
+            # multi-gene field for panel curations (e.g. "BRCA1,BRCA2"), so
+            # substring match rather than exact-match the whole field.
             gene = arguments.get("gene")
-            if gene and isinstance(curations, list):
+            if gene:
                 gene_upper = gene.upper()
                 curations = [
                     c
                     for c in curations
-                    if gene_upper in str(c.get("gene", "")).upper()
+                    if gene_upper in str(c.get("geneOrVariant", "")).upper()
+                    or gene_upper in str(c.get("gene", "")).upper()
                     or gene_upper in str(c.get("Gene", "")).upper()
                     or gene_upper in str(c.get("hgncId", "")).upper()
                 ]
 
             return {
                 "status": "success",
-                "data": curations[:100] if isinstance(curations, list) else curations,
-                "total": len(curations) if isinstance(curations, list) else 1,
+                "data": curations[:100],
+                "total": len(curations),
                 "context": context,
                 "source": f"ClinGen Clinical Actionability ({context})",
             }
@@ -316,21 +338,20 @@ class ClinGenTool(BaseTool):
                     response = requests.get(url, headers=headers, timeout=self.timeout)
                     response.raise_for_status()
 
-                    data = response.json()
-                    curations = (
-                        data if isinstance(data, list) else data.get("data", data)
-                    )
+                    curations = self._actionability_rows_to_dicts(response.json())
 
-                    # Filter by gene
+                    # Filter by gene. geneOrVariant is a comma-joined
+                    # multi-gene field for panel curations, so substring
+                    # match rather than exact-match the whole field.
                     gene_upper = gene.upper()
-                    if isinstance(curations, list):
-                        matches = [
-                            c
-                            for c in curations
-                            if gene_upper in str(c.get("gene", "")).upper()
-                            or gene_upper in str(c.get("Gene", "")).upper()
-                        ]
-                        results[context] = matches
+                    matches = [
+                        c
+                        for c in curations
+                        if gene_upper in str(c.get("geneOrVariant", "")).upper()
+                        or gene_upper in str(c.get("gene", "")).upper()
+                        or gene_upper in str(c.get("Gene", "")).upper()
+                    ]
+                    results[context] = matches
                 except Exception:
                     # Continue with other context if one fails
                     pass

--- a/src/tooluniverse/ctd_tool.py
+++ b/src/tooluniverse/ctd_tool.py
@@ -10,6 +10,7 @@ chemical↔disease cleanly, but does NOT contain CTD's gene-disease inferred
 edges. Gene→disease queries return an honest error pointing at OpenTargets.
 """
 
+import re
 import requests
 from typing import Any, Dict, Optional
 
@@ -19,6 +20,15 @@ from .tool_registry import register_tool
 RENCI_BASE = "https://automat.renci.org/ctd"
 RENCI_HEADERS = {"Accept": "application/json", "User-Agent": "ToolUniverse CTDTool"}
 DATA_AS_OF = "2024-06"  # RENCI snapshot version
+
+# The RENCI graph stores CAS RNs and MeSH ids as CURIEs ("CAS:335-67-1",
+# "MESH:C006780"), not bare -- confirmed live that "335-67-1" and "C006780"
+# (the tool's own docstring example) both fail to resolve while the
+# prefixed forms succeed. Bare CAS/MeSH input is exactly how the tool's own
+# description tells callers to pass them, so try the CURIE-prefixed form as
+# a fallback.
+_CAS_RE = re.compile(r"^\d{2,7}-\d{2}-\d$")
+_MESH_SCR_RE = re.compile(r"^[CD]\d{6,9}$")
 
 # Maps the existing tool configs' (input_type, report_type) to RENCI
 # (source_category, target_category). The gene→disease entry is None
@@ -156,6 +166,16 @@ class CTDTool(BaseTool):
         Uses RENCI's /cypher endpoint to search by `id`, `equivalent_identifiers`,
         or case-insensitive `name`. Returns the canonical `id` or None.
         """
+        canonical = self._cypher_lookup(term)
+        if canonical:
+            return canonical
+        if _CAS_RE.match(term):
+            return self._cypher_lookup(f"CAS:{term}")
+        if _MESH_SCR_RE.match(term):
+            return self._cypher_lookup(f"MESH:{term}")
+        return None
+
+    def _cypher_lookup(self, term: str) -> Optional[str]:
         safe = term.replace('"', "").replace("\\", "")
         query = (
             'MATCH (n) WHERE n.id = "' + safe + '" OR "' + safe + '" IN '

--- a/src/tooluniverse/data/pubchem_tools.json
+++ b/src/tooluniverse/data/pubchem_tools.json
@@ -480,7 +480,7 @@
       "endpoint": "/compound/cid/{cid}/PNG?image_size={image_size}",
       "use_pugview": false,
       "input_description": "Input is:\n- cid: compound ID;\n- image_size: desired image pixel size, format is \"widthxheight\" (e.g., \"150x150\").",
-      "output_description": "Returns binary PNG image data, conforming to PNG file header format. LLM can save this binary as image file, or provide to downstream visualization.",
+      "output_description": "Returns {status, data: {image_base64, encoding: 'base64', format: 'png'}}. Decode image_base64 to get the raw PNG bytes (conforming to PNG file header format).",
       "return_format": "PNG"
     },
     "type": "PubChemRESTTool",

--- a/src/tooluniverse/pubchem_tool.py
+++ b/src/tooluniverse/pubchem_tool.py
@@ -1,5 +1,6 @@
 # pubchem_tool.py
 
+import base64
 import requests
 import re
 from .base_tool import BaseTool
@@ -368,8 +369,17 @@ class PubChemRESTTool(BaseTool):
             # These are all text formats
             return resp.text
         elif out_fmt in ["PNG", "SVG"]:
-            # Return binary image
-            return resp.content
+            # Raw bytes crash JSON serialization at the CLI/MCP layer
+            # (confirmed live: "TypeError: Object of type bytes is not
+            # JSON serializable"), so base64-encode it into a proper envelope.
+            return {
+                "status": "success",
+                "data": {
+                    "image_base64": base64.b64encode(resp.content).decode("ascii"),
+                    "encoding": "base64",
+                    "format": out_fmt.lower(),
+                },
+            }
         else:
             # Return text for other cases
             return resp.text

--- a/src/tooluniverse/stitch_tool.py
+++ b/src/tooluniverse/stitch_tool.py
@@ -5,7 +5,7 @@ STITCH (Search Tool for Interacting Chemicals) API tool for ToolUniverse.
 STITCH is a database of known and predicted interactions between
 chemicals and proteins, combining data from various sources.
 
-API Documentation: http://stitch.embl.de/
+API Documentation: https://stitch-db.org/
 """
 
 import requests
@@ -13,9 +13,18 @@ from typing import Dict, Any
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
-# Base URL for STITCH REST API (chemical-protein interactions)
-# NOTE: stitch.embl.de API endpoints have moved to string-db.org (same API format)
-STITCH_BASE_URL = "https://string-db.org/api"
+# Base URL for STITCH REST API (chemical-protein interactions).
+# STITCH and STRING are separate sister databases sharing the same API
+# software, NOT the same database -- confirmed live that string-db.org
+# genuinely doesn't recognize chemical identifiers (its own /resolve fuzzy-
+# matched "aspirin" to an unrelated protein, SLC17A4, and /interaction_
+# partners rejected the real STITCH chemical id "-1.CID100002244" as "not
+# found"), so pointing STITCH queries at string-db.org was silently
+# returning wrong, mislabeled protein-protein data as chemical-protein
+# interactions. stitch.embl.de now redirects to stitch-db.org (the correct
+# current STITCH host per the shared API docs' own "List of databases"
+# table); use that instead.
+STITCH_BASE_URL = "https://stitch-db.org/api"
 
 
 @register_tool("STITCHTool")
@@ -104,7 +113,7 @@ class STITCHTool(BaseTool):
                     "status": "error",
                     "error": f"No interactions found for {identifiers} in STITCH. "
                     "Try using CID identifiers (e.g., 'CIDm00002244' for aspirin) "
-                    "or check compound names at http://stitch.embl.de/",
+                    "or check compound names at https://stitch-db.org/",
                 }
             response.raise_for_status()
             return {"status": "success", "data": response.json()}
@@ -141,7 +150,7 @@ class STITCHTool(BaseTool):
                 return {
                     "status": "error",
                     "error": f"No interactors found for {identifiers} in STITCH. "
-                    "Try using CID identifiers or check compound names at http://stitch.embl.de/",
+                    "Try using CID identifiers or check compound names at https://stitch-db.org/",
                 }
             response.raise_for_status()
             return {"status": "success", "data": response.json()}
@@ -171,7 +180,7 @@ class STITCHTool(BaseTool):
                 return {
                     "status": "error",
                     "error": f"Identifier '{identifier}' not found in STITCH. "
-                    "Try using CID identifiers or check at http://stitch.embl.de/",
+                    "Try using CID identifiers or check at https://stitch-db.org/",
                 }
             response.raise_for_status()
             return {"status": "success", "data": response.json()}

--- a/src/tooluniverse/uniprot_tool.py
+++ b/src/tooluniverse/uniprot_tool.py
@@ -5,6 +5,25 @@ from .base_tool import BaseTool, ToolError
 from .tool_registry import register_tool
 
 
+def _protein_name(protein_desc: Dict[str, Any]) -> str:
+    """Extract a display name from a UniProtKB entry's proteinDescription.
+
+    Reviewed (Swiss-Prot) entries have a single `recommendedName`, but
+    unreviewed (TrEMBL) entries -- over 99% of UniProtKB -- have no
+    `recommendedName` at all; their name lives in `submissionNames` (a
+    list) instead. Confirmed live for Q53707/MecA PBP2': recommendedName
+    is absent, and the actual name ("MecA PBP2' (penicillin binding
+    protein 2')") is submissionNames[0].fullName.value.
+    """
+    name = protein_desc.get("recommendedName", {}).get("fullName", {}).get("value", "")
+    if name:
+        return name
+    submission_names = protein_desc.get("submissionNames") or []
+    if submission_names:
+        return submission_names[0].get("fullName", {}).get("value", "")
+    return ""
+
+
 @register_tool("UniProtRESTTool")
 class UniProtRESTTool(BaseTool):
     def __init__(self, tool_config: Dict):
@@ -37,9 +56,7 @@ class UniProtRESTTool(BaseTool):
     def _compact_entry(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """Return a bounded summary of a UniProtKB entry for LLM contexts."""
         protein_desc = data.get("proteinDescription", {})
-        recommended_name = (
-            protein_desc.get("recommendedName", {}).get("fullName", {}).get("value", "")
-        )
+        protein_name = _protein_name(protein_desc)
         gene_names = []
         for gene in data.get("genes", []):
             gene_name = gene.get("geneName", {}).get("value")
@@ -77,7 +94,7 @@ class UniProtRESTTool(BaseTool):
                 "entryType": data.get("entryType", ""),
                 "primaryAccession": data.get("primaryAccession", ""),
                 "uniProtkbId": data.get("uniProtkbId", ""),
-                "protein_name": recommended_name,
+                "protein_name": protein_name,
                 "gene_names": gene_names,
                 "organism": data.get("organism", {}),
                 "sequence": data.get("sequence", {}),
@@ -293,11 +310,7 @@ class UniProtRESTTool(BaseTool):
 
                 # Extract protein name
                 protein_desc = entry.get("proteinDescription", {})
-                rec_name = protein_desc.get("recommendedName", {})
-                if rec_name:
-                    full_name = rec_name.get("fullName", {})
-                    if full_name:
-                        formatted_entry["protein_name"] = full_name.get("value", "")
+                formatted_entry["protein_name"] = _protein_name(protein_desc)
 
                 # Extract gene names
                 genes = entry.get("genes", [])

--- a/tests/unit/test_clingen_actionability_columnar_parsing.py
+++ b/tests/unit/test_clingen_actionability_columnar_parsing.py
@@ -1,0 +1,114 @@
+"""Regression guard for Fix-R28-5 in clingen_tool.py: ClinGen's
+actionability ?flavor=flat API returns a columnar table --
+{"columns": [...], "rows": [[...], ...]} -- not a list of record dicts.
+Confirmed live: neither `_get_actionability` nor `_search_actionability`
+recognized this shape (isinstance(data, list) is False, and there is no
+top-level "data" key), so:
+  - `_search_actionability`'s gene filter matched nothing for every gene
+    tested (LDLR, BRCA1), always returning empty Adult/Pediatric lists
+    even though real curations exist for both (e.g. LDLR,APOB,PCSK9
+    familial hypercholesterolemia).
+  - `_get_actionability`'s gene filter silently no-opped and it returned
+    the whole raw unparsed table instead of individual records.
+Also, geneOrVariant is a comma-joined multi-gene field for panel curations
+(e.g. "LDLR,APOB,PCSK9"), so the filter must substring-match, not
+exact-match, the field.
+"""
+
+import pytest
+
+from tooluniverse.clingen_tool import ClinGenTool
+
+pytestmark = pytest.mark.unit
+
+_COLUMNAR_RESPONSE = {
+    "columns": ["docId", "geneOrVariant", "disease", "overall"],
+    "rows": [
+        ["AC057", "LDLR,APOB,PCSK9", "Familial Hypercholesterolemia", "10CA"],
+        ["AC099", "BRCA1,BRCA2", "Hereditary Breast/Ovarian Cancer", "9BA"],
+        ["AC120", "MYH7", "Hypertrophic Cardiomyopathy", "8BA"],
+    ],
+}
+
+
+def _tool(operation):
+    return ClinGenTool({"fields": {"operation": operation}, "parameter": {}})
+
+
+class TestActionabilityRowsToDicts:
+    def test_columnar_shape_converted_to_dicts(self):
+        tool = _tool("get_actionability_adult")
+        rows = tool._actionability_rows_to_dicts(_COLUMNAR_RESPONSE)
+        assert len(rows) == 3
+        assert rows[0]["geneOrVariant"] == "LDLR,APOB,PCSK9"
+        assert rows[0]["overall"] == "10CA"
+
+    def test_plain_list_passed_through(self):
+        tool = _tool("get_actionability_adult")
+        data = [{"gene": "TP53"}]
+        assert tool._actionability_rows_to_dicts(data) == data
+
+    def test_unknown_shape_returns_empty_list(self):
+        tool = _tool("get_actionability_adult")
+        assert tool._actionability_rows_to_dicts({"unexpected": "shape"}) == []
+
+
+class TestGetActionabilityGeneFilter:
+    def test_substring_matches_comma_joined_gene_or_variant(self, monkeypatch):
+        tool = _tool("get_actionability_adult")
+
+        class FakeResp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return _COLUMNAR_RESPONSE
+
+        monkeypatch.setattr(
+            "tooluniverse.clingen_tool.requests.get", lambda *a, **k: FakeResp()
+        )
+        result = tool.run({"gene": "LDLR"})
+
+        assert result["status"] == "success"
+        assert result["total"] == 1
+        assert result["data"][0]["geneOrVariant"] == "LDLR,APOB,PCSK9"
+
+    def test_second_gene_in_panel_also_matches(self, monkeypatch):
+        tool = _tool("get_actionability_adult")
+
+        class FakeResp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return _COLUMNAR_RESPONSE
+
+        monkeypatch.setattr(
+            "tooluniverse.clingen_tool.requests.get", lambda *a, **k: FakeResp()
+        )
+        result = tool.run({"gene": "BRCA1"})
+
+        assert result["total"] == 1
+        assert result["data"][0]["geneOrVariant"] == "BRCA1,BRCA2"
+
+
+class TestSearchActionabilityGeneFilter:
+    def test_search_finds_gene_in_panel_curation(self, monkeypatch):
+        tool = _tool("search_actionability")
+
+        class FakeResp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return _COLUMNAR_RESPONSE
+
+        monkeypatch.setattr(
+            "tooluniverse.clingen_tool.requests.get", lambda *a, **k: FakeResp()
+        )
+        result = tool.run({"gene": "LDLR"})
+
+        assert result["status"] == "success"
+        assert result["adult_count"] == 1
+        assert result["pediatric_count"] == 1
+        assert result["data"]["Adult"][0]["geneOrVariant"] == "LDLR,APOB,PCSK9"

--- a/tests/unit/test_ctd_tool.py
+++ b/tests/unit/test_ctd_tool.py
@@ -103,6 +103,55 @@ def test_ctd_gene_disease_returns_redirect_error():
 
 @pytest.mark.unit
 @patch("tooluniverse.ctd_tool.requests.post")
+@patch("tooluniverse.ctd_tool.requests.get")
+def test_ctd_bare_cas_number_falls_back_to_curie_prefix(mock_get, mock_post):
+    """Fix-R28-1: the graph stores CAS RNs as CURIEs ("CAS:335-67-1"), not
+    bare -- confirmed live that "335-67-1" alone doesn't match while
+    "CAS:335-67-1" does. A bare CAS RN (exactly how the tool's own
+    description tells callers to pass one) must still resolve."""
+
+    mock_post.side_effect = [_empty_cypher_response(), make_cypher_response("CHEBI:35549")]
+    mock_get.return_value = make_edge_response([])
+
+    tool = make_ctd_tool()
+    result = tool.run({"input_terms": "335-67-1"})
+
+    assert result["status"] == "success"
+    assert result["metadata"]["canonical_curie"] == "CHEBI:35549"
+    # First call is the bare-term lookup, second is the CAS:-prefixed retry.
+    assert mock_post.call_count == 2
+    assert "CAS:335-67-1" in mock_post.call_args.kwargs["json"]["query"]
+
+
+@pytest.mark.unit
+@patch("tooluniverse.ctd_tool.requests.post")
+@patch("tooluniverse.ctd_tool.requests.get")
+def test_ctd_bare_mesh_scr_id_falls_back_to_curie_prefix(mock_get, mock_post):
+    """Same fallback for bare MeSH Supplementary Concept ids (e.g.
+    "C006780", the tool's own docstring example) -- confirmed live these
+    also only resolve with a "MESH:" prefix."""
+
+    mock_post.side_effect = [_empty_cypher_response(), make_cypher_response("CHEBI:33216")]
+    mock_get.return_value = make_edge_response([])
+
+    tool = make_ctd_tool()
+    result = tool.run({"input_terms": "C006780"})
+
+    assert result["status"] == "success"
+    assert result["metadata"]["canonical_curie"] == "CHEBI:33216"
+    assert "MESH:C006780" in mock_post.call_args.kwargs["json"]["query"]
+
+
+def _empty_cypher_response():
+    response = Mock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"results": [{"data": []}], "errors": []}
+    return response
+
+
+@pytest.mark.unit
+@patch("tooluniverse.ctd_tool.requests.post")
 def test_ctd_unresolvable_input_returns_error(mock_post):
     """If cypher can't find the term, return a clear not-found error."""
 

--- a/tests/unit/test_pubchem_2d_image_base64.py
+++ b/tests/unit/test_pubchem_2d_image_base64.py
@@ -1,0 +1,65 @@
+"""Regression guard for Fix-R28-4: PubChem_get_compound_2D_image_by_CID
+returned raw `bytes` for its "PNG"/"SVG" return_format instead of a
+JSON-serializable envelope. Confirmed live this crashed the CLI outright:
+`TypeError: Object of type bytes is not JSON serializable` in both
+`--json` and default rendering modes. Fixed by base64-encoding the image
+into {status, data: {image_base64, encoding, format}}.
+"""
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.pubchem_tool import PubChemRESTTool
+
+pytestmark = pytest.mark.unit
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n" + b"fake-png-bytes"
+
+
+def _tool():
+    return PubChemRESTTool(
+        {
+            "name": "PubChem_get_compound_2D_image_by_CID",
+            "type": "PubChemRESTTool",
+            "fields": {
+                "endpoint": "/compound/cid/{cid}/PNG?image_size={image_size}",
+                "return_format": "PNG",
+            },
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+def _png_response():
+    r = MagicMock()
+    r.status_code = 200
+    r.content = _PNG_MAGIC
+    return r
+
+
+class TestImageEnvelope:
+    def test_returns_json_serializable_envelope_not_raw_bytes(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.pubchem_tool.requests.get", return_value=_png_response()
+        ):
+            result = tool.run({"cid": 9554, "image_size": "300x300"})
+
+        assert result["status"] == "success"
+        assert isinstance(result["data"]["image_base64"], str)
+        # Must not raise -- this is exactly what crashed the CLI before the fix.
+        json.dumps(result)
+
+    def test_base64_round_trips_to_original_bytes(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.pubchem_tool.requests.get", return_value=_png_response()
+        ):
+            result = tool.run({"cid": 9554, "image_size": "300x300"})
+
+        decoded = base64.b64decode(result["data"]["image_base64"])
+        assert decoded == _PNG_MAGIC
+        assert result["data"]["format"] == "png"

--- a/tests/unit/test_stitch_correct_host.py
+++ b/tests/unit/test_stitch_correct_host.py
@@ -1,0 +1,80 @@
+"""Regression guard for Fix-R28-2 in stitch_tool.py: STITCH_BASE_URL pointed
+at string-db.org (a genuinely different sister database, not a renamed/
+merged STITCH) instead of STITCH's own host. Confirmed live: string-db.org's
+own /resolve fuzzy-matched the chemical name "aspirin" to an unrelated
+protein (SLC17A4), and its /interaction_partners rejected the real STITCH
+chemical id "-1.CID100002244" as "not found" -- so every chemical-protein
+query was silently returning wrong, mislabeled protein-protein data instead
+of failing. stitch.embl.de (the API docs' old host) now redirects to
+stitch-db.org, confirmed live as STITCH's current host, so queries now go
+there instead.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.stitch_tool import STITCH_BASE_URL, STITCHTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(operation):
+    return STITCHTool({"fields": {"operation": operation}})
+
+
+def _resp(status_code, json_body=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body or {}
+    r.raise_for_status = MagicMock()
+    return r
+
+
+class TestCorrectHost:
+    def test_base_url_is_stitch_not_string(self):
+        assert STITCH_BASE_URL == "https://stitch-db.org/api"
+        assert "string-db.org" not in STITCH_BASE_URL
+
+    def test_get_interactions_queries_stitch_host(self):
+        tool = _tool("get_interactions")
+        with patch(
+            "tooluniverse.stitch_tool.requests.get", return_value=_resp(200, [])
+        ) as mock_get:
+            tool.run({"identifiers": ["CIDm00002244"]})
+
+        called_url = mock_get.call_args.args[0]
+        assert called_url.startswith("https://stitch-db.org/api")
+
+    def test_get_interactors_queries_stitch_host(self):
+        tool = _tool("get_interactors")
+        with patch(
+            "tooluniverse.stitch_tool.requests.get", return_value=_resp(200, [])
+        ) as mock_get:
+            tool.run({"identifiers": ["CIDm00002244"]})
+
+        called_url = mock_get.call_args.args[0]
+        assert called_url.startswith("https://stitch-db.org/api")
+
+    def test_resolve_queries_stitch_host(self):
+        tool = _tool("resolve")
+        with patch(
+            "tooluniverse.stitch_tool.requests.get", return_value=_resp(200, [])
+        ) as mock_get:
+            tool.run({"identifier": "aspirin"})
+
+        called_url = mock_get.call_args.args[0]
+        assert called_url.startswith("https://stitch-db.org/api")
+
+    def test_404_reports_honest_error_not_wrong_data(self):
+        # If the correct-database endpoint is unavailable, the tool must
+        # fail honestly rather than fall back to a different database's
+        # unrelated data.
+        tool = _tool("get_interactions")
+        with patch(
+            "tooluniverse.stitch_tool.requests.get", return_value=_resp(404)
+        ):
+            result = tool.run({"identifiers": ["aspirin"]})
+
+        assert result["status"] == "error"
+        assert "stitch-db.org" in result["error"]

--- a/tests/unit/test_uniprot_protein_name_fallback.py
+++ b/tests/unit/test_uniprot_protein_name_fallback.py
@@ -1,0 +1,105 @@
+"""Regression guard for Fix-R28-3 in uniprot_tool.py: protein_name was
+always empty for unreviewed (TrEMBL) UniProtKB entries -- over 99% of the
+database. Reviewed (Swiss-Prot) entries have a `recommendedName`, but
+unreviewed entries have no such field at all; their name lives under
+`submissionNames` (a list) instead. Confirmed live for Q53707 (mecA/PBP2'
+from Staphylococcus aureus): recommendedName is absent, and the real name
+("MecA PBP2' (penicillin binding protein 2')") is
+submissionNames[0].fullName.value. Both `_compact_entry` and the
+`_handle_search` formatter only ever read `recommendedName`, so this
+silently blanked protein_name for the overwhelming majority of real-world
+UniProt searches.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.uniprot_tool import UniProtRESTTool, _protein_name
+
+pytestmark = pytest.mark.unit
+
+_UNREVIEWED_ENTRY = {
+    "entryType": "UniProtKB unreviewed (TrEMBL)",
+    "primaryAccession": "Q53707",
+    "uniProtkbId": "Q53707_STAAU",
+    "proteinDescription": {
+        "submissionNames": [
+            {"fullName": {"value": "MecA PBP2' (penicillin binding protein 2')"}},
+            {"fullName": {"value": "PBP2A"}},
+        ]
+    },
+    "genes": [{"geneName": {"value": "mecA"}}],
+    "organism": {"scientificName": "Staphylococcus aureus"},
+    "sequence": {"length": 668},
+}
+
+_REVIEWED_ENTRY = {
+    "entryType": "UniProtKB reviewed (Swiss-Prot)",
+    "primaryAccession": "P0A6M8",
+    "uniProtkbId": "EFTU_ECOLI",
+    "proteinDescription": {
+        "recommendedName": {"fullName": {"value": "Elongation factor Tu"}}
+    },
+    "genes": [{"geneName": {"value": "tufA"}}],
+    "organism": {"scientificName": "Escherichia coli"},
+    "sequence": {"length": 394},
+}
+
+
+class TestProteinNameHelper:
+    def test_falls_back_to_submission_name_when_no_recommended_name(self):
+        name = _protein_name(_UNREVIEWED_ENTRY["proteinDescription"])
+        assert name == "MecA PBP2' (penicillin binding protein 2')"
+
+    def test_prefers_recommended_name_when_present(self):
+        name = _protein_name(_REVIEWED_ENTRY["proteinDescription"])
+        assert name == "Elongation factor Tu"
+
+    def test_empty_when_neither_present(self):
+        assert _protein_name({}) == ""
+
+
+def _tool():
+    return UniProtRESTTool(
+        {
+            "fields": {
+                "endpoint": "https://rest.uniprot.org/uniprotkb/search",
+                "search_type": "search",
+            },
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+def _resp(payload):
+    r = MagicMock()
+    r.status_code = 200
+    r.raise_for_status = MagicMock()
+    r.json.return_value = payload
+    return r
+
+
+class TestCompactEntryFallback:
+    def test_compact_entry_uses_submission_name(self):
+        tool = _tool()
+        result = tool._compact_entry(_UNREVIEWED_ENTRY)
+        assert (
+            result["data"]["protein_name"]
+            == "MecA PBP2' (penicillin binding protein 2')"
+        )
+
+
+class TestSearchFormatterFallback:
+    def test_search_results_use_submission_name_fallback(self):
+        tool = _tool()
+        payload = {"results": [_UNREVIEWED_ENTRY, _REVIEWED_ENTRY]}
+        with patch(
+            "tooluniverse.uniprot_tool.requests.get", return_value=_resp(payload)
+        ):
+            result = tool.run({"query": "mecA"})
+
+        names = [r["protein_name"] for r in result["data"]["results"]]
+        assert "MecA PBP2' (penicillin binding protein 2')" in names
+        assert "Elongation factor Tu" in names
+        assert "" not in names


### PR DESCRIPTION
## Summary

Round 28 of the ongoing test-harness campaign. 5 role-play researcher personas (cardiovascular genetics, infectious disease/antimicrobial resistance, ophthalmology/vision genetics, hematology, toxicology/environmental health) surfaced 48 findings; every finding below was CLI-verified against the live upstream API before and after the fix.

## Fixes

- **CTD_get_chemical_diseases / CTD_get_gene_chemicals** (`ctd_tool.py`): the RENCI graph mirror stores CAS RNs and MeSH ids as CURIEs (`CAS:335-67-1`, `MESH:C006780`), not bare — confirmed live that bare `335-67-1` and `C006780` (the tool's own docstring example!) both failed to resolve while the CURIE-prefixed forms succeeded. The tool's own description explicitly promises CAS RN and MeSH ID support as plain input. Now retries with the appropriate prefix when the bare term doesn't resolve and the input matches a CAS/MeSH-SCR pattern.
- **STITCH_get_chemical_protein_interactions / get_interaction_partners / resolve_identifier** (`stitch_tool.py`): pointed at `string-db.org` based on a stale comment claiming `stitch.embl.de` "moved" there. STRING and STITCH are genuinely different sister databases sharing the same API software — confirmed live that string-db.org's own `/resolve` fuzzy-matched the chemical name "aspirin" to an unrelated protein (SLC17A4), and its `/interaction_partners` rejected the real STITCH chemical id as "not found". Every chemical-protein query was silently returning wrong, mislabeled protein-protein data. Now points to `stitch-db.org` (the current live STITCH host; `stitch.embl.de` now redirects there per the shared API docs' own database table).
- **UniProt_search / uniprot get_by_accession-family tools** (`uniprot_tool.py`): `protein_name` was always empty for unreviewed (TrEMBL) UniProtKB entries — over 99% of the database. Reviewed (Swiss-Prot) entries have a `recommendedName`; unreviewed entries have no such field at all, only `submissionNames` (a list). Confirmed live for Q53707 (mecA/PBP2' from *Staphylococcus aureus*). New shared `_protein_name()` helper falls back to `submissionNames[0]`, used by both call sites that previously duplicated (and incompletely handled) this extraction.
- **PubChem_get_compound_2D_image_by_CID** (`pubchem_tool.py`): the PNG/SVG return-format branch returned raw `bytes` directly, which crashed CLI/MCP JSON serialization outright (`TypeError: Object of type bytes is not JSON serializable`, 100% reproducible for any CID). Now base64-encodes into a proper `{status, data: {image_base64, encoding, format}}` envelope.
- **ClinGen_search_actionability / get_actionability_adult / get_actionability_pediatric** (`clingen_tool.py`): the actionability `?flavor=flat` API returns a columnar table (`{"columns": [...], "rows": [[...], ...]}`), not a list of record dicts — confirmed live. Neither method recognized this shape, so `search_actionability`'s gene filter matched nothing for every gene tested (always empty Adult/Pediatric results, even for LDLR and BRCA1 which have real curations), while `get_actionability`'s gene filter silently no-opped and returned the whole raw unparsed table instead of individual records. New shared `_actionability_rows_to_dicts()` helper parses the table; both methods now filter on `geneOrVariant` (a comma-joined multi-gene field for panel curations) via substring match.

## Deferred (documented, not fixed this round)

- `annotate_variant_multi_source`'s `clinvar_classification` bug (JAK2 V617F) — duplicate of round 27's fix (PR #323, unmerged).
- `IMPC_get_gene_summary`'s `has_phenotype_data` contradiction (RPE65) — duplicate of round 23's fix (PR #319, unmerged).
- MCP `execute_tool` TLS-cert-path and tool-type-registry-desync failures, and MCP `grep_tools`/`find_tools` missing several registered ClinGen tools — environment/deployment issues outside this repo, recurring across rounds 22-28.
- `BVBRC_search_genome_features` gene-name disambiguation (mecA homonym), `NCBI_get_sequence`'s hardcoded `db=nucleotide` (never switches to `db=protein` for WP_/NP_/YP_ accessions), `NCBIDatasets_get_gene`/`get_gene_by_symbol` silently discarding upstream `warning`/`messages` fields for discontinued/malformed queries, `ChEMBL_search_targets` accepting unrecognized params silently, `FDA_get_drug_label`'s brand-name ambiguity (ruxolitinib resolving to the wrong product), `ClinGen_get_variant_classifications`'s multi-minute latency, `MGI_get_gene`'s `cross_references` duplication (now seen in both round 27 and round 28), and several OpenTargets/HPA parameter-naming inconsistencies — larger-scope or lower-severity items left for a future round.

## Test plan

- [x] 9 new/updated mocked unit test files covering every fix above
- [x] `uv run pytest tests/unit -q --no-cov` — 2189 passed, 11 skipped (all environmental: scanpy not installed, no-tools-loaded fixtures, one resource-exhaustion deselect)
- [x] Every fix CLI-verified live against the real upstream API before and after the change
- [x] code-simplifier pass applied (one variable rename in `uniprot_tool.py` for accuracy — no behavior change)