### PR TITLE
Fix 3 more declared-vs-actual limit mismatches: MPD, CDC, EBIProteins

### DIFF
--- a/src/tooluniverse/cdc_tool.py
+++ b/src/tooluniverse/cdc_tool.py
@@ -42,8 +42,18 @@ class CDCRESTTool(BaseTool):
         # Socrata rejects mixing $query with the discrete $limit/$where/... params.
         soql_query = arguments.get("soql_query")
 
-        # Handle limit ($limit in Socrata)
-        limit = arguments.get("limit", 50)
+        # _build_url backs 3 registered tool names (search_datasets/get_dataset/
+        # aggregate) with different declared `limit` defaults (e.g. get_dataset
+        # default=100). Read the per-instance declared default instead of
+        # hardcoding one limit for all three, or get_dataset silently returns
+        # fewer rows than documented whenever `limit` is omitted.
+        declared_limit_default = (
+            self.tool_config.get("parameter", {})
+            .get("properties", {})
+            .get("limit", {})
+            .get("default", 50)
+        )
+        limit = arguments.get("limit", declared_limit_default)
         if limit and not soql_query:
             query_params["$limit"] = (
                 min(limit, 1000) if "views.json" in endpoint else min(limit, 50000)

--- a/src/tooluniverse/ebi_proteins_interactions_tool.py
+++ b/src/tooluniverse/ebi_proteins_interactions_tool.py
@@ -75,7 +75,7 @@ class EBIProteinsInteractionsTool(BaseTool):
                 "status": "error",
                 "error": "accession is required (e.g., 'P04637').",
             }
-        limit = int(arguments.get("limit", 25))
+        limit = int(arguments.get("limit", 50))
 
         url = f"{EBI_PROTEINS_BASE_URL}/proteins/interaction/{accession}"
         response = requests.get(

--- a/src/tooluniverse/mpd_tool.py
+++ b/src/tooluniverse/mpd_tool.py
@@ -21,7 +21,7 @@ class MPDRESTTool(BaseTool):
             # live, its phenotype endpoints require a measure ID or project
             # symbol the caller doesn't supply here.
             strain = arguments.get("strain", "C57BL/6J")
-            limit = arguments.get("limit", 5)
+            limit = arguments.get("limit", 10)
 
             # searchTerm is a free-text match, unlike biosample_ontology.term_name
             # (a tissue/cell-type ontology field, not a strain field) -- confirmed


### PR DESCRIPTION
## Summary

Continuing the broader "declared default vs. actual runtime default" sweep. Three more confirmed mismatches, found while doing a comprehensive re-scan of the tool registry (this scan also caught and fixed a mistake in an earlier pass — see #370):

- **MPD_get_phenotype_data**: declared default 10, hardcoded fallback was 5. Callers omitting `limit` silently got half the documented results.
- **CDCRESTTool**: `_build_url` backs 3 registered tool names (`cdc_data_search_datasets`, `cdc_data_get_dataset`, `cdc_data_aggregate`) sharing one hardcoded `limit` fallback (50). `cdc_data_get_dataset` declares default 100 — callers omitting `limit` silently got 50 rows instead of the documented 100. Fixed by reading the per-instance declared default from `self.tool_config` (same pattern as #366/#368/#370).
- **EBIProteins_get_interactions**: declared default 50, hardcoded fallback was 25. Callers omitting `limit` silently got half the documented results.

## Also checked this round, ruled out as false positives

- `RNAcentralGenomeTool`, `ReMapRESTTool`, `UniBindRESTTool` (×2) — all use a `fields.operation` value set explicitly per registered tool instance (read directly, not via `parameter.properties.operation.default`); confirmed each instance's `fields.operation` matches its own declared schema default.
- `LipidMapsGeneTool` — same pattern with `fields.input_item`.
- `USPTOOpenDataPortalTool` — has a generic "inject each param's own declared schema default before using it" step earlier in `run()`; the flagged literal is an unreachable fallback in a later substring check.
- `ProteinsAPIRESTTool.proteins_api_search` — `size` has no code-level default at all (passed through only if present in `arguments`); the regex hit was dead code in an unrelated function (`proteins_api_get_variants`) gated by an `if "size" in args` check that makes its own `.get(..., 100)` fallback unreachable.
- `BinaryDownloadTool.chunk_size` — regex aggregated literals across multiple `@register_tool` classes sharing one file; the literal that looked mismatched belongs to a sibling class (`FileDownloadTool`), not `BinaryDownloadTool`, whose own literal already matches.
- `ClinicalCalc_ASCVD_risk.race` — hardcoded fallback (`""`) and declared default (`"white"`) both fall through to the same "not black" branch in the ASCVD coefficient lookup, so there's no actual behavioral difference.
- `Progenetix_search_biosamples.skip` — `None`/omitted means the `skip` query param isn't sent at all, which is standard-equivalent to `skip=0` for a pagination offset.
- `MaveDBTool` (×4 tools) — `limit=0`/`None`/omitted is a deliberate, documented "return all, no cap" sentinel that already matches each tool's own declared default of 0.

## Flagged, not fixed (different bug class — needs a scope decision)

Two parameters that are **completely non-functional** regardless of what's passed, found while investigating the above:

- **`UniProt_search_uniref`'s `cluster_type`** — read from arguments but the branch that's supposed to apply it is a no-op (`if cluster_type and ...: pass`). Explicitly passing it has zero effect on the query.
- **`RGD_search_genes`'s `species`** — documented as `'rat' (default), 'human', 'mouse'`, but the search always filters results to RGD (rat-only) entries; the `species` argument is never read anywhere in `_search_genes`. A caller passing `species='human'` silently gets rat genes back with `status: success`.

Both are real "declared behavior that doesn't happen" bugs, but fixing them means either implementing real filtering logic or narrowing the documented behavior — a design call, not a mechanical default-alignment. Reporting rather than guessing at the right fix.

## Test plan

- [x] Mocked-network tests for all three tools comparing declared default vs. actual value sent/returned, before and after the fix.
- [x] `ToolUniverse().load_tools()` still loads all 2679 tools cleanly.