### PR TITLE
Fix 2 more shared-class default mismatches: DisGeNET, MyVariant

### DIFF
--- a/src/tooluniverse/disgenet_tool.py
+++ b/src/tooluniverse/disgenet_tool.py
@@ -123,16 +123,37 @@ class DisGeNETTool(BaseTool):
     @staticmethod
     def _apply_filters(rows: List[Dict[str, Any]], min_score, limit):
         if min_score is not None:
-            rows = [r for r in rows if (r.get("score") is not None and r["score"] >= min_score)]
+            rows = [
+                r
+                for r in rows
+                if (r.get("score") is not None and r["score"] >= min_score)
+            ]
         if limit:
             rows = rows[: int(limit)]
         return rows
+
+    def _declared_limit_default(self, fallback):
+        # _gene_disease and _disease_genes each back 2 registered tool names
+        # (e.g. DisGeNET_search_gene default=10 vs DisGeNET_get_gda
+        # default=25, both routed through _gene_disease). Read the
+        # per-instance declared default instead of hardcoding one limit for
+        # both, or the tool with the smaller declared default silently
+        # returns more rows than documented whenever `limit` is omitted.
+        return (
+            self.tool_config.get("parameter", {})
+            .get("properties", {})
+            .get("limit", {})
+            .get("default", fallback)
+        )
 
     def _err(self, e) -> Dict[str, Any]:
         if isinstance(e, requests.exceptions.HTTPError) and e.response is not None:
             code = e.response.status_code
             if code in (401, 403):
-                return {"status": "error", "error": "DisGeNET API key invalid or unauthorized for this resource (academic keys only access CURATED sources)."}
+                return {
+                    "status": "error",
+                    "error": "DisGeNET API key invalid or unauthorized for this resource (academic keys only access CURATED sources).",
+                }
             return {"status": "error", "error": f"DisGeNET HTTP error: {code}"}
         return {"status": "error", "error": f"DisGeNET request failed: {str(e)}"}
 
@@ -169,7 +190,10 @@ class DisGeNETTool(BaseTool):
         gene = (arguments.get("gene") or "").strip()
         disease = (arguments.get("disease") or "").strip()
         if not gene and not disease:
-            return {"status": "error", "error": "Provide 'gene' (symbol or NCBI id) or 'disease' (UMLS CUI)."}
+            return {
+                "status": "error",
+                "error": "Provide 'gene' (symbol or NCBI id) or 'disease' (UMLS CUI).",
+            }
 
         query: Dict[str, Any] = {}
         if gene:
@@ -180,7 +204,10 @@ class DisGeNETTool(BaseTool):
         if disease:
             code = self._normalize_disease(disease)
             if code is None:
-                return {"status": "error", "error": f"'{disease}' is not a UMLS CUI. Resolve the disease name to a CUI first (e.g. umls_search_concepts), then pass disease='C0152200'."}
+                return {
+                    "status": "error",
+                    "error": f"'{disease}' is not a UMLS CUI. Resolve the disease name to a CUI first (e.g. umls_search_concepts), then pass disease='C0152200'.",
+                }
             query["disease"] = code
         if arguments.get("source"):
             query["source"] = arguments["source"]
@@ -190,25 +217,40 @@ class DisGeNETTool(BaseTool):
         except Exception as e:  # noqa: BLE001 - never raise out of run()
             return self._err(e)
 
-        rows = self._apply_filters([self._fmt_gda(r) for r in payload],
-                                   arguments.get("min_score"),
-                                   arguments.get("limit", 25))
+        rows = self._apply_filters(
+            [self._fmt_gda(r) for r in payload],
+            arguments.get("min_score"),
+            arguments.get("limit", self._declared_limit_default(25)),
+        )
         return {
             "status": "success",
-            "data": {"gene": gene or None, "disease": disease or None,
-                     "associations": rows, "count": len(rows)},
-            "metadata": {"source": "DisGeNET GDA", "warnings": warnings,
-                         "note": "Academic keys return CURATED sources only."},
+            "data": {
+                "gene": gene or None,
+                "disease": disease or None,
+                "associations": rows,
+                "count": len(rows),
+            },
+            "metadata": {
+                "source": "DisGeNET GDA",
+                "warnings": warnings,
+                "note": "Academic keys return CURATED sources only.",
+            },
         }
 
     def _disease_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """All genes associated with a disease (UMLS CUI)."""
         disease = (arguments.get("disease") or "").strip()
         if not disease:
-            return {"status": "error", "error": "Missing required parameter: disease (UMLS CUI, e.g. C0152200)."}
+            return {
+                "status": "error",
+                "error": "Missing required parameter: disease (UMLS CUI, e.g. C0152200).",
+            }
         code = self._normalize_disease(disease)
         if code is None:
-            return {"status": "error", "error": f"'{disease}' is not a UMLS CUI. Resolve the disease name to a CUI first (e.g. umls_search_concepts), then pass disease='C0152200'."}
+            return {
+                "status": "error",
+                "error": f"'{disease}' is not a UMLS CUI. Resolve the disease name to a CUI first (e.g. umls_search_concepts), then pass disease='C0152200'.",
+            }
 
         query: Dict[str, Any] = {"disease": code}
         if arguments.get("source"):
@@ -223,15 +265,32 @@ class DisGeNETTool(BaseTool):
             sym = row.get("symbolOfGene")
             if sym and sym not in seen:
                 seen.add(sym)
-                genes.append({"symbol": sym, "ncbi_id": row.get("geneNcbiID"),
-                              "score": row.get("score"), "n_pmids": row.get("numPMIDs")})
-        genes = self._apply_filters(genes, arguments.get("min_score"), arguments.get("limit", 50))
+                genes.append(
+                    {
+                        "symbol": sym,
+                        "ncbi_id": row.get("geneNcbiID"),
+                        "score": row.get("score"),
+                        "n_pmids": row.get("numPMIDs"),
+                    }
+                )
+        genes = self._apply_filters(
+            genes,
+            arguments.get("min_score"),
+            arguments.get("limit", self._declared_limit_default(50)),
+        )
         return {
             "status": "success",
-            "data": {"disease": disease, "disease_code": code,
-                     "genes": genes, "gene_count": len(genes)},
-            "metadata": {"source": "DisGeNET", "warnings": warnings,
-                         "note": "Academic keys return CURATED sources only."},
+            "data": {
+                "disease": disease,
+                "disease_code": code,
+                "genes": genes,
+                "gene_count": len(genes),
+            },
+            "metadata": {
+                "source": "DisGeNET",
+                "warnings": warnings,
+                "note": "Academic keys return CURATED sources only.",
+            },
         }
 
     def _variant_disease(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
@@ -239,7 +298,10 @@ class DisGeNETTool(BaseTool):
         variant = (arguments.get("variant") or "").strip()
         gene = (arguments.get("gene") or "").strip()
         if not variant and not gene:
-            return {"status": "error", "error": "Provide 'variant' (rsID) or 'gene' (symbol)."}
+            return {
+                "status": "error",
+                "error": "Provide 'variant' (rsID) or 'gene' (symbol).",
+            }
         query: Dict[str, Any] = {}
         if variant:
             query["variant"] = variant
@@ -249,13 +311,22 @@ class DisGeNETTool(BaseTool):
             payload, warnings = self._query_summary("vda", query)
         except Exception as e:  # noqa: BLE001
             return self._err(e)
-        rows = self._apply_filters([self._fmt_vda(r) for r in payload],
-                                   arguments.get("min_score"),
-                                   arguments.get("limit", 25))
+        rows = self._apply_filters(
+            [self._fmt_vda(r) for r in payload],
+            arguments.get("min_score"),
+            arguments.get("limit", 25),
+        )
         return {
             "status": "success",
-            "data": {"variant": variant or None, "gene": gene or None,
-                     "associations": rows, "count": len(rows)},
-            "metadata": {"source": "DisGeNET VDA", "warnings": warnings,
-                         "note": "Academic keys return CURATED sources only."},
+            "data": {
+                "variant": variant or None,
+                "gene": gene or None,
+                "associations": rows,
+                "count": len(rows),
+            },
+            "metadata": {
+                "source": "DisGeNET VDA",
+                "warnings": warnings,
+                "note": "Academic keys return CURATED sources only.",
+            },
         }

--- a/src/tooluniverse/mygene_tool.py
+++ b/src/tooluniverse/mygene_tool.py
@@ -213,7 +213,21 @@ class MyVariantTool(BaseTool):
         Endpoint: GET /variant/<hgvsid>
         """
         variant_id = arguments.get("variant_id", "")
-        fields = arguments.get("fields", "dbsnp,clinvar,cadd,gnomad_genome,dbnsfp")
+        # This handler backs both MyVariant_get_variant_annotation and
+        # MyVariant_get_pathogenicity_scores (both operation="get_variant").
+        # Read the per-instance declared default instead of hardcoding the
+        # generic annotation field list for both, or
+        # MyVariant_get_pathogenicity_scores (whose schema declares a
+        # curated list of dbnsfp pathogenicity-prediction fields) silently
+        # returns generic annotation data instead whenever `fields` is
+        # omitted.
+        declared_default = (
+            self.tool_config.get("parameter", {})
+            .get("properties", {})
+            .get("fields", {})
+            .get("default", "dbsnp,clinvar,cadd,gnomad_genome,dbnsfp")
+        )
+        fields = arguments.get("fields", declared_default)
 
         if not variant_id:
             return {


### PR DESCRIPTION
## Summary

Dedicated pass over the "shared tool class hardcodes one default for multiple registered tool names" bug class (previously confirmed 3x: TCDB #363, BioRxiv/OpenAIRE #366).

- **DisGeNETTool**: `run()` dispatches by `operation` to `_gene_disease` (backs both `DisGeNET_search_gene` and `DisGeNET_get_gda`) and `_disease_genes` (backs both `DisGeNET_search_disease` and `DisGeNET_get_disease_genes`). Each handler hardcoded a single `limit` fallback matching only one of its two tools:
  - `DisGeNET_search_gene` (declared default **10**) silently returned up to **25** results when `limit` was omitted.
  - `DisGeNET_search_disease` (declared default **10**) silently returned up to **50**.
- **MyVariantTool**: `_get_variant` backs both `MyVariant_get_variant_annotation` and `MyVariant_get_pathogenicity_scores` (both `operation="get_variant"`), but hardcoded the generic annotation field list. `MyVariant_get_pathogenicity_scores` declares a curated list of dbnsfp pathogenicity-prediction fields (REVEL, AlphaMissense, SIFT, PolyPhen2, MetaRNN, GERP, phyloP, phastCons, VEST4, MutationTaster, ...) that was never actually sent to the API when `fields` was omitted — callers silently got generic annotation data instead of the promised pathogenicity scores, with `status: success` and no signal anything was off.

Both follow the established fix: read the per-instance declared default from `self.tool_config` at runtime instead of hardcoding one literal for a handler shared by multiple registered tool names.

## Other candidates checked and ruled out (false positives)

From a "Signal A" sweep (sibling tool instances of the same class disagreeing on a declared default for the same param), 13 candidates were flagged; 11 were individually verified as false positives after reading the actual dispatch path:

- **ChEMBL, CIViC** — already known false positives from #366 (regex misattributed a literal from a different tool_name branch / an internal pre-filter cap).
- **EpiGraphDB** — the literal-extraction regex can't parse scientific notation (`1e-8`, `1e-5`, `1e-4`); all 4 `pval_threshold` defaults actually match their tool's own function-scoped literal.
- **Ensembl `species`** — a generic "step 0" in `run()` injects each tool's own declared schema default for any missing URL path parameter before any special-case branch executes; the flagged hardcoded `"homo_sapiens"` literal is scoped to an unrelated gene-symbol-lookup branch. Live-tested that Ensembl's REST API accepts `"human"` (each flagged tool's declared default) as well as `"homo_sapiens"`.
- **MedlinePlus** — same generic declared-default-injection pattern (`for key, prop in self.param_schema.items(): if key not in arguments and "default" in prop: arguments[key] = prop["default"]`).
- **IntAct** — its per-tool-name hardcoded size table (`tool_query_config`) already matches each tool's declared JSON default exactly.
- **XMLTool / DatasetTool** (drugbank search/filter tools) — the mismatched literal is dead code: `limit` is a `required` parameter for all of them, so `validate_parameters` rejects any call omitting it before `run()` is ever reached. (The declared "default" in the schema is decorative/unreachable — a separate, lower-severity doc nit, not a silent-wrong-data bug.)

## Test plan

- [x] Mocked-network unit test comparing declared vs. actual result count for all 5 DisGeNET tools, before and after the fix (both flagged tools now return exactly their declared default; the other 3 were already correct).
- [x] Mocked `requests.get` comparing the `fields` param actually sent for both MyVariant tools, before and after the fix.
- [x] `ToolUniverse().load_tools()` still loads all 2679 tools cleanly (no registration/schema regressions).