### PR TITLE
Fix Round 31: annotate_variant_multi_source ClinVar/UniProt/rsid bugs, OpenTargets datasource+note bugs, CPIC alias/note fixes

### DIFF
--- a/src/tooluniverse/base_rest_tool.py
+++ b/src/tooluniverse/base_rest_tool.py
@@ -66,11 +66,18 @@ class BaseRESTTool(BaseTool):
         """
         url = self.tool_config["fields"]["endpoint"]
 
-        # Apply path_aliases: map alias → canonical name before substitution
+        # Apply path_aliases: map alias → canonical name before substitution.
+        # Fix-R31B-3: an alias key left in `args` after this point leaked into
+        # _build_params as an unrecognized query param -- confirmed live this
+        # isn't just harmless noise: PostgREST-backed APIs (e.g. CPIC) try to
+        # parse every query key as a filter expression and 400 on it
+        # ("failed to parse filter"), breaking the whole request. Always pop
+        # the alias key once consulted, whether or not the canonical name was
+        # already present.
         path_aliases = self.tool_config.get("fields", {}).get("path_aliases", {})
         for alias, canonical in path_aliases.items():
-            if alias in args and canonical not in args:
-                args[canonical] = args[alias]
+            if alias in args:
+                args.setdefault(canonical, args.pop(alias))
 
         # Replace all path parameters from user args
         for key, value in args.items():

--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -81,27 +81,39 @@ class CompoundVariantAnnotationTool(BaseTool):
         sources_failed: List[str] = []
 
         # Resolve the gene up front: ClinVar/CIViC/gnomAD/UniProt are all queried by
-        # gene (or rsid), NOT by a bare protein change like "V600E" (which matches
-        # nothing in ClinVar). Derive the gene from the explicit arg or the variant.
+        # gene, NOT by a bare protein change like "V600E" (which matches nothing in
+        # ClinVar). Derive the gene from the explicit arg, the variant, or (Fix-R31B-1)
+        # dbSNP's rsid lookup when only an rsid was given -- ClinVar's own tools have
+        # no direct rsid parameter (variant_id is ClinVar's own internal numeric id,
+        # not a dbSNP rsid; confirmed live both "query"/"variant_id" set to "rs671"
+        # return 0 results), so resolving to a gene first is the only way to use
+        # ClinVar/CIViC/UniProt at all for an rsid-only query.
         gene_for_gnomad = gene
         if not gene_for_gnomad and variant:
             parts = variant.split()
             if parts:
                 gene_for_gnomad = parts[0]
+        if not gene_for_gnomad and rsid:
+            gene_for_gnomad = self._resolve_gene_from_rsid(tu, rsid, sources_failed)
         # The protein-change token (e.g. "V600E") used to filter gene-level hits.
         variant_token = None
         if variant:
             toks = variant.split()
             variant_token = toks[-1] if toks else variant
 
-        # 1. ClinVar — query by rsid (precise) or gene; a bare protein change returns 0.
-        clinvar_query = rsid or gene_for_gnomad or variant
-        if clinvar_query:
+        # 1. ClinVar -- Fix-R31D-4/R31A-3: "query" is documented as an alias for
+        # "condition" (a disease/phenotype free-text search), not a gene or rsid
+        # lookup -- confirmed live that querying by gene name via "query" only
+        # coincidentally matched conditions whose name happens to contain the gene
+        # symbol (40 rows for HOXB13 vs the real 1943 via the dedicated "gene"
+        # param). Use "gene" directly; a bare protein change with no resolvable
+        # gene still can't be searched and is skipped, same as before.
+        if gene_for_gnomad:
             try:
                 r = tu.run_one_function(
                     {
                         "name": "ClinVar_search_variants",
-                        "arguments": {"query": clinvar_query, "limit": 20},
+                        "arguments": {"gene": gene_for_gnomad, "limit": 20},
                     }
                 )
                 error = self._sub_call_error(r)
@@ -192,6 +204,34 @@ class CompoundVariantAnnotationTool(BaseTool):
             return str(result.get("error", "unknown error"))
         return None
 
+    def _resolve_gene_from_rsid(
+        self, tu, rsid: str, sources_failed: List[str]
+    ) -> Optional[str]:
+        """Resolve an rsid to its gene symbol via dbSNP, so ClinVar/CIViC/gnomAD/
+        UniProt (all gene-keyed, none rsid-keyed) can still be queried for an
+        rsid-only request. dbSNP's esummary response has no dedicated gene field --
+        the symbol is embedded in hgvs_notation as "...|GENE=SYMBOL:geneid" -- so
+        extract it from there."""
+        try:
+            r = tu.run_one_function(
+                {"name": "dbsnp_get_variant_by_rsid", "arguments": {"rsid": rsid}}
+            )
+            error = self._sub_call_error(r)
+            if error:
+                sources_failed.append(f"dbSNP (rsid->gene): {error[:100]}")
+                return None
+            hgvs = str((r.get("data") or {}).get("hgvs_notation", ""))
+            m = re.search(r"GENE=([A-Za-z0-9\-]+):", hgvs)
+            if not m:
+                sources_failed.append(
+                    f"dbSNP (rsid->gene): no gene found in hgvs_notation for {rsid}"
+                )
+                return None
+            return m.group(1)
+        except Exception as e:
+            sources_failed.append(f"dbSNP (rsid->gene): {str(e)[:100]}")
+            return None
+
     def _parse_clinvar(self, result: Any, variant_token: str = None) -> Dict[str, Any]:
         if not isinstance(result, dict):
             return {"raw": str(result)[:200]}
@@ -199,12 +239,14 @@ class CompoundVariantAnnotationTool(BaseTool):
         variants = data.get("variants", []) if isinstance(data, dict) else []
 
         def _row(v: Dict[str, Any]) -> Dict[str, Any]:
+            # Fix-R31A-3: ClinVar_search_variants rows never carry a "condition"
+            # key (confirmed live) -- condition/disease is a search filter on
+            # that tool, not a returned field, so this always silently read "".
             return {
                 "name": v.get("title", v.get("name", "")),
                 "classification": v.get(
                     "clinical_significance", v.get("classification", "")
                 ),
-                "condition": v.get("condition", ""),
                 "review_status": v.get("review_status", ""),
             }
 
@@ -271,15 +313,22 @@ class CompoundVariantAnnotationTool(BaseTool):
         }
 
     def _parse_uniprot(self, result: Any) -> Dict[str, Any]:
+        # Fix-R31A-4: UniProt_search's "data" is a dict with a "results" list
+        # (e.g. {"total_results": N, "results": [...]}), not itself a list --
+        # confirmed live this always fell through to the raw-repr-string escape
+        # hatch below, truncating mid-object. Field is also "gene_names" (a
+        # list), not "gene_name".
         if not isinstance(result, dict):
             return {"raw": str(result)[:200]}
         data = result.get("data", {})
-        if isinstance(data, list) and data:
-            entry = data[0]
+        results = data.get("results") if isinstance(data, dict) else None
+        if isinstance(results, list) and results:
+            entry = results[0]
+            gene_names = entry.get("gene_names") or []
             return {
                 "accession": entry.get("accession", ""),
                 "protein_name": entry.get("protein_name", ""),
-                "gene_name": entry.get("gene_name", ""),
+                "gene_name": gene_names[0] if gene_names else "",
                 "function": str(entry.get("function", ""))[:300],
             }
         return {"raw": str(data)[:200]}

--- a/src/tooluniverse/cpic_search_pairs_tool.py
+++ b/src/tooluniverse/cpic_search_pairs_tool.py
@@ -107,15 +107,43 @@ class CPICGetRecommendationsTool(BaseTool):
                 "recommendations": data,
                 "count": len(data),
             }
-            # Some guidelines use dosing algorithms rather than discrete recommendations.
-            # Guideline 100425 (warfarin) is the main example — it returns 0 rows here.
+            # Fix-R31C-3: this note used to fire whenever `data` was empty and
+            # always blame it on "guideline uses a dosing algorithm" -- but
+            # confirmed live that's wrong for a multi-drug guideline filtered
+            # to a specific drug (e.g. guideline 100416/CYP2D6-opioids has 66
+            # real recommendation rows, just none for methadone/buprenorphine/
+            # naltrexone specifically -- only codeine/tramadol/hydrocodone).
+            # Distinguish "no table at all" (the real dosing-algorithm case,
+            # e.g. warfarin/100425) from "table exists, not for this drug" by
+            # checking whether the guideline has any rows once the drug
+            # filter is dropped.
             if not data:
-                result["note"] = (
-                    f"No discrete recommendations found for guideline {guideline_id}. "
-                    "Some guidelines (e.g. warfarin, guideline 100425) use a dosing "
-                    "algorithm rather than a recommendation table. "
-                    "See https://cpicpgx.org/guidelines/ for the full guideline document."
-                )
+                guideline_has_other_rows = False
+                if rxnorm_id:
+                    try:
+                        check = requests.get(
+                            url,
+                            params={"guidelineid": f"eq.{guideline_id}", "limit": 1},
+                            timeout=30,
+                        )
+                        check.raise_for_status()
+                        guideline_has_other_rows = bool(check.json())
+                    except requests.exceptions.RequestException:
+                        pass
+                if guideline_has_other_rows:
+                    result["note"] = (
+                        f"Guideline {guideline_id} has recommendation rows for "
+                        f"other drugs it covers, but none specifically for "
+                        f"'{drug}'. See https://cpicpgx.org/guidelines/ for the "
+                        "full guideline document."
+                    )
+                else:
+                    result["note"] = (
+                        f"No discrete recommendations found for guideline {guideline_id}. "
+                        "Some guidelines (e.g. warfarin, guideline 100425) use a dosing "
+                        "algorithm rather than a recommendation table. "
+                        "See https://cpicpgx.org/guidelines/ for the full guideline document."
+                    )
             return {"status": "success", "data": result}
         except requests.exceptions.RequestException as e:
             return {"status": "error", "error": f"CPIC API error: {e}"}

--- a/src/tooluniverse/data/cpic_tools.json
+++ b/src/tooluniverse/data/cpic_tools.json
@@ -6,17 +6,29 @@
       "type": "object",
       "properties": {
         "symbol": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "Gene symbol (e.g., 'CYP2D6', 'CYP2C19', 'SLCO1B1', 'TPMT', 'DPYD')"
+        },
+        "gene": {
+          "type": ["string", "null"],
+          "description": "Gene symbol alias -- alternative to symbol."
+        },
+        "gene_symbol": {
+          "type": ["string", "null"],
+          "description": "Gene symbol alias -- alternative to symbol."
         }
       },
-      "required": [
-        "symbol"
+      "required": [],
+      "anyOf": [
+        {"required": ["symbol"]},
+        {"required": ["gene"]},
+        {"required": ["gene_symbol"]}
       ]
     },
     "fields": {
       "endpoint": "https://api.cpicpgx.org/v1/gene?symbol=eq.{symbol}",
-      "uppercase_params": ["symbol"]
+      "path_aliases": {"gene": "symbol", "gene_symbol": "symbol"},
+      "uppercase_params": ["symbol", "gene", "gene_symbol"]
     },
     "type": "BaseRESTTool",
     "test_examples": [

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -269,7 +269,7 @@
     },
     {
         "name": "OpenTargets_get_evidence_by_datasource",
-        "description": "Get target-disease evidence from Open Targets filtered by configurable data sources. Unlike OpenTargets_target_disease_evidence (intogen-only), this tool accepts any datasourceIds. Valid sources include: ot_genetics_portal, eva, eva_somatic, gene_burden, genomics_england, intogen, cancer_gene_census, chembl, crispr, europepmc, expression_atlas, gene2phenotype, orphanet, uniprot_literature, uniprot_variants, clingen, phewas_catalog, reactome, progeny, slapenrich, sysbio. Returns evidence rows with scores, literature references, and source attribution.",
+        "description": "Get target-disease evidence from Open Targets filtered by configurable data sources. Unlike OpenTargets_target_disease_evidence (intogen-only), this tool accepts any datasourceIds. Valid sources include: ot_genetics_portal, eva, eva_somatic, gene_burden, genomics_england, intogen, cancer_gene_census, clinical_precedence, crispr, europepmc, expression_atlas, gene2phenotype, orphanet, uniprot_literature, uniprot_variants, clingen, phewas_catalog, reactome, progeny, slapenrich, sysbio. Note: 'chembl' was renamed to 'clinical_precedence' upstream (confirmed live: 'chembl' now returns 0 rows even for well-documented drug-target-disease evidence). Returns evidence rows with scores, literature references, and source attribution.",
         "label": [
             "Target",
             "Disease",

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -245,8 +245,18 @@ class OpentargetTool(GraphQLTool):
 
         result = super().run(arguments)
 
-        # Add note when IntOGen evidence count is 0 (Feature-122B-002)
-        if result.get("status") == "success":
+        # Add note when IntOGen evidence count is 0 (Feature-122B-002).
+        # Fix-R31D-3: this note is IntOGen-specific but was applied to every
+        # tool built on this shared base class whenever evidences.count == 0
+        # -- confirmed live it fired for OpenTargets_get_evidence_by_datasource
+        # queried with datasourceIds=["chembl"], blaming IntOGen (never
+        # queried at all) for a zero count and even telling the caller to
+        # "use OpenTargets_get_evidence_by_datasource instead" while that IS
+        # the tool being called. Gate it to the actual IntOGen-only tool.
+        if (
+            result.get("status") == "success"
+            and self.tool_config.get("name") == "OpenTargets_target_disease_evidence"
+        ):
             evidences = result.get("data", {}).get("disease", {}).get("evidences", {})
             if isinstance(evidences, dict) and evidences.get("count") == 0:
                 result.setdefault("metadata", {})["note"] = (

--- a/tests/unit/test_base_rest_param_mapping.py
+++ b/tests/unit/test_base_rest_param_mapping.py
@@ -48,6 +48,36 @@ def test_mapped_value_overrides_default_param():
 
 
 @pytest.mark.unit
+def test_path_alias_is_consumed_not_leaked_into_query_params():
+    """Fix-R31B-3: an alias key (e.g. "gene" -> "symbol") left in args after
+    _build_url resolves it used to leak into _build_params as an
+    unrecognized query param -- confirmed live this isn't harmless:
+    PostgREST-backed APIs (e.g. CPIC) try to parse every query key as a
+    filter expression and 400 with "failed to parse filter" on it, breaking
+    the whole request."""
+    tool = _make_tool({"path_aliases": {"gene": "symbol"}})
+    args = {"gene": "CYP2D6"}
+    url = tool._build_url(args)
+    assert url == "https://example.org/api"  # endpoint has no {symbol} placeholder here
+    assert "gene" not in args
+    assert args["symbol"] == "CYP2D6"
+    params = tool._build_params(args)
+    assert "gene" not in params
+    assert params["symbol"] == "CYP2D6"
+
+
+@pytest.mark.unit
+def test_path_alias_consumed_even_when_canonical_already_present():
+    # Both the alias and the canonical name are supplied -- the alias must
+    # still be dropped so it doesn't leak as a stray query param.
+    tool = _make_tool({"path_aliases": {"gene": "symbol"}})
+    args = {"gene": "CYP2D6", "symbol": "CYP2D6"}
+    tool._build_url(args)
+    assert "gene" not in args
+    assert args["symbol"] == "CYP2D6"
+
+
+@pytest.mark.unit
 def test_no_param_mapping_is_unchanged():
     # Tools without a param_mapping field keep the previous behaviour.
     tool = _make_tool({})

--- a/tests/unit/test_compound_variant_tool.py
+++ b/tests/unit/test_compound_variant_tool.py
@@ -66,6 +66,51 @@ def test_parse_clinvar_falls_back_to_gene_context_when_no_exact_match():
     assert len(out["variants"]) == 2  # gene-level context, not empty
 
 
+def test_parse_clinvar_rows_have_no_condition_key():
+    """Fix-R31A-3: ClinVar_search_variants rows never carry a "condition"
+    field (confirmed live) -- condition is a search filter on that tool,
+    not something it returns. The old code silently emitted "condition": ""
+    for every row."""
+    t = _tool()
+    real = {"data": {"total_count": 1, "variants": [
+        {"title": "NM_004004.6(GJB2):c.283G>C (p.Val95Leu)", "clinical_significance": "VUS"}]}}
+    out = t._parse_clinvar(real)
+    assert "condition" not in out["variants"][0]
+
+
+def test_parse_uniprot_reads_results_list_not_bare_list():
+    """Fix-R31A-4: UniProt_search's "data" is a dict with a "results" list
+    ({"total_results": N, "results": [...]}), not itself a list -- confirmed
+    live this always fell through to the raw-repr-string escape hatch,
+    truncating mid-object. Field is "gene_names" (a list), not "gene_name"."""
+    t = _tool()
+    real = {
+        "status": "success",
+        "data": {
+            "total_results": 1,
+            "returned": 1,
+            "results": [
+                {
+                    "accession": "P05091",
+                    "protein_name": "Aldehyde dehydrogenase, mitochondrial",
+                    "gene_names": ["ALDH2"],
+                    "function": "Mitochondrial aldehyde dehydrogenase",
+                }
+            ],
+        },
+    }
+    out = t._parse_uniprot(real)
+    assert out["accession"] == "P05091"
+    assert out["gene_name"] == "ALDH2"
+    assert "raw" not in out
+
+
+def test_parse_uniprot_falls_back_to_raw_for_unexpected_shape():
+    t = _tool()
+    out = t._parse_uniprot({"status": "success", "data": {"unexpected": "shape"}})
+    assert "raw" in out
+
+
 def test_summary_does_not_misattribute_unmatched_clinvar_context():
     """Fix-T2A-001: when clinvar has no exact match, `variants` holds unrelated
     gene-level fallback context (see test_parse_clinvar_falls_back_...). The
