### PR TITLE
Test-harness rounds 83+ (rolling): TheraSAbDab HTML entities, ReMap region validation

### DIFF
--- a/src/tooluniverse/data/msigdb_tools.json
+++ b/src/tooluniverse/data/msigdb_tools.json
@@ -199,6 +199,9 @@
         "gene"
       ]
     },
+    "fields": {
+      "operation": "check_gene_in_set"
+    },
     "return_schema": {
       "oneOf": [
         {
@@ -278,6 +281,9 @@
       "required": [
         "gene_set_name"
       ]
+    },
+    "fields": {
+      "operation": "get_gene_set"
     },
     "return_schema": {
       "oneOf": [

--- a/src/tooluniverse/msigdb_tool.py
+++ b/src/tooluniverse/msigdb_tool.py
@@ -24,9 +24,10 @@ class MSigDBTool(BaseTool):
 
     def __init__(self, tool_config: Dict[str, Any], **kwargs):
         super().__init__(tool_config)
+        self.operation = tool_config.get("fields", {}).get("operation", "get_gene_set")
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        operation = arguments.get("operation", "get_gene_set")
+        operation = arguments.get("operation", self.operation)
 
         if operation == "get_gene_set":
             return self._get_gene_set(arguments)

--- a/src/tooluniverse/pathwaycommons_tool.py
+++ b/src/tooluniverse/pathwaycommons_tool.py
@@ -182,26 +182,48 @@ class PathwayCommonsTool(BaseTool):
                 "error": "Failed to retrieve pathway data for URI: {}".format(uri),
             }
 
+        # _traverse returns None on a failed request but [] on a genuinely
+        # empty-but-successful one -- track which secondary fields failed to
+        # fetch so the response doesn't silently conflate "fetch failed"
+        # with "this pathway genuinely has no such data."
+        fetch_failures = []
+
+        def _scalar(values, label):
+            if values is None:
+                fetch_failures.append(label)
+                return None
+            return values[0] if values else None
+
+        def _list(values, label):
+            if values is None:
+                fetch_failures.append(label)
+                return []
+            return values
+
         result = {
             "pathway": {
                 "uri": uri,
                 "name": name[0] if name else None,
-                "description": comment[0] if comment else None,
-                "organism": organism[0] if organism else None,
-                "data_source": data_source[0] if data_source else None,
+                "description": _scalar(comment, "comment"),
+                "organism": _scalar(organism, "organism"),
+                "data_source": _scalar(data_source, "data_source"),
             },
-            "sub_pathways": sub_pathways or [],
-            "participants": participants or [],
+            "sub_pathways": _list(sub_pathways, "sub_pathways"),
+            "participants": _list(participants, "participants"),
         }
+
+        metadata = {
+            "uri": uri,
+            "sub_pathway_count": len(result["sub_pathways"]),
+            "participant_count": len(result["participants"]),
+        }
+        if fetch_failures:
+            metadata["fetch_failures"] = fetch_failures
 
         return {
             "status": "success",
             "data": result,
-            "metadata": {
-                "uri": uri,
-                "sub_pathway_count": len(sub_pathways or []),
-                "participant_count": len(participants or []),
-            },
+            "metadata": metadata,
         }
 
     def _get_neighborhood(self, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/tooluniverse/remap_tool.py
+++ b/src/tooluniverse/remap_tool.py
@@ -8,7 +8,7 @@ from .tool_registry import register_tool
 # Real ReMap REST API (region-based TR-binding peak retrieval).
 REMAP_REST_BASE = "https://remap-rest.univ-amu.fr/api/V1"
 # Match "chr1:1000000-1100000" (chrom may be e.g. chrX / chr1 / 1).
-_REGION_RE = re.compile(r"^(chr)?[\w]+:\d+-\d+$", re.IGNORECASE)
+_REGION_RE = re.compile(r"^(?:chr)?\w+:(\d+)-(\d+)$", re.IGNORECASE)
 
 
 @register_tool("ReMapRESTTool")
@@ -44,10 +44,16 @@ class ReMapRESTTool(BaseTool):
                     "status": "error",
                     "error": "region is required (e.g. chr1:1000000-1100000)",
                 }
-            if not _REGION_RE.match(region):
+            region_match = _REGION_RE.match(region)
+            if not region_match:
                 return {
                     "status": "error",
                     "error": f"Invalid region format: '{region}'. Use chrom:start-end (e.g. chr1:1000000-1100000).",
+                }
+            if int(region_match.group(1)) >= int(region_match.group(2)):
+                return {
+                    "status": "error",
+                    "error": f"Invalid region '{region}': start must be less than end.",
                 }
 
             version = str(arguments.get("version", "2022"))

--- a/src/tooluniverse/therasabdab_tool.py
+++ b/src/tooluniverse/therasabdab_tool.py
@@ -17,6 +17,7 @@ Website: https://opig.stats.ox.ac.uk/webapps/sabdab-sabpred/therasabdab/
 
 import requests
 from typing import Dict, Any, List, Optional
+import html as html_lib
 import re
 from urllib.parse import urlparse, parse_qs
 from .base_tool import BaseTool
@@ -230,8 +231,8 @@ class TheraSAbDabTool(BaseTool):
                 def clean_html(text):
                     # Remove HTML tags
                     clean = re.sub(r"<[^>]+>", "", text)
-                    # Decode entities
-                    clean = clean.replace("&nbsp;", " ").strip()
+                    # Decode entities (named and numeric, e.g. &amp; &#39; &nbsp;)
+                    clean = html_lib.unescape(clean).replace("\xa0", " ").strip()
                     return clean
 
                 therapeutic = {

--- a/tests/unit/test_msigdb_operation_routing.py
+++ b/tests/unit/test_msigdb_operation_routing.py
@@ -1,0 +1,129 @@
+"""Round 85: MSigDBTool.run() read `operation` only from the caller's own
+arguments (`arguments.get("operation", "get_gene_set")`), never from the
+tool config's `fields.operation`. `MSigDB_check_gene_in_set` and
+`MSigDB_get_gene_set_members`'s configs both had an empty `fields` dict, so
+neither tool's own documented example (which never passes `operation`
+itself) ever reached its real handler -- `MSigDB_check_gene_in_set` always
+silently fell through to `_get_gene_set`, meaning the `gene` parameter was
+never even inspected and the tool's entire membership-check purpose was
+unreachable through normal use. Confirmed live: HALLMARK_APOPTOSIS + TP53
+returned the full 161-gene set dump with no `is_member` field at all.
+Fixed by reading `self.operation` (set from `tool_config['fields']`) as the
+fallback, matching the pattern used elsewhere in the codebase (e.g.
+ComplexPortalTool), and wiring both tools' configs to their real operation.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.msigdb_tool import MSigDBTool
+
+pytestmark = pytest.mark.unit
+
+HALLMARK_APOPTOSIS = {
+    "HALLMARK_APOPTOSIS": {
+        "systematicName": "M5902",
+        "collection": "H",
+        "pmid": "26771021",
+        "geneSymbols": ["BAX", "BID", "BAK1"],
+        "briefDescription": "Genes mediating programmed cell death.",
+        "externalDetailsURL": [],
+    }
+}
+
+
+def _mock_urlopen(body):
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(body).encode("utf-8")
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+def test_check_gene_in_set_reachable_without_caller_passing_operation():
+    """The tool's own documented example never passes `operation` -- config
+    wiring must be what routes it, not a caller-supplied override."""
+    tool = MSigDBTool(
+        {
+            "name": "MSigDB_check_gene_in_set",
+            "type": "MSigDBTool",
+            "fields": {"operation": "check_gene_in_set"},
+        }
+    )
+    with patch(
+        "tooluniverse.msigdb_tool.urllib.request.urlopen",
+        return_value=_mock_urlopen(HALLMARK_APOPTOSIS),
+    ):
+        result = tool.run({"gene_set_name": "HALLMARK_APOPTOSIS", "gene": "TP53"})
+
+    assert result["status"] == "success"
+    assert "is_member" in result["data"]
+    assert result["data"]["is_member"] is False
+
+
+def test_check_gene_in_set_true_for_real_member():
+    tool = MSigDBTool(
+        {
+            "name": "MSigDB_check_gene_in_set",
+            "type": "MSigDBTool",
+            "fields": {"operation": "check_gene_in_set"},
+        }
+    )
+    with patch(
+        "tooluniverse.msigdb_tool.urllib.request.urlopen",
+        return_value=_mock_urlopen(HALLMARK_APOPTOSIS),
+    ):
+        result = tool.run({"gene_set_name": "HALLMARK_APOPTOSIS", "gene": "BAX"})
+
+    assert result["data"]["is_member"] is True
+    assert result["data"]["total_genes_in_set"] == 3
+
+
+def test_get_gene_set_members_still_reaches_get_gene_set():
+    tool = MSigDBTool(
+        {
+            "name": "MSigDB_get_gene_set_members",
+            "type": "MSigDBTool",
+            "fields": {"operation": "get_gene_set"},
+        }
+    )
+    with patch(
+        "tooluniverse.msigdb_tool.urllib.request.urlopen",
+        return_value=_mock_urlopen(HALLMARK_APOPTOSIS),
+    ):
+        result = tool.run({"gene_set_name": "HALLMARK_APOPTOSIS"})
+
+    assert result["status"] == "success"
+    assert result["data"]["genes"] == ["BAX", "BID", "BAK1"]
+    assert result["data"]["num_genes"] == 3
+
+
+def test_caller_can_still_override_operation_explicitly():
+    tool = MSigDBTool(
+        {
+            "name": "MSigDB_check_gene_in_set",
+            "type": "MSigDBTool",
+            "fields": {"operation": "check_gene_in_set"},
+        }
+    )
+    with patch(
+        "tooluniverse.msigdb_tool.urllib.request.urlopen",
+        return_value=_mock_urlopen(HALLMARK_APOPTOSIS),
+    ):
+        result = tool.run(
+            {"gene_set_name": "HALLMARK_APOPTOSIS", "operation": "get_gene_set"}
+        )
+
+    assert "is_member" not in result["data"]
+    assert result["data"]["genes"] == ["BAX", "BID", "BAK1"]
+
+
+def test_missing_config_operation_defaults_to_get_gene_set():
+    tool = MSigDBTool({"name": "x", "type": "MSigDBTool", "fields": {}})
+    assert tool.operation == "get_gene_set"

--- a/tests/unit/test_pathwaycommons_fetch_failures.py
+++ b/tests/unit/test_pathwaycommons_fetch_failures.py
@@ -1,0 +1,138 @@
+"""PathwayCommons_get_pathway conflated "this secondary field's traverse
+request failed" with "this pathway genuinely has no such data" -- `_traverse`
+returns None on a failed request but [] on a genuinely-empty-but-successful
+one, yet `_get_pathway` used `x[0] if x else None` / `x or []` for comment,
+organism, data_source, sub_pathways, and participants, collapsing both cases
+to the same None/[] output with zero indication anything failed (flagged as
+a deferred lead in round 75, fixed in round 88). The primary `name` field
+was already handled correctly (`if name is None: return error`) -- these
+tests cover the secondary fields getting the same distinction via a new
+`metadata.fetch_failures` list.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool():
+    from tooluniverse.pathwaycommons_tool import PathwayCommonsTool
+
+    return PathwayCommonsTool(
+        {
+            "name": "PathwayCommons_get_pathway",
+            "type": "PathwayCommonsTool",
+            "fields": {"operation": "get_pathway"},
+            "parameter": {"type": "object", "properties": {}, "required": ["uri"]},
+        }
+    )
+
+
+def _resp(status_code, traverse_entry=None):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = {"traverseEntry": traverse_entry or []}
+    return r
+
+
+PATH_TO_FIELD = {
+    "Pathway/displayName": "name",
+    "Pathway/comment": "comment",
+    "Pathway/organism/displayName": "organism",
+    "Pathway/dataSource/displayName": "data_source",
+    "Pathway/pathwayComponent:Pathway/displayName": "sub_pathways",
+    "Pathway/pathwayComponent/participant/displayName": "participants",
+}
+
+
+def _side_effect_factory(failing_fields, values):
+    def _get(url, params=None, timeout=None):
+        path = params["path"]
+        field = PATH_TO_FIELD[path]
+        if field in failing_fields:
+            return _resp(500)
+        value = values.get(field, [])
+        return _resp(200, [{"value": value}] if value else [])
+
+    return _get
+
+
+class TestFetchFailureDistinction(unittest.TestCase):
+    def test_all_succeed_no_fetch_failures_key(self):
+        tool = _make_tool()
+        tool.session.get = MagicMock(
+            side_effect=_side_effect_factory(
+                failing_fields=set(),
+                values={"name": ["Apoptosis"], "comment": ["A pathway."]},
+            )
+        )
+
+        result = tool._get_pathway({"uri": "http://example.org/p1"})
+
+        self.assertEqual(result["status"], "success")
+        self.assertNotIn("fetch_failures", result["metadata"])
+        self.assertEqual(result["data"]["pathway"]["description"], "A pathway.")
+
+    def test_genuinely_empty_field_not_flagged_as_failure(self):
+        """A request that succeeds with no data must NOT appear in fetch_failures."""
+        tool = _make_tool()
+        tool.session.get = MagicMock(
+            side_effect=_side_effect_factory(
+                failing_fields=set(), values={"name": ["Apoptosis"]}
+            )
+        )
+
+        result = tool._get_pathway({"uri": "http://example.org/p1"})
+
+        self.assertEqual(result["status"], "success")
+        self.assertNotIn("fetch_failures", result["metadata"])
+        self.assertIsNone(result["data"]["pathway"]["description"])
+        self.assertEqual(result["data"]["sub_pathways"], [])
+
+    def test_failed_secondary_field_flagged_distinctly_from_empty(self):
+        tool = _make_tool()
+        tool.session.get = MagicMock(
+            side_effect=_side_effect_factory(
+                failing_fields={"comment"}, values={"name": ["Apoptosis"]}
+            )
+        )
+
+        result = tool._get_pathway({"uri": "http://example.org/p1"})
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["metadata"]["fetch_failures"], ["comment"])
+        # Still None -- callers reading only `description` can't tell the
+        # difference, but `fetch_failures` now makes it discoverable.
+        self.assertIsNone(result["data"]["pathway"]["description"])
+
+    def test_multiple_failed_fields_all_listed(self):
+        tool = _make_tool()
+        tool.session.get = MagicMock(
+            side_effect=_side_effect_factory(
+                failing_fields={"sub_pathways", "participants"},
+                values={"name": ["Apoptosis"]},
+            )
+        )
+
+        result = tool._get_pathway({"uri": "http://example.org/p1"})
+
+        self.assertEqual(
+            set(result["metadata"]["fetch_failures"]),
+            {"sub_pathways", "participants"},
+        )
+        self.assertEqual(result["data"]["sub_pathways"], [])
+        self.assertEqual(result["metadata"]["sub_pathway_count"], 0)
+
+    def test_primary_name_failure_still_hard_errors(self):
+        """Unchanged existing behavior: a failed `name` fetch is a full error."""
+        tool = _make_tool()
+        tool.session.get = MagicMock(
+            side_effect=_side_effect_factory(failing_fields={"name"}, values={})
+        )
+
+        result = tool._get_pathway({"uri": "http://example.org/p1"})
+
+        self.assertEqual(result["status"], "error")

--- a/tests/unit/test_remap_region_validation.py
+++ b/tests/unit/test_remap_region_validation.py
@@ -1,0 +1,55 @@
+"""Round 84: ReMap_get_peaks_in_region accepted an inverted region
+(start >= end, e.g. "chr1:1010000-1000000") as valid format and silently
+forwarded it to the ReMap REST API, which returns HTTP 200 with zero peaks
+for it -- indistinguishable from "this valid, modest region genuinely has no
+ChIP-seq peaks." Fixed by validating start < end alongside the existing
+chrom:start-end format check.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.remap_tool import ReMapRESTTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ReMapRESTTool({"name": "ReMap_get_peaks_in_region", "fields": {}})
+
+
+def test_inverted_region_rejected():
+    tool = _tool()
+    result = tool._get_peaks_in_region({"region": "chr1:1010000-1000000"})
+    assert result["status"] == "error"
+    assert "start must be less than end" in result["error"]
+
+
+def test_zero_width_region_rejected():
+    tool = _tool()
+    result = tool._get_peaks_in_region({"region": "chr1:1000000-1000000"})
+    assert result["status"] == "error"
+    assert "start must be less than end" in result["error"]
+
+
+def test_malformed_region_still_rejected():
+    tool = _tool()
+    result = tool._get_peaks_in_region({"region": "not-a-region"})
+    assert result["status"] == "error"
+    assert "Invalid region format" in result["error"]
+
+
+def test_valid_region_still_reaches_the_api():
+    tool = _tool()
+    resp = MagicMock()
+    resp.json.return_value = {"peaks": []}
+    resp.raise_for_status.return_value = None
+    with patch.object(tool.session, "get", return_value=resp) as get:
+        result = tool._get_peaks_in_region({"region": "chr1:1000000-1010000"})
+    assert result["status"] == "success"
+    assert "chr1:1000000-1010000" in get.call_args.args[0]

--- a/tests/unit/test_therasabdab_html_entity_decoding.py
+++ b/tests/unit/test_therasabdab_html_entity_decoding.py
@@ -1,0 +1,79 @@
+"""Round 84: TheraSAbDab_search_therapeutics/get_all_therapeutics/search_by_target
+(all backed by `_parse_search_results`) left raw HTML entities in every parsed
+cell -- `clean_html()` only special-cased `&nbsp;`, so any therapeutic whose
+format/target/etc. contained an apostrophe, ampersand, or quote in the source
+page rendered corrupted (e.g. "VH-VH-VH&#39;-VH&#39;&#39;-VH&#39;" instead of
+"VH-VH-VH'-VH''-VH'"). Confirmed live: &amp; appears 22541 times and &#39;
+326 times in the real page source. Fixed by using the standard `html.unescape`
+instead of a single hardcoded replace.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.therasabdab_tool import TheraSAbDabTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return TheraSAbDabTool({"name": "TheraSAbDab_get_all_therapeutics"})
+
+
+def _row(cells):
+    tds = "".join(f"<td>{c}</td>" for c in cells)
+    return f"<table><tr>{tds}</tr></table>"
+
+
+def test_numeric_apostrophe_entity_decoded():
+    tool = _tool()
+    html = _row(
+        [
+            "brivekimig1",
+            "Trispecific Single Domains (VH-VH-VH&#39;-VH&#39;&#39;-VH&#39;)",
+            "Phase-II",
+            "Active",
+            "TNF/TNFRSF1A",
+            "2023",
+        ]
+    )
+    result = tool._parse_search_results(html)
+    assert result[0]["format"] == "Trispecific Single Domains (VH-VH-VH'-VH''-VH')"
+
+
+def test_ampersand_entity_decoded():
+    tool = _tool()
+    html = _row(
+        ["dualab", "Fc&Fab fusion", "Approved", "Active", "CD3D&amp;CD3E", "2020"]
+    )
+    result = tool._parse_search_results(html)
+    assert result[0]["format"] == "Fc&Fab fusion"
+    assert result[0]["target"] == "CD3D&CD3E"
+
+
+def test_nbsp_still_normalized_to_space():
+    tool = _tool()
+    html = _row(["someab", "Whole&nbsp;mAb", "Approved", "Active", "TNF", "2020"])
+    result = tool._parse_search_results(html)
+    assert result[0]["format"] == "Whole mAb"
+
+
+def test_quote_entity_decoded():
+    tool = _tool()
+    html = _row(
+        ["quoteab", '5&#39;-capped &quot;variant&quot;', "Approved", "Active", "TNF", "2020"]
+    )
+    result = tool._parse_search_results(html)
+    assert result[0]["format"] == '5\'-capped "variant"'
+
+
+def test_plain_text_without_entities_unaffected():
+    tool = _tool()
+    html = _row(["adalimumab", "Whole mAb", "Approved", "Active", "TNF/TNFA", "1999"])
+    result = tool._parse_search_results(html)
+    assert result[0]["format"] == "Whole mAb"
+    assert result[0]["inn_name"] == "adalimumab"


### PR DESCRIPTION
Rolling PR for the test-harness domain-sweep campaign, starting round 83. Per the maintainer's explicit request, this branch collects multiple rounds' fixes into one PR (commits + a new section below per round) instead of opening a fresh PR every round — the repo had accumulated 18 open test-harness PRs and merge pace couldn't keep up with one-per-round output. Each round still runs the full regression suite (must be green) and is CLI-verified against the live upstream API before fixing, same discipline as every prior round in this campaign. See prior work: PR #339 (rounds 1-41 consolidation), PR #376 (rounds 72-80 consolidation) — this PR is the same pattern applied prospectively instead of after the fact.

---

## Round 83 (2026-07-21) — clean, no fix

Two sibling-check/long-tail passes, no bugs found:
- Confirmed round 82's exact bug shape (unquoted/taxid-vs-facet-name `_f:(...)` filter mismatch) doesn't recur elsewhere in the codebase — grepped for `facets`/`_f:(` usage; the only other hits (`biosamples_tool.py`, `ebi_search_tool.py`, `idigbio_tool.py`, `pharos_tool.py`, `pubtator_tool.py`) just surface facet data from responses, none builds an IntAct-style filter expression.
- 3 fresh long-tail tool families (PGSCatalog, RxClass, GBIF) all correct — including one self-caught false alarm (an EFO trait id that looked like a MONDO-vs-EFO handling bug turned out to be a genuine upstream PGS Catalog data-coverage gap for that specific id, confirmed via the API's own `trait/search`).

## Round 84 (2026-07-21)

### Bug 1: TheraSAbDab HTML entities leak into 3 of 4 tools' output

**File:line**: `src/tooluniverse/therasabdab_tool.py:231-236` (`_parse_search_results`'s `clean_html` closure)

`TheraSAbDab_search_therapeutics`, `TheraSAbDab_get_all_therapeutics`, and `TheraSAbDab_search_by_target` all route through `_load_all_therapeutics` → `_parse_search_results`, which scrapes Thera-SAbDab's HTML table. Its `clean_html()` helper only special-cased `&nbsp;` and left every other HTML entity (`&amp;`, `&#39;`, `&quot;`, ...) raw in the output.

**Verification**: `TheraSAbDab_search_by_target({"target": "TNF"})` returned `"format": "Trispecific Single Domains (VH-VH-VH&#39;-VH&#39;&#39;-VH&#39;); Bispecific entry"` instead of the correct apostrophes. A direct fetch of the raw source page found `&amp;` 22,541 times and `&#39;` 326 times — this wasn't a one-off, isolated case. `TheraSAbDab_get_therapeutic_sequences` (a separate code path that parses URL query-string parameters, not HTML table cells) is unaffected.

**Fix**: replaced the single hardcoded `.replace("&nbsp;", " ")` with the standard `html.unescape()` (imported as `html_lib` to avoid shadowing the existing `html: str` parameter name in the same function), followed by normalizing the resulting non-breaking space to a regular space. This matches the pattern already used elsewhere in the codebase (`gpcrdb_tool.py`, `gtopdb_tool.py`, `imgt_tool.py`, `url_tool.py`, `web_search_tool.py`) — `therasabdab_tool.py` was the sole outlier still doing manual, partial entity handling.

Re-parsed the live, full 1,133-record dataset post-fix and confirmed zero genuine leftover HTML entities (one apparent match, `"CD3D&CD3E;CD19"`, is real multi-target data content, not an entity artifact).

### Bug 2: ReMap accepts inverted genomic regions as valid, silently returns 0 peaks

**File:line**: `src/tooluniverse/remap_tool.py:11,47-56` (`_REGION_RE` / `_get_peaks_in_region`)

The region validator checked the `chrom:start-end` format but never checked `start < end`. An inverted or zero-width region (e.g. a typo'd/swapped coordinate pair) passed format validation and was forwarded to the live ReMap REST API, which returns HTTP 200 with an empty peak list for it — indistinguishable from "this valid, modest region genuinely has zero ChIP-seq peaks."

**Verification**: `ReMap_get_peaks_in_region({"region": "chr1:1010000-1000000"})` returned `"status": "success", "peak_count": 0` pre-fix. A same-sized, correctly-ordered region (`chr1:1000000-1010000`) returns 7,270 real peaks.

**Fix**: capture start/end from the existing format regex and reject `start >= end` with a clear error, before the request is made. Checked for the same call pattern elsewhere (`_REGION_RE`/region-parsing across the codebase) — other tools parse genomic regions independently against different upstream APIs, not a shared/copied implementation, so this isn't a porting-gap instance; flagged as a possible future dedicated sweep candidate, not chased further this round.

## Tests

- `tests/unit/test_therasabdab_html_entity_decoding.py` (5 tests): numeric/named entity decoding, `&nbsp;` still normalizes to a space, plain text unaffected.
- `tests/unit/test_remap_region_validation.py` (4 tests): inverted region rejected, zero-width region rejected, malformed format still rejected, valid region still reaches the API.
- Existing sibling suites re-run clean: `tests/unit/test_therasabdab_target_matching.py`, `tests/unit/test_sabdab_migration_detection.py`, `tests/unit/test_sabdab_spa_migration_detection.py`, `tests/tools/test_sabdab_tool.py` (live API).
- Full suite: 100% clean (0 failures, 0 errors) on this branch.

---

## Round 85 (2026-07-21)

### Bug: MSigDB operation routing never reads tool config — `check_gene_in_set` unreachable

**File:line**: `src/tooluniverse/msigdb_tool.py:25-39` (`MSigDBTool.__init__`/`run`), `src/tooluniverse/data/msigdb_tools.json` (`MSigDB_check_gene_in_set`, `MSigDB_get_gene_set_members`)

`MSigDBTool.run()` read the dispatch key only from the caller's own arguments — `arguments.get("operation", "get_gene_set")` — never from the tool config's `fields.operation`, unlike the established pattern elsewhere in the codebase (e.g. `ComplexPortalTool`, which sets `self.operation` from config in `__init__`). Both `MSigDB_check_gene_in_set` and `MSigDB_get_gene_set_members`'s configs had an empty `fields: {}`, and — critically — neither tool's own documented example ever passes `operation` itself (that's the entire point of exposing 4 separately-named tools backed by one shared class). So `MSigDB_check_gene_in_set` always silently fell through to the `"get_gene_set"` default, which doesn't even look at the `gene` parameter.

**Verification**: `MSigDB_check_gene_in_set({"gene_set_name": "HALLMARK_APOPTOSIS", "gene": "TP53"})` returned the full 161-gene set dump (`gene_set_name`, `systematic_name`, `collection`, `pmid`, `num_genes`, `genes`, `description`, `external_url`) with **no `is_member` field anywhere in the response** — the tool's entire stated purpose (a yes/no membership check) was unreachable through normal use, 100% of the time, not an edge case.

**Fix**: `__init__` now sets `self.operation = tool_config.get("fields", {}).get("operation", "get_gene_set")`; `run()` uses `arguments.get("operation", self.operation)` (still allows an explicit caller override, just no longer requires one). Wired `MSigDB_check_gene_in_set`'s config to `fields.operation: "check_gene_in_set"` — a genuine functional fix, now returns `is_member`/`total_genes_in_set` as documented. `MSigDB_get_gene_set_members`'s own parameter schema already declared `operation` as a literal `"get_gene_set"` const (matching its current, accidentally-correct behavior, since `_get_gene_set` already returns a parsed gene list satisfying that tool's description) — wired to match with zero behavior change, just making the existing behavior config-driven instead of an accident of the same bug.

**Sibling check**: grepped the codebase for the same shape (`arguments.get("operation", "<literal>")` with no `self.operation` and no `get_schema_const_operation()`) — 6 other files match the code pattern (`crystal_structure_tool.py`, `degrees_of_unsaturation_tool.py`, `deseq2_tool.py`, `structure_annotation_tool.py`, `phykit_tool.py`, `mcp_client_tool.py`), but each maps to exactly one tool per class (no sibling tool to silently misroute to), or (for `MCPClientTool`) isn't exposed as a directly-configured tool `type` at all — MSigDB was an isolated instance of this specific bug, not systemic.

## Round 85 Tests

- `tests/unit/test_msigdb_operation_routing.py` (5 tests): `check_gene_in_set` reachable without the caller passing `operation` (mirroring the tool's own documented example), correct true/false membership results, `get_gene_set_members` still reaches the right handler, explicit caller override still works, config-default fallback.
- Full suite: 100% clean (0 failures, 0 errors) on this branch.

---

## Round 86 (2026-07-21) — clean, dedicated follow-up sweep

Systematically checked EVERY multi-tool-per-class family in the codebase for round 85's exact bug shape (a tool declares an `operation` const but the config's `fields.operation` is missing, and the Python class doesn't use a known-safe fallback). Started at 126 raw candidates; filtering out classes already using `self.operation`/`get_schema_const_operation()` left 17 across 4 families (`HuggingFaceInferenceTool`, `ReplicateTool`, `VCFStatsTool`, `COSMICTool`). All 4 individually verified safe: the first 3 mark `operation` as a `required` parameter with every tool's own `test_examples` explicitly including it (fundamentally different from MSigDB's optional-and-undocumented `operation`); `COSMICTool` has its own bespoke-but-equivalent const-lookup, reading `self.parameter`'s schema directly. Zero additional bugs — MSigDB was a genuinely isolated instance, now closed out codebase-wide with high confidence.

## Round 87 (2026-07-21) — clean, schema-conformance re-sweep

Re-ran round 77's full `scripts/test_all_tools.py --parallel --skip-remote --skip-mcp` sweep (638 patterns, 4997 tests, ~47 min) to catch anything new since round 77 given how much has landed on `main`. 20 patterns flagged with schema issues: 18 exactly match round 77's already-diagnosed list (14 confirmed detector false-positives + 4 real fixes already sitting in unmerged PR #372, naturally still flagged since this branch is off `main` which doesn't have that fix yet), plus **2 new patterns**: `semantic_scholar`/`semantic_scholar_ext` (`SemanticScholar_search_authors`/`get_paper_citations`/`get_paper_references`/`get_author_papers`). Verified via round 77's own method (`jsonschema.validate(result["data"], schema)` in isolation) that these are the same `scripts/test_new_tools.py` envelope-detection heuristic false positive, not a new bug — their schemas correctly describe the raw Semantic Scholar API's own `{total, offset, next, data: [...]}` pagination shape (which happens to have its own field named `data`), and `result["data"]` alone validates cleanly. Zero new schema-conformance bugs found.

## Round 88 (2026-07-21)

### Bug: PathwayCommons_get_pathway conflates a failed secondary-field fetch with genuine emptiness

**File:line**: `src/tooluniverse/pathwaycommons_tool.py` (`_get_pathway`, `_traverse`)

`_traverse()` returns `None` on a failed request (any non-200 status) but `[]` on a genuinely-empty-but-successful one. `_get_pathway`'s primary `name` field already handled this correctly (`if name is None: return error`), but the secondary fields (`comment`/`description`, `organism`, `data_source`, `sub_pathways`, `participants`) used `x[0] if x else None` / `x or []` — patterns that collapse `None` (request failed) and `[]` (request succeeded, no data) into the identical output, with zero indication anything went wrong. A caller reading `"description": null` can't tell whether the pathway genuinely has no description or the comment fetch quietly failed.

Originally flagged as a deferred lead in round 75 — needed a real design decision on how to represent "field failed to fetch" vs "field is genuinely empty" in the response, not a one-line fix.

**Fix**: track which specific secondary fields failed to fetch in a new `metadata.fetch_failures` list, kept out of the response entirely when everything succeeds (same "note only when non-empty" pattern used elsewhere in this campaign, e.g. round 79/80's `note`/`notes` fields). Genuinely empty fields are NOT flagged — only requests that actually returned non-200 are. Verified the happy path (a real Reactome pathway URI) is byte-identical to before, no `fetch_failures` key present. Since the underlying failure mode (a transient non-200 on PC2's `/traverse` endpoint) can't be reliably forced live on demand, verified the fix via direct mocked-failure tests instead — confirmed the fix distinguishes `None` (failure) from `[]` (empty) correctly for each secondary field independently, and that a primary `name` failure still hard-errors as before.

## Round 88 Tests

- `tests/unit/test_pathwaycommons_fetch_failures.py` (5 tests): all-succeed has no `fetch_failures` key, a genuinely-empty field is NOT flagged as a failure, a failed secondary field IS flagged and distinct from empty, multiple simultaneous failures all listed, primary `name` failure still hard-errors.
- Existing `tests/unit/test_pathwaycommons_paths.py` (13 tests) re-run clean, no regression.
- Live-verified no schema regression via `scripts/test_new_tools.py pathwaycommons -v`.
- Full suite: 100% clean (0 failures, 0 errors) on this branch.


