### PR TITLE
Fix Round 62: deprecated GBA gene symbol in ClinVar + wrong-gene UniProt match in compound variant tool

### DIFF
--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -329,6 +329,32 @@ class ClinVarSearchVariants(ClinVarRESTTool):
                 result = fallback_result
                 data = result["data"]
 
+        # Fix-R62A-1: some gene symbols are HGNC-deprecated/renamed entirely,
+        # not just informally hyphenated -- e.g. "GBA" (glucocerebrosidase,
+        # Gaucher disease) was renamed to "GBA1" in 2023 to disambiguate from
+        # the GBA2/GBA3 gene family, and ClinVar's own [gene] index has fully
+        # absorbed the rename with no backward-compat alias (confirmed live
+        # and via raw NCBI E-utils: "GBA[gene]" -> 0 hits, not even recognized
+        # as a search phrase; "GBA1[gene]" -> 786 hits). Unlike the hyphen
+        # case above, no string transform recovers the current symbol --
+        # resolve it via NCBI's own gene database (which tracks "GBA" as an
+        # alias of gene ID 2629, current official symbol "GBA1") instead of
+        # hardcoding a growing alias list.
+        if "gene" in arguments and int(data["esearchresult"].get("count", 0)) == 0:
+            resolved_gene = self._resolve_deprecated_gene_symbol(gene)
+            if resolved_gene and resolved_gene.upper() != gene.upper():
+                resolved_query_parts = [f"{resolved_gene}[gene]"] + query_parts[1:]
+                resolved_params = dict(params, term=" AND ".join(resolved_query_parts))
+                resolved_result = self._make_request(self.endpoint, resolved_params)
+                if (
+                    resolved_result.get("status") == "success"
+                    and "esearchresult" in resolved_result.get("data", {})
+                    and int(resolved_result["data"]["esearchresult"].get("count", 0))
+                    > 0
+                ):
+                    result = resolved_result
+                    data = result["data"]
+
         esearch = data["esearchresult"]
         ids = esearch.get("idlist", [])
         count = int(esearch.get("count", 0))
@@ -368,6 +394,38 @@ class ClinVarSearchVariants(ClinVarRESTTool):
         if unrecognized:
             response_data["ignored_parameters"] = unrecognized
         return {"status": "success", "data": response_data}
+
+    def _resolve_deprecated_gene_symbol(self, gene: str) -> Optional[str]:
+        """Look up `gene` in NCBI's own gene database (which tracks
+        deprecated/previous symbols as aliases, e.g. "GBA" -> current
+        official symbol "GBA1") and return its current official symbol.
+        Best-effort: returns None on any failure or if no gene is found,
+        never raises -- this is a fallback, not a hard requirement."""
+        try:
+            search_result = self._make_request(
+                "/esearch.fcgi",
+                {
+                    "db": "gene",
+                    "term": f"{gene}[sym] AND human[orgn]",
+                    "retmode": "json",
+                },
+            )
+            if search_result.get("status") != "success":
+                return None
+            ids = (
+                search_result.get("data", {}).get("esearchresult", {}).get("idlist", [])
+            )
+            if not ids:
+                return None
+            summary_result = self._make_request(
+                "/esummary.fcgi", {"db": "gene", "id": ids[0], "retmode": "json"}
+            )
+            if summary_result.get("status") != "success":
+                return None
+            gene_data = summary_result.get("data", {}).get("result", {}).get(ids[0], {})
+            return gene_data.get("name") or None
+        except Exception:
+            return None
 
 
 @register_tool("ClinVarGetVariantDetails")

--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -198,7 +198,11 @@ class CompoundVariantAnnotationTool(BaseTool):
                         "arguments": {
                             "query": gene_for_gnomad,
                             "organism": "human",
-                            "limit": 3,
+                            # Fix-R62A-2: bumped 3->5 so a correct match
+                            # ranked below UniProt's top few relevance hits
+                            # (see _parse_uniprot) is still in the fetched
+                            # set to select from.
+                            "limit": 5,
                         },
                     }
                 )