@@ -195,3 +240,95 @@ def test_clinvar_classification_set_when_exact_match_true():
     }
     s = t._build_summary(annotations, variant="L858R", gene="EGFR")
     assert s["clinvar_classification"] == "Pathogenic"
+
+
+def test_clinvar_sub_call_uses_gene_param_not_query_alias():
+    """Fix-R31D-4/R31B-1: ClinVar_search_variants' "query" param is
+    documented as an alias for "condition" (a disease/phenotype search),
+    not a gene lookup -- confirmed live that querying gene names through
+    it only coincidentally matched conditions whose name happens to
+    contain the gene symbol (e.g. 40 rows for HOXB13 vs the real 1943 via
+    the dedicated "gene" param). The aggregator must use "gene" directly."""
+    t = _tool()
+    calls = []
+
+    def fake_run_one_function(call):
+        calls.append(call)
+        if call["name"] == "ClinVar_search_variants":
+            return {"status": "success", "data": {"total_count": 1943, "variants": []}}
+        return {"status": "error", "error": "not used in this test"}
+
+    with patch(
+        "tooluniverse.execute_function.ToolUniverse.run_one_function",
+        side_effect=fake_run_one_function,
+    ), patch("tooluniverse.execute_function.ToolUniverse.load_tools", return_value=None):
+        result = t.run({"gene": "HOXB13"})
+
+    clinvar_call = next(c for c in calls if c["name"] == "ClinVar_search_variants")
+    assert clinvar_call["arguments"] == {"gene": "HOXB13", "limit": 20}
+    assert result["data"]["annotations"]["clinvar"]["total_gene_variants"] == 1943
+
+
+def test_rsid_only_query_resolves_gene_via_dbsnp_before_other_sources():
+    """Fix-R31B-1: ClinVar/CIViC/gnomAD/UniProt are all gene-keyed, none
+    rsid-keyed (confirmed live: both ClinVar's "query" and "variant_id"
+    params return 0 rows for a bare rsid like "rs671" -- variant_id is
+    ClinVar's own internal numeric id, not a dbSNP rsid). An rsid-only
+    request must resolve to a gene via dbSNP first so the other sources
+    can still be queried, instead of silently skipping all of them."""
+    t = _tool()
+    calls = []
+
+    def fake_run_one_function(call):
+        calls.append(call)
+        if call["name"] == "dbsnp_get_variant_by_rsid":
+            return {
+                "status": "success",
+                "data": {"hgvs_notation": "...|GENE=ALDH2:217"},
+            }
+        if call["name"] == "gnomad_get_gene":
+            return {"status": "success", "data": {"gene": {"gene_id": "ENSG00000111275"}}}
+        return {"status": "success", "data": {}}
+
+    with patch(
+        "tooluniverse.execute_function.ToolUniverse.run_one_function",
+        side_effect=fake_run_one_function,
+    ), patch("tooluniverse.execute_function.ToolUniverse.load_tools", return_value=None):
+        result = t.run({"rsid": "rs671"})
+
+    called_names = [c["name"] for c in calls]
+    assert "dbsnp_get_variant_by_rsid" in called_names
+    assert "gnomad_get_gene" in called_names
+    gnomad_call = next(c for c in calls if c["name"] == "gnomad_get_gene")
+    assert gnomad_call["arguments"] == {"gene_symbol": "ALDH2"}
+    assert result["data"]["annotations"]["gnomad"]["gene_id"] == "ENSG00000111275"
+
+
+def test_resolve_gene_from_rsid_extracts_symbol_from_hgvs_notation():
+    t = _tool()
+    tu_mock_result = {
+        "status": "success",
+        "data": {"hgvs_notation": "HGVS=...|SEQ=[G/A]|LEN=1|GENE=ALDH2:217"},
+    }
+
+    class _FakeTU:
+        def run_one_function(self, call):
+            return tu_mock_result
+
+    sources_failed = []
+    gene = t._resolve_gene_from_rsid(_FakeTU(), "rs671", sources_failed)
+    assert gene == "ALDH2"
+    assert sources_failed == []
+
+
+def test_resolve_gene_from_rsid_records_failure_when_gene_not_found():
+    t = _tool()
+
+    class _FakeTU:
+        def run_one_function(self, call):
+            return {"status": "success", "data": {"hgvs_notation": "no gene marker here"}}
+
+    sources_failed = []
+    gene = t._resolve_gene_from_rsid(_FakeTU(), "rs9999999", sources_failed)
+    assert gene is None
+    assert len(sources_failed) == 1

