### PR TITLE
Fix Round 49: ClinVar_search_variants hyphen-stripping broke HLA/NKX/MT- gene families

### DIFF
--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -188,15 +188,8 @@ class ClinVarSearchVariants(ClinVarRESTTool):
         # Build search query
         query_parts = []
 
+        gene_hyphen_variant = None
         if "gene" in arguments:
-            # Fix-R8B-1: HGNC gene symbols don't contain hyphens (modern
-            # nomenclature phased them out decades ago), but older
-            # literature/informal usage still writes them hyphenated (e.g.
-            # "BRCA-2", "HER-2") -- ClinVar's [gene] index only matches the
-            # canonical unhyphenated form, so a hyphenated query silently
-            # returned 0 results (confirmed live and via raw NCBI E-utils:
-            # "BRCA-2[gene]" -> 0 hits, "BRCA2[gene]" -> 21879 hits).
-            #
             # Fix-R10D-1: ClinVar's [gene] index only matches a bare HGNC
             # symbol, but a natural clinical phrasing like "NF2 gene" (used
             # verbatim in real research questions -- e.g. "look up the NF2
@@ -204,18 +197,33 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             # word "gene" becomes part of the queried string (confirmed
             # live and via raw NCBI E-utils curl: "Nf2 gene[gene]" -> 0
             # hits, "NF2[gene]" -> 2612 hits). Strip a trailing/leading
-            # "gene"/"protein" qualifier word before querying, then strip
-            # hyphens from what remains.
-            gene = (
-                re.sub(
-                    r"^\s*(?:gene|protein)\s+|\s+(?:gene|protein)\s*$",
-                    "",
-                    arguments["gene"],
-                    flags=re.IGNORECASE,
-                )
-                .strip()
-                .replace("-", "")
-            )
+            # "gene"/"protein" qualifier word before querying.
+            gene = re.sub(
+                r"^\s*(?:gene|protein)\s+|\s+(?:gene|protein)\s*$",
+                "",
+                arguments["gene"],
+                flags=re.IGNORECASE,
+            ).strip()
+
+            # Fix-R8B-1 (revised, Fix-R49A-1): some genes are informally
+            # hyphenated even though their current HGNC symbol has none (e.g.
+            # "BRCA-2" for "BRCA2", "HER-2" for "HER2" -- confirmed live via
+            # raw NCBI E-utils: "BRCA-2[gene]" -> 0 hits, "BRCA2[gene]" ->
+            # 21879 hits). R8B-1 originally handled this by unconditionally
+            # stripping every hyphen, but that silently broke every gene
+            # whose CURRENT official HGNC symbol genuinely contains one --
+            # confirmed live for the entire HLA family (HLA-B[gene] -> 130
+            # hits, HLAB[gene] -> 0), the NKX homeobox family (NKX2-5[gene]
+            # -> real hits, NKX25[gene] -> 0), and MT- mitochondrial genes
+            # (MT-ND1[gene] -> 194 hits, MTND1[gene] -> 0) -- all clinically
+            # significant gene families (HLA pharmacogenomics/transplant,
+            # NKX cardiac/pancreatic development, MT- mitochondrial disease).
+            # Query with the hyphen preserved first; only fall back to the
+            # stripped form if that returns zero results, so both the old
+            # informally-hyphenated-name case and genuinely-hyphenated
+            # official symbols work.
+            if "-" in gene:
+                gene_hyphen_variant = gene.replace("-", "")
             query_parts.append(f"{gene}[gene]")
 
         if "condition" in arguments:
@@ -304,6 +312,22 @@ class ClinVarSearchVariants(ClinVarRESTTool):
         data = result.get("data", {})
         if "esearchresult" not in data:
             return result
+
+        # Fix-R49A-1: the hyphen-preserved gene query above found nothing --
+        # retry once with the hyphen stripped, for the informally-hyphenated
+        # BRCA-2/HER-2-style names ClinVar's index doesn't recognize.
+        if gene_hyphen_variant and int(data["esearchresult"].get("count", 0)) == 0:
+            # "gene" is always the first query part appended when present.
+            fallback_query_parts = [f"{gene_hyphen_variant}[gene]"] + query_parts[1:]
+            fallback_params = dict(params, term=" AND ".join(fallback_query_parts))
+            fallback_result = self._make_request(self.endpoint, fallback_params)
+            if (
+                fallback_result.get("status") == "success"
+                and "esearchresult" in fallback_result.get("data", {})
+                and int(fallback_result["data"]["esearchresult"].get("count", 0)) > 0
+            ):
+                result = fallback_result
+                data = result["data"]
 
         esearch = data["esearchresult"]
         ids = esearch.get("idlist", [])

