### PR TITLE
Fix Round 37: disease_target_score tools wrongly required pageSize

### DIFF
--- a/src/tooluniverse/data/disease_target_score_tools.json
+++ b/src/tooluniverse/data/disease_target_score_tools.json
@@ -21,8 +21,7 @@
       },
       "required": [
         "efoId",
-        "datasourceId",
-        "pageSize"
+        "datasourceId"
       ]
     },
     "query_schema": "query getTargets($efoId: String!, $index: Int!, $size: Int!) { disease(efoId: $efoId) { id name associatedTargets(page: { index: $index, size: $size }) { count rows { target { approvedSymbol id } datasourceScores { id score } } } } }",
@@ -106,8 +105,7 @@
         }
       },
       "required": [
-        "efoId",
-        "pageSize"
+        "efoId"
       ]
     },
     "query_schema": "query getTargets($efoId: String!, $index: Int!, $size: Int!) { disease(efoId: $efoId) { id name associatedTargets(page: { index: $index, size: $size }) { count rows { target { approvedSymbol id } datasourceScores { id score } } } } }",
@@ -190,8 +188,7 @@
         }
       },
       "required": [
-        "efoId",
-        "pageSize"
+        "efoId"
       ]
     },
     "query_schema": "query getTargets($efoId: String!, $index: Int!, $size: Int!) { disease(efoId: $efoId) { id name associatedTargets(page: { index: $index, size: $size }) { count rows { target { approvedSymbol id } datasourceScores { id score } } } } }",
@@ -266,8 +263,7 @@
         }
       },
       "required": [
-        "efoId",
-        "pageSize"
+        "efoId"
       ]
     },
     "query_schema": "query getTargets($efoId: String!, $index: Int!, $size: Int!) { disease(efoId: $efoId) { id name associatedTargets(page: { index: $index, size: $size }) { count rows { target { approvedSymbol id } datasourceScores { id score } } } } }",
@@ -342,8 +338,7 @@
         }
       },
       "required": [
-        "efoId",
-        "pageSize"
+        "efoId"
       ]
     },
     "query_schema": "query getTargets($efoId: String!, $index: Int!, $size: Int!) { disease(efoId: $efoId) { id name associatedTargets(page: { index: $index, size: $size }) { count rows { target { approvedSymbol id } datasourceScores { id score } } } } }",
@@ -418,8 +413,7 @@
         }
       },
       "required": [
-        "efoId",
-        "pageSize"
+        "efoId"
       ]
     },
     "query_schema": "query getTargets($efoId: String!, $index: Int!, $size: Int!) { disease(efoId: $efoId) { id name associatedTargets(page: { index: $index, size: $size }) { count rows { target { approvedSymbol id } datasourceScores { id score } } } } }",
@@ -494,8 +488,7 @@
         }
       },
       "required": [
-        "efoId",
-        "pageSize"
+        "efoId"
       ]
     },
     "query_schema": "query getTargets($efoId: String!, $index: Int!, $size: Int!) { disease(efoId: $efoId) { id name associatedTargets(page: { index: $index, size: $size }) { count rows { target { approvedSymbol id } datasourceScores { id score } } } } }",
@@ -570,8 +563,7 @@
         }
       },
       "required": [
-        "efoId",
-        "pageSize"
+        "efoId"
       ]
     },
     "query_schema": "query getTargets($efoId: String!, $index: Int!, $size: Int!) { disease(efoId: $efoId) { id name associatedTargets(page: { index: $index, size: $size }) { count rows { target { approvedSymbol id } datasourceScores { id score } } } } }",
@@ -646,8 +638,7 @@
         }
       },
       "required": [
-        "efoId",
-        "pageSize"
+        "efoId"
       ]
     },
     "query_schema": "query getTargets($efoId: String!, $index: Int!, $size: Int!) { disease(efoId: $efoId) { id name associatedTargets(page: { index: $index, size: $size }) { count rows { target { approvedSymbol id } datasourceScores { id score } } } } }",
@@ -722,8 +713,7 @@
         }
       },
       "required": [
-        "efoId",
-        "pageSize"
+        "efoId"
       ]
     },
     "query_schema": "query getTargets($efoId: String!, $index: Int!, $size: Int!) { disease(efoId: $efoId) { id name associatedTargets(page: { index: $index, size: $size }) { count rows { target { approvedSymbol id } datasourceScores { id score } } } } }",

--- a/tests/unit/test_disease_target_score_pagination.py
+++ b/tests/unit/test_disease_target_score_pagination.py
@@ -88,3 +88,26 @@ def test_pagination_completes_without_truncation(monkeypatch):
     assert result["status"] == "success"
     assert "truncated" not in result["data"]
     assert result["data"]["total_targets_with_scores"] == 5
+
+
+# Fix-R37A-1: disease_target_score_tools.json required "pageSize" in every
+# one of these 9 tools' schemas even though pageSize's own description says
+# "default: 100" and DiseaseTargetScoreTool.run() already reads it via
+# arguments.get("pageSize", 100) -- confirmed live that omitting it (the
+# natural reading of "default: 100") previously hit a hard schema
+# validation error before this fallback ever ran.
+@pytest.mark.unit
+def test_omitted_page_size_falls_back_to_100(monkeypatch):
+    monkeypatch.setattr(gqt.time, "monotonic", lambda: 0.0)
+
+    captured = {}
+
+    def fake_execute(endpoint, query, variables):
+        captured["size"] = variables["size"]
+        return _page(variables["index"], variables["size"], total=variables["size"])
+
+    with patch.object(gqt, "execute_query", side_effect=fake_execute):
+        result = make_tool().run({"efoId": "EFO_0000339", "datasourceId": "chembl"})
+
+    assert result["status"] == "success"
+    assert captured["size"] == 100

