### PR TITLE
Fix Round 79: CPIC_get_recommendations silently ignored gene/phenotype filters

### DIFF
--- a/src/tooluniverse/cpic_search_pairs_tool.py
+++ b/src/tooluniverse/cpic_search_pairs_tool.py
@@ -117,14 +117,35 @@ class CPICGetRecommendationsTool(BaseTool):
 
         limit = arguments.get("limit", 50) or 50
         offset = arguments.get("offset", 0) or 0
+        # Fix-R79A-1: "gene"/"phenotype" are not real params (no
+        # additionalProperties: false on this schema, so they were silently
+        # accepted and dropped, not rejected) -- confirmed live that
+        # {"drug": "clopidogrel", "gene": "CYP2C19", "phenotype": "Poor
+        # Metabolizer"} returned all 24 rows across every phenotype and
+        # population/context combination for the guideline, unfiltered, with
+        # no indication either filter had zero effect. A caller very
+        # naturally guesses these param names, since the tool's own
+        # description says it "links genotype/phenotype to prescribing
+        # actions" and every returned row already carries a `phenotypes`
+        # dict keyed by gene symbol -- add real client-side filtering rather
+        # than just erroring more clearly on the unrecognized names, since
+        # the data to filter on is already present in every response.
+        gene_filter = arguments.get("gene")
+        phenotype_filter = arguments.get("phenotype")
+        filtering = bool(gene_filter or phenotype_filter)
 
         try:
             url = f"{_CPIC_API}/recommendation"
             params: Dict[str, Any] = {
                 "select": "*,drug(name)",
                 "guidelineid": f"eq.{guideline_id}",
-                "limit": limit,
-                "offset": offset,
+                # When filtering client-side, fetch a large batch up front so
+                # limit/offset apply to the FILTERED results (matching a
+                # caller's expectation of "page N of the phenotype-filtered
+                # list"), not to an arbitrary slice of the raw, unfiltered
+                # table that the filter would then be applied to piecemeal.
+                "limit": 1000 if filtering else limit,
+                "offset": 0 if filtering else offset,
             }
             # Filter by specific drug within multi-drug guidelines (e.g., CYP2D6/Opioids
             # covers codeine, tramadol, hydrocodone — filter to the requested drug).
@@ -133,11 +154,54 @@ class CPICGetRecommendationsTool(BaseTool):
             r = requests.get(url, params=params, timeout=30)
             r.raise_for_status()
             data = r.json()
+
+            available_phenotypes = None
+            if filtering:
+                available_phenotypes = sorted(
+                    {
+                        v
+                        for row in data
+                        for k, v in (row.get("phenotypes") or {}).items()
+                        if not gene_filter or k.lower() == gene_filter.lower()
+                    }
+                )
+
+                def _row_matches(row: Dict[str, Any]) -> bool:
+                    phenotypes = row.get("phenotypes") or {}
+                    if gene_filter:
+                        gene_key = next(
+                            (k for k in phenotypes if k.lower() == gene_filter.lower()),
+                            None,
+                        )
+                        if gene_key is None:
+                            return False
+                        if phenotype_filter:
+                            return (
+                                phenotypes[gene_key].lower() == phenotype_filter.lower()
+                            )
+                        return True
+                    # No gene given: match if ANY gene's phenotype value hits.
+                    return any(
+                        v.lower() == phenotype_filter.lower()
+                        for v in phenotypes.values()
+                    )
+
+                data = [row for row in data if _row_matches(row)]
+                data = data[offset : offset + limit]
+
             result: Dict[str, Any] = {
                 "guideline_id": guideline_id,
                 "recommendations": data,
                 "count": len(data),
             }
+            if filtering and not data:
+                result["note"] = (
+                    f"No recommendations matched gene={gene_filter!r} "
+                    f"phenotype={phenotype_filter!r} for guideline {guideline_id}. "
+                    f"Available phenotype values for this guideline"
+                    + (f" and gene {gene_filter}" if gene_filter else "")
+                    + f": {available_phenotypes or '[]'}."
+                )
             # Fix-R31C-3: this note used to fire whenever `data` was empty and
             # always blame it on "guideline uses a dosing algorithm" -- but
             # confirmed live that's wrong for a multi-drug guideline filtered
@@ -147,8 +211,9 @@ class CPICGetRecommendationsTool(BaseTool):
             # Distinguish "no table at all" (the real dosing-algorithm case,
             # e.g. warfarin/100425) from "table exists, not for this drug" by
             # checking whether the guideline has any rows once the drug
