### PR TITLE
Fix Round 30: Orphanet slash-encoding, gene-disease tool wrong OpenTargets call, CPIC case-sensitivity, OpenGenes 404 handling

### DIFF
--- a/src/tooluniverse/base_rest_tool.py
+++ b/src/tooluniverse/base_rest_tool.py
@@ -275,6 +275,22 @@ class BaseRESTTool(BaseTool):
                     if isinstance(value, str):
                         arguments[key] = value.lower()
 
+            # Fix-R30E-3: the mirror-image case -- CPIC's gene/allele tables
+            # store symbols uppercase (e.g. "CYP2D6"), so a lowercase or
+            # mixed-case input to `symbol=eq.{symbol}`/`genesymbol=eq.{...}`
+            # silently returns an empty success (confirmed live: "cyp2d6" ->
+            # 0 rows, "CYP2D6" -> 1). `fields.uppercase_params` lists params
+            # to upcase.
+            uppercase_params = (
+                self.tool_config.get("fields", {}).get("uppercase_params") or []
+            )
+            if uppercase_params:
+                arguments = dict(arguments)
+                for key in uppercase_params:
+                    value = arguments.get(key)
+                    if isinstance(value, str):
+                        arguments[key] = value.upper()
+
             url = self._build_url(arguments)
             params = self._build_params(arguments)
 

--- a/src/tooluniverse/compound_gene_disease_tool.py
+++ b/src/tooluniverse/compound_gene_disease_tool.py
@@ -66,11 +66,22 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
         results_by_source["OMIM"] = self._extract_genes_or_diseases(r, "OMIM")
 
         # 3. OpenTargets
-        r = _try_tool(
-            "OpenTargets",
-            "OpenTargets_get_disease_ids_by_name",
-            {"name": disease or gene},
-        )
+        # Fix-R30D-6: for a gene-only query, passing the gene symbol into
+        # OpenTargets_get_disease_ids_by_name (a disease-name search) doesn't
+        # look up the gene's associated diseases at all -- confirmed live it
+        # returns 0-1 spurious hits that merely happen to contain the gene
+        # symbol as a substring (e.g. "congenital muscular dystrophy due to
+        # LMNA mutation"), not real gene->disease associations (OpenTargets
+        # itself has 6084 for LMNA). Resolve the gene symbol to its Ensembl
+        # ID first and query its associated-diseases list instead.
+        if disease:
+            r = _try_tool(
+                "OpenTargets",
+                "OpenTargets_get_disease_ids_by_name",
+                {"name": disease},
+            )
+        else:
+            r = self._opentargets_gene_diseases(tu, gene, sources_failed)
         results_by_source["OpenTargets"] = self._extract_genes_or_diseases(
             r, "OpenTargets"
         )
@@ -105,6 +116,42 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
             },
         }
 
+    def _opentargets_gene_diseases(
+        self, tu, gene: str, sources_failed: List[str]
+    ) -> Dict[str, Any]:
+        """Resolve a gene symbol to its OpenTargets/Ensembl target ID, then
+        fetch its real associated-diseases list. OpenTargets has no
+        symbol-keyed "diseases for this gene" endpoint, so this chains the
+        target-name search (for the ID) with the ID-based diseases lookup."""
+        search = tu.run_one_function(
+            {
+                "name": "OpenTargets_get_target_id_description_by_name",
+                "arguments": {"targetName": gene},
+            }
+        )
+        hits = (search or {}).get("data", {}).get("search", {}).get("hits", [])
+        if not hits:
+            sources_failed.append(f"OpenTargets: no target match for gene '{gene}'")
+            return {"status": "error", "error": f"No target match for gene '{gene}'"}
+
+        gene_upper = gene.upper()
+        match = next(
+            (h for h in hits if h.get("name", "").upper() == gene_upper), hits[0]
+        )
+        ensembl_id = match.get("id")
+
+        result = tu.run_one_function(
+            {
+                "name": "OpenTargets_get_diseases_phenotypes_by_target_ensembl",
+                "arguments": {"ensemblId": ensembl_id},
+            }
+        )
+        if isinstance(result, dict) and result.get("status") == "error":
+            sources_failed.append(
+                f"OpenTargets: {result.get('error', 'unknown error')[:100]}"
+            )
+        return result
+
     def _extract_genes_or_diseases(
         self, result: Any, source: str
     ) -> List[Dict[str, Any]]:
@@ -138,6 +185,18 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
             for hit in hits[:30]:
                 if isinstance(hit, dict):
                     name = hit.get("name", "")
+                    items.append({"name": str(name), "score": None, "source": source})
+            return items
+
+        # OpenTargets: data has "target.associatedDiseases.rows" list (gene-only queries)
+        if isinstance(data, dict) and "target" in data:
+            rows = (
+                (data.get("target") or {}).get("associatedDiseases", {}).get("rows", [])
+            )
+            for row in rows[:30]:
+                disease = (row or {}).get("disease") or {}
+                name = disease.get("name", "")
+                if name:
                     items.append({"name": str(name), "score": None, "source": source})
             return items
 

--- a/src/tooluniverse/data/cpic_tools.json
+++ b/src/tooluniverse/data/cpic_tools.json
@@ -15,7 +15,8 @@
       ]
     },
     "fields": {
-      "endpoint": "https://api.cpicpgx.org/v1/gene?symbol=eq.{symbol}"
+      "endpoint": "https://api.cpicpgx.org/v1/gene?symbol=eq.{symbol}",
+      "uppercase_params": ["symbol"]
     },
     "type": "BaseRESTTool",
     "test_examples": [
@@ -1087,7 +1088,8 @@
       ]
     },
     "fields": {
-      "endpoint": "https://api.cpicpgx.org/v1/allele?genesymbol=eq.{genesymbol}&select=name,functionalstatus,activityvalue,clinicalfunctionalstatus&limit={limit}"
+      "endpoint": "https://api.cpicpgx.org/v1/allele?genesymbol=eq.{genesymbol}&select=name,functionalstatus,activityvalue,clinicalfunctionalstatus&limit={limit}",
+      "uppercase_params": ["genesymbol"]
     },
     "type": "BaseRESTTool",
     "test_examples": [

--- a/src/tooluniverse/open_genes_tool.py
+++ b/src/tooluniverse/open_genes_tool.py
@@ -33,11 +33,25 @@ def _evidence_counts(researches: Any) -> Dict[str, int]:
     return {k: (len(v) if isinstance(v, list) else v) for k, v in researches.items()}
 
 
-def _fetch_json(path: str, timeout: int, params: Dict[str, Any] = None) -> Any:
+def _fetch_json(
+    path: str, timeout: int, params: Dict[str, Any] = None, not_found_ok: bool = False
+) -> Any:
     """GET a JSON resource from Open Genes.
 
     Returns the parsed JSON on success, or a {"status": "error", ...} dict on
     any network/parse failure so callers can return it directly.
+
+    Fix-R30D-5: for a single-resource lookup like gene/{symbol}, Open Genes
+    signals "unknown symbol" via a genuine HTTP 404 (confirmed live:
+    gene/FAKEGENE123 -> 404 with body {"message":"Gene FAKEGENE123 not
+    found",...}) -- the same conceptual outcome as when it instead returns
+    200 with a body missing the expected fields, which callers already
+    handle gracefully. Without not_found_ok, a 404 was previously
+    indistinguishable from a real network failure, giving two different
+    envelopes for the same "not in Open Genes" case depending on which way
+    the upstream happened to signal it. `not_found_ok=True` returns None on
+    404 instead, letting the caller route it through its existing
+    graceful-empty-result handling.
     """
     try:
         resp = requests.get(
@@ -46,6 +60,8 @@ def _fetch_json(path: str, timeout: int, params: Dict[str, Any] = None) -> Any:
             headers={"Accept": "application/json"},
             timeout=timeout,
         )
+        if not_found_ok and resp.status_code == 404:
+            return None
         resp.raise_for_status()
         return resp.json()
     except requests.exceptions.Timeout:
@@ -98,11 +114,12 @@ class OpenGenesGeneTool(BaseTool):
                 "error": "'symbol' is required (e.g. 'GHR', 'FOXO3', 'TP53')",
             }
 
-        g = _fetch_json(f"gene/{symbol}", self.timeout)
+        g = _fetch_json(f"gene/{symbol}", self.timeout, not_found_ok=True)
         if isinstance(g, dict) and g.get("status") == "error":
             return g
 
