### PR TITLE
Fix Round 32: CPIC empty-result note, ChEMBL adalimumab ID, MARRVEL gene aliases, HPA tissue-panel note

### DIFF
--- a/src/tooluniverse/base_rest_tool.py
+++ b/src/tooluniverse/base_rest_tool.py
@@ -371,6 +371,22 @@ class BaseRESTTool(BaseTool):
                     result["data"] = data[: int(limit)]
                     result["count"] = int(limit)
 
+            # Fix-R32C-4/5: an exact-match backend (e.g. CPIC's PostgREST
+            # name=eq.{name}) silently returns status:success with an empty
+            # list for any name that isn't spelled/named exactly as the
+            # database stores it -- confirmed live for well-known aliases
+            # ("FK506" for tacrolimus) and spelling variants ("cyclosporin"
+            # vs the indexed "cyclosporine"), indistinguishable from "no PGx
+            # data exists for this drug". `fields.empty_result_note` lets a
+            # config surface the real constraint instead of a bare empty list.
+            empty_note = self.tool_config.get("fields", {}).get("empty_result_note")
+            if (
+                empty_note
+                and isinstance(result.get("data"), list)
+                and not result["data"]
+            ):
+                result["note"] = empty_note
+
             return result
 
         except Exception as e:

--- a/src/tooluniverse/data/chembl_tools.json
+++ b/src/tooluniverse/data/chembl_tools.json
@@ -1231,7 +1231,7 @@
         },
         "molecule_chembl_id": {
           "type": "string",
-          "description": "Filter by ChEMBL molecule ID (e.g., \"CHEMBL1201581\" for adalimumab)."
+          "description": "Filter by ChEMBL molecule ID (e.g., \"CHEMBL1201580\" for adalimumab)."
         }
       },
       "required": []
@@ -1286,7 +1286,7 @@
         },
         "drug_chembl_id": {
           "type": "string",
-          "description": "ChEMBL drug/molecule ID (e.g., \"CHEMBL1201581\" for adalimumab, \"CHEMBL4535757\" for sotorasib)."
+          "description": "ChEMBL drug/molecule ID (e.g., \"CHEMBL1201580\" for adalimumab, \"CHEMBL4535757\" for sotorasib)."
         },
         "drug_name": {
           "type": "string",

--- a/src/tooluniverse/data/cpic_tools.json
+++ b/src/tooluniverse/data/cpic_tools.json
@@ -304,7 +304,8 @@
     },
     "fields": {
       "endpoint": "https://api.cpicpgx.org/v1/drug?name=eq.{name}",
-      "lowercase_params": ["name"]
+      "lowercase_params": ["name"],
+      "empty_result_note": "No exact match for this name in CPIC. CPIC indexes one canonical spelling/name per drug (e.g. 'cyclosporine' not 'cyclosporin', 'tacrolimus' not the alternate name 'FK506') -- try CPIC_list_drugs or CPIC_search_gene_drug_pairs to browse indexed names."
     },
     "type": "BaseRESTTool",
     "test_examples": [

--- a/src/tooluniverse/data/hpa_tools.json
+++ b/src/tooluniverse/data/hpa_tools.json
@@ -847,7 +847,7 @@
       ]
     },
     "input_description": "Input Ensembl Gene ID (e.g., ENSG00000134057). This enhanced tool now uses HPA's direct JSON API for more comprehensive and faster data retrieval.",
