### PR TITLE
Fix Round 46: MultiAgentLiteratureSearch wrongly required its unused iteration/quality params

### DIFF
--- a/src/tooluniverse/data/literature_search_tools.json
+++ b/src/tooluniverse/data/literature_search_tools.json
@@ -287,7 +287,7 @@
   {
     "type": "ComposeTool",
     "name": "MultiAgentLiteratureSearch",
-    "description": "Multi-agent literature search system that uses AI agents to analyze intent, extract keywords, execute parallel searches, summarize results, and check quality iteratively",
+    "description": "Multi-agent literature search system that uses AI agents to analyze intent, extract keywords, execute parallel searches, and summarize results. Always runs a single pass -- 'max_iterations' and 'quality_threshold' are not currently applied (no iterative refinement loop is wired into the search flow yet).",
     "parameter": {
       "type": "object",
       "properties": {
@@ -297,19 +297,17 @@
         },
         "max_iterations": {
           "type": "integer",
-          "description": "Maximum number of iterations (default: 3)",
+          "description": "Not currently applied -- the search always runs a single pass. Retained for forward compatibility with a future iterative-refinement implementation.",
           "default": 3
         },
         "quality_threshold": {
           "type": "number",
-          "description": "Quality threshold for completion (default: 0.7)",
+          "description": "Not currently applied -- QualityCheckerAgent is registered as a dependency but never invoked by the current search flow. Retained for forward compatibility with a future iterative-refinement implementation.",
           "default": 0.7
         }
       },
       "required": [
-        "query",
-        "max_iterations",
-        "quality_threshold"
+        "query"
       ]
     },
     "auto_load_dependencies": true,

--- a/tests/unit/test_compound_gene_disease_opentargets_lookup.py
+++ b/tests/unit/test_compound_gene_disease_opentargets_lookup.py
@@ -187,7 +187,6 @@ class TestOpenTargetsGeneOnlyLookup:
             "status": "success",
             "data": {"search": {"hits": [{"name": "progeria"}]}},
         }
-        sources_failed = []
 
         # run() itself dispatches this, but exercising just the extraction
         # helper's untouched branch is enough to confirm no regression.

--- a/tests/unit/test_literature_search_optional_defaults.py
+++ b/tests/unit/test_literature_search_optional_defaults.py
@@ -1,0 +1,94 @@
+"""Regression guard: MultiAgentLiteratureSearch's `max_iterations` and
+`quality_threshold` were wrongly marked `required` in
+literature_search_tools.json even though each has a `default` -- but unlike
+every other tool in the round-37 backlog, these two aren't just "correctly
+defaulted in Python", they're never read at all by
+compose_scripts/enhanced_multi_agent_literature_search.py's compose()
+(confirmed by grepping the whole 314-line file). The search always runs a
+single pass (the overall-summary agent call hardcodes "iterations": "1"),
+and QualityCheckerAgent is listed as a required dependency but never
+invoked by the actual search flow. Fixed by removing both from `required`
+and correcting the tool's own description (and each param's description)
+to stop promising iterative/quality-threshold behavior that isn't wired up
+yet.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tooluniverse.compose_scripts.enhanced_multi_agent_literature_search import (
+    compose,
+)
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_config():
+    configs = json.loads((_DATA_DIR / "literature_search_tools.json").read_text())
+    for cfg in configs:
+        if cfg["name"] == "MultiAgentLiteratureSearch":
+            return cfg
+    raise AssertionError("MultiAgentLiteratureSearch not found")
+
+
+def test_requires_only_query():
+    cfg = _tool_config()
+    assert cfg["parameter"]["required"] == ["query"]
+
+
+def test_description_no_longer_promises_iterative_quality_check():
+    cfg = _tool_config()
+    assert "iteratively" not in cfg["description"]
+    assert "not currently applied" in cfg["parameter"]["properties"]["max_iterations"]["description"].lower()
+    assert "not currently applied" in cfg["parameter"]["properties"]["quality_threshold"]["description"].lower()
+
+
+def test_max_iterations_and_quality_threshold_never_read_by_compose():
+    """Static guard: if a future change wires these params into real
+    behavior, this test should be updated (and the schema/description
+    honesty fix above should be revisited) rather than silently going
+    stale."""
+    import inspect
+    import tooluniverse.compose_scripts.enhanced_multi_agent_literature_search as mod
+
+    source = inspect.getsource(mod)
+    assert '"max_iterations"' not in source
+    assert "'max_iterations'" not in source
+    assert '"quality_threshold"' not in source
+    assert "'quality_threshold'" not in source
+
+
+def test_compose_completes_with_max_iterations_and_quality_threshold_omitted():
+    """End-to-end: the search flow completes identically whether or not
+    max_iterations/quality_threshold are present in arguments, since
+    they're never read."""
+    memory_manager = MagicMock()
+    memory_manager.create_session.return_value = "session-123"
+    memory_manager.get_context_for_agent.return_value = {}
+
+    def fake_call_tool(name, args):
+        if name == "IntentAnalyzerAgent":
+            return {"user_intent": "test intent", "search_plans": []}
+        if name == "OverallSummaryAgent":
+            return {"summary": "done"}
+        raise AssertionError(f"unexpected call_tool: {name}")
+
+    emit_event = MagicMock()
+    stream_callback = MagicMock()
+
+    result = compose(
+        {"query": "CRISPR gene editing"},
+        tooluniverse=MagicMock(),
+        call_tool=fake_call_tool,
+        stream_callback=stream_callback,
+        emit_event=emit_event,
+        memory_manager=memory_manager,
+    )
+
+    assert result["success"] is True
+    assert result["results"]["total_papers"] == 0

