### PR TITLE
Fix Round 40: ChEMBL similarity tools wrongly required their default-backed params

### DIFF
--- a/src/tooluniverse/chem_tool.py
+++ b/src/tooluniverse/chem_tool.py
@@ -51,6 +51,25 @@ class ChEMBLRESTTool(BaseTool):
             # Replace placeholders in URL
             for k, v in args.items():
                 url = url.replace(f"{{{k}}}", str(v))
+            # Fix-R40A-1: ChEMBL_search_similarity's endpoint template
+            # (/similarity/{smiles}/{threshold}.json) has a path placeholder
+            # that this loop never fills unless the caller explicitly
+            # supplies it -- confirmed live a caller omitting "threshold"
+            # (relying on its own schema "default": 80) got a literal
+            # "{threshold}" left in the URL and a 404, unlike BaseRESTTool's
+            # _build_url which already falls back to schema defaults for
+            # unfilled placeholders. Mirror that behavior here.
+            for key, prop in (
+                self.tool_config.get("parameter", {}).get("properties", {}).items()
+            ):
+                placeholder = f"{{{key}}}"
+                if (
+                    placeholder in url
+                    and isinstance(prop, dict)
+                    and "default" in prop
+                    and prop["default"] is not None
+                ):
+                    url = url.replace(placeholder, str(prop["default"]))
             # Feature-31A-03 fix: /drug.json does not support pref_name__icontains filtering
             # (ChEMBL server silently ignores it). When a name query is given, route to
             # /molecule.json which supports full text filtering.