-    "output_description": "Returns gene information in compatible JSON format including Ensembl ID, gene name, gene synonyms, Uniprot ID, biological process annotations, and comprehensive RNA tissue-specific expression data.",
+    "output_description": "Returns gene information in compatible JSON format including Ensembl ID, gene name, gene synonyms, Uniprot ID, biological process annotations, and RNA tissue-specific expression data. Note: 'RNA tissue specific nTPM' only lists tissues HPA classifies as tissue-enriched/-enhanced for this gene (confirmed live, e.g. only 3 tissues for CFTR: gallbladder, intestine, pancreas) -- it is NOT a full per-tissue expression panel, so a tissue's absence does not mean zero expression there. Use HPA_get_comprehensive_gene_details_by_ensembl_id or GTEx tools for a complete tissue expression profile.",
     "test_examples": [
       {
         "ensembl_id": "ENSG00000141510"

--- a/src/tooluniverse/data/marrvel_tools.json
+++ b/src/tooluniverse/data/marrvel_tools.json
@@ -3,8 +3,12 @@
         "name": "MARRVEL_get_gene",
         "description": "Get aggregated identity and annotation for a human gene by symbol from MARRVEL: cross-references (OMIM, HGNC, Ensembl, Entrez, UniProt), chromosome/cytogenetic location, gene type, aliases, previous symbols, and the Entrez gene summary. Use as a one-call gene-identity resolver in rare-disease / Mendelian variant triage workflows. No API key required.",
         "parameter": {"type": "object", "properties": {
-            "symbol": {"type": "string", "description": "HGNC gene symbol, e.g. 'CFTR', 'BRCA1'."}
-        }, "required": ["symbol"]},
+            "symbol": {"type": ["string", "null"], "description": "HGNC gene symbol, e.g. 'CFTR', 'BRCA1'."},
+            "gene_symbol": {"type": ["string", "null"], "description": "Alias for symbol."},
+            "gene": {"type": ["string", "null"], "description": "Alias for symbol."}
+        }, "required": [], "anyOf": [
+            {"required": ["symbol"]}, {"required": ["gene_symbol"]}, {"required": ["gene"]}
+        ]},
         "fields": {"timeout": 30},
         "type": "MARRVELGeneTool",
         "test_examples": [{"symbol": "CFTR"}, {"symbol": "BRCA1"}, {"symbol": "TP53"}],
@@ -19,8 +23,12 @@
         "name": "MARRVEL_get_omim_phenotypes",
         "description": "Get OMIM phenotype/disease associations for a human gene by symbol via MARRVEL: each association's phenotype name, gene and phenotype MIM numbers, mode of inheritance, and phenotypic series. Use to enumerate the Mendelian diseases linked to a gene and their inheritance patterns. No API key required.",
         "parameter": {"type": "object", "properties": {
-            "symbol": {"type": "string", "description": "HGNC gene symbol, e.g. 'CFTR', 'BRCA1'."}
-        }, "required": ["symbol"]},
+            "symbol": {"type": ["string", "null"], "description": "HGNC gene symbol, e.g. 'CFTR', 'BRCA1'."},
+            "gene_symbol": {"type": ["string", "null"], "description": "Alias for symbol."},
+            "gene": {"type": ["string", "null"], "description": "Alias for symbol."}
+        }, "required": [], "anyOf": [
+            {"required": ["symbol"]}, {"required": ["gene_symbol"]}, {"required": ["gene"]}
+        ]},
         "fields": {"timeout": 30},
         "type": "MARRVELOmimTool",
         "test_examples": [{"symbol": "CFTR"}, {"symbol": "FBN1"}, {"symbol": "LMNA"}],

--- a/src/tooluniverse/marrvel_tool.py
+++ b/src/tooluniverse/marrvel_tool.py
@@ -20,6 +20,20 @@ MARRVEL_BASE = "http://api.marrvel.org/data"
 HUMAN_TAXON = "9606"
 
 
+def _resolve_symbol(arguments: Dict[str, Any]) -> str:
+    # Fix-R32B-4: unlike most other gene-input tools in this codebase
+    # (DGIdb, OpenTargets, ensembl_lookup_gene, ...), these tools only
+    # accepted the bare "symbol" param with no gene/gene_symbol alias --
+    # confirmed live that the natural-language guess {"gene_symbol":
+    # "PTPN22"} failed schema validation entirely.
+    return (
+        arguments.get("symbol")
+        or arguments.get("gene_symbol")
+        or arguments.get("gene")
+        or ""
+    ).strip()
+
+
 @register_tool("MARRVELGeneTool")
 class MARRVELGeneTool(BaseTool):
     """Aggregated identity/annotation for a human gene by symbol."""
