### PR TITLE
Fix Round 42: MPD_get_phenotype_data silently ignored its own strain parameter

### DIFF
--- a/src/tooluniverse/data/mpd_tools.json
+++ b/src/tooluniverse/data/mpd_tools.json
@@ -2,7 +2,7 @@
   {
     "type": "MPDRESTTool",
     "name": "MPD_get_phenotype_data",
-    "description": "Get mouse phenotype data from Mouse Phenome Database for specific strains and phenotypes",
+    "description": "Search ENCODE experiment records mentioning a given mouse strain (used as a Mouse Phenome Database alternative -- MPD's own REST API has no simple strain+category phenotype search; see https://phenome.jax.org/api for genuine curated MPD phenotype data). 'phenotype_category' is not applied -- ENCODE has no equivalent concept.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -13,7 +13,7 @@
         },
         "phenotype_category": {
           "type": "string",
-          "description": "Phenotype category (behavior, physiology, morphology)",
+          "description": "Not currently applied to the query -- ENCODE (this tool's data source) has no phenotype-category concept. Retained for forward compatibility with a future genuine MPD-backed implementation.",
           "default": "behavior"
         },
         "limit": {
@@ -24,12 +24,10 @@
           "maximum": 50
         }
       },
-      "required": [
-        "strain"
-      ]
+      "required": []
     },
     "fields": {
-      "endpoint": "https://www.encodeproject.org/search/?type=Experiment&biosample_ontology.term_name={strain}&biosample_ontology.classification=primary_cell&format=json&limit={limit}",
+      "endpoint": "https://www.encodeproject.org/search/?type=Experiment&searchTerm={strain}&format=json&limit={limit}",
       "return_format": "JSON"
     },
     "return_schema": {

--- a/src/tooluniverse/mpd_tool.py
+++ b/src/tooluniverse/mpd_tool.py
@@ -1,5 +1,6 @@
 import requests
 from typing import Any, Dict
+from urllib.parse import quote
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
@@ -14,13 +15,24 @@ class MPDRESTTool(BaseTool):
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         try:
-            # Use ENCODE as alternative data source for biological samples
+            # Use ENCODE as alternative data source for biological samples.
+            # MPD's own REST API (phenome.jax.org/api) has no endpoint that
+            # takes a strain name + phenotype category directly -- confirmed
+            # live, its phenotype endpoints require a measure ID or project
+            # symbol the caller doesn't supply here.
             strain = arguments.get("strain", "C57BL/6J")
             limit = arguments.get("limit", 5)
 
-            # Build ENCODE API URL for experiments
-            # Query for general experiments as MPD alternative
-            url = f"https://www.encodeproject.org/search/?type=Experiment&format=json&limit={limit}"
+            # searchTerm is a free-text match, unlike biosample_ontology.term_name
+            # (a tissue/cell-type ontology field, not a strain field) -- confirmed
+            # live the latter always returns zero results for real strain names,
+            # while searchTerm correctly surfaces strain-mentioning experiments
+            # (e.g. 292 hits for "C57BL/6J") and zero for strains ENCODE has no
+            # data on (e.g. "DBA/2J").
+            url = (
+                "https://www.encodeproject.org/search/?type=Experiment"
+                f"&searchTerm={quote(str(strain))}&format=json&limit={limit}"
+            )
 
             response = self.session.get(url, timeout=self.timeout)
             response.raise_for_status()
@@ -36,6 +48,15 @@ class MPDRESTTool(BaseTool):
                     "strain": strain,
                     "limit": limit,
                     "data_source": "ENCODE (MPD alternative)",
+                    "note": (
+                        "ENCODE has no mouse-phenotype-by-strain data model, so "
+                        "results are general ENCODE experiments whose free text "
+                        "mentions this strain, not curated MPD phenotype "
+                        "measurements. 'phenotype_category' is not applied -- "
+                        "ENCODE has no equivalent concept. For genuine curated "
+                        "phenotype data, query the Mouse Phenome Database "
+                        "directly at https://phenome.jax.org/api."
+                    ),
                 },
             }
         except Exception as e:

--- a/tests/unit/test_mpd_strain_filter.py
+++ b/tests/unit/test_mpd_strain_filter.py
@@ -1,0 +1,110 @@
+"""Regression guard for Fix-R42A-1: MPD_get_phenotype_data silently ignored
+its own "strain" parameter -- confirmed live, every call returned the exact
+same generic ENCODE experiment list regardless of what strain was passed.
+
+The tool's own JSON config already documented an intended fix
+(fields.endpoint templated `{strain}` into ENCODE's
+`biosample_ontology.term_name` filter), but mpd_tool.py's run() never used
+that template at all -- it hardcoded a different URL with no strain filter.
+Confirmed live that the documented template itself was also broken:
+biosample_ontology.term_name is a tissue/cell-type ontology field, not a
+strain field, so it always returns zero results for real mouse strain names.
+ENCODE's free-text `searchTerm` parameter, by contrast, was confirmed live to
+surface strain-relevant experiments (292 hits for "C57BL/6J", 3 for
+"BALB/c", correctly 0 for a strain ENCODE has no data on).
+
+Fixed by querying with searchTerm=<strain> and being explicit in the
+response that phenotype_category isn't applied (ENCODE has no such concept)
+and that this is not curated MPD phenotype data.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.mpd_tool import MPDRESTTool
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_config():
+    configs = json.loads((_DATA_DIR / "mpd_tools.json").read_text())
+    for cfg in configs:
+        if cfg["name"] == "MPD_get_phenotype_data":
+            return cfg
+    raise AssertionError("MPD_get_phenotype_data not found in mpd_tools.json")
+
+
+def test_strain_not_required():
+    cfg = _tool_config()
+    assert cfg["parameter"]["required"] == []
+
+
+def test_run_uses_search_term_not_biosample_ontology():
+    cfg = _tool_config()
+    tool = MPDRESTTool(cfg)
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"total": 292, "@graph": []}
+
+    with patch.object(tool.session, "get", return_value=resp) as mock_get:
+        result = tool.run({"strain": "C57BL/6J", "limit": 3})
+        called_url = mock_get.call_args.args[0]
+
+    assert result["status"] == "success"
+    assert "searchTerm=C57BL" in called_url
+    assert "biosample_ontology.term_name" not in called_url
+
+
+def test_run_handles_strain_with_slash():
+    cfg = _tool_config()
+    tool = MPDRESTTool(cfg)
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"total": 3, "@graph": []}
+
+    with patch.object(tool.session, "get", return_value=resp) as mock_get:
+        result = tool.run({"strain": "BALB/c", "limit": 2})
+        called_url = mock_get.call_args.args[0]
+
+    # quote()'s default safe="/" leaves the slash unescaped -- confirmed live
+    # this is exactly what ENCODE expects (searchTerm=BALB/c and
+    # searchTerm=C57BL/6J both returned correct, strain-relevant results).
+    assert "searchTerm=BALB/c" in called_url
+    assert result["status"] == "success"
+
+
+def test_run_defaults_strain_when_omitted():
+    cfg = _tool_config()
+    tool = MPDRESTTool(cfg)
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"total": 292, "@graph": []}
+
+    with patch.object(tool.session, "get", return_value=resp):
+        result = tool.run({"limit": 2})
+
+    assert result["query_info"]["strain"] == "C57BL/6J"
+
+
+def test_response_discloses_data_source_limitation():
+    cfg = _tool_config()
+    tool = MPDRESTTool(cfg)
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"total": 0, "@graph": []}
+
+    with patch.object(tool.session, "get", return_value=resp):
+        result = tool.run({"strain": "DBA/2J"})
+
+    note = result["query_info"]["note"]
+    assert "phenotype_category" in note
+    assert "not applied" in note


### PR DESCRIPTION
## Summary
- `MPD_get_phenotype_data` claims to search mouse phenotype data by strain (using ENCODE as a documented stand-in for the Mouse Phenome Database, since MPD's own REST API has no simple strain+category phenotype endpoint). But `mpd_tool.py`'s `run()` never used the `strain` argument at all -- every call returned the exact same generic ENCODE experiment list regardless of what strain was requested.
- The tool's own JSON config already documented an intended fix (`{strain}` templated into ENCODE's `biosample_ontology.term_name` filter), but `run()` never used `fields.endpoint` at all. That documented template was itself also broken -- confirmed live it always returns zero results for real strain names, since `biosample_ontology.term_name` is a tissue/cell-type ontology field, not a strain field.
- ENCODE's free-text `searchTerm` parameter does correctly surface strain-relevant experiments -- confirmed live: 292 hits for "C57BL/6J", 3 for "BALB/c", correctly 0 for a strain ENCODE has no data on ("DBA/2J"). Fixed to query with `searchTerm=<strain>`, added a response note disclosing `phenotype_category` isn't applied (ENCODE has no such concept), removed `strain` from `required` (same required-vs-default schema contradiction being cleared from the round-37 backlog elsewhere), and updated the description/endpoint template to match reality.
- Audited every other hand-rolled (non-`BaseRESTTool`) `_build_url()` for the identical URL path-placeholder default-filling gap found in ChEMBL (round 40, PR #337-equivalent) and PubChem (round 41). `ensembl_tool.py`, `medlineplus_tool.py`, `reactome_tool.py` share the same code shape but none currently has a required+default path-placeholder property -- confirmed via the scan script, nothing to fix there today.
- 3 fresh persona domains (neurodevelopmental/autism genetics, movement disorders/Parkinson's genetics, reproductive endocrinology genetics) found no new bugs this round.

## Test plan
- [x] New `tests/unit/test_mpd_strain_filter.py` (5 tests): required-list fix, `searchTerm` used instead of `biosample_ontology.term_name`, strain-with-slash handled correctly, default strain applied when omitted, response discloses the data-source limitation. All pass.
- [x] Live-verified end-to-end against the real ENCODE API: `MPD_get_phenotype_data({"strain": "C57BL/6J"})` now returns 292 strain-relevant results (previously returned unrelated generic data); `BALB/c` returns 3; omitted-strain defaults to "C57BL/6J".
- [x] Full `tests/unit` suite: exit code 0, zero failures, the same standard 11 environmental skips seen at every prior round.