### PR TITLE
Fix Round 39: CryoET, 4DN, and HCA tools wrongly required their routing field

### DIFF
--- a/src/tooluniverse/cryoet_tool.py
+++ b/src/tooluniverse/cryoet_tool.py
@@ -38,7 +38,13 @@ class CryoETTool(BaseTool):
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute the tool with given arguments."""
         try:
-            operation = arguments.get("operation", "")
+            # Fix-R39A-1: "operation" is optional in the schema (each config
+            # exposes exactly one valid value via enum+default), so a caller
+            # who omits it must still resolve to that tool instance's own
+            # operation -- the old bare "" fallback matched no dispatch
+            # branch below and would silently mis-route every one of these
+            # 7 tools.
+            operation = arguments.get("operation") or self.get_schema_const_operation()
 
             if operation == "list_datasets":
                 return self._list_datasets(arguments)

--- a/src/tooluniverse/data/cryoet_tools.json
+++ b/src/tooluniverse/data/cryoet_tools.json
@@ -42,9 +42,7 @@
           "default": 0
         }
       },
-      "required": [
-        "operation"
-      ]
+      "required": []
     },
     "return_schema": {
       "oneOf": [
@@ -175,7 +173,6 @@
         }
       },
       "required": [
-        "operation",
         "dataset_id"
       ]
     },
@@ -338,7 +335,6 @@
         }
       },
       "required": [
-        "operation",
         "dataset_id"
       ]
     },
@@ -463,7 +459,6 @@
         }
       },
       "required": [
-        "operation",
         "run_id"
       ]
     },
@@ -646,7 +641,6 @@
         }
       },
       "required": [
-        "operation",
         "run_id"
       ]
     },
@@ -808,9 +802,7 @@
           "default": 0
         }
       },
-      "required": [
-        "operation"
-      ]
+      "required": []
     },
     "return_schema": {
       "oneOf": [
@@ -1040,9 +1032,7 @@
           "default": 0
         }
       },
-      "required": [
-        "operation"
-      ]
+      "required": []
     },
     "return_schema": {
       "oneOf": [

--- a/src/tooluniverse/data/fourdn_tools.json
+++ b/src/tooluniverse/data/fourdn_tools.json
@@ -42,7 +42,7 @@
           "maximum": 100
         }
       },
-      "required": ["operation"]
+      "required": []
     },
     "return_schema": {
       "type": "object",
@@ -87,7 +87,7 @@
           "default": false
         }
       },
-      "required": ["operation", "file_accession"]
+      "required": ["file_accession"]
     },
     "return_schema": {
       "type": "object",
@@ -133,7 +133,7 @@
           "default": false
         }
       },
-      "required": ["operation", "experiment_accession"]
+      "required": ["experiment_accession"]
     },
     "return_schema": {
       "type": "object",
@@ -176,7 +176,7 @@
           "description": "4DN file accession (e.g., '4DNFIIA7E3HL'). Obtain by searching with FourDN_search_data (item_type='File')."
         }
       },
-      "required": ["operation", "file_accession"]
+      "required": ["file_accession"]
     },
     "return_schema": {
       "type": "object",

--- a/src/tooluniverse/data/hca_tools.json
+++ b/src/tooluniverse/data/hca_tools.json
@@ -28,9 +28,7 @@
                     "default": 10
                 }
             },
-            "required": [
-                "action"
-            ]
+            "required": []
         },
         "return_schema": {
             "type": "object",
@@ -101,7 +99,6 @@
                 }
             },
             "required": [
-                "action",
                 "project_id"
             ]
         },

--- a/src/tooluniverse/fourdn_tool.py
+++ b/src/tooluniverse/fourdn_tool.py
@@ -50,7 +50,14 @@ class FourDNTool(BaseTool):
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Execute the tool with given arguments."""
         try:
-            operation = arguments.get("operation", "search")
+            # Fix-R39A-2: "operation" is optional in the schema (each config
+            # exposes exactly one valid value via enum+default), so a caller
+            # who omits it must still resolve to that tool instance's own
+            # operation -- the old bare "search" literal fallback was only
+            # coincidentally correct for FourDN_search_data and would
+            # silently mis-route the other 3 tools to a search instead of
+            # their own operation.
+            operation = arguments.get("operation") or self.get_schema_const_operation()
 
             if operation == "search":
                 return self._search(arguments)

