### PR TITLE
Pin ruff to 0.15.22 in CI to restore the linting gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Check code formatting/linting requirements
         uses: astral-sh/ruff-action@v3
         with:
-          version: "latest"
+          version: "0.15.22"
 
 
       - name: Generate SDK


### PR DESCRIPTION
One-line change: pin `astral-sh/ruff-action` to `0.15.22` instead of `latest` in `.github/workflows/tests.yml`.

## What is actually failing

The red X on `Test Suite` is **not a test failure**. The job fails at the **`Check code formatting/linting requirements`** step — the ruff lint gate — which runs before anything else and takes the rest of the job with it:

| Step | Status |
|---|---|
| Check code formatting/linting requirements | **failure** |
| Generate SDK | skipped |
| Run core tests (unit + integration) | skipped |
| Test doctor CLI tool | skipped |

So the repo currently has **no CI test signal whatsoever** — not a failing one, an absent one. Every PR opened while this is broken shows a red check that says nothing about whether its code works.

## The break came from an unpinned linter, not from merged code

The workflow requested `version: "latest"`, so CI adopted a new ruff the moment it shipped. The timeline:

| When (UTC) | What |
|---|---|
| 2026-07-22T14:28:23 | last green run on `main` (`3db28a01`) |
| 2026-07-23T19:10:46 | **ruff 0.16.0 published to PyPI** |
| 2026-07-23T19:48:09 | first red run on `main` (`a46fcf7a`) — **37 minutes later** |

No linting configuration changed, and the commit that "broke" it changed no lint-relevant code. `a46fcf7a` is simply the first push that happened to land after 0.16.0 became `latest`.

## A/B evidence

Both runs on an **unmodified checkout of `a46fcf7a`**, whole repo, no other differences:

```
uvx ruff@0.15.22 check .   ->  All checks passed!
uvx ruff@0.16.0  check .   ->  Found 24173 errors.
                               [*] 19591 fixable with the `--fix` option.
```

The 24,173 findings span **3,171 files** — 2,303 of them generated wrappers under `src/tooluniverse/tools/`, 868 hand-written. They are dominated by new or newly-enabled rules, not by anything recently written:

| Rule | Count | What |
|---|---|---|
| `UP045` | 6,523 | use `X \| None` |
| `UP006` | 6,096 | use `dict` not `Dict` |
| `I001` | 3,136 | import sorting |
| `UP035` | 3,054 | deprecated `typing` imports |
| `N999` | 1,799 | "invalid module name" (flags the generated wrappers) |
| `BLE001` | 1,398 | blind `except Exception` |

Every one of these is **pre-existing**: the counts are identical with and without any current branch's changes. Nothing here was introduced by recent work.

## Interaction with the open PRs

- PR #386 adds `tests/unit/test_tools_package_imports.py`. Under 0.16.0 it is flagged **zero** times; under the 0.15.22 pin its whole branch reports `All checks passed`. This pin unblocks that PR without it needing any lint changes.
- PR #385 (the 1.4.0 release) is likewise blocked only by this gate.

## This is a deliberate unblock, not a verdict on the findings

Pinning is the minimal change that restores the gate. The ~24.2k findings from 0.16.0 (19,591 auto-fixable) are a genuine backlog and should be cleared on their own branch — a mechanical sweep of that size does not belong in an unrelated PR and would be unreviewable mixed into one. Once it is done, raise this pin.

Pinning rather than tracking `latest` is also the right steady state for a lint gate: it makes linter upgrades an explicit, reviewable change instead of something that lands unannounced and turns the whole pipeline red at an arbitrary moment.

## What to expect after merging

The lint step goes green, and **`Generate SDK`, `Run core tests`, and `Test doctor CLI tool` will actually execute again** — for the first time since 2026-07-23. Reviewers should treat the first few post-merge runs as the real signal; the test steps have not run in CI for the entire period this has been broken, so genuine test regressions could have landed unnoticed in that window.

## Verification

- `uvx ruff@0.15.22 check .` on this branch: `All checks passed!`
- Workflow YAML re-parsed after the edit; the step resolves to `astral-sh/ruff-action@v3` with `version: 0.15.22`.
- Diff is one line. No other file touched.