@@ -206,7 +210,7 @@ class CompoundVariantAnnotationTool(BaseTool):
                 if error:
                     sources_failed.append(f"UniProt: {error[:100]}")
                 else:
-                    annotations["uniprot"] = self._parse_uniprot(r)
+                    annotations["uniprot"] = self._parse_uniprot(r, gene_for_gnomad)
             except Exception as e:
                 sources_failed.append(f"UniProt: {str(e)[:100]}")
 
@@ -379,7 +383,7 @@ class CompoundVariantAnnotationTool(BaseTool):
             "variants": variants_out[:20],
         }
 
-    def _parse_uniprot(self, result: Any) -> Dict[str, Any]:
+    def _parse_uniprot(self, result: Any, gene: Optional[str] = None) -> Dict[str, Any]:
         # Fix-R31A-4: UniProt_search's "data" is a dict with a "results" list
         # (e.g. {"total_results": N, "results": [...]}), not itself a list --
         # confirmed live this always fell through to the raw-repr-string escape
@@ -391,6 +395,29 @@ class CompoundVariantAnnotationTool(BaseTool):
         results = data.get("results") if isinstance(data, dict) else None
         if isinstance(results, list) and results:
             entry = results[0]
+            # Fix-R62A-2: blindly taking the top relevance hit silently
+            # returned the WRONG gene's protein for gene-symbol families
+            # sharing a name prefix -- confirmed live querying "GBA"
+            # (glucocerebrosidase/Gaucher disease, HGNC-renamed to "GBA1" in
+            # 2023) put "GBA3" (cytosolic beta-glucosidase, an unrelated
+            # gene/enzyme) at position 0, with the correct gene only at
+            # position 3 (still tagged with the legacy "GBA" symbol in that
+            # UniProt entry's own gene_names). Prefer whichever fetched
+            # entry's gene_names contains an exact case-insensitive match to
+            # the queried gene; fall back to the top hit only when none does.
+            if gene:
+                gene_upper = gene.upper()
+                exact = next(
+                    (
+                        r
+                        for r in results
+                        if gene_upper
+                        in [g.upper() for g in (r.get("gene_names") or [])]
+                    ),
+                    None,
+                )
+                if exact:
+                    entry = exact
             gene_names = entry.get("gene_names") or []
             return {
                 "accession": entry.get("accession", ""),

--- a/tests/unit/test_clinvar_gene_hyphen_and_params.py
+++ b/tests/unit/test_clinvar_gene_hyphen_and_params.py
@@ -102,16 +102,22 @@ def test_hyphen_fallback_preserves_other_query_parts():
 
 def test_hyphenated_gene_with_no_real_match_stays_zero_after_fallback():
     """Both the hyphenated and stripped attempts genuinely finding nothing
-    must not error or loop -- just report 0."""
+    must not error or loop -- just report 0. A third call now also happens
+    (Fix-R62A-1's deprecated-symbol gene-database lookup), which itself
+    finds nothing (empty idlist) so no further retry is attempted."""
     tool = _tool()
     with patch.object(
         ClinVarSearchVariants,
         "_make_request",
-        side_effect=[_esearch_result(0), _esearch_result(0)],
+        side_effect=[
+            _esearch_result(0),
+            _esearch_result(0),
+            {"status": "success", "data": {"esearchresult": {"idlist": []}}},
+        ],
     ) as mock_request:
         result = tool.run({"gene": "NOT-A-REAL-GENE"})
 
-    assert mock_request.call_count == 2
+    assert mock_request.call_count == 3
     assert result["data"]["total_count"] == 0
 
 
@@ -178,3 +184,82 @@ def test_all_valid_params_have_no_ignored_parameters_key():
 
     assert result["status"] == "success"
     assert "ignored_parameters" not in result["data"]
+
+
+def _gene_db_result(ids):
+    return {"status": "success", "data": {"esearchresult": {"idlist": ids}}}
+
+
+def _gene_summary_result(gene_id, current_symbol):
+    return {
+        "status": "success",
+        "data": {"result": {gene_id: {"name": current_symbol}}},
+    }
+
+
+def test_deprecated_gene_symbol_resolves_via_ncbi_gene_database():
+    """Fix-R62A-1: "GBA" (glucocerebrosidase, Gaucher disease) was renamed
+    to "GBA1" in 2023 -- ClinVar's [gene] index fully absorbed the rename
+    with no backward-compat alias, unlike the hyphen case, so no string
+    transform recovers it. Confirmed live: "GBA[gene]" -> 0 hits (not even
+    a hyphen to strip), "GBA1[gene]" -> 786 hits. Resolve via NCBI's own
+    gene database (which tracks "GBA" as an alias of gene ID 2629, current
+    symbol "GBA1") and retry."""
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        side_effect=[
+            _esearch_result(0),  # GBA[gene] -- no hyphen, so only 1 attempt
+            _gene_db_result(["2629"]),  # db=gene esearch for "GBA"
+            _gene_summary_result("2629", "GBA1"),  # db=gene esummary
+            _esearch_result(786, query_translation="GBA1[gene]"),  # retry
+        ],
+    ) as mock_request:
+        result = tool.run({"gene": "GBA"})
+
+    assert mock_request.call_count == 4
+    assert mock_request.call_args_list[-1][0][1]["term"] == "GBA1[gene]"
+    assert result["data"]["total_count"] == 786
+    # search_params still echoes back what the caller actually asked for.
+    assert result["data"]["search_params"]["gene"] == "GBA"
+
+
+def test_gene_database_resolving_to_the_same_symbol_does_not_retry():
+    """If NCBI's gene database resolves the queried symbol right back to
+    itself (already current, genuinely 0 pathogenic hits for some other
+    reason -- e.g. an overly narrow significance filter), no pointless
+    retry should be attempted."""
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        side_effect=[
+            _esearch_result(0),
+            _gene_db_result(["7157"]),
+            _gene_summary_result("7157", "TP53"),
+        ],
+    ) as mock_request:
+        result = tool.run({"gene": "TP53"})
+
+    assert mock_request.call_count == 3
+    assert result["data"]["total_count"] == 0
+
+
+def test_gene_database_lookup_failure_does_not_crash_or_error():
+    """The gene-database fallback is best-effort -- a network error there
+    must not surface as a tool failure, just leave the result at 0."""
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        side_effect=[
+            _esearch_result(0),
+            {"status": "error", "error": "Could not find a suitable TLS CA certificate bundle"},
+        ],
+    ) as mock_request:
+        result = tool.run({"gene": "GBA"})
+
+    assert mock_request.call_count == 2
+    assert result["status"] == "success"
+    assert result["data"]["total_count"] == 0

--- a/tests/unit/test_compound_variant_tool.py
+++ b/tests/unit/test_compound_variant_tool.py
@@ -135,6 +135,97 @@ def test_parse_uniprot_falls_back_to_raw_for_unexpected_shape():
     assert "raw" in out
 
 
+def test_parse_uniprot_prefers_exact_gene_match_over_top_relevance_hit():
+    """Fix-R62A-2: blindly taking results[0] silently returned the WRONG
+    gene's protein for gene-symbol families sharing a name prefix --
+    confirmed live querying "GBA" (glucocerebrosidase/Gaucher disease,
+    renamed to "GBA1" in 2023): UniProt's own relevance ranking put "GBA3"
+    (cytosolic beta-glucosidase, a completely different, unrelated enzyme)
+    at position 0, with a real GBA entry only at position 3 (still tagged
+    with the legacy "GBA" symbol in that record's own gene_names)."""
+    t = _tool()
+    real = {
+        "status": "success",
+        "data": {
+            "results": [
+                {
+                    "accession": "Q9H227",
+                    "protein_name": "Cytosolic beta-glucosidase",
+                    "gene_names": ["GBA3"],
+                },
+                {
+                    "accession": "Q9HCG7",
+                    "protein_name": "Non-lysosomal glucosylceramidase",
+                    "gene_names": ["GBA2"],
+                },
+                {
+                    "accession": "P04062",
+                    "protein_name": "Lysosomal acid glucosylceramidase",
+                    "gene_names": ["GBA1"],
+                },
+                {
+                    "accession": "A0A068F658",
+                    "protein_name": "Glucosylceramidase",
+                    "gene_names": ["GBA"],
+                },
+            ],
+        },
+    }
+    out = t._parse_uniprot(real, gene="GBA")
+    assert out["accession"] == "A0A068F658"
+    assert out["gene_name"] == "GBA"
+
+
+def test_parse_uniprot_matches_case_insensitively():
+    t = _tool()
+    real = {
+        "status": "success",
+        "data": {
+            "results": [
+                {"accession": "WRONG", "protein_name": "unrelated", "gene_names": ["OTHER"]},
+                {"accession": "P51587", "protein_name": "BRCA2", "gene_names": ["BRCA2"]},
+            ],
+        },
+    }
+    out = t._parse_uniprot(real, gene="brca2")
+    assert out["accession"] == "P51587"
+
+
+def test_parse_uniprot_falls_back_to_top_hit_when_no_gene_matches():
+    """When none of the fetched results' gene_names match the queried gene
+    at all (the gene truly isn't among them, not just mis-ranked), the old
+    top-hit behavior is the only reasonable fallback -- must not error or
+    return nothing."""
+    t = _tool()
+    real = {
+        "status": "success",
+        "data": {
+            "results": [
+                {"accession": "P05091", "protein_name": "ALDH2", "gene_names": ["ALDH2"]},
+            ],
+        },
+    }
+    out = t._parse_uniprot(real, gene="COMPLETELY_UNRELATED_GENE")
+    assert out["accession"] == "P05091"
+
+
+def test_parse_uniprot_without_gene_arg_keeps_old_top_hit_behavior():
+    """Backward compatibility: gene defaults to None, so callers that don't
+    pass it (or genuinely have no gene) get exactly the pre-fix behavior."""
+    t = _tool()
+    real = {
+        "status": "success",
+        "data": {
+            "results": [
+                {"accession": "FIRST", "protein_name": "x", "gene_names": ["A"]},
+                {"accession": "SECOND", "protein_name": "y", "gene_names": ["B"]},
+            ],
+        },
+    }
+    out = t._parse_uniprot(real)
+    assert out["accession"] == "FIRST"
+
+
 def test_summary_does_not_misattribute_unmatched_clinvar_context():
     """Fix-T2A-001: when clinvar has no exact match, `variants` holds unrelated
     gene-level fallback context (see test_parse_clinvar_falls_back_...). The


### PR DESCRIPTION
## Summary

Investigated lysosomal storage disease genetics (spinal muscular atrophy/SMN1, Gaucher disease/GBA) and alpha-thalassemia/HBA1-HBA2 (a deliberate follow-up to round 60's HBB numbering finding) this round. Found and fixed two related Features, both confirmed live against real APIs:

1. **Deprecated gene symbol unhandled in `ClinVar_search_variants`**: "GBA" (glucocerebrosidase, the classic Gaucher-disease gene) was renamed to "GBA1" by HGNC in 2023, to disambiguate from the GBA2/GBA3 gene family. ClinVar's own `[gene]` index has fully absorbed the rename with no backward-compat alias — confirmed live and via raw NCBI E-utils: `GBA[gene]` → 0 hits (not even recognized as a valid search phrase), `GBA1[gene]` → 786 hits. Unlike the earlier informally-hyphenated-name case (round 49), no simple string transform recovers the current symbol here. Fixed by resolving the symbol via NCBI's own `gene` database (which tracks "GBA" as an alias of gene ID 2629, current official symbol "GBA1") as a fallback when the primary/hyphen-fallback search returns 0 results — not a hardcoded alias list, so it generalizes to any future HGNC rename NCBI's gene database already knows about.

2. **Silent wrong-gene match in `annotate_variant_multi_source`'s UniProt cross-reference**: the parser blindly took `results[0]` from `UniProt_search` — for gene-symbol families sharing a name prefix, UniProt's own relevance ranking doesn't always put the queried gene first. Confirmed live querying `{"gene": "GBA"}`: UniProt returned "GBA3" (cytosolic beta-glucosidase, a completely different, unrelated enzyme) at position 0, with a real GBA entry only at position 3 (still tagged with the legacy "GBA" symbol in that record's own `gene_names`). This is the same class of bug as round 35's CPIC citalopram/escitalopram substring-match bug — a silent wrong answer, not a clean failure. Fixed to prefer whichever fetched result's `gene_names` contains an exact case-insensitive match to the queried gene, falling back to the top hit only when none does; also bumped the UniProt fetch limit 3→5 so a correct-but-lower-ranked match stays within the fetched set.

Domain investigations that turned up no bugs: SMN1/spinal muscular atrophy (one self-caught false alarm — my own filter excluded "Werdnig-Hoffmann disease" from a results check, not a tool defect; the tool itself correctly returned it with the SMN1 gene link), HBA1/HBA2/alpha-thalassemia (CIViC has zero entries for either gene, so round 60's HBB numbering offset was moot here — deliberately not extrapolated without a live case to confirm against).

## Verification

- Raw NCBI E-utils confirmed `GBA[gene]` → 0 hits / not a recognized phrase; `GBA1[gene]` → 786 hits; `db=gene&term=GBA[sym]` → resolves to gene ID 2629, current official symbol "GBA1" (with "GBA" in `otheraliases`).
- Live `tu run ClinVar_search_variants '{"gene": "GBA", "clinical_significance": "Pathogenic"}'` before fix: 0 results. After fix: correctly returns GBA1's real pathogenic variants.
- Live `tu run annotate_variant_multi_source '{"gene": "GBA"}'` end-to-end: before fix, `uniprot.gene_name` was `"GBA3"` (wrong gene); after fix, correctly `"GBA"` (a valid GBA1-equivalent record). Querying with the current symbol `"GBA1"` correctly picks the canonical reviewed UniProt entry (P04062, GBA1_HUMAN).
- Regression-checked: a genuinely nonexistent gene symbol still correctly returns 0 (no false resolution); a valid current symbol with a bogus significance filter (0 hits for an unrelated reason) is not incorrectly "resolved" away; BRCA2 (unambiguous, no naming collision) picks the same UniProt entry as before the fix.

## Test plan

- [x] `tests/unit/test_clinvar_gene_hyphen_and_params.py`: added `test_deprecated_gene_symbol_resolves_via_ncbi_gene_database`, `test_gene_database_resolving_to_the_same_symbol_does_not_retry`, `test_gene_database_lookup_failure_does_not_crash_or_error`; updated `test_hyphenated_gene_with_no_real_match_stays_zero_after_fallback` for the new fallback call
- [x] `tests/unit/test_compound_variant_tool.py`: added `test_parse_uniprot_prefers_exact_gene_match_over_top_relevance_hit`, `test_parse_uniprot_matches_case_insensitively`, `test_parse_uniprot_falls_back_to_top_hit_when_no_gene_matches`, `test_parse_uniprot_without_gene_arg_keeps_old_top_hit_behavior`
- [x] Both test files pass (11 + 26 tests)
- [x] Full suite (`pytest tests/ --ignore=tests/test_claude_code_plugin.py`) — clean, 0 failures (the 5 `test_claude_code_plugin.py` failures are pre-existing on `main`, unrelated plugin-doc drift, confirmed in round 60)