--- a/src/tooluniverse/hca_tool.py
+++ b/src/tooluniverse/hca_tool.py
@@ -30,7 +30,17 @@ class HCATool(BaseTool):
         Returns:
             Dict[str, Any]: The results of the action.
         """
-        action = arguments.get("action")
+        # Fix-R39A-3: "action" is optional in the schema (each config
+        # exposes exactly one valid value via enum+default), so a caller
+        # who omits it must still resolve to that tool instance's own
+        # action -- there was previously no fallback at all, so an omitted
+        # action fell straight through to "Unknown action: None".
+        action = arguments.get("action") or (
+            self.tool_config.get("parameter", {})
+            .get("properties", {})
+            .get("action", {})
+            .get("default", "")
+        )
 
         if action == "search_projects":
             return self.search_projects(

--- a/tests/unit/test_cryoet_optional_operation.py
+++ b/tests/unit/test_cryoet_optional_operation.py
@@ -1,0 +1,101 @@
+"""Regression guard for Fix-R39A-1: all 7 CryoET_* tools
+(list_datasets, get_dataset, list_runs, list_tomograms, list_annotations,
+list_tiltseries, list_depositions) wrongly required "operation" even
+though each tool's operation property is a single-value enum matching
+its own "default" -- confirmed live, e.g.
+CryoET_list_datasets({"organism_name": "Homo sapiens", "limit": 3})
+previously failed outright with a schema validation error.
+
+This one needed a two-part fix (same class as round 38's CELLxGENE
+Census fix): removing "operation" from required alone was not enough,
+because CryoETTool.run()'s existing Python fallback was
+arguments.get("operation", "") -- an empty string matching none of its
+own if/elif dispatch branches. Fixed by switching to
+self.get_schema_const_operation(), the established codebase helper for
+resolving a tool's own single enum/const operation value.
+
+The genuinely-required fields on 4 of these tools -- dataset_id (no
+default; CryoET_get_dataset/list_runs) and run_id (no default;
+CryoET_list_tomograms/list_annotations) -- are unaffected and still
+required.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.cryoet_tool import CryoETTool
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _configs():
+    return json.loads((_DATA_DIR / "cryoet_tools.json").read_text())
+
+
+def _tool_config(name):
+    for cfg in _configs():
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found in cryoet_tools.json")
+
+
+@pytest.mark.parametrize(
+    "name,expected_required",
+    [
+        ("CryoET_list_datasets", []),
+        ("CryoET_get_dataset", ["dataset_id"]),
+        ("CryoET_list_runs", ["dataset_id"]),
+        ("CryoET_list_tomograms", ["run_id"]),
+        ("CryoET_list_annotations", ["run_id"]),
+        ("CryoET_list_tiltseries", []),
+        ("CryoET_list_depositions", []),
+    ],
+)
+def test_operation_no_longer_required(name, expected_required):
+    cfg = _tool_config(name)
+    assert cfg["parameter"]["required"] == expected_required
+
+
+def test_operation_omitted_passes_schema_validation():
+    cfg = _tool_config("CryoET_list_datasets")
+    tool = CryoETTool(cfg)
+    assert tool.validate_parameters({"organism_name": "Homo sapiens"}) is None
+
+
+def test_dataset_id_still_rejected_when_missing():
+    cfg = _tool_config("CryoET_get_dataset")
+    tool = CryoETTool(cfg)
+    error = tool.validate_parameters({})
+    assert error is not None
+    assert "dataset_id" in str(error)
+
+
+@pytest.mark.parametrize(
+    "name,expected_method,args",
+    [
+        ("CryoET_list_datasets", "_list_datasets", {}),
+        ("CryoET_get_dataset", "_get_dataset", {"dataset_id": 10463}),
+        ("CryoET_list_runs", "_list_runs", {"dataset_id": 10463}),
+        ("CryoET_list_tomograms", "_list_tomograms", {"run_id": 3430}),
+        ("CryoET_list_annotations", "_list_annotations", {"run_id": 3430}),
+        ("CryoET_list_tiltseries", "_list_tiltseries", {}),
+        ("CryoET_list_depositions", "_list_depositions", {}),
+    ],
+)
+def test_omitted_operation_dispatches_to_the_correct_method(
+    name, expected_method, args
+):
+    cfg = _tool_config(name)
+    tool = CryoETTool(cfg)
+
+    with patch.object(
+        tool, expected_method, return_value={"status": "success", "data": {}}
+    ) as mock_method:
+        tool.run(args)
+
+    assert mock_method.called

