### PR TITLE
Pin ruff to 0.15.22 in CI to restore a working lint gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Check code formatting/linting requirements
         uses: astral-sh/ruff-action@v3
         with:
-          version: "latest"
+          version: "0.15.22"
 
 
       - name: Generate SDK


### PR DESCRIPTION
## Summary

One-line change: pin the CI ruff version to `0.15.22` instead of `latest`.

```diff
       - name: Check code formatting/linting requirements
         uses: astral-sh/ruff-action@v3
         with:
-          version: "latest"
+          version: "0.15.22"
```

## What is actually failing

CI is red on every open PR in this repo, and **the failing step is the ruff lint gate — not the tests**. The step that fails is `Check code formatting/linting requirements`.

Because that step gates everything after it in the job, `Generate SDK`, `Run core tests (unit + integration)`, and `Test doctor CLI tool` are all reporting `skipped`. **The repo currently has no CI test signal at all** — red PRs are not telling us anything about test health, and green ones wouldn't either.

## The break came from an unpinned linter, not from any merged change

`version: "latest"` means CI silently adopts each new ruff release the moment it ships.

| Event | Time (UTC) |
|---|---|
| ruff `0.16.0` published | 2026-07-23 19:10:46 |
| `main` last green (`3db28a01`) | 2026-07-22 14:28 |
| `main` first red (`a46fcf7a`) | 2026-07-23 19:48 |

The first red run on `main` is **38 minutes after the 0.16.0 release**. No merged code sits between the last green and the first red that would explain it — the input that changed was the linter, which arrived on its own schedule rather than through review.

## A/B evidence

Whole-repo check on an unmodified tree at `a46fcf7a` (current `origin/main`, the base of this PR):

```
$ uvx ruff@0.15.22 check .
All checks passed!

$ uvx ruff@0.16.0 check .
Found 24173 errors.
[*] 19591 fixable with the `--fix` option.
```

Re-verified on this branch's tree before pushing: **`0.15.22` → `All checks passed!`**, which is what shows this pin actually restores green.

## The findings are pre-existing code, and this does not mask any incoming work

Every file flagged by 0.16.0 is pre-existing code in the repo — none of it is new. In particular, **the new test file added by #386 (`tests/unit/test_tools_package_imports.py`) is flagged zero times**; checked directly against 0.16.0 with the repo's own config:

```
$ uvx ruff@0.16.0 check --config pyproject.toml tests/unit/test_tools_package_imports.py
All checks passed!
```

So the failures on the open PRs are not caused by those PRs, and pinning does not hide anything they introduce.

## This is a deliberate unblock, stated plainly

Pinning to `0.15.22` is a deliberate decision to unblock CI now, not a claim that the 0.16.0 findings are wrong. The ~24.2k findings 0.16.0 reports (about 19.6k auto-fixable) are real output from the newer ruff, and they should be worked through on a separate branch, reviewed on their own merits, and landed before the pin is raised. Doing that cleanup inside this PR would mean a tens-of-thousands-of-lines diff sitting in front of an unblock that is urgent, and would make both harder to review.

The pin also has value beyond this incident: it makes a linter upgrade an explicit, reviewable change with its own PR, instead of something that can turn the whole repo red without anyone touching it.

## Expected effect after merge

The lint gate goes green, and **the test steps will start executing again — they have not been running.** That means this PR is also the point where real test results become visible again; if anything is genuinely broken in the test suite, it will surface after this merges rather than staying hidden behind a skipped step.

## Scope

- Only `.github/workflows/tests.yml` is touched, one line.
- No source, test, or config changes.
- Branched off current `origin/main` (`a46fcf7a`).
