### PR TITLE
Fix RGD_search_genes species filter and UniProt_search_uniref cluster_type no-op

### DIFF
--- a/src/tooluniverse/rgd_tool.py
+++ b/src/tooluniverse/rgd_tool.py
@@ -92,18 +92,38 @@ class RGDTool(BaseTool):
             "metadata": {"source": "RGD", "query_id": rgd_id},
         }
 
+    # Maps this tool's documented `species` values to the exact strings the
+    # Alliance of Genome Resources API returns in each gene hit's `species`
+    # field (confirmed live against alliancegenome.org/api/search).
+    _SPECIES_ALIASES = {
+        "rat": "Rattus norvegicus",
+        "human": "Homo sapiens",
+        "mouse": "Mus musculus",
+    }
+
     def _search_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         query = arguments.get("query") or arguments.get("gene_symbol", "")
         if not query:
             return {"status": "error", "error": "query is required"}
 
         limit = arguments.get("limit", 10)
+        declared_species_default = (
+            self.tool_config.get("parameter", {})
+            .get("properties", {})
+            .get("species", {})
+            .get("default", "rat")
+        )
+        species_arg = str(arguments.get("species") or declared_species_default).strip()
+        target_species = self._SPECIES_ALIASES.get(species_arg.lower(), species_arg)
 
-        # Use Alliance of Genome Resources search (aggregates RGD data)
+        # Use Alliance of Genome Resources search (aggregates RGD/HGNC/MGI data)
         # RGD's own symbol search is unreliable (returns 400 for many queries).
         # Note: the Alliance API no longer honours a `category=gene` query param
         # (it returns zero results) and the gene id is now in `curie` (was
-        # `primaryKey`). Fetch unfiltered and keep RGD gene hits client-side.
+        # `primaryKey`). Fetch unfiltered and keep hits for the requested
+        # species client-side -- this used to hardcode an RGD-only (rat)
+        # filter regardless of the `species` argument, so a caller passing
+        # species='human' or 'mouse' silently got rat genes back instead.
         alliance_url = "https://www.alliancegenome.org/api/search"
         params = {"q": query, "limit": max(int(limit) * 5, 25)}
         resp = self.session.get(alliance_url, params=params, timeout=self.timeout)
@@ -114,16 +134,18 @@ class RGDTool(BaseTool):
         for r in data.get("results", []):
             if r.get("category") != "gene_search_result":
                 continue
-            curie = r.get("curie", "")
-            # Filter to RGD entries only (rat genes)
-            if not curie.startswith("RGD:"):
+            if (r.get("species") or "").lower() != target_species.lower():
                 continue
+            curie = r.get("curie", "")
             genes.append(
                 {
-                    "rgd_id": curie.replace("RGD:", ""),
+                    "gene_id": curie,
+                    "rgd_id": curie.replace("RGD:", "")
+                    if curie.startswith("RGD:")
+                    else None,
                     "symbol": r.get("symbol"),
                     "name": r.get("name"),
-                    "species": r.get("species", "Rattus norvegicus"),
+                    "species": r.get("species"),
                     "synonyms": r.get("synonyms", [])[:5],
                 }
             )