--- a/tests/unit/test_clinvar_gene_hyphen_and_params.py
+++ b/tests/unit/test_clinvar_gene_hyphen_and_params.py
@@ -1,9 +1,17 @@
-"""Regression guard for two round-8 ClinVar_search_variants fixes:
+"""Regression guard for ClinVar_search_variants gene-hyphen handling and
+unrecognized-parameter fixes:
 
-Fix-R8B-1: HGNC gene symbols don't contain hyphens, but informal usage
-still writes them hyphenated (e.g. "BRCA-2"). ClinVar's [gene] index only
-matches the canonical unhyphenated form, so a hyphenated query silently
-returned 0 results.
+Fix-R8B-1/Fix-R49A-1: HGNC gene symbols usually don't contain hyphens, but
+informal usage still writes some hyphenated (e.g. "BRCA-2" for "BRCA2").
+ClinVar's [gene] index only matches the canonical unhyphenated form for
+those, so a hyphenated query silently returned 0 results. R8B-1 originally
+"fixed" this by unconditionally stripping every hyphen -- but that broke
+every gene whose CURRENT official HGNC symbol genuinely contains one
+(confirmed live: the entire HLA family, the NKX homeobox family, and MT-
+mitochondrial genes all need the hyphen PRESERVED, e.g. "HLA-B[gene]" ->
+130 hits but "HLAB[gene]" -> 0). Fix-R49A-1 queries with the hyphen
+preserved first, falling back to the stripped form only if that returns
+zero results, so both cases resolve correctly without a hardcoded gene list.
 
 Fix-R5D-1/R8C-1: an unrecognized parameter (e.g. "variant_name", which
 doesn't exist -- only "variant_id" does) was silently dropped. When it was
@@ -26,28 +34,99 @@ def _tool():
     return ClinVarSearchVariants({"name": "ClinVar_search_variants"})
 
 
-def _patch_request():
-    return patch.object(
+def _esearch_result(count, ids=None, query_translation=""):
+    return {
+        "status": "success",
+        "data": {
+            "esearchresult": {
+                "idlist": ids or [],
+                "count": str(count),
+                "querytranslation": query_translation,
+            }
+        },
+    }
+
+
+def test_hyphenated_official_symbol_is_queried_with_hyphen_preserved():
+    """HLA-B, NKX2-5, MT-ND1 etc. -- the hyphen is part of the real symbol,
+    so the first (and in this case only, since it succeeds) request must
+    keep it. ids left empty so no follow-up esummary.fcgi call is made --
+    this test only exercises the query-building/retry logic."""
+    tool = _tool()
+    with patch.object(
         ClinVarSearchVariants,
         "_make_request",
-        return_value={"status": "success", "data": {}},
-    )
+        return_value=_esearch_result(130, query_translation="HLA-B[gene]"),
+    ) as mock_request:
+        result = tool.run({"gene": "HLA-B"})
+
+    assert mock_request.call_count == 1
+    assert mock_request.call_args[0][1]["term"] == "HLA-B[gene]"
+    assert result["data"]["total_count"] == 130
 
 
-def test_hyphenated_gene_symbol_is_normalized():
+def test_informally_hyphenated_symbol_falls_back_to_stripped_form():
+    """BRCA-2 -- the hyphen-preserved attempt returns 0, so a second
+    request with the hyphen stripped must be made and its result used."""
     tool = _tool()
-    with _patch_request() as mock_request:
-        tool.run({"gene": "BRCA-2"})
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        side_effect=[
+            _esearch_result(0),
+            _esearch_result(21879, query_translation="BRCA2[gene]"),
+        ],
+    ) as mock_request:
+        result = tool.run({"gene": "BRCA-2"})
 