-            # filter is dropped.
-            if not data:
+            # filter is dropped. Skip when a gene/phenotype filter caused the
+            # emptiness -- the more specific note above already explains why.
+            if not data and not filtering:
                 guideline_has_other_rows = False
                 if rxnorm_id:
                     try:

--- a/src/tooluniverse/data/cpic_tools.json
+++ b/src/tooluniverse/data/cpic_tools.json
@@ -589,7 +589,7 @@
   },
   {
     "name": "CPIC_get_recommendations",
-    "description": "Get drug dosing recommendations from a CPIC pharmacogenomic guideline. Returns clinically actionable recommendations linking genotype/phenotype to prescribing actions (classification strength, recommendation text, allele status). Accepts drug name (e.g. 'codeine', 'abacavir') for auto-resolution to guideline_id, or provide guideline_id directly. Key guideline IDs: 100421 (HLA-B/abacavir), 100416 (CYP2D6,OPRM1,COMT/opioids-codeine), 100414 (CYP2D6,CYP2C19/tricyclic-antidepressants), 100415 (CYP2D6/tamoxifen), 100412 (CYP2C9,HLA-B/phenytoin). Note: warfarin (guideline 100425) uses a dosing calculator and returns 0 rows from this endpoint.",
+    "description": "Get drug dosing recommendations from a CPIC pharmacogenomic guideline. Returns clinically actionable recommendations linking genotype/phenotype to prescribing actions (classification strength, recommendation text, allele status). Accepts drug name (e.g. 'codeine', 'abacavir') for auto-resolution to guideline_id, or provide guideline_id directly. Without gene/phenotype, returns ALL recommendation rows for every genotype/phenotype combination the guideline covers -- pass gene (e.g. 'CYP2C19') and/or phenotype (e.g. 'Poor Metabolizer', exact CPIC term) to filter to one specific recommendation. Key guideline IDs: 100421 (HLA-B/abacavir), 100416 (CYP2D6,OPRM1,COMT/opioids-codeine), 100414 (CYP2D6,CYP2C19/tricyclic-antidepressants), 100415 (CYP2D6/tamoxifen), 100412 (CYP2C9,HLA-B/phenytoin). Note: warfarin (guideline 100425) uses a dosing calculator and returns 0 rows from this endpoint.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -605,19 +605,33 @@
           "type": "string",
           "description": "Alias for drug."
         },
+        "gene": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Filter to recommendation rows for this pharmacogene (e.g. 'CYP2C19', 'CYP2D6'), matched case-insensitively against each row's own phenotypes dict. Combine with phenotype for an exact single-row lookup."
+        },
+        "phenotype": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Filter to recommendation rows whose phenotype exactly matches this CPIC term (case-insensitive), e.g. 'Poor Metabolizer', 'Likely Poor Metabolizer', 'Normal Metabolizer', 'Ultrarapid Metabolizer'. Note 'Poor Metabolizer' and 'Likely Poor Metabolizer' are distinct CPIC categories, not synonyms -- use the exact term. If gene is also given, matches only that gene's phenotype value; otherwise matches any gene's phenotype value in the row."
+        },
         "limit": {
           "type": [
             "integer",
             "null"
           ],
-          "description": "Maximum number of recommendations to return (default 50)"
+          "description": "Maximum number of recommendations to return (default 50). Applied after gene/phenotype filtering, if any."
         },
         "offset": {
           "type": [
             "integer",
             "null"
           ],
-          "description": "Number of recommendations to skip for pagination (default 0)"
+          "description": "Number of recommendations to skip for pagination (default 0). Applied after gene/phenotype filtering, if any."
         }
       },
       "required": []
@@ -631,6 +645,11 @@
       {
         "guideline_id": 100421,
         "limit": 10
+      },
+      {
+        "drug": "clopidogrel",
+        "gene": "CYP2C19",
+        "phenotype": "Poor Metabolizer"
       }
     ],
     "return_schema": {
@@ -752,6 +771,12 @@
               "type": [
                 "integer",
                 "number"
+              ]
+            },
+            "note": {
+              "type": [
+                "string",
+                "null"
               ]
             }
           },