@@ -29,7 +43,7 @@ class MARRVELGeneTool(BaseTool):
         self.timeout = tool_config.get("fields", {}).get("timeout", 30)
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        symbol = (arguments.get("symbol") or "").strip()
+        symbol = _resolve_symbol(arguments)
         if not symbol:
             return {"status": "error", "error": "'symbol' (e.g. 'CFTR') is required"}
 
@@ -101,7 +115,7 @@ class MARRVELOmimTool(BaseTool):
         self.timeout = tool_config.get("fields", {}).get("timeout", 30)
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        symbol = (arguments.get("symbol") or "").strip()
+        symbol = _resolve_symbol(arguments)
         if not symbol:
             return {"status": "error", "error": "'symbol' (e.g. 'CFTR') is required"}
 

--- a/tests/unit/test_base_rest_param_mapping.py
+++ b/tests/unit/test_base_rest_param_mapping.py
@@ -111,3 +111,77 @@ def test_auth_param_keeps_default_token_when_env_unset(monkeypatch):
     monkeypatch.delenv("WAQI_API_KEY", raising=False)
     params = tool._build_params({"city": "Boston"})
     assert params["token"] == "demo"
+
+
+@pytest.mark.unit
+def test_empty_result_note_added_when_data_is_empty_list(monkeypatch):
+    """Fix-R32C-4/5: an exact-match backend (e.g. CPIC's PostgREST
+    name=eq.{name}) silently returns status:success with an empty list for
+    any name not spelled/named exactly as the database stores it --
+    confirmed live for well-known aliases ("FK506" for tacrolimus) and
+    spelling variants ("cyclosporin" vs the indexed "cyclosporine"),
+    indistinguishable from "no PGx data exists for this drug".
+    `fields.empty_result_note` surfaces the real constraint."""
+    import unittest.mock as mock
+
+    tool = _make_tool({"empty_result_note": "No exact match; try the canonical name."})
+
+    def fake_request(session, method, url, **kwargs):
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = []
+        resp.headers = {"content-type": "application/json"}
+        resp.text = "[]"
+        return resp
+
+    with mock.patch(
+        "tooluniverse.base_rest_tool.request_with_retry", side_effect=fake_request
+    ):
+        result = tool.run({"name": "FK506"})
+
+    assert result["note"] == "No exact match; try the canonical name."
+
+
+@pytest.mark.unit
+def test_empty_result_note_absent_when_data_is_non_empty(monkeypatch):
+    import unittest.mock as mock
+
+    tool = _make_tool({"empty_result_note": "No exact match; try the canonical name."})
+
+    def fake_request(session, method, url, **kwargs):
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = [{"name": "cyclosporine"}]
+        resp.headers = {"content-type": "application/json"}
+        resp.text = '[{"name": "cyclosporine"}]'
+        return resp
+
+    with mock.patch(
+        "tooluniverse.base_rest_tool.request_with_retry", side_effect=fake_request
+    ):
+        result = tool.run({"name": "cyclosporine"})
+
+    assert "note" not in result
+
+
+@pytest.mark.unit
+def test_no_empty_result_note_configured_is_unchanged():
+    # Tools without empty_result_note keep the previous behaviour (no note).
+    import unittest.mock as mock
+
+    tool = _make_tool({})
+
+    def fake_request(session, method, url, **kwargs):
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = []
+        resp.headers = {"content-type": "application/json"}
+        resp.text = "[]"
+        return resp
+
+    with mock.patch(
+        "tooluniverse.base_rest_tool.request_with_retry", side_effect=fake_request
+    ):
+        result = tool.run({"name": "whatever"})
+
+    assert "note" not in result

