### PR TITLE
Fix Round 73: BRENDA SABIO-RK integration silently swallowed a 2025 upstream API retirement as empty success

### DIFF
--- a/src/tooluniverse/brenda_tool.py
+++ b/src/tooluniverse/brenda_tool.py
@@ -15,7 +15,6 @@ WSDL: https://www.brenda-enzymes.org/soap/brenda_zeep.wsdl
 
 import hashlib
 import os
-import xml.etree.ElementTree as ET
 from typing import Any, Dict, List, Optional
 
 import requests
@@ -389,50 +388,71 @@ class BRENDATool(BaseTool):
     ) -> Dict[str, Any]:
         """Fetch kinetic parameters from SABIO-RK (no auth).
 
-        Reuses shared parsing from sabiork_tool module.
+        Fix-R73A-1: the legacy /sabioRestWebServices/searchKineticLaws/
+        entryIDs REST endpoint this used to call was retired by SABIO-RK in
+        2025 -- every request now 302-redirects to the sabiork.h-its.org
+        SPA's 404 page (confirmed live via raw curl), and the old status-
+        code/XML-parse checks below silently swallowed that as "0 entries,
+        success" instead of surfacing a failure. Confirmed live for EC
+        1.1.1.1 (alcohol dehydrogenase, one of the most-studied enzymes):
+        silently reported 0 SABIO-RK entries when the real count is 768.
+        Ports the same Solr-backed endpoint sabiork_tool.py's SABIORKTool
+        already migrated to (see its _search_reactions docstring) instead
+        of reimplementing a second copy of the fix. That endpoint doesn't
+        expose raw numeric parameter values (confirmed live -- SABIORKTool's
+        own "parameters" field is always empty too), so kinetic_laws entries
+        carry parameter_types/entry metadata but no Km/kcat/Ki numeric
+        values; the caller's numeric parameter_summary aggregation below
+        simply has nothing to aggregate, same as before this fix (never a
+        regression, since the old code always returned 0 entries anyway).
         """
-        from .sabiork_tool import (
-            SABIORK_BASE,
-            _is_no_data_response,
-            _parse_entry_ids,
-            _parse_sbml_kinetics,
-        )
-
-        query_parts = [f"ecnumber:{ec_number}"]
+        query_parts = [f"ECNumber:{ec_number}"]
         if organism:
             query_parts.append(f'Organism:"{organism}"')
         query = " AND ".join(query_parts)
 
         resp = requests.get(
-            f"{SABIORK_BASE}/searchKineticLaws/entryIDs?q={query}", timeout=20
+            "https://sabiork.h-its.org/api/ft/proxy-select",
+            params={
+                "q": query,
+                "df": "Everything",
+                "wt": "json",
+                "rows": limit,
+                "fl": "EntryID,ECNumber,EnzymeName,Organism,Tissue,Substrate,"
+                "Product,ParameterType,PubMedID",
+            },
+            timeout=20,
         )
-        if resp.status_code != 200:
-            return {"kinetic_laws": [], "total_count": 0}
+        resp.raise_for_status()
+        response = resp.json().get("response", {}) or {}
+        total_count = response.get("numFound", 0)
+        docs = response.get("docs", []) or []
 
-        if _is_no_data_response(resp.text):
-            return {"kinetic_laws": [], "total_count": 0}
+        def _first(v):
+            return v[0] if isinstance(v, list) and v else v
 
