### PR TITLE
Test-harness rounds 91+ (rolling): BindingDB silently-ignored filter params

### DIFF
--- a/src/tooluniverse/bindingdb_tool.py
+++ b/src/tooluniverse/bindingdb_tool.py
@@ -113,7 +113,12 @@ class BindingDBTool(BaseTool):
             ids = [single] if single else []
         if not ids:
             return {"status": "error", "error": "Provide uniprot accession(s)."}
-        cutoff = int(arguments.get("cutoff", 10000))
+        # Schema declares this param as `affinity_cutoff`; the legacy `cutoff`
+        # name is kept as a fallback (the internal search_by_target caller and
+        # any older callers pass `cutoff`). Reading only `cutoff` silently
+        # ignored a user-supplied `affinity_cutoff` and always used the 10000 nM
+        # default -- confirmed live: passing affinity_cutoff=1 echoed cutoff=10000.
+        cutoff = int(arguments.get("affinity_cutoff", arguments.get("cutoff", 10000)))
         result = _http_get(
             "getLigandsByUniprots",
             {
@@ -141,7 +146,8 @@ class BindingDBTool(BaseTool):
             ids = [s.strip() for s in ids.split(",") if s.strip()]
         if not ids:
             return {"status": "error", "error": "Provide pdb id(s)."}
-        cutoff = int(arguments.get("cutoff", 10000))
+        # Schema declares this param as `affinity_cutoff` (see uniprot handler).
+        cutoff = int(arguments.get("affinity_cutoff", arguments.get("cutoff", 10000)))
         result = _http_get(
             "getLigandsByPDBs",
             {"pdbs": ";".join(ids), "cutoff": cutoff, "response": "application/json"},
@@ -160,7 +166,12 @@ class BindingDBTool(BaseTool):
         smiles = arguments.get("smiles") or arguments.get("compound_smiles") or ""
         if not smiles:
             return {"status": "error", "error": "Provide a SMILES string."}
-        similarity = float(arguments.get("similarity", 0.85))
+        # Schema declares this param as `similarity_cutoff`; `similarity` is a
+        # legacy fallback. Reading only `similarity` silently ignored a
+        # user-supplied `similarity_cutoff` and always used the 0.85 default.
+        similarity = float(
+            arguments.get("similarity_cutoff", arguments.get("similarity", 0.85))
+        )
         result = _http_get(
             "getTargetByCompound",
             {

--- a/src/tooluniverse/biogrid_tool.py
+++ b/src/tooluniverse/biogrid_tool.py
@@ -196,21 +196,51 @@ class BioGRIDRESTTool(BaseTool):
                 "error": api_response.get("error"),
             }
 
+        # interaction_type is declared as a physical/genetic/both filter, but
+        # BioGRID's REST API can't filter on it server-side -- it must be applied
+        # client-side on each record's EXPERIMENTAL_SYSTEM_TYPE field (confirmed
+        # present in this tool's return_schema, values "physical"/"genetic").
+        # Without this it was silently ignored: every call returned all
+        # interaction types regardless of the one requested, so a PPI-only query
+        # could be polluted with genetic interactions.
+        interaction_type = str(arguments.get("interaction_type") or "both").lower()
+        interaction_type_note = None
+        if interaction_type in ("physical", "genetic") and isinstance(
+            api_response, dict
+        ):
+            total = len(api_response)
+            kept = {
+                k: v
+                for k, v in api_response.items()
+                if isinstance(v, dict)
+                and str(v.get("EXPERIMENTAL_SYSTEM_TYPE", "")).lower()
+                == interaction_type
+            }
+            api_response = kept
+            interaction_type_note = (
+                f"Filtered client-side to interaction_type='{interaction_type}' on the "
+                f"EXPERIMENTAL_SYSTEM_TYPE field ({len(kept)} of {total} interactions kept); "
+                "BioGRID's REST API does not filter by interaction type server-side."
+            )
+
         gene_names = arguments.get("gene_names", [])
+        metadata = {
+            "source": "BioGRID",
+            "gene_names": gene_names,
+            "interaction_count": len(api_response)
+            if isinstance(api_response, dict)
+            else 0,
+            "note": (
+                "BioGRID chemicalList filter is not supported by the REST API; "
+                "results reflect all protein interactions for the queried gene(s), "
+                "not filtered by chemical. Use ChEMBL_search_mechanisms or "
+                "DGIdb_search_interactions for drug-protein interaction data."
+            ),
+        }
+        if interaction_type_note:
+            metadata["interaction_type_filter"] = interaction_type_note
         return {
             "status": "success",
             "data": api_response,
-            "metadata": {
-                "source": "BioGRID",
-                "gene_names": gene_names,
-                "interaction_count": len(api_response)
-                if isinstance(api_response, dict)
-                else 0,
-                "note": (
-                    "BioGRID chemicalList filter is not supported by the REST API; "
-                    "results reflect all protein interactions for the queried gene(s), "
-                    "not filtered by chemical. Use ChEMBL_search_mechanisms or "
-                    "DGIdb_search_interactions for drug-protein interaction data."
-                ),
-            },
+            "metadata": metadata,
         }

--- a/src/tooluniverse/cbioportal_tool.py
+++ b/src/tooluniverse/cbioportal_tool.py
@@ -1,5 +1,6 @@
 import requests
 from typing import Any, Dict
+from urllib.parse import quote
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
@@ -225,6 +226,19 @@ class CBioPortalRESTTool(BaseTool):
                     "molecular_profile_id": profile_id,
                     "entrez_gene_ids": entrez_ids,
                 }
+
+            # cBioPortal_get_clinical_data declares an optional
+            # `clinical_attribute_id` filter that maps to the API's
+            # `attributeId` query param. _build_url only substitutes
+            # {placeholders}, so without this the filter was silently dropped
+            # and every call returned all clinical attributes regardless of the
+            # requested one (confirmed live: brca_tcga returns 17 attributes
+            # unfiltered vs 1 with attributeId=CANCER_TYPE).
+            if "cBioPortal_get_clinical_data" in self.tool_config.get("name", ""):
+                attribute_id = arguments.get("clinical_attribute_id")
+                if attribute_id:
+                    sep = "&" if "?" in url else "?"
+                    url = f"{url}{sep}attributeId={quote(str(attribute_id))}"
 
             # Handle regular GET or POST requests
             if method == "POST":

--- a/src/tooluniverse/compound_gene_disease_tool.py
+++ b/src/tooluniverse/compound_gene_disease_tool.py
@@ -388,5 +388,25 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
                 }
             )
 
-        associations.sort(key=lambda x: (-x["concordance"], x["name"]))
+        # Rank by cross-source concordance first (agreement = confidence), then
+        # by the best association score within a tier, then name as a stable
+        # tiebreak. Without the score term, entities in the same concordance tier
+        # were ordered alphabetically, which could bury the most-relevant entity
+        # below an alphabetically-earlier lower-scored one (e.g. for "sickle cell"
+        # the causal gene HBB -- OpenTargets' top target at score 0.81 -- sorted
+        # below BCL11A). Scores are computed here anyway; use them. Kept as an
+        # internal sort key so the output shape is unchanged.
+        for a in associations:
+            vals = [v for v in a["scores"].values() if isinstance(v, (int, float))]
+            a["_best_score"] = max(vals) if vals else None
+        associations.sort(
+            key=lambda a: (
+                -a["concordance"],
+                0 if a["_best_score"] is not None else 1,
+                -(a["_best_score"] or 0),
+                a["name"],
+            )
+        )
+        for a in associations:
+            a.pop("_best_score", None)
         return associations

--- a/src/tooluniverse/compound_gene_disease_tool.py
+++ b/src/tooluniverse/compound_gene_disease_tool.py
@@ -59,11 +59,15 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
             r = _try_tool(
                 "DisGeNET", "DisGeNET_search_gene", {"gene": gene, "limit": 20}
             )
-        results_by_source["DisGeNET"] = self._extract_genes_or_diseases(r, "DisGeNET")
+        results_by_source["DisGeNET"] = self._extract_genes_or_diseases(
+            r, "DisGeNET", query_by_disease=bool(disease)
+        )
 
         # 2. OMIM
         r = _try_tool("OMIM", "OMIM_search", {"query": disease or gene, "limit": 10})
-        results_by_source["OMIM"] = self._extract_genes_or_diseases(r, "OMIM")
+        results_by_source["OMIM"] = self._extract_genes_or_diseases(
+            r, "OMIM", query_by_disease=bool(disease)
+        )
 
         # 3. OpenTargets
         # Fix-R30D-6: for a gene-only query, passing the gene symbol into
@@ -75,15 +79,11 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
         # itself has 6084 for LMNA). Resolve the gene symbol to its Ensembl
         # ID first and query its associated-diseases list instead.
         if disease:
-            r = _try_tool(
-                "OpenTargets",
-                "OpenTargets_get_disease_ids_by_name",
-                {"name": disease},
-            )
+            r = self._opentargets_disease_genes(tu, disease, sources_failed)
         else:
             r = self._opentargets_gene_diseases(tu, gene, sources_failed)
         results_by_source["OpenTargets"] = self._extract_genes_or_diseases(
-            r, "OpenTargets"
+            r, "OpenTargets", query_by_disease=bool(disease)
         )
 
         # 4. GenCC
@@ -91,7 +91,9 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
             r = _try_tool("GenCC", "GenCC_search_gene", {"gene_symbol": gene})
         else:
             r = _try_tool("GenCC", "GenCC_search_disease", {"disease": disease})
-        results_by_source["GenCC"] = self._extract_genes_or_diseases(r, "GenCC")
+        results_by_source["GenCC"] = self._extract_genes_or_diseases(
+            r, "GenCC", query_by_disease=bool(disease)
+        )
 
         # 5. ClinVar -- Fix-R80A-1: "query" is documented as an alias for
         # "condition" (a disease/phenotype free-text search), not a gene
@@ -114,11 +116,16 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
             r = _try_tool(
                 "ClinVar", "ClinVar_search_variants", {"gene": gene, "limit": 10}
             )
-        results_by_source["ClinVar"] = self._extract_genes_or_diseases(r, "ClinVar")
+        results_by_source["ClinVar"] = self._extract_genes_or_diseases(
+            r, "ClinVar", query_by_disease=bool(disease)
+        )
 
         notes: List[str] = []
         clinvar_failed = any(f.startswith("ClinVar:") for f in sources_failed)
-        if not clinvar_failed and not results_by_source["ClinVar"]:
+        # Only the gene->disease direction has the ClinVar data-shape limitation
+        # (its rows carry no disease name). In the disease->gene direction ClinVar
+        # DOES contribute (the variants' `genes` field), so no note is needed.
+        if not clinvar_failed and not results_by_source["ClinVar"] and not disease:
             notes.append(
                 "ClinVar was queried successfully but contributed no entries to "
                 "the disease-name comparison: ClinVar_search_variants' response "
@@ -191,10 +198,55 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
             sources_failed.append(f"OpenTargets: {str(e)[:100]}")
             return {"status": "error", "error": str(e)}
 
+    def _opentargets_disease_genes(
+        self, tu, disease: str, sources_failed: List[str]
+    ) -> Dict[str, Any]:
+        """Resolve a disease name to its OpenTargets EFO id, then fetch its real
+        associated-targets (gene) list -- the disease-direction parallel of
+        _opentargets_gene_diseases. The bare disease-name search
+        (get_disease_ids_by_name / get_disease_id_description_by_name) only
+        returns matching disease *names*, NOT the genes associated with the
+        disease, so without this chaining a disease-query's OpenTargets
+        contribution was just the queried disease echoed back instead of its
+        associated genes (the disease-direction twin of the gene-direction bug
+        already fixed by Fix-R30D-6)."""
+        try:
+            search = tu.run_one_function(
+                {
+                    "name": "OpenTargets_get_disease_id_description_by_name",
+                    "arguments": {"diseaseName": disease},
+                }
+            )
+            hits = (search or {}).get("data", {}).get("search", {}).get("hits", [])
+            if not hits:
+                sources_failed.append(f"OpenTargets: no disease match for '{disease}'")
+                return {"status": "error", "error": f"No disease match for '{disease}'"}
+            efo_id = hits[0].get("id")
+            result = tu.run_one_function(
+                {
+                    "name": "OpenTargets_get_associated_targets_by_disease_efoId",
+                    "arguments": {"efoId": efo_id},
+                }
+            )
+            if isinstance(result, dict) and result.get("status") == "error":
+                sources_failed.append(
+                    f"OpenTargets: {result.get('error', 'unknown error')[:100]}"
+                )
+            return result
+        except Exception as e:
+            sources_failed.append(f"OpenTargets: {str(e)[:100]}")
+            return {"status": "error", "error": str(e)}
+
     def _extract_genes_or_diseases(
-        self, result: Any, source: str
+        self, result: Any, source: str, query_by_disease: bool = False
     ) -> List[Dict[str, Any]]:
-        """Extract gene/disease names from a tool result, handling various formats."""
+        """Extract the association *targets* from a tool result, direction-aware:
+        the associated GENES when the caller queried by disease
+        (disease->gene), the associated DISEASE names when they queried by gene
+        (gene->disease). Without the direction split, a disease query just
+        echoed back the queried disease name and dropped the genes that are the
+        actual answer (e.g. GenCC returns cystic fibrosis + CFTR; the useful
+        part for a disease query is CFTR)."""
         items = []
         if not isinstance(result, dict):
             return items
@@ -203,11 +255,15 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
 
         data = result.get("data", result)
 
-        # GenCC: data has "submissions" list
+        # GenCC "submissions" carry BOTH disease_title and gene_symbol; pick the
+        # one the caller is asking for.
         if isinstance(data, dict) and "submissions" in data:
             for sub in data["submissions"][:30]:
                 if isinstance(sub, dict):
-                    name = sub.get("disease_title") or sub.get("gene_symbol") or ""
+                    if query_by_disease:
+                        name = sub.get("gene_symbol") or sub.get("disease_title") or ""
+                    else:
+                        name = sub.get("disease_title") or sub.get("gene_symbol") or ""
                     items.append(
                         {
                             "name": str(name),
@@ -218,16 +274,7 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
                     )
             return items
 
-        # OpenTargets: data has "search.hits" list
-        if isinstance(data, dict) and "search" in data:
-            hits = data["search"].get("hits", [])
-            for hit in hits[:30]:
-                if isinstance(hit, dict):
-                    name = hit.get("name", "")
-                    items.append({"name": str(name), "score": None, "source": source})
-            return items
-
-        # OpenTargets: data has "target.associatedDiseases.rows" list (gene-only queries)
+        # OpenTargets gene->disease: "target.associatedDiseases.rows"
         if isinstance(data, dict) and "target" in data:
             rows = (
                 (data.get("target") or {}).get("associatedDiseases", {}).get("rows", [])
@@ -236,43 +283,70 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
                 disease = (row or {}).get("disease") or {}
                 name = disease.get("name", "")
                 if name:
+                    items.append(
+                        {"name": str(name), "score": row.get("score"), "source": source}
+                    )
+            return items
+
+        # OpenTargets disease->gene: "disease.associatedTargets.rows"
+        if isinstance(data, dict) and "disease" in data:
+            rows = (
+                (data.get("disease") or {}).get("associatedTargets", {}).get("rows", [])
+            )
+            for row in rows[:30]:
+                target = (row or {}).get("target") or {}
+                name = target.get("approvedSymbol", "")
+                if name:
+                    items.append(
+                        {"name": str(name), "score": row.get("score"), "source": source}
+                    )
+            return items
+
+        # OpenTargets bare disease-name search fallback: "search.hits" (names).
+        if isinstance(data, dict) and "search" in data:
+            hits = data["search"].get("hits", [])
+            for hit in hits[:30]:
+                if isinstance(hit, dict):
+                    name = hit.get("name", "")
                     items.append({"name": str(name), "score": None, "source": source})
             return items
 
-        # Fix-R80A-1: ClinVar_search_variants' rows carry variant title,
-        # genes, clinical_significance, and review_status -- NOT a
-        # condition/disease name (confirmed live, including via the raw
-        # ClinVar eSearch/eSummary shape). The old code extracted each row's
-        # `genes` field into `items` here, so gene symbols themselves (e.g.
-        # "LDLR", plus co-located genes ClinVar's `genes` array includes for
-        # overlapping variants, like the antisense RNA gene "LDLR-AS1")
-        # silently appeared as if they were disease names in the
-        # concordance table. There is currently no usable disease/condition
-        # field to extract instead -- deliberately contribute nothing rather
-        # than fabricate one; run() adds an explanatory note when this
-        # leaves ClinVar's contribution empty despite a successful query.
+        # ClinVar_search_variants rows carry a variant title + a `genes` list +
+        # clinical_significance -- NOT a condition/disease name. For a GENE
+        # query, extracting those genes would mislabel them as diseases in the
+        # concordance (Fix-R80A-1: "LDLR"/"LDLR-AS1" appeared as fake diseases)
+        # -- so contribute nothing. For a DISEASE query, though, a
+        # condition-search returns that disease's variants and their `genes`
+        # field IS the disease-associated gene set (e.g. cystic fibrosis ->
+        # CFTR), so extract it.
         if isinstance(data, dict) and "variants" in data:
+            if query_by_disease:
+                for v in (data.get("variants") or [])[:30]:
+                    if isinstance(v, dict):
+                        for g in v.get("genes", []) or []:
+                            if g:
+                                items.append(
+                                    {"name": str(g), "score": None, "source": source}
+                                )
             return items
 
-        # Generic: try common patterns
+        # Generic list: prefer the field the caller is asking for -- gene fields
+        # for a disease query, disease fields for a gene query.
         if isinstance(data, dict):
             data = data.get(
                 "results", data.get("data", data.get("genes", data.get("entries", [])))
             )
         if isinstance(data, list):
+            gene_fields = ("gene_symbol", "geneName", "gene", "symbol")
+            disease_fields = ("disease", "diseaseName", "disease_name", "title", "name")
+            order = (
+                gene_fields + disease_fields
+                if query_by_disease
+                else disease_fields + gene_fields
+            )
             for item in data[:30]:
                 if isinstance(item, dict):
-                    name = (
-                        item.get("gene_symbol")
-                        or item.get("geneName")
-                        or item.get("gene")
-                        or item.get("symbol")
-                        or item.get("title")
-                        or item.get("name")
-                        or item.get("disease")
-                        or item.get("diseaseName")
-                        or ""
-                    )
+                    name = next((item[f] for f in order if item.get(f)), "")
                     score = item.get(
                         "score", item.get("gda_score", item.get("associationScore"))
                     )

--- a/tests/tools/test_ppi_tools.py
+++ b/tests/tools/test_ppi_tools.py
@@ -134,7 +134,14 @@ class TestSTRINGTool:
         result = self.tool.run(arguments)
 
         assert "data" in result
-        assert len(result["data"]["data"]) == 1
+        # run() unwraps the TSV-parsed {"data": [...], "header": [...]} so the
+        # top-level `data` is the row list directly (matching the sibling
+        # test_make_request_success / test_parse_tsv_response and the tool's
+        # contract). The old `result["data"]["data"]` assertion predated the
+        # unwrap fix and left this test red on main.
+        assert isinstance(result["data"], list)
+        assert len(result["data"]) == 1
+        assert result["data"][0]["preferredName_A"] == "TP53"
 
 
 class TestBioGRIDTool:

--- a/tests/unit/test_bindingdb_cutoff_param_names.py
+++ b/tests/unit/test_bindingdb_cutoff_param_names.py
@@ -1,0 +1,111 @@
+"""Round 91: BindingDB silently ignored its schema-declared filter params.
+
+The tool's JSON schema declares `affinity_cutoff` (uniprot/pdb endpoints) and
+`similarity_cutoff` (compound endpoint), but the code read `cutoff`/`similarity`
+instead -- so a caller's filter value was silently dropped and the hardcoded
+default was always used (confirmed live: passing affinity_cutoff=1 echoed
+cutoff=10000). These tests capture the params actually sent to the BindingDB
+REST layer and assert the schema-declared names now flow through.
+"""
+
+from unittest.mock import patch
+
+from tooluniverse.bindingdb_tool import BindingDBTool
+
+
+def _make(operation):
+    cfg = {
+        "name": f"BindingDB_{operation}",
+        "type": "BindingDBTool",
+        "fields": {"operation": operation},
+        "parameter": {"type": "object", "properties": {}},
+    }
+    return BindingDBTool(cfg)
+
+
+def test_affinity_cutoff_flows_to_uniprots_endpoint():
+    tool = _make("get_ligands_by_uniprots")
+    captured = {}
+
+    def fake_http_get(path, params, timeout=30):
+        captured["params"] = params
+        return {"getLigandsByUniprotsResponse": {"affinities": []}}
+
+    with patch("tooluniverse.bindingdb_tool._http_get", side_effect=fake_http_get):
+        res = tool.run({"uniprot_ids": "P07900", "affinity_cutoff": 1})
+
+    assert res["status"] == "success"
+    assert captured["params"]["cutoff"] == 1
+    assert res["data"]["cutoff"] == 1
+
+
+def test_affinity_cutoff_defaults_when_omitted():
+    tool = _make("get_ligands_by_uniprots")
+    captured = {}
+
+    def fake_http_get(path, params, timeout=30):
+        captured["params"] = params
+        return {"getLigandsByUniprotsResponse": {"affinities": []}}
+
+    with patch("tooluniverse.bindingdb_tool._http_get", side_effect=fake_http_get):
+        tool.run({"uniprot_ids": "P07900"})
+
+    assert captured["params"]["cutoff"] == 10000
+
+
+def test_legacy_cutoff_name_still_accepted():
+    # Backward compatibility: the internal search_by_target caller passes `cutoff`.
+    tool = _make("get_ligands_by_uniprots")
+    captured = {}
+
+    def fake_http_get(path, params, timeout=30):
+        captured["params"] = params
+        return {"getLigandsByUniprotsResponse": {"affinities": []}}
+
+    with patch("tooluniverse.bindingdb_tool._http_get", side_effect=fake_http_get):
+        tool.run({"uniprot_ids": "P07900", "cutoff": 42})
+
+    assert captured["params"]["cutoff"] == 42
+
+
+def test_affinity_cutoff_flows_to_pdb_endpoint():
+    tool = _make("get_ligands_by_pdb")
+    captured = {}
+
+    def fake_http_get(path, params, timeout=30):
+        captured["params"] = params
+        return {"getLigandsByPDBsResponse": {"affinities": []}}
+
+    with patch("tooluniverse.bindingdb_tool._http_get", side_effect=fake_http_get):
+        tool.run({"pdb_ids": "2RGP", "affinity_cutoff": 5})
+
+    assert captured["params"]["cutoff"] == 5
+
+
+def test_similarity_cutoff_flows_to_compound_endpoint():
+    tool = _make("get_targets_by_compound")
+    captured = {}
+
+    def fake_http_get(path, params, timeout=30):
+        captured["params"] = params
+        return {"getTargetByCompoundResponse": {"affinities": []}}
+
+    with patch("tooluniverse.bindingdb_tool._http_get", side_effect=fake_http_get):
+        res = tool.run({"smiles": "CCO", "similarity_cutoff": 0.5})
+
+    assert captured["params"]["similarity"] == 0.5
+    assert res["data"]["similarity"] == 0.5
+
+
+def test_similarity_cutoff_defaults_when_omitted():
+    tool = _make("get_targets_by_compound")
+    captured = {}
+
+    def fake_http_get(path, params, timeout=30):
+        captured["params"] = params
+        return {"getTargetByCompoundResponse": {"affinities": []}}
+
+    with patch("tooluniverse.bindingdb_tool._http_get", side_effect=fake_http_get):
+        tool.run({"smiles": "CCO"})
+
+    assert captured["params"]["similarity"] == 0.85

--- a/tests/unit/test_biogrid_interaction_type_filter.py
+++ b/tests/unit/test_biogrid_interaction_type_filter.py
@@ -1,0 +1,88 @@
+"""Round 93: BioGRID_get_interactions silently ignored its interaction_type filter.
+
+`interaction_type` is declared with enum physical/genetic/both (description:
+"Type of interaction: 'physical' (protein-protein), 'genetic' ..."), but the code
+never applied it -- BioGRID's REST API can't filter on it server-side, and the
+client-side filtering the code comment described was never implemented. So every
+call returned all interaction types regardless of the one requested.
+
+BioGRID's response is a dict keyed by interaction id; each record carries an
+EXPERIMENTAL_SYSTEM_TYPE field ("physical"/"genetic") -- confirmed in this tool's
+own return_schema (src/tooluniverse/data/biogrid_tools.json). These tests mock the
+API response and assert the client-side filter now keeps only matching records.
+
+Note: BioGRID's REST API requires an access key; the key available in CI/dev is
+unauthorized (401), so this fix is verified via a mocked response shaped exactly
+like the tool's declared return_schema rather than a live call.
+"""
+
+from unittest.mock import patch
+
+from tooluniverse.biogrid_tool import BioGRIDRESTTool
+
+
+def _make():
+    cfg = {
+        "type": "BioGRIDRESTTool",
+        "name": "BioGRID_get_interactions",
+        "parameter": {
+            "required": ["gene_names"],
+            "properties": {
+                "gene_names": {"type": "array", "items": {"type": "string"}},
+                "interaction_type": {"type": "string", "default": "both"},
+            },
+        },
+        "fields": {"endpoint": "/interactions/", "return_format": "JSON"},
+    }
+    return BioGRIDRESTTool(cfg)
+
+
+# Response shaped like BioGRID JSON: {interaction_id: {record...}}, EXPERIMENTAL_SYSTEM_TYPE present.
+_FAKE_RESPONSE = {
+    "1": {"OFFICIAL_SYMBOL_A": "TP53", "OFFICIAL_SYMBOL_B": "BRCA1", "EXPERIMENTAL_SYSTEM_TYPE": "physical"},
+    "2": {"OFFICIAL_SYMBOL_A": "TP53", "OFFICIAL_SYMBOL_B": "MDM2", "EXPERIMENTAL_SYSTEM_TYPE": "physical"},
+    "3": {"OFFICIAL_SYMBOL_A": "TP53", "OFFICIAL_SYMBOL_B": "ATM", "EXPERIMENTAL_SYSTEM_TYPE": "genetic"},
+}
+
+
+def _run(tool, interaction_type):
+    args = {"gene_names": ["TP53"], "api_key": "k"}
+    if interaction_type is not None:
+        args["interaction_type"] = interaction_type
+    with patch.object(tool, "_make_request", return_value=dict(_FAKE_RESPONSE)):
+        return tool.run(args)
+
+
+def test_physical_keeps_only_physical():
+    res = _run(_make(), "physical")
+    assert res["status"] == "success"
+    assert set(res["data"].keys()) == {"1", "2"}
+    assert res["metadata"]["interaction_count"] == 2
+    assert "interaction_type_filter" in res["metadata"]
+
+
+def test_genetic_keeps_only_genetic():
+    res = _run(_make(), "genetic")
+    assert set(res["data"].keys()) == {"3"}
+    assert res["metadata"]["interaction_count"] == 1
+
+
+def test_both_returns_all_unfiltered():
+    res = _run(_make(), "both")
+    assert set(res["data"].keys()) == {"1", "2", "3"}
+    # no filter note when not filtering
+    assert "interaction_type_filter" not in res["metadata"]
+
+
+def test_omitted_returns_all_unfiltered():
+    res = _run(_make(), None)
+    assert set(res["data"].keys()) == {"1", "2", "3"}
+    assert "interaction_type_filter" not in res["metadata"]
+
+
+def test_filter_is_case_insensitive():
+    tool = _make()
+    resp = {"9": {"OFFICIAL_SYMBOL_A": "X", "EXPERIMENTAL_SYSTEM_TYPE": "Physical"}}
+    with patch.object(tool, "_make_request", return_value=resp):
+        res = tool.run({"gene_names": ["X"], "api_key": "k", "interaction_type": "physical"})
+    assert set(res["data"].keys()) == {"9"}

--- a/tests/unit/test_cbioportal_clinical_attribute_filter.py
+++ b/tests/unit/test_cbioportal_clinical_attribute_filter.py
@@ -1,0 +1,71 @@
+"""Round 92: cBioPortal_get_clinical_data silently ignored its clinical_attribute_id filter.
+
+The tool declares an optional `clinical_attribute_id` param ("filter by clinical
+attribute"), but run() only substituted {study_id}/{page_size} placeholders and
+did a plain GET -- the value was never sent, so every call returned all clinical
+attributes regardless of the requested one (confirmed live: brca_tcga returned 17
+attributes unfiltered vs 1 with attributeId=CANCER_TYPE). The fix appends the
+API's `attributeId` query param. These tests mock the HTTP session and assert the
+URL wiring.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from tooluniverse.cbioportal_tool import CBioPortalRESTTool
+
+
+def _make():
+    cfg = {
+        "name": "cBioPortal_get_clinical_data",
+        "type": "CBioPortalRESTTool",
+        "fields": {
+            "endpoint": "https://www.cbioportal.org/api/studies/{study_id}/clinical-data?pageSize={page_size}&clinicalDataType=SAMPLE",
+            "return_format": "JSON",
+        },
+        "parameter": {
+            "type": "object",
+            "properties": {
+                "study_id": {"type": "string"},
+                "page_size": {"type": "integer", "default": 50},
+                "clinical_attribute_id": {"type": "string"},
+            },
+            "required": ["study_id"],
+        },
+    }
+    return CBioPortalRESTTool(cfg)
+
+
+def _run_capture(tool, arguments):
+    captured = {}
+
+    def fake_get(url, timeout=None):
+        captured["url"] = url
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = []
+        return resp
+
+    with patch.object(tool.session, "get", side_effect=fake_get):
+        tool.run(arguments)
+    return captured["url"]
+
+
+def test_clinical_attribute_id_is_sent_as_attributeId():
+    tool = _make()
+    url = _run_capture(tool, {"study_id": "brca_tcga", "page_size": 50, "clinical_attribute_id": "CANCER_TYPE"})
+    assert "attributeId=CANCER_TYPE" in url
+
+
+def test_clinical_attribute_id_omitted_leaves_url_unfiltered():
+    tool = _make()
+    url = _run_capture(tool, {"study_id": "brca_tcga", "page_size": 50})
+    assert "attributeId" not in url
+
+
+def test_clinical_attribute_id_is_url_encoded():
+    tool = _make()
+    # attribute ids are normally simple tokens, but a value with a space must not
+    # break the query string.
+    url = _run_capture(tool, {"study_id": "brca_tcga", "page_size": 50, "clinical_attribute_id": "A B"})
+    assert "attributeId=A%20B" in url
+    assert " " not in url.split("attributeId=")[1]

--- a/tests/unit/test_compound_gene_disease_disease_direction.py
+++ b/tests/unit/test_compound_gene_disease_disease_direction.py
@@ -1,0 +1,124 @@
+"""Direction fix for gather_gene_disease_associations: the disease->gene
+direction used to echo the queried disease back instead of returning the
+associated genes.
+
+The gene->disease direction was carefully built (Fix-R30D-6 resolves gene->
+Ensembl id->associated diseases; Fix-R80A-1 stops ClinVar gene-as-disease
+fabrication), but the parallel disease->gene direction was never given the
+same treatment: `_extract_genes_or_diseases` always preferred disease-name
+fields (GenCC's disease_title over gene_symbol; OpenTargets' bare disease-name
+search over an associated-targets lookup), so a disease query returned the
+disease name itself (e.g. "cystic fibrosis") and dropped the gene (CFTR).
+
+These tests exercise the now direction-aware extractor with each source's real
+response shape, in both directions.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from tooluniverse.compound_gene_disease_tool import CompoundGeneDiseaseAssociationTool
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return CompoundGeneDiseaseAssociationTool({"name": "gather_test"})
+
+
+_GENCC = {
+    "status": "success",
+    "data": {
+        "submissions": [
+            {"disease_title": "cystic fibrosis", "gene_symbol": "CFTR", "classification": "Definitive"},
+            {"disease_title": "cystic fibrosis", "gene_symbol": "CFTR", "classification": "Definitive"},
+        ]
+    },
+}
+
+_OT_ASSOCIATED_TARGETS = {
+    "status": "success",
+    "data": {
+        "disease": {
+            "id": "MONDO_0009061",
+            "name": "cystic fibrosis",
+            "associatedTargets": {
+                "count": 4608,
+                "rows": [
+                    {"target": {"id": "ENSG00000001626", "approvedSymbol": "CFTR"}, "score": 0.918},
+                    {"target": {"id": "ENSG00000010704", "approvedSymbol": "HFE"}, "score": 0.41},
+                ],
+            },
+        }
+    },
+}
+
+_CLINVAR_CONDITION = {
+    "status": "success",
+    "data": {
+        "variants": [
+            {"title": "NM_000492.4(CFTR):c.82T>C", "genes": ["CFTR"], "clinical_significance": "Pathogenic"},
+            {"title": "NM_000492.4(CFTR):c.353C>A", "genes": ["CFTR"], "clinical_significance": "Pathogenic"},
+        ]
+    },
+}
+
+_OT_ASSOCIATED_DISEASES = {  # gene->disease shape (must still yield diseases)
+    "status": "success",
+    "data": {
+        "target": {
+            "id": "ENSG00000012048",
+            "associatedDiseases": {
+                "rows": [
+                    {"disease": {"name": "hereditary breast ovarian cancer syndrome"}, "score": 0.8},
+                ]
+            },
+        }
+    },
+}
+
+
+def _names(items):
+    return [i["name"] for i in items]
+
+
+def test_gencc_disease_query_yields_gene_not_disease():
+    t = _tool()
+    got = t._extract_genes_or_diseases(_GENCC, "GenCC", query_by_disease=True)
+    assert _names(got) == ["CFTR", "CFTR"]
+
+
+def test_gencc_gene_query_still_yields_disease():
+    t = _tool()
+    got = t._extract_genes_or_diseases(_GENCC, "GenCC", query_by_disease=False)
+    assert _names(got) == ["cystic fibrosis", "cystic fibrosis"]
+
+
+def test_opentargets_associated_targets_yields_genes():
+    t = _tool()
+    got = t._extract_genes_or_diseases(_OT_ASSOCIATED_TARGETS, "OpenTargets", query_by_disease=True)
+    assert _names(got) == ["CFTR", "HFE"]
+    assert got[0]["score"] == 0.918
+
+
+def test_opentargets_associated_diseases_still_yields_diseases():
+    t = _tool()
+    got = t._extract_genes_or_diseases(_OT_ASSOCIATED_DISEASES, "OpenTargets", query_by_disease=False)
+    assert _names(got) == ["hereditary breast ovarian cancer syndrome"]
+
+
+def test_clinvar_disease_query_extracts_genes():
+    t = _tool()
+    got = t._extract_genes_or_diseases(_CLINVAR_CONDITION, "ClinVar", query_by_disease=True)
+    assert _names(got) == ["CFTR", "CFTR"]
+
+
+def test_clinvar_gene_query_contributes_nothing():
+    # Fix-R80A-1 must still hold: no gene-as-disease fabrication for gene queries.
+    t = _tool()
+    got = t._extract_genes_or_diseases(_CLINVAR_CONDITION, "ClinVar", query_by_disease=False)
+    assert got == []

--- a/tests/unit/test_compound_gene_disease_disease_direction.py
+++ b/tests/unit/test_compound_gene_disease_disease_direction.py
@@ -122,3 +122,31 @@ def test_clinvar_gene_query_contributes_nothing():
     t = _tool()
     got = t._extract_genes_or_diseases(_CLINVAR_CONDITION, "ClinVar", query_by_disease=False)
     assert got == []
+
+
+def test_concordance_ranks_by_score_within_tier():
+    # Same concordance tier: the higher-scored entity must lead, not the
+    # alphabetically-earlier one (regression guard for the score-blind sort that
+    # buried HBB below BCL11A for sickle cell).
+    t = _tool()
+    results = {
+        "OpenTargets": [
+            {"name": "BCL11A", "score": 0.30, "source": "OpenTargets"},
+            {"name": "HBB", "score": 0.81, "source": "OpenTargets"},
+        ]
+    }
+    out = t._build_concordance(results)
+    assert [a["name"] for a in out] == ["HBB", "BCL11A"]
+    # output shape stays clean (no internal sort key leaks)
+    assert "_best_score" not in out[0]
+
+
+def test_concordance_scored_entities_lead_unscored_in_tier():
+    t = _tool()
+    results = {
+        "GenCC": [{"name": "ZZZ1", "score": None, "source": "GenCC"}],
+        "OpenTargets": [{"name": "AAA1", "score": 0.5, "source": "OpenTargets"}],
+    }
+    out = t._build_concordance(results)
+    # both concordance 1; scored AAA1 leads the unscored ZZZ1 despite alphabetical order
+    assert [a["name"] for a in out] == ["AAA1", "ZZZ1"]


### PR DESCRIPTION
Fresh rolling PR for the test-harness campaign, starting at round 91 (the previous rolling batch, rounds 83–90, shipped as #378). Each new round adds a commit + a section here.

---

## Round 91 — BindingDB silently ignored `affinity_cutoff` / `similarity_cutoff`

**Detection method:** scanned every registered tool for parameters declared in its JSON schema but never referenced anywhere in the tool's Python source — the "silently-ignored parameter" class (same shape as RGD `species` / UniProt `cluster_type` in #379). Excluded generic-plumbing base classes (`BaseRESTTool`, GraphQL, remote, agentic, package) that consume args via config-driven URL templates. Of the custom-class hits, most were false positives (JASPAR passes all args as query params via `use_params`; Zinc's property params belong to an explicitly-unsupported operation that returns a clear error) — **BindingDB was a real param-name mismatch.**

**Bug:** `BindingDBTool`'s schema declares filter params:
- `affinity_cutoff` (default 10000 nM) on `get_ligands_by_uniprot(s)` and `get_ligands_by_pdb`
- `similarity_cutoff` (default 0.85) on `get_targets_by_compound`

…but the code read `arguments.get("cutoff")` and `arguments.get("similarity")` respectively. A researcher setting `affinity_cutoff=100` to get only strong binders had that value silently dropped and always got the 10000 nM default back — **unfiltered data returned as `status: success`, no signal anything was ignored.**

**Confirmed live (before):** `BindingDB_get_ligands_by_uniprots` with `affinity_cutoff=1` returned a response echoing `"cutoff": 10000`.
**After:** it echoes the value passed — `1`, `500`, or the `10000` default when omitted; `similarity_cutoff=0.5` likewise now flows through (`0.5`).

**Fix:** read the schema-declared name first, falling back to the legacy `cutoff`/`similarity` names so the internal `search_by_target` caller (which passes `cutoff`) stays backward compatible.

**Flagged, not fixed:** `BindingDB_get_ligands_by_pdb` also declares a `sequence_identity` param the code never sends upstream at all. The `getLigandsByPDBs` endpoint is currently returning HTTP 500, so I could not verify what query-param name (if any) BindingDB uses for sequence-identity filtering — wiring an unverified name would be worse than leaving it. Called out for a future round once the endpoint recovers.

**Tests:** `tests/unit/test_bindingdb_cutoff_param_names.py` (6 tests) mocks the REST layer and asserts the declared param names reach the API call, that omitted values use the schema default, and that the legacy names stay accepted. Existing `tests/tools/test_bindingdb_tool.py` (4 tests) still pass.

---

## Round 92 — cBioPortal `get_clinical_data` silently ignored `clinical_attribute_id`

**Detection:** continued round 91's scan for parameters declared in a tool's JSON schema but never referenced in its Python source. After ruling out generic-passthrough false positives (Reactome & PubTator send all args as query params via `arguments.items()`; COD/ENCODE delegate to `BaseRESTTool`; CancerVar delegates coordinate parsing to `InterVarTool`), **cBioPortal was a real drop.**

**Bug:** `cBioPortal_get_clinical_data` declares an optional `clinical_attribute_id` param (*"Optional clinical attribute ID to filter by"*), but `run()` only substitutes `{study_id}`/`{page_size}` placeholders in the endpoint template and does a plain GET — the value was never added to the request. So the documented filter did nothing: **every call returned all clinical attributes regardless of the one requested.**

**Confirmed live** against the cBioPortal API: study `brca_tcga` returns **17** distinct clinical attributes with no filter, vs exactly **1** (`CANCER_TYPE`) when `attributeId=CANCER_TYPE` is sent — the API's `attributeId` param works; the tool just never sent it.

**Fix:** append the API's `attributeId` query param (URL-encoded) when `clinical_attribute_id` is provided; omitting it is unchanged (backward compatible).

**Tests:** `tests/unit/test_cbioportal_clinical_attribute_filter.py` (3 tests) mock the session and assert the URL wiring (sent when provided, absent when omitted, URL-encoded). Existing `tests/unit/test_cbioportal_tool.py` (6 tests) still pass.


---

## Round 93 — BioGRID `interaction_type` (physical/genetic) silently ignored

**Detection:** continued the silently-ignored-parameter scan (false positives this round: Reactome/PubTator/gnomAD/EMDB/AlphaFold pass args generically; CancerVar→InterVar delegation; IEDB filters all present in `shorthand_filters`; IntAct network endpoint 404s upstream).

**Bug:** `BioGRID_get_interactions` and `BioGRID_search_by_pubmed` declare `interaction_type` with enum `physical`/`genetic`/`both` and a description presenting it as a filter, but the value was applied **nowhere** — BioGRID's REST API can't filter on it server-side, and the client-side filtering the code's own comment described ("*filtering must be done client-side using the EXPERIMENTAL_SYSTEM_TYPE field*") was never implemented. So a caller requesting physical PPIs silently got genetic interactions mixed in.

**Fix:** apply the filter client-side on each record's `EXPERIMENTAL_SYSTEM_TYPE` field (case-insensitive) when `interaction_type` is `physical`/`genetic`; `both`/omitted unchanged. Result count + a metadata note reflect the filtering. API params untouched (still not sent server-side, matching the existing `test_build_params_interaction_types` assertion).

**Verification:** the `EXPERIMENTAL_SYSTEM_TYPE` field and its `physical`/`genetic` values are confirmed three ways in-repo — the tool's own `return_schema` (`biogrid_tools.json`), the existing `test_ppi_tools.py` docstring, and the code comment. New test file (5 tests) mocks the response shaped exactly like the `return_schema`; existing BioGRID tests still pass.

⚠️ **Verification caveat:** BioGRID's REST API requires an access key and the key in this environment returns HTTP 401, so this fix is verified via a **mocked** response (same approach as DisGeNET in #368 when no live key was available), not a live before/after. The bug itself is definitive by code inspection + the existing test documenting the no-op.

_Separately observed (not this round's scope, pre-existing on `main`): `TestSTRINGTool::test_run_success` in `test_ppi_tools.py` fails because STRING's live response now nests `data.data` as a list — a possible future-round lead, unrelated to this change._


---

## Cleanup leads (post-R93)

- **Stale test fix**: `TestSTRINGTool::test_run_success` was red on `main` (asserted the pre-unwrap `result["data"]["data"]`). `STRINGRESTTool.run()` unwraps the TSV-parsed `{"data":[...],"header":[...]}` so top-level `data` is the row list directly — matching its sibling tests and the tool contract. Verified via the same mock the test uses; corrected the stale assertion (not a tool/data bug). TestSTRINGTool now 10/10.
- **BindingDB `sequence_identity` (still deferred)**: `BindingDB_get_ligands_by_pdb` declares a `sequence_identity` param the code never sends upstream. Re-checked this round — `getLigandsByPDBs` still returns HTTP 500, so the correct upstream param name remains unverifiable. Left unwired (won't guess); revisit once the endpoint recovers.


---

## Aggregator deep-dive — `gather_gene_disease_associations` disease→gene direction

**Found via deep multi-source-aggregator role-play** (the richest remaining vein). The gene→disease direction was carefully built (Fix-R30D-6, Fix-R80A-1) and works correctly, but the **disease→gene direction returned the disease name echoed back instead of the associated genes**:

- `_extract_genes_or_diseases` was direction-blind and always preferred disease-name fields — GenCC's `disease_title` over `gene_symbol` — so a disease query dropped the gene. Confirmed live: GenCC returns 24 "cystic fibrosis → **CFTR** (Definitive)" submissions, but the tool returned "cystic fibrosis", discarding CFTR.
- OpenTargets' disease path called `get_disease_ids_by_name` (a disease-*name* search), not an associated-targets lookup — the same mistake fixed for the gene direction by Fix-R30D-6.

**Fix (both parts, so the concordance doesn't mix genes and diseases):**
1. `_extract_genes_or_diseases` is now **direction-aware** — genes for a disease query, diseases for a gene query. New OpenTargets `disease.associatedTargets` branch, and ClinVar variants' `genes` extracted for disease queries only (the R80 gene-as-disease guard still holds for gene queries).
2. New `_opentargets_disease_genes` resolves disease→EFO→associated targets (the twin of `_opentargets_gene_diseases`).

**Verified live from an origin/main worktree, both directions:** disease "cystic fibrosis" → **CFTR** now the top association (concordance=3, ClinVar+GenCC+OpenTargets agree) + real CF-related genes; gene BRCA1 → still real diseases, **no regression**. 6 new tests + existing 15 still pass.

_Process note: an initial "bug" in a sibling aggregator (`annotate_variant_multi_source`) turned out to be a stale-shared-checkout artifact — caught by re-verifying from the worktree before reporting. All investigation for this fix ran from the origin/main worktree._
