### PR TITLE
Fix Round 78: two well-known entities silently absent from cross-tool results

### DIFF
--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -240,6 +240,32 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             # Use [uid] to look up by numeric variation ID.
             query_parts.append(f"{arguments['variant_id']}[uid]")
 
+        if arguments.get("variant_name"):
+            # Fix-R78B-1: the Fix-R5D-1/R8C-1 comment above assumed there was
+            # "no such parameter" -- but ClinVar eSearch DOES support a real
+            # [Variant name] field tag (confirmed live: "HBB[gene] AND
+            # Glu7Val[Variant name]" -> 9 hits including VCV 15333, the
+            # canonical sickle-cell NM_000518.5(HBB):c.20A>T (p.Glu7Val)
+            # Pathogenic record). Without this, an exact-match lookup for a
+            # specific protein change/HGVS notation could only be done by
+            # fetching gene-level rows (capped at 100) and filtering
+            # client-side -- which silently misses old/low-ID records in any
+            # variant-dense gene, since ClinVar's default gene-level order
+            # isn't clinical-significance- or fame-ranked (confirmed live:
+            # HBB's own sickle-cell record, one of the best-known variants in
+            # human genetics, isn't within the first 100 or even the first
+            # 425-Pathogenic-filtered gene-level rows). Accepts either a
+            # single name or a list (a multi-allelic site yields one protein
+            # change per allele; only the queried allele's name will hit, so
+            # every candidate must be tried) -- combined with OR so one
+            # request covers all candidates.
+            names = arguments["variant_name"]
+            names = names if isinstance(names, list) else [names]
+            names = [str(n).strip() for n in names if str(n).strip()]
+            if names:
+                terms = " OR ".join(f"{n}[Variant name]" for n in names)
+                query_parts.append(f"({terms})" if len(names) > 1 else terms)
+
         if "clinical_significance" in arguments:
             # Feature-82A-002: NCBI silently translates [clnsig] to [All Fields],
             # returning unrelated variants. The correct syntax is the [Filter] field:
@@ -263,15 +289,16 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             )
 
         # Fix-R5D-1/R8C-1: a caller-supplied param that doesn't match any
-        # recognized name/alias (e.g. "gene_name" instead of "gene", or
-        # "variant_name" -- there is no such parameter, only "variant_id")
-        # was silently dropped. When it's the ONLY param supplied, this
+        # recognized name/alias (e.g. "gene_name" instead of "gene") was
+        # silently dropped. (Fix-R78B-1: "variant_name" -- originally called
+        # out here as "no such parameter" -- is now a real, supported param;
+        # see above.) When it's the ONLY param supplied, this
         # produced a generic "at least one search parameter is required"
         # error with no hint the parameter itself was misnamed. When OTHER
         # valid params are also supplied, the query still runs but silently
         # ignores the unrecognized one -- confirmed live that
-        # {"gene": "GJB2", "variant_name": "35delG"} returns all 739 GJB2
-        # variants with no indication the variant_name filter had zero
+        # {"gene": "GJB2", "made_up_param": "35delG"} returns all 739 GJB2
+        # variants with no indication the made_up_param filter had zero
         # effect. Name unrecognized parameter(s) in both cases.
         recognized = {
             "gene",
@@ -279,6 +306,7 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             "condition",
             "query",
             "variant_id",
+            "variant_name",
             "clinical_significance",
             "significance",
             "max_results",
@@ -293,7 +321,7 @@ class ClinVarSearchVariants(ClinVarRESTTool):
                     "error": (
                         f"Unrecognized parameter(s): {', '.join(unrecognized)}. "
                         "Valid search parameters: gene (or gene_symbol), "
-                        "condition (or query), variant_id, "
+                        "condition (or query), variant_id, variant_name, "
                         "clinical_significance (or significance)."
                     ),
                 }

--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -167,25 +167,56 @@ class CompoundVariantAnnotationTool(BaseTool):
         # gene still can't be searched and is skipped, same as before.
         if gene_for_gnomad:
             try:
+                # Fix-R78B-1: ClinVar_search_variants now supports a targeted
+                # variant_name search (ClinVar's own [Variant name] field tag)
+                # -- try that FIRST when we have candidate protein-change
+                # token(s), since it's an exact server-side lookup rather than
+                # a capped, arbitrarily-ordered gene-level browse. Confirmed
+                # live this is necessary, not just nicer: rs334/HBB's
+                # canonical sickle-cell record (VCV 15333, Pathogenic) has a
+                # low/old variant ID and isn't within the first 100 -- or even
+                # the first 425 clinical_significance=Pathogenic-filtered --
+                # gene-level rows, so the old gene-level-only fetch always
+                # reported "no exact ClinVar match" for one of the best-known
+                # pathogenic variants in human genetics.
+                parsed = None
+                if variant_token:
+                    tr = tu.run_one_function(
+                        {
+                            "name": "ClinVar_search_variants",
+                            "arguments": {
+                                "gene": gene_for_gnomad,
+                                "variant_name": variant_token,
+                                "limit": 20,
+                            },
+                        }
+                    )
+                    if not self._sub_call_error(tr):
+                        candidate = self._parse_clinvar(tr, variant_token)
+                        if candidate.get("exact_match"):
+                            parsed = candidate
+
                 # limit=100 (ClinVar_search_variants' own max) rather than 20:
-                # ClinVar_search_variants has no HGVS/protein-change search
-                # parameter, only gene/condition/clinical_significance, so an
-                # exact-match lookup for a specific variant can only work by
-                # fetching as many gene-level rows as possible and filtering
-                # client-side in _parse_clinvar -- confirmed live that even
-                # 100 isn't always enough for variant-dense genes (ACADM has
-                # 1127 ClinVar entries; a known Pathogenic founder variant
-                # still wasn't within the first 100), but it materially
-                # improves the hit rate for smaller genes versus 20.
-                r = tu.run_one_function(
-                    {
-                        "name": "ClinVar_search_variants",
-                        "arguments": {"gene": gene_for_gnomad, "limit": 100},
-                    }
-                )
-                error = self._sub_call_error(r)
+                # fallback for when no variant_token was resolvable, or the
+                # targeted variant_name search above didn't confirm a match
+                # (e.g. a token whose nomenclature ClinVar's index doesn't
+                # recognize) -- browse as many gene-level rows as possible and
+                # filter client-side in _parse_clinvar, same as before this fix.
+                if parsed is None:
+                    r = tu.run_one_function(
+                        {
+                            "name": "ClinVar_search_variants",
+                            "arguments": {"gene": gene_for_gnomad, "limit": 100},
+                        }
+                    )
+                    error = self._sub_call_error(r)
+                else:
+                    r, error = None, None
+
                 if error:
                     sources_failed.append(f"ClinVar: {error[:100]}")
+                elif parsed is not None:
+                    annotations["clinvar"] = parsed
                 else:
                     annotations["clinvar"] = self._parse_clinvar(r, variant_token)
             except Exception as e:

--- a/src/tooluniverse/data/clinvar_tools.json
+++ b/src/tooluniverse/data/clinvar_tools.json
@@ -2,7 +2,7 @@
     {
         "type": "ClinVarSearchVariants",
         "name": "ClinVar_search_variants",
-        "description": "Search for variants in ClinVar database by gene name, condition, or variant ID. Returns variant identifiers and basic information. At least one of gene, condition, or variant_id must be provided.",
+        "description": "Search for variants in ClinVar database by gene name, condition, variant ID, or variant name (protein change / HGVS notation). Returns variant identifiers and basic information. At least one of gene, condition, variant_id, or variant_name must be provided. Combine gene + variant_name for an exact-match lookup of one specific known variant instead of browsing all of a gene's ClinVar entries.",
         "parameter": {
             "type": "object",
             "properties": {
@@ -17,6 +17,14 @@
                 "variant_id": {
                     "type": "string",
                     "description": "ClinVar variant ID (e.g., '12345') At least one of gene, condition, or variant_id must be provided."
+                },
+                "variant_name": {
+                    "type": [
+                        "string",
+                        "array",
+                        "null"
+                    ],
+                    "description": "Protein change or HGVS notation to search for (e.g., 'Glu6Val', 'V600E', 'c.20A>T'), matched against ClinVar's own [Variant name] index -- combine with 'gene' for an exact-match lookup of a specific known variant instead of browsing all of a gene's ClinVar entries. A gene-level browse can silently miss well-known but old/low-ID records once a gene has more entries than max_results (e.g. HBB's canonical sickle-cell record, NM_000518.5(HBB):c.20A>T (p.Glu7Val), isn't within the first 100-425 gene-level rows). Accepts a list to try multiple candidate names in one call (e.g. every allele at a multi-allelic site) -- combined with OR."
                 },
                 "max_results": {
                     "type": "integer",
@@ -126,6 +134,11 @@
             {
                 "condition": "breast cancer",
                 "max_results": 5
+            },
+            {
+                "gene": "HBB",
+                "variant_name": "Glu6Val",
+                "max_results": 20
             }
         ],
         "label": [

--- a/src/tooluniverse/data/marrvel_tools.json
+++ b/src/tooluniverse/data/marrvel_tools.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "MARRVEL_get_gene",
-        "description": "Get aggregated identity and annotation for a human gene by symbol from MARRVEL: cross-references (OMIM, HGNC, Ensembl, Entrez, UniProt), chromosome/cytogenetic location, gene type, aliases, previous symbols, and the Entrez gene summary. Use as a one-call gene-identity resolver in rare-disease / Mendelian variant triage workflows. No API key required.",
+        "description": "Get aggregated identity and annotation for a human gene by symbol from MARRVEL: cross-references (HGNC, Ensembl, Entrez, UniProt), chromosome/cytogenetic location, gene type, aliases, previous symbols, and the Entrez gene summary. Use as a one-call gene-identity resolver in rare-disease / Mendelian variant triage workflows. Does NOT include an OMIM ID -- MARRVEL's own gene-lookup endpoint returns an unreliable placeholder value for it (confirmed live), use MARRVEL_get_omim_phenotypes for OMIM associations instead. No API key required.",
         "parameter": {"type": "object", "properties": {
             "symbol": {"type": ["string", "null"], "description": "HGNC gene symbol, e.g. 'CFTR', 'BRCA1'."},
             "gene_symbol": {"type": ["string", "null"], "description": "Alias for symbol."},

--- a/src/tooluniverse/marrvel_tool.py
+++ b/src/tooluniverse/marrvel_tool.py
@@ -88,7 +88,14 @@ class MARRVELGeneTool(BaseTool):
                 "name": rec.get("name"),
                 "entrez_id": rec.get("entrezId"),
                 "hgnc_id": xref.get("hgncId"),
-                "omim_id": xref.get("omimId"),
+                # Fix-R78A-1: MARRVEL's own /gene/taxonId/.../symbol/... endpoint
+                # returns a bogus small placeholder integer in xref.omimId (e.g.
+                # "1" for BRCA1/EGFR/APOE/MYH7/TP53, "6" for CFTR/PTEN) instead
+                # of the real 6-digit OMIM MIM number -- confirmed live across
+                # multiple genes, so this isn't a per-gene data gap. The correct
+                # gene_mim_number is only available from MARRVEL's dedicated OMIM
+                # endpoint, exposed here as MARRVEL_get_omim_phenotypes -- point
+                # callers there instead of surfacing this misleading value.
                 "ensembl_id": xref.get("ensemblId"),
                 "uniprot_id": rec.get("uniprotKBId"),
                 "chromosome": rec.get("chr"),

--- a/tests/unit/test_clinvar_gene_hyphen_and_params.py
+++ b/tests/unit/test_clinvar_gene_hyphen_and_params.py
@@ -13,12 +13,14 @@ mitochondrial genes all need the hyphen PRESERVED, e.g. "HLA-B[gene]" ->
 preserved first, falling back to the stripped form only if that returns
 zero results, so both cases resolve correctly without a hardcoded gene list.
 
-Fix-R5D-1/R8C-1: an unrecognized parameter (e.g. "variant_name", which
-doesn't exist -- only "variant_id" does) was silently dropped. When it was
-the only param supplied, this produced a generic "at least one search
-parameter is required" error; when other valid params were also supplied,
-the query ran but silently ignored the unrecognized one with no
-indication the filter had zero effect.
+Fix-R5D-1/R8C-1: an unrecognized parameter (e.g. "variant_nam", a typo of a
+real param) was silently dropped. When it was the only param supplied, this
+produced a generic "at least one search parameter is required" error; when
+other valid params were also supplied, the query ran but silently ignored
+the unrecognized one with no indication the filter had zero effect. (Note:
+"variant_name" itself was originally this fix's own illustrative example of
+a parameter that "doesn't exist" -- Fix-R78B-1 later added it as a real,
+working parameter; see test_clinvar_variant_name_search.py.)
 """
 
 from unittest.mock import patch
@@ -138,10 +140,10 @@ def test_plain_gene_symbol_unaffected():
 
 def test_unrecognized_param_alone_names_itself_in_error():
     tool = _tool()
-    result = tool.run({"variant_name": "35delG"})
+    result = tool.run({"varient_name": "35delG"})
 
     assert result["status"] == "error"
-    assert "variant_name" in result["error"]
+    assert "varient_name" in result["error"]
     assert "Unrecognized parameter" in result["error"]
 
 
@@ -163,10 +165,10 @@ def test_unrecognized_param_alongside_valid_param_is_noted_not_silently_dropped(
             },
         ],
     ):
-        result = tool.run({"gene": "GJB2", "variant_name": "35delG"})
+        result = tool.run({"gene": "GJB2", "varient_name": "35delG"})
 
     assert result["status"] == "success"
-    assert result["data"]["ignored_parameters"] == ["variant_name"]
+    assert result["data"]["ignored_parameters"] == ["varient_name"]
     assert result["data"]["total_count"] == 739
 
 

--- a/tests/unit/test_clinvar_variant_name_search.py
+++ b/tests/unit/test_clinvar_variant_name_search.py
@@ -1,0 +1,94 @@
+"""Regression guard for Fix-R78B-1: ClinVar_search_variants had no way to
+search by protein change / HGVS notation (only gene/condition/variant_id/
+clinical_significance), so an exact-match lookup for a specific known
+variant could only be done by browsing gene-level rows (capped at 100) and
+filtering client-side -- which silently misses well-known but old/low-ID
+records once a gene has more ClinVar entries than the fetch cap (confirmed
+live for HBB's canonical sickle-cell record, VCV 15333, one of the best-known
+pathogenic variants in human genetics; see test_compound_variant_tool.py for
+the full cross-tool bug this caused). ClinVar eSearch DOES support a real
+[Variant name] field tag (confirmed live via raw NCBI E-utils), so this adds
+it as a proper "variant_name" parameter.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import ClinVarSearchVariants
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ClinVarSearchVariants({"name": "ClinVar_search_variants"})
+
+
+def test_variant_name_single_string_builds_field_tag():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        result = tool.run({"gene": "HBB", "variant_name": "Glu6Val"})
+
+    assert result["status"] == "success"
+    term = mock_request.call_args[0][1]["term"]
+    assert "HBB[gene]" in term
+    assert "Glu6Val[Variant name]" in term
+    assert "AND" in term
+
+
+def test_variant_name_list_combines_with_or():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        tool.run({"gene": "HBB", "variant_name": ["Glu7Val", "Glu6Val"]})
+
+    term = mock_request.call_args[0][1]["term"]
+    assert "Glu7Val[Variant name]" in term
+    assert "Glu6Val[Variant name]" in term
+    assert " OR " in term
+    # both candidates must be inside one parenthesized OR group, ANDed with gene
+    assert "(Glu7Val[Variant name] OR Glu6Val[Variant name])" in term
+
+
+def test_variant_name_alone_is_a_valid_search_no_gene_required():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        result = tool.run({"variant_name": "V600E"})
+
+    assert result["status"] == "success"
+    assert "V600E[Variant name]" in mock_request.call_args[0][1]["term"]
+
+
+def test_variant_name_is_a_recognized_parameter_not_flagged_as_unrecognized():
+    tool = _tool()
+    result = tool.run({"variant_name_typo": "V600E"})
+    assert result["status"] == "error"
+    # the typo'd param is flagged as unrecognized, and the correct spelling
+    # is offered as a valid search parameter in the same error message
+    assert "Unrecognized parameter(s): variant_name_typo" in result["error"]
+    assert "variant_name" in result["error"]
+
+
+def test_empty_or_blank_variant_name_entries_are_dropped():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        tool.run({"gene": "HBB", "variant_name": ["", "  ", "Glu6Val"]})
+
+    term = mock_request.call_args[0][1]["term"]
+    assert "Glu6Val[Variant name]" in term
+    assert "OR" not in term  # only one real candidate survived, no OR needed

--- a/tests/unit/test_compound_variant_tool.py
+++ b/tests/unit/test_compound_variant_tool.py
@@ -671,3 +671,130 @@ def test_explicit_gene_wins_over_rsid_resolved_gene_when_both_given():
 
     gnomad_call = next(c for c in calls if c["name"] == "gnomad_get_gene")
     assert gnomad_call["arguments"]["gene_symbol"] == "HBB"
+
+
+# Fix-R78B-1: rs334 (HBB, the sickle-cell mutation) always reported "no exact
+# ClinVar match" even though ClinVar has a Pathogenic record for it (VCV
+# 15333) -- the record's low/old variant ID meant it was never within the
+# first 100 (or even 425 Pathogenic-filtered) gene-level rows the old code
+# fetched and filtered client-side. ClinVar_search_variants now supports a
+# targeted variant_name search; the ClinVar step here must try that first and
+# only fall back to the old gene-level browse when it doesn't confirm a match.
+def test_clinvar_uses_targeted_variant_name_search_when_it_finds_exact_match():
+    t = _tool()
+    calls = []
+
+    def fake_run_one_function(call):
+        calls.append(call)
+        if call["name"] == "dbsnp_get_variant_by_rsid":
+            return {
+                "status": "success",
+                "data": {"hgvs_notation": "...|NP_000509.1:p.Glu7Val|GENE=HBB:3043"},
+            }
+        if call["name"] == "ClinVar_search_variants":
+            if call["arguments"].get("variant_name"):
+                return {
+                    "status": "success",
+                    "data": {
+                        "total_count": 1,
+                        "variants": [
+                            {
+                                "title": "NM_000518.5(HBB):c.20A>T (p.Glu7Val)",
+                                "clinical_significance": "Pathogenic",
+                                "review_status": "criteria provided, multiple submitters",
+                            }
+                        ],
+                    },
+                }
+            # bulk gene-level fallback -- must NOT be reached in this test
+            raise AssertionError(
+                "bulk gene-level ClinVar fetch was called even though the "
+                "targeted variant_name search already found an exact match"
+            )
+        return {"status": "success", "data": {}}
+
+    with patch(
+        "tooluniverse.execute_function.ToolUniverse.run_one_function",
+        side_effect=fake_run_one_function,
+    ), patch("tooluniverse.execute_function.ToolUniverse.load_tools", return_value=None):
+        result = t.run({"rsid": "rs334"})
+
+    clinvar_calls = [c for c in calls if c["name"] == "ClinVar_search_variants"]
+    assert len(clinvar_calls) == 1
+    assert clinvar_calls[0]["arguments"]["variant_name"] == ["Glu7Val", "Glu6Val"]
+
+    clinvar = result["data"]["annotations"]["clinvar"]
+    assert clinvar["exact_match"] is True
+    assert clinvar["matched"] == 1
+    assert clinvar["variants"][0]["classification"] == "Pathogenic"
+    assert result["data"]["summary"]["clinvar_classification"] == "Pathogenic"
+
+
+def test_clinvar_falls_back_to_gene_level_browse_when_targeted_search_finds_nothing():
+    t = _tool()
+    calls = []
+
+    def fake_run_one_function(call):
+        calls.append(call)
+        if call["name"] == "dbsnp_get_variant_by_rsid":
+            return {
+                "status": "success",
+                "data": {"hgvs_notation": "...|NP_004324.2:p.Val600Glu|GENE=BRAF:673"},
+            }
+        if call["name"] == "ClinVar_search_variants":
+            if call["arguments"].get("variant_name"):
+                # targeted search finds nothing (e.g. nomenclature ClinVar's
+                # index doesn't recognize) -- must fall back to bulk browse
+                return {"status": "success", "data": {"total_count": 0, "variants": []}}
+            return {
+                "status": "success",
+                "data": {
+                    "total_count": 1,
+                    "variants": [
+                        {
+                            "title": "NM_004333.6(BRAF):c.1799T>A (p.Val600Glu)",
+                            "clinical_significance": "Pathogenic",
+                            "review_status": "reviewed by expert panel",
+                        }
+                    ],
+                },
+            }
+        return {"status": "success", "data": {}}
+
+    with patch(
+        "tooluniverse.execute_function.ToolUniverse.run_one_function",
+        side_effect=fake_run_one_function,
+    ), patch("tooluniverse.execute_function.ToolUniverse.load_tools", return_value=None):
+        result = t.run({"rsid": "rs113488022"})
+
+    clinvar_calls = [c for c in calls if c["name"] == "ClinVar_search_variants"]
+    assert len(clinvar_calls) == 2
+    assert clinvar_calls[0]["arguments"].get("variant_name")
+    assert "variant_name" not in clinvar_calls[1]["arguments"]
+    assert clinvar_calls[1]["arguments"]["limit"] == 100
+
+    clinvar = result["data"]["annotations"]["clinvar"]
+    assert clinvar["exact_match"] is True
+    assert clinvar["variants"][0]["classification"] == "Pathogenic"
+
+
+def test_clinvar_skips_targeted_search_when_no_variant_token_resolvable():
+    """A gene-only query (no rsid/variant, so variant_token stays None) must
+    go straight to the bulk browse -- unchanged from before this fix."""
+    t = _tool()
+    calls = []
+
+    def fake_run_one_function(call):
+        calls.append(call)
+        return {"status": "success", "data": {"total_count": 0, "variants": []}}
+
+    with patch(
+        "tooluniverse.execute_function.ToolUniverse.run_one_function",
+        side_effect=fake_run_one_function,
+    ), patch("tooluniverse.execute_function.ToolUniverse.load_tools", return_value=None):
+        t.run({"gene": "BRCA1"})
+
+    clinvar_calls = [c for c in calls if c["name"] == "ClinVar_search_variants"]
+    assert len(clinvar_calls) == 1
+    assert "variant_name" not in clinvar_calls[0]["arguments"]
+    assert clinvar_calls[0]["arguments"]["limit"] == 100

--- a/tests/unit/test_discovery_resource_tools_batch2.py
+++ b/tests/unit/test_discovery_resource_tools_batch2.py
@@ -85,12 +85,24 @@ def test_marrvel_gene_requires_symbol():
 def test_marrvel_gene_curates_xrefs():
     rec = {"symbol": "CFTR", "name": "CF transmembrane regulator", "entrezId": 1080,
            "uniprotKBId": "P13569", "chr": "7", "location": "7q31.2", "type": "protein-coding",
-           "alias": ["ABCC7"], "xref": {"omimId": "602421", "hgncId": "1884", "ensemblId": "ENSG00000001626"}}
+           "alias": ["ABCC7"], "xref": {"omimId": "6", "hgncId": "1884", "ensemblId": "ENSG00000001626"}}
     with patch("tooluniverse.marrvel_tool.requests.get", return_value=_resp(200, rec)):
         out = MARRVELGeneTool(_cfg("MARRVEL_get_gene", "MARRVELGeneTool")).run({"symbol": "CFTR"})
-    assert out["data"]["omim_id"] == "602421"
+    assert out["data"]["hgnc_id"] == "1884"
     assert out["data"]["ensembl_id"] == "ENSG00000001626"
     assert out["data"]["uniprot_id"] == "P13569"
+
+
+# Fix-R78A-1: MARRVEL's /gene/taxonId/.../symbol/... endpoint returns a bogus
+# small placeholder integer in xref.omimId ("1" for BRCA1/EGFR/APOE/MYH7/TP53,
+# "6" for CFTR/PTEN -- confirmed live) instead of the real 6-digit OMIM MIM
+# number, so it must never be surfaced as omim_id even though xref carries it.
+def test_marrvel_gene_does_not_surface_unreliable_omim_id():
+    rec = {"symbol": "TP53", "xref": {"omimId": "1", "hgncId": "11998",
+                                       "ensemblId": "ENSG00000141510"}}
+    with patch("tooluniverse.marrvel_tool.requests.get", return_value=_resp(200, rec)):
+        out = MARRVELGeneTool(_cfg("MARRVEL_get_gene", "MARRVELGeneTool")).run({"symbol": "TP53"})
+    assert "omim_id" not in out["data"]
 
 
 def test_marrvel_omim_curates_phenotypes():


### PR DESCRIPTION
## Summary

Found via a new methodology angle for this campaign: **cross-tool consistency** — querying the same well-known entity (a gene, a variant) through every tool that should know about it and comparing results, rather than testing each tool in isolation. Both findings share the same underlying bug class: **a well-known entity silently absent from a tool's results** — invisible to single-tool happy-path testing, but obviously wrong to anyone who knows the entity. Worth searching for again on different genes/variants/drugs in future rounds, not just the specific query shapes below.

1. **`MARRVEL_get_gene` exposed a bogus `omim_id` field.** MARRVEL's own `/gene/taxonId/.../symbol/...` endpoint returns a tiny placeholder integer (`"1"` for BRCA1/EGFR/APOE/MYH7/TP53, `"6"` for CFTR/PTEN) instead of the real 6-digit OMIM MIM number — confirmed live across 7 genes, so this isn't a per-gene data gap in MARRVEL's own database, it's the field itself being broken in that endpoint. The dedicated `MARRVEL_get_omim_phenotypes` tool already returns the correct `gene_mim_number` (191170 for TP53, matching HGNC's own record). Removed the misleading field from `MARRVEL_get_gene` and pointed its description at the working tool instead, rather than presenting wrong data as if genuine.

2. **`annotate_variant_multi_source` always reported "no exact ClinVar match" for rs334** — the sickle-cell HBB mutation, arguably the single most-studied point mutation in human genetics — despite ClinVar having a well-established Pathogenic record for it (VCV 15333, `NM_000518.5(HBB):c.20A>T (p.Glu7Val)`). Root cause: `ClinVar_search_variants` had no way to search by protein change/HGVS notation, only `gene`/`condition`/`clinical_significance`, so an exact-match lookup for one specific variant could only browse gene-level rows (capped at 100) and filter client-side. HBB has 1962 total ClinVar entries (still 425 after filtering to Pathogenic-only), and the sickle-cell record's low/old variant ID meant it was never within any of those capped fetches, regardless of filter.

   ClinVar's own eSearch supports a real `[Variant name]` field tag (confirmed live via raw NCBI E-utils: `HBB[gene] AND Glu7Val[Variant name]` finds VCV 15333 directly, in 9 total hits vs. browsing ~2000 gene-level rows). Added it as a proper `variant_name` parameter on `ClinVar_search_variants` (accepts a single name or a list, OR-combined — needed since a multi-allelic rsid site yields one candidate protein change per allele). Wired `annotate_variant_multi_source` to try a targeted `variant_name` search first when a candidate token is resolvable, falling back to the old gene-level browse only when that doesn't confirm a match (preserves existing behavior for cases with no resolvable token, or where the token's nomenclature isn't in ClinVar's index).

## Test plan
- [x] New tests: `tests/unit/test_clinvar_variant_name_search.py` (5 tests — single string, list/OR-combination, variant_name alone with no gene, correctly recognized as a valid param, blank entries dropped)
- [x] New tests in `tests/unit/test_compound_variant_tool.py` (3 tests — targeted search used when it confirms a match and the bulk fallback is *not* called, falls back to bulk browse when the targeted search finds nothing, and unchanged behavior when no variant_token is resolvable at all)
- [x] Updated 2 stale tests in `tests/unit/test_clinvar_gene_hyphen_and_params.py` that asserted the *old* "variant_name doesn't exist" behavior (from an earlier round's Fix-R5D-1, which used `variant_name` as its own illustrative example of an unrecognized parameter)
- [x] Updated `tests/unit/test_discovery_resource_tools_batch2.py`'s MARRVEL test to stop asserting on the removed `omim_id` field, added a dedicated regression test confirming it's never surfaced even when present in the mocked upstream response
- [x] All 83 clinvar/compound_variant unit tests pass
- [x] Live end-to-end re-verification: `annotate_variant_multi_source({"rsid": "rs334"})` now reports `clinvar_classification: "Pathogenic"`; `MARRVEL_get_gene({"symbol": "TP53"})` no longer includes `omim_id`
- [x] `scripts/test_new_tools.py` clean (0 schema-invalid) for clinvar, compound_variant, and marrvel patterns
- [x] Full suite (`pytest tests/ --maxfail=1000 --ignore=tests/test_claude_code_plugin.py`) passes, 0 failures