### PR TITLE
Fix Round 33: HPA comprehensive-details optional flags, DailyMed limit alias

### DIFF
--- a/src/tooluniverse/dailymed_tool.py
+++ b/src/tooluniverse/dailymed_tool.py
@@ -43,7 +43,11 @@ class SearchSPLTool(BaseTool):
         if arguments.get("published_date_eq"):
             params["published_date[eq]"] = arguments["published_date_eq"]
 
-        params["pagesize"] = arguments.get("pagesize", 100)
+        # Fix-R33A-1: "limit" is the dominant pagination param name across
+        # ToolUniverse (CPIC, ClinVar, GWAS, ...), so a caller guessing it
+        # here instead of DailyMed's own "pagesize" was silently ignored --
+        # confirmed live (limit=3 still returned all 44 isoniazid labels).
+        params["pagesize"] = arguments.get("pagesize") or arguments.get("limit") or 100
         params["page"] = arguments.get("page", 1)
 
         try:

--- a/src/tooluniverse/data/dailymed_tools.json
+++ b/src/tooluniverse/data/dailymed_tools.json
@@ -36,6 +36,10 @@
           "description": "Number of items per page, maximum 100, default 100.",
           "default": 100
         },
+        "limit": {
+          "type": ["integer", "null"],
+          "description": "Alias for pagesize."
+        },
         "page": {
           "type": "integer",
           "description": "Page number, starts from 1, default 1.",

--- a/src/tooluniverse/data/hpa_tools.json
+++ b/src/tooluniverse/data/hpa_tools.json
@@ -319,22 +319,22 @@
         },
         "include_images": {
           "type": "boolean",
-          "description": "Whether to include image URL information (immunofluorescence, cell line images, etc.), defaults to true."
+          "description": "Whether to include image URL information (immunofluorescence, cell line images, etc.), defaults to true.",
+          "default": true
         },
         "include_antibodies": {
           "type": "boolean",
-          "description": "Whether to include detailed antibody information (validation status, Western blot data, etc.), defaults to true."
+          "description": "Whether to include detailed antibody information (validation status, Western blot data, etc.), defaults to true.",
+          "default": true
         },
         "include_expression": {
           "type": "boolean",
-          "description": "Whether to include detailed expression data (tissue specificity, subcellular localization, etc.), defaults to true."
+          "description": "Whether to include detailed expression data (tissue specificity, subcellular localization, etc.), defaults to true.",
+          "default": true
         }
       },
       "required": [
-        "ensembl_id",
-        "include_images",
-        "include_antibodies",
-        "include_expression"
+        "ensembl_id"
       ]
     },
     "input_description": "Input Ensembl Gene ID (e.g., ENSG00000064787). The tool will parse HPA's single gene XML page to get the most comprehensive data. Optionally include detailed information for images, antibodies, and expression data.",

