### PR TITLE
Fix Round 75: iCite silently conflated failed PubMed/iCite requests with genuinely-zero-results

### DIFF
--- a/src/tooluniverse/icite_tool.py
+++ b/src/tooluniverse/icite_tool.py
@@ -60,8 +60,16 @@ class ICiteSearchPublicationsTool(BaseRESTTool):
             timeout=self.timeout,
             max_attempts=3,
         )
-        if resp.status_code != 200:
-            return []
+        # Fix-R75A-1: a genuine zero-hit PubMed query returns HTTP 200 with
+        # an empty idlist (confirmed live) -- a non-200 here always means
+        # the request itself failed (rate limit, outage, etc.), never
+        # "no results." The old `if status_code != 200: return []` made
+        # both cases produce the identical empty list, so run()'s "No
+        # PubMed results found for query: {query}" success message
+        # silently misreported real request failures as empty searches.
+        # Raise instead, so run()'s existing except-Exception surfaces it
+        # as an actual error.
+        resp.raise_for_status()
         data = resp.json()
         return data.get("esearchresult", {}).get("idlist", [])
 
@@ -77,8 +85,11 @@ class ICiteSearchPublicationsTool(BaseRESTTool):
             timeout=self.timeout,
             max_attempts=3,
         )
-        if resp.status_code != 200:
-            return []
+        # Fix-R75A-1: same reasoning as _search_pubmed -- a failed batch
+        # fetch previously vanished silently (extend() of an empty list),
+        # under-representing citation data for that PMID chunk with no
+        # error at all. Raise so the caller's except-Exception catches it.
+        resp.raise_for_status()
         data = resp.json()
         return data.get("data", [])
 

--- a/tests/unit/test_icite_failure_visibility.py
+++ b/tests/unit/test_icite_failure_visibility.py
@@ -1,0 +1,109 @@
+"""Regression guard for Fix-R75A-1: iCite_search_publications's PubMed
+eSearch and iCite batch-fetch helpers both returned an empty list on ANY
+non-200 response (rate limit, outage, etc.), identical to what a genuine
+zero-hit PubMed query also produces (confirmed live: PubMed eSearch returns
+HTTP 200 with an empty idlist for zero hits, never a non-200). run()'s "No
+PubMed results found for query: {query}" success message could not
+distinguish "the search genuinely found nothing" from "the request to
+PubMed/iCite failed" -- and a mid-batch iCite failure vanished silently
+(extend() of an empty list) with no error and no indication some PMIDs'
+citation data was simply dropped.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.icite_tool import ICiteSearchPublicationsTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ICiteSearchPublicationsTool({"name": "iCite_search_publications"})
+
+
+def _resp(status_code, json_body=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.raise_for_status = MagicMock()
+    if status_code >= 400:
+        r.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            f"{status_code} error"
+        )
+    if json_body is not None:
+        r.json.return_value = json_body
+    return r
+
+
+def test_genuine_zero_hit_query_reports_success_not_error():
+    tool = _tool()
+    with patch(
+        "tooluniverse.icite_tool.request_with_retry",
+        return_value=_resp(200, {"esearchresult": {"idlist": []}}),
+    ):
+        result = tool.run({"query": "zzznonexistentqueryxyz"})
+
+    assert result["status"] == "success"
+    assert result["data"] == []
+    assert "No PubMed results found" in result["message"]
+
+
+def test_pubmed_search_failure_is_surfaced_as_error_not_empty_success():
+    """The core confirmed-live bug: a failed PubMed request (rate limit,
+    outage) must not be silently indistinguishable from zero real hits."""
+    tool = _tool()
+    with patch(
+        "tooluniverse.icite_tool.request_with_retry",
+        return_value=_resp(503, None),
+    ):
+        result = tool.run({"query": "CRISPR gene editing"})
+
+    assert result["status"] == "error"
+    assert "message" not in result or "No PubMed results found" not in result.get(
+        "message", ""
+    )
+
+
+def test_icite_batch_failure_is_surfaced_not_silently_dropped():
+    """A failure fetching citation metrics for a batch of PMIDs (search
+    succeeded, enrichment failed) must not silently vanish -- previously
+    extend()'d an empty list with zero indication anything went wrong."""
+    tool = _tool()
+
+    def fake_request(session, method, url, **kwargs):
+        if "esearch" in url:
+            return _resp(200, {"esearchresult": {"idlist": ["12345", "67890"]}})
+        return _resp(500, None)
+
+    with patch(
+        "tooluniverse.icite_tool.request_with_retry", side_effect=fake_request
+    ):
+        result = tool.run({"query": "CRISPR gene editing"})
+
+    assert result["status"] == "error"
+
+
+def test_successful_search_and_fetch_returns_data():
+    tool = _tool()
+
+    def fake_request(session, method, url, **kwargs):
+        if "esearch" in url:
+            return _resp(200, {"esearchresult": {"idlist": ["12345"]}})
+        return _resp(
+            200,
+            {"data": [{"pmid": 12345, "citation_count": 42}]},
+        )
+
+    with patch(
+        "tooluniverse.icite_tool.request_with_retry", side_effect=fake_request
+    ):
+        result = tool.run({"query": "CRISPR gene editing"})
+
+    assert result.get("status") != "error"
+    assert result["data"][0]["pmid"] == 12345


