### PR TITLE
Fix Round 77: iCite double-wrap + overly-strict null schema types

### DIFF
--- a/src/tooluniverse/data/dailymed_tools.json
+++ b/src/tooluniverse/data/dailymed_tools.json
@@ -76,7 +76,7 @@
               "type": "string"
             },
             "next_page_url": {
-              "type": "string"
+              "type": ["string", "null"]
             },
             "total_elements": {
               "type": "integer"
@@ -91,7 +91,7 @@
               "type": ["string", "integer", "null"]
             },
             "previous_page_url": {
-              "type": "string"
+              "type": ["string", "null"]
             },
             "next_page": {
               "type": ["string", "integer", "null"]

--- a/src/tooluniverse/data/icite_tools.json
+++ b/src/tooluniverse/data/icite_tools.json
@@ -15,7 +15,8 @@
       ]
     },
     "fields": {
-      "endpoint": "https://icite.od.nih.gov/api/pubs"
+      "endpoint": "https://icite.od.nih.gov/api/pubs",
+      "extract_path": "data"
     },
     "type": "BaseRESTTool",
     "test_examples": [

--- a/src/tooluniverse/data/omicsdi_tools.json
+++ b/src/tooluniverse/data/omicsdi_tools.json
@@ -106,13 +106,13 @@
                     "type": "string"
                   },
                   "description": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "organisms": {
                     "type": ["array", "null"]
                   },
                   "publicationDate": {
-                    "type": "string"
+                    "type": ["string", "null"]
                   },
                   "omicsType": {
                     "type": "array"

--- a/src/tooluniverse/data/pdbe_graph_tools.json
+++ b/src/tooluniverse/data/pdbe_graph_tools.json
@@ -409,7 +409,7 @@
                   }
                 },
                 "cross_links": {
-                  "type": "array",
+                  "type": ["array", "null"],
                   "items": {
                     "type": "object",
                     "properties": {

--- a/tests/unit/test_icite_get_publications_extract_path.py
+++ b/tests/unit/test_icite_get_publications_extract_path.py
@@ -1,0 +1,85 @@
+"""Regression guard for Fix-R77A-1: iCite_get_publications double-wrapped its
+response.
+
+iCite_get_publications is a plain BaseRESTTool hitting the raw iCite API
+(https://icite.od.nih.gov/api/pubs) directly. The raw API's own JSON body is
+already shaped {"data": [...], ...}. Without fields.extract_path configured,
+BaseRESTTool._process_response wrapped that whole raw body under another
+top-level "data" key, producing {"data": {"data": [...], ...}} -- violating
+the declared return_schema, which requires "data" to be a bare array of
+publication objects.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import jsonschema
+import pytest
+
+from tooluniverse.base_rest_tool import BaseRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def _load_tool_config():
+    with open("src/tooluniverse/data/icite_tools.json") as f:
+        tools = json.load(f)
+    return next(t for t in tools if t["name"] == "iCite_get_publications")
+
+
+def _mock_response(payload):
+    resp = MagicMock()
+    resp.json.return_value = payload
+    resp.headers = {"content-type": "application/json"}
+    return resp
+
+
+def test_config_declares_extract_path():
+    config = _load_tool_config()
+    assert config["fields"].get("extract_path") == "data"
+
+
+def test_process_response_unwraps_raw_data_key():
+    config = _load_tool_config()
+    tool = BaseRESTTool(config)
+
+    raw_icite_body = {
+        "data": [
+            {"pmid": 24453148, "citation_count": 4},
+            {"pmid": 24453150, "citation_count": 5},
+        ],
+        "meta": {"count": 2},
+    }
+    result = tool._process_response(_mock_response(raw_icite_body), "https://icite.od.nih.gov/api/pubs")
+
+    assert result["data"] == raw_icite_body["data"]
+    assert isinstance(result["data"], list)
+
+
+def test_unwrapped_response_satisfies_return_schema():
+    config = _load_tool_config()
+    tool = BaseRESTTool(config)
+
+    raw_icite_body = {
+        "data": [{"pmid": 24453148, "citation_count": 4, "title": "t"}],
+        "meta": {"count": 1},
+    }
+    result = tool._process_response(_mock_response(raw_icite_body), "https://icite.od.nih.gov/api/pubs")
+
+    jsonschema.validate(instance=result, schema=config["return_schema"])
+
+
+def test_without_extract_path_would_double_wrap():
+    """Sanity check that the bug shape is real: dropping extract_path
+    reproduces the pre-fix double-wrap so the schema validation fails."""
+    config = _load_tool_config()
+    broken_config = json.loads(json.dumps(config))
+    del broken_config["fields"]["extract_path"]
+    tool = BaseRESTTool(broken_config)
+
+    raw_icite_body = {"data": [{"pmid": 1}], "meta": {"count": 1}}
+    result = tool._process_response(_mock_response(raw_icite_body), "https://icite.od.nih.gov/api/pubs")
+
+    assert result["data"] == raw_icite_body  # double-wrapped, not unwrapped
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=result, schema=config["return_schema"])

--- a/tests/unit/test_round77_null_permissive_schema_fields.py
+++ b/tests/unit/test_round77_null_permissive_schema_fields.py
@@ -1,0 +1,102 @@
+"""Regression guard for Fix-R77B-1: three return_schema fields declared a
+single strict type (string/array) when the underlying API can legitimately
+return null for that field, so a genuinely-empty value failed schema
+validation even though the tool itself handled it correctly.
+
+Each of these already has a sibling field in the same schema that already
+permits null (e.g. DailyMed's previous_page/next_page, OmicsDI's organisms),
+confirming these are schema-definition gaps rather than deliberate strictness.
+
+- OmicsDI_search_datasets: dataset.description / dataset.publicationDate
+  (OmicsDI aggregates multiple repositories; not all of them populate these).
+- DailyMed_search_spls: metadata.previous_page_url / metadata.next_page_url
+  (already normalized to None by SearchSPLTool on the first/last page --
+  see tests/unit/test_dailymed_null_and_headers.py).
+- PDBe_get_compound_details: <compound>[].cross_links (a compound with no
+  cross-references to external databases).
+"""
+
+import json
+
+import jsonschema
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _dataset_item_schema():
+    with open("src/tooluniverse/data/omicsdi_tools.json") as f:
+        tools = json.load(f)
+    tool = next(t for t in tools if t["name"] == "OmicsDI_search_datasets")
+    branch = tool["return_schema"]["oneOf"][0]
+    return branch["properties"]["datasets"]["items"]
+
+
+def _dailymed_metadata_schema():
+    with open("src/tooluniverse/data/dailymed_tools.json") as f:
+        tools = json.load(f)
+    tool = next(t for t in tools if t["name"] == "DailyMed_search_spls")
+    return tool["return_schema"]["properties"]["metadata"]
+
+
+def _pdbe_compound_item_schema():
+    with open("src/tooluniverse/data/pdbe_graph_tools.json") as f:
+        tools = json.load(f)
+    tool = next(t for t in tools if t["name"] == "PDBe_get_compound_details")
+    branch = tool["return_schema"]["oneOf"][0]
+    return branch["additionalProperties"]["items"]
+
+
+def test_omicsdi_dataset_allows_null_description_and_publication_date():
+    schema = _dataset_item_schema()
+    jsonschema.validate(
+        instance={
+            "id": "PXD000001",
+            "source": "PRIDE",
+            "title": "A dataset",
+            "description": None,
+            "organisms": None,
+            "publicationDate": None,
+            "omicsType": [],
+            "citationsCount": 0,
+            "viewsCount": 0,
+            "downloadCount": 0,
+        },
+        schema=schema,
+    )
+
+
+def test_omicsdi_dataset_still_requires_description_to_be_string_or_null():
+    schema = _dataset_item_schema()
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance={"description": 12345}, schema=schema)
+
+
+def test_dailymed_metadata_allows_null_page_urls():
+    schema = _dailymed_metadata_schema()
+    jsonschema.validate(
+        instance={
+            "current_url": "https://dailymed.nlm.nih.gov/dailymed/services/v2/spls.json",
+            "next_page_url": None,
+            "total_elements": 1,
+            "total_pages": 1,
+            "current_page": 1,
+            "previous_page": None,
+            "previous_page_url": None,
+            "next_page": None,
+        },
+        schema=schema,
+    )
+
+
+def test_pdbe_compound_allows_null_cross_links():
+    schema = _pdbe_compound_item_schema()
+    jsonschema.validate(
+        instance={
+            "name": "heme",
+            "formula": "C34 H32 Fe N4 O4",
+            "compound_type": "NON-POLYMER",
+            "cross_links": None,
+        },
+        schema=schema,
+    )


### PR DESCRIPTION
## Summary

Found via a schema-conformance sweep across all 638 tool config patterns (`scripts/test_all_tools.py --parallel`), 18 patterns flagged with schema mismatches. Triaged each individually with live `jsonschema.validate()` checks against both the wrapped and unwrapped output.

**One genuine bug**, `iCite_get_publications` (a plain `BaseRESTTool` hitting the raw iCite API directly): the raw API's own JSON body is already shaped `{"data": [...], ...}`. Without `fields.extract_path`, `BaseRESTTool._process_response` wrapped that whole raw body under another top-level `data` key, producing `{"data": {"data": [...], ...}}` — violating the declared `return_schema`, which requires `data` to be a bare array. Fixed by adding `extract_path: "data"`.

**Three overly-strict schema types**, all confirmed via live data where a field is legitimately `null`:
- `OmicsDI_search_datasets`: `description`, `publicationDate` — not every aggregated repository populates these (sibling field `organisms` already allowed null).
- `DailyMed_search_spls`: `metadata.next_page_url` / `previous_page_url` — `SearchSPLTool` already normalizes these to `None` on the first/last page; the schema hadn't caught up.
- `PDBe_get_compound_details`: `cross_links` — a compound with no external database cross-references.

**Methodology finding**: the other 14 flagged patterns (artic, bmrb, cdc, dailymed's search_drug_classes, encode, eurostat, fda_gsrs, gbif/gbif_ext, gtex/gtex_v2, idr, nasa_sbdb, openfoodfacts, clinical_guidelines's MAGICapp) are **false positives** of `scripts/test_new_tools.py`'s own `_schema_describes_envelope` heuristic, which misclassifies inner-data schemas as envelope schemas whenever `data`/`status` happens to be a domain field name in the underlying API's own response shape (not a description of our own `{status,data,...}` wrapper). Confirmed for each via direct `jsonschema.validate()` against both interpretations — the unwrapped `result["data"]` validates cleanly in every case. None of those tools were touched. This heuristic limitation is left as a documented follow-up rather than a rushed fix to shared test infrastructure (a naive "valid if either interpretation passes" fix would mask real bugs like this PR's iCite one).

## Test plan
- [x] New tests: `tests/unit/test_icite_get_publications_extract_path.py` (4 tests — config declares extract_path, `_process_response` unwraps correctly, unwrapped result satisfies return_schema, and a sanity check that removing extract_path reproduces the original double-wrap bug)
- [x] New tests: `tests/unit/test_round77_null_permissive_schema_fields.py` (4 tests — one per widened field, plus a negative case confirming `description` still rejects non-string/non-null)
- [x] Existing dailymed/omicsdi regression suites (29 tests across 8 files) re-run clean
- [x] `scripts/test_new_tools.py icite/omicsdi/dailymed/pdbe_graph` all show 0 schema-invalid after the fix
- [x] Full suite (`pytest tests/ --maxfail=1000 --ignore=tests/test_claude_code_plugin.py`) passes, 0 failures