### PR TITLE
Remove 2 dead tool-category registrations pointing at deleted config files

### DIFF
--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -1006,7 +1006,9 @@ default_tool_files = {
     # eQTL Catalogue - Expression quantitative trait loci associations
     "eqtl": os.path.join(current_dir, "data", "eqtl_tools.json"),
     # OSDR - NASA Open Science Data Repository (space biology studies)
-    "osdr": os.path.join(current_dir, "data", "osdr_tools.json"),
+    # Removed: API unreachable/down (see commit c70493c6); data file deleted,
+    # this entry was left behind and has been silently loading 0 tools since.
+    # "osdr": os.path.join(current_dir, "data", "osdr_tools.json"),
     # Gene2Phenotype - EBI curated gene-disease associations for clinical genetics
     "gene2phenotype": os.path.join(current_dir, "data", "gene2phenotype_tools.json"),
     # NASA Exoplanet Archive - ADQL queries for 5500+ confirmed exoplanets and stellar hosts
@@ -1122,7 +1124,9 @@ default_tool_files = {
     "opentopodata": os.path.join(current_dir, "data", "opentopodata_tools.json"),
     # Disease.sh - COVID-19 global and country-level statistics
     # NASA NeoWs - Near Earth Object data (asteroids, close approaches)
-    "nasa_neows": os.path.join(current_dir, "data", "nasa_neows_tools.json"),
+    # Removed: API unreachable/down (see commit c70493c6); data file deleted,
+    # this entry was left behind and has been silently loading 0 tools since.
+    # "nasa_neows": os.path.join(current_dir, "data", "nasa_neows_tools.json"),
     # REST Countries Extended - country details by name, region, language
     # STRING Network - protein-protein interaction networks
     "string_network": os.path.join(current_dir, "data", "string_network_tools.json"),


### PR DESCRIPTION
## Summary

Continuing the audit thread from #358 (skill/plugin drift) with a new angle: is the tool *registration* layer itself internally consistent, or has declared config drifted from actual runtime state?

Built a ground-truth list of the 610 actual `*.json` files under `src/tooluniverse/data/` and diffed it against every file path referenced in `default_config.py`'s `default_tool_files` dict (611 entries). Two active, non-commented entries — `"osdr"` and `"nasa_neows"` — point at `osdr_tools.json` / `nasa_neows_tools.json`, both deleted in `c70493c6` ("Remove OSDR, NASANeoWs, and ZINC tools: all APIs unreachable/down"). The dict entries were never cleaned up, unlike 3 sibling removals (`oxo`, `pathway_commons`, `soilgrids`) in the same file, which were correctly commented out with an "Archived at `broken_apis/...`" note.

Commented these two out the same way, with a note explaining why (no `broken_apis/` archive copy exists for these two, unlike the others, so I didn't claim one).

## CLI-verified, not just via git history
- Actually loaded ToolUniverse from source (`sys.path` pointed at this repo's `src/`, not the stale shared venv) before and after the change: **2,689 tools both times** — confirms these two contributed nothing and the fix is a true no-op removal, not a silent regression.
- Read the loader's actual error handling (`execute_function.py` around the `read_json_list` call): a `FileNotFoundError` on a registered category is caught and logged at **DEBUG** level ("Optional tool category ... not found") and skipped — so this was never a crash risk, just two categories silently no-opping since the removal commit while still visually presenting (via dict presence + comments) as live integrations.
- Extended the same check one level deeper: cross-referenced all 2,689 loaded tools' `type` fields against `STATIC_LAZY_REGISTRY` (the type→implementation-module map) for the same class of drift — a tool whose config loads fine but has no execution-time implementation mapped would be a worse bug (fails at call time, not load time). Found exactly one mismatch, `SpecialTool` (2 tools: `Finish`, `CallAgent`) — verified this is an intentional framework control sentinel (explicitly excluded from tool-finder search results in `tool_finder_keyword.py`, `tool_finder_embedding.py`, `tool_finder_llm.py`), not a bug.

## Checked and confirmed as false alarms
- 4 `data/*.json` files with no `default_tool_files` entry (`mcpautoloadertool_defaults.json`, `toolfinderkeyword_defaults.json`, `tool_page_index.json`, `api_keys_catalog.json`) — all legitimate non-tool-config support files (defaults/index files read directly by their owning tool or the plugin build script), not orphaned tool definitions.
- `remote_tools/` (29 files) and `packages/` (12 files) subdirectories — `remote_tools/` is auto-globbed by `execute_function.py` at load time (no per-file registration needed); all 12 `packages/` files are correctly registered.

Not plugin content, so no `[release:patch]` marker — this ships with the next PyPI release.

## Test plan
- [x] `python3 -c "... ToolUniverse().load_tools() ..."` from this repo's source, before and after: 2,689 tools, identical
- [x] Confirmed `osdr`/`nasa_neows` no longer appear in `tu.tool_files` after the fix
- [x] Cross-checked all loaded tool `type`s against `STATIC_LAZY_REGISTRY`; only expected sentinel mismatch