### PR TITLE
Fix Round 51: CIViC parser counted every gene-level variant as "matched"

### DIFF
--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -282,7 +282,7 @@ class CompoundVariantAnnotationTool(BaseTool):
             }
         return {}
 
-    def _parse_civic(self, result: Any, variant_token: str = None) -> Dict[str, Any]:
+    def _parse_civic(self, result: Any, variant_token=None) -> Dict[str, Any]:
         if not isinstance(result, dict):
             return {"raw": str(result)[:200]}
         # civic_get_variants_by_gene returns data.gene.variants.nodes (a list).
@@ -290,26 +290,39 @@ class CompoundVariantAnnotationTool(BaseTool):
         nodes = ((gene.get("variants") or {}) if isinstance(gene, dict) else {}).get(
             "nodes", []
         )
-        parsed = []
-        for v in nodes if isinstance(nodes, list) else []:
-            if not isinstance(v, dict):
-                continue
-            name = v.get("name", v.get("variant_name", ""))
-            if variant_token and not _title_matches(name, variant_token):
-                continue
-            parsed.append(
-                {
-                    "name": name,
-                    "civic_id": v.get("id"),
-                    "feature": (v.get("feature") or {}).get("name")
-                    if isinstance(v.get("feature"), dict)
-                    else v.get("feature"),
-                }
-            )
+        nodes = nodes if isinstance(nodes, list) else []
+        rows = [v for v in nodes if isinstance(v, dict)]
+
+        def _row(v: Dict[str, Any]) -> Dict[str, Any]:
+            return {
+                "name": v.get("name", v.get("variant_name", "")),
+                "civic_id": v.get("id"),
+                "feature": (v.get("feature") or {}).get("name")
+                if isinstance(v.get("feature"), dict)
+                else v.get("feature"),
+            }
+
+        # Fix-R51A-1: when variant_token is falsy (a gene-only query with no
+        # specific variant to look for), the old "if variant_token and not
+        # _title_matches(...): continue" filter never triggered a skip --
+        # so EVERY gene-level variant silently counted as "matched" (e.g.
+        # matched=8 out of 8 total for a bare {"gene": "MSH2"} call, wrongly
+        # implying 8 real matches when no filtering criterion was even
+        # applied). ClinVar's parser already got this right elsewhere in
+        # this file (matched=0, gene-level rows shown separately as
+        # unmatched context) -- mirror that same, correct shape here.
+        matched = [
+            _row(v)
+            for v in rows
+            if variant_token
+            and _title_matches(v.get("name", v.get("variant_name", "")), variant_token)
+        ]
+        variants_out = matched if matched else [_row(v) for v in rows[:20]]
         return {
-            "total_gene_variants": len(nodes) if isinstance(nodes, list) else 0,
-            "matched": len(parsed),
-            "variants": parsed[:20],
+            "total_gene_variants": len(nodes),
+            "matched": len(matched),
+            "exact_match": bool(matched),
+            "variants": variants_out[:20],
         }
 
     def _parse_uniprot(self, result: Any) -> Dict[str, Any]:

--- a/tests/unit/test_compound_variant_tool.py
+++ b/tests/unit/test_compound_variant_tool.py
@@ -50,8 +50,32 @@ def test_parse_civic_reads_nested_nodes_and_filters():
     out = t._parse_civic(real, "V600E")
     assert out["total_gene_variants"] == 2
     assert out["matched"] == 1
+    assert out["exact_match"] is True
     assert out["variants"][0]["name"] == "V600E"
     assert out["variants"][0]["civic_id"] == 12
+
+
+def test_parse_civic_gene_only_query_reports_zero_matched_not_all():
+    """Fix-R51A-1: a gene-only query (variant_token=None) previously counted
+    EVERY gene-level CIViC variant as "matched" -- the filter's
+    "if variant_token and not _title_matches(...): continue" never actually
+    skipped anything when variant_token was falsy, so matched silently
+    equaled total_gene_variants, wrongly implying real matches against a
+    filter that was never applied. Confirmed live for MSH2 (gene-only):
+    matched=8 out of 8 total before the fix. ClinVar's parser already gets
+    this right (matched=0, gene-level rows shown as unmatched context) --
+    CIViC's must mirror that same shape."""
+    t = _tool()
+    real = {"data": {"gene": {"id": 5, "name": "MSH2", "variants": {"nodes": [
+        {"id": 1, "name": "A1"}, {"id": 2, "name": "A2"}, {"id": 3, "name": "A3"}]}}}}
+
+    out = t._parse_civic(real, None)
+
+    assert out["total_gene_variants"] == 3
+    assert out["matched"] == 0
+    assert out["exact_match"] is False
+    # Still surfaces gene-level context, just not mislabeled as a match.
+    assert len(out["variants"]) == 3
 
 
 def test_parse_clinvar_falls_back_to_gene_context_when_no_exact_match():


### PR DESCRIPTION
## Summary

`annotate_variant_multi_source`'s `_parse_civic` filters gene-level CIViC variants against a `variant_token` with `if variant_token and not _title_matches(...): continue`. When `variant_token` is falsy (a gene-only query, no specific variant to look for), that condition never evaluates to a skip — so every variant for the gene silently gets counted as "matched" and returned, wrongly implying real matches against a filter that was never actually applied.

Confirmed live for a bare `{"gene": "MSH2"}` call: `matched: 8` out of `total_gene_variants: 8` — i.e. 100% "matched" with zero actual filtering happening. `ClinVar`'s parser in the same file already handles the identical scenario correctly (`matched: 0`, gene-level rows shown separately as unmatched context) — this brings CIViC's parser in line with that same, correct shape.

Found during round 51's Lynch syndrome (MLH1/MSH2/PMS2) research thread.

## Fix

Restructured `_parse_civic` to mirror `_parse_clinvar`'s existing pattern: only count a row as `matched` if `variant_token` is present and actually matches; otherwise return the gene-level rows as unfiltered context with `matched: 0`. Also added the same `exact_match` boolean `_parse_clinvar` already exposes, for consistency across the two.

## Also investigated (no fix needed)

While researching FBN1/Marfan syndrome, `ClinGen_get_gene_validity({"gene": "FBN1"})` was missing a "Marfan syndrome" curation that GenCC's aggregation shows exists (attributed to ClinGen as submitter). Confirmed via direct inspection of ClinGen's own raw bulk CSV export (`https://search.clinicalgenome.org/kb/gene-validity/download`) that this specific curation genuinely isn't present in that data file — an upstream ClinGen data-completeness gap, not a ToolUniverse bug. No code change made.

## Verification

- Live-confirmed the gene-only case (`{"gene": "MSH2"}`) now correctly reports `matched: 0`, `exact_match: false`, with `civic_variants_matched` correctly absent from the summary (matching how `clinvar_classification`/`clinvar_note` already behave for the no-match case).
- Live-confirmed the explicit-variant case (`{"variant": "BRAF V600E"}`) is unaffected — still correctly matches 3 CIViC variants with `exact_match: true`.
- 2 new/updated unit tests.
- Full `pytest tests/unit/` clean.

## Test plan

- [x] `pytest tests/unit/test_compound_variant_tool.py` — 19/19 pass
- [x] `pytest tests/unit/` full suite — clean
- [x] Live `tu run annotate_variant_multi_source` for both the gene-only and explicit-variant cases