### PR TITLE
Fix Round 47: ToolCompatibilityAnalyzer, ToolGraphComposer, ToolDescriptionOptimizer wrongly required their default-backed params

### DIFF
--- a/src/tooluniverse/compose_scripts/tool_description_optimizer.py
+++ b/src/tooluniverse/compose_scripts/tool_description_optimizer.py
@@ -6,7 +6,7 @@ import re
 def compose(arguments, tooluniverse, call_tool):
     tool_config = arguments["tool_config"]
     tool_name = tool_config.get("name", "unnamed_tool")
-    arguments.get("save_to_file", False)
+    save_to_file = arguments.get("save_to_file", False)
     output_file = arguments.get("output_file")
     max_iterations = arguments.get("max_iterations", 3)  # Maximum optimization rounds
     satisfaction_threshold = arguments.get(
@@ -581,9 +581,9 @@ def compose(arguments, tooluniverse, call_tool):
     print("\n✨ Final Optimized Tool Configuration:")
     print(json.dumps(final_optimized_tool_config, indent=2, ensure_ascii=False))
 
-    # 4. Save the optimized description to a file (always save, regardless of save_to_file flag)
+    # 4. Save the optimized description to a file, if requested
     file_path = None
-    if final_description:
+    if save_to_file and final_description:
         if not output_file:
             file_path = f"{tool_name}_optimized_description.txt"
         else:
@@ -657,7 +657,7 @@ def compose(arguments, tooluniverse, call_tool):
             f.write("\n```\n")
 
         print(f"✅ Optimization report saved successfully to: {file_path}")
-    else:
+    elif not final_description:
         print("⚠️ No optimized description to save")
 
     return {
@@ -677,5 +677,5 @@ def compose(arguments, tooluniverse, call_tool):
             else False
         ),
         "test_results": results,
-        "saved_to": file_path if final_description else None,
+        "saved_to": file_path,
     }

--- a/src/tooluniverse/data/optimizer_tools.json
+++ b/src/tooluniverse/data/optimizer_tools.json
@@ -31,11 +31,7 @@
         }
       },
       "required": [
-        "tool_config",
-        "save_to_file",
-        "output_file",
-        "max_iterations",
-        "satisfaction_threshold"
+        "tool_config"
       ]
     },
     "auto_load_dependencies": true,

--- a/src/tooluniverse/data/tool_composition_tools.json
+++ b/src/tooluniverse/data/tool_composition_tools.json
@@ -33,8 +33,7 @@
       },
       "required": [
         "source_tool",
-        "target_tool",
-        "analysis_depth"
+        "target_tool"
       ]
     },
     "configs": {
@@ -140,14 +139,7 @@
           "default": false
         }
       },
-      "required": [
-        "output_path",
-        "analysis_depth",
-        "min_compatibility_score",
-        "exclude_categories",
-        "max_tools_per_category",
-        "force_rebuild"
-      ]
+      "required": []
     },
     "auto_load_dependencies": true,
     "fail_on_missing_tools": false,

--- a/tests/unit/test_compound_gene_disease_opentargets_lookup.py
+++ b/tests/unit/test_compound_gene_disease_opentargets_lookup.py
@@ -187,7 +187,6 @@ class TestOpenTargetsGeneOnlyLookup:
             "status": "success",
             "data": {"search": {"hits": [{"name": "progeria"}]}},
         }
-        sources_failed = []
 
         # run() itself dispatches this, but exercising just the extraction
         # helper's untouched branch is enough to confirm no regression.

--- a/tests/unit/test_pubchem_similarity_and_image_optional_defaults.py
+++ b/tests/unit/test_pubchem_similarity_and_image_optional_defaults.py
@@ -122,5 +122,7 @@ def test_search_similarity_threshold_omitted_matches_explicit_default():
         explicit_url = mock_get.call_args.args[0]
 
     assert omitted_result["status"] == "success"
+    assert explicit_result["status"] == "success"
+    assert omitted_result == explicit_result
     assert "Threshold=90" in explicit_url
     assert "Threshold" not in omitted_url

