### PR TITLE
Fix Round 80: gather_gene_disease_associations fabricated ClinVar diseases

### DIFF
--- a/src/tooluniverse/compound_gene_disease_tool.py
+++ b/src/tooluniverse/compound_gene_disease_tool.py
@@ -93,28 +93,55 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
             r = _try_tool("GenCC", "GenCC_search_disease", {"disease": disease})
         results_by_source["GenCC"] = self._extract_genes_or_diseases(r, "GenCC")
 
-        # 5. ClinVar
-        r = _try_tool(
-            "ClinVar",
-            "ClinVar_search_variants",
-            {"query": gene or disease, "limit": 10},
-        )
+        # 5. ClinVar -- Fix-R80A-1: "query" is documented as an alias for
+        # "condition" (a disease/phenotype free-text search), not a gene
+        # lookup -- the exact same mistake already caught and fixed in the
+        # sibling compound_variant_tool.py (Fix-R31D-4/R31A-3), but never
+        # ported here. Confirmed live that {"query": "LDLR"} silently
+        # returned ClinVar rows for LDLR-related variants anyway (a
+        # coincidental partial match, not a deliberate gene lookup) whose
+        # `genes` field then got mislabeled as "disease" entries below (see
+        # that fix for why genes can't be used as disease names at all).
+        # Branch on gene/disease the same way DisGeNET/OpenTargets already do
+        # above.
+        if disease:
+            r = _try_tool(
+                "ClinVar",
+                "ClinVar_search_variants",
+                {"condition": disease, "limit": 10},
+            )
+        else:
+            r = _try_tool(
+                "ClinVar", "ClinVar_search_variants", {"gene": gene, "limit": 10}
+            )
         results_by_source["ClinVar"] = self._extract_genes_or_diseases(r, "ClinVar")
+
+        notes: List[str] = []
+        clinvar_failed = any(f.startswith("ClinVar:") for f in sources_failed)
+        if not clinvar_failed and not results_by_source["ClinVar"]:
+            notes.append(
+                "ClinVar was queried successfully but contributed no entries to "
+                "the disease-name comparison: ClinVar_search_variants' response "
+                "carries variant title/genes/clinical_significance, not a "
+                "condition/disease name, so this tool cannot extract named "
+                "disease associations from it. This is a data-shape limitation, "
+                "not evidence ClinVar has no data for this gene/disease."
+            )
 
         # Build cross-reference table
         associations = self._build_concordance(results_by_source)
 
-        return {
-            "status": "success",
-            "data": {
-                "query": {"gene": gene, "disease": disease},
-                "sources_queried": list(results_by_source.keys()),
-                "sources_failed": sources_failed,
-                "num_associations": len(associations),
-                "associations": associations[:50],
-                "per_source_results": {k: v[:10] for k, v in results_by_source.items()},
-            },
+        result: Dict[str, Any] = {
+            "query": {"gene": gene, "disease": disease},
+            "sources_queried": list(results_by_source.keys()),
+            "sources_failed": sources_failed,
+            "num_associations": len(associations),
+            "associations": associations[:50],
+            "per_source_results": {k: v[:10] for k, v in results_by_source.items()},
         }
+        if notes:
+            result["notes"] = notes
+        return {"status": "success", "data": result}
 
     def _opentargets_gene_diseases(
         self, tu, gene: str, sources_failed: List[str]
@@ -212,20 +239,19 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
                     items.append({"name": str(name), "score": None, "source": source})
             return items
 
-        # ClinVar: data has "variants" list
+        # Fix-R80A-1: ClinVar_search_variants' rows carry variant title,
+        # genes, clinical_significance, and review_status -- NOT a
+        # condition/disease name (confirmed live, including via the raw
+        # ClinVar eSearch/eSummary shape). The old code extracted each row's
+        # `genes` field into `items` here, so gene symbols themselves (e.g.
+        # "LDLR", plus co-located genes ClinVar's `genes` array includes for
+        # overlapping variants, like the antisense RNA gene "LDLR-AS1")
+        # silently appeared as if they were disease names in the
+        # concordance table. There is currently no usable disease/condition
+        # field to extract instead -- deliberately contribute nothing rather
+        # than fabricate one; run() adds an explanatory note when this
+        # leaves ClinVar's contribution empty despite a successful query.
         if isinstance(data, dict) and "variants" in data:
-            for v in data["variants"][:30]:
-                if isinstance(v, dict):
-                    genes = v.get("genes", [])
-                    for g in genes:
-                        items.append(
-                            {
-                                "name": str(g),
-                                "score": None,
-                                "source": source,
-                                "classification": v.get("clinical_significance", ""),
-                            }
-                        )
             return items
 
         # Generic: try common patterns

--- a/src/tooluniverse/data/compound_gene_disease_tools.json
+++ b/src/tooluniverse/data/compound_gene_disease_tools.json
@@ -48,6 +48,16 @@
                 },
                 "associations": {
                   "type": "array"
+                },
+                "per_source_results": {
+                  "type": "object"
+                },
+                "notes": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "description": "Present only when a source's contribution needs explanation beyond a plain empty result (e.g. it lacks the data shape this tool extracts from, distinct from genuinely having no data for the query)."
                 }
               }
             }

