### PR TITLE
Fix Sphinx docs drift on the two highest-traffic new-user pages

### DIFF
--- a/docs/guide/building_ai_scientists/claude_code.rst
+++ b/docs/guide/building_ai_scientists/claude_code.rst
@@ -35,6 +35,31 @@ Quickstart — install the plugin
 Restart Claude Code. The MCP server auto-starts via ``uvx tooluniverse`` on first use
 (~30 s cold start, instant after).
 
+.. tip::
+
+   **Recommended: turn on auto-update.** Third-party marketplaces default to no
+   auto-update, so new skills and fixes only reach you when you remember to run
+   ``claude plugin update`` yourself. Turn it on once:
+
+   .. code-block:: bash
+
+      python3 -c "
+      import json, pathlib, sys
+      p = pathlib.Path.home() / '.claude/plugins/known_marketplaces.json'
+      d = json.loads(p.read_text())
+      if 'tooluniverse' not in d:
+          sys.exit('Run the marketplace add command above first')
+      d['tooluniverse']['autoUpdate'] = True
+      p.write_text(json.dumps(d, indent=2))
+      print('autoUpdate enabled for tooluniverse')
+      "
+
+   Equivalent interactive path: ``/plugin`` → Marketplaces → ``tooluniverse`` →
+   Enable auto-update. With this on, Claude Code checks for updates in the
+   background after each session start (up to a ~10 min random delay) and
+   updates the installed plugin automatically — no more manual
+   ``claude plugin update``.
+
 .. note::
 
    **Pin to a specific version (optional):**
@@ -98,6 +123,15 @@ What you get
    * - ``/tooluniverse:literature-sweep``
      - Graded mini-review across PubMed + EuropePMC + Semantic Scholar
      - Slash command
