### PR TITLE
Fix parameter schemas that don't match what tools actually accept

### DIFF
--- a/src/tooluniverse/data/chembl_tools.json
+++ b/src/tooluniverse/data/chembl_tools.json
@@ -523,6 +523,11 @@
         "offset": {
           "type": "integer",
           "default": 0
+        },
+        "fields": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Optional list of assay fields to include in each returned assay object (projection). Mapped to ChEMBL's `only` query parameter (comma-separated)."
         }
       },
       "required": [

--- a/src/tooluniverse/data/metabolite_tools.json
+++ b/src/tooluniverse/data/metabolite_tools.json
@@ -398,6 +398,15 @@
         "compound_name": {
           "type": "string",
           "description": "Compound name (e.g., glucose)"
+        },
+        "pubchem_cid": {
+          "type": "string",
+          "description": "PubChem CID as an alternative identifier to hmdb_id or compound_name."
+        },
+        "limit": {
+          "type": "integer",
+          "default": 50,
+          "description": "Maximum number of disease associations to return (default 50)."
         }
       },
       "required": []

--- a/src/tooluniverse/data/tcdb_tools.json
+++ b/src/tooluniverse/data/tcdb_tools.json
@@ -7,14 +7,16 @@
       "operation": "get_transporter"
     },
     "timeout": 60,