--- a/tests/unit/test_compound_gene_disease_clinvar_gene_names.py
+++ b/tests/unit/test_compound_gene_disease_clinvar_gene_names.py
@@ -1,0 +1,163 @@
+"""Regression guard for Fix-R80A-1: CompoundGeneDiseaseAssociationTool's
+ClinVar sub-query used {"query": gene_or_disease} -- "query" is documented as
+an alias for "condition" (a disease/phenotype free-text search), not a gene
+lookup, the exact same mistake already caught and fixed in the sibling
+compound_variant_tool.py (Fix-R31D-4/R31A-3) but never ported here.
+
+Compounding this, the extraction logic then pulled each returned variant
+row's "genes" field and added every gene symbol as if it were a disease
+name -- confirmed live for LDLR: "LDLR" (the gene itself) and "LDLR-AS1" (a
+co-located antisense RNA gene sharing overlapping ClinVar variant records)
+both appeared as "diseases associated with LDLR" in the concordance table.
+ClinVar_search_variants' row shape (title/genes/clinical_significance/
+review_status) has no usable disease/condition name field at all, confirmed
+live -- so the fix is to branch the query correctly (gene vs condition, like
+DisGeNET/OpenTargets already do in this same file) AND stop fabricating
+disease names from gene symbols, contributing nothing from ClinVar instead
+with an explanatory note rather than silently misleading data.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.compound_gene_disease_tool import CompoundGeneDiseaseAssociationTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return CompoundGeneDiseaseAssociationTool({"name": "gather_test"})
+
+
+_LDLR_CLINVAR_RESPONSE = {
+    "status": "success",
+    "data": {
+        "total_count": 4909,
+        "variant_ids": ["1", "2"],
+        "variants": [
+            {
+                "variant_id": "1",
+                "title": "NM_000527.5(LDLR):c.2566del (p.Glu856fs)",
+                "genes": ["LDLR"],
+                "clinical_significance": "Uncertain significance",
+            },
+            {
+                "variant_id": "2",
+                "title": "NM_000527.5(LDLR):c.1A>G",
+                "genes": ["LDLR", "LDLR-AS1"],
+                "clinical_significance": "Pathogenic",
+            },
+        ],
+    },
+}
+
+
+class TestClinVarExtractionNoLongerFabricatesDiseaseNames:
+    def test_extract_returns_empty_for_clinvar_variants_shape(self):
+        tool = _tool()
+        items = tool._extract_genes_or_diseases(_LDLR_CLINVAR_RESPONSE, "ClinVar")
+        assert items == []
+
+    def test_gene_symbols_never_appear_as_disease_names_end_to_end(self):
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.side_effect = lambda call: (
+            _LDLR_CLINVAR_RESPONSE
+            if call["name"] == "ClinVar_search_variants"
+            else {"status": "error", "error": "unused source"}
+        )
+
+        with patch("tooluniverse.execute_function.ToolUniverse", return_value=tu):
+            result = tool.run({"gene": "LDLR"})
+
+        names = [a["name"] for a in result["data"]["associations"]]
+        assert "LDLR" not in names
+        assert "LDLR-AS1" not in names
+        assert result["data"]["per_source_results"]["ClinVar"] == []
+
+
+class TestClinVarQueryParameterBranching:
+    def test_gene_only_query_uses_gene_param_not_query(self):
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.side_effect = lambda call: (
+            _LDLR_CLINVAR_RESPONSE
+            if call["name"] == "ClinVar_search_variants"
+            else {"status": "error", "error": "unused source"}
+        )
+
+        with patch("tooluniverse.execute_function.ToolUniverse", return_value=tu):
+            tool.run({"gene": "LDLR"})
+
+        clinvar_call = next(
+            c.args[0]
+            for c in tu.run_one_function.call_args_list
+            if c.args[0]["name"] == "ClinVar_search_variants"
+        )
+        assert clinvar_call["arguments"] == {"gene": "LDLR", "limit": 10}
+        assert "query" not in clinvar_call["arguments"]
+
+    def test_disease_only_query_uses_condition_param(self):
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.side_effect = lambda call: (
+            {"status": "success", "data": {"variants": []}}
+            if call["name"] == "ClinVar_search_variants"
+            else {"status": "error", "error": "unused source"}
+        )
+
+        with patch("tooluniverse.execute_function.ToolUniverse", return_value=tu):
+            tool.run({"disease": "familial hypercholesterolemia"})
+
+        clinvar_call = next(
+            c.args[0]
+            for c in tu.run_one_function.call_args_list
+            if c.args[0]["name"] == "ClinVar_search_variants"
+        )
+        assert clinvar_call["arguments"] == {
+            "condition": "familial hypercholesterolemia",
+            "limit": 10,
+        }
+        assert "query" not in clinvar_call["arguments"]
+
+
+class TestNoteDistinguishesLimitationFromFailure:
+    def test_note_added_when_clinvar_succeeds_but_has_no_usable_data(self):
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.side_effect = lambda call: (
+            _LDLR_CLINVAR_RESPONSE
+            if call["name"] == "ClinVar_search_variants"
+            else {"status": "error", "error": "unused source"}
+        )
+
+        with patch("tooluniverse.execute_function.ToolUniverse", return_value=tu):
+            result = tool.run({"gene": "LDLR"})
+
+        notes = result["data"].get("notes", [])
+        assert any("ClinVar" in n and "data-shape limitation" in n for n in notes)
+
+    def test_note_not_added_when_clinvar_genuinely_fails(self):
+        """A real ClinVar failure must be surfaced via sources_failed only,
+        not conflated with the "queried fine, nothing to extract" note --
+        those are different situations a caller should be able to tell
+        apart."""
+        tool = _tool()
+        tu = MagicMock()
+        tu.run_one_function.side_effect = lambda call: (
+            {"status": "error", "error": "simulated ClinVar outage"}
+            if call["name"] == "ClinVar_search_variants"
+            else {"status": "error", "error": "unused source"}
+        )
+
+        with patch("tooluniverse.execute_function.ToolUniverse", return_value=tu):
+            result = tool.run({"gene": "LDLR"})
+
+        assert any("ClinVar" in f for f in result["data"]["sources_failed"])
+        notes = result["data"].get("notes", [])
+        assert not any("data-shape limitation" in n for n in notes)


### PR DESCRIPTION
## Summary

Continues the round-78/79 cross-tool-consistency thread, this round via the `gather_gene_disease_associations` aggregator (queried LDLR / familial hypercholesterolemia). This one is a more severe flavor of the bug class the last two rounds found: rather than silently omitting or mislabeling something, the tool **fabricated entries a researcher could plausibly cite** — reporting `LDLR` (the gene itself) and `LDLR-AS1` (a co-located antisense RNA gene) as *diseases that LDLR causes*.

Root cause, two layers:

1. **Wrong ClinVar query parameter.** The sub-call used `{"query": gene_or_disease}` — `"query"` is documented as an alias for `"condition"` (a disease/phenotype free-text search), not a gene lookup. This is the exact same mistake already caught and fixed in the sibling `compound_variant_tool.py` (Fix-R31D-4/R31A-3) — it was just never ported to this file, even though this file's own DisGeNET and OpenTargets sections already correctly branch gene-vs-disease queries a few lines above the ClinVar one.
2. **Extraction fabricated disease names from gene symbols.** Confirmed live that `ClinVar_search_variants`' row shape (`title`/`genes`/`clinical_significance`/`review_status`) has **no disease/condition name field at all** — so the old code's "pull each row's `genes` field into the disease-name list" wasn't just mislabeled, it had no correct behavior available to fall back to.

Fixed by:
- Branching the ClinVar query the same way DisGeNET/OpenTargets already do in this file: `gene` → `{"gene": gene, "limit": 10}`, `disease` → `{"condition": disease, "limit": 10}`.
- Having the extraction correctly contribute **nothing** from ClinVar, rather than fabricate wrong entries, since there's genuinely no usable field to extract a disease name from.
- Adding a `notes` field, populated only when ClinVar succeeds but has nothing to contribute — explicitly distinct from `sources_failed` (a genuine ClinVar outage), so a caller can tell "structurally can't help here" apart from "this particular call failed."

**Worth flagging as its own class going forward**: silently-missing data at least fails toward under-claiming; fabricated associations fail toward confident nonsense. And the wrong-parameter half of this bug is itself an instance of a fix landing in one tool while an identical copy of the bug persisted in a sibling tool — worth a targeted sweep sometime: when a fix lands, grep sibling tools sharing the same call pattern to check whether they need it too.

## Test plan
- [x] New test file: `tests/unit/test_compound_gene_disease_clinvar_gene_names.py` (6 tests — extraction returns empty for ClinVar's actual response shape, gene symbols never leak into `associations` end-to-end, gene query uses `gene` not `query`, disease query uses `condition`, the limitation note appears on success-but-empty, and does *not* appear on a genuine ClinVar failure)
- [x] Existing regression test `tests/unit/test_compound_gene_disease_opentargets_lookup.py` (9 tests) passes unchanged
- [x] Live end-to-end re-verification of both branches: `gather_gene_disease_associations({"gene": "LDLR"})` no longer includes `LDLR`/`LDLR-AS1` in `associations`; `gather_gene_disease_associations({"disease": "cystic fibrosis"})` runs cleanly through the `condition` path
- [x] `scripts/test_new_tools.py compound_gene_disease` clean (3/3 schema valid)
- [x] Full suite (`pytest tests/ --maxfail=1000 --ignore=tests/test_claude_code_plugin.py`) passes, 0 failures