### PR TITLE
Fix Round 38: CELLxGENE Census tools wrongly required operation, plus a broken fallback

### DIFF
--- a/src/tooluniverse/cellxgene_census_tool.py
+++ b/src/tooluniverse/cellxgene_census_tool.py
@@ -30,7 +30,13 @@ class CELLxGENECensusTool(BaseTool):
             }
 
         try:
-            operation = arguments.get("operation", "get_metadata")
+            # Fix-R38A-1: "operation" is optional in the schema now (each
+            # config exposes exactly one valid value via enum+default), so
+            # a caller who omits it must still resolve to that tool
+            # instance's own operation -- the old bare "get_metadata"
+            # fallback doesn't match any dispatch branch below and would
+            # silently mis-route every one of these 6 tools.
+            operation = arguments.get("operation") or self.get_schema_const_operation()
             census_version = arguments.get("census_version", "stable")
 
             if operation == "get_census_versions":

--- a/src/tooluniverse/data/cellxgene_census_tools.json
+++ b/src/tooluniverse/data/cellxgene_census_tools.json
@@ -112,7 +112,6 @@
         }
       },
       "required": [
-        "operation",
         "obs_value_filter"
       ]
     },
@@ -209,9 +208,7 @@
           "default": "stable"
         }
       },
-      "required": [
-        "operation"
-      ]
+      "required": []
     },
     "return_schema": {
       "type": [
@@ -310,9 +307,7 @@
           "default": "stable"
         }
       },
-      "required": [
-        "operation"
-      ]
+      "required": []
     },
     "return_schema": {
       "type": [
@@ -385,9 +380,7 @@
           "default": "stable"
         }
       },
-      "required": [
-        "operation"
-      ]
+      "required": []
     },
     "return_schema": {
       "oneOf": [
@@ -480,9 +473,7 @@
           "default": "stable"
         }
       },
-      "required": [
-        "operation"
-      ]
+      "required": []
     },
     "return_schema": {
       "type": "object",
@@ -568,7 +559,6 @@
         }
       },
       "required": [
-        "operation",
         "dataset_id"
       ]
     },