--- a/tests/unit/test_pubchem_similarity_and_image_optional_defaults.py
+++ b/tests/unit/test_pubchem_similarity_and_image_optional_defaults.py
@@ -122,5 +122,7 @@ def test_search_similarity_threshold_omitted_matches_explicit_default():
         explicit_url = mock_get.call_args.args[0]
 
     assert omitted_result["status"] == "success"
+    assert explicit_result["status"] == "success"
+    assert omitted_result == explicit_result
     assert "Threshold=90" in explicit_url
     assert "Threshold" not in omitted_url


### PR DESCRIPTION
## Summary
- Another round-37 backlog item, but a notable variant of the pattern: `MultiAgentLiteratureSearch`'s `max_iterations` and `quality_threshold` were wrongly marked `required` even though each has a `default` -- but unlike every prior fix in this backlog, these two aren't just "correctly defaulted in Python", they're **never read at all** by `compose_scripts/enhanced_multi_agent_literature_search.py`'s `compose()` (confirmed by grepping the whole 314-line file for both param names). The search always runs a single pass -- the overall-summary agent call hardcodes `"iterations": "1"` -- and `QualityCheckerAgent` is listed as a required dependency but never actually invoked by the search flow.
- Fixed the required-vs-default schema contradiction (removing both from `required` is safe: they were already 100% ignored, so omitting them changes nothing about behavior).
- Also corrected the tool's own description and each param's description, which previously promised "check quality iteratively" behavior that isn't implemented -- callers reading the schema would otherwise reasonably expect these params to control real behavior when they currently do nothing.
- 2 fresh persona domains (neurology/malignant hyperthermia pharmacogenomics, hereditary cancer syndrome genetics) found no new bugs this round.

## Test plan
- [x] New `tests/unit/test_literature_search_optional_defaults.py` (4 tests): required-list fix, description honesty fix, a static guard confirming neither param name appears anywhere in the compose script (regression guard -- if a future change wires these in, this test should be updated intentionally rather than silently going stale), and an end-to-end mocked run confirming the search completes identically with both params omitted. All pass.
- [x] Full `tests/unit` suite: exit code 0, zero failures, the same standard 11 environmental skips seen at every prior round.

Note: this PR targets `main` directly -- the round-42-45 stacking chain was reconciled into `main` via #345 (see prior PR for the squash-merge gotcha that caused that), so no more stacking is needed going forward.