### PR TITLE
Fix plugin/skill sync drift: unreachable skills, stale content, sync gaps [release:patch]

### DIFF
--- a/plugin/skills/tooluniverse-claude-code-plugin/SKILL.md
+++ b/plugin/skills/tooluniverse-claude-code-plugin/SKILL.md
@@ -100,6 +100,8 @@ The router skill auto-dispatches to the right specialized skill — no command p
 | **`/tooluniverse:compare`** | N-way side-by-side comparison with domain-appropriate columns | Slash command |
 | **`/tooluniverse:literature-sweep`** | Graded mini-review across PubMed + EuropePMC + Semantic Scholar | Slash command |
 | **`/tooluniverse:verify-references`** | Check that cited references are real and accurately described, including retraction status | Slash command |
+| **`/tooluniverse:self-review`** | Generate weighted success criteria for a task and check work against them (what's missing / done well) | Slash command |
+| **`/tooluniverse:setup-keys`** | Configure ToolUniverse API keys | Slash command |
 | **`/tooluniverse:researcher`** | Same investigation as `research`, delegated to a forked subagent | Slash command |
 | **120+ skills** | Structured workflows (drug research, variant interpretation, pharmacovigilance, CRISPR screens, statistical modeling, etc.) | Auto-activate on matching questions |
 

--- a/plugin/skills/tooluniverse-polygenic-risk-score/SKILL.md
+++ b/plugin/skills/tooluniverse-polygenic-risk-score/SKILL.md
@@ -146,9 +146,18 @@ PRS can stratify individuals for:
 ### Research Applications
 
 - **Gene discovery**: PRS-based phenome-wide association studies (PheWAS)
-- **Genetic correlation**: Compare PRS across traits
+- **Genetic correlation**: Compare PRS across traits — but for a rigorous, GWAS-summary-statistics estimate of cross-trait genetic correlation (rg), use `run_ldsc_genetic_correlation` (LD Score regression), which needs only summary stats (no individual genotypes) and corrects for sample overlap. Far more principled than correlating PRS values.
 - **Causal inference**: Mendelian randomization using PRS as instruments
 - **Simulation studies**: Model polygenic architecture
+
+### SNP-heritability and genetic correlation (LDSC)
+
+Before or alongside building a PRS, quantify how much of the trait is captured by common SNPs and how traits relate — directly from GWAS summary statistics:
+
+- `run_ldsc_heritability` — SNP-based heritability (h²_SNP) from one GWAS's summary stats; the intercept also flags confounding/inflation vs. true polygenicity. This sets the ceiling a PRS can reach (the "heritability gap" below is exactly h²_SNP minus PRS R²).
+- `run_ldsc_genetic_correlation` — genetic correlation (rg) between two GWAS, for shared-aetiology and cross-trait PRS questions.
+
+Both are remote tools (LD Score regression engine + reference LD-score panels). Use them to ground heritability/rg claims in data rather than citing literature point estimates.
 
 ### Personal Genomics
 

--- a/plugin/skills/tooluniverse-precision-oncology/API_USAGE_PATTERNS.md
+++ b/plugin/skills/tooluniverse-precision-oncology/API_USAGE_PATTERNS.md
@@ -342,7 +342,7 @@ def get_tumor_expression_context(tu, gene_symbol, cancer_type):
 ### Query Order
 1. `OpenTargets_get_associated_drugs_by_target_ensemblID` -> Approved drugs
 2. `DailyMed_search_spls` -> FDA label details
-3. `ChEMBL_get_drug_mechanisms_of_action_by_chemblId` -> Mechanism
+3. `ChEMBL_get_drug_mechanisms` -> Mechanism
 
 ### Treatment Output Example
 

--- a/plugin/skills/tooluniverse-precision-oncology/TOOLS_REFERENCE.md
+++ b/plugin/skills/tooluniverse-precision-oncology/TOOLS_REFERENCE.md
@@ -315,7 +315,7 @@ cells = tu.tools.DepMap_get_cell_lines(
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
 | `ChEMBL_search_drugs` | Search drugs | `query`, `max_phase` |
-| `ChEMBL_get_drug_mechanisms_of_action_by_chemblId` | Drug MOA | `chemblId` |
+| `ChEMBL_get_drug_mechanisms` | Drug MOA | `drug_chembl_id` |
 | `ChEMBL_get_target_activities` | Bioactivity data | `target_chembl_id` |
 
 ### DailyMed

--- a/plugin/skills/tooluniverse-protein-interactions/DOMAIN_ANALYSIS.md
+++ b/plugin/skills/tooluniverse-protein-interactions/DOMAIN_ANALYSIS.md
@@ -175,12 +175,9 @@
 - **Use Case**: Protein structure and complex formation
 - **API**: Public REST API
 
-**Tools (5)** - Use for structural analysis:
-1. `SASBDB_search_entries` - Find structural data
-2. `SASBDB_get_entry` - Get entry metadata
-3. `SASBDB_get_entry` - Get structural models
-4. `SASBDB_get_entry` - Get scattering data
-5. `SASBDB_download_data` - Download raw data
+**Tools (2)** - Use for structural analysis:
+1. `SASBDB_search_entries` - Find structural data (by molecular type, or list all entries)
+2. `SASBDB_get_entry` - Get entry metadata, experimental conditions, publication info, and data file URLs (one call covers structure/scattering data access — there is no separate download tool)
 
 ---
 

--- a/plugin/skills/tooluniverse-rare-disease-diagnosis/TOOLS_REFERENCE.md
+++ b/plugin/skills/tooluniverse-rare-disease-diagnosis/TOOLS_REFERENCE.md
@@ -748,7 +748,7 @@ def analyze_vus_structure(tu, uniprot_id, variant_position):
 | Primary | Fallback 1 | Fallback 2 |
 |---------|------------|------------|
 | `kegg_get_gene_info` | `ReactomeContent_search` | `KEGG_get_gene_pathways` |
-| `intact_search_interactions` | `STRING_interactions` | Literature search |
+| `intact_search_interactions` | `STRING_get_interaction_partners` | Literature search |
 
 ### Variant Annotation
 | Primary | Fallback 1 | Fallback 2 |

--- a/plugin/skills/tooluniverse-regulatory-genomics/SKILL.md
+++ b/plugin/skills/tooluniverse-regulatory-genomics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tooluniverse-regulatory-genomics
-description: Transcription factor binding, cis-regulatory elements (cCREs), chromatin accessibility, and regulatory annotation using JASPAR (motifs), ENCODE (cCREs, ChIP-seq), RegulomeDB (regulatory variant scoring), UCSC. Use for regulatory element annotation, TF-binding-site prediction, and regulatory-region functional impact assessment.
+description: Transcription factor binding, cis-regulatory elements (cCREs), chromatin accessibility, and regulatory annotation using JASPAR (motifs), ENCODE (cCREs, ChIP-seq), RegulomeDB (regulatory variant scoring), UCSC — plus sequence-based deep-learning prediction of regulatory activity and non-coding variant effects (AlphaGenome, Enformer, Borzoi, ChromBPNet, Evo 2). Use for regulatory element annotation, TF-binding-site prediction, regulatory-region functional impact assessment, and predicting how a non-coding variant or a raw DNA sequence affects expression/chromatin/accessibility. Use this whenever a user asks what regulates a gene, whether a SNP hits a regulatory element, or to predict a non-coding variant's functional effect from sequence.
 disable-model-invocation: true
 ---
 
@@ -42,6 +42,9 @@ When analysis requires computation (statistics, data processing, scoring, enrich
 - "Is rs1234567 in a regulatory region?"
 - "What TF motifs overlap this genomic region?"
 - "Find ENCODE experiments for ATAC-seq in cancer cell lines"
+- "Predict the effect of this non-coding variant on expression / chromatin accessibility"
+- "Predict regulatory activity (expression, accessibility, TF binding) directly from a DNA sequence"
+- "Which of these enhancer variants is predicted to be most disruptive?"
 
 ---
 
@@ -64,6 +67,20 @@ When analysis requires computation (statistics, data processing, scoring, enrich
 | `UCSC_get_encode_cCREs` | Get cCREs overlapping a genomic region | `chrom`, `start`, `end` |
 | `RegulomeDB_query_variant` | Score regulatory impact of a variant | `rsid` (e.g., "rs4994") |
 | `ENCODE_search_biosamples` | Find available cell lines/tissues in ENCODE | `term_name`, `biosample_type`, `limit` |
+
+### Sequence-based deep-learning models (predict, don't just annotate)
+
+The tools above tell you what is *known* to be at a locus (databases). These models instead *predict* regulatory activity directly from the DNA sequence, and — by scoring a reference vs. alternate window — predict what a non-coding variant *does*. RegulomeDB ranks a variant by overlap with existing annotations; these give a quantitative, tissue-aware effect size even for novel variants with no annotation. Reach for them when annotation is silent or when the question is "how much does this allele change regulation".
+
+| Tool | Op | Predicts | Context | Access |
+|------|----|----------|---------|--------|
+| `AlphaGenome_predict_interval` / `AlphaGenome_score_variant` | profile region / score variant | RNA-seq, ATAC, CAGE, splice tracks (frontier accuracy, single-base) | up to 1 Mb | hosted API — `ALPHA_GENOME_API_KEY` |
+| `run_enformer_predict` / `run_enformer_variant_effect` | profile / score | 5,313 human (+1,643 mouse) tracks: expression, chromatin, TF binding | 196 kb | remote MCP server |
+| `run_borzoi_predict` / `run_borzoi_variant_effect` | profile / score | RNA-seq coverage (expression / polyA / splicing emphasis), 7,611 tracks | 524 kb | remote MCP server |
+| `run_chrombpnet_predict` / `run_chrombpnet_variant_effect` | profile / score | chromatin accessibility (ATAC / DNase), base-resolution profile + counts | ~2 kb | remote MCP server |
+| `Evo2_score_variant` | score | genome-foundation-model delta log-likelihood; coding **and** non-coding | up to 1 Mb | hosted NIM — `NVIDIA_API_KEY` |
+
+**Picking one:** `AlphaGenome_*` is the broadest readout + longest context when its key is set; `run_enformer_*` / `run_borzoi_*` are the published, self-hostable equivalents (Enformer for general regulation, Borzoi when expression/splicing is the question); `run_chrombpnet_*` when the question is specifically chromatin accessibility; `Evo2_score_variant` as a sequence-only check that also covers coding variants. Outputs are Δ (alt − ref) effect sizes, not calibrated probabilities — rank/calibrate against known variants. If no key/server is provisioned, fall back to the annotation tools above and say so.
 
 ---
 

--- a/plugin/skills/tooluniverse-statistical-modeling/TOOLS_REFERENCE.md
+++ b/plugin/skills/tooluniverse-statistical-modeling/TOOLS_REFERENCE.md
@@ -77,7 +77,7 @@ These ToolUniverse tools can be used to retrieve data before modeling:
 |------|-----------|---------|
 | `FAERS_calculate_disproportionality` | `drug_name`, `adverse_event` | `{metrics: {PRR, ROR, IC}, signal_detection}` |
 | `FAERS_stratify_by_demographics` | `drug_name`, `adverse_event`, `stratify_by` | Stratified counts |
-| `FAERS_count_patient_reaction` | `medicinalproduct` | `[{term, count}]` |
+| `FAERS_count_reactions_by_drug_event` | `medicinalproduct` | `[{term, count}]` (grouped by MedDRA Preferred Term) |
 
 ### Gene-Disease Evidence
 

--- a/plugin/skills/tooluniverse-variant-interpretation/SKILL.md
+++ b/plugin/skills/tooluniverse-variant-interpretation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tooluniverse-variant-interpretation
-description: Clinical variant interpretation from raw variant calls to ACMG-classified recommendations with structural impact analysis. Use for VUS classification, pathogenicity assessment with cited criteria, structure-based variant impact (AlphaFold/PDB), and producing clinical-grade variant reports for return of results or molecular tumor boards.
+description: Clinical variant interpretation from raw variant calls to ACMG-classified recommendations with structural impact analysis. Use for VUS classification, pathogenicity assessment with cited criteria, structure-based variant impact (AlphaFold/PDB), non-coding/regulatory variant effect prediction with sequence deep-learning models (AlphaGenome, Enformer, Borzoi, ChromBPNet, Evo 2), and producing clinical-grade variant reports for return of results or molecular tumor boards. Use this whenever a user asks about a variant's significance, an intronic/promoter/enhancer/UTR non-coding variant's functional impact, or needs ACMG classification — even if they don't say "ACMG".
 disable-model-invocation: true
 ---
 
@@ -37,7 +37,7 @@ When asked about a variant's significance, query ClinVar/gnomAD/CIViC FIRST. Nev
 ```
 Phase 1: VARIANT IDENTITY        → Normalize HGVS, map gene/transcript/consequence
 Phase 2: CLINICAL DATABASES       → ClinVar, gnomAD, OMIM, ClinGen, COSMIC, SpliceAI
-Phase 2.5: REGULATORY CONTEXT     → ChIPAtlas, ENCODE (non-coding variants only)
+Phase 2.5: REGULATORY CONTEXT     → ChIPAtlas/ENCODE annotation + DL variant-effect (AlphaGenome/Enformer/Borzoi/ChromBPNet/Evo2) (non-coding only)
 Phase 3: COMPUTATIONAL PREDICTIONS → CADD, AlphaMissense, EVE, SIFT/PolyPhen
 Phase 4: STRUCTURAL ANALYSIS      → PDB/AlphaFold2, domains, functional sites (VUS/novel)
 Phase 4.5: EXPRESSION CONTEXT     → CELLxGENE, GTEx tissue expression
@@ -82,7 +82,23 @@ See `CODE_PATTERNS.md` for implementation details.
 
 Apply for intronic (non-splice), promoter, UTR, or intergenic variants near disease genes.
 
-Tools: `ChIPAtlas_enrichment_analysis`, `ChIPAtlas_get_peak_data`, `ENCODE_search_experiments`, `ENCODE_get_experiment`
+**Annotation — what regulatory element is here:** `ChIPAtlas_enrichment_analysis`, `ChIPAtlas_get_peak_data`, `ENCODE_search_experiments`, `ENCODE_get_experiment`. These tell you whether the variant falls in a known TF-binding peak, enhancer, or open-chromatin region.
+
+**Prediction — what the variant *does* to regulation:** annotation says an element is present, not whether this specific allele disrupts it. Sequence-based deep-learning models answer that directly: they read the reference and alternate DNA windows and predict the change in regulatory signal. This is what turns "the variant is in an enhancer" into "the variant is predicted to reduce accessibility/expression in the relevant tissue" — the mechanistic evidence ACMG PS3/PP3 actually needs for a non-coding variant, where SIFT/PolyPhen/AlphaMissense do not apply.
+
+| Tool | Predicts | Context | Access |
+|---|---|---|---|
+| `AlphaGenome_score_variant` | Δ across RNA-seq / ATAC / CAGE / splice tracks (frontier accuracy, single-base) | up to 1 Mb | hosted API — needs `ALPHA_GENOME_API_KEY` |
+| `run_enformer_variant_effect` | Δ across 5,313 human tracks (expression, chromatin, TF binding) | 196 kb | remote MCP server |
+| `run_borzoi_variant_effect` | Δ in RNA-seq coverage (expression / polyA / splicing emphasis) | 524 kb | remote MCP server |
+| `run_chrombpnet_variant_effect` | Δ in chromatin accessibility (ATAC / DNase), base-resolution | ~2 kb | remote MCP server |
+| `Evo2_score_variant` | Genome-foundation-model delta log-likelihood; covers coding **and** non-coding | up to 1 Mb | hosted NIM — needs `NVIDIA_API_KEY` |
+
+**Reading the score:** these return Δ (alt − ref) effect sizes, *not* calibrated pathogenicity probabilities. A large predicted disruption in a tissue-relevant track is mechanistic support (PS3_supporting / PP3) for a non-coding variant; near-zero across tracks supports BP4. Rank or calibrate against known regulatory variants rather than applying an absolute cutoff.
+
+**Which to pick:** start with `AlphaGenome_score_variant` (broadest readout, longest context, frontier accuracy) when its key is set; `run_enformer_variant_effect` / `run_borzoi_variant_effect` are the named, self-hostable equivalents (Enformer for general regulation, Borzoi when expression/splicing is the question); `run_chrombpnet_variant_effect` when the hypothesis is specifically chromatin accessibility; `Evo2_score_variant` as a sequence-only check that also works on coding variants. If no key/server is provisioned, fall back to the ChIPAtlas/ENCODE annotation above and note the predictive gap rather than guessing.
+
+**Inputs:** `AlphaGenome_score_variant` takes `chromosome` + `position` + `reference_bases`/`alternate_bases` (+ `output_type`, `sequence_length`); `Evo2_score_variant` takes a DNA window as `sequence` + `position` + `alternate` (point substitution) or `ref_sequence`/`alt_sequence`, plus optional `model` (`evo2-40b` default, `evo2-7b` faster); the Enformer/Borzoi/ChromBPNet remote tools take the variant locus and score the change over their output tracks.
 
 ## Phase 2.9: Short-Circuit Check
 

--- a/plugin/skills/tooluniverse-variant-interpretation/TOOLS_REFERENCE.md
+++ b/plugin/skills/tooluniverse-variant-interpretation/TOOLS_REFERENCE.md
@@ -613,6 +613,20 @@ peaks = tu.tools.ChIPAtlas_get_peak_data(
 | `ENCODE_get_experiment` | Experiment details | `accession` |
 | `ENCODE_get_biosample` | Sample annotations | `accession` |
 
+### Sequence Deep-Learning Variant-Effect Predictors
+
+Predict the functional impact of a non-coding (and, for Evo 2, any) variant directly from sequence — the mechanistic evidence (PS3_supporting / PP3) that SIFT/PolyPhen/AlphaMissense cannot give for non-coding loci. Outputs are Δ (alt − ref) effect sizes, not calibrated probabilities.
+
+| Tool | Predicts | Access |
+|------|----------|--------|
+| `AlphaGenome_score_variant` | RNA-seq/ATAC/CAGE/splice track Δ (1 Mb, single-base) | hosted API — `ALPHA_GENOME_API_KEY` |
+| `run_enformer_variant_effect` | Δ across 5,313 human tracks (196 kb) | remote MCP server |
+| `run_borzoi_variant_effect` | RNA-seq coverage Δ (expression/splicing, 524 kb) | remote MCP server |
+| `run_chrombpnet_variant_effect` | chromatin accessibility Δ (ATAC/DNase, base-res) | remote MCP server |
+| `Evo2_score_variant` | genome-LM delta log-likelihood; coding + non-coding | hosted NIM — `NVIDIA_API_KEY` |
+
+**Inputs**: `AlphaGenome_score_variant` → `chromosome`,`position`,`reference_bases`,`alternate_bases`,`output_type`,`sequence_length`. `Evo2_score_variant` → `sequence`+`position`+`alternate` (or `ref_sequence`/`alt_sequence`), optional `model` (`evo2-40b`/`evo2-7b`). The Enformer/Borzoi/ChromBPNet remote tools take the variant locus. See SKILL.md Phase 2.5 for selection guidance.
+
 **Example - Get regulatory annotations**:
 ```python
 # Search for regulatory data near variant

--- a/plugin/skills/tooluniverse-variant-interpretation/TOOLS_REFERENCE.md
+++ b/plugin/skills/tooluniverse-variant-interpretation/TOOLS_REFERENCE.md
@@ -761,8 +761,8 @@ result = tu.tools.OMIM_search(query="BRCA1")
 
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
-| `ClinGen_gene_validity` | Get curation status | `gene` |
-| `ClinGen_dosage` | Dosage sensitivity | `gene` |
+| `ClinGen_get_gene_validity` | Get curation status | `gene` |
+| `ClinGen_dosage_by_gene` | Dosage sensitivity | `gene` |
 
 **Gene Validity Levels**:
 | Level | Meaning |

--- a/plugin/skills/tooluniverse/SKILL.md
+++ b/plugin/skills/tooluniverse/SKILL.md
@@ -124,6 +124,8 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**TCGA**", "cancer genomics cohort", "GDC analysis", "TCGA mutations", "pan-cancer" | `Skill(skill="tooluniverse-cancer-genomics-tcga")` |
 | "**immunotherapy response**", "checkpoint inhibitor response", "TMB", "MSI", "PD-L1", "ICI response" | `Skill(skill="tooluniverse-immunotherapy-response-prediction")` |
 | "**rare disease diagnosis**", "differential diagnosis", "phenotype matching", "HPO", "patient with [symptoms]" | `Skill(skill="tooluniverse-rare-disease-diagnosis")` |
+| "**clinical risk score**", "CHA2DS2-VASc", "HAS-BLED", "CURB-65", "qSOFA", "Child-Pugh", "MELD-Na", "Wells score", "ASCVD risk", "eGFR CKD-EPI", "bedside risk calculator" | `Skill(skill="tooluniverse-clinical-risk-scoring")` |
+| "**device adverse events**", "device recall", "MAUDE", "food/supplement adverse event", "CAERS", "veterinary adverse event", "drug shortage" | `Skill(skill="tooluniverse-product-safety-surveillance")` |
 | "**variant interpretation**", "VUS", "pathogenicity", "clinical significance", "is [variant] pathogenic" | `Skill(skill="tooluniverse-variant-interpretation")` |
 | "**clinical guidelines**", "practice guidelines", "treatment guidelines", "dosing recommendations", "standard of care" | `Skill(skill="tooluniverse-clinical-guidelines")` |
 | "**patient stratification**", "precision medicine", "biomarker stratification", "treatment selection" | `Skill(skill="tooluniverse-precision-medicine-stratification")` |
@@ -143,6 +145,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**small molecule discovery**", "chemical biology", "compound sourcing", "hit finding", "chemical probe" | `Skill(skill="tooluniverse-small-molecule-discovery")` |
 | "**chemical sourcing**", "buy compound", "vendor search", "Enamine", "MolPort", "compound availability" | `Skill(skill="tooluniverse-chemical-sourcing")` |
 | "**GPCR**", "G-protein coupled receptor", "GPCRdb", "receptor ligand", "biased agonist" | `Skill(skill="tooluniverse-gpcr-structural-pharmacology")` |
+| "**dereplicate**", "natural product identification", "NPAtlas", "ChemOnt classification", "ClassyFire", "producing organism" | `Skill(skill="tooluniverse-natural-product-dereplication")` |
 
 ### 5. Genomics & Variant Analysis
 
@@ -159,6 +162,13 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**regulatory variant**", "non-coding variant", "eQTL variant", "regulatory region variant" | `Skill(skill="tooluniverse-regulatory-variant-analysis")` |
 | "**rare disease genomics**", "Orphanet gene", "rare disease gene", "causative gene", "exome diagnosis" | `Skill(skill="tooluniverse-rare-disease-genomics")` |
 | "**1000 Genomes**", "IGSR", "population frequency", "superpopulation", "AFR/EUR/EAS/SAS/AMR" | `Skill(skill="tooluniverse-population-genetics-1000genomes")` |
+| "**PheWAS**", "phenome-wide association", "cross-ancestry replication", "cross-biobank", "FinnGen", "BioBank Japan", "pleiotropy of a variant" | `Skill(skill="tooluniverse-phewas")` |
+| "**Mendelian randomization**", "MR causal inference", "instrumental variable", "does X cause Y", "genetic causal evidence" | `Skill(skill="tooluniverse-mendelian-randomization")` |
+| "**loss-of-function mechanism**", "LoF mechanism", "why is this variant LoF", "structural stability vs functional disruption" | `Skill(skill="tooluniverse-protein-lof-mechanism")` |
+| "**SAE feature**", "sparse autoencoder variant", "ESMC SAE", "mechanistic variant interpretation" | `Skill(skill="tooluniverse-protein-sae-variant-interpretation")` |
+| "**per-residue annotation**", "binding interface residues", "ligand pocket residues", "buried vs surface residues", "PDB structural annotation" | `Skill(skill="tooluniverse-protein-structural-annotation-pdb")` |
+| "**why are these residues critical**", "residue functional mechanism", "DMS hotspot interpretation", "catalytic vs structural residue" | `Skill(skill="tooluniverse-residue-functional-mechanism-interpretation")` |
+| "**validate variant predictor**", "DMS validation", "deep mutational scanning benchmark", "predictor vs experimental effect" | `Skill(skill="tooluniverse-variant-predictor-dms-validation")` |
 
 ### 6. Systems & Network Analysis
 
@@ -208,6 +218,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**protein modification**", "PTM analysis", "phosphorylation site", "ubiquitination", "glycosylation" | `Skill(skill="tooluniverse-protein-modification-analysis")` |
 | "**structural proteomics**", "cross-linking mass spec", "XL-MS", "HDX-MS", "structural biology" | `Skill(skill="tooluniverse-structural-proteomics")` |
 | "**protein structure prediction**", "AlphaFold prediction", "structure modeling", "homology modeling" | `Skill(skill="tooluniverse-protein-structure-prediction")` |
+| "**FASTQ QC**", "FastQC", "MultiQC", "adapter trimming", "fastp", "Cutadapt", "read quality", "sequence duplication" | `Skill(skill="tooluniverse-fastq-qc")` |
 
 ### 8. Clinical Trials & Study Design
 
@@ -231,6 +242,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**ecology**", "biodiversity", "invasive species", "pollinator", "food web", "conservation", "community ecology", "trophic" | `Skill(skill="tooluniverse-ecology-biodiversity")` |
 | "**microbiome**", "gut microbiota", "dysbiosis", "microbiome composition", "16S rRNA" | `Skill(skill="tooluniverse-microbiome-research")` |
 | "**adverse outcome pathway**", "AOP", "key event", "molecular initiating event", "KER" | `Skill(skill="tooluniverse-adverse-outcome-pathway")` |
+| "**genome assembly**", "assembly N50", "RefSeq assembly QC", "plasmid count", "NCBI Datasets genome" | `Skill(skill="tooluniverse-microbial-genome-characterization")` |
 
 ### 10. Specialized Biology
 
@@ -272,6 +284,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**custom tool**", "add my own tool", "local tool", "create tool", "extend ToolUniverse" | `Skill(skill="tooluniverse-custom-tool")` |
 | "**SDK**", "Python SDK", "build AI scientist", "programmatic access", "**import tooluniverse**", "**coding API**", "**tu build**", "**typed wrappers**" | `Skill(skill="tooluniverse-sdk")` |
 | "**install skills**", "missing skills", "skill not found", "add skills" | `Skill(skill="tooluniverse-install-skills")` |
+| "**self-review**", "check my work", "definition of done", "evaluation rubric", "success criteria", "grading criteria", "LLM-as-judge" | `Skill(skill="tooluniverse-self-review")` |
 
 ---
 

--- a/plugin/sync-skills.sh
+++ b/plugin/sync-skills.sh
@@ -29,9 +29,13 @@ set -euo pipefail
 cd "$(dirname "$0")"
 REPO_ROOT="$(cd .. && pwd)"
 
-# Codex-host-specific skills that should NOT ship in the Claude packaging
-# (mirror of how the Codex sync drops tooluniverse-claude-code-plugin).
-CLAUDE_EXCLUDE="tooluniverse-codex-plugin"
+# Skills that should NOT ship in the Claude packaging:
+#   tooluniverse-codex-plugin — Codex-host-specific install docs (mirror of
+#                                how the Codex sync drops tooluniverse-claude-code-plugin)
+#   tooluniverse-cs-setup      — Claude Science install docs (different host
+#                                entirely: conda env + host.skills.* API, no
+#                                MCP/uvx/plugin marketplace involved)
+CLAUDE_EXCLUDE="tooluniverse-codex-plugin tooluniverse-cs-setup"
 
 # Recreate plugin/skills/ from scratch (Claude packaging — all user-facing skills)
 rm -rf skills

--- a/plugins/tooluniverse/skills/setup-tooluniverse/SKILL.md
+++ b/plugins/tooluniverse/skills/setup-tooluniverse/SKILL.md
@@ -151,7 +151,7 @@ Make sure Step 2 is done (`uv --version` works).
 > claude plugin marketplace add mims-harvard/ToolUniverse
 > claude plugin install tooluniverse@tooluniverse
 > ```
-> This installs MCP server + 115 skills + slash commands in one step.
+> This installs MCP server + 115 skills + slash commands in one step. Then see the `tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update" step so future releases apply without manual `claude plugin update`.
 
 | Client | File | How to Access |
 |--------|------|---------------|

--- a/plugins/tooluniverse/skills/tooluniverse-polygenic-risk-score/SKILL.md
+++ b/plugins/tooluniverse/skills/tooluniverse-polygenic-risk-score/SKILL.md
@@ -146,9 +146,18 @@ PRS can stratify individuals for:
 ### Research Applications
 
 - **Gene discovery**: PRS-based phenome-wide association studies (PheWAS)
-- **Genetic correlation**: Compare PRS across traits
+- **Genetic correlation**: Compare PRS across traits — but for a rigorous, GWAS-summary-statistics estimate of cross-trait genetic correlation (rg), use `run_ldsc_genetic_correlation` (LD Score regression), which needs only summary stats (no individual genotypes) and corrects for sample overlap. Far more principled than correlating PRS values.
 - **Causal inference**: Mendelian randomization using PRS as instruments
 - **Simulation studies**: Model polygenic architecture
+
+### SNP-heritability and genetic correlation (LDSC)
+
+Before or alongside building a PRS, quantify how much of the trait is captured by common SNPs and how traits relate — directly from GWAS summary statistics:
+
+- `run_ldsc_heritability` — SNP-based heritability (h²_SNP) from one GWAS's summary stats; the intercept also flags confounding/inflation vs. true polygenicity. This sets the ceiling a PRS can reach (the "heritability gap" below is exactly h²_SNP minus PRS R²).
+- `run_ldsc_genetic_correlation` — genetic correlation (rg) between two GWAS, for shared-aetiology and cross-trait PRS questions.
+
+Both are remote tools (LD Score regression engine + reference LD-score panels). Use them to ground heritability/rg claims in data rather than citing literature point estimates.
 
 ### Personal Genomics
 

--- a/plugins/tooluniverse/skills/tooluniverse-precision-oncology/API_USAGE_PATTERNS.md
+++ b/plugins/tooluniverse/skills/tooluniverse-precision-oncology/API_USAGE_PATTERNS.md
@@ -342,7 +342,7 @@ def get_tumor_expression_context(tu, gene_symbol, cancer_type):
 ### Query Order
 1. `OpenTargets_get_associated_drugs_by_target_ensemblID` -> Approved drugs
 2. `DailyMed_search_spls` -> FDA label details
-3. `ChEMBL_get_drug_mechanisms_of_action_by_chemblId` -> Mechanism
+3. `ChEMBL_get_drug_mechanisms` -> Mechanism
 
 ### Treatment Output Example
 

--- a/plugins/tooluniverse/skills/tooluniverse-precision-oncology/TOOLS_REFERENCE.md
+++ b/plugins/tooluniverse/skills/tooluniverse-precision-oncology/TOOLS_REFERENCE.md
@@ -315,7 +315,7 @@ cells = tu.tools.DepMap_get_cell_lines(
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
 | `ChEMBL_search_drugs` | Search drugs | `query`, `max_phase` |
-| `ChEMBL_get_drug_mechanisms_of_action_by_chemblId` | Drug MOA | `chemblId` |
+| `ChEMBL_get_drug_mechanisms` | Drug MOA | `drug_chembl_id` |
 | `ChEMBL_get_target_activities` | Bioactivity data | `target_chembl_id` |
 
 ### DailyMed

--- a/plugins/tooluniverse/skills/tooluniverse-protein-interactions/DOMAIN_ANALYSIS.md
+++ b/plugins/tooluniverse/skills/tooluniverse-protein-interactions/DOMAIN_ANALYSIS.md
@@ -175,12 +175,9 @@
 - **Use Case**: Protein structure and complex formation
 - **API**: Public REST API
 
-**Tools (5)** - Use for structural analysis:
-1. `SASBDB_search_entries` - Find structural data
-2. `SASBDB_get_entry` - Get entry metadata
-3. `SASBDB_get_entry` - Get structural models
-4. `SASBDB_get_entry` - Get scattering data
-5. `SASBDB_download_data` - Download raw data
+**Tools (2)** - Use for structural analysis:
+1. `SASBDB_search_entries` - Find structural data (by molecular type, or list all entries)
+2. `SASBDB_get_entry` - Get entry metadata, experimental conditions, publication info, and data file URLs (one call covers structure/scattering data access — there is no separate download tool)
 
 ---
 

--- a/plugins/tooluniverse/skills/tooluniverse-rare-disease-diagnosis/TOOLS_REFERENCE.md
+++ b/plugins/tooluniverse/skills/tooluniverse-rare-disease-diagnosis/TOOLS_REFERENCE.md
@@ -748,7 +748,7 @@ def analyze_vus_structure(tu, uniprot_id, variant_position):
 | Primary | Fallback 1 | Fallback 2 |
 |---------|------------|------------|
 | `kegg_get_gene_info` | `ReactomeContent_search` | `KEGG_get_gene_pathways` |
-| `intact_search_interactions` | `STRING_interactions` | Literature search |
+| `intact_search_interactions` | `STRING_get_interaction_partners` | Literature search |
 
 ### Variant Annotation
 | Primary | Fallback 1 | Fallback 2 |

--- a/plugins/tooluniverse/skills/tooluniverse-regulatory-genomics/SKILL.md
+++ b/plugins/tooluniverse/skills/tooluniverse-regulatory-genomics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: tooluniverse-regulatory-genomics
-description: "Transcription factor binding, cis-regulatory elements (cCREs), chromatin accessibility, and regulatory annotation using JASPAR (motifs), ENCODE (cCREs, ChIP-seq), RegulomeDB (regulatory variant scoring), UCSC. Use for regulatory element annotation, TF-binding-site prediction, and regulatory-region functional impact assessment."
+description: "Transcription factor binding, cis-regulatory elements (cCREs), chromatin accessibility, and regulatory annotation using JASPAR (motifs), ENCODE (cCREs, ChIP-seq), RegulomeDB (regulatory variant scoring), UCSC — plus sequence-based deep-learning prediction of regulatory activity and non-coding variant effects (AlphaGenome, Enformer, Borzoi, ChromBPNet, Evo 2). Use for regulatory element annotation, TF-binding-site prediction, regulatory-region functional impact assessment, and predicting how a non-coding variant or a raw DNA sequence affects expression/chromatin/accessibility. Use this whenever a user asks what regulates a gene, whether a SNP hits a regulatory element, or to predict a non-coding variant's functional effect from sequence."
 ---
 
 # Regulatory Genomics Research Skill
@@ -42,6 +42,9 @@ When analysis requires computation (statistics, data processing, scoring, enrich
 - "Is rs1234567 in a regulatory region?"
 - "What TF motifs overlap this genomic region?"
 - "Find ENCODE experiments for ATAC-seq in cancer cell lines"
+- "Predict the effect of this non-coding variant on expression / chromatin accessibility"
+- "Predict regulatory activity (expression, accessibility, TF binding) directly from a DNA sequence"
+- "Which of these enhancer variants is predicted to be most disruptive?"
 
 ---
 
@@ -64,6 +67,20 @@ When analysis requires computation (statistics, data processing, scoring, enrich
 | `UCSC_get_encode_cCREs` | Get cCREs overlapping a genomic region | `chrom`, `start`, `end` |
 | `RegulomeDB_query_variant` | Score regulatory impact of a variant | `rsid` (e.g., "rs4994") |
 | `ENCODE_search_biosamples` | Find available cell lines/tissues in ENCODE | `term_name`, `biosample_type`, `limit` |
+
+### Sequence-based deep-learning models (predict, don't just annotate)
+
+The tools above tell you what is *known* to be at a locus (databases). These models instead *predict* regulatory activity directly from the DNA sequence, and — by scoring a reference vs. alternate window — predict what a non-coding variant *does*. RegulomeDB ranks a variant by overlap with existing annotations; these give a quantitative, tissue-aware effect size even for novel variants with no annotation. Reach for them when annotation is silent or when the question is "how much does this allele change regulation".
+
+| Tool | Op | Predicts | Context | Access |
+|------|----|----------|---------|--------|
+| `AlphaGenome_predict_interval` / `AlphaGenome_score_variant` | profile region / score variant | RNA-seq, ATAC, CAGE, splice tracks (frontier accuracy, single-base) | up to 1 Mb | hosted API — `ALPHA_GENOME_API_KEY` |
+| `run_enformer_predict` / `run_enformer_variant_effect` | profile / score | 5,313 human (+1,643 mouse) tracks: expression, chromatin, TF binding | 196 kb | remote MCP server |
+| `run_borzoi_predict` / `run_borzoi_variant_effect` | profile / score | RNA-seq coverage (expression / polyA / splicing emphasis), 7,611 tracks | 524 kb | remote MCP server |
+| `run_chrombpnet_predict` / `run_chrombpnet_variant_effect` | profile / score | chromatin accessibility (ATAC / DNase), base-resolution profile + counts | ~2 kb | remote MCP server |
+| `Evo2_score_variant` | score | genome-foundation-model delta log-likelihood; coding **and** non-coding | up to 1 Mb | hosted NIM — `NVIDIA_API_KEY` |
+
+**Picking one:** `AlphaGenome_*` is the broadest readout + longest context when its key is set; `run_enformer_*` / `run_borzoi_*` are the published, self-hostable equivalents (Enformer for general regulation, Borzoi when expression/splicing is the question); `run_chrombpnet_*` when the question is specifically chromatin accessibility; `Evo2_score_variant` as a sequence-only check that also covers coding variants. Outputs are Δ (alt − ref) effect sizes, not calibrated probabilities — rank/calibrate against known variants. If no key/server is provisioned, fall back to the annotation tools above and say so.
 
 ---
 

--- a/plugins/tooluniverse/skills/tooluniverse-statistical-modeling/TOOLS_REFERENCE.md
+++ b/plugins/tooluniverse/skills/tooluniverse-statistical-modeling/TOOLS_REFERENCE.md
@@ -77,7 +77,7 @@ These ToolUniverse tools can be used to retrieve data before modeling:
 |------|-----------|---------|
 | `FAERS_calculate_disproportionality` | `drug_name`, `adverse_event` | `{metrics: {PRR, ROR, IC}, signal_detection}` |
 | `FAERS_stratify_by_demographics` | `drug_name`, `adverse_event`, `stratify_by` | Stratified counts |
-| `FAERS_count_patient_reaction` | `medicinalproduct` | `[{term, count}]` |
+| `FAERS_count_reactions_by_drug_event` | `medicinalproduct` | `[{term, count}]` (grouped by MedDRA Preferred Term) |
 
 ### Gene-Disease Evidence
 

--- a/plugins/tooluniverse/skills/tooluniverse-variant-interpretation/SKILL.md
+++ b/plugins/tooluniverse/skills/tooluniverse-variant-interpretation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: tooluniverse-variant-interpretation
-description: "Clinical variant interpretation from raw variant calls to ACMG-classified recommendations with structural impact analysis. Use for VUS classification, pathogenicity assessment with cited criteria, structure-based variant impact (AlphaFold/PDB), and producing clinical-grade variant reports for return of results or molecular tumor boards."
+description: "Clinical variant interpretation from raw variant calls to ACMG-classified recommendations with structural impact analysis. Use for VUS classification, pathogenicity assessment with cited criteria, structure-based variant impact (AlphaFold/PDB), non-coding/regulatory variant effect prediction with sequence deep-learning models (AlphaGenome, Enformer, Borzoi, ChromBPNet, Evo 2), and producing clinical-grade variant reports for return of results or molecular tumor boards. Use this whenever a user asks about a variant's significance, an intronic/promoter/enhancer/UTR non-coding variant's functional impact, or needs ACMG classification — even if they don't say \"ACMG\"."
 ---
 
 # Clinical Variant Interpreter
@@ -37,7 +37,7 @@ When asked about a variant's significance, query ClinVar/gnomAD/CIViC FIRST. Nev
 ```
 Phase 1: VARIANT IDENTITY        → Normalize HGVS, map gene/transcript/consequence
 Phase 2: CLINICAL DATABASES       → ClinVar, gnomAD, OMIM, ClinGen, COSMIC, SpliceAI
-Phase 2.5: REGULATORY CONTEXT     → ChIPAtlas, ENCODE (non-coding variants only)
+Phase 2.5: REGULATORY CONTEXT     → ChIPAtlas/ENCODE annotation + DL variant-effect (AlphaGenome/Enformer/Borzoi/ChromBPNet/Evo2) (non-coding only)
 Phase 3: COMPUTATIONAL PREDICTIONS → CADD, AlphaMissense, EVE, SIFT/PolyPhen
 Phase 4: STRUCTURAL ANALYSIS      → PDB/AlphaFold2, domains, functional sites (VUS/novel)
 Phase 4.5: EXPRESSION CONTEXT     → CELLxGENE, GTEx tissue expression
@@ -82,7 +82,23 @@ See `CODE_PATTERNS.md` for implementation details.
 
 Apply for intronic (non-splice), promoter, UTR, or intergenic variants near disease genes.
 
-Tools: `ChIPAtlas_enrichment_analysis`, `ChIPAtlas_get_peak_data`, `ENCODE_search_experiments`, `ENCODE_get_experiment`
+**Annotation — what regulatory element is here:** `ChIPAtlas_enrichment_analysis`, `ChIPAtlas_get_peak_data`, `ENCODE_search_experiments`, `ENCODE_get_experiment`. These tell you whether the variant falls in a known TF-binding peak, enhancer, or open-chromatin region.
+
+**Prediction — what the variant *does* to regulation:** annotation says an element is present, not whether this specific allele disrupts it. Sequence-based deep-learning models answer that directly: they read the reference and alternate DNA windows and predict the change in regulatory signal. This is what turns "the variant is in an enhancer" into "the variant is predicted to reduce accessibility/expression in the relevant tissue" — the mechanistic evidence ACMG PS3/PP3 actually needs for a non-coding variant, where SIFT/PolyPhen/AlphaMissense do not apply.
+
+| Tool | Predicts | Context | Access |
+|---|---|---|---|
+| `AlphaGenome_score_variant` | Δ across RNA-seq / ATAC / CAGE / splice tracks (frontier accuracy, single-base) | up to 1 Mb | hosted API — needs `ALPHA_GENOME_API_KEY` |
+| `run_enformer_variant_effect` | Δ across 5,313 human tracks (expression, chromatin, TF binding) | 196 kb | remote MCP server |
+| `run_borzoi_variant_effect` | Δ in RNA-seq coverage (expression / polyA / splicing emphasis) | 524 kb | remote MCP server |
+| `run_chrombpnet_variant_effect` | Δ in chromatin accessibility (ATAC / DNase), base-resolution | ~2 kb | remote MCP server |
+| `Evo2_score_variant` | Genome-foundation-model delta log-likelihood; covers coding **and** non-coding | up to 1 Mb | hosted NIM — needs `NVIDIA_API_KEY` |
+
+**Reading the score:** these return Δ (alt − ref) effect sizes, *not* calibrated pathogenicity probabilities. A large predicted disruption in a tissue-relevant track is mechanistic support (PS3_supporting / PP3) for a non-coding variant; near-zero across tracks supports BP4. Rank or calibrate against known regulatory variants rather than applying an absolute cutoff.
+
+**Which to pick:** start with `AlphaGenome_score_variant` (broadest readout, longest context, frontier accuracy) when its key is set; `run_enformer_variant_effect` / `run_borzoi_variant_effect` are the named, self-hostable equivalents (Enformer for general regulation, Borzoi when expression/splicing is the question); `run_chrombpnet_variant_effect` when the hypothesis is specifically chromatin accessibility; `Evo2_score_variant` as a sequence-only check that also works on coding variants. If no key/server is provisioned, fall back to the ChIPAtlas/ENCODE annotation above and note the predictive gap rather than guessing.
+
+**Inputs:** `AlphaGenome_score_variant` takes `chromosome` + `position` + `reference_bases`/`alternate_bases` (+ `output_type`, `sequence_length`); `Evo2_score_variant` takes a DNA window as `sequence` + `position` + `alternate` (point substitution) or `ref_sequence`/`alt_sequence`, plus optional `model` (`evo2-40b` default, `evo2-7b` faster); the Enformer/Borzoi/ChromBPNet remote tools take the variant locus and score the change over their output tracks.
 
 ## Phase 2.9: Short-Circuit Check
 

--- a/plugins/tooluniverse/skills/tooluniverse-variant-interpretation/TOOLS_REFERENCE.md
+++ b/plugins/tooluniverse/skills/tooluniverse-variant-interpretation/TOOLS_REFERENCE.md
@@ -613,6 +613,20 @@ peaks = tu.tools.ChIPAtlas_get_peak_data(
 | `ENCODE_get_experiment` | Experiment details | `accession` |
 | `ENCODE_get_biosample` | Sample annotations | `accession` |
 
+### Sequence Deep-Learning Variant-Effect Predictors
+
+Predict the functional impact of a non-coding (and, for Evo 2, any) variant directly from sequence — the mechanistic evidence (PS3_supporting / PP3) that SIFT/PolyPhen/AlphaMissense cannot give for non-coding loci. Outputs are Δ (alt − ref) effect sizes, not calibrated probabilities.
+
+| Tool | Predicts | Access |
+|------|----------|--------|
+| `AlphaGenome_score_variant` | RNA-seq/ATAC/CAGE/splice track Δ (1 Mb, single-base) | hosted API — `ALPHA_GENOME_API_KEY` |
+| `run_enformer_variant_effect` | Δ across 5,313 human tracks (196 kb) | remote MCP server |
+| `run_borzoi_variant_effect` | RNA-seq coverage Δ (expression/splicing, 524 kb) | remote MCP server |
+| `run_chrombpnet_variant_effect` | chromatin accessibility Δ (ATAC/DNase, base-res) | remote MCP server |
+| `Evo2_score_variant` | genome-LM delta log-likelihood; coding + non-coding | hosted NIM — `NVIDIA_API_KEY` |
+
+**Inputs**: `AlphaGenome_score_variant` → `chromosome`,`position`,`reference_bases`,`alternate_bases`,`output_type`,`sequence_length`. `Evo2_score_variant` → `sequence`+`position`+`alternate` (or `ref_sequence`/`alt_sequence`), optional `model` (`evo2-40b`/`evo2-7b`). The Enformer/Borzoi/ChromBPNet remote tools take the variant locus. See SKILL.md Phase 2.5 for selection guidance.
+
 **Example - Get regulatory annotations**:
 ```python
 # Search for regulatory data near variant

--- a/plugins/tooluniverse/skills/tooluniverse-variant-interpretation/TOOLS_REFERENCE.md
+++ b/plugins/tooluniverse/skills/tooluniverse-variant-interpretation/TOOLS_REFERENCE.md
@@ -761,8 +761,8 @@ result = tu.tools.OMIM_search(query="BRCA1")
 
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
-| `ClinGen_gene_validity` | Get curation status | `gene` |
-| `ClinGen_dosage` | Dosage sensitivity | `gene` |
+| `ClinGen_get_gene_validity` | Get curation status | `gene` |
+| `ClinGen_dosage_by_gene` | Dosage sensitivity | `gene` |
 
 **Gene Validity Levels**:
 | Level | Meaning |

--- a/plugins/tooluniverse/skills/tooluniverse/SKILL.md
+++ b/plugins/tooluniverse/skills/tooluniverse/SKILL.md
@@ -125,6 +125,8 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**TCGA**", "cancer genomics cohort", "GDC analysis", "TCGA mutations", "pan-cancer" | `Skill(skill="tooluniverse-cancer-genomics-tcga")` |
 | "**immunotherapy response**", "checkpoint inhibitor response", "TMB", "MSI", "PD-L1", "ICI response" | `Skill(skill="tooluniverse-immunotherapy-response-prediction")` |
 | "**rare disease diagnosis**", "differential diagnosis", "phenotype matching", "HPO", "patient with [symptoms]" | `Skill(skill="tooluniverse-rare-disease-diagnosis")` |
+| "**clinical risk score**", "CHA2DS2-VASc", "HAS-BLED", "CURB-65", "qSOFA", "Child-Pugh", "MELD-Na", "Wells score", "ASCVD risk", "eGFR CKD-EPI", "bedside risk calculator" | `Skill(skill="tooluniverse-clinical-risk-scoring")` |
+| "**device adverse events**", "device recall", "MAUDE", "food/supplement adverse event", "CAERS", "veterinary adverse event", "drug shortage" | `Skill(skill="tooluniverse-product-safety-surveillance")` |
 | "**variant interpretation**", "VUS", "pathogenicity", "clinical significance", "is [variant] pathogenic" | `Skill(skill="tooluniverse-variant-interpretation")` |
 | "**clinical guidelines**", "practice guidelines", "treatment guidelines", "dosing recommendations", "standard of care" | `Skill(skill="tooluniverse-clinical-guidelines")` |
 | "**patient stratification**", "precision medicine", "biomarker stratification", "treatment selection" | `Skill(skill="tooluniverse-precision-medicine-stratification")` |
@@ -144,6 +146,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**small molecule discovery**", "chemical biology", "compound sourcing", "hit finding", "chemical probe" | `Skill(skill="tooluniverse-small-molecule-discovery")` |
 | "**chemical sourcing**", "buy compound", "vendor search", "Enamine", "MolPort", "compound availability" | `Skill(skill="tooluniverse-chemical-sourcing")` |
 | "**GPCR**", "G-protein coupled receptor", "GPCRdb", "receptor ligand", "biased agonist" | `Skill(skill="tooluniverse-gpcr-structural-pharmacology")` |
+| "**dereplicate**", "natural product identification", "NPAtlas", "ChemOnt classification", "ClassyFire", "producing organism" | `Skill(skill="tooluniverse-natural-product-dereplication")` |
 
 ### 5. Genomics & Variant Analysis
 
@@ -160,6 +163,13 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**regulatory variant**", "non-coding variant", "eQTL variant", "regulatory region variant" | `Skill(skill="tooluniverse-regulatory-variant-analysis")` |
 | "**rare disease genomics**", "Orphanet gene", "rare disease gene", "causative gene", "exome diagnosis" | `Skill(skill="tooluniverse-rare-disease-genomics")` |
 | "**1000 Genomes**", "IGSR", "population frequency", "superpopulation", "AFR/EUR/EAS/SAS/AMR" | `Skill(skill="tooluniverse-population-genetics-1000genomes")` |
+| "**PheWAS**", "phenome-wide association", "cross-ancestry replication", "cross-biobank", "FinnGen", "BioBank Japan", "pleiotropy of a variant" | `Skill(skill="tooluniverse-phewas")` |
+| "**Mendelian randomization**", "MR causal inference", "instrumental variable", "does X cause Y", "genetic causal evidence" | `Skill(skill="tooluniverse-mendelian-randomization")` |
+| "**loss-of-function mechanism**", "LoF mechanism", "why is this variant LoF", "structural stability vs functional disruption" | `Skill(skill="tooluniverse-protein-lof-mechanism")` |
+| "**SAE feature**", "sparse autoencoder variant", "ESMC SAE", "mechanistic variant interpretation" | `Skill(skill="tooluniverse-protein-sae-variant-interpretation")` |
+| "**per-residue annotation**", "binding interface residues", "ligand pocket residues", "buried vs surface residues", "PDB structural annotation" | `Skill(skill="tooluniverse-protein-structural-annotation-pdb")` |
+| "**why are these residues critical**", "residue functional mechanism", "DMS hotspot interpretation", "catalytic vs structural residue" | `Skill(skill="tooluniverse-residue-functional-mechanism-interpretation")` |
+| "**validate variant predictor**", "DMS validation", "deep mutational scanning benchmark", "predictor vs experimental effect" | `Skill(skill="tooluniverse-variant-predictor-dms-validation")` |
 
 ### 6. Systems & Network Analysis
 
@@ -209,6 +219,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**protein modification**", "PTM analysis", "phosphorylation site", "ubiquitination", "glycosylation" | `Skill(skill="tooluniverse-protein-modification-analysis")` |
 | "**structural proteomics**", "cross-linking mass spec", "XL-MS", "HDX-MS", "structural biology" | `Skill(skill="tooluniverse-structural-proteomics")` |
 | "**protein structure prediction**", "AlphaFold prediction", "structure modeling", "homology modeling" | `Skill(skill="tooluniverse-protein-structure-prediction")` |
+| "**FASTQ QC**", "FastQC", "MultiQC", "adapter trimming", "fastp", "Cutadapt", "read quality", "sequence duplication" | `Skill(skill="tooluniverse-fastq-qc")` |
 
 ### 8. Clinical Trials & Study Design
 
@@ -232,6 +243,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**ecology**", "biodiversity", "invasive species", "pollinator", "food web", "conservation", "community ecology", "trophic" | `Skill(skill="tooluniverse-ecology-biodiversity")` |
 | "**microbiome**", "gut microbiota", "dysbiosis", "microbiome composition", "16S rRNA" | `Skill(skill="tooluniverse-microbiome-research")` |
 | "**adverse outcome pathway**", "AOP", "key event", "molecular initiating event", "KER" | `Skill(skill="tooluniverse-adverse-outcome-pathway")` |
+| "**genome assembly**", "assembly N50", "RefSeq assembly QC", "plasmid count", "NCBI Datasets genome" | `Skill(skill="tooluniverse-microbial-genome-characterization")` |
 
 ### 10. Specialized Biology
 
@@ -273,6 +285,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**custom tool**", "add my own tool", "local tool", "create tool", "extend ToolUniverse" | `Skill(skill="tooluniverse-custom-tool")` |
 | "**SDK**", "Python SDK", "build AI scientist", "programmatic access", "**import tooluniverse**", "**coding API**", "**tu build**", "**typed wrappers**" | `Skill(skill="tooluniverse-sdk")` |
 | "**install skills**", "missing skills", "skill not found", "add skills" | `Skill(skill="tooluniverse-install-skills")` |
+| "**self-review**", "check my work", "definition of done", "evaluation rubric", "success criteria", "grading criteria", "LLM-as-judge" | `Skill(skill="tooluniverse-self-review")` |
 
 ---
 

--- a/scripts/sync-codex-plugin-skills.sh
+++ b/scripts/sync-codex-plugin-skills.sh
@@ -18,8 +18,10 @@ for skill_dir in "$REPO_ROOT/skills/tooluniverse" "$REPO_ROOT"/skills/tooluniver
     name="$(basename "$skill_dir")"
 
     # Claude-specific install docs are useful in the Claude plugin, but not in
-    # the Codex plugin's skill router surface.
-    if [ "$name" = "tooluniverse-claude-code-plugin" ]; then
+    # the Codex plugin's skill router surface. Same for Claude Science install
+    # docs (different host entirely: conda env + host.skills.* API, no
+    # MCP/uvx/plugin marketplace involved).
+    if [ "$name" = "tooluniverse-claude-code-plugin" ] || [ "$name" = "tooluniverse-cs-setup" ]; then
         continue
     fi
 

--- a/skills/tooluniverse-claude-code-plugin/SKILL.md
+++ b/skills/tooluniverse-claude-code-plugin/SKILL.md
@@ -99,6 +99,9 @@ The router skill auto-dispatches to the right specialized skill — no command p
 | **`/tooluniverse:cross-validate`** | Verify a claim across 3+ independent databases | Slash command |
 | **`/tooluniverse:compare`** | N-way side-by-side comparison with domain-appropriate columns | Slash command |
 | **`/tooluniverse:literature-sweep`** | Graded mini-review across PubMed + EuropePMC + Semantic Scholar | Slash command |
+| **`/tooluniverse:verify-references`** | Check that cited references are real and accurately described, including retraction status | Slash command |
+| **`/tooluniverse:self-review`** | Generate weighted success criteria for a task and check work against them (what's missing / done well) | Slash command |
+| **`/tooluniverse:setup-keys`** | Configure ToolUniverse API keys | Slash command |
 | **`/tooluniverse:researcher`** | Same investigation as `research`, delegated to a forked subagent | Slash command |
 | **120+ skills** | Structured workflows (drug research, variant interpretation, pharmacovigilance, CRISPR screens, statistical modeling, etc.) | Auto-activate on matching questions |
 

--- a/skills/tooluniverse-precision-oncology/API_USAGE_PATTERNS.md
+++ b/skills/tooluniverse-precision-oncology/API_USAGE_PATTERNS.md
@@ -342,7 +342,7 @@ def get_tumor_expression_context(tu, gene_symbol, cancer_type):
 ### Query Order
 1. `OpenTargets_get_associated_drugs_by_target_ensemblID` -> Approved drugs
 2. `DailyMed_search_spls` -> FDA label details
-3. `ChEMBL_get_drug_mechanisms_of_action_by_chemblId` -> Mechanism
+3. `ChEMBL_get_drug_mechanisms` -> Mechanism
 
 ### Treatment Output Example
 

--- a/skills/tooluniverse-precision-oncology/TOOLS_REFERENCE.md
+++ b/skills/tooluniverse-precision-oncology/TOOLS_REFERENCE.md
@@ -315,7 +315,7 @@ cells = tu.tools.DepMap_get_cell_lines(
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
 | `ChEMBL_search_drugs` | Search drugs | `query`, `max_phase` |
-| `ChEMBL_get_drug_mechanisms_of_action_by_chemblId` | Drug MOA | `chemblId` |
+| `ChEMBL_get_drug_mechanisms` | Drug MOA | `drug_chembl_id` |
 | `ChEMBL_get_target_activities` | Bioactivity data | `target_chembl_id` |
 
 ### DailyMed

--- a/skills/tooluniverse-protein-interactions/DOMAIN_ANALYSIS.md
+++ b/skills/tooluniverse-protein-interactions/DOMAIN_ANALYSIS.md
@@ -175,12 +175,9 @@
 - **Use Case**: Protein structure and complex formation
 - **API**: Public REST API
 
-**Tools (5)** - Use for structural analysis:
-1. `SASBDB_search_entries` - Find structural data
-2. `SASBDB_get_entry` - Get entry metadata
-3. `SASBDB_get_entry` - Get structural models
-4. `SASBDB_get_entry` - Get scattering data
-5. `SASBDB_download_data` - Download raw data
+**Tools (2)** - Use for structural analysis:
+1. `SASBDB_search_entries` - Find structural data (by molecular type, or list all entries)
+2. `SASBDB_get_entry` - Get entry metadata, experimental conditions, publication info, and data file URLs (one call covers structure/scattering data access — there is no separate download tool)
 
 ---
 

--- a/skills/tooluniverse-rare-disease-diagnosis/TOOLS_REFERENCE.md
+++ b/skills/tooluniverse-rare-disease-diagnosis/TOOLS_REFERENCE.md
@@ -748,7 +748,7 @@ def analyze_vus_structure(tu, uniprot_id, variant_position):
 | Primary | Fallback 1 | Fallback 2 |
 |---------|------------|------------|
 | `kegg_get_gene_info` | `ReactomeContent_search` | `KEGG_get_gene_pathways` |
-| `intact_search_interactions` | `STRING_interactions` | Literature search |
+| `intact_search_interactions` | `STRING_get_interaction_partners` | Literature search |
 
 ### Variant Annotation
 | Primary | Fallback 1 | Fallback 2 |

--- a/skills/tooluniverse-statistical-modeling/TOOLS_REFERENCE.md
+++ b/skills/tooluniverse-statistical-modeling/TOOLS_REFERENCE.md
@@ -77,7 +77,7 @@ These ToolUniverse tools can be used to retrieve data before modeling:
 |------|-----------|---------|
 | `FAERS_calculate_disproportionality` | `drug_name`, `adverse_event` | `{metrics: {PRR, ROR, IC}, signal_detection}` |
 | `FAERS_stratify_by_demographics` | `drug_name`, `adverse_event`, `stratify_by` | Stratified counts |
-| `FAERS_count_patient_reaction` | `medicinalproduct` | `[{term, count}]` |
+| `FAERS_count_reactions_by_drug_event` | `medicinalproduct` | `[{term, count}]` (grouped by MedDRA Preferred Term) |
 
 ### Gene-Disease Evidence
 

--- a/skills/tooluniverse-variant-interpretation/TOOLS_REFERENCE.md
+++ b/skills/tooluniverse-variant-interpretation/TOOLS_REFERENCE.md
@@ -761,8 +761,8 @@ result = tu.tools.OMIM_search(query="BRCA1")
 
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
-| `ClinGen_gene_validity` | Get curation status | `gene` |
-| `ClinGen_dosage` | Dosage sensitivity | `gene` |
+| `ClinGen_get_gene_validity` | Get curation status | `gene` |
+| `ClinGen_dosage_by_gene` | Dosage sensitivity | `gene` |
 
 **Gene Validity Levels**:
 | Level | Meaning |

--- a/skills/tooluniverse/SKILL.md
+++ b/skills/tooluniverse/SKILL.md
@@ -124,6 +124,8 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**TCGA**", "cancer genomics cohort", "GDC analysis", "TCGA mutations", "pan-cancer" | `Skill(skill="tooluniverse-cancer-genomics-tcga")` |
 | "**immunotherapy response**", "checkpoint inhibitor response", "TMB", "MSI", "PD-L1", "ICI response" | `Skill(skill="tooluniverse-immunotherapy-response-prediction")` |
 | "**rare disease diagnosis**", "differential diagnosis", "phenotype matching", "HPO", "patient with [symptoms]" | `Skill(skill="tooluniverse-rare-disease-diagnosis")` |
+| "**clinical risk score**", "CHA2DS2-VASc", "HAS-BLED", "CURB-65", "qSOFA", "Child-Pugh", "MELD-Na", "Wells score", "ASCVD risk", "eGFR CKD-EPI", "bedside risk calculator" | `Skill(skill="tooluniverse-clinical-risk-scoring")` |
+| "**device adverse events**", "device recall", "MAUDE", "food/supplement adverse event", "CAERS", "veterinary adverse event", "drug shortage" | `Skill(skill="tooluniverse-product-safety-surveillance")` |
 | "**variant interpretation**", "VUS", "pathogenicity", "clinical significance", "is [variant] pathogenic" | `Skill(skill="tooluniverse-variant-interpretation")` |
 | "**clinical guidelines**", "practice guidelines", "treatment guidelines", "dosing recommendations", "standard of care" | `Skill(skill="tooluniverse-clinical-guidelines")` |
 | "**patient stratification**", "precision medicine", "biomarker stratification", "treatment selection" | `Skill(skill="tooluniverse-precision-medicine-stratification")` |
@@ -143,6 +145,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**small molecule discovery**", "chemical biology", "compound sourcing", "hit finding", "chemical probe" | `Skill(skill="tooluniverse-small-molecule-discovery")` |
 | "**chemical sourcing**", "buy compound", "vendor search", "Enamine", "MolPort", "compound availability" | `Skill(skill="tooluniverse-chemical-sourcing")` |
 | "**GPCR**", "G-protein coupled receptor", "GPCRdb", "receptor ligand", "biased agonist" | `Skill(skill="tooluniverse-gpcr-structural-pharmacology")` |
+| "**dereplicate**", "natural product identification", "NPAtlas", "ChemOnt classification", "ClassyFire", "producing organism" | `Skill(skill="tooluniverse-natural-product-dereplication")` |
 
 ### 5. Genomics & Variant Analysis
 
@@ -159,6 +162,13 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**regulatory variant**", "non-coding variant", "eQTL variant", "regulatory region variant" | `Skill(skill="tooluniverse-regulatory-variant-analysis")` |
 | "**rare disease genomics**", "Orphanet gene", "rare disease gene", "causative gene", "exome diagnosis" | `Skill(skill="tooluniverse-rare-disease-genomics")` |
 | "**1000 Genomes**", "IGSR", "population frequency", "superpopulation", "AFR/EUR/EAS/SAS/AMR" | `Skill(skill="tooluniverse-population-genetics-1000genomes")` |
+| "**PheWAS**", "phenome-wide association", "cross-ancestry replication", "cross-biobank", "FinnGen", "BioBank Japan", "pleiotropy of a variant" | `Skill(skill="tooluniverse-phewas")` |
+| "**Mendelian randomization**", "MR causal inference", "instrumental variable", "does X cause Y", "genetic causal evidence" | `Skill(skill="tooluniverse-mendelian-randomization")` |
+| "**loss-of-function mechanism**", "LoF mechanism", "why is this variant LoF", "structural stability vs functional disruption" | `Skill(skill="tooluniverse-protein-lof-mechanism")` |
+| "**SAE feature**", "sparse autoencoder variant", "ESMC SAE", "mechanistic variant interpretation" | `Skill(skill="tooluniverse-protein-sae-variant-interpretation")` |
+| "**per-residue annotation**", "binding interface residues", "ligand pocket residues", "buried vs surface residues", "PDB structural annotation" | `Skill(skill="tooluniverse-protein-structural-annotation-pdb")` |
+| "**why are these residues critical**", "residue functional mechanism", "DMS hotspot interpretation", "catalytic vs structural residue" | `Skill(skill="tooluniverse-residue-functional-mechanism-interpretation")` |
+| "**validate variant predictor**", "DMS validation", "deep mutational scanning benchmark", "predictor vs experimental effect" | `Skill(skill="tooluniverse-variant-predictor-dms-validation")` |
 
 ### 6. Systems & Network Analysis
 
@@ -208,6 +218,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**protein modification**", "PTM analysis", "phosphorylation site", "ubiquitination", "glycosylation" | `Skill(skill="tooluniverse-protein-modification-analysis")` |
 | "**structural proteomics**", "cross-linking mass spec", "XL-MS", "HDX-MS", "structural biology" | `Skill(skill="tooluniverse-structural-proteomics")` |
 | "**protein structure prediction**", "AlphaFold prediction", "structure modeling", "homology modeling" | `Skill(skill="tooluniverse-protein-structure-prediction")` |
+| "**FASTQ QC**", "FastQC", "MultiQC", "adapter trimming", "fastp", "Cutadapt", "read quality", "sequence duplication" | `Skill(skill="tooluniverse-fastq-qc")` |
 
 ### 8. Clinical Trials & Study Design
 
@@ -231,6 +242,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**ecology**", "biodiversity", "invasive species", "pollinator", "food web", "conservation", "community ecology", "trophic" | `Skill(skill="tooluniverse-ecology-biodiversity")` |
 | "**microbiome**", "gut microbiota", "dysbiosis", "microbiome composition", "16S rRNA" | `Skill(skill="tooluniverse-microbiome-research")` |
 | "**adverse outcome pathway**", "AOP", "key event", "molecular initiating event", "KER" | `Skill(skill="tooluniverse-adverse-outcome-pathway")` |
+| "**genome assembly**", "assembly N50", "RefSeq assembly QC", "plasmid count", "NCBI Datasets genome" | `Skill(skill="tooluniverse-microbial-genome-characterization")` |
 
 ### 10. Specialized Biology
 
@@ -272,6 +284,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**custom tool**", "add my own tool", "local tool", "create tool", "extend ToolUniverse" | `Skill(skill="tooluniverse-custom-tool")` |
 | "**SDK**", "Python SDK", "build AI scientist", "programmatic access", "**import tooluniverse**", "**coding API**", "**tu build**", "**typed wrappers**" | `Skill(skill="tooluniverse-sdk")` |
 | "**install skills**", "missing skills", "skill not found", "add skills" | `Skill(skill="tooluniverse-install-skills")` |
+| "**self-review**", "check my work", "definition of done", "evaluation rubric", "success criteria", "grading criteria", "LLM-as-judge" | `Skill(skill="tooluniverse-self-review")` |
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up audit after fixing `tooluniverse-self-review`'s invisibility (plugin auto-update, PR #285). Two commits, both CLI/repo-verified against `origin/main` before fixing (not fixed on inspection alone):

### Commit 1 — plugin/skill sync drift

1. **12 skills unreachable via natural-language routing.** `skills/tooluniverse/SKILL.md` (the router — the only broadly auto-matchable skill; the other 135 have `disable-model-invocation: true` and can only be reached via `Skill()`) never listed: `tooluniverse-self-review`, `tooluniverse-phewas`, `tooluniverse-mendelian-randomization`, `tooluniverse-fastq-qc`, `tooluniverse-clinical-risk-scoring`, `tooluniverse-product-safety-surveillance`, `tooluniverse-natural-product-dereplication`, and 5 protein-variant-mechanism skills. Added routing table rows for all 12.
2. **`tooluniverse-claude-code-plugin`'s "What you get" table was missing 3 of 8 slash commands** (verify-references, self-review, setup-keys).
3. **`plugin/skills/` (shipped) had drifted stale relative to `skills/` (canonical) for 4 skills** — missing LDSC heritability/genetic-correlation tools and sequence deep-learning variant-effect tools (AlphaGenome, Enformer, Borzoi, ChromBPNet, Evo2). Verified every referenced tool actually exists in the registry before syncing.
4. **Both skill-sync scripts were missing `tooluniverse-cs-setup` from their exclude lists** — confirmed by actually running the sync script and watching it leak Claude-Science-only install instructions into both plugins.

### Commit 2 — full tool-registry sweep (this round)

Extracted every backtick-quoted, tool-name-shaped token from all ~150 skills (1,880 candidates) and diffed against the full active tool registry (2,822 tools, built from `src/tooluniverse/data/**/*.json` excluding `broken_apis/`). After filtering false positives — Enrichr gene-set-library names (`GO_Biological_Process_2021`, `MSigDB_Hallmark_2020`, etc., which are parameter *values* not tool names), env vars, code parameters, a deliberate naming-convention teaching example in `devtu-create-tool` — **5 genuine stale tool-name references survived**, each with the neighboring table entries spot-checked as real (isolated bad entries, not whole-table corruption):

- `tooluniverse-precision-oncology`: `ChEMBL_get_drug_mechanisms_of_action_by_chemblId` → `ChEMBL_get_drug_mechanisms` (also fixed the shown param name)
- `tooluniverse-variant-interpretation`: `ClinGen_gene_validity` → `ClinGen_get_gene_validity`; `ClinGen_dosage` → `ClinGen_dosage_by_gene` (matched on param signature)
- `tooluniverse-statistical-modeling`: `FAERS_count_patient_reaction` → `FAERS_count_reactions_by_drug_event` (matched on param + description)
- `tooluniverse-rare-disease-diagnosis`: `STRING_interactions` → `STRING_get_interaction_partners`
- `tooluniverse-protein-interactions`: SASBDB section claimed "5 tools" but listed `SASBDB_get_entry` three times under three fictional purposes (metadata / structural models / scattering data) plus a nonexistent `SASBDB_download_data`. Collapsed to the real 2 tools — `SASBDB_get_entry`'s actual description already covers all three claimed purposes in one call.

**`[release:patch]`** (carried from commit 1) so this — and PR #285's still-unreleased auto-update docs — actually reach auto-update users on the next version bump.

## What I checked but found to be false alarms
- Skill directory structure vs. `origin/main`'s actual shipped mirrors — only the 2 known-intentional exclusions are absent; nothing else missing.
- `plugin.json` / marketplace.json version agreement — consistent.
- `scripts/build-plugin.sh` would leak cs-setup/codex-plugin too, but confirmed it's dead code — the real release workflow never calls it. Not fixed (out of scope), noted for awareness.
- ~700 of the ~1540 initial "stale reference" candidates from a first-pass `comm`-based diff were a locale/sort-order artifact of `comm`, not real gaps — redid the diff in Python (set difference) and got the correct, much smaller 834-candidate list before manually reviewing.
- Env vars, Enrichr gene-set-library parameter values, and a deliberate bad-example-for-teaching-purposes mention in `devtu-create-tool` all pattern-matched as "tool-shaped" but are not tool references.
- Checked whether any `run_*`-style (lowercase remote-tool convention) references were stale — zero found; all real.

## Reported, not fixed — scope decision for follow-up
**69 registered tool-source integrations (~340+ tools) have zero textual mention anywhere in the ~150-skill corpus** — `euhealthinfo` (21 tools, EU health statistics), `EBIProteins` (19 tools), `HFInference` (10), `BMRB`, `NeuroMorpho`, `BiGG`, and 63 others, all with 3+ registered tools each. Spot-verified the two largest are real, substantial, correctly-registered integrations with no alternate-phrasing mention either — this isn't a detection artifact. These tools remain technically reachable via `find_tools`/`grep_tools` semantic search, so this is a curated-guidance gap rather than the "fully unreachable" severity of the routing-table bug in commit 1. Writing accurate skill guidance for 69 domains is a much larger scope than this audit pass — flagging for a prioritization decision rather than attempting it here.

## Test plan
- [x] `comm`-diffed the router's mentioned skill names against all 138 `tooluniverse-*` skill directories before and after the fix — 0 real gaps remain
- [x] Verified all newly-synced tool names from commit 1 exist in the registry
- [x] Ran `plugin/sync-skills.sh` after each fix and confirmed the shipped mirrors match canonical exactly, with `tooluniverse-cs-setup` still correctly excluded
- [x] For each of the 5 stale references in commit 2: confirmed the old name has zero registry matches, confirmed the replacement name exists with matching parameters/description, and spot-checked neighboring table rows are real
- [x] `git diff --stat` reviewed after each commit — no unexpected changes