### PR TITLE
Fix Round 82: ComplexPortal species filter never matches (taxid vs facet-name mismatch)

### DIFF
--- a/src/tooluniverse/complex_portal_tool.py
+++ b/src/tooluniverse/complex_portal_tool.py
@@ -25,6 +25,54 @@ from .tool_registry import register_tool
 # Base URL for Complex Portal API (IntAct complex-ws)
 COMPLEX_PORTAL_BASE = "https://www.ebi.ac.uk/intact/complex-ws"
 
+# Complex Portal's `species_f` search facet is indexed by full UniProt-style
+# organism name strings (confirmed via the API's own `facets` response), NOT
+# NCBI taxonomy IDs -- a raw "9606" never matches anything in the facet
+# index and silently no-ops the filter. This maps the common taxonomy IDs
+# and casual names callers are likely to pass to the exact facet strings.
+SPECIES_TAXID_TO_NAME = {
+    "9606": "Homo sapiens",
+    "10090": "Mus musculus",
+    "10116": "Rattus norvegicus",
+    "7227": "Drosophila melanogaster",
+    "6239": "Caenorhabditis elegans",
+    "7955": "Danio rerio",
+    "3702": "Arabidopsis thaliana",
+    "9031": "Gallus gallus",
+    "9913": "Bos taurus",
+    "4932": "Saccharomyces cerevisiae (strain ATCC 204508 / S288c)",
+    "559292": "Saccharomyces cerevisiae (strain ATCC 204508 / S288c)",
+    "83333": "Escherichia coli (strain K12)",
+    "511145": "Escherichia coli (strain K12)",
+    "284812": "Schizosaccharomyces pombe (strain 972 / ATCC 24843)",
+    "2697049": "Severe acute respiratory syndrome coronavirus 2",
+    "694009": "Severe acute respiratory syndrome coronavirus",
+}
+SPECIES_NAME_ALIASES = {
+    "human": "Homo sapiens",
+    "mouse": "Mus musculus",
+    "rat": "Rattus norvegicus",
+    "fly": "Drosophila melanogaster",
+    "fruit fly": "Drosophila melanogaster",
+    "worm": "Caenorhabditis elegans",
+    "zebrafish": "Danio rerio",
+    "yeast": "Saccharomyces cerevisiae (strain ATCC 204508 / S288c)",
+    "e. coli": "Escherichia coli (strain K12)",
+    "e.coli": "Escherichia coli (strain K12)",
+    "ecoli": "Escherichia coli (strain K12)",
+}
+
+
+def _resolve_species_facet_name(species: str) -> str:
+    """Translate a caller-supplied taxonomy ID or common name to the exact
+    organism name string Complex Portal's species_f facet is indexed by.
+    Falls back to the input as-is, so a caller who already knows and passes
+    the exact facet name (e.g. a less common organism) still works."""
+    key = species.strip()
+    return (
+        SPECIES_TAXID_TO_NAME.get(key) or SPECIES_NAME_ALIASES.get(key.lower()) or key
+    )
+
 
 @register_tool("ComplexPortalTool")
 class ComplexPortalTool(BaseTool):
@@ -73,11 +121,12 @@ class ComplexPortalTool(BaseTool):
             return {"status": "error", "error": "query parameter is required"}
 
         try:
+            species_name = _resolve_species_facet_name(species) if species else None
             url = f"{COMPLEX_PORTAL_BASE}/search/{query}"
             params = {
                 "format": "json",
                 "facets": "species_f",
-                "filters": f"species_f:({species})" if species else None,
+                "filters": f'species_f:("{species_name}")' if species_name else None,
                 "first": first,
                 "number": min(number, 100),
             }