--- a/tests/unit/test_discovery_resource_tools_batch2.py
+++ b/tests/unit/test_discovery_resource_tools_batch2.py
@@ -103,6 +103,42 @@ def test_marrvel_omim_curates_phenotypes():
     assert out["data"][0]["phenotype_mim_number"] == 219700
 
 
+# Fix-R32B-4: unlike DGIdb/OpenTargets/ensembl_lookup_gene/etc., these two
+# MARRVEL tools only accepted the bare "symbol" param with no gene/
+# gene_symbol alias -- confirmed live the natural-language guess
+# {"gene_symbol": "PTPN22"} failed schema validation entirely.
+def test_marrvel_gene_accepts_gene_symbol_alias():
+    rec = {"symbol": "CFTR", "xref": {}}
+    with patch("tooluniverse.marrvel_tool.requests.get", return_value=_resp(200, rec)):
+        out = MARRVELGeneTool(_cfg("MARRVEL_get_gene", "MARRVELGeneTool")).run(
+            {"gene_symbol": "CFTR"}
+        )
+    assert out["status"] == "success"
+
+
+def test_marrvel_gene_accepts_gene_alias():
+    rec = {"symbol": "CFTR", "xref": {}}
+    with patch("tooluniverse.marrvel_tool.requests.get", return_value=_resp(200, rec)):
+        out = MARRVELGeneTool(_cfg("MARRVEL_get_gene", "MARRVELGeneTool")).run(
+            {"gene": "CFTR"}
+        )
+    assert out["status"] == "success"
+
+
+def test_marrvel_omim_accepts_gene_symbol_alias():
+    body = {"phenotypes": []}
+    with patch("tooluniverse.marrvel_tool.requests.get", return_value=_resp(200, body)):
+        out = MARRVELOmimTool(_cfg("MARRVEL_get_omim_phenotypes", "MARRVELOmimTool")).run(
+            {"gene_symbol": "PTPN22"}
+        )
+    assert out["status"] == "success"
+
+
+def test_marrvel_omim_still_requires_some_gene_identifier():
+    out = MARRVELOmimTool(_cfg("MARRVEL_get_omim_phenotypes", "MARRVELOmimTool")).run({})
+    assert out["status"] == "error"
+
+
 # --------------------------- CTIS --------------------------- #
 def test_ctis_search_requires_query():
     out = CTISSearchTrialsTool(_cfg("CTIS_search_trials", "CTISSearchTrialsTool")).run({})

--- a/tests/unit/test_round32_config_fixes.py
+++ b/tests/unit/test_round32_config_fixes.py
@@ -1,0 +1,51 @@
+"""Config-content regression guards for two Round 32 fixes that don't need
+a live/mocked tool run to verify -- just that the JSON config says the
+right thing.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_config(filename, name):
+    configs = json.loads((_DATA_DIR / filename).read_text())
+    for cfg in configs:
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found in {filename}")
+
+
+class TestCpicDrugInfoEmptyResultNote:
+    def test_empty_result_note_is_configured(self):
+        cfg = _tool_config("cpic_tools.json", "CPIC_get_drug_info")
+        note = cfg["fields"]["empty_result_note"]
+        assert "cyclosporine" in note
+        assert "FK506" in note
+
+
+class TestChemblAdalimumabExampleIdCorrected:
+    """Fix-R32B-7: multiple tool descriptions in chembl_tools.json claimed
+    CHEMBL1201581 was adalimumab -- confirmed live via ChEMBL_get_drug that
+    CHEMBL1201581 is actually infliximab ("Infliximab (chimeric mab)"), and
+    CHEMBL1201580 is the real adalimumab (confirmed via its "D2E7"
+    development-code biotherapeutic description and "Abrilada" biosimilar
+    synonym). A researcher trusting the old example would silently pull
+    the wrong drug's mechanism-of-action data."""
+
+    def test_search_drugs_example_uses_correct_adalimumab_id(self):
+        cfg = _tool_config("chembl_tools.json", "ChEMBL_search_drugs")
+        desc = cfg["parameter"]["properties"]["molecule_chembl_id"]["description"]
+        assert "CHEMBL1201580" in desc
+        assert "CHEMBL1201581" not in desc
+
+    def test_get_drug_mechanisms_example_uses_correct_adalimumab_id(self):
+        cfg = _tool_config("chembl_tools.json", "ChEMBL_get_drug_mechanisms")
+        desc = cfg["parameter"]["properties"]["drug_chembl_id"]["description"]
+        assert "CHEMBL1201580" in desc
+        assert "CHEMBL1201581" not in desc


