### PR TITLE
Fix 22-tool shared-class default mismatch: XMLTool, DatasetTool drugbank search/filter

### DIFF
--- a/src/tooluniverse/dataset_tool.py
+++ b/src/tooluniverse/dataset_tool.py
@@ -131,7 +131,14 @@ class DatasetTool(BaseTool):
         search_fields = arguments.get("search_fields")
         case_sensitive = arguments.get("case_sensitive", False)
         exact_match = arguments.get("exact_match", False)
-        limit = arguments.get("limit", 50)
+        # _drugbank_search backs multiple registered tool names with
+        # different declared `limit` defaults (e.g. diqt_search default 100
+        # vs drugbank_full_search/dict_search/etc default 10). Read the
+        # per-instance declared default instead of hardcoding one limit for
+        # every tool routed through this handler.
+        limit = arguments.get(
+            "limit", self.parameters.get("limit", {}).get("default", 50)
+        )
 
         if not query:
             return {
@@ -260,7 +267,11 @@ class DatasetTool(BaseTool):
         field = arguments.get("field")
         condition = arguments.get("condition")
         value = arguments.get("value", "")
-        limit = arguments.get("limit", 100)
+        # _drugbank_filter backs multiple registered tool names too; read
+        # the per-instance declared default rather than hardcoding one.
+        limit = arguments.get(
+            "limit", self.parameters.get("limit", {}).get("default", 100)
+        )
 
         if not field or not condition:
             return {

--- a/src/tooluniverse/xml_tool.py
+++ b/src/tooluniverse/xml_tool.py
@@ -156,6 +156,22 @@ class XMLDatasetTool(BaseTool):
             ]
         return self._record_cache
 
+    def _declared_limit_default(self, fallback):
+        # _search and _filter each back multiple registered tool names with
+        # different declared `limit` defaults (e.g. mesh_* tools default 50,
+        # drugbank_*_search-style tools default 10, sharing _search; only
+        # drugbank_filter_drugs_by_name uses _filter, default 10 vs the
+        # hardcoded 100). Read the per-instance declared default instead of
+        # hardcoding one limit for every tool routed through the same
+        # handler, or tools with a smaller declared default silently return
+        # more rows than documented whenever `limit` is omitted.
+        return (
+            self.tool_config.get("parameter", {})
+            .get("properties", {})
+            .get("limit", {})
+            .get("default", fallback)
+        )
+
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Main entry point for the tool."""
         if not self.records:
@@ -184,7 +200,9 @@ class XMLDatasetTool(BaseTool):
         # Parse search parameters with sensible defaults
         case_sensitive = arguments.get("case_sensitive", False)
         exact_match = arguments.get("exact_match", False)
-        limit = min(arguments.get("limit", 50), 1000)  # Cap at 1000
+        limit = min(
+            arguments.get("limit", self._declared_limit_default(50)), 1000
+        )  # Cap at 1000
 
         search_query = query if case_sensitive else query.lower()
         results = []
@@ -271,7 +289,9 @@ class XMLDatasetTool(BaseTool):
         field = self.filter_field
         condition = arguments.get("condition")
         value = arguments.get("value", "")
-        limit = min(arguments.get("limit", 100), 1000)  # Cap at 1000
+        limit = min(
+            arguments.get("limit", self._declared_limit_default(100)), 1000
+        )  # Cap at 1000
 
         if not field or not condition:
             return {


### PR DESCRIPTION
## Summary

`XMLTool._search`/`_filter` and `DatasetTool._drugbank_search`/`_drugbank_filter` each back many registered tool names sharing one hardcoded `limit` fallback per handler, but the tools declare different per-instance defaults:

- `XMLTool._search` (hardcoded fallback 50) backs 4 `mesh_*` tools (declared default 50, correct) **and** 14 `drugbank_*_search`-style tools (declared default 10) — the drugbank tools silently returned up to 50 results instead of the documented 10 whenever `limit` was omitted.
- `XMLTool._filter` (hardcoded fallback 100) backs `drugbank_filter_drugs_by_name` (declared default 10) — silently returned up to 100 instead of 10.
- `DatasetTool._drugbank_search` (hardcoded fallback 50) backs 6 tools: 5 declare default 10 (silently got up to 50) and `diqt_search` declares default 100 (silently got at most 50 — fewer than documented).
- `DatasetTool._drugbank_filter` (hardcoded fallback 100) backs `drugbank_vocab_filter` (declared default 10) — silently returned up to 100 instead of 10.

**22 tools total.** Fixed with the established pattern: read the per-instance declared default from `self.tool_config`/`self.parameters` at runtime instead of hardcoding one literal for a handler shared by multiple registered tool names (same pattern as #366, #368).

## Correction to #368

An earlier pass this round (#368) had ruled this exact cluster out as a false positive, reasoning that `limit` was a `required` schema parameter (making the mismatched literal dead code, since `validate_parameters` would reject any call omitting it). That reasoning was based on reading `xml_tools.json`/`dataset_tools.json` from a long-stale local development branch that happened to have unrelated, unmerged local history diverging from `origin/main` specifically on those two files — on `origin/main`, `limit` is **not** required for any of these tools, so the mismatch is live, not dead code.

Re-verified this round by reading the files from a clean `git archive origin/main` snapshot and a fresh worktree (never the long-lived local checkout), and by mocking each handler with fake in-memory data (bypassing the network/dataset-loading layer entirely) to compare declared vs. actual result counts before and after the fix.

## Test plan

- [x] Mocked `XMLDatasetTool._search`/`_filter` and `DatasetTool._drugbank_search`/`_drugbank_filter` with synthetic in-memory records, comparing declared default vs. actual result count for representative tools from each affected/unaffected group, before and after the fix.
- [x] `ToolUniverse().load_tools()` still loads all 2679 tools cleanly.