### PR TITLE
Fix Round 45: DrugSafetyAnalyzer and BiomarkerDiscoveryWorkflow wrongly required their default-backed params

### DIFF
--- a/src/tooluniverse/data/compose_tools.json
+++ b/src/tooluniverse/data/compose_tools.json
@@ -26,8 +26,7 @@
       },
       "required": [
         "drug_name",
-        "patient_sex",
-        "serious_events_only"
+        "patient_sex"
       ]
     },
     "auto_load_dependencies": true,
@@ -536,8 +535,7 @@
         }
       },
       "required": [
-        "disease_condition",
-        "sample_type"
+        "disease_condition"
       ]
     },
     "auto_load_dependencies": true,

--- a/tests/unit/test_compose_tools_optional_defaults.py
+++ b/tests/unit/test_compose_tools_optional_defaults.py
@@ -1,0 +1,91 @@
+"""Regression guard: DrugSafetyAnalyzer's `serious_events_only` and
+BiomarkerDiscoveryWorkflow's `sample_type` were wrongly marked `required`
+in compose_tools.json even though each has a working `default` and their
+composition functions already handle the omitted case via
+`arguments.get(x, default)` -- confirmed live, both tools previously
+failed schema validation when the param was omitted despite being fully
+answerable without it.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.compose_scripts.drug_safety_analyzer import (
+    compose as drug_safety_compose,
+)
+from tooluniverse.compose_scripts.biomarker_discovery import (
+    compose as biomarker_compose,
+)
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_config(name):
+    configs = json.loads((_DATA_DIR / "compose_tools.json").read_text())
+    for cfg in configs:
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found in compose_tools.json")
+
+
+def test_drug_safety_analyzer_requires_only_drug_name_and_patient_sex():
+    cfg = _tool_config("DrugSafetyAnalyzer")
+    assert cfg["parameter"]["required"] == ["drug_name", "patient_sex"]
+
+
+def test_biomarker_discovery_workflow_requires_only_disease_condition():
+    cfg = _tool_config("BiomarkerDiscoveryWorkflow")
+    assert cfg["parameter"]["required"] == ["disease_condition"]
+
+
+def test_drug_safety_compose_defaults_serious_events_only_to_false():
+    calls = []
+
+    def fake_call_tool(name, args):
+        calls.append((name, args))
+        return {"result": []}
+
+    result = drug_safety_compose(
+        {"drug_name": "aspirin", "patient_sex": "Female"},
+        tooluniverse=None,
+        call_tool=fake_call_tool,
+    )
+
+    assert result["analysis_parameters"]["serious_events_only"] is False
+    faers_call = next(c for c in calls if c[0] == "FAERS_count_reactions_by_drug_event")
+    assert "serious" not in faers_call[1]
+
+
+def test_drug_safety_compose_honors_explicit_serious_events_only():
+    calls = []
+
+    def fake_call_tool(name, args):
+        calls.append((name, args))
+        return {"result": []}
+
+    result = drug_safety_compose(
+        {"drug_name": "aspirin", "patient_sex": "Female", "serious_events_only": True},
+        tooluniverse=None,
+        call_tool=fake_call_tool,
+    )
+
+    assert result["analysis_parameters"]["serious_events_only"] is True
+    faers_call = next(c for c in calls if c[0] == "FAERS_count_reactions_by_drug_event")
+    assert faers_call[1]["serious"] == "Yes"
+
+
+def test_biomarker_compose_defaults_sample_type_to_blood():
+    def fake_call_tool(name, args):
+        return {"result": []}
+
+    result = biomarker_compose(
+        {"disease_condition": "diabetes"},
+        tooluniverse=None,
+        call_tool=fake_call_tool,
+    )
+
+    assert result["sample_type"] == "blood"


### PR DESCRIPTION
## Summary
- Two more tools from the round-37 backlog (JSON-schema property both `"required"` and given a `"default"`, so the default can never be reached), both pure schema-only fixes:
  - `DrugSafetyAnalyzer`: `serious_events_only` wrongly required (`compose_scripts/drug_safety_analyzer.py`'s `compose()` already does `arguments.get("serious_events_only", False)`).
  - `BiomarkerDiscoveryWorkflow`: `sample_type` wrongly required (`compose_scripts/biomarker_discovery.py`'s `compose()` already does `arguments.get("sample_type", "blood")`).
- Confirmed live for both: omitting the param previously failed schema validation despite the tool being fully answerable without it; both now succeed with the correct default applied.
- `nvidia_nim_tools.json`'s two remaining candidates (`format`, `num_output_samples`) were investigated but **deliberately deferred, not fixed**: no NVIDIA API key is available in this environment to live-verify whether NVIDIA's server-side default actually matches the schema's documented default when the field is omitted from the request body — unlike the `compose_tools.json` pair, these tools pass arguments through directly to the API with no client-side default substitution. Shipping an unverified fix here risks the exact silent-behavior-change class of bug this backlog effort exists to catch.
- 2 fresh persona domains (skeletal dysplasia/orthopedic genetics, thyroid endocrinology genetics) found no new bugs this round.

## Test plan
- [x] New `tests/unit/test_compose_tools_optional_defaults.py` (5 tests): required-list fix for both tools, plus assertions confirming the schema default actually reaches the composition function's downstream tool calls when the param is omitted (and that explicit values still override it). All pass.
- [x] Live-verified end-to-end: `DrugSafetyAnalyzer({"drug_name": "aspirin", "patient_sex": "Female"})` and `BiomarkerDiscoveryWorkflow({"disease_condition": "diabetes"})` both now succeed with the previously-required param omitted, correctly applying the default.
- [x] Full `tests/unit` suite: exit code 0, zero failures, the same standard 11 environmental skips seen at every prior round.