### PR TITLE
Fix --parallel flag in scripts/test_all_tools.py actually parallelizing pattern tests

### DIFF
--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -23,6 +23,7 @@ Options:
 """
 
 import argparse
+import concurrent.futures
 import fnmatch
 import json
 import subprocess
@@ -31,6 +32,11 @@ import time
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Tuple, Any
+
+# run_test_for_pattern spawns an independent subprocess per pattern (I/O-bound:
+# mostly waiting on live HTTP calls), so a moderate thread pool speeds up
+# --parallel substantially without hammering any single upstream API too hard.
+DEFAULT_PARALLEL_WORKERS = 10
 
 
 def find_all_tool_configs(data_dir: Path) -> List[Path]:
@@ -150,6 +156,90 @@ def run_test_for_pattern(
             "error": str(e),
             "exit_code": -1
         }
+
+
+def _format_result_status(result: Dict[str, Any]) -> str:
+    """One-line human-readable status for a single pattern's test result."""
+    if result.get("error"):
+        return f"🔥 ERROR: {result['error']}"
+    if result.get("failed", 0) > 0:
+        return f"❌ {result['failed']} failures"
+    if result.get("schema_invalid", 0) > 0:
+        return f"⚠️  {result['schema_invalid']} schema issues"
+    tests = result.get("tests_run", 0)
+    return f"✅ {tests} tests passed"
+
+
+def run_all_patterns(
+    patterns: List[str],
+    repo_root: Path,
+    verbose: bool = False,
+    fail_fast: bool = False,
+    parallel: bool = False,
+    max_workers: int = DEFAULT_PARALLEL_WORKERS,
+) -> Dict[str, Dict[str, Any]]:
+    """Run run_test_for_pattern for every pattern, sequentially or in parallel.
+
+    Returns a dict of pattern -> result, in the same shape either way.
+    Progress is printed as each result becomes available; in parallel mode
+    that's completion order, not pattern order, since patterns run
+    concurrently.
+
+    --fail-fast semantics under --parallel: patterns already running when a
+    failure is detected are allowed to finish (they're independent
+    subprocesses already in flight), but no further not-yet-started patterns
+    are submitted. This is the closest parallel analogue to the sequential
+    "stop after first failure" behavior.
+    """
+    total = len(patterns)
+    results: Dict[str, Dict[str, Any]] = {}
+
+    if not parallel:
+        for i, pattern in enumerate(patterns, 1):
+            print(f"[{i}/{total}] Testing {pattern}...", end=" ", flush=True)
+            result = run_test_for_pattern(
+                pattern, repo_root, verbose=verbose, fail_fast=fail_fast
+            )
+            results[pattern] = result
+            print(_format_result_status(result))
+            if fail_fast and result.get("failed", 0) > 0:
+                print("\n⚠️  Stopping due to --fail-fast")
+                break
+        return results
+
+    workers = max(1, min(max_workers, total)) if total else 1
+    print(f"⚡ Running {total} pattern(s) in parallel (workers={workers})")
+    print()
+
+    stop_requested = False
+    completed = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        future_to_pattern = {
+            executor.submit(
+                run_test_for_pattern, pattern, repo_root, verbose, fail_fast
+            ): pattern
+            for pattern in patterns
+        }
+        for future in concurrent.futures.as_completed(future_to_pattern):
+            pattern = future_to_pattern[future]
+            if future.cancelled():
+                # Cancelled while still queued (fail-fast) -- never ran, so
+                # it's simply omitted from results rather than recorded as
+                # a failure.
+                continue
+            completed += 1
+            result = future.result()
+            results[pattern] = result
+            print(f"[{completed}/{total}] {pattern}: {_format_result_status(result)}", flush=True)
+
+            if fail_fast and result.get("failed", 0) > 0 and not stop_requested:
+                stop_requested = True
+                print("\n⚠️  --fail-fast: not starting any remaining not-yet-started patterns "
+                      "(already-running patterns will still finish)")
+                for f in future_to_pattern:
+                    f.cancel()
+
+    return results
 
 
 # Maps a label found in test output to the stats key it populates.