--- a/tests/unit/test_cpic_brand_name_error.py
+++ b/tests/unit/test_cpic_brand_name_error.py
@@ -43,3 +43,55 @@ def test_missing_drug_and_guideline_id_keeps_original_error():
 
     assert result["status"] == "error"
     assert "Either guideline_id or drug name is required" in result["error"]
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.json.return_value = json_body
+    r.raise_for_status.return_value = None
+    return r
+
+
+class TestEmptyRecommendationNoteAccuracy:
+    """Regression guard for Fix-R31C-3: the "empty recommendations" note
+    always blamed "guideline uses a dosing algorithm rather than a table",
+    even for a multi-drug guideline (e.g. CYP2D6/opioids, 100416) filtered
+    down to a specific drug it doesn't have a row for -- confirmed live
+    that guideline has 66 real recommendation rows, just none for
+    methadone/buprenorphine/naltrexone (only codeine/tramadol/hydrocodone).
+    The note must now distinguish "no table at all" from "table exists,
+    not for this drug"."""
+
+    def test_drug_filtered_to_zero_rows_in_a_populated_guideline(self):
+        tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+
+        def fake_get(url, params=None, **kwargs):
+            if url.endswith("/drug"):
+                return _resp([{"guidelineid": 100416, "rxnormid": "6813"}])
+            if "drugid" in (params or {}):
+                return _resp([])  # filtered to this drug: no rows
+            return _resp([{"guidelineid": 100416}])  # unfiltered: guideline has rows
+
+        with patch(
+            "tooluniverse.cpic_search_pairs_tool.requests.get", side_effect=fake_get
+        ):
+            result = tool.run({"drug": "methadone"})
+
+        note = result["data"]["note"]
+        assert "other drugs it covers" in note
+        assert "dosing algorithm" not in note
+
+    def test_guideline_with_genuinely_no_table_keeps_dosing_algorithm_note(self):
+        tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+
+        def fake_get(url, params=None, **kwargs):
+            if url.endswith("/drug"):
+                return _resp([{"guidelineid": 100425, "rxnormid": "11289"}])
+            return _resp([])  # both the drug-filtered AND unfiltered checks are empty
+
+        with patch(
+            "tooluniverse.cpic_search_pairs_tool.requests.get", side_effect=fake_get
+        ):
+            result = tool.run({"drug": "warfarin"})
+
+        assert "dosing algorithm" in result["data"]["note"]