-        try:
-            entry_ids = _parse_entry_ids(resp.text)
-        except ET.ParseError:
-            return {"kinetic_laws": [], "total_count": 0}
-
-        total = len(entry_ids)
-        if total == 0:
-            return {"kinetic_laws": [], "total_count": 0}
-
-        fetch_ids = entry_ids[:limit]
-        resp2 = requests.get(
-            f"{SABIORK_BASE}/kineticLaws?kinlawids={','.join(fetch_ids)}", timeout=30
-        )
-        if resp2.status_code != 200:
-            return {"kinetic_laws": [], "total_count": total}
-
-        records = _parse_sbml_kinetics(resp2.text)
-        for i, rec in enumerate(records):
-            if i < len(fetch_ids):
-                rec["sabiork_entry_id"] = fetch_ids[i]
-        return {"kinetic_laws": records, "total_count": total}
+        kinetic_laws = [
+            {
+                "sabiork_entry_id": str(_first(d.get("EntryID")) or ""),
+                "ec_number": _first(d.get("ECNumber")),
+                "enzyme_name": _first(d.get("EnzymeName")),
+                "organism": _first(d.get("Organism")),
+                "tissue": _first(d.get("Tissue")),
+                "substrates": d.get("Substrate")
+                if isinstance(d.get("Substrate"), list)
+                else [],
+                "products": d.get("Product")
+                if isinstance(d.get("Product"), list)
+                else [],
+                "parameter_types": d.get("ParameterType")
+                if isinstance(d.get("ParameterType"), list)
+                else [],
+                "parameters": [],
+                "pubmed_id": _first(d.get("PubMedID")),
+            }
+            for d in docs
+        ]
+        return {"kinetic_laws": kinetic_laws, "total_count": total_count}
 
     def _get_enzyme_kinetics(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/tests/tools/test_sabiork_tool.py
+++ b/tests/tools/test_sabiork_tool.py
@@ -71,16 +71,34 @@ class TestSABIORKToolDirect:
 
     @patch("tooluniverse.sabiork_tool.requests.get")
     def test_search_by_ec_number(self, mock_get, tool):
-        # Mock entry ID response then SBML response
-        mock_ids_resp = MagicMock()
-        mock_ids_resp.status_code = 200
-        mock_ids_resp.text = ENTRY_IDS_XML
-
-        mock_sbml_resp = MagicMock()
-        mock_sbml_resp.status_code = 200
-        mock_sbml_resp.text = SBML_XML
-
-        mock_get.side_effect = [mock_ids_resp, mock_sbml_resp]
+        # Fix-R73B-1: these tests still mocked the legacy two-step XML
+        # flow (entry-IDs then SBML fetch) that _search_reactions no longer
+        # uses -- it migrated to the single-call Solr endpoint (see its own
+        # docstring: the legacy REST endpoint was retired by SABIO-RK in
+        # 2025). Confirmed live that requests to the legacy endpoint now
+        # 302-redirect to a JS SPA 404 page. Mock the real Solr JSON shape.
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "response": {
+                "numFound": 3,
+                "docs": [
+                    {
+                        "EntryID": 11020,
+                        "ECNumber": ["1.1.1.1"],
+                        "EnzymeName": ["alcohol dehydrogenase"],
+                        "Substrate": ["Ethanol"],
+                        "Product": ["Acetaldehyde"],
+                        "Parameter": [
+                            {"type": "kcat", "value": 4.916667, "unit": "s^{-1}"},
+                            {"type": "Km", "value": 0.0041, "unit": "M"},
+                            {"type": "Ki", "value": 4.3e-7, "unit": "M"},
+                        ],
+                    }
+                ],
+            }
+        }
+        mock_get.return_value = mock_resp
 
         result = tool.run(
             {"operation": "search_reactions", "ec_number": "1.1.1.1", "limit": 3}
@@ -105,7 +123,7 @@ class TestSABIORKToolDirect:
     def test_no_results(self, mock_get, tool):
         mock_resp = MagicMock()
         mock_resp.status_code = 200
-        mock_resp.text = "no data found"
+        mock_resp.json.return_value = {"response": {"numFound": 0, "docs": []}}
         mock_get.return_value = mock_resp
 
         result = tool.run(
@@ -122,7 +140,7 @@ class TestSABIORKToolDirect:
                 "substrate": "ethanol",
             }
         )
-        assert "ecnumber:1.1.1.1" in q
+        assert "ECNumber:1.1.1.1" in q
         assert 'Organism:"Homo sapiens"' in q
         assert 'Substrate:"ethanol"' in q
         assert " AND " in q

