### PR TITLE
Fix Round 72: ClinGen gene-symbol filters used substring matching

### DIFF
--- a/src/tooluniverse/clingen_tool.py
+++ b/src/tooluniverse/clingen_tool.py
@@ -123,14 +123,18 @@ class ClinGenTool(BaseTool):
             # Parse CSV response
             curations = self._parse_csv(response.text)
 
-            # Filter by gene symbol (case-insensitive)
-            # Handle both "GENE SYMBOL" (from CSV) and "Gene Symbol" key formats
+            # Filter by gene symbol (case-insensitive, EXACT match -- this
+            # column holds a single precise HGNC symbol, not free text, and
+            # substring matching silently pulled in unrelated genes whose
+            # symbol happens to contain the query, e.g. "OTC" -> "NOTCH1"/
+            # "NOTCH2" (confirmed live). Mirrors _get_gene_validity's already-
+            # correct exact-match filter above.
             gene_upper = gene.upper()
-            matches = []
-            for c in curations:
-                gene_val = c.get("GENE SYMBOL", c.get("Gene Symbol", ""))
-                if gene_upper in gene_val.upper():
-                    matches.append(c)
+            matches = [
+                c
+                for c in curations
+                if c.get("GENE SYMBOL", c.get("Gene Symbol", "")).upper() == gene_upper
+            ]
 
             return {
                 "status": "success",
@@ -165,7 +169,11 @@ class ClinGenTool(BaseTool):
             # Parse CSV response
             curations = self._parse_csv(response.text)
 
-            # Optional filtering by gene
+            # Optional filtering by gene -- EXACT match (case-insensitive):
+            # this column holds a single precise HGNC symbol, not free text,
+            # and substring matching silently pulled in unrelated genes
+            # whose symbol happens to contain the query, e.g. "OTC" ->
+            # "NOTCH1"/"NOTCH2" (confirmed live).
             gene = arguments.get("gene")
             if gene:
                 gene_upper = gene.upper()
@@ -173,8 +181,8 @@ class ClinGenTool(BaseTool):
                 curations = [
                     c
                     for c in curations
-                    if gene_upper
-                    in c.get("GENE SYMBOL", c.get("Gene Symbol", "")).upper()
+                    if c.get("GENE SYMBOL", c.get("Gene Symbol", "")).upper()
+                    == gene_upper
                 ]
 
             return {
@@ -210,16 +218,21 @@ class ClinGenTool(BaseTool):
             # Parse CSV response
             curations = self._parse_csv(response.text)
 
-            # Filter by gene symbol (case-insensitive)
+            # Filter by gene symbol (case-insensitive, EXACT match -- this
+            # column holds a single precise HGNC symbol, not free text, and
+            # substring matching silently pulled in unrelated genes whose
+            # symbol happens to contain the query, e.g. "OTC" -> "NOTCH1"/
+            # "NOTCH2" (confirmed live).
             # Handle different column name formats from different endpoints
             gene_upper = gene.upper()
-            matches = []
-            for c in curations:
-                gene_val = c.get(
+            matches = [
+                c
+                for c in curations
+                if c.get(
                     "GENE SYMBOL", c.get("GENE/REGION", c.get("Gene Symbol", ""))
-                )
-                if gene_upper in gene_val.upper():
-                    matches.append(c)
+                ).upper()
+                == gene_upper
+            ]
 
             return {
                 "status": "success",

--- a/tests/unit/test_clingen_gene_symbol_exact_match.py
+++ b/tests/unit/test_clingen_gene_symbol_exact_match.py
@@ -1,0 +1,107 @@
+"""Regression guard for Fix-R72A-1: ClinGen's gene-validity and dosage-
+sensitivity gene filters used substring matching (`gene_upper in
+symbol.upper()`) instead of exact matching, against a column that holds a
+single precise HGNC symbol, not free text. Confirmed live: querying "OTC"
+(ornithine transcarbamylase deficiency) also silently returned "NOTCH1" and
+"NOTCH2" curations, since "OTC" is a literal substring of "NOTCH1"/"NOTCH2".
+`_get_gene_validity` already used the correct exact-match pattern -- this
+brings `_search_gene_validity`, `_get_dosage_sensitivity`, and
+`_search_dosage_sensitivity` in line with it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.clingen_tool import ClinGenTool
+
+pytestmark = pytest.mark.unit
+
+CSV_TEXT = (
+    '"CLINGEN DOSAGE SENSITIVITY CURATIONS","","","","",""\n'
+    '"FILE CREATED: 2026-07-21","","","","",""\n'
+    '"GENE SYMBOL","HGNC ID","HAPLOINSUFFICIENCY","TRIPLOSENSITIVITY","ONLINE REPORT","DATE"\n'
+    '"NOTCH1","HGNC:7881","Sufficient Evidence for Haploinsufficiency","No Evidence for Triplosensitivity","url1","date1"\n'
+    '"NOTCH2","HGNC:7882","No Evidence for Haploinsufficiency","No Evidence for Triplosensitivity","url2","date2"\n'
+    '"OTC","HGNC:8512","Sufficient Evidence for Haploinsufficiency","No Evidence for Triplosensitivity","url3","date3"\n'
+)
+
+
+def _tool(operation):
+    return ClinGenTool({"name": "clingen_test", "fields": {"operation": operation}})
+
+
+def _resp():
+    r = MagicMock()
+    r.text = CSV_TEXT
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def test_get_dosage_sensitivity_exact_matches_otc_not_notch():
+    tool = _tool("get_dosage_sensitivity")
+    with patch("tooluniverse.clingen_tool.requests.get", return_value=_resp()):
+        result = tool.run({"gene": "OTC"})
+
+    assert result["status"] == "success"
+    assert result["data"] == [
+        {
+            "GENE SYMBOL": "OTC",
+            "HGNC ID": "HGNC:8512",
+            "HAPLOINSUFFICIENCY": "Sufficient Evidence for Haploinsufficiency",
+            "TRIPLOSENSITIVITY": "No Evidence for Triplosensitivity",
+            "ONLINE REPORT": "url3",
+            "DATE": "date3",
+        }
+    ]
+    assert result["total"] == 1
+
+
+def test_search_dosage_sensitivity_exact_matches_otc_not_notch():
+    tool = _tool("search_dosage_sensitivity")
+    with patch("tooluniverse.clingen_tool.requests.get", return_value=_resp()):
+        result = tool.run({"gene": "OTC"})
+
+    assert result["status"] == "success"
+    assert len(result["data"]) == 1
+    assert result["data"][0]["GENE SYMBOL"] == "OTC"
+
+
+def test_search_gene_validity_exact_matches_otc_not_notch():
+    tool = _tool("search_gene_validity")
+    with patch("tooluniverse.clingen_tool.requests.get", return_value=_resp()):
+        result = tool.run({"gene": "OTC"})
+
+    assert result["status"] == "success"
+    assert len(result["data"]) == 1
+    assert result["data"][0]["GENE SYMBOL"] == "OTC"
+
+
+def test_get_dosage_sensitivity_case_insensitive_still_matches():
+    tool = _tool("get_dosage_sensitivity")
+    with patch("tooluniverse.clingen_tool.requests.get", return_value=_resp()):
+        result = tool.run({"gene": "otc"})
+
+    assert len(result["data"]) == 1
+    assert result["data"][0]["GENE SYMBOL"] == "OTC"
+
+
+def test_get_dosage_sensitivity_genuinely_nonexistent_gene_returns_empty():
+    tool = _tool("get_dosage_sensitivity")
+    with patch("tooluniverse.clingen_tool.requests.get", return_value=_resp()):
+        result = tool.run({"gene": "NOTAREALGENE12345"})
+
+    assert result["status"] == "success"
+    assert result["data"] == []
+    assert result["total"] == 0
+
+
+def test_get_dosage_sensitivity_notch1_query_does_not_pull_in_otc():
+    """The inverse check: querying the longer symbol must not match the
+    shorter one it happens to contain either."""
+    tool = _tool("get_dosage_sensitivity")
+    with patch("tooluniverse.clingen_tool.requests.get", return_value=_resp()):
+        result = tool.run({"gene": "NOTCH1"})
+
+    assert len(result["data"]) == 1
+    assert result["data"][0]["GENE SYMBOL"] == "NOTCH1"


### PR DESCRIPTION
## Summary

Round 72 shifted methodology per user direction: rather than picking another disease-area domain (9 consecutive clean domain-style rounds showed diminishing returns), this round used error-path/boundary-input testing against existing tool categories. Found and fixed a real, confirmed bug on the first pass:

**ClinGen's gene-validity and dosage-sensitivity search/filter functions matched gene symbols via substring containment** (`gene_upper in symbol.upper()`) against a column that holds a single precise HGNC symbol, not free text. Confirmed live: querying `{"gene": "OTC"}` (ornithine transcarbamylase deficiency) silently also returned **"NOTCH1" and "NOTCH2"** curations, since "OTC" is a literal substring of "N**OTC**H1"/"N**OTC**H2". Confirmed the exact blast radius via the raw ClinGen bulk CSV: exactly these 3 gene symbols contain "OTC" as a substring, matching the live result precisely.

Notably, `_get_gene_validity` (the sibling "get all, optionally filter by gene" function) **already used the correct exact-match pattern** — this bug was an inconsistency within the same file, not a uniform design choice. Fixed `_search_gene_validity`, `_get_dosage_sensitivity`, and `_search_dosage_sensitivity` to match it.

**Deliberately left untouched**: the actionability functions (`_get_actionability`/`_fetch_actionability_context`) also substring-match, but against `geneOrVariant`, which is explicitly documented as a comma-joined multi-gene panel field (e.g. `"BRCA1,BRCA2"`) — a genuine design constraint requiring substring matching, not the same bug. It likely has a *related* but distinct issue (the same "OTC"-in-"NOTCH1,NOTCH2" collision could theoretically occur within a joined field too) that would need its own investigation into the real-world field structure before changing — flagged for a future round rather than bundled in here.

## Verification

- Raw ClinGen bulk CSV (`search.clinicalgenome.org/kb/gene-dosage/download`) parsed directly: exactly `NOTCH1`, `NOTCH2`, `OTC` contain "OTC" as a substring — matches the live buggy result precisely before the fix.
- Live `tu run ClinGen_get_dosage_sensitivity '{"gene": "OTC"}'` before fix: 3 results (NOTCH1, NOTCH2, OTC). After fix: exactly 1 (OTC).
- Live-verified all three fixed operations (`get_dosage_sensitivity`, `search_dosage_sensitivity`, `search_gene_validity`) individually.
- Regression-checked: lowercase `"otc"` still matches (case-insensitivity preserved); a genuinely nonexistent gene symbol still correctly returns empty; querying the longer symbol (`"NOTCH1"`) doesn't spuriously match the shorter one it contains.

## Test plan

- [x] New `tests/unit/test_clingen_gene_symbol_exact_match.py`: 6 tests covering all three fixed operations, case-insensitivity, nonexistent-gene, and the inverse-direction collision check
- [x] Full ClinGen test suite (27 tests across all `test_clingen_*.py` files) — passes, no regressions
- [x] Full suite (`pytest tests/ --ignore=tests/test_claude_code_plugin.py`) — clean, 0 failures (the `test_claude_code_plugin.py` failures are pre-existing on `main`, unrelated plugin-doc drift, confirmed in earlier rounds)