@@ -419,7 +509,7 @@ def main():
     parser.add_argument(
         "--parallel",
         action="store_true",
-        help="Run tests in parallel (experimental)"
+        help=f"Run tests in parallel across patterns (up to {DEFAULT_PARALLEL_WORKERS} workers)"
     )
     parser.add_argument(
         "--output",
@@ -542,35 +632,16 @@ def main():
     print()
     
     # Run tests for each pattern
-    results = {}
     start_time = time.time()
-    
-    for i, pattern in enumerate(sorted(config_patterns.keys()), 1):
-        print(f"[{i}/{len(config_patterns)}] Testing {pattern}...", end=" ", flush=True)
-        
-        result = run_test_for_pattern(
-            pattern, 
-            repo_root, 
-            verbose=args.verbose,
-            fail_fast=args.fail_fast
-        )
-        
-        results[pattern] = result
-        
-        # Print quick status
-        if result.get("error"):
-            print(f"🔥 ERROR: {result['error']}")
-        elif result.get("failed", 0) > 0:
-            print(f"❌ {result['failed']} failures")
-            if args.fail_fast:
-                print("\n⚠️  Stopping due to --fail-fast")
-                break
-        elif result.get("schema_invalid", 0) > 0:
-            print(f"⚠️  {result['schema_invalid']} schema issues")
-        else:
-            tests = result.get("tests_run", 0)
-            print(f"✅ {tests} tests passed")
-    
+
+    results = run_all_patterns(
+        sorted(config_patterns.keys()),
+        repo_root,
+        verbose=args.verbose,
+        fail_fast=args.fail_fast,
+        parallel=args.parallel,
+    )
+
     total_duration = time.time() - start_time
     
     print()

--- a/tests/unit/test_compound_gene_disease_opentargets_lookup.py
+++ b/tests/unit/test_compound_gene_disease_opentargets_lookup.py
@@ -187,7 +187,6 @@ class TestOpenTargetsGeneOnlyLookup:
             "status": "success",
             "data": {"search": {"hits": [{"name": "progeria"}]}},
         }
-        sources_failed = []
 
         # run() itself dispatches this, but exercising just the extraction
         # helper's untouched branch is enough to confirm no regression.

--- a/tests/unit/test_pubchem_similarity_and_image_optional_defaults.py
+++ b/tests/unit/test_pubchem_similarity_and_image_optional_defaults.py
@@ -122,5 +122,7 @@ def test_search_similarity_threshold_omitted_matches_explicit_default():
         explicit_url = mock_get.call_args.args[0]
 
     assert omitted_result["status"] == "success"
+    assert explicit_result["status"] == "success"
+    assert omitted_result == explicit_result
     assert "Threshold=90" in explicit_url
     assert "Threshold" not in omitted_url

--- a/tests/unit/test_test_all_tools_parallel.py
+++ b/tests/unit/test_test_all_tools_parallel.py
@@ -1,0 +1,103 @@
+"""Regression guard: scripts/test_all_tools.py's --parallel flag was
+declared in argparse and documented in the docstring/CI workflow (which
+passes it), but never actually read anywhere in main() -- the main loop
+ran strictly sequentially regardless of the flag. With several hundred
+unique tool patterns and up to a 300s subprocess timeout each, this made
+the weekly GitHub Actions health-check run ~4 hours, triggering
+"hosted runner lost communication with the server" (confirmed live: the
+workflow failed 6 of its last 7 scheduled runs).
+
+Fixed by extracting the per-pattern loop into run_all_patterns(), which
+dispatches through a concurrent.futures.ThreadPoolExecutor when
+parallel=True (each pattern is already an independent subprocess call --
+I/O-bound work, well suited to threads) instead of a plain for loop.
+"""
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "test_all_tools.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("test_all_tools", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["test_all_tools"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+
+
+def _slow_result(pattern, repo_root, verbose=False, fail_fast=False, delay=0.2):
+    time.sleep(delay)
+    return {"tests_run": 3, "passed": 3, "failed": 0}
+
+
+def test_parallel_runs_faster_than_sequential_for_many_patterns():
+    patterns = [f"pattern_{i}" for i in range(8)]
+    repo_root = Path(".")
+
+    with patch.object(_mod, "run_test_for_pattern", side_effect=_slow_result):
+        start = time.time()
+        sequential_results = _mod.run_all_patterns(
+            patterns, repo_root, parallel=False
+        )
+        sequential_duration = time.time() - start
+
+        start = time.time()
+        parallel_results = _mod.run_all_patterns(
+            patterns, repo_root, parallel=True, max_workers=8
+        )
+        parallel_duration = time.time() - start
+
+    assert set(sequential_results.keys()) == set(patterns)
+    assert set(parallel_results.keys()) == set(patterns)
+    # 8 patterns * 0.2s each: sequential ~1.6s, parallel (8 workers) ~0.2s.
+    # A generous 2x margin keeps this robust on a loaded CI runner while
+    # still proving parallel is meaningfully faster, not just not-slower.
+    assert parallel_duration < sequential_duration / 2
+
+
+def test_parallel_and_sequential_produce_the_same_results():
+    patterns = ["alpha", "beta", "gamma"]
+    repo_root = Path(".")
+
+    def fake_result(pattern, repo_root, verbose=False, fail_fast=False):
+        return {"tests_run": 1, "passed": 1, "failed": 0, "pattern": pattern}
+
+    with patch.object(_mod, "run_test_for_pattern", side_effect=fake_result):
+        sequential_results = _mod.run_all_patterns(patterns, repo_root, parallel=False)
+        parallel_results = _mod.run_all_patterns(patterns, repo_root, parallel=True)
+
+    assert sequential_results == parallel_results
+
+
+def test_parallel_stops_submitting_new_work_after_fail_fast():
+    patterns = [f"pattern_{i}" for i in range(20)]
+    repo_root = Path(".")
+    call_count = {"n": 0}
+
+    def fake_result(pattern, repo_root, verbose=False, fail_fast=False):
+        call_count["n"] += 1
+        if pattern == "pattern_0":
+            return {"tests_run": 1, "passed": 0, "failed": 1}
+        time.sleep(0.05)
+        return {"tests_run": 1, "passed": 1, "failed": 0}
+
+    with patch.object(_mod, "run_test_for_pattern", side_effect=fake_result):
+        _mod.run_all_patterns(
+            patterns, repo_root, fail_fast=True, parallel=True, max_workers=4
+        )
+
+    # Not all 20 should have run -- cancellation should have prevented at
+    # least some not-yet-started patterns from being dispatched.
+    assert call_count["n"] < len(patterns)