--- a/tests/unit/test_disease_target_score_required_params.py
+++ b/tests/unit/test_disease_target_score_required_params.py
@@ -1,0 +1,43 @@
+"""Config-content regression guard for Fix-R37A-1: none of the 9
+disease_target_score_tools.json tools should require "pageSize", since it
+always has a working `"default": 100` that DiseaseTargetScoreTool.run()
+already applies via arguments.get("pageSize", 100).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_configs():
+    return json.loads((_DATA_DIR / "disease_target_score_tools.json").read_text())
+
+
+def test_no_tool_requires_page_size():
+    for cfg in _tool_configs():
+        required = cfg["parameter"]["required"]
+        assert "pageSize" not in required, cfg["name"]
+
+
+def test_efo_id_still_required_everywhere():
+    for cfg in _tool_configs():
+        required = cfg["parameter"]["required"]
+        assert "efoId" in required, cfg["name"]
+
+
+def test_generic_tool_still_requires_datasource_id():
+    cfg = next(c for c in _tool_configs() if c["name"] == "disease_target_score")
+    assert cfg["parameter"]["required"] == ["efoId", "datasourceId"]
+
+
+def test_datasource_specific_tools_have_no_datasource_id_param():
+    for cfg in _tool_configs():
+        if cfg["name"] == "disease_target_score":
+            continue
+        assert "datasourceId" not in cfg["parameter"]["properties"], cfg["name"]
+        assert cfg["parameter"]["required"] == ["efoId"], cfg["name"]


### PR DESCRIPTION
## Summary

Ninth round-tool-sweep in this stacking chain (based on #333 / round 36's branch tip, since #326-#333 remain unmerged). The session's subagent spawn cap remains fully exhausted (6th consecutive round), so this round's investigation was again done directly via CLI across 3 domains: pain medicine/anesthesiology pharmacogenomics, sports medicine/exercise genetics, rare disease/newborn screening genetics.

Round 37 opened by acting on round 36's lesson -- ran a codebase-wide scan for any tool property that has both a JSON-schema `"default"` value AND appears in that same tool's `"required"` array (a direct logical contradiction, since a required field's default can never be reached). Found **61 candidate instances across roughly 15 data files**. Rather than fixing all of them in one pass without individually live-verifying each, picked the clearest, most confidently systemic cluster to fix this round and left the rest as a documented backlog.

1 confirmed fix affecting **9 tools sharing one root cause** -- live-verified before and after:

- **disease_target_score_tools.json**: `disease_target_score` and its 8 datasource-specific variants (`chembl`/`eva`/`eva_somatic`/`cancer_gene_census`/`cancer_biomarkers`/`europepmc`/`expression_atlas`/`genomics_england`/`reactome_disease_target_score`) all required `pageSize` even though it defaults to 100 in both the schema description and `DiseaseTargetScoreTool.run()`'s own `arguments.get("pageSize", 100)` fallback. Confirmed live: `disease_target_score({"efoId": "MONDO_0011996", "datasourceId": "clinical_precedence"})` previously failed outright with a schema validation error despite being fully answerable without `pageSize` (now correctly returns real BCR-ABL1/CML target-score data, ABL1 top-ranked). Fixed by removing `pageSize` from all 9 `required` arrays.

## Backlog for future rounds (found but not yet individually verified/fixed)

The same default-vs-required contradiction also appears on `operation`/`action` routing fields across several other shared tool types: `cellxgene_census_tools.json` (6 tools), `cryoet_tools.json` (7 tools), `fourdn_tools.json` (4 tools), and `hca_tools.json` (2 tools). These need the same live-verify-before-fixing treatment, since an `operation` field could plausibly be vestigial/baked into `tool_config` rather than genuinely read from caller arguments -- worth checking each before assuming it's the same bug class.

## Also investigated, confirmed correct (no action needed)

- CPIC recommendations for codeine, tramadol, and fentanyl (including a reconfirmation that round 31's "guideline covers other drugs" note and round 35's exact-match drug resolution both still hold).
- gnomAD constraints for OPRM1 and ACTN3.
- ClinVar variants for RYR1 and PAH; MARRVEL OMIM phenotypes for RYR1 (malignant hyperthermia); Orphanet search for MCAD deficiency; GenCC gene-disease validity for ACADM.
- One self-caught false alarm: `HPO_get_genes_by_phenotype` appeared to return unrelated genes for "Hyperphenylalaninemia" but the actual issue was using the wrong HPO term ID (`HP:0003074` instead of the correct `HP:0004923`), confirmed via a live ontology lookup before concluding no bug existed.

## Test plan

- [x] New mocked unit test for the pageSize-omitted case (falls back to 100) plus config-content regression tests asserting no `disease_target_score` tool requires `pageSize` while `efoId` (and `datasourceId` for the generic tool) remain required.
- [x] Full `tests/unit` suite passes with only the standard ~11 environmental skips (scanpy not installed x2, no-tools-loaded/no-instantiable-tools fixtures x7, one resource-exhaustion deselect, `ClinVar_get_clinical_significance` import gap) -- zero failures.