--- a/tests/unit/test_tool_description_optimizer_optional_defaults.py
+++ b/tests/unit/test_tool_description_optimizer_optional_defaults.py
@@ -1,0 +1,91 @@
+"""Regression guard for the round-37 backlog's ToolDescriptionOptimizer fix,
+plus a genuine behavior bug found while fixing it:
+
+- save_to_file, output_file, max_iterations, satisfaction_threshold were all
+  wrongly marked required in optimizer_tools.json even though max_iterations/
+  satisfaction_threshold have schema defaults the compose() function already
+  reads correctly, and output_file/save_to_file are handled gracefully when
+  omitted (output_file falls back to "<tool_name>_optimized_description.txt";
+  save_to_file previously had no schema default at all despite promising one
+  implicitly via its boolean type).
+- Separately: compose()'s own code read save_to_file into a throwaway
+  expression (`arguments.get("save_to_file", False)` with no assignment) and
+  a comment literally said "always save, regardless of save_to_file flag" --
+  the file was written to disk unconditionally, ignoring the flag entirely,
+  contradicting the schema's own description ("If true, save..."). Fixed to
+  actually gate the file write on save_to_file, restoring the tool's
+  documented contract.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tooluniverse.compose_scripts.tool_description_optimizer import compose
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_config():
+    configs = json.loads((_DATA_DIR / "optimizer_tools.json").read_text())
+    for cfg in configs:
+        if cfg["name"] == "ToolDescriptionOptimizer":
+            return cfg
+    raise AssertionError("ToolDescriptionOptimizer not found")
+
+
+def test_requires_only_tool_config():
+    cfg = _tool_config()
+    assert cfg["parameter"]["required"] == ["tool_config"]
+
+
+def _fake_call_tool(name, args):
+    if name == "TestCaseGenerator":
+        return [{"query": "test"}]
+    if name == "DescriptionAnalyzer":
+        return {"optimized_description": "A better description.", "rationale": "why"}
+    if name == "DescriptionQualityEvaluator":
+        return {"overall_score": 9, "is_satisfactory": True, "feedback": "great"}
+    raise AssertionError(f"unexpected call_tool: {name}")
+
+
+def _run_compose(tmp_path, save_to_file):
+    tooluniverse = MagicMock()
+    tooluniverse.run_one_function.return_value = {"status": "success"}
+    output_file = str(tmp_path / "report.txt")
+
+    result = compose(
+        {
+            "tool_config": {"name": "SomeTool", "description": "original desc"},
+            "save_to_file": save_to_file,
+            "output_file": output_file,
+            "max_iterations": 1,
+            "satisfaction_threshold": 8,
+        },
+        tooluniverse=tooluniverse,
+        call_tool=_fake_call_tool,
+    )
+    return result, output_file
+
+
+def test_save_to_file_false_does_not_write_a_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        result, output_file = _run_compose(tmp_path, save_to_file=False)
+
+        assert result["saved_to"] is None
+        assert not Path(output_file).exists()
+
+
+def test_save_to_file_true_writes_a_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        result, output_file = _run_compose(tmp_path, save_to_file=True)
+
+        assert result["saved_to"] == output_file
+        assert Path(output_file).exists()

--- a/tests/unit/test_tool_graph_composer_optional_defaults.py
+++ b/tests/unit/test_tool_graph_composer_optional_defaults.py
@@ -1,0 +1,66 @@
+"""Regression guard: ToolGraphComposer's output_path, analysis_depth,
+min_compatibility_score, exclude_categories, max_tools_per_category, and
+force_rebuild were all wrongly marked required in tool_composition_tools.json
+even though each has a schema default that compose_scripts/tool_graph_
+composer.py's compose() already reads correctly via arguments.get(x, default).
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tooluniverse.agentic_tool import AgenticTool
+from tooluniverse.compose_scripts.tool_graph_composer import compose
+
+pytestmark = pytest.mark.unit
+
+_DATA_DIR = Path(__file__).parent.parent.parent / "src" / "tooluniverse" / "data"
+
+
+def _tool_config(name):
+    configs = json.loads((_DATA_DIR / "tool_composition_tools.json").read_text())
+    for cfg in configs:
+        if cfg["name"] == name:
+            return cfg
+    raise AssertionError(f"{name} not found")
+
+
+def test_tool_graph_composer_requires_nothing():
+    cfg = _tool_config("ToolGraphComposer")
+    assert cfg["parameter"]["required"] == []
+
+
+def test_tool_compatibility_analyzer_requires_only_source_and_target():
+    cfg = _tool_config("ToolCompatibilityAnalyzer")
+    assert cfg["parameter"]["required"] == ["source_tool", "target_tool"]
+
+
+def test_compose_uses_defaults_when_all_args_omitted():
+    tooluniverse = MagicMock()
+    tooluniverse.all_tool_dict = {}  # no tools -> clean early return, no LLM calls
+
+    with tempfile.TemporaryDirectory() as tmp:
+        output_path = str(Path(tmp) / "graph")
+        result = compose({"output_path": output_path}, tooluniverse, call_tool=MagicMock())
+
+    assert result["status"] == "error"
+    assert result["message"] == "No tools available for analysis after filtering"
+    assert result["tools_analyzed"] == 0
+
+
+def test_tool_compatibility_analyzer_fills_analysis_depth_default():
+    """AgenticTool has its own generic default-filling mechanism (fills
+    missing input_arguments from each property's schema "default" before
+    formatting the prompt) -- confirmed here via get_prompt_preview(), which
+    exercises that exact logic without needing a working LLM API key."""
+    cfg = _tool_config("ToolCompatibilityAnalyzer")
+    tool = AgenticTool(cfg)
+
+    preview = tool.get_prompt_preview(
+        {"source_tool": '{"name": "a"}', "target_tool": '{"name": "b"}'}
+    )
+
+    assert "Analysis Depth: detailed" in preview


