### PR TITLE
Fix 4 issues found by code review of PR #339

### DIFF
--- a/src/tooluniverse/cli.py
+++ b/src/tooluniverse/cli.py
@@ -537,8 +537,10 @@ def _render_run(d: dict) -> str:
     # openFDA's "use a .exact keyword field" hint) — short_err is usually
     # just a generic "<Tool> API error". Surface it instead of dropping it.
     detail = d.get("detail")
+    detail_already_shown = False
     if isinstance(detail, str) and detail.strip() and detail.strip() not in short_err:
         lines.append(f"Detail: {detail.strip()[:300]}")
+        detail_already_shown = True
     details = d.get("error_details") or {}
 
     # Feature-25B-02: for "tool not found" errors, replace generic network tips
@@ -596,7 +598,19 @@ def _render_run(d: dict) -> str:
             nested.get("detail") if isinstance(nested, dict) else None
         )
         detail_hint = _extract_detail_hint(raw_detail)
-        if detail_hint and detail_hint != hint:
+        # When `detail` is a plain (non-JSON) string, _extract_detail_hint's
+        # fallback returns that exact string (capped the same way), which
+        # would just repeat the "Detail: ..." line above -- both come from
+        # the same d["detail"] value. Skip in that case; still show it when
+        # extraction actually pulled a more specific sub-field out of JSON.
+        is_raw_passthrough_of_shown_detail = detail_already_shown and detail_hint == (
+            detail if len(detail) <= 300 else detail[:297] + "..."
+        )
+        if (
+            detail_hint
+            and detail_hint != hint
+            and not is_raw_passthrough_of_shown_detail
+        ):
             cli_steps = [*cli_steps, f"Upstream detail: {detail_hint}"]
         if cli_steps:
             lines.append("Tips:")

--- a/src/tooluniverse/clingen_tool.py
+++ b/src/tooluniverse/clingen_tool.py
@@ -458,8 +458,9 @@ class ClinGenTool(BaseTool):
                 "source": "ClinGen Evidence Repository",
             }
             if not data:
+                queried = f"gene '{gene}'" if gene else f"variant '{variant}'"
                 result["note"] = (
-                    f"No variant classifications found for {gene}. "
+                    f"No variant classifications found for {queried}. "
                     "The ClinGen Evidence Repository only contains variants "
                     "curated by Variant Curation Expert Panels (VCEPs). "
                     "Not all genes have active VCEPs. Try ClinGen_get_gene_validity "

--- a/src/tooluniverse/compound_gene_disease_tool.py
+++ b/src/tooluniverse/compound_gene_disease_tool.py
@@ -122,35 +122,47 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
         """Resolve a gene symbol to its OpenTargets/Ensembl target ID, then
         fetch its real associated-diseases list. OpenTargets has no
         symbol-keyed "diseases for this gene" endpoint, so this chains the
-        target-name search (for the ID) with the ID-based diseases lookup."""
-        search = tu.run_one_function(
-            {
-                "name": "OpenTargets_get_target_id_description_by_name",
-                "arguments": {"targetName": gene},
-            }
-        )
-        hits = (search or {}).get("data", {}).get("search", {}).get("hits", [])
-        if not hits:
-            sources_failed.append(f"OpenTargets: no target match for gene '{gene}'")
-            return {"status": "error", "error": f"No target match for gene '{gene}'"}
+        target-name search (for the ID) with the ID-based diseases lookup.
 
-        gene_upper = gene.upper()
-        match = next(
-            (h for h in hits if h.get("name", "").upper() == gene_upper), hits[0]
-        )
-        ensembl_id = match.get("id")
-
-        result = tu.run_one_function(
-            {
-                "name": "OpenTargets_get_diseases_phenotypes_by_target_ensembl",
-                "arguments": {"ensemblId": ensembl_id},
-            }
-        )
-        if isinstance(result, dict) and result.get("status") == "error":
-            sources_failed.append(
-                f"OpenTargets: {result.get('error', 'unknown error')[:100]}"
+        Both calls are wrapped the same way `_try_tool` wraps every other
+        source in `run()` -- an unhandled exception here (e.g. a network
+        error) would otherwise propagate out of `run()` and kill the whole
+        multi-source lookup instead of just marking OpenTargets failed."""
+        try:
+            search = tu.run_one_function(
+                {
+                    "name": "OpenTargets_get_target_id_description_by_name",
+                    "arguments": {"targetName": gene},
+                }
             )
-        return result
+            hits = (search or {}).get("data", {}).get("search", {}).get("hits", [])
+            if not hits:
+                sources_failed.append(f"OpenTargets: no target match for gene '{gene}'")
+                return {
+                    "status": "error",
+                    "error": f"No target match for gene '{gene}'",
+                }
+
+            gene_upper = gene.upper()
+            match = next(
+                (h for h in hits if h.get("name", "").upper() == gene_upper), hits[0]
+            )
+            ensembl_id = match.get("id")
+
+            result = tu.run_one_function(
+                {
+                    "name": "OpenTargets_get_diseases_phenotypes_by_target_ensembl",
+                    "arguments": {"ensemblId": ensembl_id},
+                }
+            )
+            if isinstance(result, dict) and result.get("status") == "error":
+                sources_failed.append(
+                    f"OpenTargets: {result.get('error', 'unknown error')[:100]}"
+                )
+            return result
+        except Exception as e:
+            sources_failed.append(f"OpenTargets: {str(e)[:100]}")
+            return {"status": "error", "error": str(e)}
 
     def _extract_genes_or_diseases(
         self, result: Any, source: str

--- a/tests/tools/test_guideline_tools.py
+++ b/tests/tools/test_guideline_tools.py
@@ -286,12 +286,26 @@ class TestGuidelineToolsIntegration:
             config = {"name": name, "type": type_name}
             tool = tool_class(config)
             result = tool.run({"query": "diabetes", "limit": 1})
-            
+
             # All should return list, a {"status": "success", "data": [...]}
             # envelope (Fix-R9E-1), or an error dict.
             assert isinstance(result, (list, dict))
 
-            if isinstance(result, dict) and result.get("status") == "success":
+            if tool_class is PubMedGuidelinesTool:
+                # Fix-R9E-1 specifically wraps PubMedGuidelinesTool's
+                # bare-list success case in this envelope -- assert it's
+                # actually present (not just conditionally unwrapped like
+                # below) so a revert of that fix fails this test instead of
+                # silently passing.
+                assert isinstance(result, dict), (
+                    "PubMedGuidelinesTool regressed to a bare-list success "
+                    "return; Fix-R9E-1 requires the {status, data} envelope"
+                )
+                assert result.get("status") in ("success", "error")
+                if result.get("status") == "success":
+                    assert "data" in result
+                    result = result["data"]
+            elif isinstance(result, dict) and result.get("status") == "success":
                 result = result["data"]
 
             if isinstance(result, list):

--- a/tests/unit/test_cli_error_rendering_fixes.py
+++ b/tests/unit/test_cli_error_rendering_fixes.py
@@ -95,3 +95,41 @@ def test_detail_dict_falls_back_to_message_when_no_hint():
     rendered = _render_run(result)
 
     assert "some upstream error message" in rendered
+
+
+def test_plain_string_detail_is_not_shown_twice():
+    """Fix (PR #339 review): when `detail` is a plain (non-JSON) string,
+    _extract_detail_hint's fallback used to return that exact same string,
+    so it was printed once as "Detail: ..." and then again as
+    "Upstream detail: ..." -- redundant duplication of the same info."""
+    result = {
+        "status": "error",
+        "error": "Tool X API error",
+        "detail": "Not Found: the resource does not exist",
+    }
+
+    rendered = _render_run(result)
+
+    assert rendered.count("Not Found: the resource does not exist") == 1
+    assert "Detail: Not Found: the resource does not exist" in rendered
+    assert "Upstream detail:" not in rendered
+
+
+def test_json_detail_with_extractable_key_still_shows_both_lines():
+    """A JSON-encoded detail that _extract_detail_hint can actually pull a
+    more specific sub-field out of is NOT a pure duplicate -- both the raw
+    "Detail:" line and the extracted "Upstream detail:" line should still
+    appear, since they show genuinely different content."""
+    result = {
+        "status": "error",
+        "error": "SASBDB API error",
+        "detail": '{"code": "404", "status": "The Uniprot code p00698 does not exist in the SASBDB"}',
+    }
+
+    rendered = _render_run(result)
+
+    assert 'Detail: {"code": "404"' in rendered
+    assert (
+        "Upstream detail: The Uniprot code p00698 does not exist in the SASBDB"
+        in rendered
+    )

--- a/tests/unit/test_clingen_variant_classifications_speed.py
+++ b/tests/unit/test_clingen_variant_classifications_speed.py
@@ -118,6 +118,24 @@ class TestRequiresGeneOrVariant:
 
         assert result["status"] == "success"
 
+    def test_empty_result_for_uncurated_variant_does_not_say_none(self):
+        """Fix (PR #339 review): the empty-result guard was widened from
+        `if not data and gene:` to `if not data:` to also cover variant-only
+        queries, but the note text still hardcoded `for {gene}` -- a
+        variant-only query with zero results printed "...for None." since
+        `gene` is unset in that branch."""
+        tool = _tool()
+        with patch(
+            "tooluniverse.clingen_tool.requests.get",
+            return_value=_resp({"variantInterpretations": []}),
+        ):
+            result = tool.run({"variant": "CA9999999999"})
+
+        assert result["status"] == "success"
+        assert result["data"] == []
+        assert "None" not in result["note"]
+        assert "CA9999999999" in result["note"]
+
 
 class TestVariantFilterPrecision:
     def test_variant_query_narrowed_to_exact_match(self):

--- a/tests/unit/test_compound_gene_disease_opentargets_lookup.py
+++ b/tests/unit/test_compound_gene_disease_opentargets_lookup.py
@@ -97,6 +97,61 @@ class TestOpenTargetsGeneOnlyLookup:
         assert second_call.args[0]["arguments"] == {"ensemblId": "ENSG00000160789"}
         assert sources_failed == []
 
+    def test_exception_from_run_one_function_is_caught_not_raised(self):
+        """Fix (PR #339 review): _opentargets_gene_diseases previously had no
+        try/except around its two tu.run_one_function calls, unlike every
+        other source in run() which routes through _try_tool -- an
+        unhandled exception here (e.g. a network error) would propagate out
+        of run() and crash the whole multi-source lookup instead of just
+        marking OpenTargets failed."""
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.side_effect = ConnectionError("simulated network failure")
+        sources_failed = []
+
+        result = tool._opentargets_gene_diseases(tu, "LMNA", sources_failed)
+
+        assert result["status"] == "error"
+        assert "simulated network failure" in result["error"]
+        assert len(sources_failed) == 1
+        assert "OpenTargets" in sources_failed[0]
+        assert "simulated network failure" in sources_failed[0]
+
+    def test_exception_on_second_call_is_also_caught(self):
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.side_effect = [
+            _TARGET_SEARCH_RESPONSE,
+            TimeoutError("simulated timeout"),
+        ]
+        sources_failed = []
+
+        result = tool._opentargets_gene_diseases(tu, "LMNA", sources_failed)
+
+        assert result["status"] == "error"
+        assert "simulated timeout" in result["error"]
+        assert len(sources_failed) == 1
+
+    def test_gene_only_query_degrades_gracefully_on_opentargets_exception(self):
+        """End-to-end: run() must not raise even when OpenTargets's chained
+        lookup blows up -- other sources still return normally."""
+        tool = _tool()
+        tu = MagicMock()
+
+        def fake_run(call):
+            if call["name"] == "OpenTargets_get_target_id_description_by_name":
+                raise ConnectionError("simulated network failure")
+            return {"status": "error", "error": "unused source"}
+
+        tu.run_one_function.side_effect = fake_run
+
+        with patch("tooluniverse.execute_function.ToolUniverse", return_value=tu):
+            result = tool.run({"gene": "LMNA"})
+
+        assert result["status"] == "success"
+        failed = result["data"]["sources_failed"]
+        assert any("OpenTargets" in f and "simulated network failure" in f for f in failed)
+
     def test_no_target_match_records_failure_without_crashing(self):
         tool = _tool()
         tu = MagicMock()


### PR DESCRIPTION
## Summary

Targeted fix round addressing 4 issues found by a code review of PR #339's consolidation (rounds 1-41). Each was live-verified before writing a regression test.

1. **`compound_gene_disease_tool.py`**: `_opentargets_gene_diseases()` (added for gene-only queries) called `tu.run_one_function()` twice with no try/except, unlike every other source in this file which routes through the local `_try_tool()` closure. An unhandled exception here (e.g. a network error) would propagate out of `run()` and crash the whole multi-source lookup instead of just marking OpenTargets failed. Wrapped both calls the same way `_try_tool` does — a gene-only query now degrades gracefully on a network error, confirmed live via a simulated `ConnectionError`.

2. **`cli.py`**: `_render_run` had two separate code paths both surfacing the error envelope's `detail` field — an unconditional "Detail: ..." line and a later "Upstream detail: ..." line via `_extract_detail_hint()`. When `detail` is a plain (non-JSON) string, `_extract_detail_hint`'s fallback returns that same raw string, so both lines printed identical info. Fixed by tracking whether the "Detail:" line was already shown and skipping "Upstream detail:" when it would be a pure passthrough duplicate — still shows both when JSON extraction pulls a genuinely different, more specific sub-field (confirmed live for both cases).

3. **`clingen_tool.py`**, `_get_variant_classifications`: the empty-result guard was widened from `if not data and gene:` to `if not data:` to also cover variant-only queries, but the message text still hardcoded `"No variant classifications found for {gene}."`, so a variant-only query with zero results printed "...for None." Fixed to reference whichever of gene/variant was actually supplied — confirmed live with a real uncurated variant ID.

4. **`tests/tools/test_guideline_tools.py`**, `test_all_tools_return_consistent_format`: the envelope-unwrap assertion was unconditional/optional, so if the `{"status":"success","data":[...]}` envelope fix (Fix-R9E-1) were fully reverted, this test would still pass. Fixed to require the envelope specifically for `PubMedGuidelinesTool` — the only one of the three tools Fix-R9E-1 actually covers (confirmed by reading `EuropePMCGuidelinesTool`'s and `TRIPDatabaseTool`'s real `run()` implementations: both legitimately return bare lists on success, no envelope). Verified the new assertion both passes against real live behavior and would catch a simulated revert.

## Test plan
- [x] New/updated regression tests across 4 files (`test_compound_gene_disease_opentargets_lookup.py` +3, `test_cli_error_rendering_fixes.py` +2, `test_clingen_variant_classifications_speed.py` +1, `test_guideline_tools.py` tightened): all pass.
- [x] Live-verified each of the 4 fixes end-to-end before writing tests (simulated network failure for #1, both duplicate and genuine-extraction cases for #2, a real ClinGen API call for #3, live run of the integration test for #4).
- [x] Full `tests/unit` suite: exit code 0, zero failures, the same standard 11 environmental skips seen at every prior round.