--- a/tests/unit/test_fourdn_optional_operation.py
+++ b/tests/unit/test_fourdn_optional_operation.py
@@ -1,0 +1,97 @@
+"""Regression guard for Fix-R39A-2: all 4 FourDN_* tools (search_data,
+get_file_metadata, get_experiment_metadata, get_download_url) wrongly
+required "operation" even though each tool's operation property is a
+single-value enum matching its own "default" -- confirmed live, e.g.
+FourDN_get_file_metadata({"file_accession": "4DNFIIA7E3HL"}) previously
+failed outright with a schema validation error.
+
+Two-part fix, same class as round 38's CELLxGENE Census fix and this
+round's CryoET fix: removing "operation" from required alone was not
+enough, because FourDNTool.run()'s existing Python fallback was
+arguments.get("operation", "search") -- a literal only coincidentally
+correct for FourDN_search_data itself. The other 3 tools would have
+silently mis-routed to a search instead of their own operation. Fixed by
+switching to self.get_schema_const_operation().
+
+file_accession (get_file_metadata, get_download_url) and
+experiment_accession (get_experiment_metadata) have no defaults and are
+unaffected -- still required.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.fourdn_tool import FourDNTool
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _configs():
+    return json.loads((_DATA_DIR / "fourdn_tools.json").read_text())
+
+
+def _tool_config(name):
+    for cfg in _configs():
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found in fourdn_tools.json")
+
+
+@pytest.mark.parametrize(
+    "name,expected_required",
+    [
+        ("FourDN_search_data", []),
+        ("FourDN_get_file_metadata", ["file_accession"]),
+        ("FourDN_get_experiment_metadata", ["experiment_accession"]),
+        ("FourDN_get_download_url", ["file_accession"]),
+    ],
+)
+def test_operation_no_longer_required(name, expected_required):
+    cfg = _tool_config(name)
+    assert cfg["parameter"]["required"] == expected_required
+
+
+def test_operation_omitted_passes_schema_validation():
+    cfg = _tool_config("FourDN_search_data")
+    tool = FourDNTool(cfg)
+    assert tool.validate_parameters({"query": "Hi-C"}) is None
+
+
+def test_file_accession_still_rejected_when_missing():
+    cfg = _tool_config("FourDN_get_file_metadata")
+    tool = FourDNTool(cfg)
+    error = tool.validate_parameters({})
+    assert error is not None
+    assert "file_accession" in str(error)
+
+
+@pytest.mark.parametrize(
+    "name,expected_method,args",
+    [
+        ("FourDN_search_data", "_search", {}),
+        ("FourDN_get_file_metadata", "_get_file_metadata", {"file_accession": "x"}),
+        (
+            "FourDN_get_experiment_metadata",
+            "_get_experiment_metadata",
+            {"experiment_accession": "x"},
+        ),
+        ("FourDN_get_download_url", "_download_file_url", {"file_accession": "x"}),
+    ],
+)
+def test_omitted_operation_dispatches_to_the_correct_method(
+    name, expected_method, args
+):
+    cfg = _tool_config(name)
+    tool = FourDNTool(cfg)
+
+    with patch.object(
+        tool, expected_method, return_value={"status": "success", "data": {}}
+    ) as mock_method:
+        tool.run(args)
+
+    assert mock_method.called

--- a/tests/unit/test_hca_optional_action.py
+++ b/tests/unit/test_hca_optional_action.py
@@ -1,0 +1,84 @@
+"""Regression guard for Fix-R39A-3: both hca_search_projects and
+hca_get_file_manifest wrongly required "action" even though each tool's
+action property is a single-value enum matching its own "default" --
+confirmed live, e.g. hca_get_file_manifest({"project_id": "..."})
+previously failed outright with a schema validation error.
+
+Two-part fix, same class as round 38's CELLxGENE Census fix and this
+round's CryoET/FourDN fixes: removing "action" from required alone was
+not enough. Unlike those other tools (which use the "operation" property
+name and BaseTool.get_schema_const_operation()), HCATool.run() previously
+had NO fallback at all for "action" (arguments.get("action")), so an
+omitted action fell straight through to "Unknown action: None". Since
+get_schema_const_operation() is hardcoded to the "operation" property
+name, this tool needed an inline equivalent lookup against its own
+"action" property's schema default instead.
+
+project_id (get_file_manifest) has no default and is unaffected -- still
+required.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.hca_tool import HCATool
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _configs():
+    return json.loads((_DATA_DIR / "hca_tools.json").read_text())
+
+
+def _tool_config(name):
+    for cfg in _configs():
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found in hca_tools.json")
+
+
+def test_search_projects_has_no_required_params():
+    cfg = _tool_config("hca_search_projects")
+    assert cfg["parameter"]["required"] == []
+
+
+def test_get_file_manifest_requires_only_project_id():
+    cfg = _tool_config("hca_get_file_manifest")
+    assert cfg["parameter"]["required"] == ["project_id"]
+
+
+def test_omitted_action_dispatches_to_search_projects():
+    cfg = _tool_config("hca_search_projects")
+    tool = HCATool(cfg)
+
+    with patch.object(
+        tool, "search_projects", return_value={"total_hits": 0, "projects": []}
+    ) as mock_method:
+        tool.run({"organ": "heart"})
+
+    assert mock_method.called
+
+
+def test_omitted_action_dispatches_to_get_file_manifest():
+    cfg = _tool_config("hca_get_file_manifest")
+    tool = HCATool(cfg)
+
+    with patch.object(
+        tool, "get_file_manifest", return_value={"total_files": 0, "files": []}
+    ) as mock_method:
+        tool.run({"project_id": "abc123"})
+
+    assert mock_method.called
+
+
+def test_get_file_manifest_still_requires_project_id():
+    cfg = _tool_config("hca_get_file_manifest")
+    tool = HCATool(cfg)
+
+    with pytest.raises(ValueError, match="project_id"):
+        tool.run({})


