### PR TITLE
Fix Round 35: CPIC drug-name resolution silently substituted a different drug

### DIFF
--- a/src/tooluniverse/cpic_search_pairs_tool.py
+++ b/src/tooluniverse/cpic_search_pairs_tool.py
@@ -35,8 +35,25 @@ def _resolve_drug_to_guideline_id(
         )
         r.raise_for_status()
         rows = r.json()
-        if rows and rows[0].get("guidelineid"):
-            return rows[0]["guidelineid"], rows[0].get("rxnormid")
+        if not rows:
+            return None
+        # Fix-R35C-1: substring `ilike` matching picks a false first hit
+        # whenever one drug name is a substring of another -- confirmed
+        # live for "citalopram" (a substring of "escitalopram") and
+        # "phenytoin" (a substring of "fosphenytoin"): querying the shorter
+        # name silently returned the OTHER drug's guideline/rxnorm id
+        # because it happened to sort first in CPIC's unordered response,
+        # so CPIC_get_recommendations returned a different drug's dosing
+        # guidance with no indication of the substitution. Prefer an exact
+        # case-insensitive match; only fall back to the first fuzzy hit
+        # when no exact match exists (genuine partial/typo queries).
+        exact = next(
+            (row for row in rows if row.get("name", "").lower() == drug_name.lower()),
+            None,
+        )
+        row = exact or rows[0]
+        if row.get("guidelineid"):
+            return row["guidelineid"], row.get("rxnormid")
     except Exception:
         pass
     return None