-    assert "BRCA2[gene]" in mock_request.call_args[0][1]["term"]
-    assert "BRCA-2" not in mock_request.call_args[0][1]["term"]
+    assert mock_request.call_count == 2
+    assert mock_request.call_args_list[0][0][1]["term"] == "BRCA-2[gene]"
+    assert mock_request.call_args_list[1][0][1]["term"] == "BRCA2[gene]"
+    assert result["data"]["total_count"] == 21879
+
+
+def test_hyphen_fallback_preserves_other_query_parts():
+    """gene + condition together -- the fallback retry must keep the
+    condition term, not just the gene term."""
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        side_effect=[_esearch_result(0), _esearch_result(203)],
+    ) as mock_request:
+        tool.run({"gene": "BRCA-2", "condition": "breast cancer"})
+
+    second_term = mock_request.call_args_list[1][0][1]["term"]
+    assert second_term == 'BRCA2[gene] AND "breast cancer"[dis]'
+
+
+def test_hyphenated_gene_with_no_real_match_stays_zero_after_fallback():
+    """Both the hyphenated and stripped attempts genuinely finding nothing
+    must not error or loop -- just report 0."""
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        side_effect=[_esearch_result(0), _esearch_result(0)],
+    ) as mock_request:
+        result = tool.run({"gene": "NOT-A-REAL-GENE"})
+
+    assert mock_request.call_count == 2
+    assert result["data"]["total_count"] == 0
 
 
 def test_plain_gene_symbol_unaffected():
+    """No hyphen in the gene arg -- exactly one request, no fallback
+    attempt regardless of what count comes back."""
     tool = _tool()
-    with _patch_request() as mock_request:
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value=_esearch_result(1624),
+    ) as mock_request:
         tool.run({"gene": "BRCA2"})
 
+    assert mock_request.call_count == 1
     assert "BRCA2[gene]" in mock_request.call_args[0][1]["term"]
 
 


### PR DESCRIPTION
## Summary

`ClinVar_search_variants`' round-8 fix (Fix-R8B-1) unconditionally strips hyphens from gene arguments to handle informally-hyphenated names like "BRCA-2" (whose real HGNC symbol, `BRCA2`, has none). That blanket stripping silently broke every gene whose *current* official HGNC symbol genuinely contains a hyphen.

Confirmed live and via raw NCBI E-utils:
- `HLA-B[gene]` → 130 hits, `HLAB[gene]` → 0
- `NKX2-5[gene]` → 849 hits, `NKX25[gene]` → 0
- `MT-ND1[gene]` → 194 hits, `MTND1[gene]` → 0

These are clinically significant gene families — HLA (pharmacogenomics, transplant medicine, autoimmune disease), NKX homeobox genes (cardiac/pancreatic development), MT- mitochondrial genes (mitochondrial disease genetics) — so this wasn't a narrow edge case.

Found during round 49's congenital heart disease genetics research thread: `ClinVar_search_variants({"gene": "NKX2-5"})` silently returned 0 results for a well-studied, real gene.

## Fix

Query with the hyphen preserved first (correct for the larger class of genuinely-hyphenated official symbols), falling back to the stripped form only if that returns zero results (still correct for the BRCA-2-style informally-hyphenated case). No hardcoded gene list needed — the fallback logic self-adapts based on the actual NCBI response.

## Verification

- Live-confirmed all three previously-broken families now return correct non-zero counts with the hyphen preserved (HLA-B: 130, NKX2-5: 849, MT-ND1: 194).
- Live-confirmed BRCA-2 still correctly falls back to the stripped form and returns 21879 (same as before this fix).
- Live-confirmed the gene+condition combined case correctly preserves the condition term through the fallback retry.
- Live-confirmed a genuinely nonexistent gene still correctly returns 0 with no infinite retry.
- Live-confirmed the round-10 "NF2 gene" trailing-qualifier-word fix (Fix-R10D-1) is unaffected.
- 5 new/updated unit tests in `test_clinvar_gene_hyphen_and_params.py`.
- Full `pytest tests/unit/` clean.

## Test plan

- [x] `pytest tests/unit/test_clinvar_gene_hyphen_and_params.py` and sibling ClinVar test files — all pass
- [x] `pytest tests/unit/` full suite — clean
- [x] Live `tu run ClinVar_search_variants` for HLA-B, NKX2-5, MT-ND1, BRCA-2, a plain gene, gene+condition, and a nonexistent gene