### PR TITLE
Fix Round 56: CPIC drug lookup reported network failures as drug-not-found

### DIFF
--- a/src/tooluniverse/cpic_search_pairs_tool.py
+++ b/src/tooluniverse/cpic_search_pairs_tool.py
@@ -21,41 +21,49 @@ def _resolve_drug_to_guideline_id(
 ) -> Optional[Tuple[int, Optional[str]]]:
     """Look up CPIC guideline ID and RxNorm ID for a drug name via CPIC API.
 
-    Returns (guideline_id, rxnorm_id) tuple, or None if not found.
-    rxnorm_id may be None if the drug has no RxNorm entry.
-    """
-    try:
-        r = requests.get(
-            f"{_CPIC_API}/drug",
-            params={
-                "select": "name,guidelineid,rxnormid",
-                "name": f"ilike.*{drug_name}*",
-            },
-            timeout=15,
-        )
-        r.raise_for_status()
-        rows = r.json()
-        if not rows:
-            return None
-        # Fix-R35C-1: substring `ilike` matching picks a false first hit
-        # whenever one drug name is a substring of another -- confirmed
-        # live for "citalopram" (a substring of "escitalopram") and
-        # "phenytoin" (a substring of "fosphenytoin"): querying the shorter
-        # name silently returned the OTHER drug's guideline/rxnorm id
-        # because it happened to sort first in CPIC's unordered response,
-        # so CPIC_get_recommendations returned a different drug's dosing
-        # guidance with no indication of the substitution. Prefer an exact
-        # case-insensitive match; only fall back to the first fuzzy hit
-        # when no exact match exists (genuine partial/typo queries).
-        exact = next(
-            (row for row in rows if row.get("name", "").lower() == drug_name.lower()),
-            None,
-        )
-        row = exact or rows[0]
-        if row.get("guidelineid"):
-            return row["guidelineid"], row.get("rxnormid")
-    except Exception:
-        pass
+    Returns (guideline_id, rxnorm_id) tuple, or None if genuinely not found
+    (the request succeeded but no matching drug/guideline exists). Raises
+    requests.exceptions.RequestException on a request failure (network
+    error, timeout, HTTP error) -- Fix-R56A-1: this used to swallow those
+    the same way as a genuine "not found", so a transient CPIC API hiccup
+    (confirmed live: a `Max retries exceeded`/connection error while testing
+    this exact endpoint) was reported to the caller as "No CPIC guideline
+    found for drug 'simvastatin'" even though simvastatin IS in CPIC's
+    /drug table with a real guidelineid (100426) -- misleading a caller
+    into concluding the drug has no CPIC coverage at all. The rest of this
+    file already distinguishes RequestException from a genuine empty result
+    (see CPICGetRecommendationsTool.run's own /recommendation call below);
+    this makes the /drug lookup consistent with that same pattern instead
+    of being the one place that still conflates them."""
+    r = requests.get(
+        f"{_CPIC_API}/drug",
+        params={
+            "select": "name,guidelineid,rxnormid",
+            "name": f"ilike.*{drug_name}*",
+        },
+        timeout=15,
+    )
+    r.raise_for_status()
+    rows = r.json()
+    if not rows:
+        return None
+    # Fix-R35C-1: substring `ilike` matching picks a false first hit
+    # whenever one drug name is a substring of another -- confirmed
+    # live for "citalopram" (a substring of "escitalopram") and
+    # "phenytoin" (a substring of "fosphenytoin"): querying the shorter
+    # name silently returned the OTHER drug's guideline/rxnorm id
+    # because it happened to sort first in CPIC's unordered response,
+    # so CPIC_get_recommendations returned a different drug's dosing
+    # guidance with no indication of the substitution. Prefer an exact
+    # case-insensitive match; only fall back to the first fuzzy hit
+    # when no exact match exists (genuine partial/typo queries).
+    exact = next(
+        (row for row in rows if row.get("name", "").lower() == drug_name.lower()),
+        None,
+    )
+    row = exact or rows[0]
+    if row.get("guidelineid"):
+        return row["guidelineid"], row.get("rxnormid")
     return None
 
 
@@ -82,7 +90,13 @@ class CPICGetRecommendationsTool(BaseTool):
                         "Use CPIC_list_guidelines to browse available guidelines."
                     ),
                 }
-            result = _resolve_drug_to_guideline_id(drug)
+            try:
+                result = _resolve_drug_to_guideline_id(drug)
+            except requests.exceptions.RequestException as e:
+                return {
+                    "status": "error",
+                    "error": f"CPIC API error while resolving drug '{drug}': {e}",
+                }
             if result is None:
                 # Fix-R5C-2: CPIC's /drug table only has generic names (no
                 # brand-name field), so a brand name like "zoloft" never

--- a/tests/unit/test_cpic_brand_name_error.py
+++ b/tests/unit/test_cpic_brand_name_error.py
@@ -9,6 +9,7 @@ real constraint and suggests trying the generic name instead.
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from tooluniverse.cpic_search_pairs_tool import (
     CPICGetRecommendationsTool,
@@ -46,6 +47,56 @@ def test_missing_drug_and_guideline_id_keeps_original_error():
 
     assert result["status"] == "error"
     assert "Either guideline_id or drug name is required" in result["error"]
+
+
+class TestRequestFailureDistinctFromGenuineNotFound:
+    """Regression guard for Fix-R56A-1: _resolve_drug_to_guideline_id's bare
+    `except Exception: pass` reported a transient CPIC API failure (network
+    error, timeout) identically to a drug genuinely not being in CPIC's
+    database -- confirmed live for simvastatin, which IS in CPIC's /drug
+    table with a real guidelineid (100426), but a connection hiccup while
+    testing this exact endpoint produced "No CPIC guideline found for drug
+    'simvastatin'", wrongly implying the drug has no CPIC coverage at all.
+    A request failure must now surface as its own distinct error."""
+
+    def test_connection_error_reports_api_failure_not_drug_not_found(self):
+        tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+
+        with patch(
+            "tooluniverse.cpic_search_pairs_tool.requests.get",
+            side_effect=requests.exceptions.ConnectionError("simulated connection failure"),
+        ):
+            result = tool.run({"drug": "simvastatin"})
+
+        assert result["status"] == "error"
+        assert "CPIC API error" in result["error"]
+        assert "simvastatin" in result["error"]
+        # Must NOT claim the drug has no guideline -- that's a different,
+        # false claim about CPIC's actual data.
+        assert "No CPIC guideline found" not in result["error"]
+
+    def test_genuinely_empty_drug_lookup_still_reports_not_found(self):
+        """A real 'not in CPIC' case (request succeeds, zero rows) must
+        keep reporting the original not-found message, not an API error."""
+        tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+
+        with patch(
+            "tooluniverse.cpic_search_pairs_tool.requests.get",
+            return_value=_empty_drug_lookup_response(),
+        ):
+            result = tool.run({"drug": "not-a-real-drug-xyz"})
+
+        assert result["status"] == "error"
+        assert "No CPIC guideline found" in result["error"]
+        assert "CPIC API error" not in result["error"]
+
+    def test_resolve_helper_raises_on_request_failure_rather_than_swallowing_it(self):
+        with patch(
+            "tooluniverse.cpic_search_pairs_tool.requests.get",
+            side_effect=requests.exceptions.Timeout("simulated timeout"),
+        ):
+            with pytest.raises(requests.exceptions.RequestException):
+                _resolve_drug_to_guideline_id("simvastatin")
 
 
 def _resp(json_body):


### PR DESCRIPTION
## Summary

`_resolve_drug_to_guideline_id`'s bare `except Exception: pass` swallowed network errors, timeouts, and HTTP failures from the CPIC `/drug` lookup the same way as a genuine empty result, so a transient API hiccup was reported to the caller as `"No CPIC guideline found for drug '<name>'"` — misleadingly implying the drug has no CPIC pharmacogenomic coverage at all.

Found live during round 56's familial hypercholesterolemia/statin pharmacogenomics research thread: querying `simvastatin` hit a genuine connection error while testing and produced exactly this message — even though simvastatin IS in CPIC's `/drug` table with a populated `guidelineid` (100426, the SLCO1B1/statins guideline), confirmed directly against CPIC's own API.

The rest of this same file already distinguishes `RequestException` from a genuine empty result for the downstream `/recommendation` call (`CPICGetRecommendationsTool.run`'s own `except requests.exceptions.RequestException`) — the `/drug` lookup was the one remaining place still conflating the two failure modes.

## Fix

`_resolve_drug_to_guideline_id` now raises `requests.exceptions.RequestException` instead of swallowing it. The caller catches it separately and reports an accurate `"CPIC API error while resolving drug '<name>': <reason>"` message, distinct from the genuine not-found case (request succeeds, zero matching rows).

## Verification

- Live-reproduced the original bug: a connection error while testing `simvastatin` produced the misleading not-found message.
- Live-confirmed `simvastatin` resolves correctly once the network is healthy (real dosing recommendation returned, SLCO1B1 status → statin dose guidance).
- Live-confirmed a genuinely nonexistent drug still correctly reports "No CPIC guideline found".
- 4 new unit tests: simulated connection error reports the new distinct API-error message (not the not-found one), a genuine empty lookup still reports the original not-found message, and the helper function itself raises on request failure rather than returning `None`.
- Full `pytest tests/unit/` clean.

## Test plan

- [x] `pytest tests/unit/test_cpic_brand_name_error.py` — 10/10 pass
- [x] `pytest tests/unit/ -k cpic` — 18/18 pass
- [x] `pytest tests/unit/` full suite — clean
- [x] Live `tu run CPIC_get_recommendations` for the happy path, a simulated network failure, and a genuinely nonexistent drug