--- a/tests/unit/test_brenda_sabiork_solr_migration.py
+++ b/tests/unit/test_brenda_sabiork_solr_migration.py
@@ -1,0 +1,180 @@
+"""Regression guard for Fix-R73A-1: BRENDA_get_enzyme_kinetics'
+_fetch_sabiork_kinetics called the legacy SABIO-RK REST endpoint
+(/sabioRestWebServices/searchKineticLaws/entryIDs), retired by SABIO-RK in
+2025 -- every request 302-redirects to a JS SPA 404 page (confirmed live via
+raw curl). The old code's status_code-!=-200 and XML-ParseError checks
+silently swallowed this as "0 entries, success" instead of surfacing a
+failure -- confirmed live for EC 1.1.1.1 (alcohol dehydrogenase): reported 0
+SABIO-RK entries when the real count is 768. This ports the same Solr-backed
+endpoint (https://sabiork.h-its.org/api/ft/proxy-select) that
+sabiork_tool.py's SABIORKTool already migrated to.
+
+Fix-R14D-1's own failure-visibility tests (test_brenda_sabiork_failure_
+visibility.py) mock _fetch_sabiork_kinetics at the method level and are
+unaffected by this internal rewrite -- these tests instead exercise
+_fetch_sabiork_kinetics itself, mocking the HTTP layer.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.brenda_tool import BRENDATool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return BRENDATool({"name": "BRENDA_get_enzyme_kinetics"})
+
+
+def _solr_response(num_found, docs):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json.return_value = {"response": {"numFound": num_found, "docs": docs}}
+    return r
+
+
+def test_fetches_via_solr_endpoint_not_legacy_rest():
+    tool = _tool()
+    with patch("tooluniverse.brenda_tool.requests.get") as mock_get:
+        mock_get.return_value = _solr_response(0, [])
+        tool._fetch_sabiork_kinetics("1.1.1.1")
+
+    called_url = mock_get.call_args[0][0]
+    assert called_url == "https://sabiork.h-its.org/api/ft/proxy-select"
+    assert "sabioRestWebServices" not in called_url
+    assert mock_get.call_args[1]["params"]["q"] == "ECNumber:1.1.1.1"
+
+
+def test_real_entry_count_is_reported_not_zero():
+    """The core confirmed-live symptom: a well-studied enzyme (EC 1.1.1.1)
+    has hundreds of real SABIO-RK entries, not zero."""
+    tool = _tool()
+    docs = [
+        {
+            "EntryID": 3805,
+            "ECNumber": ["1.1.1.1"],
+            "EnzymeName": ["alcohol dehydrogenase"],
+            "Organism": ["Saccharomyces cerevisiae"],
+            "ParameterType": ["Km", "kcat"],
+        }
+    ]
+    with patch("tooluniverse.brenda_tool.requests.get") as mock_get:
+        mock_get.return_value = _solr_response(768, docs)
+        result = tool._fetch_sabiork_kinetics("1.1.1.1")
+
+    assert result["total_count"] == 768
+    assert len(result["kinetic_laws"]) == 1
+    law = result["kinetic_laws"][0]
+    assert law["sabiork_entry_id"] == "3805"
+    assert law["enzyme_name"] == "alcohol dehydrogenase"
+    assert law["parameter_types"] == ["Km", "kcat"]
+
+
+def test_organism_filter_included_in_query():
+    tool = _tool()
+    with patch("tooluniverse.brenda_tool.requests.get") as mock_get:
+        mock_get.return_value = _solr_response(0, [])
+        tool._fetch_sabiork_kinetics("1.1.1.1", organism="Homo sapiens")
+
+    assert mock_get.call_args[1]["params"]["q"] == (
+        'ECNumber:1.1.1.1 AND Organism:"Homo sapiens"'
+    )
+
+
+def test_non_200_response_raises_instead_of_silently_returning_zero():
+    """The exact confirmed-live failure mode: a redirect-to-404 response.
+    Must raise so the caller's existing sabiork_error mechanism (Fix-R14D-1)
+    actually fires, instead of silently reporting 0 entries as success."""
+    tool = _tool()
+    with patch("tooluniverse.brenda_tool.requests.get") as mock_get:
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "404 Client Error"
+        )
+        mock_get.return_value = resp
+
+        with pytest.raises(requests.exceptions.HTTPError):
+            tool._fetch_sabiork_kinetics("1.1.1.1")
+
+
+def test_non_json_response_raises_instead_of_silently_returning_zero():
+    tool = _tool()
+    with patch("tooluniverse.brenda_tool.requests.get") as mock_get:
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.side_effect = ValueError("not JSON")
+        mock_get.return_value = resp
+
+        with pytest.raises(ValueError):
+            tool._fetch_sabiork_kinetics("1.1.1.1")
+
+
+def test_end_to_end_failure_now_reaches_sabiork_error(monkeypatch):
+    """Combines this fix with Fix-R14D-1's existing mechanism: a raised
+    exception from _fetch_sabiork_kinetics (now reachable, since the legacy
+    silent-swallow paths are gone) must surface via metadata.sabiork_error,
+    not silently report kinetic_parameters as an empty-but-successful list."""
+    tool = _tool()
+    monkeypatch.setattr(
+        tool,
+        "_fetch_expasy_enzyme",
+        lambda ec: {
+            "name": "alcohol dehydrogenase",
+            "alternative_names": [],
+            "catalytic_activity": [],
+            "comments": [],
+        },
+    )
+    with patch("tooluniverse.brenda_tool.requests.get") as mock_get:
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "404 Client Error"
+        )
+        mock_get.return_value = resp
+
+        result = tool._get_enzyme_kinetics({"ec_number": "1.1.1.1"})
+
+    assert result["status"] == "success"
+    assert result["data"]["kinetic_parameters"] == []
+    assert result["data"]["sabiork_total_entries"] == 0
+    assert "sabiork_error" in result["metadata"]
+    assert "SABIO-RK" not in result["metadata"]["sources"]
+
+
+def test_no_parameter_summary_fabricated_when_values_unavailable():
+    """The new Solr endpoint doesn't expose raw numeric parameter values
+    (confirmed live -- SABIORKTool's own "parameters" field is always
+    empty too). parameter_summary must stay honestly absent, not be
+    fabricated from empty data."""
+    tool = _tool()
+    monkeypatch_docs = [
+        {
+            "EntryID": 3805,
+            "ECNumber": ["1.1.1.1"],
+            "EnzymeName": ["alcohol dehydrogenase"],
+            "ParameterType": ["Km", "kcat"],
+        }
+    ]
+    with patch("tooluniverse.brenda_tool.requests.get") as mock_get, patch.object(
+        BRENDATool,
+        "_fetch_expasy_enzyme",
+        return_value={
+            "name": "alcohol dehydrogenase",
+            "alternative_names": [],
+            "catalytic_activity": [],
+            "comments": [],
+        },
+    ):
+        mock_get.return_value = _solr_response(768, monkeypatch_docs)
+        result = tool._get_enzyme_kinetics({"ec_number": "1.1.1.1"})
+
+    assert result["status"] == "success"
+    assert "parameter_summary" not in result["data"]
+    assert result["data"]["sabiork_total_entries"] == 768


### PR DESCRIPTION
## Summary

Round 73 continued the new error-path/boundary-testing methodology. Firing malformed/empty/boundary inputs at `BRENDA_get_enzyme_kinetics` (a never-before-touched tool in this campaign) surfaced a clean, well-scoped bug pattern the methodology was designed to catch: a **silent upstream API retirement masquerading as "no data."**

**BRENDA_get_enzyme_kinetics's SABIO-RK sub-fetch called a dead REST endpoint.** `_fetch_sabiork_kinetics` called `/sabioRestWebServices/searchKineticLaws/entryIDs`, which SABIO-RK retired in 2025 — every request now 302-redirects to a JS SPA 404 page (confirmed live via raw `curl`). The old status-code/XML-parse checks silently swallowed this as `{"kinetic_laws": [], "total_count": 0}` instead of surfacing a failure. Confirmed live for EC 1.1.1.1 (alcohol dehydrogenase, one of the most-studied enzymes in biochemistry): the tool reported **0** SABIO-RK entries when the real count is **768**.

Notably, `sabiork_tool.py`'s own standalone `SABIORKTool` had **already been migrated** to a working Solr-backed endpoint (`https://sabiork.h-its.org/api/ft/proxy-select`) by an earlier fix (its own docstring explains the 2025 retirement) — but `brenda_tool.py`'s separate, parallel SABIO-RK integration was never updated to match. Ported the same working approach rather than reimplementing a second copy of the fix.

The new Solr endpoint doesn't expose raw numeric parameter values (confirmed live — `SABIORKTool`'s own `"parameters"` field is always empty too), so `kinetic_laws` entries now carry real entry/type metadata but no Km/kcat/Ki numeric values. This is **not a regression**: the old code's numeric `parameter_summary` aggregation was already always empty too, since `kinetic_laws` was always `[]`.

**Also fixed 3 pre-existing stale tests** in `tests/tools/test_sabiork_tool.py` that predated `SABIORKTool`'s own Solr migration — they still mocked the retired two-step XML flow and were silently broken (excluded from the default CI sweep via `pytest.ini`'s `--ignore=tests/tools`), since whoever fixed the tool itself didn't update its own tests to match.

## Verification

- Raw `curl` against the legacy endpoint: `302 Found` → `Location: /ui/404`; following the redirect (as `requests` does by default) lands on a 200-OK HTML SPA shell, not real SABIO-RK data.
- Live `tu run BRENDA_get_enzyme_kinetics '{"ec_number": "1.1.1.1"}'` before fix: `sabiork_total_entries: 0`. After fix: `sabiork_total_entries: 768`, `sources: ["ExPASy ENZYME", "SABIO-RK"]`.
- Confirmed `parameter_summary` stays honestly absent both before and after (no fabricated numeric data).
- Regression-checked error paths (malformed EC number, nonempty-but-nonexistent EC number, empty string, no args) — all still correctly distinguish "bad query" from "no data," unaffected by this fix.

## Test plan

- [x] New `tests/unit/test_brenda_sabiork_solr_migration.py`: 7 tests — correct Solr endpoint/query construction, real entry-count reporting, organism filter, non-200/non-JSON responses now raise (reaching the existing `sabiork_error` surfacing mechanism from an earlier fix) instead of silently returning zero, and no fabricated `parameter_summary`
- [x] Existing `tests/unit/test_brenda_sabiork_failure_visibility.py` (3 tests, mocks at the method level) — unaffected, still passes
- [x] Fixed 3 stale tests in `tests/tools/test_sabiork_tool.py` to mock the real Solr response shape instead of the retired XML flow — all 10 tests in that file now pass
- [x] Full suite (`pytest tests/ --ignore=tests/test_claude_code_plugin.py`) — clean, 0 failures