@@ -135,6 +157,7 @@ class RGDTool(BaseTool):
             "data": genes,
             "metadata": {
                 "query": query,
+                "species": target_species,
                 "returned": len(genes),
                 "total_alliance_results": data.get("total", 0),
                 "source": "RGD via Alliance of Genome Resources",

--- a/src/tooluniverse/uniprot_tool.py
+++ b/src/tooluniverse/uniprot_tool.py
@@ -489,7 +489,13 @@ class UniProtRESTTool(BaseTool):
     def _handle_uniref_search(self, arguments: Dict[str, Any]) -> Any:
         """Handle UniRef search queries"""
         query = arguments.get("query", "")
-        cluster_type = arguments.get("cluster_type", "")
+        declared_cluster_type_default = (
+            self.tool_config.get("parameter", {})
+            .get("properties", {})
+            .get("cluster_type", {})
+            .get("default", "")
+        )
+        cluster_type = arguments.get("cluster_type", declared_cluster_type_default)
         limit_value = arguments.get("limit", 25)
         if isinstance(limit_value, str):
             limit_value = int(limit_value)
@@ -497,11 +503,28 @@ class UniProtRESTTool(BaseTool):
 
         # Build query - if cluster_type specified and not in query, add it
         # Note: UniRef search accepts queries like "P04637" or "id:UniRef50_P04637"
+        # cluster_type is applied via UniProt's `identity:` query filter
+        # (0.5/0.9/1.0 for UniRef50/90/100 -- confirmed live against
+        # rest.uniprot.org/uniref/search). Skip it when the query already
+        # names a UniRef cluster directly (e.g. "UniRef50_P04637") or
+        # already carries its own identity filter, so we don't override an
+        # explicit caller choice.
         full_query = query
-        if cluster_type and "uniref" not in query.lower():
-            # User can filter by cluster type in their query if needed
-            # For now, just use the query as-is - API will return matching clusters
-            pass
+        cluster_identity = {
+            "UniRef100": "1.0",
+            "UniRef90": "0.9",
+            "UniRef50": "0.5",
+        }.get(cluster_type)
+        if (
+            cluster_identity
+            and "uniref" not in query.lower()
+            and "identity:" not in query.lower()
+        ):
+            full_query = (
+                f"({query}) AND identity:{cluster_identity}"
+                if query
+                else f"identity:{cluster_identity}"
+            )
 
         params = {"query": full_query, "size": str(limit), "format": "json"}
         url = "https://rest.uniprot.org/uniref/search"


### PR DESCRIPTION
## Summary

Fixes the two findings flagged (not fixed) at the end of the shared-class-default sweep (#368/#370/#371): parameters that were documented but had **zero effect on behavior**, regardless of what a caller passed — a more serious variant of the declared-default mismatches fixed elsewhere in that sweep, since here the tool silently does something entirely different from what it claims rather than just using a slightly-off default.

### RGD_search_genes

Documented as *"Supports rat, human, and mouse species"* via a `species` parameter, but `_search_genes` always hardcoded a `curie.startswith("RGD:")` filter and never read `species` at all — a caller passing `species='human'` silently got rat genes back with `status: success`, no signal anything was off.

Fixed by filtering on the Alliance of Genome Resources API's own `species` field instead of hardcoding the RGD-only prefix check (confirmed live: it returns `"Rattus norvegicus"` / `"Homo sapiens"` / `"Mus musculus"` for rat/human/mouse gene hits respectively). Also reads the declared `species` default from the tool's own schema instead of the behavior being implicitly rat-only.

Result shape gains a species-agnostic `gene_id` field (the raw curie), since non-rat hits don't have an `"RGD:"`-prefixed id. `rgd_id` stays populated for the rat case (backward compatible) and is explicitly `null` for human/mouse hits.

### UniProt_search_uniref

`cluster_type` was read from `arguments` but the branch meant to apply it was a bare `pass` — explicitly requesting `UniRef100` silently returned a mix of UniRef50/90/100 clusters anyway.

Fixed by applying UniProt's `identity:` query filter (confirmed live: `identity:0.5/0.9/1.0` map to UniRef50/90/100), skipped only when the caller's query already names a UniRef cluster directly (e.g. `"UniRef50_P05067"`) or already carries its own `identity:` filter, so an explicit caller choice in the query string isn't overridden. Also fixed the omitted-parameter case to read the declared `cluster_type` default (`UniRef50`) from the schema instead of falling back to `""` (which left it unfiltered).

## Test plan

- [x] Live calls against the real Alliance of Genome Resources API confirming `species` field values and that `RGD_search_genes` now returns the right species for `rat`/`human`/`mouse`/omitted.
- [x] Live calls against the real UniProt UniRef REST API confirming `identity:` filtering behavior, and that `UniProt_search_uniref` now returns exactly the requested `entryType` for `UniRef50`/`UniRef90`/`UniRef100`/omitted, and that a direct `UniRef90_...` query is unaffected by an explicit (different) `cluster_type`.
- [x] End-to-end smoke test through `ToolUniverse.run_one_function` for both tools (full validation + `return_schema` path).
- [x] `ToolUniverse().load_tools()` still loads all 2679 tools cleanly.