### PR TITLE
Fix Round 44: Fatcat, OpenAIRE, NeuroMorpho, and TRIP tools wrongly required their default-backed params

### DIFF
--- a/src/tooluniverse/cli.py
+++ b/src/tooluniverse/cli.py
@@ -537,8 +537,10 @@ def _render_run(d: dict) -> str:
     # openFDA's "use a .exact keyword field" hint) — short_err is usually
     # just a generic "<Tool> API error". Surface it instead of dropping it.
     detail = d.get("detail")
+    detail_already_shown = False
     if isinstance(detail, str) and detail.strip() and detail.strip() not in short_err:
         lines.append(f"Detail: {detail.strip()[:300]}")
+        detail_already_shown = True
     details = d.get("error_details") or {}
 
     # Feature-25B-02: for "tool not found" errors, replace generic network tips
@@ -596,7 +598,19 @@ def _render_run(d: dict) -> str:
             nested.get("detail") if isinstance(nested, dict) else None
         )
         detail_hint = _extract_detail_hint(raw_detail)
-        if detail_hint and detail_hint != hint:
+        # When `detail` is a plain (non-JSON) string, _extract_detail_hint's
+        # fallback returns that exact string (capped the same way), which
+        # would just repeat the "Detail: ..." line above -- both come from
+        # the same d["detail"] value. Skip in that case; still show it when
+        # extraction actually pulled a more specific sub-field out of JSON.
+        is_raw_passthrough_of_shown_detail = detail_already_shown and detail_hint == (
+            detail if len(detail) <= 300 else detail[:297] + "..."
+        )
+        if (
+            detail_hint
+            and detail_hint != hint
+            and not is_raw_passthrough_of_shown_detail
+        ):
             cli_steps = [*cli_steps, f"Upstream detail: {detail_hint}"]
         if cli_steps:
             lines.append("Tips:")

--- a/src/tooluniverse/clingen_tool.py
+++ b/src/tooluniverse/clingen_tool.py
@@ -458,8 +458,9 @@ class ClinGenTool(BaseTool):
                 "source": "ClinGen Evidence Repository",
             }
             if not data:
+                queried = f"gene '{gene}'" if gene else f"variant '{variant}'"
                 result["note"] = (
-                    f"No variant classifications found for {gene}. "
+                    f"No variant classifications found for {queried}. "
                     "The ClinGen Evidence Repository only contains variants "
                     "curated by Variant Curation Expert Panels (VCEPs). "
                     "Not all genes have active VCEPs. Try ClinGen_get_gene_validity "

--- a/src/tooluniverse/compound_gene_disease_tool.py
+++ b/src/tooluniverse/compound_gene_disease_tool.py
@@ -122,35 +122,47 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
         """Resolve a gene symbol to its OpenTargets/Ensembl target ID, then
         fetch its real associated-diseases list. OpenTargets has no
         symbol-keyed "diseases for this gene" endpoint, so this chains the
-        target-name search (for the ID) with the ID-based diseases lookup."""
-        search = tu.run_one_function(
-            {
-                "name": "OpenTargets_get_target_id_description_by_name",
-                "arguments": {"targetName": gene},
-            }
-        )
-        hits = (search or {}).get("data", {}).get("search", {}).get("hits", [])
-        if not hits:
-            sources_failed.append(f"OpenTargets: no target match for gene '{gene}'")
-            return {"status": "error", "error": f"No target match for gene '{gene}'"}
+        target-name search (for the ID) with the ID-based diseases lookup.
 
-        gene_upper = gene.upper()
-        match = next(
-            (h for h in hits if h.get("name", "").upper() == gene_upper), hits[0]
-        )
-        ensembl_id = match.get("id")
-
-        result = tu.run_one_function(
-            {
-                "name": "OpenTargets_get_diseases_phenotypes_by_target_ensembl",
-                "arguments": {"ensemblId": ensembl_id},
-            }
-        )
-        if isinstance(result, dict) and result.get("status") == "error":
-            sources_failed.append(
-                f"OpenTargets: {result.get('error', 'unknown error')[:100]}"
+        Both calls are wrapped the same way `_try_tool` wraps every other
+        source in `run()` -- an unhandled exception here (e.g. a network
+        error) would otherwise propagate out of `run()` and kill the whole
+        multi-source lookup instead of just marking OpenTargets failed."""
+        try:
+            search = tu.run_one_function(
+                {
+                    "name": "OpenTargets_get_target_id_description_by_name",
+                    "arguments": {"targetName": gene},
+                }
             )
-        return result
+            hits = (search or {}).get("data", {}).get("search", {}).get("hits", [])
+            if not hits:
+                sources_failed.append(f"OpenTargets: no target match for gene '{gene}'")
+                return {
+                    "status": "error",
+                    "error": f"No target match for gene '{gene}'",
+                }
+
+            gene_upper = gene.upper()
+            match = next(
+                (h for h in hits if h.get("name", "").upper() == gene_upper), hits[0]
+            )
+            ensembl_id = match.get("id")
+
+            result = tu.run_one_function(
+                {
+                    "name": "OpenTargets_get_diseases_phenotypes_by_target_ensembl",
+                    "arguments": {"ensemblId": ensembl_id},
+                }
+            )
+            if isinstance(result, dict) and result.get("status") == "error":
+                sources_failed.append(
+                    f"OpenTargets: {result.get('error', 'unknown error')[:100]}"
+                )
+            return result
+        except Exception as e:
+            sources_failed.append(f"OpenTargets: {str(e)[:100]}")
+            return {"status": "error", "error": str(e)}
 
     def _extract_genes_or_diseases(
         self, result: Any, source: str

--- a/src/tooluniverse/data/fatcat_tools.json
+++ b/src/tooluniverse/data/fatcat_tools.json
@@ -19,8 +19,7 @@
         }
       },
       "required": [
-        "query",
-        "max_results"
+        "query"
       ]
     },
     "return_schema": {

--- a/src/tooluniverse/data/neuromorpho_tools.json
+++ b/src/tooluniverse/data/neuromorpho_tools.json
@@ -435,9 +435,7 @@
           "default": 500
         }
       },
-      "required": [
-        "field_name"
-      ]
+      "required": []
     },
     "fields": {
       "endpoint_type": "neuron",

--- a/src/tooluniverse/data/openaire_tools.json
+++ b/src/tooluniverse/data/openaire_tools.json
@@ -29,9 +29,7 @@
         }
       },
       "required": [
-        "query",
-        "max_results",
-        "type"
+        "query"
       ]
     },
     "return_schema": {

--- a/src/tooluniverse/data/unified_guideline_tools.json
+++ b/src/tooluniverse/data/unified_guideline_tools.json
@@ -180,8 +180,7 @@
         }
       },
       "required": [
-        "query",
-        "search_type"
+        "query"
       ]
     },
     "return_schema": {

--- a/tests/tools/test_guideline_tools.py
+++ b/tests/tools/test_guideline_tools.py
@@ -286,12 +286,26 @@ class TestGuidelineToolsIntegration:
             config = {"name": name, "type": type_name}
             tool = tool_class(config)
             result = tool.run({"query": "diabetes", "limit": 1})
-            
+
             # All should return list, a {"status": "success", "data": [...]}
             # envelope (Fix-R9E-1), or an error dict.
             assert isinstance(result, (list, dict))
 
-            if isinstance(result, dict) and result.get("status") == "success":
+            if tool_class is PubMedGuidelinesTool:
+                # Fix-R9E-1 specifically wraps PubMedGuidelinesTool's
+                # bare-list success case in this envelope -- assert it's
+                # actually present (not just conditionally unwrapped like
+                # below) so a revert of that fix fails this test instead of
+                # silently passing.
+                assert isinstance(result, dict), (
+                    "PubMedGuidelinesTool regressed to a bare-list success "
+                    "return; Fix-R9E-1 requires the {status, data} envelope"
+                )
+                assert result.get("status") in ("success", "error")
+                if result.get("status") == "success":
+                    assert "data" in result
+                    result = result["data"]
+            elif isinstance(result, dict) and result.get("status") == "success":
                 result = result["data"]
 
             if isinstance(result, list):

--- a/tests/unit/test_cli_error_rendering_fixes.py
+++ b/tests/unit/test_cli_error_rendering_fixes.py
@@ -95,3 +95,41 @@ def test_detail_dict_falls_back_to_message_when_no_hint():
     rendered = _render_run(result)
 
     assert "some upstream error message" in rendered
+
+
+def test_plain_string_detail_is_not_shown_twice():
+    """Fix (PR #339 review): when `detail` is a plain (non-JSON) string,
+    _extract_detail_hint's fallback used to return that exact same string,
+    so it was printed once as "Detail: ..." and then again as
+    "Upstream detail: ..." -- redundant duplication of the same info."""
+    result = {
+        "status": "error",
+        "error": "Tool X API error",
+        "detail": "Not Found: the resource does not exist",
+    }
+
+    rendered = _render_run(result)
+
+    assert rendered.count("Not Found: the resource does not exist") == 1
+    assert "Detail: Not Found: the resource does not exist" in rendered
+    assert "Upstream detail:" not in rendered
+
+
+def test_json_detail_with_extractable_key_still_shows_both_lines():
+    """A JSON-encoded detail that _extract_detail_hint can actually pull a
+    more specific sub-field out of is NOT a pure duplicate -- both the raw
+    "Detail:" line and the extracted "Upstream detail:" line should still
+    appear, since they show genuinely different content."""
+    result = {
+        "status": "error",
+        "error": "SASBDB API error",
+        "detail": '{"code": "404", "status": "The Uniprot code p00698 does not exist in the SASBDB"}',
+    }
+
+    rendered = _render_run(result)
+
+    assert 'Detail: {"code": "404"' in rendered
+    assert (
+        "Upstream detail: The Uniprot code p00698 does not exist in the SASBDB"
+        in rendered
+    )

--- a/tests/unit/test_clingen_variant_classifications_speed.py
+++ b/tests/unit/test_clingen_variant_classifications_speed.py
@@ -118,6 +118,24 @@ class TestRequiresGeneOrVariant:
 
         assert result["status"] == "success"
 
+    def test_empty_result_for_uncurated_variant_does_not_say_none(self):
+        """Fix (PR #339 review): the empty-result guard was widened from
+        `if not data and gene:` to `if not data:` to also cover variant-only
+        queries, but the note text still hardcoded `for {gene}` -- a
+        variant-only query with zero results printed "...for None." since
+        `gene` is unset in that branch."""
+        tool = _tool()
+        with patch(
+            "tooluniverse.clingen_tool.requests.get",
+            return_value=_resp({"variantInterpretations": []}),
+        ):
+            result = tool.run({"variant": "CA9999999999"})
+
+        assert result["status"] == "success"
+        assert result["data"] == []
+        assert "None" not in result["note"]
+        assert "CA9999999999" in result["note"]
+
 
 class TestVariantFilterPrecision:
     def test_variant_query_narrowed_to_exact_match(self):

--- a/tests/unit/test_compound_gene_disease_opentargets_lookup.py
+++ b/tests/unit/test_compound_gene_disease_opentargets_lookup.py
@@ -97,6 +97,61 @@ class TestOpenTargetsGeneOnlyLookup:
         assert second_call.args[0]["arguments"] == {"ensemblId": "ENSG00000160789"}
         assert sources_failed == []
 
+    def test_exception_from_run_one_function_is_caught_not_raised(self):
+        """Fix (PR #339 review): _opentargets_gene_diseases previously had no
+        try/except around its two tu.run_one_function calls, unlike every
+        other source in run() which routes through _try_tool -- an
+        unhandled exception here (e.g. a network error) would propagate out
+        of run() and crash the whole multi-source lookup instead of just
+        marking OpenTargets failed."""
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.side_effect = ConnectionError("simulated network failure")
+        sources_failed = []
+
+        result = tool._opentargets_gene_diseases(tu, "LMNA", sources_failed)
+
+        assert result["status"] == "error"
+        assert "simulated network failure" in result["error"]
+        assert len(sources_failed) == 1
+        assert "OpenTargets" in sources_failed[0]
+        assert "simulated network failure" in sources_failed[0]
+
+    def test_exception_on_second_call_is_also_caught(self):
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.side_effect = [
+            _TARGET_SEARCH_RESPONSE,
+            TimeoutError("simulated timeout"),
+        ]
+        sources_failed = []
+
+        result = tool._opentargets_gene_diseases(tu, "LMNA", sources_failed)
+
+        assert result["status"] == "error"
+        assert "simulated timeout" in result["error"]
+        assert len(sources_failed) == 1
+
+    def test_gene_only_query_degrades_gracefully_on_opentargets_exception(self):
+        """End-to-end: run() must not raise even when OpenTargets's chained
+        lookup blows up -- other sources still return normally."""
+        tool = _tool()
+        tu = MagicMock()
+
+        def fake_run(call):
+            if call["name"] == "OpenTargets_get_target_id_description_by_name":
+                raise ConnectionError("simulated network failure")
+            return {"status": "error", "error": "unused source"}
+
+        tu.run_one_function.side_effect = fake_run
+
+        with patch("tooluniverse.execute_function.ToolUniverse", return_value=tu):
+            result = tool.run({"gene": "LMNA"})
+
+        assert result["status"] == "success"
+        failed = result["data"]["sources_failed"]
+        assert any("OpenTargets" in f and "simulated network failure" in f for f in failed)
+
     def test_no_target_match_records_failure_without_crashing(self):
         tool = _tool()
         tu = MagicMock()

--- a/tests/unit/test_r44_optional_default_params.py
+++ b/tests/unit/test_r44_optional_default_params.py
@@ -1,0 +1,127 @@
+"""Regression guard for Fix-R44A-1: four more round-37-backlog tools wrongly
+required params that already have a working Python-level default:
+
+- Fatcat_search_scholar's `max_results` (fatcat_tool.py already does
+  `int(arguments.get("max_results", 10))`).
+- OpenAIRE_search_publications' `max_results` and `type` (openaire_tool.py
+  already does `int(arguments.get("max_results", 10))` and
+  `arguments.get("type", "publications")`, a valid enum value that maps to
+  a real endpoint via `_endpoint_for_type`).
+- NeuroMorpho_get_field_values' `field_name` (neuromorpho_tool.py already
+  does `arguments.get("field_name", "species")`).
+- TRIP_Database_Guidelines_Search's `search_type` (unified_guideline_tools.py
+  already does `arguments.get("search_type", "guideline")`).
+
+Confirmed live for all four: omitting the param previously failed schema
+validation despite the tool being fully answerable without it.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.fatcat_tool import FatcatScholarTool
+from tooluniverse.openaire_tool import OpenAIRETool
+from tooluniverse.neuromorpho_tool import NeuroMorphoTool
+from tooluniverse.unified_guideline_tools import TRIPDatabaseTool
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_config(filename, name):
+    configs = json.loads((_DATA_DIR / filename).read_text())
+    for cfg in configs:
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found in {filename}")
+
+
+def test_fatcat_requires_only_query():
+    cfg = _tool_config("fatcat_tools.json", "Fatcat_search_scholar")
+    assert cfg["parameter"]["required"] == ["query"]
+
+
+def test_openaire_requires_only_query():
+    cfg = _tool_config("openaire_tools.json", "OpenAIRE_search_publications")
+    assert cfg["parameter"]["required"] == ["query"]
+
+
+def test_neuromorpho_field_values_requires_nothing():
+    cfg = _tool_config("neuromorpho_tools.json", "NeuroMorpho_get_field_values")
+    assert cfg["parameter"]["required"] == []
+
+
+def test_trip_requires_only_query():
+    cfg = _tool_config("unified_guideline_tools.json", "TRIP_Database_Guidelines_Search")
+    assert cfg["parameter"]["required"] == ["query"]
+
+
+def test_fatcat_run_uses_default_max_results_when_omitted():
+    cfg = _tool_config("fatcat_tools.json", "Fatcat_search_scholar")
+    tool = FatcatScholarTool(cfg)
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"estimate": {"total": 0}, "results": []}
+
+    with patch("tooluniverse.fatcat_tool.requests.get", return_value=resp) as mock_get:
+        tool.run({"query": "CRISPR"})
+        params = mock_get.call_args.kwargs["params"]
+
+    assert params["limit"] == 10
+
+
+def test_openaire_run_uses_defaults_when_omitted():
+    cfg = _tool_config("openaire_tools.json", "OpenAIRE_search_publications")
+    tool = OpenAIRETool(cfg)
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"response": {"results": {}}}
+
+    with patch("tooluniverse.openaire_tool.requests.get", return_value=resp) as mock_get:
+        result = tool.run({"query": "CRISPR"})
+        endpoint = mock_get.call_args.args[0]
+        params = mock_get.call_args.kwargs["params"]
+
+    assert endpoint == "https://api.openaire.eu/search/publications"
+    assert params["size"] == 10
+    assert result["data"]["type"] == "publications"
+
+
+def test_neuromorpho_field_values_run_uses_default_field_name_when_omitted():
+    cfg = _tool_config("neuromorpho_tools.json", "NeuroMorpho_get_field_values")
+    tool = NeuroMorphoTool(cfg)
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"fields": ["mouse", "rat"], "page": {}}
+
+    with patch(
+        "tooluniverse.neuromorpho_tool.requests.get", return_value=resp
+    ) as mock_get:
+        tool.run({})
+        called_url = mock_get.call_args.args[0]
+
+    assert called_url.endswith("/neuron/fields/species")
+
+
+def test_trip_run_uses_default_search_type_when_omitted():
+    cfg = _tool_config("unified_guideline_tools.json", "TRIP_Database_Guidelines_Search")
+    tool = TRIPDatabaseTool(cfg)
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.content = b"<results><total>0</total><count>0</count></results>"
+    resp.raise_for_status.return_value = None
+
+    with patch.object(tool.session, "get", return_value=resp) as mock_get:
+        tool.run({"query": "diabetes management"})
+        params = mock_get.call_args.kwargs["params"]
+
+    assert params["searchType"] == "guideline"