--- a/tests/unit/test_dailymed_search_spls_limit_alias.py
+++ b/tests/unit/test_dailymed_search_spls_limit_alias.py
@@ -1,0 +1,52 @@
+"""Regression guard for Fix-R33A-1: DailyMed_search_spls only recognized its
+own "pagesize" param, so a caller guessing the far more common ToolUniverse
+pagination name "limit" (used by CPIC, ClinVar, GWAS, ...) was silently
+ignored -- confirmed live, {"drug_name": "isoniazid", "limit": 3} returned
+all 44 matching labels instead of 3.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.dailymed_tool import SearchSPLTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return SearchSPLTool({"name": "DailyMed_search_spls", "parameter": {"properties": {}}})
+
+
+def _resp():
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"data": [], "metadata": {}}
+    return resp
+
+
+def test_limit_alias_maps_to_pagesize():
+    tool = _tool()
+    with patch("tooluniverse.dailymed_tool.requests.get", return_value=_resp()) as mock_get:
+        tool.run({"drug_name": "isoniazid", "limit": 3})
+
+    params = mock_get.call_args.kwargs["params"]
+    assert params["pagesize"] == 3
+
+
+def test_pagesize_still_takes_precedence_over_limit():
+    tool = _tool()
+    with patch("tooluniverse.dailymed_tool.requests.get", return_value=_resp()) as mock_get:
+        tool.run({"drug_name": "isoniazid", "pagesize": 5, "limit": 3})
+
+    params = mock_get.call_args.kwargs["params"]
+    assert params["pagesize"] == 5
+
+
+def test_no_pagination_arg_defaults_to_100():
+    tool = _tool()
+    with patch("tooluniverse.dailymed_tool.requests.get", return_value=_resp()) as mock_get:
+        tool.run({"drug_name": "isoniazid"})
+
+    params = mock_get.call_args.kwargs["params"]
+    assert params["pagesize"] == 100

--- a/tests/unit/test_hpa_comprehensive_gene_details_optional_flags.py
+++ b/tests/unit/test_hpa_comprehensive_gene_details_optional_flags.py
@@ -1,0 +1,37 @@
+"""Regression guard for Fix-R33A-2: HPA_get_comprehensive_gene_details_by_
+ensembl_id's schema marked include_images/include_antibodies/include_expression
+as required, even though their descriptions promise "defaults to true" and the
+Python run() already reads them via arguments.get(..., True). Any caller who
+omitted them (the natural reading of "defaults to true") hit a hard schema
+validation error before the tool's own default logic ever ran -- confirmed
+live for a bare {"ensembl_id": ...} call.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_config():
+    configs = json.loads((_DATA_DIR / "hpa_tools.json").read_text())
+    for cfg in configs:
+        if cfg["name"] == "HPA_get_comprehensive_gene_details_by_ensembl_id":
+            return cfg
+    raise AssertionError("HPA_get_comprehensive_gene_details_by_ensembl_id not found")
+
+
+def test_only_ensembl_id_is_required():
+    cfg = _tool_config()
+    assert cfg["parameter"]["required"] == ["ensembl_id"]
+
+
+def test_optional_flags_carry_a_matching_default():
+    cfg = _tool_config()
+    props = cfg["parameter"]["properties"]
+    for name in ("include_images", "include_antibodies", "include_expression"):
+        assert props[name]["default"] is True


### PR DESCRIPTION
## Summary

Fifth round-tool-sweep in this stacking chain (based on #329 / round 32's branch tip, since #326/#327/#328/#329 remain unmerged). The session's subagent spawn cap (200/200) was still fully exhausted this round (confirmed by a direct retry that failed identically), so this round's persona role-play investigation was done directly via CLI across 3 domains -- ophthalmology/inherited retinal disease genetics, endocrinology/diabetes pharmacogenomics, hepatology/drug-induced liver injury pharmacogenomics -- instead of spawning researcher subagents.

2 confirmed fixes, both live-verified against upstream APIs before and after:

- **hpa_tools.json**: `HPA_get_comprehensive_gene_details_by_ensembl_id` required `include_images`/`include_antibodies`/`include_expression` in its schema even though every one of their descriptions promises "defaults to true" and the Python `run()` already reads them via `arguments.get(x, True)`. Any caller who took the description at its word and omitted them hit a hard schema validation error before the tool's own default logic ever ran. Live-verified: `{"ensembl_id": "ENSG00000156313"}` (RPGR) previously failed with `'include_images' is a required property`; now succeeds and returns the full comprehensive record. Removed the three flags from `required` and added matching `"default": true` schema entries.
- **dailymed_tool.py / dailymed_tools.json**: `DailyMed_search_spls` only recognized its own `pagesize` param. A caller guessing `limit` -- the dominant pagination param name across ToolUniverse (CPIC, ClinVar, GWAS, ...) -- was silently ignored with no error: `{"drug_name": "isoniazid", "limit": 3}` returned all 44 matching labels instead of 3. Added `limit` as an alias for `pagesize`.

## Also investigated, confirmed correct (no action needed)

- ClinVar gene searches for RPGR, ABCB11, ATP7B -- all return real, correctly-shaped data.
- CPIC drug/allele lookups for glimepiride and HLA-B gene-drug pairs, including a direct confirmation that round 31's "guideline covers other drugs, not this one" note (from PR #328) fires correctly for glimepiride's own G6PD guideline record.
- GWAS Catalog SNP lookups for TCF7L2, PubMed literature search, DailyMed SPL search -- all working.

## Test plan

- [x] New mocked unit tests for both fixes: `limit`/`pagesize` precedence and default fallback (DailyMed); required-array and default-value config checks (HPA).
- [x] Full `tests/unit` suite passes with only the standard ~11 environmental skips (scanpy not installed x2, no-tools-loaded/no-instantiable-tools fixtures x7, one resource-exhaustion deselect, `ClinVar_get_clinical_significance` import gap) -- zero failures.