--- a/tests/unit/test_cpic_brand_name_error.py
+++ b/tests/unit/test_cpic_brand_name_error.py
@@ -10,7 +10,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tooluniverse.cpic_search_pairs_tool import CPICGetRecommendationsTool
+from tooluniverse.cpic_search_pairs_tool import (
+    CPICGetRecommendationsTool,
+    _resolve_drug_to_guideline_id,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -95,3 +98,79 @@ class TestEmptyRecommendationNoteAccuracy:
             result = tool.run({"drug": "warfarin"})
 
         assert "dosing algorithm" in result["data"]["note"]
+
+
+class TestExactMatchPreferredOverSubstring:
+    """Regression guard for Fix-R35C-1: CPIC's /drug lookup used a fuzzy
+    `ilike.*name*` substring match and always took the first result --
+    confirmed live that querying "citalopram" (a substring of
+    "escitalopram") silently returned escitalopram's guideline/rxnorm id
+    instead, because escitalopram happened to sort first in CPIC's
+    unordered response. Same collision confirmed for "phenytoin" (a
+    substring of "fosphenytoin"). A clinician asking for one drug's dosing
+    guidance would silently receive a different, related drug's guidance
+    with no indication of the substitution."""
+
+    def test_exact_match_wins_over_a_substring_match_sorted_first(self):
+        # escitalopram sorts before citalopram in the fuzzy result set, but
+        # querying "citalopram" must resolve to citalopram's own record.
+        rows = [
+            {"name": "escitalopram", "guidelineid": 100413, "rxnormid": "321988"},
+            {"name": "citalopram", "guidelineid": 100413, "rxnormid": "2556"},
+        ]
+        resp = MagicMock()
+        resp.json.return_value = rows
+        resp.raise_for_status.return_value = None
+
+        with patch(
+            "tooluniverse.cpic_search_pairs_tool.requests.get", return_value=resp
+        ):
+            guideline_id, rxnorm_id = _resolve_drug_to_guideline_id("citalopram")
+
+        assert guideline_id == 100413
+        assert rxnorm_id == "2556"
+
+    def test_no_exact_match_falls_back_to_first_fuzzy_hit(self):
+        rows = [{"name": "escitalopram", "guidelineid": 100413, "rxnormid": "321988"}]
+        resp = MagicMock()
+        resp.json.return_value = rows
+        resp.raise_for_status.return_value = None
+
+        with patch(
+            "tooluniverse.cpic_search_pairs_tool.requests.get", return_value=resp
+        ):
+            guideline_id, rxnorm_id = _resolve_drug_to_guideline_id("citalop")
+
+        assert guideline_id == 100413
+        assert rxnorm_id == "321988"
+
+    def test_end_to_end_recommendations_use_the_exact_drug(self):
+        tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+
+        def fake_get(url, params=None, **kwargs):
+            if url.endswith("/drug"):
+                return _resp(
+                    [
+                        {
+                            "name": "fosphenytoin",
+                            "guidelineid": 100412,
+                            "rxnormid": "72236",
+                        },
+                        {
+                            "name": "phenytoin",
+                            "guidelineid": 100412,
+                            "rxnormid": "8183",
+                        },
+                    ]
+                )
+            assert params.get("drugid") == "eq.RxNorm:8183"
+            return _resp(
+                [{"drugid": "RxNorm:8183", "drug": {"name": "phenytoin"}}]
+            )
+
+        with patch(
+            "tooluniverse.cpic_search_pairs_tool.requests.get", side_effect=fake_get
+        ):
+            result = tool.run({"drug": "phenytoin"})
+
+        assert result["data"]["recommendations"][0]["drug"]["name"] == "phenytoin"


### PR DESCRIPTION
## Summary

Seventh round-tool-sweep in this stacking chain (based on #331 / round 34's branch tip, since #326-#331 remain unmerged). The session's subagent spawn cap remains fully exhausted (4th consecutive round), so this round's investigation was again done directly via CLI across 3 domains: hematology-oncology/leukemia genomics, nephrology/CKD genetics, psychiatry/psychopharmacogenomics.

1 confirmed fix, live-verified before and after -- **higher severity than a typical round's findings**, since it silently substitutes one drug's clinical guidance for another's rather than merely ignoring a param or hard-erroring:

- **cpic_search_pairs_tool.py**: `CPIC_get_recommendations` resolves a drug name to a guideline/rxnorm id via a fuzzy `ilike.*name*` substring match against CPIC's `/drug` table, then blindly takes the first result row. Whenever one drug's name is a substring of another's, this silently resolves to the WRONG drug with no indication of the substitution: querying `"citalopram"` returned **escitalopram's** guideline/rxnorm id (confirmed live -- `"citalopram"` is a substring of `"escitalopram"`, which happened to sort first in CPIC's unordered response), so every recommendation row that came back was for escitalopram's dosing guidance, not citalopram's. Confirmed the same collision independently for `"phenytoin"` (a substring of `"fosphenytoin"`). A clinician asking for one drug's CYP2C19/CYP2D6 dosing guidance would silently receive a different, related-but-distinct drug's guidance instead. Fixed by preferring an exact case-insensitive name match over the first fuzzy hit, with the fuzzy fallback preserved for genuine partial/typo queries (e.g. `"citalop"`).

## Also investigated, confirmed correct (no action needed)

- ClinVar gene searches for FLT3 (AML) and COL4A5 (Alport syndrome).
- gnomAD constraint metrics for APOL1; GWAS Catalog SNPs for APOL1; MARRVEL OMIM phenotypes for APOL1 (FSGS).
- OncoKB variant annotation for FLT3 (correctly reports its demo-mode-unavailable warning, confirming an earlier round's fix still holds) and BRAF (real demo-mode data).
- CPIC recommendations for amitriptyline (no collision); CPIC's clean rejection of a non-indexed drug (aripiprazole) with an actionable error message.

## Test plan

- [x] New mocked unit tests: exact match wins over a substring match sorted first, fuzzy fallback still applies when no exact match exists, and an end-to-end `CPIC_get_recommendations` call resolves to the exact requested drug.
- [x] Full `tests/unit` suite passes with only the standard ~11 environmental skips (scanpy not installed x2, no-tools-loaded/no-instantiable-tools fixtures x7, one resource-exhaustion deselect, `ClinVar_get_clinical_significance` import gap) -- zero failures.