--- a/tests/unit/test_cellxgene_census_optional_operation.py
+++ b/tests/unit/test_cellxgene_census_optional_operation.py
@@ -1,0 +1,135 @@
+"""Regression guard for Fix-R38A-1: CELLxGENE_get_cell_metadata,
+CELLxGENE_get_gene_metadata, CELLxGENE_get_expression_data,
+CELLxGENE_get_presence_matrix, CELLxGENE_get_embeddings, and
+CELLxGENE_download_h5ad all wrongly required "operation" even though
+each tool's `operation` property is a single-value enum matching its own
+"default" (each tool instance only ever has one valid operation, e.g.
+CELLxGENE_get_gene_metadata always defaults/enums to "get_var_metadata"),
+and CELLxGENECensusTool.run() already reads it via
+arguments.get("operation", "get_metadata") with the schema default
+available as a fallback. A caller who reasonably omitted a param that
+can only ever have one value hit a hard schema validation error --
+confirmed live via BaseTool.validate_parameters() (the package itself,
+cellxgene_census/tiledbsoma, isn't installed in this environment, but
+schema validation runs before the tool's run() ever imports it).
+
+The genuinely-required fields on two of these tools -- obs_value_filter
+(no default; the Census has 50M+ cells and an unfiltered query times
+out) and dataset_id (no default) -- are unaffected and still required.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The tool imports these optional heavy packages at call time; stub them so
+# CELLxGENECensusTool.run() reaches its own dispatch logic under test.
+sys.modules.setdefault("cellxgene_census", MagicMock())
+sys.modules.setdefault("tiledbsoma", MagicMock())
+
+from tooluniverse.cellxgene_census_tool import CELLxGENECensusTool
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _configs():
+    return json.loads((_DATA_DIR / "cellxgene_census_tools.json").read_text())
+
+
+def _tool_config(name):
+    for cfg in _configs():
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found in cellxgene_census_tools.json")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "CELLxGENE_get_gene_metadata",
+        "CELLxGENE_get_expression_data",
+        "CELLxGENE_get_presence_matrix",
+        "CELLxGENE_get_embeddings",
+    ],
+)
+def test_operation_only_tools_have_no_required_params(name):
+    cfg = _tool_config(name)
+    assert cfg["parameter"]["required"] == []
+
+
+def test_get_cell_metadata_requires_only_obs_value_filter():
+    cfg = _tool_config("CELLxGENE_get_cell_metadata")
+    assert cfg["parameter"]["required"] == ["obs_value_filter"]
+
+
+def test_download_h5ad_requires_only_dataset_id():
+    cfg = _tool_config("CELLxGENE_download_h5ad")
+    assert cfg["parameter"]["required"] == ["dataset_id"]
+
+
+def test_operation_omitted_passes_schema_validation():
+    cfg = _tool_config("CELLxGENE_get_gene_metadata")
+    tool = CELLxGENECensusTool(cfg)
+    assert tool.validate_parameters({"organism": "Homo sapiens"}) is None
+
+
+def test_obs_value_filter_alone_passes_cell_metadata_validation():
+    cfg = _tool_config("CELLxGENE_get_cell_metadata")
+    tool = CELLxGENECensusTool(cfg)
+    args = {"obs_value_filter": 'tissue_general == "lung"'}
+    assert tool.validate_parameters(args) is None
+
+
+def test_cell_metadata_still_rejects_missing_obs_value_filter():
+    cfg = _tool_config("CELLxGENE_get_cell_metadata")
+    tool = CELLxGENECensusTool(cfg)
+    error = tool.validate_parameters({})
+    assert error is not None
+    assert "obs_value_filter" in str(error)
+
+
+def test_download_h5ad_still_rejects_missing_dataset_id():
+    cfg = _tool_config("CELLxGENE_download_h5ad")
+    tool = CELLxGENECensusTool(cfg)
+    error = tool.validate_parameters({})
+    assert error is not None
+    assert "dataset_id" in str(error)
+
+
+# Fix-R38A-1 (part 2): making "operation" schema-optional is not enough on
+# its own -- run() previously fell back to a bare "get_metadata" literal
+# that matches none of its own if/elif dispatch branches, so an omitted
+# operation would have silently mis-routed to the "Unknown operation"
+# error path even after the schema fix. The correct fallback (matching the
+# pattern already used by ~27 other tool classes in this codebase) is
+# self.get_schema_const_operation(), which resolves each tool's own single
+# enum value from its config.
+@pytest.mark.parametrize(
+    "name,expected_method",
+    [
+        ("CELLxGENE_get_cell_metadata", "_get_obs_metadata"),
+        ("CELLxGENE_get_gene_metadata", "_get_var_metadata"),
+        ("CELLxGENE_get_expression_data", "_get_anndata"),
+        ("CELLxGENE_get_presence_matrix", "_get_presence_matrix"),
+        ("CELLxGENE_get_embeddings", "_get_embeddings"),
+        ("CELLxGENE_download_h5ad", "_download_h5ad"),
+    ],
+)
+def test_omitted_operation_dispatches_to_the_correct_method(name, expected_method):
+    cfg = _tool_config(name)
+    tool = CELLxGENECensusTool(cfg)
+
+    with patch.object(
+        tool, expected_method, return_value={"status": "success", "data": []}
+    ) as mock_method:
+        # A superset covering every tool's other required field is safe
+        # here since the dispatched method itself is mocked out; the only
+        # thing under test is dispatch routing when "operation" is absent.
+        tool.run({"obs_value_filter": "x", "dataset_id": "y"})
+
+    assert mock_method.called


### PR DESCRIPTION
## Summary

Tenth round-tool-sweep in this stacking chain (based on #334 / round 37's branch tip, since #326-#334 remain unmerged). The session's subagent spawn cap remains fully exhausted (7th consecutive round), so this round's investigation was again done directly via CLI across 3 domains: critical care/ICU pharmacogenomics, pediatric oncology/solid tumor genomics, obstetrics/maternal-fetal medicine genetics.

This round worked through the top-priority item queued in the round-37 backlog: `cellxgene_census_tools.json`'s 6-tool `operation` cluster, all built on `CELLxGENECensusTool`. Verified via `BaseTool.validate_parameters()` directly (the underlying `cellxgene_census`/`tiledbsoma` packages aren't installed in this environment, but schema validation runs before that import is reached, so this is a fully valid verification path).

1 confirmed fix affecting **6 tools -- this one needed two parts, not one**:

- **cellxgene_census_tools.json**: each tool's `operation` property is a single-value enum matching its own `default` (e.g. `CELLxGENE_get_gene_metadata` always resolves to `"get_var_metadata"`), yet every one of the 6 tools required it. Removed from `required`.
- **cellxgene_census_tool.py**: removing the schema requirement alone was **not** sufficient. `CELLxGENECensusTool.run()`'s existing fallback was `arguments.get("operation", "get_metadata")` -- and `"get_metadata"` matches none of the tool's own if/elif dispatch branches. A caller who omitted `operation` would have silently mis-routed to the "Unknown operation" error path even after the schema fix. Caught this by testing the actual functional dispatch (mocking the two heavy packages so `run()` reaches its own logic) rather than stopping at schema validation. Fixed by switching the fallback to `self.get_schema_const_operation()` -- an existing `BaseTool` helper already used by ~27 other tool classes in this codebase for exactly this purpose. Verified end-to-end: with `operation` omitted, `run()` now dispatches to the correct private method for every one of the 6 tools.

Genuinely-required fields (`obs_value_filter` -- no default, the Census has 50M+ cells and an unfiltered query times out; `dataset_id` -- no default) are unaffected and still correctly rejected when missing.

## Backlog note

The two remaining queued "operation"/"action" clusters, `cryoet_tools.json` and `fourdn_tools.json`, were confirmed via code inspection this round to have the same two-part bug -- `cryoet_tool.py` falls back to a bare empty string (wrong for all 7 tools) and `fourdn_tool.py` falls back to a literal `"search"` (only coincidentally right for one of its 4 tools). Whoever picks those up next should apply the same two-part treatment, not just the schema fix. (Full detail in project memory: `project_test_harness_r37_required_default_backlog.md`.)

## Also investigated, confirmed correct (no action needed)

- CPIC's "guideline covers other drugs" note for morphine; FAERS disproportionality for propofol/bradycardia; cBioPortal cancer studies list.
- OncoKB TP53 R175H annotation; ClinVar variants for RB1 and F5; MARRVEL OMIM phenotypes for F5 (recurrent pregnancy loss); PGS Catalog trait search for preeclampsia.

## Test plan

- [x] New mocked unit tests covering config-content (required arrays), schema-validation-level behavior (operation omitted passes, other required fields still correctly rejected), and full functional dispatch routing (operation omitted still calls the correct private method for all 6 tools).
- [x] Full `tests/unit` suite passes with only the standard ~11 environmental skips (scanpy not installed x2, no-tools-loaded/no-instantiable-tools fixtures x7, one resource-exhaustion deselect, `ClinVar_get_clinical_significance` import gap) -- zero failures.