### PR DESCRIPTION
## Summary

Eleventh round-tool-sweep in this stacking chain (based on #335 / round 38's branch tip, since #326-#335 remain unmerged). The session's subagent spawn cap remains fully exhausted (8th consecutive round), so this round's investigation was again done directly via CLI across 2 domains: gastroenterology/IBD genetics, allergy and anaphylaxis genetics.

This round cleared the **entire "highest-priority clusters" section** of the round-37 backlog by applying the two-part fix pattern established in round 38 to all three remaining `operation`/`action` routing-field clusters -- schema required-array fix AND Python fallback fix together, since a schema-only fix would leave the tool silently mis-routing.

**13 tools fixed across 3 files**, all live-verified against their real, reachable upstream APIs:

- **cryoet_tools.json / cryoet_tool.py**: 7 tools (`list_datasets`, `get_dataset`, `list_runs`, `list_tomograms`, `list_annotations`, `list_tiltseries`, `list_depositions`). `CryoETTool.run()` fell back to a bare empty string, matching no dispatch branch. Confirmed live via the CryoET GraphQL API -- e.g. `CryoET_list_datasets({"organism_name": "Homo sapiens", "limit": 3})` now returns real datasets, and `CryoET_get_dataset({"dataset_id": 10463})` correctly dispatches to the right query.
- **fourdn_tools.json / fourdn_tool.py**: 4 tools (`search_data`, `get_file_metadata`, `get_experiment_metadata`, `get_download_url`). `FourDNTool.run()` fell back to a literal `"search"`, only coincidentally correct for one of the four tools. Confirmed live via the 4DN Data Portal API -- also incidentally confirms the earlier SSL certificate issue tracked in `broken_apis.md` has since been resolved upstream.
- **hca_tools.json / hca_tool.py**: 2 tools (`search_projects`, `get_file_manifest`). This one is a distinct **third sub-pattern**: `HCATool` uses a differently-named routing field (`"action"`, not `"operation"`) with no fallback at all, so `BaseTool.get_schema_const_operation()` (hardcoded to the `"operation"` property name) couldn't be reused directly -- fixed with an inline equivalent lookup against the tool's own `"action"` property schema default. Confirmed live via the HCA Azul API.

Every genuinely-required field with no schema default (`dataset_id`/`run_id` for CryoET, `file_accession`/`experiment_accession` for 4DN, `project_id` for HCA) was confirmed unaffected via live regression checks -- still correctly rejected when missing.

## Also investigated, confirmed correct (no action needed)

- ClinVar variants for NOD2 and TPSAB1; GenCC gene-disease validity for NOD2 (Blau syndrome); PGS Catalog trait search for Crohn disease; MARRVEL OMIM phenotypes for FLG (atopic dermatitis).
- One investigated-and-ruled-out finding: `Orphanet_search_by_name` returned no good matches for "hereditary alpha-tryptasemia" across several phrasings, including a bare "tryptasemia" substring returning zero hits even in fuzzy search mode -- confirmed this is a genuine upstream Orphanet coverage gap for a recently characterized condition, not a tool defect.

## Test plan

- [x] New mocked unit tests per tool family covering config-content (required arrays), schema-validation-level behavior, and full functional dispatch routing (operation/action omitted still calls the correct method, with genuinely-required fields still rejected).
- [x] Full `tests/unit` suite passes with only the standard ~11 environmental skips (scanpy not installed x2, no-tools-loaded/no-instantiable-tools fixtures x7, one resource-exhaustion deselect, `ClinVar_get_clinical_significance` import gap) -- zero failures.