### PR TITLE
Fix Round 36: seven DatasetTool-typed tools wrongly required params with real defaults

### DIFF
--- a/src/tooluniverse/data/dataset_tools.json
+++ b/src/tooluniverse/data/dataset_tools.json
@@ -22,29 +22,28 @@
           "items": {
             "type": "string"
           },
-          "description": "Fields to search in. Available fields: 'DrugBank ID', 'Accession Numbers', 'Common name', 'CAS', 'UNII', 'Synonyms', 'Standard InChI Key'."
+          "description": "Fields to search in. Available fields: 'DrugBank ID', 'Accession Numbers', 'Common name', 'CAS', 'UNII', 'Synonyms', 'Standard InChI Key'. Defaults to ['Common name', 'Synonyms', 'DrugBank ID']."
         },
         "case_sensitive": {
           "type": "boolean",
-          "description": "Whether the search should be case sensitive."
+          "description": "Whether the search should be case sensitive.",
+          "default": false
         },
         "exact_match": {
           "type": "boolean",
-          "description": "Whether to perform exact matching instead of substring matching."
+          "description": "Whether to perform exact matching instead of substring matching.",
+          "default": false
         },
         "limit": {
           "type": "integer",
           "description": "Maximum number of results to return.",
           "minimum": 1,
-          "maximum": 1000
+          "maximum": 1000,
+          "default": 10
         }
       },
       "required": [
-        "query",
-        "search_fields",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "query_schema": {
@@ -164,7 +163,7 @@
       "properties": {
         "field": {
           "type": "string",
-          "description": "The field to filter on",
+          "description": "The field to filter on. Defaults to 'Common name'.",
           "enum": [
             "DrugBank ID",
             "Accession Numbers",
@@ -173,18 +172,20 @@
             "UNII",
             "Synonyms",
             "Standard InChI Key"
-          ]
+          ],
+          "default": "Common name"
         },
         "condition": {
           "type": "string",
-          "description": "The type of filtering condition to apply. Filter is case-insensitive.",
+          "description": "The type of filtering condition to apply. Filter is case-insensitive. Defaults to 'contains'.",
           "enum": [
             "contains",
             "starts_with",
             "ends_with",
             "exact",
             "not_empty"
-          ]
+          ],
+          "default": "contains"
         },
         "value": {
           "type": "string",
@@ -194,14 +195,11 @@
           "type": "integer",
           "description": "Maximum number of results to return.",
           "minimum": 1,
-          "maximum": 1000
+          "maximum": 1000,
+          "default": 10
         }
       },