-    "args": [
-      {
-        "name": "uniprot_accession",
-        "type": "string",
-        "description": "UniProt accession ID of the transporter protein (e.g., P11166 for GLUT1, P08183 for P-glycoprotein/MDR1). Aliases: uniprot_id, accession.",
-        "required": true
-      }
-    ],
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "uniprot_accession": {
+          "type": "string",
+          "description": "UniProt accession ID of the transporter protein (e.g., P11166 for GLUT1, P08183 for P-glycoprotein/MDR1). Aliases: uniprot_id, accession."
+        }
+      },
+      "required": ["uniprot_accession"]
+    },
     "return_schema": {
       "oneOf": [
         {
@@ -74,26 +76,24 @@
       "operation": "search_family"
     },
     "timeout": 60,
-    "args": [
-      {
-        "name": "family_id",
-        "type": "string",
-        "description": "TC family ID or prefix to search (e.g., '2.A.1' for Major Facilitator Superfamily, '1.A.1' for VIC superfamily). Matches all families starting with this prefix.",
-        "required": false
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "family_id": {
+          "type": "string",
+          "description": "TC family ID or prefix to search (e.g., '2.A.1' for Major Facilitator Superfamily, '1.A.1' for VIC superfamily). Matches all families starting with this prefix. Either family_id or family_name is required."
+        },
+        "family_name": {
+          "type": "string",
+          "description": "Text to search in family descriptions (e.g., 'Major Facilitator', 'ABC', 'glucose'). Case-insensitive. Either family_id or family_name is required."
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Maximum number of families to return (default 20, max 100)."
+        }
       },
-      {
-        "name": "family_name",
-        "type": "string",
-        "description": "Text to search in family descriptions (e.g., 'Major Facilitator', 'ABC', 'glucose'). Case-insensitive.",
-        "required": false
-      },
-      {
-        "name": "limit",
-        "type": "integer",
-        "description": "Maximum number of families to return (default 20, max 100).",
-        "required": false
-      }
-    ],
+      "required": []
+    },
     "return_schema": {
       "oneOf": [
         {
@@ -148,20 +148,20 @@
       "operation": "search_by_substrate"
     },
     "timeout": 60,
-    "args": [
-      {
-        "name": "substrate_name",
-        "type": "string",
-        "description": "Name of the substrate to search for (e.g., 'glucose', 'sodium', 'chloride', 'ATP'). Case-insensitive partial match. Aliases: substrate.",
-        "required": true
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "substrate_name": {
+          "type": "string",
+          "description": "Name of the substrate to search for (e.g., 'glucose', 'sodium', 'chloride', 'ATP'). Case-insensitive partial match. Aliases: substrate."
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Maximum number of results to return (default 20, max 100)."
+        }
       },
-      {
-        "name": "limit",
-        "type": "integer",
-        "description": "Maximum number of results to return (default 20, max 100).",
-        "required": false
-      }
-    ],
+      "required": ["substrate_name"]
+    },
     "return_schema": {
       "oneOf": [
         {


### PR DESCRIPTION
## Summary

Continuing the "declared vs runtime reality" audit (#358, #359, #361) with the params-vs-runtime angle: cross-referenced every tool's declared `parameter.properties`/`required` against its own `test_examples` argument keys, within the same JSON config (static check, no live calls needed — ran across all ~2,824 active tool configs, excluding `broken_apis/`).

Zero tools had a `required` param that's never demonstrated in any example (good sign — schemas and examples broadly agree on what's required). 21 tools had a `test_example` using a key not present in the declared schema. Live-tested a representative sample from every distinct pattern among those 21 before deciding what was a real bug vs. harmless.

## Real bugs, fixed

**`TCDB_get_transporter` / `TCDB_search_family` / `TCDB_search_by_substrate`** — `parameter` was entirely `null`. Root cause: `tcdb_tools.json` used a one-off `"args": [...]` list format instead of the standard `"parameter": {type: object, properties: {...}}` JSON-Schema format every other tool config in the ~2,800-tool registry uses (`grep -rl '"args": \[' src/tooluniverse/data/*.json` → only this one file; nothing in `execute_function.py`/`tool_defaults.py` reads that key). `tu info` showed **zero parameters** for all three tools. Confirmed live:
```
$ tu run TCDB_get_transporter '{}'   # matches what the empty schema implies is valid
Error: uniprot_accession is required
```
The schema wasn't just incomplete, it was actively misleading. Read `tcdb_tool.py`'s `run()` directly to get the true full parameter set — including undocumented aliases (`uniprot_id`/`accession` for `TCDB_get_transporter`; `substrate` for `TCDB_search_by_substrate`) that wouldn't have been visible from the 2 test_examples alone — and converted all three to the standard format.

**`ChEMBL_get_target_assays`** — missing `fields` (projection param). Confirmed via `chem_tool.py`'s request builder that it's genuinely read (`args.get("fields")`) and mapped to ChEMBL's `only` query param — the sibling tool `ChEMBL_search_assays` already declares this same param correctly, just not this one.

**`HMDB_get_diseases`** — missing `limit` (`metabolite_tool.py`: `arguments.get("limit", 50)`) and `pubchem_cid` (`_extract_identifier()`: accepted as a third identifier alias alongside `hmdb_id`/`compound_name`, silently undocumented).

All verified via `tu test` (all pass) and a full `ToolUniverse().load_tools()` from source before/after (2,689 tools both times — no regression).

## Caught during verification, not fixed
`HMDB_get_diseases` fails an unrelated `return_schema` check (live API response includes fields the schema doesn't declare). Confirmed **pre-existing** — ran the same test against the unmodified file (`git stash` the change, retest, `git stash pop`) and it fails identically. Same reasoning as #361: that's the existing tool-schema-fix harness's territory (50+ rounds already working this problem class), not a "docs describe something nonexistent" bug.

## Checked, confirmed harmless (not asserted, verified by reading source)
- **9 tools** (ARCHS4 ×2, OmniPath, PathwayCommons ×4, TDC ×2) have `operation` as an extra `test_example` key. `fields.operation` in the tool config already fixes the instance's behavior; the `arguments.get("operation")` fallback in code is redundant when that's set (confirmed in `archs4_tool.py`). Cosmetic test-example cruft.
- **4 ChEMBL tools'** test_examples use the raw wire-format name `target_chembl_id__exact` instead of the documented alias `target_chembl_id`. Confirmed via `chem_tool.py`: a generic filter-passthrough forwards any Django-style-suffixed key straight to the ChEMBL API, so both names produce the identical outbound request. Style inconsistency in the example, not a bug.
- **`web_search`/`web_api_documentation_search`** test_examples embed `description`/`expected_output_type` keys. Confirmed via `web_search_tool.py`'s `run()`: neither key is ever read. Harmless leftover test-metadata inside the arguments dict.
- **`OpenTargets_search_gwas_studies_by_disease`**'s extra `size` key — not independently source-verified (time-boxed this round); flagging as lower-confidence rather than asserting either way.

## Test plan
- [x] `tu test` for all 3 TCDB tools, `ChEMBL_get_target_assays`, `HMDB_get_diseases` — pass (HMDB's pre-existing unrelated return_schema failure confirmed via stash/unstash comparison)
- [x] `tu info` re-checked for all 3 TCDB tools — now shows real parameters instead of none
- [x] `tu run TCDB_get_transporter '{}'` still correctly errors post-fix (schema now matches this reality instead of contradicting it)
- [x] Full `ToolUniverse().load_tools()` from source before/after: 2,689 tools, identical
- [x] `git diff origin/main --stat` reviewed: exactly the 3 intended files, applied via saved patches (not a wholesale file copy) per the process lesson from #361