### PR DESCRIPTION
## Summary

Round 75 continued the error-path/boundary-testing methodology (round 73 found and fixed a similar-shaped bug in BRENDA's SABIO-RK integration). This round specifically hunted for other instances of the same silent-degradation pattern the user flagged as worth watching for: an upstream request failure masquerading as "no data."

**`iCite_search_publications`'s PubMed eSearch and iCite batch-fetch helpers both returned an empty list on ANY non-200 response** (rate limit, outage, etc.) — structurally identical to what a genuine zero-hit PubMed query also produces. Confirmed live: PubMed eSearch returns HTTP 200 with an empty `idlist` for genuine zero hits, never a non-200 — so a non-200 response here always means the request itself failed. The old code made both cases produce the identical empty list, so `run()`'s `"No PubMed results found for query: {query}"` success message could not distinguish a real (empty) search result from a failed request.

A second, related issue: a mid-batch iCite metrics fetch failure (search succeeded, enrichment failed for one chunk of PMIDs) vanished silently — `all_pubs.extend(self._fetch_icite(chunk))` just added nothing for that chunk — under-representing citation data with zero indication anything went wrong.

Fixed both helpers to `raise_for_status()` instead of silently returning `[]`, so `run()`'s existing `except Exception` handler correctly surfaces the failure as a real error.

**Third confirmed instance of this exact shape this campaign** (SABIO-RK round 73, this one, plus a related lower-severity variant flagged in `pathwaycommons_tool.py`'s `_traverse` helper but deliberately not fixed here since it needs more schema-contract thought first) — systemic enough to warrant a dedicated codebase-wide sweep, planned for round 76.

## Verification

- Raw `curl` against PubMed eSearch with a query guaranteed to have zero real hits: `HTTP 200`, `idlist: []` — confirms a non-200 response is never a legitimate "no results" outcome for this endpoint.
- Live `tu run iCite_search_publications` with a real query returns correct results; with a genuinely nonexistent query still correctly reports `status: success, data: [], message: "No PubMed results found..."` (unaffected — this fix only changes behavior on actual request failures).
- Regression-checked all existing iCite tests (7 tests in `test_researcher_simulation_fixes.py`, all mock `status_code=200` and are unaffected by the `raise_for_status()` change since a 200 response never raises).

## Test plan

- [x] New `tests/unit/test_icite_failure_visibility.py`: 4 tests — genuine zero-hit still reports success, a failed PubMed search now surfaces as an error (not a false "no results" message), a failed iCite batch fetch now surfaces as an error (not silently dropped), successful search+fetch still returns data correctly
- [x] Existing `tests/tools/test_researcher_simulation_fixes.py` iCite tests (7 tests) — all still pass, no regressions
- [x] Full suite (`pytest tests/ --ignore=tests/test_claude_code_plugin.py`) — clean; one `test_http_api_thread_pool.py::test_environment_variable_configuration` failure during the full run was a resource-contention subprocess timeout, confirmed unrelated and non-reproducing in isolation (7.42s pass, well under its 10s timeout)