-      "required": [
-        "field",
-        "condition",
-        "limit"
-      ]
+      "required": []
     },
     "query_schema": {
       "field": "Common name",
@@ -315,29 +313,28 @@
           "items": {
             "type": "string"
           },
-          "description": "Columns to search in. Choose from: 'drugbank_id', 'name', 'synonyms'."
+          "description": "Columns to search in. Choose from: 'drugbank_id', 'name', 'synonyms'. Defaults to ['name', 'synonyms', 'drugbank_id']."
         },
         "case_sensitive": {
           "type": "boolean",
-          "description": "Match text with exact case if true."
+          "description": "Match text with exact case if true.",
+          "default": false
         },
         "exact_match": {
           "type": "boolean",
-          "description": "Field value must equal query exactly if true; otherwise substring match."
+          "description": "Field value must equal query exactly if true; otherwise substring match.",
+          "default": false
         },
         "limit": {
           "type": "integer",
           "description": "Max number of rows to return.",
           "minimum": 1,
-          "maximum": 1000
+          "maximum": 1000,
+          "default": 10
         }
       },
       "required": [
-        "query",
-        "search_fields",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "query_schema": {
@@ -518,29 +515,28 @@
           "items": {
             "type": "string"
           },
-          "description": "Columns to search. Choose from: 'DrugBank ID', 'Name', 'CAS Number', 'Drug Type', 'KEGG Compound ID', 'KEGG Drug ID', 'PubChem Compound ID', 'PubChem Substance ID', 'ChEBI ID', 'PharmGKB ID', 'HET ID', 'UniProt ID', 'Wikipedia ID', 'Drugs.com Link', 'NDC ID', 'ChemSpider ID', 'BindingDB ID', 'TTD ID'."
+          "description": "Columns to search. Choose from: 'DrugBank ID', 'Name', 'CAS Number', 'Drug Type', 'KEGG Compound ID', 'KEGG Drug ID', 'PubChem Compound ID', 'PubChem Substance ID', 'ChEBI ID', 'PharmGKB ID', 'HET ID', 'UniProt ID', 'Wikipedia ID', 'Drugs.com Link', 'NDC ID', 'ChemSpider ID', 'BindingDB ID', 'TTD ID'. Defaults to ['DrugBank ID', 'Name']."
         },
         "case_sensitive": {
           "type": "boolean",
-          "description": "Match text with exact case if true."
+          "description": "Match text with exact case if true.",
+          "default": false
         },
         "exact_match": {
           "type": "boolean",
-          "description": "Field value must equal query exactly if true; otherwise substring match."
+          "description": "Field value must equal query exactly if true; otherwise substring match.",
+          "default": false
         },
         "limit": {
           "type": "integer",
           "description": "Maximum number of rows to return.",
           "minimum": 1,
-          "maximum": 1000
+          "maximum": 1000,
+          "default": 10
         }
       },
       "required": [
-        "query",
-        "search_fields",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "query_schema": {
@@ -766,29 +762,28 @@
           "items": {
             "type": "string"
           },
-          "description": "Columns to search. Choose from: 'Trade Name', 'Generic/Proper Name(s)', 'Active Ingredient(s)'."
+          "description": "Columns to search. Choose from: 'Trade Name', 'Generic/Proper Name(s)', 'Active Ingredient(s)'. Defaults to all three."
         },
         "case_sensitive": {
           "type": "boolean",
-          "description": "Match text with exact case if true."
+          "description": "Match text with exact case if true.",
+          "default": false
         },
         "exact_match": {
           "type": "boolean",
-          "description": "Field value must equal query exactly if true; otherwise substring match."
+          "description": "Field value must equal query exactly if true; otherwise substring match.",
+          "default": false
         },
         "limit": {
           "type": "integer",
           "description": "Maximum number of rows to return.",
           "minimum": 1,
-          "maximum": 1000
+          "maximum": 1000,
+          "default": 10
         }
       },
       "required": [
-        "query",
-        "search_fields",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "query_schema": {
@@ -916,29 +911,28 @@
           "items": {
             "type": "string"
           },
-          "description": "Columns to search. Choose from: 'Compound Name'."
+          "description": "Columns to search. Choose from: 'Compound Name'. Defaults to ['Compound Name']."
         },
         "case_sensitive": {
           "type": "boolean",
-          "description": "Match text with exact case if true."
+          "description": "Match text with exact case if true.",
+          "default": false
         },
         "exact_match": {
           "type": "boolean",
-          "description": "Field value must equal query exactly if true; otherwise substring match."
+          "description": "Field value must equal query exactly if true; otherwise substring match.",
+          "default": false
         },
         "limit": {
           "type": "integer",
           "description": "Maximum number of rows to return.",
           "minimum": 1,
-          "maximum": 1000
+          "maximum": 1000,
+          "default": 10
         }
       },
       "required": [
-        "query",
-        "search_fields",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "query_schema": {
@@ -1045,29 +1039,28 @@
           "items": {
             "type": "string"
           },
-          "description": "Columns to search. Choose from: 'Generic/Proper Name(s)', 'DrugBank ID'."
+          "description": "Columns to search. Choose from: 'Generic/Proper Name(s)', 'DrugBank ID'. Defaults to both."
         },
         "case_sensitive": {
           "type": "boolean",
-          "description": "Match text with exact case if true."
+          "description": "Match text with exact case if true.",
+          "default": false
         },
         "exact_match": {
           "type": "boolean",
-          "description": "Field value must equal query exactly if true; otherwise substring match."
+          "description": "Field value must equal query exactly if true; otherwise substring match.",
+          "default": false
         },
         "limit": {
           "type": "integer",
           "description": "Maximum number of rows to return.",
           "minimum": 1,
-          "maximum": 1000
+          "maximum": 1000,
+          "default": 100
         }
       },
       "required": [
-        "query",
-        "search_fields",
-        "case_sensitive",
-        "exact_match",
-        "limit"
+        "query"
       ]
     },
     "query_schema": {

--- a/tests/unit/test_dataset_tool_optional_params.py
+++ b/tests/unit/test_dataset_tool_optional_params.py
@@ -1,0 +1,137 @@
+"""Regression guard for Fix-R36A-1: every `DatasetTool`-typed tool
+(drugbank_vocab_search, drugbank_vocab_filter, drugbank_full_search,
+drugbank_links_search, dict_search, dili_search, diqt_search) marked
+search_fields/case_sensitive/exact_match/limit (or field/condition/limit
+for the filter variant) as schema-`required`, even though every one of
+them has a real, working default value in the tool's own `query_schema`
+config block and DatasetTool.run() already merges those defaults in
+before applying caller-supplied overrides (`query_params =
+deepcopy(self.query_schema)` then overlay `arguments`). Any caller who
+supplied only the one truly-essential param (`query`, or `field`+
+`condition` for the filter tool) hit a hard schema validation error
+before the tool's own default-merging logic ever ran -- confirmed live,
+e.g. dict_search({"query": "terfenadine"}) previously failed outright.
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from tooluniverse.dataset_tool import DatasetTool
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+_DATASET_TOOL_NAMES = [
+    "drugbank_vocab_search",
+    "drugbank_vocab_filter",
+    "drugbank_full_search",
+    "drugbank_links_search",
+    "dict_search",
+    "dili_search",
+    "diqt_search",
+]
+
+
+def _tool_config(name):
+    configs = json.loads((_DATA_DIR / "dataset_tools.json").read_text())
+    for cfg in configs:
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found in dataset_tools.json")
+
+
+@pytest.mark.parametrize("name", _DATASET_TOOL_NAMES)
+def test_required_params_are_only_the_ones_without_a_query_schema_default(name):
+    cfg = _tool_config(name)
+    required = set(cfg["parameter"]["required"])
+    query_schema_keys = set(cfg.get("query_schema", {}).keys())
+    # Nothing that has a query_schema default should still be required.
+    assert not (required & query_schema_keys)
+
+
+def test_search_tools_still_require_query():
+    for name in (
+        "drugbank_vocab_search",
+        "drugbank_full_search",
+        "drugbank_links_search",
+        "dict_search",
+        "dili_search",
+        "diqt_search",
+    ):
+        cfg = _tool_config(name)
+        assert cfg["parameter"]["required"] == ["query"]
+
+
+def test_filter_tool_has_no_required_params():
+    cfg = _tool_config("drugbank_vocab_filter")
+    assert cfg["parameter"]["required"] == []
+
+
+def _make_search_tool():
+    tool = DatasetTool.__new__(DatasetTool)
+    tool.tool_config = {"name": "dict_search"}
+    tool.query_schema = {
+        "search_fields": ["Trade Name", "Generic/Proper Name(s)"],
+        "case_sensitive": False,
+        "exact_match": False,
+        "limit": 10,
+    }
+    tool.parameters = {
+        "query": {},
+        "search_fields": {},
+        "case_sensitive": {},
+        "exact_match": {},
+        "limit": {},
+    }
+    tool.dataset = pd.DataFrame(
+        {
+            "Trade Name": ["Seldane"],
+            "Generic/Proper Name(s)": ["Terfenadine"],
+        }
+    )
+    return tool
+
+
+def test_query_only_call_uses_query_schema_defaults_end_to_end():
+    tool = _make_search_tool()
+    result = tool.run({"query": "terfenadine"})
+
+    assert "error" not in result
+    assert result["total_results"] == 1
+    assert result["search_parameters"]["search_fields"] == [
+        "Trade Name",
+        "Generic/Proper Name(s)",
+    ]
+    assert result["search_parameters"]["limit"] == 10
+
+
+def _make_filter_tool():
+    tool = DatasetTool.__new__(DatasetTool)
+    tool.tool_config = {"name": "drugbank_vocab_filter"}
+    tool.query_schema = {"field": "Common name", "condition": "contains", "limit": 10}
+    tool.parameters = {"field": {}, "condition": {}, "value": {}, "limit": {}}
+    tool.dataset = pd.DataFrame({"Common name": ["Aspirin", "Ibuprofen"]})
+    return tool
+
+
+def test_filter_empty_args_falls_back_to_defaults_and_reports_missing_value():
+    tool = _make_filter_tool()
+    result = tool.run({})
+
+    # field/condition/limit all resolved from query_schema with no schema
+    # error; the only real gap (a missing "value" for "contains") is caught
+    # by the tool's own runtime validation with an actionable message.
+    assert result["status"] == "error"
+    assert "value" in result["error"]
+    assert "contains" in result["error"]
+
+
+def test_filter_with_not_empty_condition_needs_no_value():
+    tool = _make_filter_tool()
+    result = tool.run({"condition": "not_empty"})
+
+    assert "error" not in result
+    assert result["total_matches"] == 2


### PR DESCRIPTION
## Summary

Eighth round-tool-sweep in this stacking chain (based on #332 / round 35's branch tip, since #326-#332 remain unmerged). The session's subagent spawn cap remains fully exhausted (5th consecutive round), so this round's investigation was again done directly via CLI across 3 domains: medical genetics/prenatal screening, immunology/primary immunodeficiency genetics, toxicology/environmental exposure genetics.

Round 36 opened by systematically re-probing other fuzzy-name-resolution helpers across the codebase, per the lesson from round 35's CPIC substring-collision bug (`cryoet_tool.py`, `iedb_tool.py`, `drugcentral_tool.py`, `gwas_tool.py`) -- all confirmed safe, either exact match by design or a multi-result filter shown to the caller rather than a silent single-row pick. A useful negative result, not a wasted check.

1 confirmed fix affecting **7 tools that share one root cause** -- live-verified before and after:

- **dataset_tools.json**: `drugbank_vocab_search`, `drugbank_vocab_filter`, `drugbank_full_search`, `drugbank_links_search`, `dict_search`, `dili_search`, and `diqt_search` are all built on the same generic `DatasetTool` class, whose `run()` starts from `deepcopy(self.query_schema)` (a config block with real, working defaults for every non-essential param) and only then overlays whatever the caller supplied. Every one of these tools' JSON schemas still marked `search_fields`/`case_sensitive`/`exact_match`/`limit` (or `field`/`condition`/`limit` for the filter variant) as `required`, blocking that default-merging logic from ever running for a caller who -- reasonably -- supplied only the truly essential param. Confirmed live: `dict_search({"query": "terfenadine"})` previously failed outright with a schema validation error despite the tool being fully capable of answering with just that one argument (and correctly did once fixed, returning terfenadine's real DICTrank cardiotoxicity record -- terfenadine is a classic QT-prolongation/Torsades de Pointes example). Same bug class as an earlier round's HPA comprehensive-details fix, this time caught systemically across a whole shared tool type at once. Fixed by removing the over-required params from each tool's `required` array (keeping `query` for the six search-style tools; `drugbank_vocab_filter` needs nothing, since `field`/`condition`/`limit` all default too and `value` already had its own clear runtime validation for when it's genuinely needed).

## Also investigated, confirmed correct (no action needed)

- ClinVar gene searches for SMN1 (SMA) and IL2RG (X-SCID).
- Orphanet name search for 22q11.2 deletion syndrome (DiGeorge).
- GenCC gene-disease validity for TBX1.
- MARRVEL OMIM phenotypes for BTK (X-linked agammaglobulinemia).
- IEDB B-cell epitope prediction on its own documented example.
- ADMETAI toxicity prediction correctly reporting its missing optional ML dependency rather than failing silently.

## Test plan

- [x] New config-content regression tests asserting every `DatasetTool`-typed tool's `required` array contains only params without a `query_schema` default, plus end-to-end mocked functional tests for the search and filter code paths with minimal arguments.
- [x] Full `tests/unit` suite passes with only the standard ~11 environmental skips (scanpy not installed x2, no-tools-loaded/no-instantiable-tools fixtures x7, one resource-exhaustion deselect, `ClinVar_get_clinical_significance` import gap) -- zero failures.