--- a/tests/unit/test_cpic_recommendations_gene_phenotype_filter.py
+++ b/tests/unit/test_cpic_recommendations_gene_phenotype_filter.py
@@ -1,0 +1,141 @@
+"""Regression guard for Fix-R79A-1: CPIC_get_recommendations had no way to
+filter by gene/phenotype -- "gene" and "phenotype" are not real parameters
+(no additionalProperties: false on this schema, so they were silently
+accepted and dropped rather than rejected), confirmed live that
+{"drug": "clopidogrel", "gene": "CYP2C19", "phenotype": "Poor Metabolizer"}
+returned all 24 rows across every phenotype/population combination for the
+guideline, completely unfiltered, with no indication either filter had zero
+effect. A caller very naturally guesses these names, since the tool's own
+description says it "links genotype/phenotype to prescribing actions" and
+every row already carries a `phenotypes` dict keyed by gene symbol.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.cpic_search_pairs_tool import CPICGetRecommendationsTool
+
+pytestmark = pytest.mark.unit
+
+_CLOPIDOGREL_ROWS = [
+    {"id": 1, "phenotypes": {"CYP2C19": "Indeterminate"}, "drugrecommendation": "No recommendation"},
+    {"id": 2, "phenotypes": {"CYP2C19": "Poor Metabolizer"}, "drugrecommendation": "Avoid clopidogrel"},
+    {"id": 3, "phenotypes": {"CYP2C19": "Likely Poor Metabolizer"}, "drugrecommendation": "Avoid clopidogrel (likely)"},
+    {"id": 4, "phenotypes": {"CYP2C19": "Normal Metabolizer"}, "drugrecommendation": "Standard dose"},
+    {"id": 5, "phenotypes": {"CYP2C19": "Poor Metabolizer"}, "drugrecommendation": "Avoid clopidogrel (alt population)"},
+]
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.json.return_value = json_body
+    r.raise_for_status.return_value = None
+    return r
+
+
+def _fake_get_for_guideline_id(rows):
+    def fake_get(url, params=None, **kwargs):
+        return _resp(rows)
+
+    return fake_get
+
+
+def test_gene_and_phenotype_together_returns_only_exact_matches():
+    tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+
+    with patch(
+        "tooluniverse.cpic_search_pairs_tool.requests.get",
+        side_effect=_fake_get_for_guideline_id(_CLOPIDOGREL_ROWS),
+    ):
+        result = tool.run(
+            {"guideline_id": 100411, "gene": "CYP2C19", "phenotype": "Poor Metabolizer"}
+        )
+
+    recs = result["data"]["recommendations"]
+    assert result["data"]["count"] == 2
+    assert {r["id"] for r in recs} == {2, 5}
+    # "Poor Metabolizer" must not also match "Likely Poor Metabolizer" -- a
+    # distinct, clinically different CPIC category, not a synonym.
+    assert all(r["phenotypes"]["CYP2C19"] == "Poor Metabolizer" for r in recs)
+
+
+def test_phenotype_alone_matches_any_gene_in_the_row():
+    tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+
+    with patch(
+        "tooluniverse.cpic_search_pairs_tool.requests.get",
+        side_effect=_fake_get_for_guideline_id(_CLOPIDOGREL_ROWS),
+    ):
+        result = tool.run({"guideline_id": 100411, "phenotype": "poor metabolizer"})
+
+    # case-insensitive match, no gene given
+    assert result["data"]["count"] == 2
+    assert {r["id"] for r in result["data"]["recommendations"]} == {2, 5}
+
+
+def test_gene_alone_matches_all_phenotypes_for_that_gene():
+    tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+
+    with patch(
+        "tooluniverse.cpic_search_pairs_tool.requests.get",
+        side_effect=_fake_get_for_guideline_id(_CLOPIDOGREL_ROWS),
+    ):
+        result = tool.run({"guideline_id": 100411, "gene": "cyp2c19"})
+
+    assert result["data"]["count"] == len(_CLOPIDOGREL_ROWS)
+
+
+def test_no_match_returns_helpful_note_with_available_phenotypes():
+    tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+
+    with patch(
+        "tooluniverse.cpic_search_pairs_tool.requests.get",
+        side_effect=_fake_get_for_guideline_id(_CLOPIDOGREL_ROWS),
+    ):
+        result = tool.run(
+            {"guideline_id": 100411, "gene": "CYP2C19", "phenotype": "Super Metabolizer"}
+        )
+
+    assert result["data"]["count"] == 0
+    note = result["data"]["note"]
+    assert "Super Metabolizer" in note
+    assert "Poor Metabolizer" in note  # a real available value is surfaced
+    assert "dosing algorithm" not in note  # must not collide with Fix-R31C-3's note
+
+
+def test_limit_and_offset_apply_after_filtering_not_before():
+    tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+
+    with patch(
+        "tooluniverse.cpic_search_pairs_tool.requests.get",
+        side_effect=_fake_get_for_guideline_id(_CLOPIDOGREL_ROWS),
+    ):
+        result = tool.run(
+            {"guideline_id": 100411, "phenotype": "Poor Metabolizer", "limit": 1}
+        )
+
+    # 2 rows match "Poor Metabolizer"; limit=1 must slice the FILTERED set
+    # (giving id 2), not the raw unfiltered 5-row table.
+    assert result["data"]["count"] == 1
+    assert result["data"]["recommendations"][0]["id"] == 2
+
+
+def test_no_gene_or_phenotype_given_keeps_original_unfiltered_behavior():
+    """Existing callers with no gene/phenotype must see zero behavior
+    change: the request goes out with the caller's own limit/offset, no
+    client-side filtering happens at all."""
+    tool = CPICGetRecommendationsTool({"name": "CPIC_get_recommendations"})
+    captured_params = {}
+
+    def fake_get(url, params=None, **kwargs):
+        captured_params.update(params or {})
+        return _resp(_CLOPIDOGREL_ROWS)
+
+    with patch("tooluniverse.cpic_search_pairs_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"guideline_id": 100411, "limit": 10, "offset": 5})
+
+    assert captured_params["limit"] == 10
+    assert captured_params["offset"] == 5
+    assert result["data"]["count"] == len(_CLOPIDOGREL_ROWS)
+    assert "note" not in result["data"]


### PR DESCRIPTION
## Summary

Continues round 78's cross-tool-consistency work, this round in a new tool family. Found via a pharmacogenomics cross-check (CYP2C19/clopidogrel, an FDA boxed-warning gene-drug pair): `CPIC_get_recommendations({"drug": "clopidogrel", "gene": "CYP2C19", "phenotype": "Poor Metabolizer"})` returned all 24 recommendation rows across every phenotype and population combination for the guideline, completely unfiltered. Neither `gene` nor `phenotype` was a real parameter — the schema has no `additionalProperties: false`, so both were silently accepted and dropped with no indication either had zero effect.

This is a clean "declared vs. actual" case: the tool's own description explicitly promises to link *"genotype/phenotype to prescribing actions,"* and every returned row already carries a `phenotypes` dict keyed by gene symbol — a caller very naturally guesses these param names and gets silently unfiltered results back instead of an error or a working filter.

Added real client-side filtering:
- **Exact case-insensitive match on the phenotype value, not substring.** `"Poor Metabolizer"` and `"Likely Poor Metabolizer"` are distinct CPIC categories with different clinical recommendations, not synonyms — a substring match would have silently merged two clinically different recommendations into one result, which is the same silent-wrongness shape as round 78's MARRVEL/ClinVar findings, just at the string-matching layer instead of the missing-capability layer.
- `limit`/`offset` now apply *after* filtering rather than before, by fetching a larger batch server-side whenever a filter is active — so pagination is over the filtered set a caller actually asked for, not an arbitrary raw slice of the unfiltered table.
- A no-match result now includes a note listing the guideline's actual available phenotype values (e.g. `Poor Metabolizer`, `Likely Poor Metabolizer`, `Normal Metabolizer`, ...) instead of a bare empty list — turns "did I typo the phenotype string?" into something answerable from the response itself.

Also verified round 78's ClinVar exact-match fix (still-unmerged PR #373) generalizes correctly to a different gene/variant — APOE/rs429358, the variant defining the Alzheimer's-risk APOE4 allele — before looking for new bugs this round. Confirming a fix holds on a fresh entity, not just the one that surfaced it, seemed worth doing before moving on.

## Test plan
- [x] New test file: `tests/unit/test_cpic_recommendations_gene_phenotype_filter.py` (6 tests — gene+phenotype exact match, phenotype-only across any gene, gene-only across all its phenotypes, no-match note with real available values, limit/offset applied after filtering, and unchanged behavior when no filter is given)
- [x] Existing CPIC tests (17 across `test_cpic_brand_name_error.py`, `test_cpic_get_gene_info_aliases.py`) pass unchanged
- [x] Live re-verification: `CPIC_get_recommendations({"drug":"clopidogrel","gene":"CYP2C19","phenotype":"Poor Metabolizer"})` now returns exactly 3 matching rows instead of all 24
- [x] `scripts/test_new_tools.py cpic` clean (16/16 schema valid)
- [x] Full suite (`pytest tests/ --maxfail=1000 --ignore=tests/test_claude_code_plugin.py`) passes, 0 failures