### PR TITLE
Fix Codex skill-sync destroying folded description frontmatter

### DIFF
--- a/scripts/build-codex-plugin.sh
+++ b/scripts/build-codex-plugin.sh
@@ -3,11 +3,14 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PLUGIN_SRC="$REPO_ROOT/plugins/tooluniverse"
-DIST_DIR="$REPO_ROOT/dist/tooluniverse-codex-plugin"
+# Both destinations can be redirected so tests (and dry runs) can build the
+# plugin into a temp tree without regenerating tracked files in place.
+SKILLS_DEST="${CODEX_PLUGIN_SKILLS_DEST:-$PLUGIN_SRC/skills}"
+DIST_DIR="${CODEX_PLUGIN_DIST:-$REPO_ROOT/dist/tooluniverse-codex-plugin}"
 
 echo "Building ToolUniverse Codex plugin..."
 
-"$REPO_ROOT/scripts/sync-codex-plugin-skills.sh"
+CODEX_PLUGIN_SKILLS_DEST="$SKILLS_DEST" "$REPO_ROOT/scripts/sync-codex-plugin-skills.sh"
 
 rm -rf "$DIST_DIR"
 mkdir -p "$DIST_DIR"
@@ -19,7 +22,7 @@ echo "  [+] Codex plugin manifest"
 cp "$PLUGIN_SRC/.mcp.json" "$DIST_DIR/"
 echo "  [+] MCP server config"
 
-cp -r "$PLUGIN_SRC/skills" "$DIST_DIR/"
+cp -r "$SKILLS_DEST" "$DIST_DIR/skills"
 echo "  [+] Skills"
 
 cp "$PLUGIN_SRC/README.md" "$DIST_DIR/"