--- a/src/tooluniverse/data/chembl_tools.json
+++ b/src/tooluniverse/data/chembl_tools.json
@@ -22,9 +22,7 @@
         }
       },
       "required": [
-        "query",
-        "similarity_threshold",
-        "max_results"
+        "query"
       ]
     },
     "test_examples": [
@@ -1591,8 +1589,7 @@
         }
       },
       "required": [
-        "smiles",
-        "threshold"
+        "smiles"
       ]
     },
     "return_schema": {

--- a/tests/unit/test_chembl_similarity_optional_defaults.py
+++ b/tests/unit/test_chembl_similarity_optional_defaults.py
@@ -1,0 +1,89 @@
+"""Regression guard for Fix-R40A-1: ChEMBL_search_similar_molecules and
+ChEMBL_search_similarity both wrongly required similarity_threshold/
+max_results (resp. threshold) even though each has a working "default" --
+confirmed live, e.g. ChEMBL_search_similarity({"smiles": "CCO"}) previously
+failed outright with a schema validation error.
+
+ChEMBL_search_similar_molecules needed only the schema fix (chem_tool.py's
+_search_similar_molecules already reads its args via
+arguments.get("similarity_threshold", 80) / arguments.get("max_results", 20)).
+
+ChEMBL_search_similarity needed a two-part fix, a NEW sub-pattern (not the
+operation/action routing field from rounds 38-39): its endpoint template
+(/similarity/{smiles}/{threshold}.json) has a URL PATH placeholder, and
+ChEMBLRESTTool._build_url() only substituted placeholders explicitly present
+in the caller's args -- unlike BaseRESTTool's _build_url(), it had no
+fallback to schema defaults for unfilled placeholders. Confirmed live: with
+only the schema fix, the caller passed validation but the request went out
+with a literal "{threshold}" left in the URL, producing a 404. Fixed by
+adding the same schema-default-filling loop BaseRESTTool already has.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.chem_tool import ChEMBLRESTTool
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_config(name):
+    configs = json.loads((_DATA_DIR / "chembl_tools.json").read_text())
+    for cfg in configs:
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found in chembl_tools.json")
+
+
+def test_search_similar_molecules_requires_only_query():
+    cfg = _tool_config("ChEMBL_search_similar_molecules")
+    assert cfg["parameter"]["required"] == ["query"]
+
+
+def test_search_similarity_requires_only_smiles():
+    cfg = _tool_config("ChEMBL_search_similarity")
+    assert cfg["parameter"]["required"] == ["smiles"]
+
+
+def test_build_url_fills_missing_path_placeholder_from_schema_default():
+    cfg = _tool_config("ChEMBL_search_similarity")
+    tool = ChEMBLRESTTool(cfg)
+
+    url = tool._build_url({"smiles": "CCO"})
+
+    assert "{threshold}" not in url
+    assert url.endswith("/similarity/CCO/80.json")
+
+
+def test_build_url_still_honors_explicit_threshold():
+    cfg = _tool_config("ChEMBL_search_similarity")
+    tool = ChEMBLRESTTool(cfg)
+
+    url = tool._build_url({"smiles": "CCO", "threshold": 95})
+
+    assert url.endswith("/similarity/CCO/95.json")
+
+
+def test_search_similarity_end_to_end_with_threshold_omitted():
+    cfg = _tool_config("ChEMBL_search_similarity")
+    tool = ChEMBLRESTTool(cfg)
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"molecules": []}
+    resp.raise_for_status = MagicMock()
+
+    with patch(
+        "tooluniverse.chem_tool.request_with_retry", return_value=resp
+    ) as mock_request:
+        result = tool.run({"smiles": "CCO"})
+
+    assert result["status"] == "success"
+    called_url = mock_request.call_args.args[2]
+    assert "{threshold}" not in called_url
+    assert called_url.endswith("/similarity/CCO/80.json")


### PR DESCRIPTION
## Summary

Twelfth round-tool-sweep in this stacking chain (based on #336 / round 39's branch tip, since #326-#336 remain unmerged). The session's subagent spawn cap remains fully exhausted (9th consecutive round), so this round's investigation was again done directly via CLI across 3 domains: emergency medicine/toxicology overdose genetics, general surgery/perioperative genomics, radiology/nuclear medicine genomics.

This round picked off the `chembl_tools.json` item from the round-37 backlog's lower-priority list -- 2 tools fixed, live-verified before and after:

- **ChEMBL_search_similar_molecules** needed only a schema fix. Removed `similarity_threshold`/`max_results` from `required`; `chem_tool.py`'s `_search_similar_molecules` already had working `arguments.get(x, default)` fallbacks for both.
- **ChEMBL_search_similarity** needed a two-part fix -- a **new sub-pattern**, distinct from the `operation`/`action` routing-field bug found in rounds 38-39. Its endpoint template uses a URL path placeholder (`/similarity/{smiles}/{threshold}.json`), and `ChEMBLRESTTool._build_url()` in `chem_tool.py` (a separate class that subclasses `BaseTool` directly, not `BaseRESTTool`) only filled placeholders explicitly present in the caller's args, with no fallback to schema defaults for unfilled ones -- unlike `BaseRESTTool`'s `_build_url`, which already has exactly this fallback logic. Confirmed live: with only the schema fix, a caller omitting `threshold` got a literal `"{threshold}"` left in the URL and a 404. Fixed by adding the same schema-default-filling loop `BaseRESTTool` already has, directly into `ChEMBLRESTTool._build_url()`. Verified live: omitting `threshold` now correctly builds `"/similarity/CCO/80.json"` and returns real results; an explicit `threshold=95` still works unchanged.

## Also investigated, confirmed correct (no action needed)

Reconfirmed 3 earlier-round fixes still hold on fresh real-world cases: CPIC CYP2C19 gene info; FAERS acetaminophen/hepatic-failure disproportionality; `dict_search` for digoxin cardiotoxicity (reconfirms round 36's `DatasetTool` limit-omitted fix); ClinVar and MARRVEL for BCHE (postanesthetic apnea); DailyMed cefazolin search returning exactly the requested count (reconfirms round 33's limit-alias fix); gnomAD constraints, Pharos tissue expression, and DGIdb drug-gene interactions for SSTR2.

## Test plan

- [x] New mocked unit tests covering config-content (required arrays), the URL-building fix directly (path placeholder filled from schema default, explicit override still honored), and a full `run()` dispatch test with threshold omitted.
- [x] Full `tests/unit` suite passes with only the standard ~11 environmental skips (scanpy not installed x2, no-tools-loaded/no-instantiable-tools fixtures x7, one resource-exhaustion deselect, `ClinVar_get_clinical_significance` import gap) -- zero failures.