### PR TITLE
Fix 34 tool defects from researcher role-play (14 HIGH: clinical-safety variant summary + silent-false-empty filters/delimiters)

### DIFF
--- a/src/tooluniverse/alliance_genome_tool.py
+++ b/src/tooluniverse/alliance_genome_tool.py
@@ -11,12 +11,32 @@ API: https://www.alliancegenome.org/api
 No authentication required.
 """
 
-import requests
+import re
+from html import unescape
 from typing import Dict, Any
+
+import requests
+
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 ALLIANCE_BASE = "https://www.alliancegenome.org/api"
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _strip_html(text):
+    """Strip inline HTML markup from an Alliance text field.
+
+    Alliance phenotype/description fields embed markup (e.g. italicised gene
+    symbols: 'anatomical structure <i>acta1a</i> expression decreased amount')
+    that leaks literal <i>...</i> tags into the JSON a caller renders. Remove the
+    tags and unescape entities so downstream consumers get clean plain text."""
+    if not isinstance(text, str):
+        return text
+    # Unescape entities FIRST so an entity-encoded tag ('&lt;i&gt;') becomes a
+    # real tag and is then removed too, not just literal '<i>' markup.
+    return _HTML_TAG_RE.sub("", unescape(text)).strip()
 
 
 @register_tool("AllianceGenomeTool")
@@ -370,7 +390,7 @@ class AllianceGenomeTool(BaseTool):
                 {
                     "gene_symbol": gene_symbol,
                     "gene_id": subject.get("primaryExternalId"),
-                    "phenotype_statement": r.get("phenotypeStatement"),
+                    "phenotype_statement": _strip_html(r.get("phenotypeStatement")),
                 }
             )
 

--- a/src/tooluniverse/chebi_tool.py
+++ b/src/tooluniverse/chebi_tool.py
@@ -31,6 +31,19 @@ def _strip_html(text):
     return text
 
 
+def _normalize_chebi_id(chebi_id):
+    """Accept the 'CHEBI:16113' CURIE that ChEBI_search / ChEBI_get_compound
+    emit (chebi_accession) and reduce it to the bare id the ontology endpoints
+    expect. Without this, chaining ChEBI_search -> ChEBI_get_ontology_parents
+    broke: the ontology tools required a bare integer and rejected the prefixed
+    accession the search hands back."""
+    if isinstance(chebi_id, str):
+        chebi_id = chebi_id.strip()
+        if chebi_id.upper().startswith("CHEBI:"):
+            chebi_id = chebi_id.split(":", 1)[1].strip()
+    return chebi_id
+
+
 @register_tool("ChEBITool")
 class ChEBITool(BaseTool):
     """
@@ -250,6 +263,7 @@ class ChEBITool(BaseTool):
                 "error": "chebi_id parameter is required (e.g., 15365 for aspirin)",
             }
 
+        chebi_id = _normalize_chebi_id(chebi_id)
         url = f"{CHEBI_BASE_URL}/ontology/children/{chebi_id}/"
         response = requests.get(
             url,
@@ -301,6 +315,7 @@ class ChEBITool(BaseTool):
                 "error": "chebi_id parameter is required (e.g., 15377 for water)",
             }
 
+        chebi_id = _normalize_chebi_id(chebi_id)
         url = f"{CHEBI_BASE_URL}/ontology/parents/{chebi_id}/"
         response = requests.get(
             url,

--- a/src/tooluniverse/chem_tool.py
+++ b/src/tooluniverse/chem_tool.py
@@ -248,6 +248,24 @@ class ChEMBLRESTTool(BaseTool):
             return parent_id
         return mol_id
 
+    def _fetch_parent_chembl_id(self, chembl_id: str) -> Optional[str]:
+        """Resolve a ChEMBL molecule id to its parent (active-moiety) id.
+
+        /mechanism.json indexes records under the PARENT molecule, but
+        ChEMBL_search_drugs hands back the salt/child id (e.g. dolutegravir
+        CHEMBL1213165, parent CHEMBL1229211), so a mechanism query on the child
+        matched nothing. Fetch the molecule record and return its parent id, or
+        None if it has no distinct parent / the lookup fails."""
+        base = f"{self.base_url}/molecule/{chembl_id}.json"
+        headers = {"Accept": "application/json", "User-Agent": "ToolUniverse/1.0"}
+        try:
+            resp = requests.get(base, headers=headers, timeout=20)
+            resp.raise_for_status()
+            parent = self._extract_parent_chembl_id(resp.json())
+            return parent if parent and parent != chembl_id else None
+        except Exception:
+            return None
+
     def _lookup_chembl_id_by_name(self, drug_name: str) -> Optional[str]:
         """Look up a ChEMBL molecule ID by preferred name (case-insensitive).
 
@@ -483,6 +501,47 @@ class ChEMBLRESTTool(BaseTool):
                     if key in data and isinstance(data[key], list):
                         response_data["count"] = len(data[key])
                         break
+
+            # ChEMBL_get_drug_mechanisms: /mechanism.json indexes records under
+            # the PARENT molecule. A caller who passes a salt/child id -- exactly
+            # what ChEMBL_search_drugs returns (e.g. dolutegravir CHEMBL1213165,
+            # parent CHEMBL1229211) -- got a silent empty. On an empty result,
+            # resolve the parent and retry once so the search->mechanism chain
+            # works instead of falsely reporting "no mechanism on file".
+            if (
+                tool_name == "ChEMBL_get_drug_mechanisms"
+                and isinstance(data, dict)
+                and not data.get("mechanisms")
+                and mol_id
+            ):
+                parent_id = self._fetch_parent_chembl_id(mol_id)
+                if parent_id:
+                    retry_args = dict(arguments)
+                    retry_args["drug_chembl_id"] = parent_id
+                    retry_params = self._build_params(retry_args)
+                    retry_resp = request_with_retry(
+                        self.session,
+                        "GET",
+                        url,
+                        params=retry_params,
+                        timeout=self.timeout,
+                        max_attempts=3,
+                        backoff_seconds=0.5,
+                    )
+                    retry_resp.raise_for_status()
+                    retry_data = retry_resp.json()
+                    if isinstance(retry_data, dict) and retry_data.get("mechanisms"):
+                        response_data["data"] = retry_data
+                        response_data["url"] = retry_resp.url
+                        response_data["count"] = len(retry_data["mechanisms"])
+                        response_data.setdefault("metadata", {})[
+                            "resolved_parent_chembl_id"
+                        ] = parent_id
+                        response_data["metadata"]["note"] = (
+                            f"No mechanisms indexed under '{mol_id}' (a salt/child "
+                            f"molecule); returned mechanisms for its parent "
+                            f"'{parent_id}'."
+                        )
 
             return response_data
 

--- a/src/tooluniverse/civic_tool.py
+++ b/src/tooluniverse/civic_tool.py
@@ -17,6 +17,45 @@ from .tool_registry import register_tool
 CIVIC_BASE_URL = "https://civicdb.org/api"
 CIVIC_GRAPHQL_URL = f"{CIVIC_BASE_URL}/graphql"
 
+# Fixed CIViC GraphQL enum vocabularies. An invalid value was passed straight to
+# the API and came back as an opaque "GraphQL query errors" with no hint; we
+# validate up front and name the allowed values instead.
+CIVIC_EVIDENCE_TYPES = {
+    "DIAGNOSTIC",
+    "PROGNOSTIC",
+    "PREDICTIVE",
+    "PREDISPOSING",
+    "FUNCTIONAL",
+    "ONCOGENIC",
+}
+CIVIC_EVIDENCE_SIGNIFICANCES = {
+    "SENSITIVITYRESPONSE",
+    "RESISTANCE",
+    "BETTER_OUTCOME",
+    "POOR_OUTCOME",
+    "POSITIVE",
+    "NEGATIVE",
+    "NA",
+    "ADVERSE_RESPONSE",
+    "PATHOGENIC",
+    "LIKELY_PATHOGENIC",
+    "BENIGN",
+    "LIKELY_BENIGN",
+    "UNCERTAIN_SIGNIFICANCE",
+    "REDUCED_SENSITIVITY",
+    "GAIN_OF_FUNCTION",
+    "LOSS_OF_FUNCTION",
+    "UNALTERED_FUNCTION",
+    "NEOMORPHIC",
+    "UNKNOWN",
+    "DOMINANT_NEGATIVE",
+    "PREDISPOSITION",
+    "PROTECTIVENESS",
+    "ONCOGENICITY",
+    "LIKELY_ONCOGENIC",
+}
+CIVIC_EVIDENCE_DIRECTIONS = {"SUPPORTS", "DOES_NOT_SUPPORT", "NA"}
+
 
 @register_tool("CIViCTool")
 class CIViCTool(BaseTool):
@@ -251,6 +290,25 @@ class CIViCTool(BaseTool):
         # Feature-61A-001: extend to catch ANY unrecognized parameter that would be silently
         # ignored, causing unfiltered evidence dumps (e.g. description="ESR1", gene_id=38).
         if tool_name == "civic_search_evidence_items":
+            # Validate enum-valued filters up front: an invalid value (e.g.
+            # evidence_type="BANANA") was passed straight to the CIViC GraphQL API
+            # and returned an opaque "GraphQL query errors" with no hint of what
+            # was wrong or what is valid.
+            for _enum_arg, _valid in (
+                ("evidence_type", CIVIC_EVIDENCE_TYPES),
+                ("significance", CIVIC_EVIDENCE_SIGNIFICANCES),
+                ("evidence_direction", CIVIC_EVIDENCE_DIRECTIONS),
+            ):
+                _val = arguments.get(_enum_arg)
+                if _val is not None and str(_val).upper() not in _valid:
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"Invalid {_enum_arg} '{_val}'. Allowed values: "
+                            + ", ".join(sorted(_valid))
+                            + "."
+                        ),
+                    }
             _known_params = {
                 "molecular_profile",
                 "disease",

--- a/src/tooluniverse/civic_tool.py
+++ b/src/tooluniverse/civic_tool.py
@@ -313,6 +313,31 @@ class CIViCTool(BaseTool):
                     ),
                 }
 
+        # civic_search_molecular_profiles only filters by query/name (free-text)
+        # + limit; the GraphQL query binds nothing else. A param like variant_id
+        # (a very natural thing to pass -- "profiles for CIViC variant 78") was
+        # silently ignored, returning the full unfiltered profile list (BRAF
+        # V600E, ERBB2 Amplification, ...) as a plausible-but-wrong "success".
+        # Reject unrecognized params with an actionable hint, mirroring
+        # civic_search_evidence_items.
+        if tool_name == "civic_search_molecular_profiles":
+            _known = {"query", "name", "limit", "operation", "after"}
+            _known.update(self.param_map.keys())
+            _known.update(self.array_wrap.keys())
+            unknown = sorted(k for k in arguments if k not in _known)
+            if unknown:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"Unrecognized parameter(s) for civic_search_molecular_profiles:"
+                        f" {', '.join(unknown)}. These are silently ignored by the CIViC"
+                        f" GraphQL API, returning the full unfiltered profile list."
+                        f" Supported filters: query (or name, free-text e.g. 'KRAS G12C'),"
+                        f" limit. To get profiles for a specific variant id, use"
+                        f" civic_get_variant with that id."
+                    ),
+                }
+
         # civic_search_variants: if gene/gene_name provided, look up gene_id then get variants.
         # Feature-41A-01: also handle combined gene+query — get gene variants, filter client-side.
         if tool_name == "civic_search_variants":

--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -209,6 +209,7 @@ class ClinVarSearchVariants(ClinVarRESTTool):
 
         # Build search query
         query_parts = []
+        compound_clnsig = False
 
         gene_hyphen_variant = None
         if "gene" in arguments:
@@ -309,11 +310,27 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             # using the already-verified [Filter] path while compound values
             # fall through to the [prop] path -- this can only add matches
             # the old query missed, never drop ones it already found.
-            clnsig = arguments["clinical_significance"].lower().replace("_", " ")
-            clnsig_prop = clnsig.replace(" ", "_")
-            query_parts.append(
-                f'("clinsig {clnsig}"[Filter] OR clinsig_{clnsig_prop}[prop])'
-            )
+            # A COMPOUND aggregate class like "Pathogenic/Likely pathogenic" has
+            # no single NCBI clinsig token -- the slash breaks BOTH the [Filter]
+            # phrase and the [prop] token, so the old query silently returned 0
+            # even though the tool's OWN get_clinical_significance emits that exact
+            # value. Treat "/" as OR and expand to the individual clinsig classes
+            # (the clinically-actionable union), each via the proven
+            # [Filter]-OR-[prop] path.
+            _raw_clnsig = str(arguments["clinical_significance"])
+            _components = [c.strip() for c in _raw_clnsig.split("/") if c.strip()]
+            compound_clnsig = len(_components) > 1
+            _clauses = []
+            for _comp in _components:
+                _c = _comp.lower().replace("_", " ")
+                _c_prop = _c.replace(" ", "_")
+                _clauses.append(f'("clinsig {_c}"[Filter] OR clinsig_{_c_prop}[prop])')
+            if _clauses:
+                query_parts.append(
+                    "(" + " OR ".join(_clauses) + ")"
+                    if len(_clauses) > 1
+                    else _clauses[0]
+                )
 
         # Fix-R5D-1/R8C-1: a caller-supplied param that doesn't match any
         # recognized name/alias (e.g. "gene_name" instead of "gene") was
@@ -450,6 +467,13 @@ class ClinVarSearchVariants(ClinVarRESTTool):
         }
         if unrecognized:
             response_data["ignored_parameters"] = unrecognized
+        if compound_clnsig:
+            response_data["clinical_significance_note"] = (
+                "The '/' in the requested clinical_significance was treated as OR: "
+                "results are the union of the individual classes (e.g. Pathogenic "
+                "AND Likely pathogenic), which is broader than only the aggregate "
+                "'Pathogenic/Likely pathogenic' review class."
+            )
         return {"status": "success", "data": response_data}
 
     def _resolve_deprecated_gene_symbol(self, gene: str) -> Optional[str]:

--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -176,6 +176,20 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             arguments = dict(arguments, gene=arguments["gene_symbol"])
         if not arguments.get("clinical_significance") and arguments.get("significance"):
             arguments = dict(arguments, clinical_significance=arguments["significance"])
+        # An rsID (e.g. rs4244285) passed as `query` was aliased to `condition`
+        # and searched as a DISEASE term ('rs4244285[dis]'), silently returning
+        # 0 -- but ClinVar's free-text index DOES match a bare rsID (confirmed
+        # live: term=rs4244285 -> 37 records). Route an rsID to a bare-term
+        # search so the standard PGx chain rsID -> ClinVar works instead of a
+        # false 'not found'.
+        _rsid_src = arguments.get("rsid") or arguments.get("query")
+        if (
+            not arguments.get("rsid")
+            and isinstance(_rsid_src, str)
+            and re.fullmatch(r"rs\d+", _rsid_src.strip(), re.IGNORECASE)
+        ):
+            arguments = dict(arguments, rsid=_rsid_src.strip())
+            arguments.pop("query", None)
         if not arguments.get("condition") and arguments.get("query"):
             arguments = dict(arguments, condition=arguments["query"])
         # `variant` is the intuitive name for the variant filter (the schema
@@ -242,6 +256,11 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             if " " in condition and not condition.startswith('"'):
                 condition = f'"{condition}"'
             query_parts.append(f"{condition}[dis]")
+
+        if arguments.get("rsid"):
+            # Search a dbSNP rsID as a bare free-text term -- ClinVar matches it
+            # across the record (not via [dis]/[gene]/[Variant name]).
+            query_parts.append(str(arguments["rsid"]).strip())
 
         if "variant_id" in arguments:
             # Feature-70B-004: [variant_id] is not recognized by ClinVar eSearch.
@@ -316,6 +335,7 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             "variant_id",
             "variant_name",
             "variant",
+            "rsid",
             "clinical_significance",
             "significance",
             "max_results",

--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -178,6 +178,14 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             arguments = dict(arguments, clinical_significance=arguments["significance"])
         if not arguments.get("condition") and arguments.get("query"):
             arguments = dict(arguments, condition=arguments["query"])
+        # `variant` is the intuitive name for the variant filter (the schema
+        # calls it `variant_name`). Passing `variant` used to be silently
+        # dropped whenever a valid param like `gene` was also present, so
+        # {"gene":"KRAS","variant":"G12C"} returned ALL 599 KRAS variants
+        # instead of the 2 G12C ones -- a dangerous silent full-gene dump.
+        # Alias it, mirroring the gene_symbol/significance/query aliases above.
+        if not arguments.get("variant_name") and arguments.get("variant"):
+            arguments = dict(arguments, variant_name=arguments["variant"])
 
         params = {
             "db": "clinvar",
@@ -307,6 +315,7 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             "query",
             "variant_id",
             "variant_name",
+            "variant",
             "clinical_significance",
             "significance",
             "max_results",

--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -300,6 +300,19 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             names = arguments["variant_name"]
             names = names if isinstance(names, list) else [names]
             names = [str(n).strip() for n in names if str(n).strip()]
+            # NCBI's [Variant name] index mangles the '.' in an HGVS reference
+            # prefix ('p.Glu342Lys' -> 'p0x2eGlu342Lys') and matches nothing, so a
+            # clinician typing standard HGVS got a silent false-empty. Strip the
+            # leading reference-type prefix so 'p.Glu342Lys' -> 'Glu342Lys' (which
+            # matches). Verified live: SERPINA1 p.Glu342Lys 0 -> 2 hits (Z-allele).
+            names = [re.sub(r"(?i)^[pcgmnor]\.", "", n) for n in names]
+            # An rsID passed as variant_name (e.g. rs776746) belongs in a bare
+            # free-text search, not the [Variant name] field, which returns 0 for
+            # it -- route it like the rsid param instead of a false-empty.
+            rsid_names = [n for n in names if re.fullmatch(r"rs\d+", n, re.IGNORECASE)]
+            names = [n for n in names if n not in rsid_names]
+            for _rs in rsid_names:
+                query_parts.append(_rs)
             if names:
                 terms = " OR ".join(f"{n}[Variant name]" for n in names)
                 query_parts.append(f"({terms})" if len(names) > 1 else terms)

--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -12,6 +12,16 @@ from typing import Dict, Any, Optional
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
+# Human-readable clinical-significance classes whose NCBI clinsig [prop] token is
+# NOT the naive underscore form. Confirmed live: "Uncertain significance" ->
+# clinsig_vus[prop] (BRCA2: 4345), while clinsig_uncertain_significance[prop]
+# returns 0 -- so filtering for VUS, the single LARGEST ClinVar category,
+# silently returned an empty success. Keyed by the normalized (lowercased,
+# spaces) class name.
+_CLINSIG_PROP_ALIASES = {
+    "uncertain significance": "vus",
+}
+
 
 class ClinVarRESTTool(BaseTool):
     """Base class for ClinVar REST API tools."""
@@ -324,7 +334,13 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             for _comp in _components:
                 _c = _comp.lower().replace("_", " ")
                 _c_prop = _c.replace(" ", "_")
-                _clauses.append(f'("clinsig {_c}"[Filter] OR clinsig_{_c_prop}[prop])')
+                _forms = f'"clinsig {_c}"[Filter] OR clinsig_{_c_prop}[prop]'
+                # Some classes index under a different NCBI token (e.g. VUS);
+                # OR it in so a valid class is never a silent false-empty.
+                _alias = _CLINSIG_PROP_ALIASES.get(_c)
+                if _alias:
+                    _forms += f" OR clinsig_{_alias}[prop]"
+                _clauses.append(f"({_forms})")
             if _clauses:
                 query_parts.append(
                     "(" + " OR ".join(_clauses) + ")"

--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -50,6 +50,37 @@ _AA_3TO1 = {v.upper(): k for k, v in _AA_1TO3.items()}
 _MATURE_PROTEIN_OFFSET_GENES = {"HBB"}
 
 
+# ClinVar clinical-significance terms ranked most→least clinically significant.
+# Used to pick the headline classification when a query matches several ClinVar
+# variants (e.g. a multi-allelic rsid whose alleles carry different
+# classifications): the most severe must surface, never merely the first in the
+# list — reporting a VUS while a Pathogenic allele is hidden is dangerous.
+_CLINVAR_SEVERITY_ORDER = [
+    "pathogenic",
+    "pathogenic/likely pathogenic",
+    "likely pathogenic",
+    "established risk allele",
+    "likely risk allele",
+    "uncertain risk allele",
+    "drug response",
+    "conflicting classifications of pathogenicity",
+    "conflicting interpretations of pathogenicity",
+    "uncertain significance",
+    "likely benign",
+    "benign/likely benign",
+    "benign",
+]
+_CLINVAR_SEVERITY_RANK = {term: i for i, term in enumerate(_CLINVAR_SEVERITY_ORDER)}
+
+
+def _clinvar_severity_key(classification: str) -> int:
+    """Sort key: lower = more clinically significant. Unknown terms sort after
+    all pathogenic/risk terms but before benign, so a recognized Pathogenic
+    always wins over an unrecognized label."""
+    norm = str(classification or "").strip().lower()
+    return _CLINVAR_SEVERITY_RANK.get(norm, len(_CLINVAR_SEVERITY_ORDER) - 3)
+
+
 def _offset_protein_tokens(tokens: List[str], gene: Optional[str]) -> List[str]:
     """For genes in _MATURE_PROTEIN_OFFSET_GENES, add a position-1 candidate
     for each RefSeq-numbered token so mature-protein-numbered records (like
@@ -502,7 +533,11 @@ class CompoundVariantAnnotationTool(BaseTool):
         gene: str = None,
         rsid: str = None,
     ) -> Dict[str, Any]:
-        summary = {"query": variant or gene or rsid, "sources_with_data": []}
+        # Reflect the identifier the caller actually queried: a variant or rsid
+        # is more specific than the gene it was resolved to, so prefer them over
+        # the (possibly rsid-derived) gene symbol -- otherwise an rsid-only query
+        # mislabels summary.query as the gene (e.g. "BRCA2" for rs80358981).
+        summary = {"query": variant or rsid or gene, "sources_with_data": []}
 
         # A source counts as "with data" only if it returned actual results — not
         # merely because the sub-call did not throw.
@@ -535,7 +570,24 @@ class CompoundVariantAnnotationTool(BaseTool):
                 if v.get("classification")
             ]
             if classifications:
-                summary["clinvar_classification"] = classifications[0]
+                # Surface the MOST clinically significant classification, not the
+                # first one listed. A multi-allelic match (e.g. rs80358981 =
+                # c.7558C>G VUS + c.7558C>T Pathogenic) previously reported the
+                # leading VUS and hid the Pathogenic allele -- a dangerous
+                # mis-summary. When the matches disagree, also expose every
+                # distinct classification so the curator sees the full picture.
+                summary["clinvar_classification"] = min(
+                    classifications, key=_clinvar_severity_key
+                )
+                distinct = list(dict.fromkeys(classifications))
+                if len(distinct) > 1:
+                    summary["clinvar_classifications"] = distinct
+                    summary["clinvar_note"] = (
+                        "Multiple ClinVar classifications matched the query "
+                        "(e.g. a multi-allelic site); clinvar_classification "
+                        "reports the most clinically significant. See "
+                        "annotations.clinvar.variants for per-allele detail."
+                    )
         elif clinvar.get("variants"):
             summary["clinvar_classification"] = None
             summary["clinvar_note"] = (

--- a/src/tooluniverse/data/bvbrc_tools.json
+++ b/src/tooluniverse/data/bvbrc_tools.json
@@ -254,7 +254,7 @@
   },
   {
     "name": "BVBRC_search_amr",
-    "description": "Search for antimicrobial resistance (AMR) phenotype data in BV-BRC. Returns resistance/susceptibility data for pathogens against specific antibiotics, including MIC values, testing methods, and evidence. Essential for AMR surveillance research. Example: search for methicillin resistance in Staphylococcus aureus.",
+    "description": "Search for antimicrobial resistance (AMR) phenotype data in BV-BRC. Returns resistance/susceptibility data for pathogens against specific antibiotics, including MIC values, testing methods, and evidence. Essential for AMR surveillance research. Filter by 'antibiotic' (e.g. 'methicillin'), 'resistant_phenotype', and/or a specific BV-BRC 'genome_id'. There is no organism/species parameter: to scope results to one organism, first obtain its genome_id(s) (e.g. via BVBRC_search_genome_features / BVBRC_search_specialty_genes with taxon_id) and pass genome_id here.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/chebi_tools.json
+++ b/src/tooluniverse/data/chebi_tools.json
@@ -256,8 +256,11 @@
       "type": "object",
       "properties": {
         "chebi_id": {
-          "type": "integer",
-          "description": "ChEBI numeric identifier (without 'CHEBI:' prefix). Examples: 15365 (aspirin), 17234 (glucose), 16236 (ethanol)."
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "ChEBI numeric identifier (with or without the 'CHEBI:' prefix). Examples: 15365 (aspirin), 17234 (glucose), 16236 (ethanol)."
         }
       },
       "required": [
@@ -358,8 +361,11 @@
       "type": "object",
       "properties": {
         "chebi_id": {
-          "type": "integer",
-          "description": "ChEBI numeric identifier (without 'CHEBI:' prefix). Examples: 15377 (water), 15365 (aspirin), 17234 (glucose)."
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "ChEBI numeric identifier (with or without the 'CHEBI:' prefix). Examples: 15377 (water), 15365 (aspirin), 17234 (glucose)."
         }
       },
       "required": [

--- a/src/tooluniverse/data/civic_tools.json
+++ b/src/tooluniverse/data/civic_tools.json
@@ -443,6 +443,13 @@
             "null"
           ],
           "description": "Filter by evidence type. Values: PREDICTIVE (drug response), DIAGNOSTIC (disease diagnosis), PROGNOSTIC (patient outcomes), PREDISPOSING (disease risk), ONCOGENIC (variant pathogenicity), FUNCTIONAL (molecular function)."
+        },
+        "significance": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Filter by clinical significance. Values depend on evidence_type, e.g. SENSITIVITYRESPONSE, RESISTANCE (predictive); BETTER_OUTCOME, POOR_OUTCOME (prognostic); POSITIVE, NEGATIVE (diagnostic); ONCOGENIC, PROTECTIVE. Use to separate, e.g., resistance from sensitivity evidence for a variant."
         }
       },
       "required": []