### PR DESCRIPTION
## Summary
- Four more tools from the round-37 backlog (JSON-schema property both `"required"` and given a `"default"`, so the default can never be reached), all matching the backlog's first sub-pattern (pure Python `.get(x, default)` fallback already correct, only the schema wrongly required it):
  - `Fatcat_search_scholar`: `max_results` wrongly required (`fatcat_tool.py` already does `int(arguments.get("max_results", 10))`).
  - `OpenAIRE_search_publications`: `max_results` and `type` wrongly required (`openaire_tool.py` already does `int(arguments.get("max_results", 10))` and `arguments.get("type", "publications")` -- a valid enum value that maps to a real endpoint via `_endpoint_for_type`).
  - `NeuroMorpho_get_field_values`: `field_name` wrongly required (`neuromorpho_tool.py` already does `arguments.get("field_name", "species")`).
  - `TRIP_Database_Guidelines_Search`: `search_type` wrongly required (`unified_guideline_tools.py` already does `arguments.get("search_type", "guideline")`).
- Confirmed live for all four: omitting the param previously failed schema validation ("'<param>' is a required property") despite the tool being fully answerable without it; all four now succeed and return real results.
- 2 fresh persona domains (pediatric neurology/epilepsy genetics, inherited metabolic disease genetics) found no new bugs this round.

## Test plan
- [x] New `tests/unit/test_r44_optional_default_params.py` (8 tests): required-list fix for all four tools, plus mocked-request assertions confirming the schema default actually reaches the outgoing API call when the param is omitted. All pass.
- [x] Live-verified end-to-end: `Fatcat_search_scholar`, `OpenAIRE_search_publications`, `NeuroMorpho_get_field_values`, and `TRIP_Database_Guidelines_Search` all now succeed with the previously-required param omitted, returning real results.
- [x] Full `tests/unit` suite: exit code 0, zero failures, the same standard 11 environmental skips seen at every prior round.