### PR TITLE
Fix Round 60: HBB variant-numbering mismatch and gene+rsid token resolution gap

### DIFF
--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -37,6 +37,33 @@ _AA_1TO3 = {
 }
 _AA_3TO1 = {v.upper(): k for k, v in _AA_1TO3.items()}
 
+# Genes whose historically-established variant nomenclature numbers residues
+# from the mature protein (after post-translational cleavage of the
+# initiator Met), one less than RefSeq's precursor-based protein HGVS
+# numbering. Confirmed live for HBB via rs334, the sickle-cell mutation:
+# dbSNP and ClinVar both report "p.Glu7Val" (NP_000509.1, Met-inclusive)
+# while CIViC and essentially all clinical/scientific literature call it
+# "Glu6Val"/"E6V" (mature-protein numbering, predating RefSeq by decades).
+# Without this offset, an rsid-only query for this gene's best-known variant
+# can never report exact_match=True even when CIViC's sole HBB entry IS that
+# exact variant.
+_MATURE_PROTEIN_OFFSET_GENES = {"HBB"}
+
+
+def _offset_protein_tokens(tokens: List[str], gene: Optional[str]) -> List[str]:
+    """For genes in _MATURE_PROTEIN_OFFSET_GENES, add a position-1 candidate
+    for each RefSeq-numbered token so mature-protein-numbered records (like
+    CIViC's) can still match."""
+    if gene not in _MATURE_PROTEIN_OFFSET_GENES:
+        return tokens
+    offset_tokens = []
+    for tok in tokens:
+        m = re.fullmatch(r"([A-Za-z]{3})(\d+)([A-Za-z]{3})", tok)
+        if m:
+            ref, pos, alt = m.group(1), m.group(2), m.group(3)
+            offset_tokens.append(f"{ref}{int(pos) - 1}{alt}")
+    return list(dict.fromkeys(tokens + offset_tokens))
+
 
 def _variant_match_forms(token: str) -> List[str]:
     """Expand a protein change to every form that appears in records: 1-letter
@@ -115,12 +142,21 @@ class CompoundVariantAnnotationTool(BaseTool):
         if variant:
             toks = variant.split()
             variant_token = toks[-1] if toks else variant
-        if not gene_for_gnomad and rsid:
-            gene_for_gnomad, rsid_variant_token = self._resolve_gene_from_rsid(
+        # Confirmed live for rs334+gene="HBB" (the sickle-cell mutation) given
+        # together: the old "not gene_for_gnomad and rsid" guard skipped this
+        # resolution entirely whenever gene was explicit, so variant_token
+        # stayed None and CIViC/ClinVar matching silently never ran even
+        # though CIViC's sole HBB entry IS the queried variant. Resolve from
+        # rsid whenever a token is still missing, not only when gene is also
+        # missing -- keep the explicit gene if one was given rather than
+        # letting the resolved gene override it.
+        if rsid and not variant_token:
+            resolved_gene, rsid_variant_token = self._resolve_gene_from_rsid(
                 tu, rsid, sources_failed
             )
-            if not variant_token:
-                variant_token = rsid_variant_token
+            if not gene_for_gnomad:
+                gene_for_gnomad = resolved_gene
+            variant_token = rsid_variant_token
 
         # 1. ClinVar -- Fix-R31D-4/R31A-3: "query" is documented as an alias for
         # "condition" (a disease/phenotype free-text search), not a gene or rsid
@@ -281,6 +317,7 @@ class CompoundVariantAnnotationTool(BaseTool):
             variant_tokens = list(
                 dict.fromkeys(re.findall(r"p\.([A-Za-z]{3}\d+[A-Za-z]{3})", hgvs))
             )
+            variant_tokens = _offset_protein_tokens(variant_tokens, gene)
             return gene, (variant_tokens or None)
         except Exception as e:
             sources_failed.append(f"dbSNP (rsid->gene): {str(e)[:100]}")

--- a/tests/unit/test_compound_variant_tool.py
+++ b/tests/unit/test_compound_variant_tool.py
@@ -11,6 +11,7 @@ from tooluniverse.compound_variant_tool import (
     CompoundVariantAnnotationTool,
     _variant_match_forms,
     _title_matches,
+    _offset_protein_tokens,
 )
 
 
@@ -189,7 +190,9 @@ def test_run_records_sub_call_failures_instead_of_empty_success():
     error dict, e.g. a network outage), the aggregator must report those
     failures in sources_failed rather than silently treating them as
     "gene has zero known variants" (a dangerous false negative for a
-    clinically significant gene like BRCA1)."""
+    clinically significant gene like BRCA1). 5 failures, not 4: since
+    Fix-R60A-2, dbSNP is queried for its protein-change token even when gene
+    was already supplied, so it also has a chance to fail."""
     t = _tool()
 
     def fake_run_one_function(call):
@@ -205,7 +208,7 @@ def test_run_records_sub_call_failures_instead_of_empty_success():
 
     data = result["data"]
     assert data["annotations"] == {}
-    assert len(data["sources_failed"]) == 4
+    assert len(data["sources_failed"]) == 5
     assert all("TLS" in msg for msg in data["sources_failed"])
     assert data["sources_queried"] == []
 
@@ -451,3 +454,129 @@ def test_rsid_only_query_derives_variant_token_for_exact_matching():
     assert clinvar["exact_match"] is True
     assert clinvar["matched"] == 1
     assert result["data"]["summary"]["clinvar_classification"] == "Pathogenic/Likely pathogenic"
+
+
+def test_offset_protein_tokens_adds_mature_protein_numbering_for_hbb():
+    """Fix-R60A-1: dbSNP/ClinVar number HBB's protein from the RefSeq
+    precursor (Met-inclusive: NP_000509.1), but CIViC and essentially all
+    clinical literature use the historical mature-protein numbering, one
+    less. Confirmed live for rs334 (the sickle-cell mutation): dbSNP/ClinVar
+    report "p.Glu7Val" while CIViC's sole HBB entry is "E6V" -- without this
+    offset, the two conventions can never match."""
+    tokens = _offset_protein_tokens(["Glu7Val", "Glu7Gly"], "HBB")
+    assert "Glu7Val" in tokens
+    assert "Glu6Val" in tokens
+    assert "Glu6Gly" in tokens
+    assert _title_matches("E6V", tokens)
+
+
+def test_offset_protein_tokens_leaves_other_genes_unchanged():
+    """The mature-protein numbering offset is a documented quirk specific to
+    a small set of genes (confirmed for HBB) -- applying it universally would
+    risk false-positive matches against an unrelated variant that happens to
+    sit one residue away. Genes outside the confirmed set must be untouched."""
+    tokens = _offset_protein_tokens(["Lys329Glu"], "ACADM")
+    assert tokens == ["Lys329Glu"]
+
+
+def test_resolve_gene_from_rsid_applies_mature_protein_offset_for_hbb():
+    t = _tool()
+
+    class _FakeTU:
+        def run_one_function(self, call):
+            return {
+                "status": "success",
+                "data": {
+                    "hgvs_notation": (
+                        "HGVS=NM_000518.5:c.20A>T,NP_000509.1:p.Glu7Val"
+                        "|SEQ=[T/A]|LEN=1|GENE=HBB:3043"
+                    )
+                },
+            }
+
+    sources_failed = []
+    gene, variant_tokens = t._resolve_gene_from_rsid(_FakeTU(), "rs334", sources_failed)
+    assert gene == "HBB"
+    assert variant_tokens == ["Glu7Val", "Glu6Val"]
+    assert _title_matches("E6V", variant_tokens)
+
+
+def test_gene_and_rsid_given_together_still_resolves_variant_token():
+    """Fix-R60A-2: the old "not gene_for_gnomad and rsid" guard only called
+    _resolve_gene_from_rsid when gene was NOT already given -- so the very
+    common {"gene": ..., "rsid": ...} query shape skipped protein-token
+    resolution entirely, leaving variant_token permanently None and
+    ClinVar/CIViC matching silently inert. Confirmed live for
+    {"rsid": "rs334", "gene": "HBB"}: CIViC's sole HBB entry ("E6V") went
+    unmatched even though it IS the queried variant. dbsnp_get_variant_by_rsid
+    must still be called (and its token used) whenever a token is missing,
+    even when gene was already supplied -- and the explicit gene must win
+    over whatever dbSNP resolves, in case they ever disagree."""
+    t = _tool()
+    calls = []
+
+    def fake_run_one_function(call):
+        calls.append(call)
+        if call["name"] == "dbsnp_get_variant_by_rsid":
+            return {
+                "status": "success",
+                "data": {
+                    "hgvs_notation": (
+                        "HGVS=...|NP_000509.1:p.Glu7Val|GENE=HBB:3043"
+                    )
+                },
+            }
+        if call["name"] == "civic_get_variants_by_gene":
+            return {
+                "status": "success",
+                "data": {
+                    "gene": {
+                        "variants": {
+                            "nodes": [{"id": 4420, "name": "E6V", "feature": {"name": "HBB"}}]
+                        }
+                    }
+                },
+            }
+        return {"status": "success", "data": {}}
+
+    with patch(
+        "tooluniverse.execute_function.ToolUniverse.run_one_function",
+        side_effect=fake_run_one_function,
+    ), patch("tooluniverse.execute_function.ToolUniverse.load_tools", return_value=None):
+        result = t.run({"rsid": "rs334", "gene": "HBB"})
+
+    called_names = [c["name"] for c in calls]
+    assert "dbsnp_get_variant_by_rsid" in called_names
+    civic_call = next(c for c in calls if c["name"] == "civic_get_variants_by_gene")
+    assert civic_call["arguments"]["gene_symbol"] == "HBB"
+    civic = result["data"]["annotations"]["civic"]
+    assert civic["matched"] == 1
+    assert civic["exact_match"] is True
+
+
+def test_explicit_gene_wins_over_rsid_resolved_gene_when_both_given():
+    """When gene and rsid are both supplied, the explicit gene must be used
+    for the ClinVar/CIViC/gnomAD/UniProt sub-queries even though
+    _resolve_gene_from_rsid is now also called (for its token) -- the
+    resolved gene must never silently override an explicit, user-supplied
+    one."""
+    t = _tool()
+    calls = []
+
+    def fake_run_one_function(call):
+        calls.append(call)
+        if call["name"] == "dbsnp_get_variant_by_rsid":
+            return {
+                "status": "success",
+                "data": {"hgvs_notation": "...|GENE=SOMEOTHERGENE:1"},
+            }
+        return {"status": "success", "data": {}}
+
+    with patch(
+        "tooluniverse.execute_function.ToolUniverse.run_one_function",
+        side_effect=fake_run_one_function,
+    ), patch("tooluniverse.execute_function.ToolUniverse.load_tools", return_value=None):
+        t.run({"rsid": "rs334", "gene": "HBB"})
+
+    gnomad_call = next(c for c in calls if c["name"] == "gnomad_get_gene")
+    assert gnomad_call["arguments"]["gene_symbol"] == "HBB"


### PR DESCRIPTION
## Summary

Investigated hemoglobinopathy genetics (HBB/sickle cell disease, GAA/Pompe disease) as this round's two domains. Found and fixed two related Features in `annotate_variant_multi_source` (compound variant tool), both confirmed live against real APIs:

1. **HBB mature-protein numbering mismatch**: dbSNP and ClinVar number HBB's protein from the RefSeq precursor (Met-inclusive, e.g. `p.Glu7Val`), but CIViC and essentially all clinical/scientific literature use the historical mature-protein numbering, one residue lower (`Glu6Val`/`E6V`). Confirmed live for rs334, the sickle-cell mutation: CIViC's sole HBB entry ("E6V") could never be matched even though it IS the queried variant. Fixed with a small, gene-scoped offset table (currently just the confirmed case, HBB) rather than a universal offset, to avoid false-positive matches for unrelated genes/positions.

2. **gene+rsid together skipped token resolution entirely**: the old guard (`if not gene_for_gnomad and rsid`) only resolved the rsid's protein-change token via dbSNP when `gene` was *not* already supplied. So the very common query shape `{"gene": "HBB", "rsid": "rs334"}` left `variant_token` permanently `None`, silently disabling ClinVar/CIViC exact-matching regardless of gene. Now resolves whenever a token is still missing, and keeps the explicit gene if one was given (never lets the resolved gene silently override it).

Domain 2 (GAA/Pompe disease) investigation turned up no bugs — ClinVar, gnomAD constraint, MedGen, and ClinGen dosage sensitivity all behaved correctly; CIViC has no GAA entries (expected, GAA isn't oncology-relevant).

## Verification

- Raw dbSNP (`api.ncbi.nlm.nih.gov/variation/v0/refsnp/334`) and raw ClinVar esummary both confirmed to independently use `p.Glu7Val` numbering; CIViC confirmed via live tool call to use `E6V`.
- Live `tu run annotate_variant_multi_source '{"rsid": "rs334", "gene": "HBB"}'` before fix: `civic.matched: 0, exact_match: false`. After fix: `matched: 1, exact_match: true`.
- Regression-checked the pre-existing ACADM case (rs77931234) with gene+rsid together: same pre-existing "not within first 100 ClinVar rows" limitation as before, unchanged by this fix (CIViC has no ACADM entry at all, unrelated).
- Regression-checked a non-offset gene (GAA, rs386834236, an intronic splice variant) with gene+rsid together: no crash, sensible empty-match output.

## Test plan

- [x] Added `test_offset_protein_tokens_adds_mature_protein_numbering_for_hbb`, `test_offset_protein_tokens_leaves_other_genes_unchanged`, `test_resolve_gene_from_rsid_applies_mature_protein_offset_for_hbb`, `test_gene_and_rsid_given_together_still_resolves_variant_token`, `test_explicit_gene_wins_over_rsid_resolved_gene_when_both_given`
- [x] Updated `test_run_records_sub_call_failures_instead_of_empty_success` (4→5 expected failures: dbSNP is now also queried, and can now also fail, when gene+rsid are both given)
- [x] `tests/unit/test_compound_variant_tool.py` — 27 passed
- [x] Full suite (`pytest tests/ --ignore=tests/test_claude_code_plugin.py`) — clean; the 5 `test_claude_code_plugin.py` failures are pre-existing on main (confirmed via a clean worktree off `origin/main`), unrelated to this change (plugin README/skill-doc drift, not tool code)