### PR TITLE
Document tu build's undocumented side effect on the installed package

### DIFF
--- a/plugin/skills/setup-tooluniverse/SKILL.md
+++ b/plugin/skills/setup-tooluniverse/SKILL.md
@@ -78,7 +78,7 @@ First run takes ~30s (downloads package), then instant. **Shortcut**: `uv tool i
 | `tu info` | Show tool parameters and schema | `tu info PubMed_search_articles` |
 | `tu run` | Execute a tool | `tu run PubMed_search_articles '{"query": "CRISPR"}'` |
 | `tu test` | Test a tool with its example inputs | `tu test UniProt_get_entry_by_accession` |
-| `tu build` | Generate typed Python wrappers for Coding API | `tu build --output ./my_tools` |
+| `tu build` | Generate typed Python wrappers for Coding API (also regenerates the internal lazy-load registry in place — unaffected by `--output`) | `tu build --output ./my_tools` |
 | `tu serve` | Start MCP stdio server (same as `uvx tooluniverse`) | `tu serve` |
 
 **Output flags** (most commands except `build`/`serve`): `--json` (pretty) or `--raw` (compact, pipe-friendly).

--- a/plugins/tooluniverse/skills/setup-tooluniverse/SKILL.md
+++ b/plugins/tooluniverse/skills/setup-tooluniverse/SKILL.md
@@ -79,7 +79,7 @@ First run takes ~30s (downloads package), then instant. **Shortcut**: `uv tool i
 | `tu info` | Show tool parameters and schema | `tu info PubMed_search_articles` |
 | `tu run` | Execute a tool | `tu run PubMed_search_articles '{"query": "CRISPR"}'` |
 | `tu test` | Test a tool with its example inputs | `tu test UniProt_get_entry_by_accession` |
-| `tu build` | Generate typed Python wrappers for Coding API | `tu build --output ./my_tools` |
+| `tu build` | Generate typed Python wrappers for Coding API (also regenerates the internal lazy-load registry in place — unaffected by `--output`) | `tu build --output ./my_tools` |
 | `tu serve` | Start MCP stdio server (same as `uvx tooluniverse`) | `tu serve` |
 
 **Output flags** (most commands except `build`/`serve`): `--json` (pretty) or `--raw` (compact, pipe-friendly).

--- a/skills/setup-tooluniverse/SKILL.md
+++ b/skills/setup-tooluniverse/SKILL.md
@@ -78,7 +78,7 @@ First run takes ~30s (downloads package), then instant. **Shortcut**: `uv tool i
 | `tu info` | Show tool parameters and schema | `tu info PubMed_search_articles` |
 | `tu run` | Execute a tool | `tu run PubMed_search_articles '{"query": "CRISPR"}'` |
 | `tu test` | Test a tool with its example inputs | `tu test UniProt_get_entry_by_accession` |
-| `tu build` | Generate typed Python wrappers for Coding API | `tu build --output ./my_tools` |
+| `tu build` | Generate typed Python wrappers for Coding API (also regenerates the internal lazy-load registry in place — unaffected by `--output`) | `tu build --output ./my_tools` |
 | `tu serve` | Start MCP stdio server (same as `uvx tooluniverse`) | `tu serve` |
 
 **Output flags** (most commands except `build`/`serve`): `--json` (pretty) or `--raw` (compact, pipe-friendly).

--- a/src/tooluniverse/cli.py
+++ b/src/tooluniverse/cli.py
@@ -1949,7 +1949,10 @@ def main() -> None:
     # ── build ─────────────────────────────────────────────────────────────────
     p = sub.add_parser(
         "build",
-        help="Rebuild the static tool registry (run after adding new built-in tools)",
+        help=(
+            "Rebuild the static tool registry and regenerate coding-API "
+            "wrapper files (run after adding new built-in tools)"
+        ),
     )
     p.add_argument(
         "--output",
@@ -1957,7 +1960,9 @@ def main() -> None:
         default=None,
         help=(
             "Directory to write coding-API wrapper files into "
-            "(default: .tooluniverse/coding_api/)"
+            "(default: .tooluniverse/coding_api/). Only affects the wrapper "
+            "files — the static lazy registry is always regenerated in "
+            "place inside the installed package, regardless of --output."
         ),
     )
     p.set_defaults(func=cmd_build)


### PR DESCRIPTION
## Summary

Continuing the "declared vs runtime reality" audit thread (#358, #359) with a new angle: do documented example invocations actually run, and does CLI documentation match actual CLI behavior?

**Actually ran every documented example command** from `setup-tooluniverse`'s CLI reference table (`tu status`, `tu list --mode basic --limit 20`, `tu find 'protein structure analysis'`, `tu grep '^UniProt' --mode regex`, `tu info PubMed_search_articles`, `tu run PubMed_search_articles '{"query": "CRISPR"}'`) against the current source (`PYTHONPATH=src`, not the stale shared venv this machine's `tu` resolves to). All six ran cleanly and matched their documented behavior — no discrepancies.

**`tu build` was the one real gap.** Its own top-level help (`"Rebuild the static tool registry (run after adding new built-in tools)"`) and its `--output` flag help (`"Directory to write coding-API wrapper files into"`) each describe only *one* of the two things it actually does. Confirmed by reading `cmd_build()` and `generate_lazy_registry.py` directly: every `tu build` call unconditionally overwrites `src/tooluniverse/_lazy_registry_static.py` **in place inside the installed package**, then writes coding-API wrappers to `--output`. Neither help surface — nor the `setup-tooluniverse` skill's CLI table — mentioned the registry side effect. A user running `tu build --output ./my_tools` expecting output scoped to that directory would not expect their installed package's internal registry file to also get rewritten as an unconditional side effect.

Updated the top-level help, the `--output` flag help, and the skill doc row to state both effects. Verified via `tu --help` / `tu build --help` from the fixed source that the descriptions now read correctly (see below).

## Also checked, not a docs bug
Ran `tu test UniProt_get_entry_by_accession` (also documented) — the underlying tool call succeeds and returns real data, but fails a `return_schema` check. Not fixed here: that's tool-schema drift against a live upstream API response, squarely the territory of the project's existing tool-fix harness (50+ rounds already actively working this exact problem class across ~2,700 tools). It's not a "docs describe a nonexistent CLI flag/skill" bug like the `tu build` gap above, so chasing it here would just duplicate/collide with that ongoing work rather than add anything new.

## Process note
First attempt at this fix accidentally copied `cli.py` wholesale from the long-lived shared dev checkout into the worktree — that checkout is on a stale feature branch missing several later fix-rounds' work already on `origin/main` (R13D-1, R22B-04, Feature-23B-02, etc.), so the copy would have silently reverted them. Caught it via `git diff origin/main -- src/tooluniverse/cli.py` before pushing, reset, and re-applied only the intended ~10-line change directly against a fresh `origin/main` checkout. Verified the final diff is exactly the intended change and nothing else.

## Test plan
- [x] Ran all 6 documented CLI example commands from the setup-tooluniverse table against current source; all succeeded, matched docs
- [x] Read `cmd_build()` and `generate_lazy_registry.py` to confirm the undocumented side effect (always rewrites `_lazy_registry_static.py` regardless of `--output`)
- [x] `tu --help` and `tu build --help` re-verified from the fixed source render the corrected text
- [x] `git diff origin/main -- src/tooluniverse/cli.py` reviewed to confirm only the intended ~10-line change is present (after catching and discarding the bad wholesale-copy attempt)