--- a/scripts/compact_codex_skill_description.py
+++ b/scripts/compact_codex_skill_description.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Compact an over-long skill ``description:`` in a generated Codex SKILL.md.
+
+Codex rejects skill descriptions longer than 1024 characters, so the generated
+Codex plugin copies (never the canonical ``skills/`` source) get their
+``description:`` frontmatter truncated to fit. This script performs that
+normalization in place on a single ``SKILL.md`` file: it reads the description,
+truncates it if necessary, and rewrites it as a single JSON-quoted line.
+
+It deliberately fails loudly rather than guessing, because a silent guess is
+what previously corrupted skill descriptions:
+
+  * PyYAML is a declared dependency (see ``pyproject.toml``). If it cannot be
+    imported, the *wrong interpreter* is running the sync -- that must surface as
+    an error, not be swallowed. The regex fallback below cannot read a YAML
+    folded/literal block scalar, so running without PyYAML used to rewrite a
+    real description down to the bare block-scalar indicator (``">-"``) and
+    delete the folded text underneath.
+  * If extraction ever falls back to the line regex and captures a block-scalar
+    indicator (``>``, ``>-``, ``|`` ...) or an empty value, the script aborts
+    instead of writing that back.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import NoReturn, Optional
+
+# A missing PyYAML means the sync is running under the wrong interpreter. Import
+# at module scope and unguarded so that failure is loud (ImportError), never a
+# silent fallback to the description-destroying regex path.
+import yaml
+
+MAX_DESCRIPTION_LEN = 1024
+TRUNCATED_TARGET_LEN = 1000
+
+# YAML block-scalar indicators. A regex that reads only the ``description:`` line
+# captures one of these tokens instead of the folded/literal text that lives on
+# the following indented lines.
+BLOCK_SCALAR_INDICATORS = frozenset({">", ">-", ">+", "|", "|-", "|+"})
+
+
+def _fail(message: str) -> NoReturn:
+    sys.stderr.write(f"compact_codex_skill_description: {message}\n")
+    raise SystemExit(1)
+
+
+def extract_description(frontmatter: str, path: Path) -> Optional[str]:
+    """Return the description string, or ``None`` when there is no field to compact.
+
+    Aborts with a non-zero exit when a description is present but cannot be read
+    without guessing (empty, non-string, or a bare block-scalar indicator picked
+    up by the regex fallback).
+    """
+    try:
+        data = yaml.safe_load(frontmatter)
+    except yaml.YAMLError:
+        data = None
+
+    if isinstance(data, dict):
+        value = data.get("description")
+        if value is None:
+            # No description key at all -- nothing to compact, leave file as-is.
+            return None
+        if not isinstance(value, str):
+            _fail(f"{path}: description is not a string ({type(value).__name__})")
+        if not value.strip():
+            _fail(f"{path}: description is empty")
+        return value
+
+    # YAML did not parse into a mapping; fall back to a single-line regex and
+    # refuse to write anything that is obviously not the real description.
+    match = re.search(r"(?m)^description:\s*(.*)$", frontmatter)
+    if not match:
+        return None
+    candidate = match.group(1).strip().strip("\"'")
+    if not candidate or candidate in BLOCK_SCALAR_INDICATORS:
+        _fail(
+            f"{path}: could not extract a usable description. The regex fallback "
+            f"captured {candidate!r}, which is a YAML block-scalar indicator "
+            f"(or empty) rather than the description text. Refusing to write it "
+            f"-- doing so would destroy the description. This usually means the "
+            f"sync ran under an interpreter without PyYAML; re-run with the repo "
+            f"venv (source .venv/bin/activate)."
+        )
+    return candidate
+
+
+def _truncate(description: str) -> str:
+    return description[:TRUNCATED_TARGET_LEN].rsplit(" ", 1)[0].rstrip(" ,;:-") + "..."
+
+
+def compact(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return
+    try:
+        _, frontmatter, body = text.split("---", 2)
+    except ValueError:
+        return
+
+    description = extract_description(frontmatter, path)
+    if description is None:
+        return
+
+    if len(description) > MAX_DESCRIPTION_LEN:
+        description = _truncate(description)
+
+    new_lines = []
+    skipping_description_block = False
+
+    for line in frontmatter.splitlines():
+        if skipping_description_block:
+            if line.startswith((" ", "\t")) or not line.strip():
+                continue
+            skipping_description_block = False
+
+        if re.match(r"^description:\s*", line):
+            new_lines.append(
+                f"description: {json.dumps(description, ensure_ascii=False)}"
+            )
+            if re.match(r"^description:\s*[|>]", line):
+                skipping_description_block = True
+            continue
+
+        new_lines.append(line)
+
+    path.write_text("---\n" + "\n".join(new_lines) + "\n---" + body, encoding="utf-8")
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    if len(args) != 1:
+        _fail("usage: compact_codex_skill_description.py <path-to-SKILL.md>")
+    compact(Path(args[0]))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync-codex-plugin-skills.sh
+++ b/scripts/sync-codex-plugin-skills.sh
@@ -5,7 +5,23 @@ set -euo pipefail
 # root skills/ tree. Do not edit plugins/tooluniverse/skills/ directly.
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-DEST_DIR="$REPO_ROOT/plugins/tooluniverse/skills"
+# Destination defaults to the tracked plugin copy but can be redirected (e.g. to
+# a temp dir) so tests can exercise the sync without mutating tracked files.
+DEST_DIR="${CODEX_PLUGIN_SKILLS_DEST:-$REPO_ROOT/plugins/tooluniverse/skills}"
+
+# Resolve a known-good interpreter for the description-compaction step. PyYAML is
+# a declared dependency; prefer the repo venv (or an active virtualenv) over a
+# bare `python3` on PATH that may lack PyYAML. If none of these has PyYAML, the
+# compaction script fails loudly rather than corrupting skill descriptions.
+if [ -n "${CODEX_PLUGIN_PYTHON:-}" ]; then
+    PYTHON_BIN="$CODEX_PLUGIN_PYTHON"
+elif [ -n "${VIRTUAL_ENV:-}" ] && [ -x "$VIRTUAL_ENV/bin/python" ]; then
+    PYTHON_BIN="$VIRTUAL_ENV/bin/python"
+elif [ -x "$REPO_ROOT/.venv/bin/python" ]; then
+    PYTHON_BIN="$REPO_ROOT/.venv/bin/python"
+else
+    PYTHON_BIN="python3"
+fi
 
 rm -rf "$DEST_DIR"
 mkdir -p "$DEST_DIR"
@@ -50,63 +66,12 @@ for skill_dir in "$REPO_ROOT/skills/tooluniverse" "$REPO_ROOT"/skills/tooluniver
     mv "$tmp_file" "$DEST_DIR/$name/SKILL.md"
 
     # Codex rejects skill descriptions over 1024 characters. Keep the root
-    # skill source untouched and compact only the generated plugin copy.
-    python3 - "$DEST_DIR/$name/SKILL.md" <<'PY'
-import json
-import re
-import sys
-from pathlib import Path
-
-path = Path(sys.argv[1])
-text = path.read_text(encoding="utf-8")
-if not text.startswith("---\n"):
-    raise SystemExit(0)
-
-try:
-    _, frontmatter, body = text.split("---", 2)
-except ValueError:
-    raise SystemExit(0)
-
-description = None
-try:
-    import yaml
-
-    data = yaml.safe_load(frontmatter)
-    if isinstance(data, dict) and isinstance(data.get("description"), str):
-        description = data["description"]
-except Exception:
-    pass
-
-if description is None:
-    match = re.search(r"(?m)^description:\s*(.*)$", frontmatter)
-    if match:
-        description = match.group(1).strip().strip("\"'")
-
-if not description:
-    raise SystemExit(0)
-
-if len(description) > 1024:
-    description = description[:1000].rsplit(" ", 1)[0].rstrip(" ,;:-") + "..."
-
-new_lines = []
-skipping_description_block = False
-
-for line in frontmatter.splitlines():
-    if skipping_description_block:
-        if line.startswith((" ", "\t")) or not line.strip():
-            continue
-        skipping_description_block = False
-
-    if re.match(r"^description:\s*", line):
-        new_lines.append(f"description: {json.dumps(description, ensure_ascii=False)}")
-        if re.match(r"^description:\s*[|>]", line):
-            skipping_description_block = True
-        continue
-
-    new_lines.append(line)
-
-path.write_text("---\n" + "\n".join(new_lines) + "\n---" + body, encoding="utf-8")
-PY
+    # skill source untouched and compact only the generated plugin copy. The
+    # compaction runs as a standalone script (not an inline heredoc) so it is
+    # unit-testable and so a missing PyYAML fails loudly instead of silently
+    # rewriting the description to a bare YAML block-scalar indicator.
+    "$PYTHON_BIN" "$REPO_ROOT/scripts/compact_codex_skill_description.py" \
+        "$DEST_DIR/$name/SKILL.md"
 
     count=$((count + 1))
 done

--- a/tests/unit/test_codex_plugin.py
+++ b/tests/unit/test_codex_plugin.py
@@ -1,8 +1,11 @@
 """Tests for the Codex plugin packaging."""
 
+import importlib.util
 import json
+import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -15,7 +18,27 @@ PLUGIN_JSON = PLUGIN_DIR / ".codex-plugin" / "plugin.json"
 MCP_JSON = PLUGIN_DIR / ".mcp.json"
 SKILLS_DIR = PLUGIN_DIR / "skills"
 BUILD_SCRIPT = REPO_ROOT / "scripts" / "build-codex-plugin.sh"
+COMPACT_SCRIPT = REPO_ROOT / "scripts" / "compact_codex_skill_description.py"
 DIST_DIR = REPO_ROOT / "dist" / "tooluniverse-codex-plugin"
+
+
+def _load_compact_module():
+    spec = importlib.util.spec_from_file_location(
+        "compact_codex_skill_description", COMPACT_SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# Load the compaction module once and reuse it. Sourcing BLOCK_SCALAR_INDICATORS
+# from the module (rather than re-declaring it) keeps the test's placeholder
+# check tied to the exact set the script's guard enforces. A generated
+# description equal to one of these tokens is the signature of the YAML-roundtrip
+# corruption: a sync without PyYAML captured the indicator instead of the folded
+# text on the lines below it.
+COMPACT_MODULE = _load_compact_module()
+BLOCK_SCALAR_INDICATORS = COMPACT_MODULE.BLOCK_SCALAR_INDICATORS
 
 
 def _parse_frontmatter(path: Path) -> dict:
@@ -85,11 +108,132 @@ class TestCodexPluginSkills:
         assert len(description) <= 1024, f"{skill_file} description exceeds 1024 chars"
         assert data.get("disable-model-invocation") is not True
 
+    @pytest.mark.parametrize("skill_file", sorted(SKILLS_DIR.glob("*/SKILL.md")))
+    def test_synced_description_is_not_placeholder(self, skill_file):
+        """No generated description is empty or a bare YAML block-scalar indicator.
+
+        This is the invariant the YAML-roundtrip bug violated: a sync run under
+        an interpreter without PyYAML rewrote folded ``description: >-`` blocks
+        down to the literal ``">-"`` token and deleted the real text.
+        """
+        data = _parse_frontmatter(skill_file)
+        description = data.get("description")
+        assert isinstance(description, str) and description.strip(), (
+            f"{skill_file} has an empty or missing description"
+        )
+        assert description.strip() not in BLOCK_SCALAR_INDICATORS, (
+            f"{skill_file} description is a bare YAML block-scalar indicator "
+            f"({description!r}); the sync ran without PyYAML and corrupted it"
+        )
+
 
 @pytest.mark.unit
-def test_build_codex_plugin():
-    """The build script assembles a complete dist/ plugin bundle."""
-    subprocess.run([str(BUILD_SCRIPT)], cwd=REPO_ROOT, check=True)
-    assert (DIST_DIR / ".codex-plugin" / "plugin.json").is_file()
-    assert (DIST_DIR / ".mcp.json").is_file()
-    assert (DIST_DIR / "skills" / "tooluniverse" / "SKILL.md").is_file()
+class TestCodexSkillDescriptionCompaction:
+    """Direct tests for the description-compaction step of the skills sync."""
+
+    FOLDED = (
+        "---\n"
+        "name: sample\n"
+        "description: >-\n"
+        "  First line of the description. Second clause continues here and\n"
+        "  wraps onto a third physical line for good measure.\n"
+        "disable-model-invocation: true\n"
+        "---\n\n"
+        "# Body\n"
+    )
+
+    def test_folded_scalar_description_is_preserved(self, tmp_path):
+        """A folded block scalar is normalized to a single line, text intact."""
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(self.FOLDED, encoding="utf-8")
+
+        COMPACT_MODULE.compact(skill)
+
+        description = _parse_frontmatter(skill)["description"]
+        assert description.strip() not in BLOCK_SCALAR_INDICATORS
+        assert "First line of the description" in description
+        assert "wraps onto a third physical line" in description
+
+    def test_long_description_is_truncated(self, tmp_path):
+        """A description over 1024 chars is truncated to fit, with an ellipsis."""
+        long_text = "word " * 400  # ~2000 chars, well over the 1024 limit
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(
+            f"---\nname: sample\ndescription: >-\n  {long_text}\n---\n\n# Body\n",
+            encoding="utf-8",
+        )
+
+        COMPACT_MODULE.compact(skill)
+
+        description = _parse_frontmatter(skill)["description"]
+        assert len(description) <= 1024
+        assert description.endswith("...")
+
+    def test_extract_aborts_on_block_scalar_indicator(self, tmp_path):
+        """The regex fallback must abort rather than emit an indicator token."""
+        # Frontmatter that fails YAML parsing (unterminated flow sequence) yet
+        # still carries a clean ``description: >-`` line for the regex to see.
+        frontmatter = (
+            "\nname: sample\ndescription: >-\n  real text\nbad: [unterminated\n"
+        )
+        with pytest.raises(SystemExit) as exc:
+            COMPACT_MODULE.extract_description(frontmatter, tmp_path / "SKILL.md")
+        assert exc.value.code == 1
+
+    def test_sync_without_pyyaml_aborts_and_preserves_file(self, tmp_path):
+        """No PyYAML -> loud abort with the file untouched (the crux regression).
+
+        Against the OLD inline logic this exact path silently rewrote the file
+        to ``description: ">-"`` and deleted the folded text, exiting 0. The
+        fixed script imports yaml unguarded, so a missing PyYAML aborts loudly
+        and never touches the file.
+        """
+        skill = tmp_path / "SKILL.md"
+        skill.write_text(self.FOLDED, encoding="utf-8")
+
+        # Shadow PyYAML with a module that raises ImportError, simulating a bare
+        # ``python3`` on PATH that lacks the declared PyYAML dependency.
+        fake_mods = tmp_path / "fakemods"
+        fake_mods.mkdir()
+        (fake_mods / "yaml.py").write_text(
+            'raise ImportError("simulated missing PyYAML")\n', encoding="utf-8"
+        )
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(fake_mods) + os.pathsep + env.get("PYTHONPATH", "")
+
+        result = subprocess.run(
+            [sys.executable, str(COMPACT_SCRIPT), str(skill)],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode != 0, (
+            "sync must fail loudly when PyYAML is unavailable, but it exited 0"
+        )
+        after = skill.read_text(encoding="utf-8")
+        assert 'description: ">-"' not in after, "description was corrupted"
+        assert after == self.FOLDED, "file was modified despite the abort"
+
+
+@pytest.mark.unit
+def test_build_codex_plugin(tmp_path):
+    """The build script assembles a complete plugin bundle.
+
+    It builds into a temp destination via the ``CODEX_PLUGIN_*`` overrides so the
+    test never regenerates tracked files in place -- which is what let the
+    YAML-roundtrip bug corrupt committed skills when tests ran under the wrong
+    interpreter.
+    """
+    skills_dest = tmp_path / "skills"
+    dist_dir = tmp_path / "dist"
+    env = dict(os.environ)
+    env["CODEX_PLUGIN_SKILLS_DEST"] = str(skills_dest)
+    env["CODEX_PLUGIN_DIST"] = str(dist_dir)
+
+    subprocess.run([str(BUILD_SCRIPT)], cwd=REPO_ROOT, check=True, env=env)
+
+    assert (dist_dir / ".codex-plugin" / "plugin.json").is_file()
+    assert (dist_dir / ".mcp.json").is_file()
+    assert (dist_dir / "skills" / "tooluniverse" / "SKILL.md").is_file()


### PR DESCRIPTION
## Problem

`scripts/sync-codex-plugin-skills.sh` compacts over-long skill `description:` frontmatter for the generated Codex plugin copies. It did this with an inline python block whose `import yaml` was wrapped in a **bare `except Exception: pass`**.

Run under an interpreter without PyYAML — e.g. `pytest` without `source .venv/bin/activate`, where PATH resolves to a system python (on this machine `/opt/homebrew/bin/python3`, which has no PyYAML) — the `ImportError` was silently swallowed and the code fell back to a line regex:

```python
re.search(r"(?m)^description:\s*(.*)$", frontmatter)
```

For a YAML **folded block scalar** (`description: >-` with the text on the following indented lines) that regex captures the *indicator token*, not the content. The script then wrote `description: ">-"` and set `skipping_description_block = True`, which **deleted the real folded text** beneath — silently, with exit 0. Because the skill router matches on `description:`, a `">"` description makes that skill unroutable with no error.

### Reproduction (exact fallback path, PyYAML simulated-missing)

Input:
```yaml
description: >-
  Run the full self-improvement cycle: discover APIs, create tools, test with
  personas, fix issues, and push via git. Use when asked to run a debug round.
```
Output after the old logic (exit `0`, no warning):
```yaml
description: ">-"
```
The two folded lines were destroyed. Confirmed the bare `except Exception:` was still present on the branch base, and confirmed real synced skills use folded scalars (e.g. `tooluniverse-self-review`, `tooluniverse-product-safety-surveillance`).

## Fixes (all four)

1. **Fail loud on missing PyYAML.** `import yaml` is now unguarded at module scope, so a wrong interpreter surfaces as `ImportError` instead of being swallowed. Only `yaml.YAMLError` is caught, narrowly, around `safe_load`.
2. **Guard the fallback.** If the regex fallback captures a YAML block-scalar indicator (`>`, `>-`, `>+`, `|`, `|-`, `|+`) or an empty value, the script now **aborts with a clear error** instead of writing it.
3. **Resolve a known-good interpreter.** The sync resolves `CODEX_PLUGIN_PYTHON` → active `VIRTUAL_ENV` → repo `.venv` → `python3`, rather than trusting a bare `python3` on PATH.
4. **Build into a temp destination.** `sync-codex-plugin-skills.sh` and `build-codex-plugin.sh` honor `CODEX_PLUGIN_SKILLS_DEST` / `CODEX_PLUGIN_DIST` overrides, and `test_build_codex_plugin` now builds into a `tmp_path` instead of regenerating tracked files in place — so this class of corruption is impossible during tests regardless of the interpreter.

The compaction logic was extracted verbatim into a standalone, unit-testable script, `scripts/compact_codex_skill_description.py`. It produces **byte-identical output to the previous inline logic on the happy path**, verified across all 137 synced skills.

## Regression tests (`tests/unit/test_codex_plugin.py`)

- `test_synced_description_is_not_placeholder` — asserts no synced `skills/**/SKILL.md` `description:` is empty or equal to a block-scalar indicator token.
- `test_folded_scalar_description_is_preserved` / `test_long_description_is_truncated` — the fix keeps folded descriptions intact (and truncates >1024 chars with an ellipsis).
- `test_extract_aborts_on_block_scalar_indicator` — the guarded fallback aborts.
- `test_sync_without_pyyaml_aborts_and_preserves_file` — with PyYAML shadowed, the script exits non-zero and leaves the file byte-for-byte intact.

**Old vs new**, same no-PyYAML input: the old logic exits `0` and rewrites the file to `description: ">-"` (the regression test's assertions fail); the new script exits `1` and leaves the file unchanged (assertions pass). `286 passed, 0 failed` under `tests/unit/test_codex_plugin.py`.

## Notes

- No canonical `skills/**/SKILL.md` content is edited by this PR — only the two sync scripts, the new standalone script, and the test file.