### PR DESCRIPTION
## Summary

Fourth round-tool-sweep in this stacking chain (based on #328 / round 31's branch tip, since #326/#327/#328 remain unmerged). 4 confirmed, live-verified fixes from 3 researcher-persona role-play sessions (pulmonology, rheumatology, transplant medicine pharmacogenomics -- the session's subagent spawn cap was hit mid-round, so only 3 of the planned 5 personas ran).

- **base_rest_tool.py**: new generic `fields.empty_result_note` mechanism -- surfaces an explanatory note when an exact-match backend returns an empty list, instead of building a growing per-drug alias table.
- **cpic_tools.json**: `CPIC_get_drug_info` now explains that CPIC indexes one canonical name per drug (e.g. "cyclosporine" not "cyclosporin", "tacrolimus" not "FK506") via the new `empty_result_note` field. Live-verified: `{"name": "FK506"}` now returns the note; `{"name": "cyclosporine"}` (a real match) does not.
- **chembl_tools.json**: corrected two tool descriptions that misidentified `CHEMBL1201581` as adalimumab -- it's actually infliximab (confirmed via `ChEMBL_get_drug` showing `"Infliximab (chimeric mab)"`). `CHEMBL1201580` is the real adalimumab (confirmed via its "D2E7" development code and "Abrilada" biosimilar synonym).
- **marrvel_tool.py / marrvel_tools.json**: `MARRVEL_get_gene` and `MARRVEL_get_omim_phenotypes` now accept `gene`/`gene_symbol` aliases -- the natural-language guess `{"gene_symbol": "PTPN22"}` previously failed schema validation entirely, unlike every other gene-input tool in the codebase. Live-verified against CFTR and PTPN22.
- **hpa_tools.json**: `HPA_get_gene_basic_info_by_ensembl_id`'s description now clarifies that "RNA tissue specific nTPM" only lists tissues HPA classifies as enriched/enhanced (confirmed live: only 3 tissues returned for CFTR -- gallbladder, intestine, pancreas), not a full per-tissue panel, and points to the comprehensive-details tool / GTEx for full coverage.

## Deferred / false positives this round

- All three personas independently reported the OpenTargets IntOGen note-misattribution bug already fixed in round 31 (`graphql_tool.py`) -- re-verified live in this worktree multiple times, the fix is present and no misattributed note appears. No action needed.
- `IPD_search_hla_alleles` claimed nonexistent by one persona -- re-verified live, the tool exists and returns correct real HLA allele data.
- `ClinGen_get_variant_classifications` claimed to hang 10+ minutes even on its own BRCA1 test example -- re-verified live, both CFTR (4.45s) and BRCA1 (3.0s) return quickly using the current (post round-29) endpoint.

## Test plan

- [x] New/updated unit tests for `empty_result_note` (added/absent/unconfigured cases), MARRVEL gene/gene_symbol alias handling (both tools), and config-content regression guards for the CPIC note text and corrected ChEMBL IDs -- all mocked, no network calls.
- [x] Full `tests/unit` suite passes with only the standard ~11 environmental skips (scanpy not installed x2, no-tools-loaded/no-instantiable-tools fixtures x7, one resource-exhaustion deselect, `ClinVar_get_clinical_significance` import gap) -- zero failures.