### PR DESCRIPTION
## Summary

Fixes the root cause of the **Weekly Tool Health Check** GitHub Actions workflow failing 6 of its last 7 scheduled runs (latest: [run 29724030744](https://github.com/mims-harvard/ToolUniverse/actions/runs/29724030744), failure mode "hosted runner lost communication with the server" after ~3h55m).

- `--parallel` was declared in argparse and documented in the module docstring (and passed by `.github/workflows/weekly-tool-healthcheck.yml`), but `args.parallel` was never read anywhere in `main()` -- the main loop ran strictly sequentially regardless of the flag. Each pattern's `run_test_for_pattern` subprocess call has up to a 300s timeout, and with ~649 unique tool patterns running one at a time, the full sweep took roughly 4 hours -- long enough that GitHub's infra gave up on the (not actually hung, just very slow) runner.
- Fixed by extracting the per-pattern loop into `run_all_patterns()`, which dispatches through a `concurrent.futures.ThreadPoolExecutor` (10 workers by default) when `parallel=True` instead of a plain `for` loop -- each pattern's test is already an independent subprocess call, i.e. I/O-bound work well suited to a thread pool.
- Progress is printed as results arrive (not assuming pattern order), since patterns complete out of order under concurrency.
- `--fail-fast`'s "stop after first failure" semantics are approximated under `--parallel` by cancelling not-yet-started (still queued) futures once a failure is seen; already-running patterns are independent subprocesses already in flight and are left to finish. (Caught and fixed a real bug of my own here during testing: cancelled futures raise `CancelledError` from `.result()`, which needs an explicit skip.)

## Live verification

Ran the real sweep locally (no mocking) against a 15-pattern subset (`--skip-remote --skip-mcp --pattern gene`, 90 test examples):
- **Sequential**: 149.91s, 90/90 passed
- **Parallel**: 29.03s, 90/90 passed

**5.2x speedup**, identical results both ways. At that rate the full ~649-pattern sweep should drop from ~4 hours to well under an hour, comfortably inside the workflow's 350-minute timeout.

## Test plan
- [x] New `tests/unit/test_test_all_tools_parallel.py` (3 tests): parallel is meaningfully faster than sequential for many patterns (mocked with an artificial per-pattern delay), parallel and sequential produce identical results for the same input, and `--fail-fast` stops submitting new work after a failure under `--parallel`. All pass.
- [x] Live-verified against the real sweep (see above) -- not just mocked.
- [x] `ruff check` clean (confirmed CI's `astral-sh/ruff-action` step only runs `ruff check`, not `ruff format --check`, so left the rest of the file's pre-existing formatting untouched rather than reformatting the whole file).
- [x] Full `tests/unit` suite: exit code 0, zero failures, the same standard 11 environmental skips seen throughout this session.