--- a/tests/unit/test_cpic_get_gene_info_aliases.py
+++ b/tests/unit/test_cpic_get_gene_info_aliases.py
@@ -1,0 +1,88 @@
+"""Regression guard for Fix-R31B-3: CPIC_get_gene_info only accepted a
+`symbol` parameter, unlike its sibling tool CPIC_search_gene_drug_pairs
+which already documents `gene`/`gene_symbol` as aliases -- confirmed live
+that the natural-language guess `{"gene": "CYP2D6"}` failed schema
+validation on this tool while working fine on the sibling. Added the same
+aliases via `fields.path_aliases` (mapped to the canonical `symbol` before
+the URL is built) plus an `anyOf` schema so any one of the three names
+satisfies validation.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.base_rest_tool import BaseRESTTool
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_config():
+    configs = json.loads((_DATA_DIR / "cpic_tools.json").read_text())
+    for cfg in configs:
+        if cfg["name"] == "CPIC_get_gene_info":
+            return cfg
+    raise AssertionError("CPIC_get_gene_info not found")
+
+
+def _tool():
+    return BaseRESTTool(_tool_config())
+
+
+class TestSchemaAcceptsAllAliases:
+    def test_symbol_alone_is_valid(self):
+        assert _tool().validate_parameters({"symbol": "CYP2D6"}) is None
+
+    def test_gene_alone_is_valid(self):
+        assert _tool().validate_parameters({"gene": "CYP2D6"}) is None
+
+    def test_gene_symbol_alone_is_valid(self):
+        assert _tool().validate_parameters({"gene_symbol": "CYP2D6"}) is None
+
+    def test_none_of_the_three_is_invalid(self):
+        assert _tool().validate_parameters({}) is not None
+
+
+class TestAliasResolvesToCanonicalUrlParam:
+    def test_gene_alias_builds_symbol_url_without_leaking_gene_param(self):
+        tool = _tool()
+        args = {"gene": "CYP2D6"}
+        url = tool._build_url(args)
+        params = tool._build_params(args)
+
+        assert "symbol=eq.CYP2D6" in url
+        assert "gene" not in params
+
+    def test_gene_symbol_alias_resolves_to_symbol_in_url(self):
+        tool = _tool()
+        args = {"gene_symbol": "CYP2C19"}
+        url = tool._build_url(args)
+
+        assert "symbol=eq.CYP2C19" in url
+
+    def test_run_uppercases_a_lowercase_gene_alias(self):
+        # End-to-end: run()'s uppercase_params step (Fix-R30E-3) must apply
+        # regardless of which alias name the caller used.
+        tool = _tool()
+        import unittest.mock as mock
+
+        captured = {}
+
+        def fake_request(session, method, url, **kwargs):
+            captured["url"] = url
+            resp = mock.MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = []
+            resp.headers = {"content-type": "application/json"}
+            resp.text = "[]"
+            return resp
+
+        with mock.patch(
+            "tooluniverse.base_rest_tool.request_with_retry", side_effect=fake_request
+        ):
+            tool.run({"gene": "cyp2d6"})
+
+        assert "symbol=eq.CYP2D6" in captured["url"]

--- a/tests/unit/test_graphql_tool_round26_fixes.py
+++ b/tests/unit/test_graphql_tool_round26_fixes.py
@@ -48,10 +48,11 @@ class TestRemoveNoneAndEmptyValues:
         assert cleaned == {"c": "keep", "d": [1, 2]}
 
 
-def _tool():
+def _tool(name="OpenTargets_get_associated_diseases_by_target_ensemblID"):
     tool = OpentargetTool.__new__(OpentargetTool)
     tool.endpoint_url = "https://api.platform.opentargets.org/api/v4/graphql"
     tool.query_schema = "query searchStudies($diseaseIds: [String!]) { studies { count } }"
+    tool.tool_config = {"name": name}
     return tool
 
 
@@ -86,5 +87,43 @@ class TestLegacyEfoStudiesNote:
             return_value={"status": "success", "data": {"studies": {"count": 0}}},
         ):
             result = tool.run({"diseaseIds": ["MONDO_9999999"]})
+
+        assert "metadata" not in result or "note" not in result.get("metadata", {})
+
+
+class TestIntOGenNoteNotMisattributed:
+    """Regression guard for Fix-R31D-3: the IntOGen "0 evidence rows" note
+    (Feature-122B-002, above) was applied to EVERY OpentargetTool-based tool
+    whenever evidences.count == 0, not just the actual IntOGen-only tool
+    (OpenTargets_target_disease_evidence). Confirmed live: querying
+    OpenTargets_get_evidence_by_datasource with datasourceIds=["chembl"]
+    (a datasource IntOGen never touches) got the note blaming IntOGen for
+    the zero count -- even telling the caller to "use
+    OpenTargets_get_evidence_by_datasource instead" while that IS the tool
+    being called."""
+
+    def _zero_evidence_result(self):
+        return {
+            "status": "success",
+            "data": {"disease": {"id": "MONDO_0005233", "evidences": {"count": 0}}},
+        }
+
+    def test_note_fires_for_the_real_intogen_tool(self):
+        tool = _tool(name="OpenTargets_target_disease_evidence")
+        with patch(
+            "tooluniverse.graphql_tool.GraphQLTool.run",
+            return_value=self._zero_evidence_result(),
+        ):
+            result = tool.run({"efoId": "EFO_0001360"})
+
+        assert "IntOGen" in result["metadata"]["note"]
+
+    def test_note_does_not_fire_for_other_evidence_tools(self):
+        tool = _tool(name="OpenTargets_get_evidence_by_datasource")
+        with patch(
+            "tooluniverse.graphql_tool.GraphQLTool.run",
+            return_value=self._zero_evidence_result(),
+        ):
+            result = tool.run({"efoId": "MONDO_0005233", "datasourceIds": ["chembl"]})
 
         assert "metadata" not in result or "note" not in result.get("metadata", {})

--- a/tests/unit/test_opentargets_evidence_datasource_description.py
+++ b/tests/unit/test_opentargets_evidence_datasource_description.py
@@ -1,0 +1,35 @@
+"""Regression guard for Fix-R31D-2: OpenTargets_get_evidence_by_datasource's
+description listed "chembl" as a valid datasourceId, but confirmed live
+that "chembl" now returns 0 rows on the current Open Targets platform even
+for well-documented drug-target-disease evidence (e.g. EGFR/non-small cell
+lung carcinoma), while "clinical_precedence" -- not listed -- returns the
+real data. GraphQL introspection against the target's own evidence rows
+confirmed "clinical_precedence" is the current id; "chembl" appears
+retired/renamed upstream.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_config(name):
+    configs = json.loads((_DATA_DIR / "opentarget_tools.json").read_text())
+    for cfg in configs:
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found")
+
+
+def test_description_no_longer_lists_retired_chembl_datasource():
+    cfg = _tool_config("OpenTargets_get_evidence_by_datasource")
+    valid_sources_text = cfg["description"]
+    assert "clinical_precedence" in valid_sources_text
+    # "chembl" is still mentioned (as a note that it was renamed), but must
+    # not appear as a bare comma-separated entry in the valid-sources list.
+    assert ", chembl," not in valid_sources_text


