### PR TITLE
Fix Round 76: dedicated sweep for non-200-silently-swallowed-into-empty-success (Orphanet + AlphaMissense)

### DIFF
--- a/src/tooluniverse/alphamissense_tool.py
+++ b/src/tooluniverse/alphamissense_tool.py
@@ -89,19 +89,33 @@ class AlphaMissenseTool(BaseTool):
 
     def _fetch_single_residue(
         self, uniprot_id: str, position: int
-    ) -> Optional[Dict[str, Any]]:
-        """Fetch one residue's AlphaMissense scores; returns None on error."""
+    ) -> "tuple[Optional[Dict[str, Any]], bool]":
+        """Fetch one residue's AlphaMissense scores.
+
+        Fix-R76A-2: returns (data, failed) rather than just data. Confirmed
+        live the API 404s with a clear "no data for this residue" message
+        for a position outside its actual coverage (e.g. resi=99999 on a
+        real protein) -- that's a legitimate empty result, not a failure.
+        Only a non-404 non-200 status or a request exception is a genuine
+        failure. The caller previously dropped ALL non-200 positions from
+        the output identically (`if s is not None`), so a batch of
+        genuinely-failed positions (rate limit, timeout) vanished from the
+        response with zero indication anything went wrong, indistinguishable
+        from AlphaMissense simply not covering those residues.
+        """
         try:
             r = requests.get(
                 f"{ALPHAMISSENSE_BASE_URL}/hotspotapi",
                 params={"uid": uniprot_id, "resi": position},
                 timeout=self.timeout,
             )
+            if r.status_code == 404:
+                return None, False
             if r.status_code != 200:
-                return None
-            return r.json()
+                return None, True
+            return r.json(), False
         except requests.exceptions.RequestException:
-            return None
+            return None, True
 
     def _get_protein_scores(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -144,6 +158,7 @@ class AlphaMissenseTool(BaseTool):
 
         # 2. Concurrent per-residue fetch
         scores: List[Optional[Dict[str, Any]]] = [None] * len(positions)
+        failed: List[bool] = [False] * len(positions)
         with ThreadPoolExecutor(max_workers=20) as executor:
             future_to_idx = {
                 executor.submit(self._fetch_single_residue, uniprot_id, p): i
@@ -152,13 +167,29 @@ class AlphaMissenseTool(BaseTool):
             for fut in as_completed(future_to_idx):
                 idx = future_to_idx[fut]
                 try:
-                    scores[idx] = fut.result()
+                    scores[idx], failed[idx] = fut.result()
                 except Exception:
-                    scores[idx] = None
+                    scores[idx], failed[idx] = None, True
 
         n_fetched = sum(1 for s in scores if s is not None)
+        n_failed = sum(failed)
         if n_fetched == 0:
             pdb_url = f"{ALPHAMISSENSE_BASE_URL}/pdb/AF-{uniprot_id}-F1-AM_v4.pdb"
+            # Fix-R76A-2: distinguish "every position genuinely has no
+            # AlphaMissense data" (all 404s) from "every request failed"
+            # (rate limit/timeout/5xx) -- confirmed live 404 means "no data
+            # for this residue," a non-404 non-200 or a raised exception
+            # means the request itself failed.
+            if n_failed == len(positions):
+                return {
+                    "status": "error",
+                    "error": (
+                        f"Could not fetch AlphaMissense data for '{uniprot_id}' "
+                        f"-- all {len(positions)} position requests failed "
+                        "(rate limit, timeout, or upstream error). This is not "
+                        "necessarily 'no data', just a failed lookup; retry later."
+                    ),
+                }
             return {
                 "status": "error",
                 "error": (
@@ -169,14 +200,16 @@ class AlphaMissenseTool(BaseTool):
                 "pdb_download": pdb_url,
             }
 
-        # 3. Aggregate into per-position list (drop Nones from failed positions)
+        # 3. Aggregate into per-position list (drop positions with no data,
+        # whether genuinely absent or failed to fetch -- n_positions_failed
+        # below is what makes the difference honest instead of silent).
         per_position = [
             {"position": p, **(s or {})}
             for p, s in zip(positions, scores)
             if s is not None
         ]
 
-        return {
+        result: Dict[str, Any] = {
             "status": "success",
             "data": {
                 "uniprot_id": uniprot_id,
@@ -193,6 +226,18 @@ class AlphaMissenseTool(BaseTool):
                 "pdb_download": f"{ALPHAMISSENSE_BASE_URL}/pdb/AF-{uniprot_id}-F1-AM_v4.pdb",
             },
         }
+        if n_failed:
+            # Fix-R76A-2: previously these positions vanished from the
+            # response with zero indication anything failed, indistinguishable
+            # from AlphaMissense simply not covering them.
+            result["data"]["n_positions_failed"] = n_failed
+            result["data"]["note"] = (
+                f"{n_failed} of {len(positions)} position requests failed "
+                "(rate limit, timeout, or upstream error) and are missing "
+                "from scores, not necessarily because AlphaMissense lacks "
+                "data for them. Retry to attempt to fill in the gaps."
+            )
+        return result
 
     def _get_variant_score(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/src/tooluniverse/orphanet_tool.py
+++ b/src/tooluniverse/orphanet_tool.py
@@ -325,45 +325,76 @@ class OrphanetTool(BaseTool):
             )
         return genes
 
-    def _fetch_genes_for_code(self, orpha_code, headers) -> List[Dict]:
-        """Fetch gene associations for a single ORPHA code. Returns [] on failure."""
+    def _fetch_genes_for_code(self, orpha_code, headers) -> "tuple[List[Dict], bool]":
+        """Fetch gene associations for a single ORPHA code.
+
+        Fix-R76A-1: returns (genes, failed) rather than just genes -- the
+        caller's subtype-fallback search is deliberately triggered on an
+        empty result regardless of cause (a parent ORPHA code often
+        genuinely has zero direct gene entries by design, and retrying via
+        a different endpoint is worth attempting even after a transient
+        failure), so this still swallows the exception to keep that
+        resilience behavior. But confirmed live this previously let a
+        real API failure (rate limit, 5xx, timeout) end up reported as
+        unconditional "status": "success" with "genes": [] -- clinically
+        indistinguishable from "Orphadata has no gene curation for this
+        disease." The caller uses `failed` to make that distinction
+        honest in the final response instead of silently equating the two.
+        """
         try:
             response = requests.get(
                 f"{ORPHADATA_API_URL}/rd-associated-genes/orphacodes/{orpha_code}",
                 timeout=self.timeout,
                 headers=headers,
             )
+            if response.status_code == 404:
+                # Pre-existing, deliberate behavior (see
+                # test_valid_code_with_no_data_still_returns_success_empty):
+                # this endpoint 404s for a valid disease that simply has no
+                # gene curation records -- confirmed empty, not a failure.
+                return [], False
             if response.status_code != 200:
-                return []
+                return [], True
             results = response.json().get("data", {}).get("results", {})
-            return self._extract_genes_from_associations(
-                results.get("DisorderGeneAssociation", [])
+            return (
+                self._extract_genes_from_associations(
+                    results.get("DisorderGeneAssociation", [])
+                ),
+                False,
             )
         except Exception:
-            return []
+            return [], True
 
     def _find_subtype_codes(
         self, disease_name: str, exclude_code: str, headers
-    ) -> List[Dict]:
-        """Find orphacodes whose name contains disease_name, excluding exclude_code."""
+    ) -> "tuple[List[Dict], bool]":
+        """Find orphacodes whose name contains disease_name, excluding
+        exclude_code. Returns (codes, failed) -- see _fetch_genes_for_code."""
         try:
             response = requests.get(
                 f"{ORPHADATA_API_URL}/rd-associated-genes/orphacodes",
                 timeout=self.timeout,
                 headers=headers,
             )
+            if response.status_code == 404:
+                # Same precedent as _fetch_genes_for_code: this API 404s
+                # for "no records", not just for genuinely missing routes.
+                return [], False
             if response.status_code != 200:
-                return []
+                return [], True
             all_entries = response.json().get("data", {}).get("results", [])
             disease_lower = disease_name.lower()
-            return [
-                entry
-                for entry in all_entries
-                if disease_lower in entry.get("Preferred term", "").lower()
-                and str(entry.get("ORPHAcode", "")) != str(exclude_code)
-            ]
+            return (
+                [
+                    entry
+                    for entry in all_entries
+                    if disease_lower in entry.get("Preferred term", "").lower()
+                    and str(entry.get("ORPHAcode", "")) != str(exclude_code)
+                ],
+                False,
+            )
         except Exception:
-            return []
+            return [], True
 
     def _get_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -426,21 +457,27 @@ class OrphanetTool(BaseTool):
             }
 
             # Strategy 1: Direct orphacode lookup via Orphadata
-            genes = self._fetch_genes_for_code(orpha_code, orphadata_headers)
+            genes, any_fetch_failed = self._fetch_genes_for_code(
+                orpha_code, orphadata_headers
+            )
 
             # Strategy 2: If no genes found and we have a disease name, search
             # for subtypes in the Orphadata orphacodes list (parent codes like
             # "Marfan syndrome" 558 lack direct gene entries, but subtypes like
-            # "Marfan syndrome type 1" 284963 have them)
+            # "Marfan syndrome type 1" 284963 have them). Attempted regardless
+            # of *why* strategy 1 came up empty (genuine absence or a failed
+            # request) -- it's a different endpoint and may succeed either way.
             if not genes and disease_name:
-                matching_codes = self._find_subtype_codes(
+                matching_codes, subtype_search_failed = self._find_subtype_codes(
                     disease_name, orpha_code, orphadata_headers
                 )
+                any_fetch_failed = any_fetch_failed or subtype_search_failed
                 existing_symbols = set()
                 for entry in matching_codes[:5]:
-                    sub_genes = self._fetch_genes_for_code(
+                    sub_genes, sub_failed = self._fetch_genes_for_code(
                         entry.get("ORPHAcode"), orphadata_headers
                     )
+                    any_fetch_failed = any_fetch_failed or sub_failed
                     if not sub_genes:
                         continue
                     subtype_sources.append(
@@ -453,6 +490,24 @@ class OrphanetTool(BaseTool):
                         if g["Symbol"] not in existing_symbols:
                             genes.append(g)
                             existing_symbols.add(g["Symbol"])
+
+            # Fix-R76A-1: an empty `genes` list must not be reported as an
+            # unqualified success when it's actually because one or more
+            # Orphadata requests failed (rate limit, 5xx, timeout) -- that's
+            # clinically indistinguishable from "Orphadata has no gene
+            # curation for this disease" otherwise. Only genuinely-confirmed
+            # empty (every fetch succeeded, all returned zero genes) is a
+            # clean success.
+            if not genes and any_fetch_failed:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"Could not confirm gene associations for ORPHA:{orpha_code} "
+                        "-- one or more Orphadata requests failed. This is not "
+                        "necessarily 'no genes known', just an incomplete lookup; "
+                        "retry later."
+                    ),
+                }
 
             result_data = {
                 "orpha_code": orpha_code,

--- a/tests/unit/test_alphamissense_failure_visibility.py
+++ b/tests/unit/test_alphamissense_failure_visibility.py
@@ -1,0 +1,167 @@
+"""Regression guard for Fix-R76A-2: AlphaMissense_get_protein_scores's
+per-residue fetch helper (_fetch_single_residue) treated every non-200
+response identically, dropping the position from the output with zero
+indication of what happened. Confirmed live: the API 404s with a clear
+"no data for this residue" message for a position outside its real coverage
+(e.g. resi=99999 on a real protein) -- a legitimate empty result, not a
+failure -- while a genuine request failure (rate limit, timeout, 5xx) is a
+different thing entirely. Also confirmed live during this fix's own testing:
+1 of 20 real requests for a real protein failed, and previously would have
+silently vanished from the response with no trace.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.alphamissense_tool import AlphaMissenseTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return AlphaMissenseTool({"name": "AlphaMissense_get_protein_scores"})
+
+
+def _fasta_resp(length=5):
+    r = MagicMock()
+    r.status_code = 200
+    r.text = ">sp|TEST|TEST\n" + "A" * length
+    return r
+
+
+def _score_resp(status_code, body=None):
+    r = MagicMock()
+    r.status_code = status_code
+    if body is not None:
+        r.json.return_value = body
+    return r
+
+
+def test_fetch_single_residue_404_is_not_marked_failed():
+    """A 404 means "AlphaMissense has no data for this residue" -- a
+    legitimate empty result, confirmed live, not a failure."""
+    tool = _tool()
+    with patch(
+        "tooluniverse.alphamissense_tool.requests.get",
+        return_value=_score_resp(404),
+    ):
+        data, failed = tool._fetch_single_residue("P05067", 99999)
+
+    assert data is None
+    assert failed is False
+
+
+def test_fetch_single_residue_500_is_marked_failed():
+    tool = _tool()
+    with patch(
+        "tooluniverse.alphamissense_tool.requests.get",
+        return_value=_score_resp(500),
+    ):
+        data, failed = tool._fetch_single_residue("P05067", 100)
+
+    assert data is None
+    assert failed is True
+
+
+def test_fetch_single_residue_request_exception_is_marked_failed():
+    tool = _tool()
+    with patch(
+        "tooluniverse.alphamissense_tool.requests.get",
+        side_effect=requests.exceptions.Timeout("timed out"),
+    ):
+        data, failed = tool._fetch_single_residue("P05067", 100)
+
+    assert data is None
+    assert failed is True
+
+
+def test_partial_failure_is_surfaced_not_silently_dropped():
+    """The core confirmed-live bug: some positions failing (not 404 -- a
+    real request failure) must not silently vanish from the response."""
+    tool = _tool()
+
+    def fake_get(url, params=None, timeout=None):
+        if "uniprot.org" in url or "fasta" in url.lower():
+            return _fasta_resp(length=3)
+        resi = params.get("resi") if params else None
+        if resi == 2:
+            return _score_resp(500)
+        return _score_resp(200, {"uid": "TEST", "resi": resi, "mean_all": 0.1})
+
+    with patch.object(tool, "_fetch_protein_length", return_value=3), patch(
+        "tooluniverse.alphamissense_tool.requests.get", side_effect=fake_get
+    ):
+        result = tool.run({"uniprot_id": "TEST"})
+
+    assert result["status"] == "success"
+    assert result["data"]["n_positions_failed"] == 1
+    assert "note" in result["data"]
+    assert len(result["data"]["scores"]) == 2
+
+
+def test_all_positions_genuinely_no_data_reports_database_absence():
+    """All-404 (genuinely no AlphaMissense coverage) keeps the existing,
+    correct "may not be in the database" message -- not the new
+    all-requests-failed message."""
+    tool = _tool()
+
+    def fake_get(url, params=None, timeout=None):
+        if "resi" not in (params or {}):
+            return _fasta_resp(length=2)
+        return _score_resp(404)
+
+    with patch.object(tool, "_fetch_protein_length", return_value=2), patch(
+        "tooluniverse.alphamissense_tool.requests.get", side_effect=fake_get
+    ):
+        result = tool.run({"uniprot_id": "TEST"})
+
+    assert result["status"] == "error"
+    assert "may not be in the AlphaMissense database" in result["error"]
+
+
+def test_all_positions_genuinely_failed_reports_failure_not_absence():
+    """All-500 (every request genuinely failed) must not use the same
+    "may not be in the database" message as all-404 -- that's misleading
+    when the real cause is a request failure, not missing coverage."""
+    tool = _tool()
+
+    def fake_get(url, params=None, timeout=None):
+        if "resi" not in (params or {}):
+            return _fasta_resp(length=2)
+        return _score_resp(503)
+
+    with patch.object(tool, "_fetch_protein_length", return_value=2), patch(
+        "tooluniverse.alphamissense_tool.requests.get", side_effect=fake_get
+    ):
+        result = tool.run({"uniprot_id": "TEST"})
+
+    assert result["status"] == "error"
+    assert "may not be in the AlphaMissense database" not in result["error"]
+    assert "failed" in result["error"].lower()
+
+
+def test_no_failures_omits_failure_fields():
+    """Backward compatibility: when nothing fails, the response must not
+    gain the new n_positions_failed/note keys."""
+    tool = _tool()
+
+    def fake_get(url, params=None, timeout=None):
+        if "resi" not in (params or {}):
+            return _fasta_resp(length=2)
+        resi = params.get("resi")
+        return _score_resp(200, {"uid": "TEST", "resi": resi, "mean_all": 0.1})
+
+    with patch.object(tool, "_fetch_protein_length", return_value=2), patch(
+        "tooluniverse.alphamissense_tool.requests.get", side_effect=fake_get
+    ):
+        result = tool.run({"uniprot_id": "TEST"})
+
+    assert result["status"] == "success"
+    assert "n_positions_failed" not in result["data"]
+    assert "note" not in result["data"]

--- a/tests/unit/test_orphanet_gene_fetch_failure_visibility.py
+++ b/tests/unit/test_orphanet_gene_fetch_failure_visibility.py
@@ -1,0 +1,131 @@
+"""Regression guard for Fix-R76A-1: Orphanet_get_genes's internal helpers
+(_fetch_genes_for_code, _find_subtype_codes) swallowed ALL request failures
+(non-200, exceptions) into an empty list, identical in shape to a genuine
+"this disease has no known gene associations" result. Confirmed via code
+reading and live testing: the caller then unconditionally reported
+"status": "success" with "genes": [] regardless of whether Orphadata
+genuinely had no data or the request itself failed (rate limit, 5xx,
+timeout) -- clinically indistinguishable outcomes for a rare-disease
+gene-association lookup tool. Fixed by threading a (result, failed) tuple
+through both helpers so the caller can tell the difference, while
+preserving the existing subtype-fallback resilience behavior (still
+attempted regardless of *why* the primary lookup came up empty).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.orphanet_tool import OrphanetTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return OrphanetTool({"name": "Orphanet_get_genes"})
+
+
+def _name_resp(disease_name="Test Disease"):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = {"Preferred term": disease_name}
+    return r
+
+
+def _genes_resp(status_code, associations=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = {
+        "data": {"results": {"DisorderGeneAssociation": associations or []}}
+    }
+    return r
+
+
+def _route(name_response, genes_response):
+    def fake_get(url, timeout=None, headers=None):
+        if "ClinicalEntity" in url:
+            return name_response
+        return genes_response
+
+    return fake_get
+
+
+def test_genuinely_no_genes_reports_success():
+    """A confirmed-empty result (200, zero associations, no disease name to
+    even try the subtype fallback with) must stay a clean success."""
+    tool = _tool()
+    with patch(
+        "tooluniverse.orphanet_tool.requests.get",
+        side_effect=_route(_name_resp(""), _genes_resp(200, [])),
+    ):
+        result = tool.run({"operation": "get_genes", "orpha_code": "999999"})
+
+    assert result["status"] == "success"
+    assert result["data"]["genes"] == []
+
+
+def test_failed_gene_fetch_is_not_reported_as_confirmed_empty():
+    """The core confirmed bug: a request failure (503) must not produce
+    the same "status": "success", "genes": [] shape as a genuine empty
+    result -- that's clinically misleading for a gene-association lookup."""
+    tool = _tool()
+    with patch(
+        "tooluniverse.orphanet_tool.requests.get",
+        side_effect=_route(_name_resp(""), _genes_resp(503)),
+    ):
+        result = tool.run({"operation": "get_genes", "orpha_code": "558"})
+
+    assert result["status"] == "error"
+
+
+def test_successful_direct_lookup_unaffected():
+    tool = _tool()
+    associations = [
+        {
+            "DisorderGeneAssociationType": {"name": "Disease-causing"},
+            "Gene": {
+                "Symbol": "FBN1",
+                "Name": "fibrillin 1",
+                "GeneType": {"name": "gene with protein product"},
+                "LocusList": {"Locus": []},
+            },
+            "SourceOfValidation": None,
+        }
+    ]
+    with patch(
+        "tooluniverse.orphanet_tool.requests.get",
+        side_effect=_route(_name_resp("Marfan syndrome"), _genes_resp(200, associations)),
+    ):
+        result = tool.run({"operation": "get_genes", "orpha_code": "284963"})
+
+    assert result["status"] == "success"
+    assert len(result["data"]["genes"]) == 1
+    assert result["data"]["genes"][0]["Symbol"] == "FBN1"
+
+
+def test_fetch_genes_for_code_returns_failed_flag():
+    tool = _tool()
+    with patch(
+        "tooluniverse.orphanet_tool.requests.get",
+        return_value=_genes_resp(500),
+    ):
+        genes, failed = tool._fetch_genes_for_code("558", {})
+
+    assert genes == []
+    assert failed is True
+
+
+def test_fetch_genes_for_code_confirmed_empty_not_marked_failed():
+    tool = _tool()
+    with patch(
+        "tooluniverse.orphanet_tool.requests.get",
+        return_value=_genes_resp(200, []),
+    ):
+        genes, failed = tool._fetch_genes_for_code("558", {})
+
+    assert genes == []
+    assert failed is False


### PR DESCRIPTION
## Summary

Per the user's explicit direction, this round was a dedicated codebase-wide grep sweep for the exact signature confirmed twice already (round 73's SABIO-RK fix, round 75's iCite fix): a request-failure helper returning `[]`/`{}`/`None` on any non-200 status or parse failure, without raising or setting `status: error` — indistinguishable from a genuinely empty/absent result.

Grepped for `status_code != 200` (and related failure checks) across `src/tooluniverse/*.py`, filtered out the many already-correct `{"status": "error", ...}` returns, and triaged the remainder by checking each candidate's caller to see whether the failure signal actually reaches the top-level response. Found and fixed two real instances:

**`Orphanet_get_genes`'s `_fetch_genes_for_code`/`_find_subtype_codes`** swallowed every non-200/exception into an empty list, so a failed Orphadata request (rate limit, 5xx, timeout) was reported identically to "this disease genuinely has no known gene associations." Fixed by threading a `(result, failed)` tuple through both helpers so the caller can tell the difference — while carefully preserving the pre-existing, **deliberate** behavior that a 404 from this specific endpoint means confirmed-no-records, not a failure (an existing test, `test_valid_code_with_no_data_still_returns_success_empty`, already required this; an early version of this fix broke it and had to be corrected before shipping — this distinction between real failure and real emptiness is the crux of the whole bug class, and it's just as important not to overcorrect into treating every empty/404 as a failure).

**`AlphaMissense_get_protein_scores`'s per-residue fetch helper (`_fetch_single_residue`)** treated every non-200 response identically, dropping the position from the output with zero indication anything failed — indistinguishable from AlphaMissense simply not covering that residue. Confirmed live that a 404 here means "no data for this residue" (a real, legitimate empty result, e.g. an out-of-range position), while other non-200s or request exceptions are genuine failures. Same fix shape: distinguish confirmed-empty from failure, and surface an honest `n_positions_failed`/`note` when failures occur instead of silently vanishing them. Live-verified during this fix's own testing that 1 of 20 real position requests genuinely failed and is now correctly surfaced instead of silently dropped.

**Recurring meta-pattern, now confirmed a 3rd time**: in each of these files, a *sibling* function already handled this correctly (`sabiork_tool.py`'s already-migrated `SABIORKTool` vs `brenda_tool.py`'s stale copy; `orphanet_tool.py`'s `_get_gene_validity`-style "get" operations vs the "search"-style helpers; `alphamissense_tool.py`'s `_get_residue_scores` vs the `_fetch_single_residue` helper used by `get_protein_scores`). Worth grepping for "the same operation implemented twice in one file, compare their error handling" as a search heuristic in future sweeps.

**Not included**: `pathwaycommons_tool.py`'s `_traverse` helper, a related but lower-severity variant (secondary fields conflate a failed fetch with genuinely-empty via `x or []` fallbacks) flagged in round 75 — deferred, needs more schema-contract thought before fixing.

## Verification

- Orphanet: live `tu run Orphanet_get_genes '{"orpha_code": "558"}'` (Marfan syndrome, a known parent-code case requiring the subtype-fallback search) still works correctly end-to-end after the fix. Confirmed the 404-preserving behavior via the existing test suite, which caught my initial fix attempt breaking it.
- AlphaMissense: raw `curl` against the live API confirms 404 with a clear "no data for this residue" message for an out-of-range position (`resi=99999`), vs. a real score for a valid position — confirming 404 is the correct "confirmed empty" signal to preserve. Live `tu run AlphaMissense_get_protein_scores` during testing surfaced a real `n_positions_failed: 1` for a genuine live failure.

## Test plan

- [x] New `tests/unit/test_orphanet_gene_fetch_failure_visibility.py`: 5 tests — genuine empty stays success, a genuine request failure is now an error (not confirmed-empty), successful lookup unaffected, and the helper-level `(genes, failed)` tuple behaves correctly for both cases
- [x] New `tests/unit/test_alphamissense_failure_visibility.py`: 7 tests — 404 not marked failed, 500/timeout marked failed, partial failure surfaced (not silently dropped), all-genuinely-empty vs all-genuinely-failed produce distinct error messages, and no failure fields when nothing fails (backward compatibility)
- [x] All existing Orphanet tests (32 total across `test_orphanet_invalid_code_validation.py`, `test_orphanet_classification_hierarchy.py`, `test_orphanet_gene_name_slash_encoding.py`, `tests/tools/test_orphanet_tool.py`) — pass, no regressions (this is what caught and forced the correction of my initial overcorrection)
- [x] All existing AlphaMissense tests (14 total, live integration) — pass, no regressions
- [x] Full suite (`pytest tests/ --ignore=tests/test_claude_code_plugin.py`) — clean, 0 failures