--- a/src/tooluniverse/data/civic_tools.json
+++ b/src/tooluniverse/data/civic_tools.json
@@ -448,7 +448,7 @@
       "required": []
     },
     "fields": {
-      "query": "query SearchEvidenceItems($limit: Int, $status: EvidenceStatusFilter, $therapyName: String, $diseaseName: String, $molecularProfileName: String, $evidenceType: EvidenceType) { evidenceItems(first: $limit, status: $status, therapyName: $therapyName, diseaseName: $diseaseName, molecularProfileName: $molecularProfileName, evidenceType: $evidenceType) { nodes { id description evidenceLevel evidenceType evidenceDirection significance status disease { name } therapies { name } molecularProfile { id name } source { citation } } } }",
+      "query": "query SearchEvidenceItems($limit: Int, $status: EvidenceStatusFilter, $therapyName: String, $diseaseName: String, $molecularProfileName: String, $evidenceType: EvidenceType, $significance: EvidenceSignificance) { evidenceItems(first: $limit, status: $status, therapyName: $therapyName, diseaseName: $diseaseName, molecularProfileName: $molecularProfileName, evidenceType: $evidenceType, significance: $significance) { nodes { id description evidenceLevel evidenceType evidenceDirection significance status disease { name } therapies { name } molecularProfile { id name } source { citation } } } }",
       "operation_name": "SearchEvidenceItems",
       "param_map": {
         "therapy": "therapyName",

--- a/src/tooluniverse/data/gprofiler_tools.json
+++ b/src/tooluniverse/data/gprofiler_tools.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "gProfiler_enrichment",
-        "description": "Perform functional enrichment analysis on a gene list using g:Profiler (g:GOSt) from the University of Tartu. Identifies statistically overrepresented biological functions, pathways, and phenotypes in your gene list. Supports multiple data sources: Gene Ontology (GO:BP, GO:MF, GO:CC), KEGG pathways, Reactome, WikiPathways, Human Phenotype Ontology (HP), miRNA targets (MIRNA), CORUM protein complexes, and Transcription Factor targets (TF). Returns enriched terms with p-values (g:SCS multiple testing correction), term sizes, intersection genes, precision, and recall. Input is a list of gene symbols (e.g., ['TP53', 'BRCA1', 'EGFR', 'KRAS', 'PTEN']). Supports 500+ organisms (use NCBI taxonomy prefix, e.g., 'hsapiens', 'mmusculus', 'dmelanogaster').",
+        "description": "Perform functional enrichment analysis on a gene list using g:Profiler (g:GOSt) from the University of Tartu. Identifies statistically overrepresented biological functions, pathways, and phenotypes in your gene list. Supports multiple data sources: Gene Ontology (GO:BP, GO:MF, GO:CC), KEGG pathways, Reactome, WikiPathways, Human Phenotype Ontology (HP), miRNA targets (MIRNA), CORUM protein complexes, and Transcription Factor targets (TF). Returns enriched terms with p-values (g:SCS multiple testing correction), term sizes, intersection genes, precision, and recall. Input is a comma-separated string of gene symbols (e.g., 'TP53,BRCA1,EGFR,KRAS,PTEN') -- a JSON array is not accepted. Supports 500+ organisms (use NCBI taxonomy prefix, e.g., 'hsapiens', 'mmusculus', 'dmelanogaster').",
         "parameter": {
             "type": "object",
             "properties": {

--- a/src/tooluniverse/data/gwas_tools.json
+++ b/src/tooluniverse/data/gwas_tools.json
@@ -8,7 +8,7 @@
       "properties": {
         "disease_trait": {
           "type": "string",
-          "description": "Disease or trait name for text-based search (e.g., 'diabetes', 'coronary artery disease', 'breast cancer'). NOTE: GWAS associations are indexed by trait/disease, not by gene or drug name \u2014 passing a gene symbol or drug name here will fail. Use efo_id for precise filtering."
+          "description": "Disease or trait name for text-based search (e.g., 'diabetes', 'coronary artery disease', 'breast cancer'). NOTE: GWAS associations are indexed by trait/disease, not by gene or drug name — passing a gene symbol or drug name here will fail. Use efo_id for precise filtering."
         },
         "query": {
           "type": "string",
@@ -2073,8 +2073,8 @@
         },
         "size": {
           "type": "integer",
-          "description": "Max associations to return.",
-          "default": 5
+          "description": "Max associations to return (default 100; results are sorted by p-value, most significant first).",
+          "default": 100
         }
       },
       "required": [

--- a/src/tooluniverse/data/hpa_tools.json
+++ b/src/tooluniverse/data/hpa_tools.json
@@ -551,7 +551,7 @@
   {
     "type": "HPAGetProteinInteractionsTool",
     "name": "HPA_get_protein_interactions_by_gene",
-    "description": "Fetch known protein-protein interaction partners for a given gene from Human Protein Atlas database.",
+    "description": "DEPRECATED / non-functional: the Human Protein Atlas search API no longer exposes protein-protein interaction (ppi) data, so this tool returns an error. For PPI partners use STRING_get_interactions (by gene symbol) or EBIProteins_get_interactions (by UniProt accession) instead.",
     "fields": {
       "endpoint": "https://www.proteinatlas.org/api/search_download.php",
       "timeout": 30,

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -16,13 +16,22 @@
                 "efoId": {
                     "type": "string",
                     "description": "The efoId of a disease or phenotype."
+                },
+                "size": {
+                    "type": "integer",
+                    "description": "Number of top-scored associated targets to return (default 50). A disease can have thousands of associated targets; raise this to retrieve more than the first page.",
+                    "default": 50
+                },
+                "index": {
+                    "type": "integer",
+                    "description": "Zero-based page index for paginating beyond the first `size` targets (default 0)."
                 }
             },
             "required": [
                 "efoId"
             ]
         },
-        "query_schema": "\nquery associatedTargets($efoId: String!) {\n  disease(efoId: $efoId) {\n    id\n    name\n    associatedTargets {\n      count\n      rows {\n        target {\n          id\n          approvedSymbol\n        }\n        score\n      }\n    }\n  }\n}\n",
+        "query_schema": "\nquery associatedTargets($efoId: String!, $size: Int = 50, $index: Int = 0) {\n  disease(efoId: $efoId) {\n    id\n    name\n    associatedTargets(page: {index: $index, size: $size}) {\n      count\n      rows {\n        target {\n          id\n          approvedSymbol\n        }\n        score\n      }\n    }\n  }\n}\n",
         "type": "OpenTarget",
         "test_examples": [
             {

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -3141,7 +3141,7 @@
     },
     {
         "name": "OpenTargets_get_approved_indications_by_drug_chemblId",
-        "description": "Retrieve detailed information about multiple drugs using a list of ChEMBL IDs.",
+        "description": "Retrieve the approved (APPROVAL-stage) disease indications for a single drug by its ChEMBL ID. For the full indication list including investigational (Phase 1-3) diseases with their max clinical stage, use OpenTargets_get_drug_indications_by_chemblId.",
         "parameter": {
             "type": "object",
             "properties": {

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -128,7 +128,7 @@
                 "ensemblId"
             ]
         },
-        "query_schema": "\nquery associatedDiseases($ensemblId: String!, $page: Pagination) {\n  target(ensemblId: $ensemblId) {\n    id\n    approvedSymbol\n    associatedDiseases(page: $page) {\n      count\n      rows {\n        disease {\n          id\n          name\n        }\n        datasourceScores {\n          id\n          score\n        }\n      }\n    }\n  }\n}\n",
+        "query_schema": "\nquery associatedDiseases($ensemblId: String!, $page: Pagination) {\n  target(ensemblId: $ensemblId) {\n    id\n    approvedSymbol\n    associatedDiseases(page: $page) {\n      count\n      rows {\n        score\n        disease {\n          id\n          name\n        }\n        datasourceScores {\n          id\n          score\n        }\n      }\n    }\n  }\n}\n",
         "type": "OpenTarget",
         "test_examples": [
             {

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -2904,7 +2904,7 @@
     },
     {
         "name": "OpenTargets_get_known_drugs_by_drug_chemblId",
-        "description": "Get a list of known drugs and associated information using the specified chemblId.",
+        "description": "Get a drug's known clinical information for the specified ChEMBL ID: its approved/investigational indications (diseases, each with the maximum clinical phase reached), its mechanisms of action (with the molecular targets acted on), and any drug safety warnings.",
         "parameter": {
             "type": "object",
             "properties": {
@@ -2917,7 +2917,7 @@
                 "chemblId"
             ]
         },
-        "query_schema": "\n  query drugKnownDrugs($chemblId: String!) {\n    drug(chemblId: $chemblId) {\n      id\n      name\n      maximumClinicalStage\n      drugType\n      drugWarnings {\n        toxicityClass\n        description\n      }\n    }\n  }\n  ",
+        "query_schema": "\n  query drugKnownDrugs($chemblId: String!) {\n    drug(chemblId: $chemblId) {\n      id\n      name\n      maximumClinicalStage\n      drugType\n      indications {\n        count\n        rows {\n          maxClinicalStage\n          disease {\n            id\n            name\n          }\n        }\n      }\n      mechanismsOfAction {\n        rows {\n          mechanismOfAction\n          actionType\n          targetName\n          targets {\n            id\n            approvedSymbol\n          }\n        }\n      }\n      drugWarnings {\n        toxicityClass\n        description\n      }\n    }\n  }\n  ",
         "label": [
             "OpenTarget",
             "Drug",

--- a/src/tooluniverse/enrichr_tool.py
+++ b/src/tooluniverse/enrichr_tool.py
@@ -4,6 +4,9 @@ import urllib.parse
 import networkx as nx
 from .base_tool import BaseTool
 from .tool_registry import register_tool
+from .logging_config import get_logger
+
+logger = get_logger("EnrichrTool")
 
 
 @register_tool("EnrichrTool")
@@ -65,16 +68,18 @@ class EnrichrTool(BaseTool):
         for hit in hits:
             symbol = hit.get("symbol", "")
             if symbol.upper() == gene_name.upper():
-                print(
-                    f"[enrichr_api] Using the official gene name: '{symbol}' instead of {gene_name}",
-                    flush=True,
+                logger.debug(
+                    "[enrichr_api] Using the official gene name: '%s' instead of %s",
+                    symbol,
+                    gene_name,
                 )
                 return symbol
             aliases = hit.get("alias", [])
             if any(gene_name.upper() == alias.upper() for alias in aliases):
-                print(
-                    f"[enrichr_api] Using the official gene name: '{symbol}' instead of {gene_name}",
-                    flush=True,
+                logger.debug(
+                    "[enrichr_api] Using the official gene name: '%s' instead of %s",
+                    symbol,
+                    gene_name,
                 )
                 return symbol
 
@@ -82,9 +87,10 @@ class EnrichrTool(BaseTool):
         top_hit = hits[0]
         symbol = top_hit.get("symbol", None)
         if symbol:
-            print(
-                f"[enrichr_api] Using the official gene name: '{symbol}' instead of {gene_name}",
-                flush=True,
+            logger.debug(
+                "[enrichr_api] Using the official gene name: '%s' instead of %s",
+                symbol,
+                gene_name,
             )
             return symbol
         else:
@@ -221,7 +227,7 @@ class EnrichrTool(BaseTool):
         """
         # Convert each gene to its official name and log the result
         genes = [self.get_official_gene_name(gene) for gene in genes]
-        print("Official gene names:", genes)
+        logger.debug("Official gene names: %s", genes)
 
         # Ensure at least two genes are provided for path ranking
         if len(genes) < 2:
@@ -259,13 +265,14 @@ class EnrichrTool(BaseTool):
 
         # Check for empty outputs and print helper messages
         if not connected_path:
-            print(
-                f"[Enrichr] No ranked paths were found between the gene pair {genes}."
+            logger.debug(
+                "[Enrichr] No ranked paths were found between the gene pair %s.", genes
             )
 
         if not connections:
-            print(
-                f"[Enrichr] No connection between genes and terms in the enriched graph of {genes}."
+            logger.debug(
+                "[Enrichr] No connection between genes and terms in the enriched graph of %s.",
+                genes,
             )
 
         return connected_path, connections

--- a/src/tooluniverse/genomics_gene_search_tool.py
+++ b/src/tooluniverse/genomics_gene_search_tool.py
@@ -18,13 +18,26 @@ class GWASGeneSearch(BaseTool):
             {"Accept": "application/json", "Content-Type": "application/json"}
         )
 
+    @staticmethod
+    def _pvalue_sort_key(assoc):
+        """Numeric p-value for sorting; unparseable/missing sort last."""
+        try:
+            return float(assoc.get("p_value"))
+        except (TypeError, ValueError):
+            return float("inf")
+
     def run(self, arguments):
         gene_name = arguments.get("gene_name")
         if not gene_name:
             return {"status": "error", "error": "Missing required parameter: gene_name"}
 
-        # Search for associations by gene name
-        size = int(arguments.get("size", 5))
+        # Default of 100 (was 5): a well-studied gene has hundreds of GWAS
+        # associations (TCF7L2 has 902), and the API returns them UNSORTED, so a
+        # size-5 default silently surfaced 5 arbitrary rows -- for TCF7L2 all 5
+        # were anthropometric (hip/waist/BMI) while its 37 flagship type-2-
+        # diabetes associations were hidden, misleading a clinician into thinking
+        # it is not a T2D locus. Also matches the sibling trait-search default.
+        size = int(arguments.get("size") or arguments.get("limit") or 100)
         url = f"{self.base_url}/v2/associations"
         params = {"mapped_gene": gene_name, "size": size, "page": 0}
 
@@ -37,6 +50,11 @@ class GWASGeneSearch(BaseTool):
             associations = []
             if "_embedded" in data and "associations" in data["_embedded"]:
                 associations = data["_embedded"]["associations"]
+
+            # The API does not order by significance, but the tool description
+            # promises the "strongest" associations -- sort the returned set by
+            # p-value (most significant first) so the top rows are the strongest.
+            associations = sorted(associations, key=self._pvalue_sort_key)
 
             return {
                 "gene_name": gene_name,

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -110,7 +110,13 @@ class GraphQLTool(BaseTool):
     def run(self, arguments):
         arguments = copy.deepcopy(arguments)
         if "size" in self.parameters and "size" not in arguments:
-            arguments["size"] = self.default_size
+            # Honor the size parameter's own schema default when it declares one
+            # (e.g. a targets-by-disease tool that pages 50 at a time); fall back
+            # to the generic default only when the tool declares no size default.
+            # Otherwise this hardcoded 5 silently overrode a tool's intended
+            # larger default, capping results far below what the query allows.
+            size_default = self.parameters["size"].get("default", self.default_size)
+            arguments["size"] = size_default
         result = execute_query(
             endpoint_url=self.endpoint_url, query=self.query_schema, variables=arguments
         )

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -176,6 +176,15 @@ def _ot_entity_not_found_message(arguments):
             "Verify the ID (e.g. ENSG00000141510 for TP53) or pass gene_symbol "
             "to auto-resolve it."
         )
+    variant_id = arguments.get("variantId")
+    if variant_id is not None:
+        return (
+            f"OpenTargets returned no variant for ID '{variant_id}'. Use the "
+            "chr_pos_ref_alt format with UNDERSCORES (e.g. '19_44908684_T_C'); "
+            "the hyphen form gnomAD emits ('19-44908684-T-C') is auto-converted, "
+            "so a remaining failure means the variant is genuinely absent from "
+            "OpenTargets. rsIDs are not accepted here."
+        )
     return (
         "OpenTargets returned no entity for the provided identifier(s). Verify "
         "the ID is current — OpenTargets periodically remaps disease IDs from "
@@ -189,11 +198,36 @@ class OpentargetTool(GraphQLTool):
         self.endpoint_url = "https://api.platform.opentargets.org/api/v4/graphql"
         super().__init__(tool_config, self.endpoint_url)
 
+    @staticmethod
+    def _normalize_variant_id(value):
+        """Accept gnomAD's hyphen-delimited variant id and convert it to the
+        underscore form OpenTargets requires. gnomad_search_variants /
+        gnomad_get_variant_populations emit 'chr-pos-ref-alt' (e.g.
+        '19-44908684-T-C'), but OpenTargets' variant(variantId:) wants
+        'chr_pos_ref_alt' -- feeding the hyphen form straight through returned a
+        misleading "no entity ... EFO to MONDO" error, a cross-tool chaining
+        break. Only rewrite when the value is exactly chr-pos-ref-alt (4
+        hyphen-separated parts, no underscores); leave everything else untouched.
+        """
+        if not isinstance(value, str) or "_" in value or "-" not in value:
+            return value
+        parts = value.split("-")
+        if len(parts) == 4 and all(parts):
+            return "_".join(parts)
+        return value
+
     def _empty_result_error(self, arguments):
         return _ot_entity_not_found_message(arguments)
 
     def run(self, arguments):
         arguments = copy.deepcopy(arguments)
+
+        # Accept gnomAD's hyphen-delimited variant id (chr-pos-ref-alt) and
+        # convert it to the underscore form OpenTargets requires -- must run
+        # BEFORE the query and before the hyphen->space retry below (which is
+        # for hyphenated NAMES, not coordinate ids).
+        if arguments.get("variantId"):
+            arguments["variantId"] = self._normalize_variant_id(arguments["variantId"])
 
         # Normalize common aliases before resolution
         if "ensemblId" not in arguments and "gene_symbol" not in arguments:

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -3,6 +3,7 @@ from graphql.language import parse
 from graphql.validation import validate
 from .base_tool import BaseTool
 from .tool_registry import register_tool
+import re
 import requests
 import copy
 import time
@@ -222,6 +223,21 @@ class OpentargetTool(GraphQLTool):
             return "_".join(parts)
         return value
 
+    @staticmethod
+    def _normalize_ot_disease_id(value):
+        """Convert a colon ontology CURIE to the underscore form OpenTargets
+        uses. OpenTargets keys diseases/phenotypes as 'MONDO_0010315' /
+        'EFO_0005555' / 'OMIM_300400', but every other tool (HPO, Monarch,
+        OpenTargets' OWN cross-reference output) emits the canonical colon form
+        'MONDO:0010315'. Feeding the colon form to OpenTargets_map_any_disease_id
+        returned a silent empty (just the echoed term, no cross-refs) -- even the
+        tool's documented 'OMIM:604302' example was broken. Rewrite an exact
+        PREFIX:suffix CURIE; leave Ensembl/ChEMBL ids and everything else alone."""
+        if not isinstance(value, str) or ":" not in value:
+            return value
+        m = re.match(r"^([A-Za-z]+):([A-Za-z0-9]+)$", value.strip())
+        return f"{m.group(1)}_{m.group(2)}" if m else value
+
     def _empty_result_error(self, arguments):
         return _ot_entity_not_found_message(arguments)
 
@@ -234,6 +250,17 @@ class OpentargetTool(GraphQLTool):
         # for hyphenated NAMES, not coordinate ids).
         if arguments.get("variantId"):
             arguments["variantId"] = self._normalize_variant_id(arguments["variantId"])
+
+        # Accept the canonical colon CURIE ('MONDO:0010315') that HPO/Monarch and
+        # OpenTargets' own xref output emit, converting to the underscore form
+        # OpenTargets keys on -- otherwise the colon form silently returns empty.
+        for _id_key in ("inputId", "efoId", "entityId"):
+            if arguments.get(_id_key):
+                arguments[_id_key] = self._normalize_ot_disease_id(arguments[_id_key])
+        if isinstance(arguments.get("diseaseIds"), list):
+            arguments["diseaseIds"] = [
+                self._normalize_ot_disease_id(v) for v in arguments["diseaseIds"]
+            ]
 
         # Normalize common aliases before resolution
         if "ensemblId" not in arguments and "gene_symbol" not in arguments:

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -333,6 +333,32 @@ class OpentargetTool(GraphQLTool):
                     "For non-oncology phenotypes, use OpenTargets_get_evidence_by_datasource instead."
                 )
 
+        # OpenTargets_get_approved_indications: the query returns ALL indications
+        # with their maxClinicalStage, so the tool -- despite its name -- listed
+        # investigational (PHASE_1/2) diseases alongside approved ones (e.g.
+        # selpercatinib: 17 rows, only 5 APPROVAL). A clinician trusting the
+        # "approved" name would treat Phase-2 indications as approved. Filter to
+        # APPROVAL-stage rows so the tool matches its name; the unfiltered list is
+        # available via OpenTargets_get_drug_indications_by_chemblId.
+        if (
+            result.get("status") == "success"
+            and self.tool_config.get("name")
+            == "OpenTargets_get_approved_indications_by_drug_chemblId"
+        ):
+            indications = (result.get("data", {}).get("drug", {}) or {}).get(
+                "indications"
+            )
+            if isinstance(indications, dict) and isinstance(
+                indications.get("rows"), list
+            ):
+                approved = [
+                    r
+                    for r in indications["rows"]
+                    if isinstance(r, dict) and r.get("maxClinicalStage") == "APPROVAL"
+                ]
+                indications["rows"] = approved
+                indications["count"] = len(approved)
+
         # A diseaseIds-filtered list query (e.g. studies(diseaseIds: ...))
         # has no single entity to resolve to null, so the EFO->MONDO
         # not-found detection above never fires for it -- it just returns a

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -262,6 +262,26 @@ class OpentargetTool(GraphQLTool):
                 self._normalize_ot_disease_id(v) for v in arguments["diseaseIds"]
             ]
 
+        # Bridge efoId -> diseaseIds for tools whose query takes the diseaseIds
+        # ARRAY (e.g. search_gwas_studies_by_disease). Every OTHER OpenTargets
+        # disease tool uses `efoId`, so a user naturally reuses it here -- but the
+        # unrecognized efoId was silently ignored and the tool returned a
+        # plausible "0 studies" success (Parkinson's MONDO_0005180: efoId -> 0,
+        # diseaseIds -> 103).
+        if (
+            "diseaseIds" in self.query_schema
+            and not arguments.get("diseaseIds")
+            and arguments.get("efoId")
+        ):
+            arguments["diseaseIds"] = [arguments.pop("efoId")]
+
+        # Strip a versioned Ensembl id suffix ('ENSG00000120659.16') that
+        # UniProt_id_mapping emits -- OpenTargets rejects it ("no target for
+        # Ensembl ID ...") and only accepts the unversioned form.
+        _ens = arguments.get("ensemblId")
+        if isinstance(_ens, str):
+            arguments["ensemblId"] = re.sub(r"^(ENSG\d+)\.\d+$", r"\1", _ens)
+
         # Normalize common aliases before resolution
         if "ensemblId" not in arguments and "gene_symbol" not in arguments:
             for alias in ("target", "gene", "gene_name"):

--- a/src/tooluniverse/gwas_tool.py
+++ b/src/tooluniverse/gwas_tool.py
@@ -273,10 +273,23 @@ class GWASAssociationSearch(GWASRESTTool):
             params["accession_id"] = accession_id
 
         sort = self._coerce_str(arguments.get("sort"))
+        direction = self._coerce_str(arguments.get("direction"))
+        # A p_value threshold is applied CLIENT-SIDE to the fetched page (the API
+        # has no server-side p-value filter), but the API returns associations
+        # UNSORTED -- so without sorting by significance the fetched window omits
+        # the strongest loci and a strict threshold falsely returns 0 (SLE
+        # p<=1e-100 -> 0 even though hits exist at p=2e-298). When a p-value
+        # filter is requested and the caller gave no explicit sort, fetch
+        # most-significant-first so the threshold actually sees the top hits.
+        if not sort and (
+            arguments.get("p_value") is not None
+            or arguments.get("p_value_threshold") is not None
+        ):
+            sort = "p_value"
+            if not direction:
+                direction = "asc"
         if sort:
             params["sort"] = sort
-
-        direction = self._coerce_str(arguments.get("direction"))
         if direction:
             params["direction"] = direction
 

--- a/src/tooluniverse/hpo_tool.py
+++ b/src/tooluniverse/hpo_tool.py
@@ -20,6 +20,24 @@ HPO_BASE_URL = "https://ontology.jax.org/api/hp"
 HPO_ANNOTATION_URL = "https://ontology.jax.org/api/network/annotation"
 
 
+def _normalize_hpo_id(term_id: str) -> str:
+    """Normalize an HPO term id to the canonical colon CURIE 'HP:0001250'.
+
+    Accepts the underscore form 'HP_0001250' (which OpenTargets and other tools
+    emit, e.g. phenotypeHPO.id) and a bare numeric id '0001250'. Without this,
+    'HP_0001250' failed the old `startswith("HP:")` check and was turned into
+    'HP:HP_0001250', causing an HPO API 404 -- a cross-tool chaining break in the
+    OpenTargets-phenotype -> HPO_get_term path a clinician follows."""
+    tid = str(term_id).strip()
+    # Underscore CURIE from OpenTargets et al. -> colon CURIE.
+    if tid.upper().startswith("HP_"):
+        tid = "HP:" + tid[3:]
+    elif not tid.upper().startswith("HP:"):
+        tid = f"HP:{tid}"
+    # Canonicalize the prefix case ('hp:' -> 'HP:').
+    return "HP:" + tid.split(":", 1)[1] if ":" in tid else tid
+
+
 @register_tool("HPOTool")
 class HPOTool(BaseTool):
     """
@@ -203,8 +221,7 @@ class HPOTool(BaseTool):
                 "status": "error",
                 "error": "term_id parameter is required (e.g., 'HP:0001250')",
             }
-        if not str(term_id).startswith("HP:"):
-            term_id = f"HP:{term_id}"
+        term_id = _normalize_hpo_id(term_id)
 
         try:
             limit = int(arguments.get("limit", 50))
@@ -247,9 +264,8 @@ class HPOTool(BaseTool):
                 "error": "term_id parameter is required (e.g., 'HP:0001250')",
             }
 
-        # Normalize the ID format
-        if not term_id.startswith("HP:"):
-            term_id = f"HP:{term_id}"
+        # Normalize the ID format (accepts HP:xxx, HP_xxx, and bare digits)
+        term_id = _normalize_hpo_id(term_id)
 
         url = f"{HPO_BASE_URL}/terms/{term_id}"
         response = requests.get(url, timeout=self.timeout)
@@ -333,8 +349,7 @@ class HPOTool(BaseTool):
                 "error": "term_id parameter is required (e.g., 'HP:0001250')",
             }
 
-        if not term_id.startswith("HP:"):
-            term_id = f"HP:{term_id}"
+        term_id = _normalize_hpo_id(term_id)
 
         direction = arguments.get("direction", "children")
 

--- a/src/tooluniverse/lipidmaps_tool.py
+++ b/src/tooluniverse/lipidmaps_tool.py
@@ -171,6 +171,24 @@ class LipidMapsTool(BaseTool):
         if not input_value:
             return {"status": "error", "error": "input_value parameter is required"}
 
+        # Reject unrecognized parameters. `xref_type` has a default (kegg_id), so
+        # a typo like `input_type` (instead of `xref_type`) was silently accepted
+        # and the lookup fell back to kegg_id -- a PubChem CID searched as a KEGG
+        # id then returned an empty "not found" the user wrongly trusted. Name
+        # the bad parameter instead of silently returning a false empty.
+        _recognized = {"input_value", "output_item", "xref_type", "input_item"}
+        unknown = sorted(k for k in arguments if k not in _recognized)
+        if unknown:
+            return {
+                "status": "error",
+                "error": (
+                    f"Unrecognized parameter(s): {', '.join(unknown)}. Supported: "
+                    "input_value, xref_type (e.g. 'pubchem_cid', 'hmdb_id', "
+                    "'chebi_id', 'kegg_id', 'inchi_key', 'abbrev_chains'), "
+                    "output_item. Did you mean 'xref_type'?"
+                ),
+            }
+
         # Allow the input item (the LMSD lookup key) to be overridden per call
         # via xref_type / input_item, falling back to the config default. This
         # powers the cross-reference lookup tool without a new tool class.

--- a/src/tooluniverse/monarch_v3_tool.py
+++ b/src/tooluniverse/monarch_v3_tool.py
@@ -11,12 +11,30 @@ API: https://api.monarchinitiative.org/v3/api/
 No authentication required. Free public access.
 """
 
-import requests
+import re
 from typing import Dict, Any
+
+import requests
+
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 MONARCH_BASE_URL = "https://api.monarchinitiative.org/v3/api"
+
+_UNDERSCORE_CURIE_RE = re.compile(r"^([A-Za-z]+)_(\d+)$")
+
+
+def _normalize_curie(entity_id: str) -> str:
+    """Convert an underscore-delimited ontology CURIE to the colon form Monarch
+    requires. OpenTargets and other tools emit 'MONDO_0004995' / 'EFO_0008572' /
+    'Orphanet_238583', but Monarch's /entity endpoint 404s on those and needs
+    'MONDO:0004995'. Feeding one tool's output into Mondo_get_disease broke with
+    a bare 404 that never revealed the delimiter was the cause."""
+    if not isinstance(entity_id, str):
+        return entity_id
+    stripped = entity_id.strip()
+    m = _UNDERSCORE_CURIE_RE.match(stripped)
+    return f"{m.group(1)}:{m.group(2)}" if m else stripped
 
 
 @register_tool("MonarchV3Tool")
@@ -86,7 +104,9 @@ class MonarchV3Tool(BaseTool):
 
     def _get_entity(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get detailed entity information by CURIE identifier."""
-        entity_id = arguments.get("entity_id") or arguments.get("id", "")
+        entity_id = _normalize_curie(
+            arguments.get("entity_id") or arguments.get("id", "")
+        )
         if not entity_id:
             return {
                 "status": "error",
@@ -120,8 +140,8 @@ class MonarchV3Tool(BaseTool):
 
     def _get_associations(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get associations for an entity with optional filtering by category."""
-        subject = arguments.get("subject", "")
-        obj = arguments.get("object", "")
+        subject = _normalize_curie(arguments.get("subject", ""))
+        obj = _normalize_curie(arguments.get("object", ""))
         if not subject and not obj:
             return {
                 "status": "error",
@@ -264,7 +284,7 @@ class MonarchV3Tool(BaseTool):
 
     def _mondo_get_disease(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get detailed Mondo disease information including hierarchy and cross-references."""
-        disease_id = arguments.get("disease_id", "").strip()
+        disease_id = _normalize_curie(arguments.get("disease_id", ""))
         if not disease_id:
             return {
                 "status": "error",
@@ -344,7 +364,7 @@ class MonarchV3Tool(BaseTool):
 
     def _mondo_get_phenotypes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get HPO phenotypes associated with a Mondo disease."""
-        disease_id = arguments.get("disease_id", "").strip()
+        disease_id = _normalize_curie(arguments.get("disease_id", ""))
         if not disease_id:
             return {
                 "status": "error",
@@ -392,7 +412,7 @@ class MonarchV3Tool(BaseTool):
 
     def _histopheno(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get phenotype counts by body system for a disease."""
-        entity_id = arguments.get("entity_id", "").strip()
+        entity_id = _normalize_curie(arguments.get("entity_id", ""))
         if not entity_id:
             return {
                 "status": "error",
@@ -429,7 +449,7 @@ class MonarchV3Tool(BaseTool):
 
     def _get_mappings(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get cross-ontology mappings for an entity."""
-        entity_id = arguments.get("entity_id", "").strip()
+        entity_id = _normalize_curie(arguments.get("entity_id", ""))
         if not entity_id:
             return {
                 "status": "error",

--- a/src/tooluniverse/openfda_adv_tool.py
+++ b/src/tooluniverse/openfda_adv_tool.py
@@ -193,8 +193,14 @@ class FDADrugAdverseEventTool(BaseTool):
                         field_parts.append(f'{fda_field_name}:"{mapped_value}"')
                     else:
                         field_parts.append(f"{fda_field_name}:{mapped_value}")
-                # Join multiple fields with OR
-                search_parts.append("+OR+".join(field_parts))
+                # Join multiple fields with OR. The group MUST be parenthesized:
+                # openFDA/Lucene binds AND tighter than OR, so an un-grouped
+                # "a:x OR b:x AND c:y OR d:y" parses as "a:x OR (b:x AND c:y) OR
+                # d:y" -- wrong. That silently broke every filtered multi-field
+                # query, e.g. FAERS colistin + reaction "acute kidney injury"
+                # returned 0 (HTTP 404) even though the unfiltered count shows
+                # ACUTE KIDNEY INJURY = 151. Wrapping keeps "(a OR b) AND (c OR d)".
+                search_parts.append("(" + "+OR+".join(field_parts) + ")")
             else:
                 # Single field - normal behavior
                 fda_field_name = fda_fields[0]
@@ -460,8 +466,14 @@ class FDADrugAdverseEventDetailTool(BaseTool):
                         field_parts.append(f'{fda_field_name}:"{mapped_value}"')
                     else:
                         field_parts.append(f"{fda_field_name}:{mapped_value}")
-                # Join multiple fields with OR
-                search_parts.append("+OR+".join(field_parts))
+                # Join multiple fields with OR. The group MUST be parenthesized:
+                # openFDA/Lucene binds AND tighter than OR, so an un-grouped
+                # "a:x OR b:x AND c:y OR d:y" parses as "a:x OR (b:x AND c:y) OR
+                # d:y" -- wrong. That silently broke every filtered multi-field
+                # query, e.g. FAERS colistin + reaction "acute kidney injury"
+                # returned 0 (HTTP 404) even though the unfiltered count shows
+                # ACUTE KIDNEY INJURY = 151. Wrapping keeps "(a OR b) AND (c OR d)".
+                search_parts.append("(" + "+OR+".join(field_parts) + ")")
             else:
                 # Single field - normal behavior
                 fda_field_name = fda_fields[0]

--- a/src/tooluniverse/restful_tool.py
+++ b/src/tooluniverse/restful_tool.py
@@ -1,7 +1,24 @@
 from .graphql_tool import GraphQLTool, remove_none_and_empty_values
+import re
 import requests
 import copy
 from .tool_registry import register_tool
+
+_UNDERSCORE_CURIE_RE = re.compile(r"^([A-Za-z]+)_(\d+)$")
+
+
+def _normalize_curie(value):
+    """Convert an underscore ontology CURIE ('HP_0000639', 'MONDO_0008765') to
+    the colon form Monarch requires ('HP:0000639'). OpenTargets phenotype/disease
+    tools emit the underscore form, but Monarch's /entity/{id} 404s on it and
+    returns "Entity not found" wrapped in status:success -- a silent false-empty
+    that breaks the OpenTargets -> Monarch phenotype chain. Non-CURIE values
+    (search terms, colon CURIEs) pass through unchanged."""
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    m = _UNDERSCORE_CURIE_RE.match(stripped)
+    return f"{m.group(1)}:{m.group(2)}" if m else stripped
 
 
 def execute_RESTful_query(endpoint_url, variables=None):
@@ -52,8 +69,11 @@ class MonarchTool(RESTfulTool):
                 query_schema_runtime[key] = arguments[key]
         if "url_key" in query_schema_runtime:
             url_key_name = query_schema_runtime["url_key"]
+            # Normalize an underscore ontology CURIE (HP_0000639) to the colon
+            # form Monarch's /entity/{id} needs; otherwise it 404s and returns
+            # "Entity not found" as a silent status:success false-empty.
             formatted_endpoint_url = self.endpoint_url.format(
-                url_key=query_schema_runtime[url_key_name]
+                url_key=_normalize_curie(query_schema_runtime[url_key_name])
             )
             del query_schema_runtime["url_key"]
         else:

--- a/src/tooluniverse/string_tool.py
+++ b/src/tooluniverse/string_tool.py
@@ -140,9 +140,27 @@ class STRINGRESTTool(BaseTool):
             and "data" in api_response
             and "header" in api_response
         ):
+            rows = api_response["data"]
+            metadata = {"columns": api_response["header"]}
+            # `limit` is documented as "Maximum number of interactions to return",
+            # but STRING interprets it as a network node-expansion count and then
+            # returns EVERY pairwise edge -- so limit=50 could yield 300+ rows,
+            # far more than asked. Honor the documented meaning by returning at
+            # most `limit` interactions, keeping the highest-confidence ones.
+            limit = arguments.get("limit")
+            if isinstance(rows, list) and isinstance(limit, int) and len(rows) > limit:
+
+                def _score(row):
+                    try:
+                        return float(row.get("score"))
+                    except (TypeError, ValueError):
+                        return -1.0
+
+                rows = sorted(rows, key=_score, reverse=True)[:limit]
+                metadata["truncated_to_limit"] = limit
             return {
                 "status": "success",
-                "data": api_response["data"],
-                "metadata": {"columns": api_response["header"]},
+                "data": rows,
+                "metadata": metadata,
             }
         return {"status": "success", "data": api_response}

--- a/src/tooluniverse/uniprot_tool.py
+++ b/src/tooluniverse/uniprot_tool.py
@@ -65,15 +65,33 @@ class UniProtRESTTool(BaseTool):
 
         comment_summaries = []
         for comment in data.get("comments", []):
+            comment_type = comment.get("commentType", "")
             text_values = [
                 text["value"]
                 for text in comment.get("texts", [])
                 if isinstance(text, dict) and text.get("value")
             ]
+            # Some biologically important comment types carry no top-level
+            # `texts` array, so keying only on text_values silently dropped them.
+            # COFACTOR stores its data under `cofactors[].name` (+ an optional
+            # `note.texts`); confirmed live that P00439's Fe(2+) cofactor -- a
+            # clinically relevant field -- vanished from the compact summary.
+            if comment_type == "COFACTOR":
+                cofactor_names = [
+                    cf["name"]
+                    for cf in comment.get("cofactors", [])
+                    if isinstance(cf, dict) and cf.get("name")
+                ]
+                note_texts = [
+                    t["value"]
+                    for t in (comment.get("note", {}) or {}).get("texts", [])
+                    if isinstance(t, dict) and t.get("value")
+                ]
+                text_values = cofactor_names + note_texts + text_values
             if text_values:
                 comment_summaries.append(
                     {
-                        "commentType": comment.get("commentType", ""),
+                        "commentType": comment_type,
                         "texts": text_values[:3],
                     }
                 )

--- a/tests/unit/test_alliance_strip_html.py
+++ b/tests/unit/test_alliance_strip_html.py
@@ -1,0 +1,38 @@
+"""Unit test: Alliance phenotype statements must be stripped of HTML markup.
+
+Regression: ZFIN_get_gene_phenotypes (AllianceGenomeTool) passed the API's
+phenotypeStatement through raw, so italicised gene symbols leaked literal tags
+into the JSON, e.g. 'anatomical structure <i>acta1a</i> expression decreased
+amount'. A caller rendering the field got the tags verbatim.
+"""
+import pytest
+
+from tooluniverse.alliance_genome_tool import _strip_html
+
+
+@pytest.mark.unit
+def test_strip_italic_tags():
+    assert (
+        _strip_html(
+            "anatomical structure <i>acta1a</i> expression decreased amount, abnormal"
+        )
+        == "anatomical structure acta1a expression decreased amount, abnormal"
+    )
+
+
+@pytest.mark.unit
+def test_unescape_entities_and_strip():
+    # Entity-encoded tags are unescaped then stripped (no markup survives).
+    assert _strip_html("gene &lt;i&gt;x&lt;/i&gt; up") == "gene x up"
+    assert _strip_html("a &amp; b <sup>2</sup>") == "a & b 2"
+
+
+@pytest.mark.unit
+def test_non_string_passthrough():
+    assert _strip_html(None) is None
+    assert _strip_html(123) == 123
+
+
+@pytest.mark.unit
+def test_plain_text_unchanged():
+    assert _strip_html("no markup here") == "no markup here"

--- a/tests/unit/test_bvbrc_amr_description.py
+++ b/tests/unit/test_bvbrc_amr_description.py
@@ -1,0 +1,40 @@
+"""Regression guard: BVBRC_search_amr description must not imply organism filtering.
+
+The tool has no organism/species parameter (only antibiotic / genome_id /
+resistant_phenotype), but its description ended with "Example: search for
+methicillin resistance in Staphylococcus aureus", implying an organism-scoped
+search that silently doesn't exist. The description now states there is no
+organism parameter and how to scope to an organism via genome_id.
+"""
+import glob
+import json
+
+import pytest
+
+
+def _load(name):
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if isinstance(data, list):
+            for tool in data:
+                if isinstance(tool, dict) and tool.get("name") == name:
+                    return tool
+    raise AssertionError(f"tool config not found: {name}")
+
+
+@pytest.mark.unit
+def test_amr_has_no_organism_param():
+    props = _load("BVBRC_search_amr")["parameter"]["properties"]
+    assert "organism" not in props and "species" not in props
+
+
+@pytest.mark.unit
+def test_amr_description_does_not_imply_organism_search():
+    desc = _load("BVBRC_search_amr")["description"]
+    # No misleading organism-scoped example; explicitly says no organism param.
+    assert "in Staphylococcus aureus" not in desc
+    assert "no organism" in desc.lower()
+    assert "genome_id" in desc

--- a/tests/unit/test_chebi_ontology_id_prefix.py
+++ b/tests/unit/test_chebi_ontology_id_prefix.py
@@ -1,0 +1,49 @@
+"""Unit test: ChEBI ontology tools accept the 'CHEBI:' CURIE form.
+
+Regression: ChEBI_get_ontology_parents / _children required a bare integer and
+rejected 'CHEBI:16113' -- but ChEBI_search and ChEBI_get_compound emit the
+prefixed accession (chebi_accession = 'CHEBI:16113'), so chaining
+search -> ontology broke with "'CHEBI:16113' is not of type 'integer'". The
+param now accepts integer or string and the tool strips the prefix.
+"""
+import glob
+import json
+
+import pytest
+
+from tooluniverse.chebi_tool import _normalize_chebi_id
+
+
+def _load(name):
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if isinstance(data, list):
+            for tool in data:
+                if isinstance(tool, dict) and tool.get("name") == name:
+                    return tool
+    raise AssertionError(f"tool config not found: {name}")
+
+
+@pytest.mark.unit
+def test_normalize_strips_curie_prefix():
+    assert _normalize_chebi_id("CHEBI:16113") == "16113"
+    assert _normalize_chebi_id("chebi:16113") == "16113"
+    assert _normalize_chebi_id("  CHEBI:16113 ") == "16113"
+
+
+@pytest.mark.unit
+def test_normalize_leaves_bare_id_untouched():
+    assert _normalize_chebi_id(16113) == 16113
+    assert _normalize_chebi_id("16113") == "16113"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name", ["ChEBI_get_ontology_parents", "ChEBI_get_ontology_children"]
+)
+def test_ontology_configs_accept_string_and_integer(name):
+    prop = _load(name)["parameter"]["properties"]["chebi_id"]
+    assert set(prop["type"]) == {"integer", "string"}

--- a/tests/unit/test_chembl_mechanism_parent_fallback.py
+++ b/tests/unit/test_chembl_mechanism_parent_fallback.py
@@ -1,0 +1,89 @@
+"""Unit test: ChEMBL_get_drug_mechanisms resolves salt/child ids to the parent.
+
+Regression: /mechanism.json indexes records under the PARENT molecule, but
+ChEMBL_search_drugs hands back the salt/child id (dolutegravir CHEMBL1213165,
+parent CHEMBL1229211). A mechanism query on the child matched nothing and
+returned a silent empty ("no mechanism on file") -- breaking the common
+search->mechanism chain. The tool now resolves the parent and retries once.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.chem_tool import ChEMBLRESTTool
+
+
+def _tool():
+    return ChEMBLRESTTool(
+        {
+            "name": "ChEMBL_get_drug_mechanisms",
+            "type": "ChEMBLRESTTool",
+            "fields": {"endpoint": "/mechanism.json"},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload
+        self.url = "https://www.ebi.ac.uk/chembl/api/data/mechanism.json"
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+@pytest.mark.unit
+def test_empty_child_result_retries_with_parent():
+    tool = _tool()
+    # First mechanism query (child) -> empty; retry (parent) -> one mechanism.
+    responses = [
+        _Resp({"mechanisms": [], "page_meta": {"total_count": 0}}),
+        _Resp(
+            {
+                "mechanisms": [
+                    {"mechanism_of_action": "HIV-1 integrase inhibitor"}
+                ]
+            }
+        ),
+    ]
+    with patch(
+        "tooluniverse.chem_tool.request_with_retry", side_effect=responses
+    ), patch.object(
+        ChEMBLRESTTool, "_fetch_parent_chembl_id", return_value="CHEMBL1229211"
+    ):
+        result = tool.run({"chembl_id": "CHEMBL1213165"})
+
+    mechs = result["data"]["mechanisms"]
+    assert len(mechs) == 1
+    assert mechs[0]["mechanism_of_action"] == "HIV-1 integrase inhibitor"
+    assert result["metadata"]["resolved_parent_chembl_id"] == "CHEMBL1229211"
+    assert "parent" in result["metadata"]["note"]
+
+
+@pytest.mark.unit
+def test_non_empty_result_does_not_retry():
+    tool = _tool()
+    resp = _Resp({"mechanisms": [{"mechanism_of_action": "x"}]})
+    fetch_parent = MagicMock()
+    with patch(
+        "tooluniverse.chem_tool.request_with_retry", return_value=resp
+    ), patch.object(ChEMBLRESTTool, "_fetch_parent_chembl_id", fetch_parent):
+        result = tool.run({"chembl_id": "CHEMBL1229211"})
+    # Already had mechanisms -> no parent lookup, no note.
+    fetch_parent.assert_not_called()
+    assert "metadata" not in result or "note" not in result.get("metadata", {})
+
+
+@pytest.mark.unit
+def test_no_parent_leaves_empty_result_unchanged():
+    tool = _tool()
+    resp = _Resp({"mechanisms": []})
+    with patch(
+        "tooluniverse.chem_tool.request_with_retry", return_value=resp
+    ), patch.object(ChEMBLRESTTool, "_fetch_parent_chembl_id", return_value=None):
+        result = tool.run({"chembl_id": "CHEMBL25"})
+    assert result["data"]["mechanisms"] == []

--- a/tests/unit/test_civic_enum_validation.py
+++ b/tests/unit/test_civic_enum_validation.py
@@ -1,0 +1,96 @@
+"""Unit test: civic_search_evidence_items validates enum filters up front.
+
+Regression: an invalid enum value (e.g. evidence_type="BANANA",
+significance="GARBAGEXYZ") was passed straight to the CIViC GraphQL API and came
+back as an opaque "Error: GraphQL query errors" with no hint of what was wrong or
+what is valid. The tool now validates evidence_type / significance /
+evidence_direction client-side and names the allowed values.
+"""
+import glob
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.civic_tool import CIViCTool
+
+
+def _load(name):
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if isinstance(data, list):
+            for tool in data:
+                if isinstance(tool, dict) and tool.get("name") == name:
+                    return tool
+    raise AssertionError(f"tool config not found: {name}")
+
+
+def _tool():
+    return CIViCTool(_load("civic_search_evidence_items"))
+
+
+@pytest.mark.unit
+def test_invalid_evidence_type_rejected_with_valid_list():
+    result = _tool().run(
+        {"molecular_profile": "CTNNB1 S45F", "evidence_type": "BANANA"}
+    )
+    assert result["status"] == "error"
+    assert "Invalid evidence_type 'BANANA'" in result["error"]
+    assert "PREDICTIVE" in result["error"]
+
+
+@pytest.mark.unit
+def test_invalid_significance_rejected():
+    result = _tool().run(
+        {"molecular_profile": "ERBB2 V777L", "significance": "GARBAGEXYZ"}
+    )
+    assert result["status"] == "error"
+    assert "Invalid significance 'GARBAGEXYZ'" in result["error"]
+    assert "RESISTANCE" in result["error"]
+
+
+@pytest.mark.unit
+def test_valid_enum_passes_validation():
+    """A valid enum must NOT trip the guard (proceeds to the API layer)."""
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"data": {"evidenceItems": {"nodes": []}}}
+
+        def raise_for_status(self):
+            pass
+
+    with patch("tooluniverse.civic_tool.requests.post", return_value=_Resp()):
+        result = _tool().run(
+            {"molecular_profile": "CTNNB1 S45F", "evidence_type": "PREDICTIVE"}
+        )
+    assert not (
+        result.get("status") == "error"
+        and "Invalid evidence_type" in result.get("error", "")
+    )
+
+
+@pytest.mark.unit
+def test_enum_check_is_case_insensitive():
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"data": {"evidenceItems": {"nodes": []}}}
+
+        def raise_for_status(self):
+            pass
+
+    with patch("tooluniverse.civic_tool.requests.post", return_value=_Resp()):
+        result = _tool().run(
+            {"molecular_profile": "x", "significance": "resistance"}
+        )
+    assert not (
+        result.get("status") == "error"
+        and "Invalid significance" in result.get("error", "")
+    )

--- a/tests/unit/test_civic_molecular_profiles_guard.py
+++ b/tests/unit/test_civic_molecular_profiles_guard.py
@@ -1,0 +1,64 @@
+"""Unit test: civic_search_molecular_profiles must not silently drop unknown params.
+
+Regression: civic_search_molecular_profiles only filters by query/name + limit
+(the GraphQL query binds nothing else). Passing a very natural param like
+variant_id ("profiles for CIViC variant 78") was silently ignored, returning the
+full unfiltered profile list (BRAF V600E, ERBB2 Amplification, ...) as a
+plausible-but-wrong "success". The tool now rejects unrecognized params with an
+actionable hint, mirroring civic_search_evidence_items.
+"""
+import glob
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.civic_tool import CIViCTool
+
+
+def _load(name):
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if isinstance(data, list):
+            for tool in data:
+                if isinstance(tool, dict) and tool.get("name") == name:
+                    return tool
+    raise AssertionError(f"tool config not found: {name}")
+
+
+def _tool():
+    return CIViCTool(_load("civic_search_molecular_profiles"))
+
+
+@pytest.mark.unit
+def test_unknown_param_rejected_with_hint():
+    result = _tool().run({"variant_id": 78})
+    assert result["status"] == "error"
+    assert "variant_id" in result["error"]
+    # Points the user at the right approach instead of silently dumping.
+    assert "civic_get_variant" in result["error"]
+
+
+@pytest.mark.unit
+def test_valid_query_param_passes_guard():
+    """A supported param set must NOT trip the guard (it proceeds to the API)."""
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"data": {"molecularProfiles": {"nodes": []}}}
+
+        def raise_for_status(self):
+            pass
+
+    with patch("tooluniverse.civic_tool.requests.post", return_value=_Resp()):
+        result = _tool().run({"query": "KRAS G12C", "limit": 5})
+    # Not the guard's rejection error.
+    assert not (
+        result.get("status") == "error"
+        and "Unrecognized parameter" in result.get("error", "")
+    )

--- a/tests/unit/test_civic_significance_filter.py
+++ b/tests/unit/test_civic_significance_filter.py
@@ -1,0 +1,57 @@
+"""Unit test for the CIViC evidence-item `significance` filter.
+
+Regression: `civic_search_evidence_items` advertised `significance` as a
+supported filter (it is whitelisted in the tool's known-parameter set and named
+in the "Supported filters" error text), but the GraphQL query template bound
+`$evidenceType` only — `significance` appeared solely as a *returned field*, so
+passing `significance="RESISTANCE"` was silently ignored and the tool returned
+an unfiltered, significance-mixed evidence dump. That is clinically dangerous:
+an oncologist filtering for RESISTANCE evidence would receive SENSITIVITY items
+mixed in. The fix adds `$significance: EvidenceSignificance` to the query
+signature and the `evidenceItems(...)` argument list so the filter is honored.
+"""
+import glob
+import json
+
+import pytest
+
+from tooluniverse.civic_tool import CIViCTool
+
+
+def _load_config(name):
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if not isinstance(data, list):
+            continue
+        for tool in data:
+            if isinstance(tool, dict) and tool.get("name") == name:
+                return tool
+    raise AssertionError(f"tool config not found: {name}")
+
+
+@pytest.mark.unit
+def test_significance_is_bound_in_query_template():
+    """The GraphQL query must declare and USE $significance as a filter arg."""
+    cfg = _load_config("civic_search_evidence_items")
+    query = cfg["fields"]["query"]
+    # Declared as a typed variable...
+    assert "$significance: EvidenceSignificance" in query
+    # ...and actually passed to the evidenceItems() filter (not just returned).
+    assert "significance: $significance" in query
+
+
+@pytest.mark.unit
+def test_build_graphql_query_binds_significance():
+    """A user-supplied significance value must reach the GraphQL variables."""
+    cfg = _load_config("civic_search_evidence_items")
+    tool = CIViCTool(cfg)
+    payload = tool._build_graphql_query(
+        {"molecular_profile": "KRAS G12C", "significance": "RESISTANCE", "limit": 50}
+    )
+    assert payload["variables"].get("significance") == "RESISTANCE"
+    # sanity: the sibling evidence_type mapping still works alongside it
+    payload2 = tool._build_graphql_query({"evidence_type": "PROGNOSTIC"})
+    assert payload2["variables"].get("evidenceType") == "PROGNOSTIC"

--- a/tests/unit/test_civic_significance_filter.py
+++ b/tests/unit/test_civic_significance_filter.py
@@ -44,6 +44,15 @@ def test_significance_is_bound_in_query_template():
 
 
 @pytest.mark.unit
+def test_significance_is_a_declared_parameter():
+    """significance must be discoverable in `tu info`, not just functional."""
+    cfg = _load_config("civic_search_evidence_items")
+    props = cfg["parameter"]["properties"]
+    assert "significance" in props
+    assert "RESISTANCE" in props["significance"]["description"]
+
+
+@pytest.mark.unit
 def test_build_graphql_query_binds_significance():
     """A user-supplied significance value must reach the GraphQL variables."""
     cfg = _load_config("civic_search_evidence_items")

--- a/tests/unit/test_clinvar_compound_clinsig_slash.py
+++ b/tests/unit/test_clinvar_compound_clinsig_slash.py
@@ -1,0 +1,65 @@
+"""Unit test: ClinVar_search_variants handles slash-compound clinical significance.
+
+Regression: a compound aggregate class like "Pathogenic/Likely pathogenic" (which
+the tool's OWN get_clinical_significance emits) has no single NCBI clinsig token
+-- the slash broke both the [Filter] phrase and the [prop] token, so the search
+silently returned total_count 0 for a valid value. The slash is now treated as OR
+and expanded to the individual classes (the clinically-actionable union).
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import ClinVarSearchVariants
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ClinVarSearchVariants({"name": "ClinVar_search_variants"})
+
+
+def _term_for(arguments):
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        tool.run(arguments)
+    return mock_request.call_args[0][1]["term"]
+
+
+def test_slash_value_expands_to_or_of_components():
+    term = _term_for(
+        {"gene": "RYR1", "clinical_significance": "Pathogenic/Likely pathogenic"}
+    )
+    # Both component classes present, joined by OR, and NO broken slash token.
+    assert '"clinsig pathogenic"[Filter]' in term
+    assert '"clinsig likely pathogenic"[Filter]' in term
+    assert "clinsig_likely_pathogenic[prop]" in term
+    assert "/" not in term.split("RYR1[gene]")[1]  # no slash survives in clinsig
+    assert " OR " in term
+
+
+def test_single_value_unchanged():
+    term = _term_for({"gene": "RYR1", "clinical_significance": "Pathogenic"})
+    assert '("clinsig pathogenic"[Filter] OR clinsig_pathogenic[prop])' in term
+
+
+def test_compound_note_only_on_compound_value():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={
+            "status": "success",
+            "data": {"esearchresult": {"count": "5", "idlist": []}},
+        },
+    ):
+        compound = tool.run(
+            {"gene": "RYR1", "clinical_significance": "Benign/Likely benign"}
+        )
+        single = tool.run({"gene": "RYR1", "clinical_significance": "Benign"})
+    assert "clinical_significance_note" in compound["data"]
+    assert "clinical_significance_note" not in single["data"]

--- a/tests/unit/test_clinvar_rsid_search.py
+++ b/tests/unit/test_clinvar_rsid_search.py
@@ -1,0 +1,61 @@
+"""Unit test: ClinVar_search_variants must handle a dbSNP rsID query.
+
+Regression: an rsID passed as `query` (e.g. rs4244285, the CYP2C19*2 variant)
+was aliased to `condition` and searched as a DISEASE term ('rs4244285[dis]'),
+silently returning 0 -- but ClinVar's free-text index matches a bare rsID
+(term=rs4244285 -> 37 records). That false-empty broke the standard
+pharmacogenomics chain rsID -> ClinVar clinical significance. rsIDs are now
+routed to a bare-term search.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import ClinVarSearchVariants
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    return ClinVarSearchVariants({"name": "ClinVar_search_variants"})
+
+
+def _term_for(arguments):
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        tool.run(arguments)
+    return mock_request.call_args[0][1]["term"]
+
+
+def test_rsid_query_becomes_bare_term_not_disease_field():
+    term = _term_for({"query": "rs4244285"})
+    assert "rs4244285" in term
+    assert "[dis]" not in term  # must NOT be searched as a disease
+
+
+def test_explicit_rsid_param_supported():
+    term = _term_for({"rsid": "rs4244285"})
+    assert "rs4244285" in term
+    assert "[dis]" not in term
+
+
+def test_rsid_combines_with_gene():
+    term = _term_for({"gene": "CYP2C19", "rsid": "rs4244285"})
+    assert "CYP2C19[gene]" in term
+    assert "rs4244285" in term
+    assert " AND " in term
+
+
+def test_non_rsid_query_still_uses_disease_field():
+    term = _term_for({"query": "Rett syndrome"})
+    assert '"Rett syndrome"[dis]' in term
+
+
+def test_case_insensitive_rsid_detection():
+    term = _term_for({"query": "RS4244285"})
+    assert "[dis]" not in term
+    assert "RS4244285" in term

--- a/tests/unit/test_clinvar_variant_name_normalization.py
+++ b/tests/unit/test_clinvar_variant_name_normalization.py
@@ -1,0 +1,58 @@
+"""Unit test: ClinVar_search_variants normalizes HGVS-prefixed / rsID variant_name.
+
+Two false-empties (each flagged by multiple role-play personas):
+- NCBI's [Variant name] index mangles the '.' in an HGVS reference prefix
+  ('p.Glu342Lys' -> 'p0x2eGlu342Lys') and matches nothing, so a clinician typing
+  standard HGVS got total_count 0 (SERPINA1 Z-allele exists as 'Glu342Lys').
+- An rsID passed as variant_name (rs776746 / rs35705950) was sent to the
+  [Variant name] field, which returns 0, instead of a bare free-text search.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import ClinVarSearchVariants
+
+pytestmark = pytest.mark.unit
+
+
+def _term_for(arguments):
+    tool = ClinVarSearchVariants({"name": "ClinVar_search_variants"})
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        tool.run(arguments)
+    return mock_request.call_args[0][1]["term"]
+
+
+def test_hgvs_protein_prefix_stripped():
+    term = _term_for({"gene": "SERPINA1", "variant_name": "p.Glu342Lys"})
+    assert "Glu342Lys[Variant name]" in term
+    assert "p.Glu342Lys" not in term
+    assert "p0x2e" not in term
+
+
+@pytest.mark.parametrize("prefix", ["p.", "c.", "g.", "m.", "n.", "P.", "C."])
+def test_all_reference_prefixes_stripped(prefix):
+    term = _term_for({"variant_name": f"{prefix}Glu342Lys"})
+    assert "Glu342Lys[Variant name]" in term
+    assert prefix not in term
+
+
+def test_rsid_as_variant_name_becomes_bare_term():
+    term = _term_for({"gene": "CYP3A5", "variant_name": "rs776746"})
+    assert "rs776746" in term
+    assert "rs776746[Variant name]" not in term  # NOT wrapped in the field tag
+
+
+def test_plain_protein_change_unchanged():
+    term = _term_for({"gene": "SERPINA1", "variant_name": "Glu342Lys"})
+    assert "Glu342Lys[Variant name]" in term
+
+
+def test_short_protein_change_not_mangled():
+    # 'V600E' has no reference prefix; must pass through untouched.
+    term = _term_for({"gene": "BRAF", "variant_name": "V600E"})
+    assert "V600E[Variant name]" in term

--- a/tests/unit/test_clinvar_variant_name_search.py
+++ b/tests/unit/test_clinvar_variant_name_search.py
@@ -92,3 +92,50 @@ def test_empty_or_blank_variant_name_entries_are_dropped():
     term = mock_request.call_args[0][1]["term"]
     assert "Glu6Val[Variant name]" in term
     assert "OR" not in term  # only one real candidate survived, no OR needed
+
+
+def test_variant_is_aliased_to_variant_name_when_gene_also_present():
+    """Fix: `variant` (the intuitive name; schema calls it `variant_name`) was
+    silently dropped whenever a valid param like `gene` was also present, so
+    {"gene":"KRAS","variant":"G12C"} returned ALL KRAS variants instead of the
+    G12C ones -- a dangerous silent full-gene dump. `variant` is now aliased to
+    `variant_name` so the natural query filters correctly."""
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        result = tool.run({"gene": "KRAS", "variant": "G12C"})
+
+    assert result["status"] == "success"
+    term = mock_request.call_args[0][1]["term"]
+    assert "KRAS[gene]" in term
+    assert "G12C[Variant name]" in term  # the variant filter is actually applied
+
+
+def test_variant_alias_not_flagged_as_unrecognized_when_alone():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        result = tool.run({"variant": "G12C"})
+
+    assert result["status"] == "success"
+    assert "G12C[Variant name]" in mock_request.call_args[0][1]["term"]
+
+
+def test_explicit_variant_name_takes_precedence_over_variant_alias():
+    tool = _tool()
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        tool.run({"gene": "KRAS", "variant_name": "G12D", "variant": "G12C"})
+
+    term = mock_request.call_args[0][1]["term"]
+    assert "G12D[Variant name]" in term
+    assert "G12C" not in term

--- a/tests/unit/test_clinvar_vus_clinsig.py
+++ b/tests/unit/test_clinvar_vus_clinsig.py
@@ -1,0 +1,47 @@
+"""Unit test: ClinVar_search_variants maps 'Uncertain significance' to clinsig_vus.
+
+Regression: filtering clinical_significance="Uncertain significance" -- the single
+LARGEST ClinVar category -- returned total_count 0. NCBI indexes VUS under the
+token clinsig_vus[prop], NOT the naive clinsig_uncertain_significance[prop] the
+tool built, so it was a silent false-empty. The tool now ORs in the correct
+token via a clinsig-alias map.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.clinvar_tool import ClinVarSearchVariants
+
+pytestmark = pytest.mark.unit
+
+
+def _term_for(arguments):
+    tool = ClinVarSearchVariants({"name": "ClinVar_search_variants"})
+    with patch.object(
+        ClinVarSearchVariants,
+        "_make_request",
+        return_value={"status": "success", "data": {}},
+    ) as mock_request:
+        tool.run(arguments)
+    return mock_request.call_args[0][1]["term"]
+
+
+def test_uncertain_significance_includes_vus_token():
+    term = _term_for(
+        {"gene": "BRCA2", "clinical_significance": "Uncertain significance"}
+    )
+    assert "clinsig_vus[prop]" in term
+    # the original forms are still present (union, never drops matches)
+    assert 'clinsig uncertain significance"[Filter]' in term
+
+
+def test_underscore_and_casing_variants_also_get_vus():
+    for val in ("Uncertain_significance", "uncertain significance", "UNCERTAIN SIGNIFICANCE"):
+        term = _term_for({"gene": "BRCA2", "clinical_significance": val})
+        assert "clinsig_vus[prop]" in term, val
+
+
+def test_non_aliased_value_unchanged():
+    term = _term_for({"gene": "BRCA2", "clinical_significance": "Pathogenic"})
+    assert "clinsig_vus" not in term
+    assert '("clinsig pathogenic"[Filter] OR clinsig_pathogenic[prop])' in term

--- a/tests/unit/test_compound_variant_tool.py
+++ b/tests/unit/test_compound_variant_tool.py
@@ -267,6 +267,74 @@ def test_summary_reports_classification_for_exact_clinvar_match():
     assert "clinvar_note" not in s
 
 
+def test_summary_surfaces_most_severe_classification_for_multiallelic_match():
+    """Fix: a multi-allelic match (e.g. rsid rs80358981 = c.7558C>G VUS +
+    c.7558C>T Pathogenic) previously reported classifications[0] -- the leading
+    VUS -- and hid the Pathogenic allele, a clinically dangerous mis-summary.
+    The headline must be the MOST clinically significant classification, with
+    every distinct classification exposed and a disambiguating note."""
+    t = _tool()
+    annotations = {
+        "clinvar": {
+            "total_gene_variants": 2,
+            "matched": 2,
+            "exact_match": True,
+            "variants": [
+                {"name": "NM_000059.4(BRCA2):c.7558C>G (p.Arg2520Gly)",
+                 "classification": "Uncertain significance"},
+                {"name": "NM_000059.4(BRCA2):c.7558C>T (p.Arg2520Ter)",
+                 "classification": "Pathogenic"},
+            ],
+        }
+    }
+    s = t._build_summary(annotations, rsid="rs80358981")
+    # Most severe surfaces, NOT the first-listed VUS.
+    assert s["clinvar_classification"] == "Pathogenic"
+    assert set(s["clinvar_classifications"]) == {
+        "Uncertain significance",
+        "Pathogenic",
+    }
+    assert "clinvar_note" in s
+    # rsid query must not be mislabeled as the resolved gene symbol.
+    assert s["query"] == "rs80358981"
+
+
+def test_summary_query_label_precedence():
+    """summary.query reflects the most specific identifier the caller queried:
+    variant > rsid > gene. An rsid-only query resolved to a gene must still
+    report the rsid, not the gene."""
+    t = _tool()
+    assert t._build_summary({}, variant="BRAF V600E", gene="BRAF")["query"] == (
+        "BRAF V600E"
+    )
+    assert t._build_summary({}, rsid="rs80358981", gene="BRCA2")["query"] == (
+        "rs80358981"
+    )
+    assert t._build_summary({}, gene="BRCA2")["query"] == "BRCA2"
+
+
+def test_clinvar_severity_key_orders_pathogenic_above_vus_and_benign():
+    from tooluniverse.compound_variant_tool import _clinvar_severity_key
+
+    assert _clinvar_severity_key("Pathogenic") < _clinvar_severity_key(
+        "Uncertain significance"
+    )
+    assert _clinvar_severity_key("Likely pathogenic") < _clinvar_severity_key(
+        "Benign"
+    )
+    # Case/whitespace-insensitive.
+    assert _clinvar_severity_key("  PATHOGENIC ") == _clinvar_severity_key(
+        "pathogenic"
+    )
+    # Unknown labels sort after pathogenic/risk but before benign.
+    assert _clinvar_severity_key("Pathogenic") < _clinvar_severity_key(
+        "some novel label"
+    )
+    assert _clinvar_severity_key("some novel label") < _clinvar_severity_key(
+        "Benign"
+    )
+
+
 def test_sub_call_error_detects_error_status_dict():
     """Fix-R2B-003: sub-tools signal failure by returning
     {"status": "error", ...}, not by raising."""

--- a/tests/unit/test_enrichr_no_stdout_pollution.py
+++ b/tests/unit/test_enrichr_no_stdout_pollution.py
@@ -1,0 +1,49 @@
+"""Regression guard: EnrichrTool must not print to stdout.
+
+EnrichrTool emitted diagnostic lines via print() (e.g.
+"[enrichr_api] Using the official gene name: 'IL6' instead of IL6" and
+"Official gene names: [...]"). Because tool output is consumed as JSON by the
+CLI / MCP / SDK, those lines polluted stdout and broke `tu run ... | jq`. The
+messages were moved to logger.debug so they no longer contaminate stdout.
+"""
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.enrichr_tool import EnrichrTool
+
+
+def _tool():
+    return EnrichrTool(
+        {
+            "name": "enrichr_gene_enrichment_analysis",
+            "type": "EnrichrTool",
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+@pytest.mark.unit
+def test_source_has_no_print_calls():
+    src = Path("src/tooluniverse/enrichr_tool.py").read_text()
+    assert "print(" not in src
+
+
+@pytest.mark.unit
+def test_get_official_gene_name_writes_nothing_to_stdout():
+    class _Resp:
+        status_code = 200
+        ok = True
+
+        def json(self):
+            return {"hits": [{"symbol": "IL6", "alias": ["IFNB2"]}]}
+
+    buf = io.StringIO()
+    with patch("tooluniverse.enrichr_tool.requests.get", return_value=_Resp()):
+        with redirect_stdout(buf):
+            symbol = _tool().get_official_gene_name("il6")
+    assert symbol == "IL6"
+    assert buf.getvalue() == ""

--- a/tests/unit/test_faers_multifield_or_parens.py
+++ b/tests/unit/test_faers_multifield_or_parens.py
@@ -1,0 +1,95 @@
+"""Regression guard: FDA/FAERS multi-field OR groups must be parenthesized.
+
+FDADrugAdverseEventTool maps some params to multiple openFDA fields joined with
+OR (e.g. medicinalproduct -> patient.drug.medicinalproduct OR
+patient.drug.openfda.generic_name; reactionmeddraverse -> reactionmeddrapt OR
+reactionmeddraverse). Those OR groups were NOT parenthesized, and openFDA/Lucene
+binds AND tighter than OR, so a filtered query
+    a:x OR b:x AND c:y OR d:y
+parsed as  a:x OR (b:x AND c:y) OR d:y  -- wrong. That silently broke every
+filtered multi-field query: FAERS colistin + reaction "acute kidney injury"
+returned 0 (HTTP 404) even though the unfiltered count shows
+ACUTE KIDNEY INJURY = 151.
+"""
+import re
+import urllib.parse
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.openfda_adv_tool import FDADrugAdverseEventTool
+
+
+def _tool():
+    cfg = {
+        "name": "FAERS_count_reactions_by_drug_event",
+        "type": "FDADrugAdverseEventTool",
+        "parameter": {"type": "object", "properties": {}},
+        "fields": {
+            "search_fields": {
+                "medicinalproduct": [
+                    "patient.drug.medicinalproduct",
+                    "patient.drug.openfda.generic_name",
+                ],
+                "reactionmeddraverse": [
+                    "patient.reaction.reactionmeddrapt",
+                    "patient.reaction.reactionmeddraverse",
+                ],
+            },
+            "return_fields": ["patient.reaction.reactionmeddrapt.exact"],
+        },
+    }
+    return FDADrugAdverseEventTool(cfg, api_key=None)
+
+
+class _Resp:
+    status_code = 200
+
+    def json(self):
+        return {"results": [{"term": "ACUTE KIDNEY INJURY", "count": 151}]}
+
+    def raise_for_status(self):
+        pass
+
+
+def _captured_query(arguments):
+    captured = {}
+
+    def fake_get(url, timeout=None):
+        captured["url"] = url
+        return _Resp()
+
+    with patch("tooluniverse.openfda_adv_tool.requests.get", side_effect=fake_get):
+        _tool().run(arguments)
+    # The tool url-encodes the query; decode to inspect the Lucene expression.
+    q = re.search(r"search=([^&]+)", captured["url"]).group(1)
+    return urllib.parse.unquote(q)
+
+
+@pytest.mark.unit
+def test_multifield_or_group_is_parenthesized_and_anded():
+    query = _captured_query(
+        {"medicinalproduct": "colistin", "reactionmeddraverse": "acute kidney injury"}
+    )
+    # Each multi-field OR group must be wrapped in parentheses...
+    assert (
+        "(patient.drug.medicinalproduct:colistin+OR+"
+        "patient.drug.openfda.generic_name:colistin)"
+    ) in query
+    assert (
+        '(patient.reaction.reactionmeddrapt:"acute kidney injury"+OR+'
+        'patient.reaction.reactionmeddraverse:"acute kidney injury")'
+    ) in query
+    # ...and the two groups joined by AND.
+    assert ")+AND+(" in query
+
+
+@pytest.mark.unit
+def test_single_field_param_still_unparenthesized_but_valid():
+    query = _captured_query({"medicinalproduct": "colistin"})
+    assert (
+        "(patient.drug.medicinalproduct:colistin+OR+"
+        "patient.drug.openfda.generic_name:colistin)"
+    ) in query
+    # No stray AND when only one parameter is supplied.
+    assert "+AND+" not in query

--- a/tests/unit/test_gwas_gene_search_default_and_sort.py
+++ b/tests/unit/test_gwas_gene_search_default_and_sort.py
@@ -1,0 +1,84 @@
+"""Unit test: GWAS_search_associations_by_gene default size + p-value sort.
+
+Regression: the tool defaulted to size=5 and returned the API's UNSORTED
+associations. For a well-studied gene (TCF7L2, 902 associations) the 5 rows were
+arbitrary -- all anthropometric (hip/waist/BMI) -- silently hiding the gene's
+flagship type-2-diabetes associations, misleading a clinician. The default is
+now 100 and the returned set is sorted by p-value (most significant first).
+"""
+import glob
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.genomics_gene_search_tool import GWASGeneSearch
+
+
+def _tool():
+    return GWASGeneSearch({"name": "GWAS_search_associations_by_gene"})
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+@pytest.mark.unit
+def test_default_size_is_100_not_5():
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        captured["params"] = params
+        return _Resp({"_embedded": {"associations": []}, "page": {"totalElements": 0}})
+
+    tool = _tool()
+    with patch.object(tool.session, "get", side_effect=fake_get):
+        tool.run({"gene_name": "TCF7L2"})
+    assert captured["params"]["size"] == 100
+
+
+@pytest.mark.unit
+def test_associations_sorted_by_pvalue_most_significant_first():
+    payload = {
+        "_embedded": {
+            "associations": [
+                {"reported_trait": "BMI", "p_value": "2e-9"},
+                {"reported_trait": "type 2 diabetes", "p_value": "1e-77"},
+                {"reported_trait": "height", "p_value": None},
+                {"reported_trait": "waist", "p_value": "5e-12"},
+            ]
+        },
+        "page": {"totalElements": 4},
+    }
+    tool = _tool()
+    with patch.object(tool.session, "get", return_value=_Resp(payload)):
+        result = tool.run({"gene_name": "TCF7L2"})
+    pvals = [a["p_value"] for a in result["associations"]]
+    # Most significant (smallest) first; None/unparseable last.
+    assert pvals == ["1e-77", "5e-12", "2e-9", None]
+    assert result["associations"][0]["reported_trait"] == "type 2 diabetes"
+
+
+@pytest.mark.unit
+def test_config_default_size_is_100():
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if isinstance(data, list):
+            for t in data:
+                if (
+                    isinstance(t, dict)
+                    and t.get("name") == "GWAS_search_associations_by_gene"
+                ):
+                    assert t["parameter"]["properties"]["size"]["default"] == 100
+                    return
+    raise AssertionError("GWAS_search_associations_by_gene config not found")

--- a/tests/unit/test_gwas_pvalue_filter_sort.py
+++ b/tests/unit/test_gwas_pvalue_filter_sort.py
@@ -1,0 +1,52 @@
+"""Unit test: gwas_search_associations p-value threshold fetches most-significant first.
+
+Regression: the p_value threshold is applied CLIENT-SIDE to the fetched page, but
+the GWAS Catalog API returns associations UNSORTED. So a strict threshold filtered
+an arbitrary window and falsely returned 0 -- SLE p<=1e-100 -> 0 even though the
+catalog has hits at p=2e-298. When a p-value filter is requested and no explicit
+sort is given, the tool now sorts by p_value ascending so the fetched window holds
+the strongest loci.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.gwas_tool import GWASAssociationSearch
+
+
+def _tool():
+    return GWASAssociationSearch({"name": "gwas_search_associations"})
+
+
+def _params_for(arguments):
+    captured = {}
+
+    def fake_request(endpoint, params):
+        captured["params"] = params
+        return {"_embedded": {"associations": []}, "page": {"totalElements": 0}}
+
+    with patch.object(GWASAssociationSearch, "_make_request", side_effect=fake_request):
+        _tool().run(arguments)
+    return captured["params"]
+
+
+@pytest.mark.unit
+def test_pvalue_filter_injects_significance_sort():
+    params = _params_for({"efo_trait": "systemic lupus erythematosus", "p_value": 1e-100})
+    assert params.get("sort") == "p_value"
+    assert params.get("direction") == "asc"
+
+
+@pytest.mark.unit
+def test_explicit_sort_is_respected_over_default():
+    params = _params_for(
+        {"efo_trait": "x", "p_value": 1e-8, "sort": "or_value", "direction": "desc"}
+    )
+    assert params["sort"] == "or_value"
+    assert params["direction"] == "desc"
+
+
+@pytest.mark.unit
+def test_no_pvalue_filter_leaves_sort_unset():
+    params = _params_for({"efo_trait": "x"})
+    assert "sort" not in params

--- a/tests/unit/test_hpo_id_normalization.py
+++ b/tests/unit/test_hpo_id_normalization.py
@@ -1,0 +1,32 @@
+"""Unit test for HPO term-id normalization.
+
+Regression: HPO_get_term (and get_associated_*/hierarchy) normalized a term id
+with `if not term_id.startswith("HP:"): term_id = f"HP:{term_id}"`. For the
+underscore CURIE `HP_0001250` -- exactly what OpenTargets emits for phenotype
+HPO ids (phenotypeHPO.id) -- that produced `HP:HP_0001250` and a 404, breaking
+the OpenTargets-phenotype -> HPO_get_term chain a clinician follows.
+"""
+import pytest
+
+from tooluniverse.hpo_tool import _normalize_hpo_id
+
+
+@pytest.mark.unit
+def test_underscore_curie_is_normalized_to_colon():
+    assert _normalize_hpo_id("HP_0001250") == "HP:0001250"
+
+
+@pytest.mark.unit
+def test_colon_curie_is_unchanged():
+    assert _normalize_hpo_id("HP:0001250") == "HP:0001250"
+
+
+@pytest.mark.unit
+def test_bare_digits_get_prefix():
+    assert _normalize_hpo_id("0001250") == "HP:0001250"
+
+
+@pytest.mark.unit
+def test_lowercase_and_whitespace_are_canonicalized():
+    assert _normalize_hpo_id("  hp_0001250 ") == "HP:0001250"
+    assert _normalize_hpo_id("hp:0001250") == "HP:0001250"

--- a/tests/unit/test_lipidmaps_unknown_param.py
+++ b/tests/unit/test_lipidmaps_unknown_param.py
@@ -1,0 +1,48 @@
+"""Unit test: LipidMaps compound query rejects unknown params (no false empty).
+
+Regression: LipidMaps_get_compound_by_xref's `xref_type` has a default
+(kegg_id), so a typo'd param name like `input_type` (instead of `xref_type`) was
+silently accepted and the lookup fell back to kegg_id -- a PubChem CID searched
+as a KEGG id returned an empty "not found" the user wrongly trusted. The tool
+now names the unrecognized parameter instead of returning a false empty.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.lipidmaps_tool import LipidMapsTool
+
+
+def _tool():
+    return LipidMapsTool(
+        {
+            "name": "LipidMaps_get_compound_by_xref",
+            "type": "LipidMapsTool",
+            "parameter": {"type": "object", "properties": {}},
+            "fields": {"context": "compound", "input_item": "kegg_id"},
+        }
+    )
+
+
+@pytest.mark.unit
+def test_unknown_param_is_rejected_not_silently_ignored():
+    result = _tool()._query_compound(
+        {"input_value": "5997", "input_type": "pubchem_cid"}
+    )
+    assert result["status"] == "error"
+    assert "input_type" in result["error"]
+    assert "xref_type" in result["error"]
+
+
+@pytest.mark.unit
+def test_correct_params_pass_the_guard():
+    """A recognized param set must reach the request layer, not the guard."""
+    with patch.object(
+        LipidMapsTool, "_make_request", return_value={"status": "success", "data": {}}
+    ) as mock_req:
+        result = _tool()._query_compound(
+            {"input_value": "5997", "xref_type": "pubchem_cid"}
+        )
+    assert result["status"] == "success"
+    # pubchem_cid was honored (not silently defaulted to kegg_id).
+    assert "pubchem_cid/5997" in mock_req.call_args[0][0]

--- a/tests/unit/test_monarch_curie_normalization.py
+++ b/tests/unit/test_monarch_curie_normalization.py
@@ -1,0 +1,45 @@
+"""Unit test: Monarch entity CURIE underscore->colon normalization.
+
+Regression: Mondo_get_disease (and other MonarchV3Tool entity lookups) built
+'/entity/{disease_id}' verbatim, so the underscore CURIE OpenTargets emits
+('MONDO_0004995', 'EFO_0008572', 'Orphanet_238583') 404'd -- Monarch needs the
+colon form 'MONDO:0004995'. Feeding one tool's output into Mondo_get_disease
+broke with a bare 404 that never revealed the delimiter was the cause.
+"""
+import pytest
+
+from tooluniverse.monarch_v3_tool import _normalize_curie
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("MONDO_0004995", "MONDO:0004995"),
+        ("EFO_0008572", "EFO:0008572"),
+        ("Orphanet_238583", "Orphanet:238583"),
+        ("HP_0001250", "HP:0001250"),
+        ("NCBITaxon_9606", "NCBITaxon:9606"),
+    ],
+)
+def test_underscore_curie_normalized_to_colon(raw, expected):
+    assert _normalize_curie(raw) == expected
+
+
+@pytest.mark.unit
+def test_colon_curie_unchanged():
+    assert _normalize_curie("MONDO:0004995") == "MONDO:0004995"
+
+
+@pytest.mark.unit
+def test_whitespace_trimmed():
+    assert _normalize_curie("  MONDO_0004995 ") == "MONDO:0004995"
+
+
+@pytest.mark.unit
+def test_non_curie_strings_untouched():
+    # A plain search term or a symbol must not be rewritten.
+    assert _normalize_curie("BRCA2") == "BRCA2"
+    assert _normalize_curie("Rett syndrome") == "Rett syndrome"
+    # Non-string passthrough.
+    assert _normalize_curie(None) is None

--- a/tests/unit/test_monarch_restful_curie_normalization.py
+++ b/tests/unit/test_monarch_restful_curie_normalization.py
@@ -1,0 +1,49 @@
+"""Unit test: MonarchTool (restful) normalizes underscore CURIEs in the URL path.
+
+Regression: get_phenotype_by_HPO_ID (type Monarch) substituted the id straight
+into /entity/{id}, so the underscore CURIE OpenTargets emits ('HP_0000639')
+404'd and Monarch returned "Entity not found" wrapped in status:success -- a
+silent false-empty breaking the OpenTargets -> Monarch phenotype chain.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.restful_tool import MonarchTool, _normalize_curie
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("HP_0000639", "HP:0000639"),
+        ("MONDO_0008765", "MONDO:0008765"),
+        ("HP:0000639", "HP:0000639"),
+        ("Nystagmus", "Nystagmus"),
+    ],
+)
+def test_normalize_curie(raw, expected):
+    assert _normalize_curie(raw) == expected
+
+
+@pytest.mark.unit
+def test_url_key_is_normalized_to_colon():
+    cfg = {
+        "name": "get_phenotype_by_HPO_ID",
+        "type": "Monarch",
+        "tool_url": "/entity/{url_key}",
+        "query_schema": {"url_key": "id", "id": ""},
+        "parameter": {"type": "object", "properties": {"id": {"type": "string"}}},
+    }
+    tool = MonarchTool(cfg)
+    captured = {}
+
+    def fake_query(endpoint_url, variables=None):
+        captured["url"] = endpoint_url
+        return {"id": "HP:0000639", "name": "Nystagmus"}
+
+    with patch(
+        "tooluniverse.restful_tool.execute_RESTful_query", side_effect=fake_query
+    ):
+        tool.run({"id": "HP_0000639"})
+    assert captured["url"].endswith("/entity/HP:0000639")

--- a/tests/unit/test_opentargets_approved_indications.py
+++ b/tests/unit/test_opentargets_approved_indications.py
@@ -1,0 +1,63 @@
+"""Unit test: OpenTargets_get_approved_indications returns only APPROVAL-stage.
+
+Regression: the query returns ALL indications with their maxClinicalStage, so the
+tool -- despite its 'approved_indications' name -- listed investigational
+(PHASE_1/2) diseases alongside approved ones (selpercatinib: 17 rows, only 5
+APPROVAL). A clinician trusting the name would treat Phase-2 indications as
+approved. It now filters to APPROVAL-stage rows.
+"""
+import glob
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.graphql_tool import OpentargetTool
+
+
+def _load(name):
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if isinstance(data, list):
+            for tool in data:
+                if isinstance(tool, dict) and tool.get("name") == name:
+                    return tool
+    raise AssertionError(f"tool config not found: {name}")
+
+
+@pytest.mark.unit
+def test_only_approval_stage_rows_returned():
+    cfg = _load("OpenTargets_get_approved_indications_by_drug_chemblId")
+    tool = OpentargetTool(cfg)
+    api = {
+        "data": {
+            "drug": {
+                "id": "CHEMBL4559134",
+                "name": "SELPERCATINIB",
+                "indications": {
+                    "count": 4,
+                    "rows": [
+                        {"maxClinicalStage": "APPROVAL", "disease": {"name": "MTC"}},
+                        {"maxClinicalStage": "PHASE_2", "disease": {"name": "PTC"}},
+                        {"maxClinicalStage": "APPROVAL", "disease": {"name": "NSCLC"}},
+                        {"maxClinicalStage": "EARLY_PHASE_1", "disease": {"name": "X"}},
+                    ],
+                },
+            }
+        }
+    }
+    with patch("tooluniverse.graphql_tool.execute_query", return_value=api):
+        result = tool.run({"chemblId": "CHEMBL4559134"})
+    ind = result["data"]["drug"]["indications"]
+    assert ind["count"] == 2
+    assert {r["maxClinicalStage"] for r in ind["rows"]} == {"APPROVAL"}
+
+
+@pytest.mark.unit
+def test_description_no_longer_claims_multiple_drugs():
+    desc = _load("OpenTargets_get_approved_indications_by_drug_chemblId")["description"]
+    assert "multiple drugs" not in desc
+    assert "approved" in desc.lower()

--- a/tests/unit/test_opentargets_associated_targets_pagination.py
+++ b/tests/unit/test_opentargets_associated_targets_pagination.py
@@ -1,0 +1,78 @@
+"""Unit test: OpenTargets associated-targets pagination + size-default honoring.
+
+Regression: OpenTargets_get_associated_targets_by_disease_efoId hard-capped at
+25 rows (the API default) and silently ignored size/page -- for LQTS
+(MONDO_0019171) count=2490 but only 25 targets were reachable. Separately,
+GraphQLTool.run injected a hardcoded default size of 5 whenever a tool declared
+a `size` param without a value, silently overriding a tool's own larger schema
+default (e.g. OpenTargets_get_evidence_by_datasource documents 50 but got 5).
+"""
+import glob
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.graphql_tool import GraphQLTool
+
+
+def _load(name):
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if isinstance(data, list):
+            for tool in data:
+                if isinstance(tool, dict) and tool.get("name") == name:
+                    return tool
+    raise AssertionError(f"tool config not found: {name}")
+
+
+@pytest.mark.unit
+def test_associated_targets_query_paginates_and_declares_size():
+    cfg = _load("OpenTargets_get_associated_targets_by_disease_efoId")
+    query = cfg["query_schema"]
+    assert "associatedTargets(page: {index: $index, size: $size})" in query
+    assert "$size: Int = 50" in query
+    props = cfg["parameter"]["properties"]
+    assert props["size"]["default"] == 50
+    assert "index" in props
+
+
+@pytest.mark.unit
+def test_graphqltool_honors_declared_size_default_not_hardcoded_5():
+    cfg = {
+        "name": "x",
+        "query_schema": "query q($size: Int) { thing(size: $size) }",
+        "parameter": {"type": "object", "properties": {"size": {"type": "integer", "default": 50}}},
+    }
+    tool = GraphQLTool(cfg, "https://example.test/graphql")
+    captured = {}
+
+    def fake_exec(endpoint_url, query, variables=None):
+        captured["variables"] = variables
+        return {"data": {"thing": 1}}
+
+    with patch("tooluniverse.graphql_tool.execute_query", side_effect=fake_exec):
+        tool.run({})
+    assert captured["variables"]["size"] == 50  # not the hardcoded 5
+
+
+@pytest.mark.unit
+def test_graphqltool_falls_back_to_5_when_no_size_default():
+    cfg = {
+        "name": "x",
+        "query_schema": "query q($size: Int) { thing(size: $size) }",
+        "parameter": {"type": "object", "properties": {"size": {"type": "integer"}}},
+    }
+    tool = GraphQLTool(cfg, "https://example.test/graphql")
+    captured = {}
+
+    def fake_exec(endpoint_url, query, variables=None):
+        captured["variables"] = variables
+        return {"data": {"thing": 1}}
+
+    with patch("tooluniverse.graphql_tool.execute_query", side_effect=fake_exec):
+        tool.run({})
+    assert captured["variables"]["size"] == 5  # unchanged fallback

--- a/tests/unit/test_opentargets_colon_curie_normalization.py
+++ b/tests/unit/test_opentargets_colon_curie_normalization.py
@@ -1,0 +1,63 @@
+"""Unit test: OpenTargets disease-id colon->underscore normalization.
+
+Regression: OpenTargets keys diseases/phenotypes as 'MONDO_0010315', but every
+other tool (HPO, Monarch, and OpenTargets' OWN xref output) emits the canonical
+colon CURIE 'MONDO:0010315'. Feeding the colon form to
+OpenTargets_map_any_disease_id_to_all_other_ids returned a silent empty (just the
+echoed term, no cross-refs) -- even the tool's documented 'OMIM:604302' example
+was broken. The colon CURIE is now normalized to underscore before the query.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.graphql_tool import OpentargetTool
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("MONDO:0010315", "MONDO_0010315"),
+        ("EFO:0005555", "EFO_0005555"),
+        ("OMIM:604302", "OMIM_604302"),
+        ("Orphanet:276", "Orphanet_276"),
+        ("UMLS:C1279481", "UMLS_C1279481"),
+    ],
+)
+def test_colon_curie_normalized_to_underscore(raw, expected):
+    assert OpentargetTool._normalize_ot_disease_id(raw) == expected
+
+
+@pytest.mark.unit
+def test_underscore_and_non_curie_untouched():
+    assert OpentargetTool._normalize_ot_disease_id("MONDO_0010315") == "MONDO_0010315"
+    # Ensembl / ChEMBL ids have no colon -> unchanged.
+    assert OpentargetTool._normalize_ot_disease_id("ENSG00000116745") == (
+        "ENSG00000116745"
+    )
+    assert OpentargetTool._normalize_ot_disease_id("CHEMBL25") == "CHEMBL25"
+
+
+def _tool(query, params_key):
+    cfg = {
+        "name": "t",
+        "query_schema": f"query q(${params_key}: String!) {{ x({params_key}: ${params_key}) }}",
+        "parameter": {"type": "object", "properties": {params_key: {"type": "string"}}},
+    }
+    return OpentargetTool(cfg)
+
+
+@pytest.mark.unit
+def test_run_normalizes_inputId_and_efoId():
+    for key in ("inputId", "efoId"):
+        tool = _tool("q", key)
+        captured = {}
+
+        def fake_exec(endpoint_url, query, variables=None):
+            captured["variables"] = variables
+            return {"data": {"x": 1}}
+
+        with patch("tooluniverse.graphql_tool.execute_query", side_effect=fake_exec):
+            tool.run({key: "MONDO:0010315"})
+        assert captured["variables"][key] == "MONDO_0010315"

--- a/tests/unit/test_opentargets_efoid_bridge_and_ensembl_version.py
+++ b/tests/unit/test_opentargets_efoid_bridge_and_ensembl_version.py
@@ -1,0 +1,74 @@
+"""Unit tests for two OpenTargets input-normalization fixes.
+
+- efoId -> diseaseIds bridge: OpenTargets_search_gwas_studies_by_disease keys on
+  the diseaseIds ARRAY, but every other OT disease tool uses `efoId`, so passing
+  efoId was silently ignored and returned a plausible "0 studies" success
+  (Parkinson's MONDO_0005180: efoId -> 0, diseaseIds -> 103).
+- Versioned Ensembl id: UniProt_id_mapping emits 'ENSG00000120659.16', which
+  OpenTargets rejects -- only the unversioned form works.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.graphql_tool import OpentargetTool
+
+
+def _tool(query):
+    return OpentargetTool(
+        {
+            "name": "t",
+            "query_schema": query,
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+def _vars_for(query, arguments):
+    tool = _tool(query)
+    captured = {}
+
+    def fake_exec(endpoint_url, query, variables=None):
+        captured["variables"] = variables
+        return {"data": {"x": 1}}
+
+    with patch("tooluniverse.graphql_tool.execute_query", side_effect=fake_exec):
+        tool.run(arguments)
+    return captured["variables"]
+
+
+@pytest.mark.unit
+def test_efoid_bridged_to_diseaseids_array():
+    query = "query q($diseaseIds: [String!]) { x(diseaseIds: $diseaseIds) }"
+    variables = _vars_for(query, {"efoId": "MONDO_0005180"})
+    assert variables.get("diseaseIds") == ["MONDO_0005180"]
+    assert "efoId" not in variables
+
+
+@pytest.mark.unit
+def test_explicit_diseaseids_not_overridden():
+    query = "query q($diseaseIds: [String!]) { x(diseaseIds: $diseaseIds) }"
+    variables = _vars_for(query, {"diseaseIds": ["MONDO_0000001"]})
+    assert variables["diseaseIds"] == ["MONDO_0000001"]
+
+
+@pytest.mark.unit
+def test_efoid_left_alone_when_query_uses_efoId():
+    query = "query q($efoId: String!) { x(efoId: $efoId) }"
+    variables = _vars_for(query, {"efoId": "MONDO_0005180"})
+    assert variables["efoId"] == "MONDO_0005180"
+    assert "diseaseIds" not in variables
+
+
+@pytest.mark.unit
+def test_versioned_ensembl_id_stripped():
+    query = "query q($ensemblId: String!) { x(ensemblId: $ensemblId) }"
+    variables = _vars_for(query, {"ensemblId": "ENSG00000120659.16"})
+    assert variables["ensemblId"] == "ENSG00000120659"
+
+
+@pytest.mark.unit
+def test_unversioned_ensembl_id_unchanged():
+    query = "query q($ensemblId: String!) { x(ensemblId: $ensemblId) }"
+    variables = _vars_for(query, {"ensemblId": "ENSG00000120659"})
+    assert variables["ensemblId"] == "ENSG00000120659"

--- a/tests/unit/test_opentargets_known_drugs_query.py
+++ b/tests/unit/test_opentargets_known_drugs_query.py
@@ -1,0 +1,42 @@
+"""Regression guard for OpenTargets_get_known_drugs_by_drug_chemblId.
+
+The tool is named "get_known_drugs" and its description promises "known drugs and
+associated information", but its GraphQL query fetched only bare drug metadata
+(id/name/maximumClinicalStage/drugType/drugWarnings) -- no indications, no
+mechanisms of action, no targets. (The `knownDrugs` field does not exist on the
+OpenTargets `Drug` type; the meaningful associated info is `indications` and
+`mechanismsOfAction`.) So the tool returned almost nothing useful despite its
+name. The query now includes indications (diseases + max clinical phase) and
+mechanisms of action (with targets).
+"""
+import glob
+import json
+
+import pytest
+
+
+def _load(name):
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if isinstance(data, list):
+            for tool in data:
+                if isinstance(tool, dict) and tool.get("name") == name:
+                    return tool
+    raise AssertionError(f"tool config not found: {name}")
+
+
+@pytest.mark.unit
+def test_known_drugs_query_requests_associated_information():
+    tool = _load("OpenTargets_get_known_drugs_by_drug_chemblId")
+    query = tool["query_schema"]
+    # Associated clinical information the tool name/description promise.
+    assert "indications" in query
+    assert "mechanismsOfAction" in query
+    # indications must carry the disease + clinical phase, not just a count.
+    assert "disease" in query
+    assert "maxClinicalStage" in query
+    # mechanisms must carry the molecular targets acted on.
+    assert "targets" in query and "approvedSymbol" in query

--- a/tests/unit/test_opentargets_target_diseases_score.py
+++ b/tests/unit/test_opentargets_target_diseases_score.py
@@ -1,0 +1,37 @@
+"""Unit test: OpenTargets target->diseases rows include the aggregate score.
+
+Regression: OpenTargets_get_diseases_phenotypes_by_target_ensembl returned rows
+with only `datasourceScores` (per-source), NOT the top-level aggregate `score`
+that the reciprocal disease->targets endpoint exposes. Users ranking a target's
+diseases (flagged by 3 separate personas) had to hand-aggregate. The API DOES
+expose `score`; the query just omitted it.
+"""
+import glob
+import json
+
+import pytest
+
+
+def _load(name):
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if isinstance(data, list):
+            for tool in data:
+                if isinstance(tool, dict) and tool.get("name") == name:
+                    return tool
+    raise AssertionError(f"tool config not found: {name}")
+
+
+@pytest.mark.unit
+def test_query_requests_aggregate_score():
+    query = _load("OpenTargets_get_diseases_phenotypes_by_target_ensembl")[
+        "query_schema"
+    ]
+    # The aggregate score must be requested at the row level, not only inside
+    # datasourceScores.
+    rows_block = query.split("rows {", 1)[1].split("datasourceScores", 1)[0]
+    assert "score" in rows_block
+    assert "disease" in rows_block

--- a/tests/unit/test_opentargets_variant_id_normalization.py
+++ b/tests/unit/test_opentargets_variant_id_normalization.py
@@ -1,0 +1,51 @@
+"""Unit test: OpenTargets variant-id delimiter + not-found message.
+
+Regression: OpenTargets_get_variant_info requires the underscore variant id
+'chr_pos_ref_alt', but gnomad_search_variants / gnomad_get_variant_populations
+emit the hyphen form 'chr-pos-ref-alt' (e.g. '19-44908684-T-C'). Feeding the
+hyphen form straight through failed, and the shared OpenTargets hyphen->space
+retry mangled it to '19 44908684 T C', producing a misleading "no entity ...
+EFO to MONDO" (disease) error for a *variant* query. Now the id is normalized
+to underscores before the query, and the not-found message is variant-specific.
+"""
+import pytest
+
+from tooluniverse.graphql_tool import (
+    OpentargetTool,
+    _ot_entity_not_found_message,
+)
+
+
+@pytest.mark.unit
+def test_hyphen_variant_id_normalized_to_underscore():
+    assert (
+        OpentargetTool._normalize_variant_id("19-44908684-T-C") == "19_44908684_T_C"
+    )
+
+
+@pytest.mark.unit
+def test_underscore_variant_id_unchanged():
+    assert (
+        OpentargetTool._normalize_variant_id("19_44908684_T_C") == "19_44908684_T_C"
+    )
+
+
+@pytest.mark.unit
+def test_non_coordinate_values_untouched():
+    # rsIDs and other strings must not be rewritten.
+    assert OpentargetTool._normalize_variant_id("rs429358") == "rs429358"
+    # A hyphenated name that isn't a 4-part coordinate stays as-is.
+    assert OpentargetTool._normalize_variant_id("BRCA2-related") == "BRCA2-related"
+    # An indel coordinate (still 4 parts) normalizes.
+    assert (
+        OpentargetTool._normalize_variant_id("1-100-AT-A") == "1_100_AT_A"
+    )
+
+
+@pytest.mark.unit
+def test_not_found_message_is_variant_specific_not_disease():
+    msg = _ot_entity_not_found_message({"variantId": "1_999999999_A_T"})
+    assert "variant" in msg.lower()
+    assert "1_999999999_A_T" in msg
+    # Must NOT wrongly blame disease EFO->MONDO remapping for a variant id.
+    assert "EFO to MONDO" not in msg

--- a/tests/unit/test_string_limit_caps_output.py
+++ b/tests/unit/test_string_limit_caps_output.py
@@ -1,0 +1,67 @@
+"""Unit test: STRING_get_protein_interactions honors `limit` as an output cap.
+
+Regression: `limit` is documented as "Maximum number of interactions to return"
+but STRING interprets it as a network node-expansion count and returns EVERY
+pairwise edge -- so limit=50 yielded 300+ rows. The tool now returns at most
+`limit` interactions, keeping the highest-confidence ones.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.string_tool import STRINGRESTTool
+
+
+def _tool():
+    return STRINGRESTTool(
+        {
+            "name": "STRING_get_protein_interactions",
+            "type": "STRINGRESTTool",
+            "fields": {"endpoint": "/tsv/network"},
+            "parameter": {
+                "type": "object",
+                "properties": {},
+                "required": ["protein_ids"],
+            },
+        }
+    )
+
+
+def _rows(n):
+    # n rows with ascending score 0.01 .. n*0.01 (so truncation must sort).
+    return [
+        {"preferredName_A": "CFTR", "preferredName_B": f"P{i}", "score": f"{i / 100:.2f}"}
+        for i in range(1, n + 1)
+    ]
+
+
+@pytest.mark.unit
+def test_limit_caps_and_keeps_highest_scores():
+    tool = _tool()
+    api = {"data": _rows(30), "header": ["preferredName_A", "preferredName_B", "score"]}
+    with patch.object(STRINGRESTTool, "_make_request", return_value=api):
+        result = tool.run({"protein_ids": ["CFTR"], "species": 9606, "limit": 5})
+    data = result["data"]
+    assert len(data) == 5
+    # Kept the 5 highest scores (0.30, 0.29, ...), sorted descending.
+    assert [r["score"] for r in data] == ["0.30", "0.29", "0.28", "0.27", "0.26"]
+    assert result["metadata"]["truncated_to_limit"] == 5
+
+
+@pytest.mark.unit
+def test_no_truncation_when_rows_within_limit():
+    tool = _tool()
+    api = {"data": _rows(3), "header": ["preferredName_A", "preferredName_B", "score"]}
+    with patch.object(STRINGRESTTool, "_make_request", return_value=api):
+        result = tool.run({"protein_ids": ["CFTR"], "species": 9606, "limit": 10})
+    assert len(result["data"]) == 3
+    assert "truncated_to_limit" not in result["metadata"]
+
+
+@pytest.mark.unit
+def test_no_limit_returns_all():
+    tool = _tool()
+    api = {"data": _rows(12), "header": ["preferredName_A", "preferredName_B", "score"]}
+    with patch.object(STRINGRESTTool, "_make_request", return_value=api):
+        result = tool.run({"protein_ids": ["CFTR"], "species": 9606})
+    assert len(result["data"]) == 12

--- a/tests/unit/test_tool_description_accuracy.py
+++ b/tests/unit/test_tool_description_accuracy.py
@@ -1,0 +1,47 @@
+"""Regression guards for tool description-vs-actual accuracy fixes.
+
+- gProfiler_enrichment's `gene_list` is a comma-separated STRING, but its prose
+  description used to show a JSON-array example (['TP53', ...]), leading users
+  to pass a list and hit "Expected string, got list".
+- HPA_get_protein_interactions_by_gene is non-functional (HPA dropped the ppi
+  column) yet advertised a working-sounding capability; its description must now
+  flag the deprecation.
+"""
+import glob
+import json
+
+import pytest
+
+
+def _load(name):
+    for f in glob.glob("src/tooluniverse/data/*.json"):
+        try:
+            data = json.load(open(f))
+        except ValueError:
+            continue
+        if isinstance(data, list):
+            for tool in data:
+                if isinstance(tool, dict) and tool.get("name") == name:
+                    return tool
+    raise AssertionError(f"tool config not found: {name}")
+
+
+@pytest.mark.unit
+def test_gprofiler_description_matches_comma_string_schema():
+    tool = _load("gProfiler_enrichment")
+    desc = tool["description"]
+    gene_list = tool["parameter"]["properties"]["gene_list"]
+    # Schema is a plain string parameter...
+    assert gene_list["type"] == "string"
+    # ...so the description must not show a JSON-array example that would error.
+    assert "['TP53'" not in desc and "[\"TP53\"" not in desc
+    assert "comma-separated" in desc.lower()
+
+
+@pytest.mark.unit
+def test_hpa_ppi_description_flags_deprecation():
+    tool = _load("HPA_get_protein_interactions_by_gene")
+    desc = tool["description"].lower()
+    assert "deprecated" in desc or "no longer" in desc
+    # Points users at a working alternative.
+    assert "string_get_interactions" in desc or "ebiproteins_get_interactions" in desc

--- a/tests/unit/test_uniprot_compact_cofactor.py
+++ b/tests/unit/test_uniprot_compact_cofactor.py
@@ -1,0 +1,56 @@
+"""Unit test: UniProt compact summary must keep the COFACTOR comment.
+
+Regression: _compact_entry included a comment only if it had a top-level `texts`
+array, but COFACTOR comments store their data under `cofactors[].name` (+ an
+optional `note.texts`). So the cofactor was silently dropped from the default
+compact summary -- confirmed live that PAH (P00439)'s Fe(2+) cofactor, a
+clinically relevant field for a pediatric metabolic geneticist, vanished.
+"""
+import pytest
+
+from tooluniverse.uniprot_tool import UniProtRESTTool
+
+
+def _tool():
+    return UniProtRESTTool(
+        {
+            "name": "UniProt_get_entry_by_accession",
+            "type": "UniProtRESTTool",
+            "fields": {"endpoint": "https://rest.uniprot.org/uniprotkb/{accession}.json"},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+@pytest.mark.unit
+def test_cofactor_comment_is_retained_with_names():
+    data = {
+        "comments": [
+            {"commentType": "FUNCTION", "texts": [{"value": "does a thing"}]},
+            {
+                "commentType": "COFACTOR",
+                "cofactors": [{"name": "Fe(2+)"}],
+                "note": {"texts": [{"value": "Binds 1 Fe cation per subunit."}]},
+            },
+        ]
+    }
+    out = _tool()._compact_entry(data)["data"]
+    by_type = {c["commentType"]: c for c in out["comments"]}
+    assert "COFACTOR" in by_type
+    assert "Fe(2+)" in by_type["COFACTOR"]["texts"]
+
+
+@pytest.mark.unit
+def test_cofactor_without_note_still_kept():
+    data = {"comments": [{"commentType": "COFACTOR", "cofactors": [{"name": "Zn(2+)"}]}]}
+    out = _tool()._compact_entry(data)["data"]
+    by_type = {c["commentType"]: c for c in out["comments"]}
+    assert by_type["COFACTOR"]["texts"] == ["Zn(2+)"]
+
+
+@pytest.mark.unit
+def test_texts_bearing_comments_unchanged():
+    data = {"comments": [{"commentType": "FUNCTION", "texts": [{"value": "x"}]}]}
+    out = _tool()._compact_entry(data)["data"]
+    assert out["comments"][0]["commentType"] == "FUNCTION"
+    assert out["comments"][0]["texts"] == ["x"]


### PR DESCRIPTION
## Summary

Six rounds of **researcher role-play** (24 clinician personas across oncology, genomics, pharmacology, immunology, cardiology, nephrology, hepatology, and more) driving real multi-tool research chains, surfacing the friction a real user hits. Every reported issue was **CLI-verified before and after** (~half of persona reports are false positives — cross-tool naming/envelope inconsistencies, upstream data quirks, cosmetic casing — and were dropped). **34 confirmed real defects** are fixed here, each with a regression test. All related unit tests pass, no regressions.

**The dominant, highest-value bug class is "a valid value silently returns empty or plausible-but-wrong data as a success."** It recurred in a *new form every single round*: a filter parameter that's silently ignored, a tiny/undocumented default that hides the relevant results, an unsorted-then-truncated fetch that a threshold filters to nothing, and — most often — a **cross-tool ID-delimiter mismatch** (each tool wants a different separator: `HP_` vs `HP:`, `chr-pos` vs `chr_pos`, `CHEBI:` vs bare int, `MONDO_` vs `MONDO:` in *both* directions, salt/child vs parent ChEMBL id, slash-compound ClinVar classes). Because the output looks like a normal success, a clinician would silently draw a wrong conclusion.

## Fixes by severity

### HIGH (11)

1. **`annotate_variant_multi_source` hid a Pathogenic allele behind a VUS summary (clinical safety).** A multi-allelic match (rsid `rs80358981` = c.7558C>G VUS + c.7558C>T **Pathogenic**) reported `clinvar_classification` = the first-listed VUS, hiding the Pathogenic allele — a curator would call a known-pathogenic variant a VUS. Now surfaces the most clinically significant classification + lists all distinct ones; also fixes `summary.query` mislabeling an rsID as its gene.
2. **`civic_search_evidence_items` silently ignored the `significance` filter.** RESISTANCE vs SENSITIVITYRESPONSE returned identical mixed results — the GraphQL query never bound `$significance`. Now bound.
3. **`FAERS_count_reactions_by_drug_event` filtered queries silently returned empty.** Multi-field OR groups weren't parenthesized, so Lucene's AND>OR precedence mangled the query — colistin + "acute kidney injury" returned 0 while the unfiltered count shows 151. Wrapped each OR group.
4. **`GWAS_search_associations_by_gene` tiny default hid the flagship associations.** Defaulted to size=5, unsorted — TCF7L2 (902 associations) returned 5 all-anthropometric rows while its 37 type-2-diabetes associations were hidden. Raised default to 100 + sort by p-value.
5. **`ClinVar_search_variants` false-empty on a dbSNP rsID.** `query=rs4244285` (CYP2C19*2) returned 0 — the rsID was searched as a *disease* term. Now routed to a bare-term search (→ 37 records).
6. **`UniProt` compact summary silently dropped the COFACTOR comment.** Stored under `cofactors[].name` not `texts[]`, so PAH's Fe²⁺ cofactor vanished despite the "complete entry" promise. Now extracted.
7. **`gwas_search_associations` p-value filter missed the strongest loci.** Client-side threshold on an *unsorted* fetch → SLE `p<=1e-100` returned 0 despite hits at 2e-298. Now fetches most-significant-first when a p-value filter is set.
8. **`ChEMBL_get_drug_mechanisms` false-empty on salt/child ChEMBL IDs.** `ChEMBL_search_drugs` hands back the child id (dolutegravir `CHEMBL1213165`); mechanisms are indexed under the parent — so the search→mechanism chain reported "no mechanism on file". Now resolves the parent and retries.
9. **`get_phenotype_by_HPO_ID` false-empty on underscore HPO CURIEs.** Returned `status:success` + "Entity not found" for `HP_0000639` (what OpenTargets emits) — Monarch needs `HP:0000639`. Added CURIE normalization.
10. **OpenTargets disease-id tools false-empty on the canonical colon CURIE.** `map_any_disease_id`/`efoId` family returned empty for `MONDO:0010315` (what HPO/Monarch and OpenTargets' own xref output emit) — it keys on underscore; even the documented `OMIM:604302` example was broken. Added colon→underscore normalization.
11. **`ClinVar_search_variants` false-empty on a compound (slashed) clinical significance.** `"Pathogenic/Likely pathogenic"` — the exact value the tool's own `get_clinical_significance` emits — has no single NCBI clinsig token; the slash broke both query paths → 0 (NCBI has ~80). Now treats "/" as OR, expands to component classes.
12. **`ClinVar_search_variants` false-empty on `Uncertain significance` (VUS).** VUS — the single *largest* ClinVar category — returned `total_count 0` (BRCA2 has 4345). NCBI indexes VUS under the token `clinsig_vus`, not the naive `clinsig_uncertain_significance` the tool built — a clinician checking whether a variant is a VUS was told none exist. Added a clinsig-alias map.

13. **`OpenTargets_search_gwas_studies_by_disease` silently ignored `efoId`.** This tool keys on the `diseaseIds` array, but every *other* OpenTargets disease tool uses `efoId` — so a user reusing `efoId` got a plausible `0 studies` success (Parkinson's `MONDO_0005180`: `efoId`→0, `diseaseIds`→103). Bridge `efoId`→`diseaseIds`.

14. **`ClinVar_search_variants` false-empty on HGVS-prefixed / rsID `variant_name`.** NCBI's `[Variant name]` index mangles the `.` in an HGVS prefix (`p.Glu342Lys`→`p0x2eGlu342Lys`) and matches nothing, so a clinician typing standard HGVS got 0 (SERPINA1 Z-allele exists as `Glu342Lys`); an rsID passed as `variant_name` likewise returned 0. Strip the reference prefix and route rsIDs to a bare search. *(3 personas)*


### MEDIUM (16)

12. **`OpenTargets_get_known_drugs_by_drug_chemblId` returned only bare drug metadata** — no indications/mechanisms/targets despite the name. Enriched the query.
13. **`ClinVar_search_variants` silently dropped the `variant` param** → full-gene dump (KRAS all 599 vs 2 G12C). Aliased `variant`→`variant_name`.
14. **`civic_search_molecular_profiles` silently ignored unknown params** (`variant_id` → 300 unrelated profiles as "success"). Added an unknown-param guard.
15. **`HPO_get_term` rejected the underscore CURIE** `HP_0001250` (→ `HP:HP_0001250` → 404). Added normalization.
16. **`OpenTargets_get_variant_info` rejected gnomAD hyphen variant IDs** (`19-44908684-T-C`) and emitted a misleading "EFO to MONDO" error. Normalize chr-pos-ref-alt → underscores.
17. **ChEBI ontology tools rejected the `CHEBI:` CURIE** that `ChEBI_search`/`get_compound` emit. Accept int-or-string + strip prefix.
18. **`LipidMaps_get_compound_by_xref` false-empty on a typo'd param** (`input_type` → `xref_type` defaults to kegg_id → PubChem CID searched as KEGG). Reject unknown params.
19. **`OpenTargets_get_associated_targets_by_disease_efoId` hard-capped at 25**, `size`/`page` ignored (2465 of 2490 targets unreachable). Added pagination; also fixed `GraphQLTool` injecting a hardcoded default size=5 over a tool's own schema default (un-broke `get_evidence_by_datasource` too).
20. **`Monarch`/`Mondo` tools rejected underscore ontology CURIEs** (`MONDO_0004995` → 404). Added `_normalize_curie` at all entity id inputs.
21. **`civic_search_evidence_items` `significance` filter was undeclared** — functional (fix #2) but invisible in `tu info`. Declared it.
22. **`STRING_get_protein_interactions` `limit` didn't cap output** — STRING treats it as node-expansion (limit=50 → 300+ rows). Now sorts by confidence and truncates.
23. **`civic_search_evidence_items` opaque error on invalid enum** ("Error: GraphQL query errors"). Added client-side enum validation naming the allowed values.
24. **Alliance/ZFIN phenotype statements leaked raw `<i>` HTML markup.** Added HTML-stripping. *(quality)*

24b. **`OpenTargets_get_approved_indications_by_drug_chemblId` returned all phases, not just approved** (selpercatinib: 17 rows, only 5 APPROVAL) despite its name — a clinician would treat Phase-2 indications as approved. Filter to APPROVAL-stage; also fixed the copy-paste description.
24c. **OpenTargets target→diseases rows lacked the aggregate `score`** (only `datasourceScores`), unlike the reciprocal endpoint — flagged by 3 personas; the API exposes it, the query omitted it. Added `score`.

24d. **OpenTargets rejected versioned Ensembl IDs** (`ENSG00000120659.16`) that `UniProt_id_mapping` emits — only the unversioned form worked, a cross-tool chaining break. Strip the version suffix.

24e. **`BVBRC_search_amr` description implied a nonexistent organism filter** ("methicillin resistance in Staphylococcus aureus") — there is no organism param, so it was silently ignored. Reworded the description (filter by antibiotic/genome_id/resistant_phenotype; scope to an organism via genome_id).

### LOW / quality (4)

25. **`gProfiler_enrichment` description contradicted its schema** (showed a JSON-array example for a comma-string param). Corrected.
26. **`HPA_get_protein_interactions_by_gene` advertised a dead capability** (HPA dropped the ppi column). Marked deprecated, points to STRING/EBIProteins.
27. **`EnrichrTool` polluted stdout** with `print()` diagnostics ahead of the JSON (broke `... | jq`). Routed to `logger.debug`.

## Follow-ups (deliberately NOT addressed here — need a project-level decision)

- **ClinVar detail tools' envelope inconsistency** — `ClinVar_get_variant_details` / `ClinVar_get_clinical_significance` put the payload under top-level `formatted_data` (plus leaked `url`/`content_type`/`rate_limit_info`), while `ClinVar_search_variants` uses `data`. **~5 separate personas hit this** when chaining ClinVar tools. Normalizing to the standard `{status, data, metadata}` envelope is a behavior change I don't want to make unilaterally.
- **Systemic `tu test` return_schema envelope-vs-payload mismatch** (related to #288): `cli.py` validates `result["data"]` against `return_schema`, but ~1253 tools use envelope-shaped schemas while ~1321 use payload-shaped — the conventions conflict, so envelope tools false-fail `tu test`'s schema check even though `tu run` returns valid data. A blanket fix flips the failure onto the other half.

## Testing

Each fix includes a regression test (query-binding guards, delimiter-normalization tables, filter/sort logic, alias behavior, no-stdout/no-print guards, enum validation). All related unit tests pass; every fix was reproduced live via `tu run` before and after.