### PR DESCRIPTION
## Note on base branch

This PR targets `test-harness/round-30-domain-sweep` (PR #327), not `main`, since PR #326 (rounds 1-29 consolidated) and PR #327 (round 30) are both still open/unmerged and this round was branched from #327's tip to avoid rediscovering/duplicate-fixing bugs already resolved there. Once #326 and #327 merge into `main`, this PR should be retargeted to `main`. The diff below is round 31's changes only.

## Summary

Round 31 of the test-harness sweep: 5 role-play researcher personas exercised otolaryngology/hearing genetics, nutritional genomics, addiction medicine pharmacogenomics, urology/GU oncology genetics, and vaccine immunology -- domains not previously covered. All 5 hit the same recurring session-wide MCP-server environment issue (stale uv cache) and worked around it via the CLI fallback. Notably, 4 different personas independently hit distinct bugs concentrated in one shared tool.

## Fixes

- **annotate_variant_multi_source** (`CompoundVariantAnnotationTool`), three sub-fixes found by 3 different personas:
  - ClinVar sub-call used `query` (documented as an alias for `condition`, a disease-name search), not the dedicated `gene` parameter -- confirmed live this only *coincidentally* matched conditions whose name happened to contain the gene symbol (40 rows for HOXB13 vs the real 1943 via the correct `gene` param). Also added rsid→gene resolution via dbSNP, since none of ClinVar/CIViC/gnomAD/UniProt are rsid-keyed (confirmed live both `query` and `variant_id` set to a bare rsid return 0 rows) -- an rsid-only query no longer silently skips every source.
  - ClinVar result rows always had `"condition": ""` -- confirmed live `ClinVar_search_variants` never returns a condition field at all (it's a search filter on that tool, not a returned field). Removed the misleading always-empty key.
  - UniProt parsing expected `data` to itself be a list; the real shape is a dict with a `results` list -- confirmed live this always fell through to a truncated Python `repr()` string instead of parsed fields.
- **OpenTargets_get_evidence_by_datasource**: the `chembl` datasourceId is retired upstream (confirmed live + via GraphQL evidence introspection: `clinical_precedence` is the current id covering the same drug-evidence category) -- updated the description's valid-sources list. Also fixed a shared bug in `graphql_tool.py`: the IntOGen-specific "0 evidence rows" note fired for *any* `OpentargetTool`-based tool with a zero count, not just the actual IntOGen tool -- confirmed live it misattributed a zero count from this tool's own `chembl` query to IntOGen (never queried), even telling the caller to "use OpenTargets_get_evidence_by_datasource instead" while that IS the tool being called.
- **CPIC_get_gene_info**: added `gene`/`gene_symbol` aliases for `symbol`, matching the sibling tool `CPIC_search_gene_drug_pairs`' existing alias pattern. While implementing this, found and fixed a real bug in the shared `BaseRESTTool` `path_aliases` mechanism it depends on: an alias key wasn't removed from `args` after being mapped to its canonical name, so it leaked into the query string as an unrecognized param -- confirmed live this isn't harmless, PostgREST-backed APIs (CPIC) try to parse every query key as a filter and 400 with "failed to parse filter" on it, breaking the whole request.
- **CPIC_get_recommendations**: the "no recommendations found" note always claimed "this guideline uses a dosing algorithm rather than a recommendation table" whenever the drug-filtered result was empty -- confirmed live this is wrong for a multi-drug guideline filtered to a drug it doesn't cover (e.g. CYP2D6/opioids guideline 100416 has 66 real recommendation rows, just none for methadone/buprenorphine/naltrexone, only codeine/tramadol/hydrocodone). Now distinguishes "no table at all" from "table exists, not for this drug".

## Deferred (documented, not fixed this round)

- `EVA_get_variants_by_gene`'s response size (per-sample genotype dumps making a 30-variant response ~474k lines) -- real usability issue but a larger-scope fix (would need a summary/compact mode).
- Orphanet has no disease-name-to-ORPHA-code resolution tool, so `Orphanet_get_genes` silently returns empty for a disease name instead of a numeric code -- a genuine coverage gap, not a code bug in the existing tool.
- `search_clinical_trials` intermittently returning a JSON-decode error disguised as "no studies found" -- plausible but not reliably reproduced this round.
- `OpenTargets_get_associated_targets_by_disease_efoId`'s lack of pagination despite the API supporting it, `dbsnp_search_by_gene`'s lack of relevance ordering, HPA nTPM fields returning null even for well-characterized genes (not independently verified against the live HPA UI), `dbsnp_get_variant_by_rsid`'s always-"N" allele field, and `CPIC_get_drug_info`'s silent empty result for brand names -- lower-severity or larger-scope items.
- Recurring MCP `execute_tool` TLS-cert-path and tool-type-registry-desync failures, and `find_tools`/`grep_tools` surfacing renamed/nonexistent tool names -- environment/deployment issues outside this repo, recurring across every round.
- **Two false positives caught via live re-verification**: (1) a persona reported `IEDB_predict_mhcii_binding`'s `percentile_rank` always 100.0 -- this exact bug was already fixed in an earlier round and the current code correctly maps `rank`→`percentile_rank` (confirmed live for the exact peptide cited in the report). (2) a persona reported `ClinGen_get_variant_classifications` taking ~230s for GJB2 -- the current code responds in ~3.7s, matching round 29's fix; likely a transient environment issue during that persona's session, not a regression.

## Test plan

- [x] 12 new/updated mocked unit test files covering every fix above
- [x] Full `tests/unit` suite green (only the usual environmental skips)
- [x] Every fix CLI-verified live against the real upstream API before and after the change
- [x] code-simplifier pass applied (one redundant nested-if simplified, rest already clean)