### PR DESCRIPTION
## Summary
- Three more round-37 backlog tools:
  - `ToolCompatibilityAnalyzer` (AgenticTool): `analysis_depth` wrongly required. Confirmed `AgenticTool` has its own generic default-filling mechanism (fills missing `input_arguments` from each property's schema default before formatting the LLM prompt) -- verified via `get_prompt_preview()`, which exercises that exact logic without needing a working LLM API key.
  - `ToolGraphComposer` (ComposeTool): all 6 of its params (`output_path`, `analysis_depth`, `min_compatibility_score`, `exclude_categories`, `max_tools_per_category`, `force_rebuild`) wrongly required despite each having a schema default `compose_scripts/tool_graph_composer.py`'s `compose()` already reads correctly.
  - `ToolDescriptionOptimizer` (ComposeTool): `save_to_file`, `output_file`, `max_iterations`, `satisfaction_threshold` wrongly required. While fixing this one, found a genuine behavior bug alongside the schema issue: `compose_scripts/tool_description_optimizer.py` read `save_to_file` into a throwaway expression with no assignment, and a comment literally said "always save, regardless of save_to_file flag" -- the optimization report was written to disk unconditionally, ignoring the flag entirely and contradicting the schema's own description ("If true, save..."). Fixed to actually gate the file write on `save_to_file`, restoring the tool's documented contract.
- Also fixed 2 ruff `F841` unused-variable lint failures the user flagged from PR #346's CI (pre-existing on `main` via #345, unrelated to this round's own changes): `test_compound_gene_disease_opentargets_lookup.py`'s unused `sources_failed` (genuinely dead boilerplate -- removed) and `test_pubchem_similarity_and_image_optional_defaults.py`'s unused `explicit_result` (the test's own name -- "matches_explicit_default" -- called for asserting equivalence, not deleting it, so added the missing assertion instead).
- 2 fresh persona domains (dermato-oncology/melanoma genetics, andrology/male infertility genetics) found no new bugs this round.

## Test plan
- [x] New `tests/unit/test_tool_graph_composer_optional_defaults.py` (4 tests) and `tests/unit/test_tool_description_optimizer_optional_defaults.py` (3 tests): required-list fixes, AgenticTool default-fill verification, and the save_to_file gating behavior fix (mocked -- confirms no file written when False, file written when True). All pass.
- [x] Fixed 2 pre-existing tests now also pass their proper assertions; `ruff check` clean on both.
- [x] Full `tests/unit` suite: exit code 0, zero failures, the same standard 11 environmental skips seen at every prior round.