### PR TITLE
Fix Round 34: IEDB MHC-II binding endpoint hard-errors on short sequences

### DIFF
--- a/src/tooluniverse/data/iedb_prediction_tools.json
+++ b/src/tooluniverse/data/iedb_prediction_tools.json
@@ -94,6 +94,10 @@
           "type": "string",
           "description": "Prediction method: 'netmhciipan_el' (recommended), 'netmhciipan_ba', 'nn_align'",
           "default": "netmhciipan_el"
+        },
+        "length": {
+          "type": ["integer", "null"],
+          "description": "Sliding-window peptide length IEDB scores within 'sequence'. IEDB defaults this to 15 server-side and errors if 'sequence' is shorter than it; omit to auto-match the sequence's own length when it's under 15."
         }
       },
       "required": [

--- a/src/tooluniverse/iedb_prediction_tool.py
+++ b/src/tooluniverse/iedb_prediction_tool.py
@@ -326,6 +326,19 @@ class IEDBPredictionTool(BaseTool):
             "sequence_text": sequence,
             "allele": allele,
         }
+        # Fix-R34A-1: IEDB's mhcii endpoint defaults its sliding-window
+        # length to 15 server-side and hard-errors on any shorter sequence
+        # ("length of input sequence is less than the input/default length
+        # 15") -- confirmed live, including against this tool's own <15-
+        # residue test example. Unlike the MHC-I methods in this file,
+        # this endpoint never exposed a length override. Auto-shrink the
+        # window to the sequence's own length when it's under 15, mirroring
+        # the MHC-I `length` param.
+        length = arguments.get("length")
+        if length is None and len(sequence) < 15:
+            length = len(sequence)
+        if length is not None:
+            data["length"] = str(length)
 
         resp = requests.post(
             f"{IEDB_TOOLS_BASE}/mhcii/",

--- a/tests/unit/test_iedb_mhcii_fixes.py
+++ b/tests/unit/test_iedb_mhcii_fixes.py
@@ -112,3 +112,47 @@ def test_empty_response_is_reported_as_error():
         result = tool.run({"sequence": "A" * 20, "allele": "HLA-DRB1*01:01"})
 
     assert result["status"] == "error"
+
+
+# Fix-R34A-1: IEDB's mhcii endpoint defaults its sliding-window length to 15
+# server-side and hard-errors on any shorter sequence -- confirmed live,
+# including against this tool's own registered <15-residue test example
+# ("PKYVKQNTLKLAT", 13 residues). Unlike the MHC-I methods in this file,
+# this endpoint never passed a length override even though IEDB's API
+# accepts one (confirmed live: length=13 makes the same short peptide
+# succeed). Auto-shrink the window to the sequence's own length when it's
+# under 15.
+_TSV = "allele\tseq_num\tstart\tend\tlength\tcore_peptide\tpeptide\tscore\trank\nHLA-DRB1*01:01\t1\t1\t13\t13\tYVKQNTLKL\tPKYVKQNTLKLAT\t0.8871\t0.23\n"
+
+
+def test_short_sequence_auto_shrinks_length_param():
+    tool = _tool("predict_mhcii")
+    with patch(
+        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp(_TSV)
+    ) as mock_post:
+        result = tool.run({"sequence": "PKYVKQNTLKLAT", "allele": "HLA-DRB1*01:01"})
+
+    assert result["status"] == "success"
+    assert mock_post.call_args.kwargs["data"]["length"] == "13"
+
+
+def test_long_sequence_omits_length_param_by_default():
+    tool = _tool("predict_mhcii")
+    with patch(
+        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp(_TSV)
+    ) as mock_post:
+        tool.run({"sequence": "A" * 20, "allele": "HLA-DRB1*01:01"})
+
+    assert "length" not in mock_post.call_args.kwargs["data"]
+
+
+def test_explicit_length_argument_takes_precedence():
+    tool = _tool("predict_mhcii")
+    with patch(
+        "tooluniverse.iedb_prediction_tool.requests.post", return_value=_resp(_TSV)
+    ) as mock_post:
+        tool.run(
+            {"sequence": "A" * 20, "allele": "HLA-DRB1*01:01", "length": 11}
+        )
+
+    assert mock_post.call_args.kwargs["data"]["length"] == "11"


### PR DESCRIPTION
## Summary

Sixth round-tool-sweep in this stacking chain (based on #330 / round 33's branch tip, since #326-#330 remain unmerged). The session's subagent spawn cap remains fully exhausted (now confirmed across 3 consecutive rounds), so this round's investigation was again done directly via CLI across 3 domains: cardiology/inherited arrhythmia and cardiomyopathy genetics, neurology/epilepsy pharmacogenomics, infectious disease/antimicrobial resistance genomics.

1 confirmed fix, live-verified before and after:

- **iedb_prediction_tool.py / iedb_prediction_tools.json**: IEDB's `mhcii` endpoint defaults its sliding-window scoring length to 15 residues server-side and hard-errors on any shorter sequence (`"The length of input sequence is less than the input/default length 15."`) -- confirmed live, including against this tool's own registered test example (`"PKYVKQNTLKLAT"`, 13 residues). Unlike the sibling MHC-I methods in the same file, this endpoint never exposed IEDB's own supported `length` override parameter, so any short peptide always failed with no way to work around it. Auto-shrinks the window to the sequence's own length when it's under 15, and exposes `length` in the schema for explicit control, mirroring the MHC-I pattern. Live-verified: the tool's own example now succeeds (`percentile_rank: 0.23`, strong binder), and a normal-length sequence still defaults to window=15 with no regression.

## Also investigated, confirmed correct (no action needed)

- ClinVar gene searches for KCNQ1 (Long QT) and SCN1A (Dravet syndrome).
- CPIC recommendations for clopidogrel (CYP2C19), carbamazepine (HLA-A/B), and abacavir (HLA-B*57:01).
- gnomAD constraint metrics for MYH7 (hypertrophic cardiomyopathy).
- BV-BRC antimicrobial-resistance phenotype and specialty-gene searches (MRSA, blaKPC, M. tuberculosis resistance genes).
- GTEx expression and ClinGen variant classifications for SCN1A (fast, correct).
- Orphanet name search for Brugada syndrome.
- This also reconfirmed two earlier-round fixes still work correctly on fresh real-world cases: round 32's MARRVEL `gene_symbol` alias (KCNQ1 OMIM phenotypes) and round 31's CPIC "guideline covers other drugs, not this one" note.

## Test plan

- [x] New mocked unit tests for the length auto-shrink/override behavior (short-sequence auto-fill, long-sequence no-op, explicit override takes precedence).
- [x] Full `tests/unit` suite passes with only the standard ~11 environmental skips (scanpy not installed x2, no-tools-loaded/no-instantiable-tools fixtures x7, one resource-exhaustion deselect, `ClinVar_get_clinical_significance` import gap) -- zero failures.