+   * - ``/tooluniverse:verify-references``
+     - Check that cited references are real and accurately described, including retraction status
+     - Slash command
+   * - ``/tooluniverse:self-review``
+     - Generate weighted success criteria for a task and check work against them (what's missing / done well)
+     - Slash command
+   * - ``/tooluniverse:setup-keys``
+     - Configure ToolUniverse API keys
+     - Slash command
    * - ``/tooluniverse:researcher``
      - Same investigation as ``research``, delegated to a forked-context subagent that returns one summary (use when you don't want intermediate tool-call output in your main thread)
      - Slash command
@@ -108,6 +142,9 @@ What you get
 
 Update / uninstall
 ------------------
+
+If you enabled auto-update above, updates happen automatically in the
+background — no action needed. Otherwise, update manually:
 
 .. code-block:: bash
 

--- a/docs/guide/python_guide.rst
+++ b/docs/guide/python_guide.rst
@@ -97,7 +97,7 @@ Get your first scientific query running in 5 minutes:
       .. code-block:: python
 
          # Load only specific tool categories
-         tu.load_tools(tool_type=['uniprot', 'ChEMBL', 'opentarget'])
+         tu.load_tools(categories=['uniprot', 'ChEMBL', 'opentarget'])
 
 .. card:: Step 3: Execute Your First Tool
  :class-card: step-card current
@@ -286,7 +286,7 @@ Common Examples
 
    # Search scientific papers
    result = tu.run({
-       "name": "PubTator_search_publications",
+       "name": "PubTator3_LiteratureSearch",
        "arguments": {
            "query": "CRISPR cancer therapy",
            "limit": 10
@@ -424,7 +424,7 @@ Tool Loading Options
    tu.load_tools()
 
    # Load specific categories
-   tu.load_tools(tool_type=['uniprot', 'ChEMBL', 'opentarget'])
+   tu.load_tools(categories=['uniprot', 'ChEMBL', 'opentarget'])
 
    # Load only specific tools by name
    tu.load_tools(include_tools=['UniProt_get_function_by_accession', 'PubMed_search_articles'])


### PR DESCRIPTION
## Summary

Docs-vs-code angle on the "declared vs runtime reality" audit (#358, #359, #361, #363), prioritizing pages a new user hits first per feedback on the last round: `docs/index.rst`'s "Get Started" section links to exactly 3 pages — `guide/building_ai_scientists/index` (→ `claude_code.rst`), `guide/tu_cli`, `guide/python_guide`. Checked all three, plus a full-tree internal-link audit, before touching anything.

## Full-tree check — clean, confirms no fix needed
Wrote a resolver for every `:doc:` role across the whole docs tree (1,391 references, all `.rst` files, correctly implementing Sphinx's relative-to-current-file resolution — not absolute-from-root). **Zero broken.** One reference I initially suspected was broken (a bare `` `mcp_support` `` in `claude_code.rst`) turned out correct once I checked it resolves relative to *its own* file's directory rather than the page I'd been comparing it against — good reminder to trust the resolver over manual path reasoning.

## `tu_cli.rst` — already accurate, no fix needed
Read the whole page, live-ran every example command against current source, including two not yet covered by prior rounds: `tu test Dryad_search_datasets`, `tu run list_tools '{"mode": "categories"}'`, `tu info UniProt_get_entry_by_accession ChEMBL_get_molecule`. All correct. Notably its `tu build` description already stated both side effects fixed in #361 — this file was independently accurate before that fix even landed.

## Real bugs found and fixed (both live-verified before *and* after the fix)

**`docs/guide/python_guide.rst`:**
- Quick Start / Tool Loading Options both call `tu.load_tools(tool_type=[...])`. `tool_type` is a real parameter, but `load_tools()`'s own docstring says `"Deprecated alias for categories"` — confirmed live: it works but emits `DeprecationWarning: load_tools(tool_type=...) is deprecated; use categories= instead` on a brand-new user's very first Quick Start run. Changed both occurrences to `categories=`.
- The Literature Search example calls `PubTator_search_publications`, which **does not exist** in the registry — confirmed via a full `ToolUniverse().load_tools()` name-set lookup. Found the real tool (`PubTator3_LiteratureSearch`, same `query`/`limit` params), confirmed its exact signature, and live-ran it successfully before swapping the name in.

**`docs/guide/building_ai_scientists/claude_code.rst`** — the primary Claude Code plugin install page, linked directly from the homepage. Had the same two gaps already found and fixed elsewhere this thread, but this is an independent file that never got either fix ported to it:
1. "What you get" table missing 3 of 8 slash commands (`verify-references`, `self-review`, `setup-keys`) — same class of gap as the skill doc fixed earlier this thread.
2. Zero mention of enabling plugin auto-update (#285/#358) — added the same guidance used in the skill doc, plus a note in "Update / uninstall" that the manual step is unnecessary once it's on.

## Verified clean (not touched)
Rest of both files checked against live source before ruling them fine: `tool_specification()`'s return shape (`{name, description, parameters: {type, properties, required}}`), `list_built_in_tools(mode='config'|'type')`, the three `Tool_Finder_*` tool names and their `description`/`limit` params, the direct-import calling convention (`from tooluniverse.tools import X`), `docs/.env.template`'s existence, and the `hooks/index` doc target — all matched.

## Validation
Bare `docutils` reports false-positive "unknown directive" errors on every Sphinx-specific directive this project uses (`tab-set`, `card`, `grid`, `dropdown`, `seealso`, `button-ref`, `toctree`, the `:doc:` role) since it doesn't load Sphinx's own extensions — not a real signal. Installed the actual project doc extensions (`sphinx-design`, `sphinx-tabs`, `sphinx-copybutton`, `sphinx-reredirects`, `myst-parser`, `shibuya`) and ran a real `sphinx-build -b dummy` against the full tree: **zero warnings or errors on either edited file.** The build's ~150 pre-existing warnings are all unrelated (ghost_tool/medrxiv_tool import failures, autodoc docstring formatting across dozens of tool modules) and match already-documented known-noise from an earlier docs cleanup round — not chased here, same call as prior rounds.

## Test plan
- [x] `tu.load_tools(tool_type=[...])` reproduces the DeprecationWarning live; `categories=[...]` does not
- [x] `PubTator_search_publications` confirmed absent from the live tool registry; `PubTator3_LiteratureSearch` confirmed present with matching params and live-ran successfully
- [x] Full :doc: cross-reference resolver run across all 1,391 references in the docs tree — 0 broken, before and after this change
- [x] Real `sphinx-build -b dummy` run against the full docs tree after the edits — 0 new warnings/errors, exit 0
- [x] `git diff origin/main --stat` reviewed: exactly the 2 intended files, applied via saved patches (not a wholesale file copy)