@@ -125,7 +174,7 @@ class ComplexPortalTool(BaseTool):
                 "status": "success",
                 "data": {
                     "query": query,
-                    "species_filter": species,
+                    "species_filter": species_name,
                     "complexes": complexes,
                     "count": len(complexes),
                     "total_found": total_found,

--- a/src/tooluniverse/data/complex_portal_tools.json
+++ b/src/tooluniverse/data/complex_portal_tools.json
@@ -11,7 +11,7 @@
         },
         "species": {
           "type": "string",
-          "description": "NCBI taxonomy ID to filter by species (default: '9606' for human). Use '10090' for mouse, '10116' for rat, '' for all species.",
+          "description": "NCBI taxonomy ID or common species name to filter by species (default: '9606' for human). Common IDs/names are mapped to Complex Portal's organism index, e.g. '10090' or 'mouse' for Mus musculus, '10116' or 'rat' for Rattus norvegicus, 'yeast' for Saccharomyces cerevisiae; pass '' for all species.",
           "default": "9606"
         },
         "number": {

--- a/tests/unit/test_complex_portal_species_filter.py
+++ b/tests/unit/test_complex_portal_species_filter.py
@@ -1,0 +1,114 @@
+"""Complex Portal species filter (round 82).
+
+Complex Portal's `species_f` search facet is indexed by full organism name
+strings (e.g. "Homo sapiens"), not NCBI taxonomy IDs -- confirmed live
+against the API's own `facets` response. The tool's documented default
+("9606") never matched anything, silently no-opping the species filter for
+every caller. These tests cover the taxid/alias -> facet-name resolution
+and the properly-quoted filter string, with mocks (no live calls).
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool():
+    from tooluniverse.complex_portal_tool import ComplexPortalTool
+
+    return ComplexPortalTool(
+        {
+            "name": "ComplexPortal_search_complexes",
+            "type": "ComplexPortalTool",
+            "fields": {"operation": "search_complexes"},
+        }
+    )
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.json.return_value = json_body
+    r.raise_for_status.return_value = None
+    return r
+
+
+class TestResolveSpeciesFacetName(unittest.TestCase):
+    def test_common_taxid_resolves_to_facet_name(self):
+        from tooluniverse.complex_portal_tool import _resolve_species_facet_name
+
+        self.assertEqual(_resolve_species_facet_name("9606"), "Homo sapiens")
+        self.assertEqual(_resolve_species_facet_name("10090"), "Mus musculus")
+        self.assertEqual(_resolve_species_facet_name("10116"), "Rattus norvegicus")
+
+    def test_common_name_alias_resolves_to_facet_name(self):
+        from tooluniverse.complex_portal_tool import _resolve_species_facet_name
+
+        self.assertEqual(_resolve_species_facet_name("human"), "Homo sapiens")
+        self.assertEqual(_resolve_species_facet_name("Human"), "Homo sapiens")
+        self.assertEqual(
+            _resolve_species_facet_name("yeast"),
+            "Saccharomyces cerevisiae (strain ATCC 204508 / S288c)",
+        )
+
+    def test_unmapped_value_passes_through_unchanged(self):
+        from tooluniverse.complex_portal_tool import _resolve_species_facet_name
+
+        self.assertEqual(
+            _resolve_species_facet_name("Mus musculus"), "Mus musculus"
+        )
+        self.assertEqual(_resolve_species_facet_name("Some Rare Organism"), "Some Rare Organism")
+
+
+class TestSearchComplexesSpeciesFilter(unittest.TestCase):
+    def test_default_species_filters_by_homo_sapiens_quoted(self):
+        tool = _make_tool()
+        with patch("tooluniverse.complex_portal_tool.requests.get") as get:
+            get.return_value = _resp({"elements": [], "totalNumberOfResults": 0})
+            result = tool.run({"query": "proteasome"})
+
+        filters = get.call_args.kwargs["params"]["filters"]
+        self.assertEqual(filters, 'species_f:("Homo sapiens")')
+        self.assertEqual(result["data"]["species_filter"], "Homo sapiens")
+
+    def test_taxid_9606_resolves_and_quotes(self):
+        tool = _make_tool()
+        with patch("tooluniverse.complex_portal_tool.requests.get") as get:
+            get.return_value = _resp({"elements": [], "totalNumberOfResults": 0})
+            tool.run({"query": "proteasome", "species": "9606"})
+
+        filters = get.call_args.kwargs["params"]["filters"]
+        self.assertEqual(filters, 'species_f:("Homo sapiens")')
+
+    def test_mouse_taxid_resolves_and_quotes(self):
+        tool = _make_tool()
+        with patch("tooluniverse.complex_portal_tool.requests.get") as get:
+            get.return_value = _resp({"elements": [], "totalNumberOfResults": 0})
+            tool.run({"query": "kinase", "species": "10090"})
+
+        filters = get.call_args.kwargs["params"]["filters"]
+        self.assertEqual(filters, 'species_f:("Mus musculus")')
+
+    def test_empty_species_disables_filter(self):
+        tool = _make_tool()
+        with patch("tooluniverse.complex_portal_tool.requests.get") as get:
+            get.return_value = _resp({"elements": [], "totalNumberOfResults": 0})
+            tool.run({"query": "TP53", "species": ""})
+
+        params = get.call_args.kwargs["params"]
+        self.assertNotIn("filters", params)
+
+    def test_unmapped_species_name_is_quoted_verbatim(self):
+        tool = _make_tool()
+        with patch("tooluniverse.complex_portal_tool.requests.get") as get:
+            get.return_value = _resp({"elements": [], "totalNumberOfResults": 0})
+            tool.run({"query": "TP53", "species": "Gallus gallus"})
+
+        filters = get.call_args.kwargs["params"]["filters"]
+        self.assertEqual(filters, 'species_f:("Gallus gallus")')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`ComplexPortal_search_complexes`'s `species` parameter has never actually filtered results, for any caller, including the tool's own documented default.

**Root cause**: `complex_portal_tool.py`'s `_search_complexes` builds `filters=species_f:({species})` with `species` defaulting to `"9606"` (an NCBI taxonomy ID). EBI Complex Portal's `species_f` search facet is indexed by full organism-name strings (e.g. `"Homo sapiens"`), not taxonomy IDs — confirmed via the API's own `facets` response. Even the correct name-based value fails unless it's quoted inside the filter expression, which the code also never did.

**File:line**: `src/tooluniverse/complex_portal_tool.py:68,80` (`_search_complexes`)

## Verification

Raw `curl` comparison against the live API, before any fix:

```
filters=species_f:(9606)         -> totalNumberOfResults: 417, mixed species
filters=species_f:(human)        -> totalNumberOfResults: 417, mixed species (identical)
(no filter at all)               -> totalNumberOfResults: 417, mixed species (identical)
filters=species_f:(Homo sapiens) -> totalNumberOfResults: 417, mixed species (unquoted multi-word still fails)
filters=species_f:("Homo sapiens") -> totalNumberOfResults: 303, species: {'Homo sapiens; 9606'} only
```

The last line — the only one that actually filters — requires both (a) the facet's real name-based value and (b) proper quoting. Every caller who passed the tool's own documented default (`"9606"`) has always silently gotten unfiltered, mixed-species results while the response's own `species_filter` field implied filtering had happened.

Confirmed live post-fix via the CLI (`tu run ComplexPortal_search_complexes`):
- Default (no `species` arg) → resolves to `"Homo sapiens"`, `total_found: 303`, all results `Homo sapiens; 9606`.
- `"species": "9606"` → same as default.
- `"species": "human"` (alias) → same as default.
- `"species": "Mus musculus"` (unmapped-but-already-correct value, passed through) → `total_found: 171`, all results `Mus musculus; 10090`.

Both counts match the API's own `facets` response for those organisms exactly.

## Fix

Added `SPECIES_TAXID_TO_NAME` / `SPECIES_NAME_ALIASES` lookup tables (covering Complex Portal's actual model-organism roster, taken from the API's own facet response) and a `_resolve_species_facet_name()` helper. Common taxonomy IDs and casual names (`"human"`, `"mouse"`, `"yeast"`, ...) resolve to the exact facet string; anything unmapped passes through unchanged (still correctly quoted) so a caller who already knows the exact facet name is unaffected. The `species_filter` field in the response now reports the resolved name actually used, not the raw input, so callers can see what was applied.

Checked for the same call pattern elsewhere in the codebase (`grep -rn "species_f\|COMPLEX_PORTAL_BASE"`) — `intact_tool.py` also hits Complex Portal's `complex-ws` base URL but its `_use_complex_web_service`/`_get_complex_details` paths have no species filter at all, so there's no sibling porting-gap here.

## Tests

- New `tests/unit/test_complex_portal_species_filter.py` (8 tests, mocked, no live calls): taxid/alias/fallback resolution, and that `_search_complexes` builds the correctly quoted `filters` param for the default, a mapped taxid, an alias, an empty species (no filter), and an unmapped name.
- Existing `tests/tools/test_complex_portal_tool.py` (7 tests, live API) still passes unmodified.
- Full suite: 100% clean (0 failures, 0 errors) on this branch.

## Other findings this round (no fix needed)

Spot-checked 4 additional long-tail tools (RGD, TogoID, Pfam, Norine) across different call shapes — all correct, no new bugs.