-        # Unknown symbols return a string/error page rather than a gene object.
+        # Unknown symbols 404, or return a string/error page instead of a
+        # gene object; both mean the same thing to a caller.
         if not isinstance(g, dict) or not g.get("symbol"):
             return {
                 "status": "success",

--- a/src/tooluniverse/orphanet_tool.py
+++ b/src/tooluniverse/orphanet_tool.py
@@ -37,6 +37,18 @@ def normalize_lang(lang: str) -> str:
     return lang.upper() if lang else "EN"
 
 
+def _encode_orphadata_gene_name(name: str) -> str:
+    """URL-encode a gene name for the Orphadata /genes/names/{name} path.
+
+    Fix-R30D-2: some official gene names contain a literal "/" (e.g. "lamin
+    A/C" for LMNA) -- confirmed live that Orphadata's router 404s on the
+    correctly percent-encoded form (%2F) but succeeds if the slash is
+    replaced with a hyphen first. Only affects this Orphadata gene-name
+    endpoint, not the separate RDcode disease-name search endpoints.
+    """
+    return urllib.parse.quote(name.replace("/", "-"), safe="")
+
+
 @register_tool("OrphanetTool")
 class OrphanetTool(BaseTool):
     """
@@ -949,7 +961,7 @@ class OrphanetTool(BaseTool):
         }
 
         try:
-            encoded_name = urllib.parse.quote(gene_name, safe="")
+            encoded_name = _encode_orphadata_gene_name(gene_name)
             response = requests.get(
                 f"{ORPHADATA_API_URL}/rd-associated-genes/genes/names/{encoded_name}",
                 timeout=self.timeout,
@@ -960,7 +972,7 @@ class OrphanetTool(BaseTool):
             if response.status_code == 404:
                 full_name = self._resolve_gene_symbol(gene_name)
                 if full_name:
-                    encoded_name = urllib.parse.quote(full_name, safe="")
+                    encoded_name = _encode_orphadata_gene_name(full_name)
                     response = requests.get(
                         f"{ORPHADATA_API_URL}/rd-associated-genes/genes/names/{encoded_name}",
                         timeout=self.timeout,

--- a/tests/unit/test_compound_gene_disease_opentargets_lookup.py
+++ b/tests/unit/test_compound_gene_disease_opentargets_lookup.py
@@ -1,0 +1,191 @@
+"""Regression guard for Fix-R30D-6: CompoundGeneDiseaseAssociationTool's
+OpenTargets sub-query, for a gene-only request (no disease given), passed
+the gene SYMBOL into OpenTargets_get_disease_ids_by_name -- a disease-NAME
+search. Confirmed live for LMNA: that call returns 0-1 spurious hits that
+merely contain "LMNA" as a substring (e.g. "congenital muscular dystrophy
+due to LMNA mutation"), not LMNA's real 6084 OpenTargets disease
+associations (confirmed via OpenTargets_get_diseases_phenotypes_by_target_
+ensembl once resolved to its Ensembl ID, ENSG00000160789) -- so the
+concordance table could never show OpenTargets agreeing with any other
+source on a gene-only query, undermining the tool's whole purpose.
+
+Fixed by resolving the gene symbol to its Ensembl target ID via
+OpenTargets_get_target_id_description_by_name first, then querying that
+ID's real associated-diseases list.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.compound_gene_disease_tool import CompoundGeneDiseaseAssociationTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return CompoundGeneDiseaseAssociationTool({"name": "gather_test"})
+
+
+_TARGET_SEARCH_RESPONSE = {
+    "status": "success",
+    "data": {
+        "search": {
+            "hits": [
+                {"id": "ENSG00000160789", "name": "LMNA", "description": "lamin A/C"},
+                {"id": "ENSG00000146147", "name": "MLIP", "description": "..."},
+            ]
+        }
+    },
+}
+
+_ASSOCIATED_DISEASES_RESPONSE = {
+    "status": "success",
+    "data": {
+        "target": {
+            "id": "ENSG00000160789",
+            "approvedSymbol": "LMNA",
+            "associatedDiseases": {
+                "count": 2,
+                "rows": [
+                    {
+                        "disease": {
+                            "id": "MONDO_0005021",
+                            "name": "dilated cardiomyopathy",
+                        }
+                    },
+                    {
+                        "disease": {
+                            "id": "MONDO_0016419",
+                            "name": "Hutchinson-Gilford progeria syndrome",
+                        }
+                    },
+                ],
+            },
+        }
+    },
+}
+
+
+class TestOpenTargetsGeneOnlyLookup:
+    def test_resolves_gene_symbol_before_fetching_diseases(self):
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.side_effect = [
+            _TARGET_SEARCH_RESPONSE,
+            _ASSOCIATED_DISEASES_RESPONSE,
+        ]
+        sources_failed = []
+
+        result = tool._opentargets_gene_diseases(tu, "LMNA", sources_failed)
+
+        assert result == _ASSOCIATED_DISEASES_RESPONSE
+        first_call, second_call = tu.run_one_function.call_args_list
+        assert (
+            first_call.args[0]["name"]
+            == "OpenTargets_get_target_id_description_by_name"
+        )
+        assert first_call.args[0]["arguments"] == {"targetName": "LMNA"}
+        assert (
+            second_call.args[0]["name"]
+            == "OpenTargets_get_diseases_phenotypes_by_target_ensembl"
+        )
+        assert second_call.args[0]["arguments"] == {"ensemblId": "ENSG00000160789"}
+        assert sources_failed == []
+
+    def test_no_target_match_records_failure_without_crashing(self):
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.return_value = {
+            "status": "success",
+            "data": {"search": {"hits": []}},
+        }
+        sources_failed = []
+
+        result = tool._opentargets_gene_diseases(tu, "NOTAREALGENE", sources_failed)
+
+        assert result["status"] == "error"
+        assert len(sources_failed) == 1
+        assert "NOTAREALGENE" in sources_failed[0]
+
+    def test_extracts_real_disease_names_from_associated_diseases_shape(self):
+        tool = _tool()
+        items = tool._extract_genes_or_diseases(
+            _ASSOCIATED_DISEASES_RESPONSE, "OpenTargets"
+        )
+
+        names = [i["name"] for i in items]
+        assert "Hutchinson-Gilford progeria syndrome" in names
+        assert "dilated cardiomyopathy" in names
+        assert all(i["source"] == "OpenTargets" for i in items)
+
+    def test_disease_query_still_uses_direct_name_search(self):
+        """A disease-provided query is unaffected -- still the original,
+        already-correct OpenTargets_get_disease_ids_by_name path."""
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.return_value = {
+            "status": "success",
+            "data": {"search": {"hits": [{"name": "progeria"}]}},
+        }
+        sources_failed = []
+
+        # run() itself dispatches this, but exercising just the extraction
+        # helper's untouched branch is enough to confirm no regression.
+        r = tu.run_one_function(
+            {
+                "name": "OpenTargets_get_disease_ids_by_name",
+                "arguments": {"name": "progeria"},
+            }
+        )
+        items = tool._extract_genes_or_diseases(r, "OpenTargets")
+        assert items[0]["name"] == "progeria"
+
+
+class TestRunDispatch:
+    def test_gene_only_query_routes_through_target_resolution(self):
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.side_effect = lambda call: {
+            "OpenTargets_get_target_id_description_by_name": _TARGET_SEARCH_RESPONSE,
+            "OpenTargets_get_diseases_phenotypes_by_target_ensembl": _ASSOCIATED_DISEASES_RESPONSE,
+        }.get(call["name"], {"status": "error", "error": "unused source"})
+
+        with patch("tooluniverse.execute_function.ToolUniverse", return_value=tu):
+            result = tool.run({"gene": "LMNA"})
+
+        assert result["status"] == "success"
+        ot_names = [
+            r["name"] for r in result["data"]["per_source_results"]["OpenTargets"]
+        ]
+        assert "Hutchinson-Gilford progeria syndrome" in ot_names
+        # The bug's spurious substring-match shape must not appear.
+        assert "congenital muscular dystrophy due to LMNA mutation" not in ot_names
+
+    def test_disease_query_still_calls_disease_name_search_directly(self):
+        tool = _tool()
+        tu = MagicMock()
+
+        def fake_run(call):
+            if call["name"] == "OpenTargets_get_disease_ids_by_name":
+                assert call["arguments"] == {"name": "progeria"}
+                return {
+                    "status": "success",
+                    "data": {"search": {"hits": [{"name": "progeria"}]}},
+                }
+            return {"status": "error", "error": "unused source"}
+
+        tu.run_one_function.side_effect = fake_run
+
+        with patch("tooluniverse.execute_function.ToolUniverse", return_value=tu):
+            result = tool.run({"disease": "progeria"})
+
+        assert result["status"] == "success"
+        # The target-resolution helper must never be invoked for a
+        # disease-provided query.
+        called_names = [c.args[0]["name"] for c in tu.run_one_function.call_args_list]
+        assert "OpenTargets_get_target_id_description_by_name" not in called_names

--- a/tests/unit/test_open_genes_not_found_consistency.py
+++ b/tests/unit/test_open_genes_not_found_consistency.py
@@ -1,0 +1,80 @@
+"""Regression guard for Fix-R30D-5: OpenGenesGeneTool's "gene not found"
+outcome had two different response envelopes depending on how the upstream
+API happened to signal it.
+
+Confirmed live: an unknown symbol (e.g. FAKEGENE123) gets a genuine HTTP 404
+from open-genes.com/api/gene/{symbol} with body
+{"message": "Gene FAKEGENE123 not found", ...}. Before this fix, _fetch_json
+let requests.raise_for_status() turn that into a hard requests.HTTPError,
+caught by the generic RequestException handler and returned as
+{"status": "error", ...} -- a different shape than the tool's own existing
+handling for a 200-with-malformed-body response (which it already treated
+gracefully as {"status": "success", "data": {}, "metadata": {"note": ...}}).
+Both cases mean the same thing to a caller and now return the same shape.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.open_genes_tool import OpenGenesGeneTool, _fetch_json
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return OpenGenesGeneTool({"name": "opengenes_test", "fields": {}})
+
+
+def _404_response():
+    r = MagicMock()
+    r.status_code = 404
+    r.raise_for_status = MagicMock(
+        side_effect=requests.exceptions.HTTPError("404 Client Error")
+    )
+    r.json.return_value = {"message": "Gene FAKEGENE123 not found", "status": 404}
+    return r
+
+
+class TestNotFoundEnvelopeConsistency:
+    def test_404_response_treated_as_graceful_not_found(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.open_genes_tool.requests.get", return_value=_404_response()
+        ):
+            result = tool.run({"symbol": "FAKEGENE123"})
+
+        assert result["status"] == "success"
+        assert result["data"] == {}
+        assert "not in Open Genes" in result["metadata"]["note"]
+
+    def test_real_network_failure_still_reports_as_error(self):
+        tool = _tool()
+        with patch(
+            "tooluniverse.open_genes_tool.requests.get",
+            side_effect=requests.exceptions.ConnectionError("boom"),
+        ):
+            result = tool.run({"symbol": "FOXO3"})
+
+        assert result["status"] == "error"
+
+    def test_fetch_json_not_found_ok_returns_none_on_404(self):
+        with patch(
+            "tooluniverse.open_genes_tool.requests.get", return_value=_404_response()
+        ):
+            result = _fetch_json("gene/FAKEGENE123", 30, not_found_ok=True)
+
+        assert result is None
+
+    def test_fetch_json_without_not_found_ok_still_errors_on_404(self):
+        with patch(
+            "tooluniverse.open_genes_tool.requests.get", return_value=_404_response()
+        ):
+            result = _fetch_json("gene/FAKEGENE123", 30)
+
+        assert result["status"] == "error"

--- a/tests/unit/test_orphanet_gene_name_slash_encoding.py
+++ b/tests/unit/test_orphanet_gene_name_slash_encoding.py
@@ -1,0 +1,99 @@
+"""Regression guard for Fix-R30D-2: OrphanetTool's gene-disease lookup
+silently returned 0 diseases for any gene whose full name contains a
+literal "/" (e.g. "lamin A/C" for LMNA, which has 21 curated Orphanet
+disease associations including Hutchinson-Gilford progeria syndrome).
+
+Confirmed live against the real Orphadata API:
+  - urllib.parse.quote("lamin A/C", safe="") -> "lamin%20A%2FC" -> 404
+  - "lamin A-C" (slash replaced with a hyphen before encoding) -> 200, with
+    all 21 real disease associations.
+Orphadata's router doesn't decode a percent-encoded slash (%2F) back to "/"
+before matching the path segment, so the correctly-encoded form 404s.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.orphanet_tool import OrphanetTool, _encode_orphadata_gene_name
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return OrphanetTool({"name": "orphanet_test"})
+
+
+def _resp(status_code, json_body=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = json_body or {}
+    if status_code >= 400:
+        import requests
+
+        r.raise_for_status.side_effect = requests.exceptions.HTTPError(response=r)
+    else:
+        r.raise_for_status = MagicMock()
+    return r
+
+
+class TestOrphadataGeneNameEncoding:
+    def test_slash_replaced_with_hyphen_not_percent_encoded(self):
+        assert _encode_orphadata_gene_name("lamin A/C") == "lamin%20A-C"
+
+    def test_names_without_slash_unaffected(self):
+        assert _encode_orphadata_gene_name("fibrillin 1") == "fibrillin%201"
+
+
+class TestGetGeneDiseasesWithSlashInName:
+    def test_symbol_resolving_to_slash_name_finds_diseases(self):
+        tool = _tool()
+        gene_list_resp = _resp(
+            200,
+            {
+                "data": {
+                    "results": [
+                        {"symbol": "LMNA", "name": "lamin A/C"},
+                    ]
+                }
+            },
+        )
+        diseases_resp = _resp(
+            200,
+            {
+                "data": {
+                    "results": [
+                        {
+                            "ORPHAcode": 740,
+                            "Preferred term": "Hutchinson-Gilford progeria syndrome",
+                        }
+                    ]
+                    * 21
+                }
+            },
+        )
+
+        captured_urls = []
+
+        def fake_get(url, **kwargs):
+            captured_urls.append(url)
+            if "genes/names/lamin%20A%2FC" in url:
+                return _resp(404)
+            if "genes/names/lamin%20A-C" in url:
+                return diseases_resp
+            if url.endswith("genes?page=1"):
+                return gene_list_resp
+            return _resp(404)
+
+        with patch("tooluniverse.orphanet_tool.requests.get", side_effect=fake_get):
+            result = tool.run({"operation": "get_gene_diseases", "gene_symbol": "LMNA"})
+
+        assert result["status"] == "success"
+        assert result["data"]["disease_count"] == 21
+        # The first attempt uses the un-mangled percent-encoded slash and
+        # 404s (matching live behavior); the retry uses the hyphen form.
+        assert any("lamin%20A-C" in u for u in captured_urls)

--- a/tests/unit/test_round007_fixes.py
+++ b/tests/unit/test_round007_fixes.py
@@ -140,5 +140,56 @@ class TestBaseRESTLowercaseParams(unittest.TestCase):
         self.assertNotIn("Clopidogrel", captured["url"])
 
 
+# ---------------------------------------------------------------------------
+# Fix-R30E-3: BaseRESTTool uppercase_params upcases before request
+# ---------------------------------------------------------------------------
+class TestBaseRESTUppercaseParams(unittest.TestCase):
+    """Regression guard for Fix-R30E-3: CPIC's gene/allele tables store
+    symbols uppercase (opposite of CPIC's drug-name table, Feature-007-003
+    above) -- confirmed live that CPIC_get_gene_info({"symbol": "cyp2d6"})
+    silently returned status:success with 0 rows while "CYP2D6" returned
+    real data. `fields.uppercase_params` mirrors `lowercase_params` for this
+    direction."""
+
+    def _make_tool(self):
+        from tooluniverse.base_rest_tool import BaseRESTTool
+
+        config = {
+            "name": "CPIC_get_gene_info",
+            "type": "BaseRESTTool",
+            "parameter": {
+                "type": "object",
+                "properties": {"symbol": {"type": "string"}},
+                "required": ["symbol"],
+            },
+            "fields": {
+                "endpoint": "https://api.cpicpgx.org/v1/gene?symbol=eq.{symbol}",
+                "uppercase_params": ["symbol"],
+            },
+        }
+        return BaseRESTTool(config)
+
+    def test_lowercase_symbol_is_uppercased_in_url(self):
+        tool = self._make_tool()
+        captured = {}
+
+        def fake_request(session, method, url, **kwargs):
+            captured["url"] = url
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = []
+            resp.headers = {"content-type": "application/json"}
+            resp.text = "[]"
+            return resp
+
+        with patch(
+            "tooluniverse.base_rest_tool.request_with_retry", side_effect=fake_request
+        ):
+            tool.run({"symbol": "cyp2d6"})
+
+        self.assertIn("symbol=eq.CYP2D6", captured["url"])
+        self.assertNotIn("cyp2d6", captured["url"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Note on base branch

This PR targets `test-harness/consolidated-rounds-1-29` (PR #326), not `main`, since #326 is still open/unmerged and this round was branched from its tip to avoid rediscovering/duplicate-fixing bugs already resolved there. Once #326 merges into `main`, this PR should be retargeted to `main` (or merged after #326 lands, whichever is cleaner) -- the diff below is round 30's changes only.

## Summary

Round 30 of the test-harness sweep: 5 role-play researcher personas exercised dermatology/skin genetics, reproductive medicine/fertility genetics, sleep medicine/circadian biology, geriatrics/aging biology, and forensic/population genetics -- domains not previously covered. All 5 hit a session-wide MCP-server environment issue (stale uv cache breaking network/native-library tool calls, consistent with prior rounds' recurring finding) and worked around it via the CLI fallback, surfacing several genuine, CLI-verified issues.

## Fixes

- **Orphanet_get_gene_diseases**: gene names containing a literal "/" (e.g. "lamin A/C" for LMNA, which has 21 curated Orphanet disease associations including Hutchinson-Gilford progeria syndrome) silently returned 0 diseases. Confirmed live: the correctly percent-encoded slash (`%2F`) 404s on Orphadata's router, while replacing "/" with "-" before encoding succeeds. Added a shared `_encode_orphadata_gene_name()` helper.
- **gather_gene_disease_associations** (`CompoundGeneDiseaseAssociationTool`): for a gene-only query, the OpenTargets sub-call passed the gene *symbol* into `OpenTargets_get_disease_ids_by_name` (a disease-name search), returning 0-1 spurious substring-match hits instead of the gene's real disease associations (confirmed live: LMNA has 6084 in OpenTargets). This meant the tool's core concordance-scoring feature could never show OpenTargets agreeing with any other source on a gene-only query -- directly undermining its purpose. Fixed by resolving the gene symbol to its Ensembl target ID first, then querying its real associated-diseases list.
- **CPIC_get_gene_info / CPIC_get_alleles**: CPIC's gene/allele tables store symbols uppercase, so a lowercase or mixed-case input silently returned `status: success` with 0 rows (confirmed live: `"cyp2d6"` → 0 rows, `"CYP2D6"` → 1). Added an `uppercase_params` config mechanism to `BaseRESTTool`, mirroring the existing `lowercase_params` one already used for CPIC's drug-name table (which stores lowercase -- the opposite direction).
- **OpenGenesGeneTool**: an unknown gene symbol signals "not found" via a genuine HTTP 404 (confirmed live), which the tool's generic exception handler previously turned into a hard error -- a different response envelope than the tool's own existing graceful handling for the same conceptual outcome (a 200 response with a malformed/empty body). Added a `not_found_ok` option to the shared `_fetch_json()` helper so both paths route through the same graceful "not in Open Genes" response.

## Deferred (documented, not fixed this round)

- `ChEMBL_search_mechanisms`'s `target_chembl_id` param being declared in the schema despite being rejected at runtime -- confirmed this is deliberate, self-documenting design (the schema description itself says "NOT SUPPORTED", and the runtime rejection message correctly redirects callers to the right alternative tools), not a bug.
- `GTEx_get_median_gene_expression`'s description mismatch with "V11" -- already fixed in a prior round; both tool descriptions in this worktree already correctly state V8 is the default and V11 doesn't exist via this API. The persona's finding was likely against the stale MCP server.
- `EVA_get_variants_by_gene`'s `cohortStats.ALL` showing zeroed ref/alt allele counts while a real minor-allele-frequency value (0.0059) sits correctly in the adjacent `maf` field -- this is legitimate (if unusually shaped) upstream data for a summary-only submission lacking individual genotype breakdowns, not a ToolUniverse defect.
- `dbsnp_search_by_gene`'s lack of relevance/significance ordering, ChEMBL's literal substring target-name matching, ARNTL/BMAL1 Ensembl symbol alias resolution (confirmed upstream Ensembl behavior, not ours to fix), and DGIdb's duplicate interaction-type entries -- lower-severity or larger-scope items left for a future round.
- Recurring MCP `execute_tool` TLS-cert-path and tool-type-registry-desync failures, and `find_tools`/`grep_tools` surfacing renamed/nonexistent tool names (e.g. `OpenTargets_get_asso_targ_by_dise_efoI`) -- environment/deployment issues outside this repo, recurring across every round.

## Test plan

- [x] 4 new/updated mocked unit test files covering every fix above
- [x] Full `tests/unit` suite green (only the usual environmental skips)
- [x] Every fix CLI-verified live against the real upstream API before and after the change
- [x] code-simplifier pass applied (only reflow needed, logic already clean)