### PR TITLE
Fix Round 140: honor HPO_search_terms max_results and Enrichr empty-libs default

### DIFF
--- a/src/tooluniverse/data/enrichr_tools.json
+++ b/src/tooluniverse/data/enrichr_tools.json
@@ -19,7 +19,7 @@
           "items": {
             "type": "string"
           },
-          "description": "List of enrichment libraries to use for analysis.",
+          "description": "List of Enrichr enrichment libraries to query (e.g. 'KEGG_2021_Human', 'GO_Biological_Process_2023'). Omitting this or passing an empty list uses a broad default set of pathway/ontology libraries.",
           "default": [
             "WikiPathways_2024_Human",
             "Reactome_Pathways_2024",
@@ -40,11 +40,26 @@
           "BRCA1",
           "EGFR"
         ],
-        "libs": []
+        "libs": [
+          "KEGG_2021_Human"
+        ]
       }
     ],
     "return_schema": {
-      "type": "string"
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "connected_paths": {
+          "type": "object",
+          "description": "Ranked weighted paths between the first two genes routed through shared enrichment terms."
+        },
+        "connections": {
+          "type": "object",
+          "description": "Per gene-to-term connectivity paths found in the enrichment graph."
+        }
+      }
     }
   }
 ]

--- a/src/tooluniverse/enrichr_tool.py
+++ b/src/tooluniverse/enrichr_tool.py
@@ -15,6 +15,16 @@ class EnrichrTool(BaseTool):
     Tool to perform gene enrichment analysis using Enrichr.
     """
 
+    # Default enrichment libraries used when the caller does not specify any
+    # (or passes an empty list).
+    DEFAULT_LIBS = [
+        "WikiPathways_2024_Human",
+        "Reactome_Pathways_2024",
+        "MSigDB_Hallmark_2020",
+        "GO_Molecular_Function_2023",
+        "GO_Biological_Process_2023",
+    ]
+
     def __init__(self, tool_config):
         super().__init__(tool_config)
         # Constants
@@ -24,22 +34,24 @@ class EnrichrTool(BaseTool):
     def run(self, arguments):
         """Main entry point for the tool."""
         genes = arguments.get("gene_list")
-        libs = arguments.get(
-            "libs",
-            [
-                "WikiPathways_2024_Human",
-                "Reactome_Pathways_2024",
-                "MSigDB_Hallmark_2020",
-                "GO_Molecular_Function_2023",
-                "GO_Biological_Process_2023",
-            ],
-        )
+        # ``libs`` defaults to a broad set of pathway/ontology libraries. An
+        # explicitly-supplied empty list (e.g. ``"libs": []``) is treated as
+        # "use the default" rather than "query nothing" -- otherwise a valid
+        # call would silently return an empty enrichment wrapped in success.
+        libs = arguments.get("libs") or self.DEFAULT_LIBS
         connected_path, connections = self.enrichr_api(genes, libs)
-        # Convert to JSON string for schema compatibility
-        import json
-
-        result = {"connected_paths": connected_path, "connections": connections}
-        return {"status": "success", "data": json.dumps(result, indent=2)}
+        return {
+            "status": "success",
+            "data": {
+                "connected_paths": connected_path,
+                "connections": connections,
+            },
+            "metadata": {
+                "source": "Enrichr (maayanlab.cloud)",
+                "libraries": list(libs),
+                "gene_count": len(genes) if genes else 0,
+            },
+        }
 
     def get_official_gene_name(self, gene_name):
         """
@@ -55,7 +67,7 @@ class EnrichrTool(BaseTool):
         encoded_gene_name = urllib.parse.quote(gene_name)
         url = f"https://mygene.info/v3/query?q={encoded_gene_name}&fields=symbol,alias&species=human"
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         if response.status_code != 200:
             return f"Error querying MyGene.info API: {response.status_code}"
 
@@ -110,7 +122,7 @@ class EnrichrTool(BaseTool):
             "list": (None, gene_list),
             "description": (None, f"Gene list for {gene_list}"),
         }
-        response = requests.post(self.enrichr_url, files=payload)
+        response = requests.post(self.enrichr_url, files=payload, timeout=30)
 
         if not response.ok:
             return "Error submitting gene list to Enrichr"
@@ -129,7 +141,7 @@ class EnrichrTool(BaseTool):
             dict: The enrichment results.
         """
         query_string = f"?userListId={user_list_id}&backgroundType={library}"
-        response = requests.get(self.enrichment_url + query_string)
+        response = requests.get(self.enrichment_url + query_string, timeout=60)
 
         if not response.ok:
             return f"Error fetching enrichment results for {library}"

--- a/src/tooluniverse/hpo_tool.py
+++ b/src/tooluniverse/hpo_tool.py
@@ -306,18 +306,29 @@ class HPOTool(BaseTool):
         if not query:
             return {"status": "error", "error": "query parameter is required"}
 
-        max_results = arguments.get("max_results", 10)
-        if max_results > 50:
-            max_results = 50
+        # Coerce max_results robustly: the schema allows integer|null, so a
+        # caller may omit it, pass null, or pass an out-of-range value. Using
+        # the raw value directly would crash on None (None > 50) and let
+        # negatives/zero through.
+        try:
+            max_results = int(arguments.get("max_results") or 10)
+        except (TypeError, ValueError):
+            max_results = 10
+        max_results = max(1, min(max_results, 50))
 
         url = f"{HPO_BASE_URL}/search"
-        params = {"q": query, "max": max_results}
+        # The JAX ontology search endpoint sizes the page with `limit`. The
+        # previous `max` key was silently ignored, capping every result set at
+        # the API default of 10 regardless of the requested count.
+        params = {"q": query, "limit": max_results}
 
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
         data = response.json()
 
-        terms = data.get("terms", [])
+        # Defensive truncation in case an upstream change ever returns more
+        # rows than requested.
+        terms = data.get("terms", [])[:max_results]
         results = []
         for term in terms:
             results.append(
@@ -337,6 +348,10 @@ class HPOTool(BaseTool):
                 "source": "HPO (JAX Ontology)",
                 "query": query,
                 "total_results": len(results),
+                # Total matches available across all pages (the API reports this
+                # as `totalCount`), so callers can see more terms exist beyond
+                # the returned page instead of assuming this page is exhaustive.
+                "total_available": data.get("totalCount", len(results)),
             },
         }
 

--- a/tests/unit/test_enrichr_empty_libs.py
+++ b/tests/unit/test_enrichr_empty_libs.py
@@ -1,0 +1,101 @@
+"""Regression tests for enrichr_gene_enrichment_analysis input/output handling.
+
+Two confirmed defects in the freshly-wrapped 1.4.0 tool:
+
+* An explicit empty ``libs`` list (which is the tool's own documented example,
+  ``{"gene_list": [...], "libs": []}``) queried zero libraries and returned an
+  empty enrichment wrapped in ``status: success`` -- the "valid input silently
+  returns empty as success" class. Empty/omitted ``libs`` must fall back to the
+  default library set.
+* ``data`` was a double-JSON-encoded string (``json.dumps(result)``), forcing
+  every consumer to ``json.loads`` a second time, inconsistent with every other
+  ToolUniverse tool. ``data`` must be a structured object.
+
+These are unit-level (``run`` logic) and mock out the network via ``enrichr_api``.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    from tooluniverse.enrichr_tool import EnrichrTool
+
+    return EnrichrTool(
+        {"name": "enrichr_gene_enrichment_analysis", "type": "EnrichrTool"}
+    )
+
+
+_FAKE_RESULT = (
+    {"Path: ['TP53', 'term', 'BRCA1']": "Total Weight: 12.0"},
+    {"Connectivity: TP53 - term": [[["TP53", "term"], 1]]},
+)
+
+
+class TestEnrichrLibsFallback(unittest.TestCase):
+    def test_empty_libs_falls_back_to_default(self):
+        """libs=[] must query the default library set, not zero libraries."""
+        from tooluniverse.enrichr_tool import EnrichrTool
+
+        tool = _tool()
+        with patch.object(
+            type(tool), "enrichr_api", return_value=_FAKE_RESULT
+        ) as api:
+            tool.run({"gene_list": ["TP53", "BRCA1"], "libs": []})
+        called_libs = api.call_args.args[1]
+        self.assertEqual(called_libs, EnrichrTool.DEFAULT_LIBS)
+
+    def test_omitted_libs_falls_back_to_default(self):
+        """Omitting libs also uses the default set."""
+        from tooluniverse.enrichr_tool import EnrichrTool
+
+        tool = _tool()
+        with patch.object(
+            type(tool), "enrichr_api", return_value=_FAKE_RESULT
+        ) as api:
+            tool.run({"gene_list": ["TP53", "BRCA1"]})
+        self.assertEqual(api.call_args.args[1], EnrichrTool.DEFAULT_LIBS)
+
+    def test_explicit_libs_used_verbatim(self):
+        """A non-empty libs list is passed through unchanged."""
+        tool = _tool()
+        with patch.object(
+            type(tool), "enrichr_api", return_value=_FAKE_RESULT
+        ) as api:
+            tool.run(
+                {"gene_list": ["TP53", "BRCA1"], "libs": ["KEGG_2021_Human"]}
+            )
+        self.assertEqual(api.call_args.args[1], ["KEGG_2021_Human"])
+
+
+class TestEnrichrOutputShape(unittest.TestCase):
+    def test_data_is_structured_object_not_string(self):
+        """data must be a dict with connected_paths/connections, not a JSON string."""
+        tool = _tool()
+        with patch.object(type(tool), "enrichr_api", return_value=_FAKE_RESULT):
+            result = tool.run({"gene_list": ["TP53", "BRCA1"], "libs": ["X"]})
+        self.assertEqual(result["status"], "success")
+        data = result["data"]
+        self.assertIsInstance(data, dict)
+        self.assertIn("connected_paths", data)
+        self.assertIn("connections", data)
+        self.assertIsInstance(data["connected_paths"], dict)
+
+    def test_metadata_reports_libraries_and_gene_count(self):
+        """metadata surfaces the libraries queried and the gene count."""
+        tool = _tool()
+        with patch.object(type(tool), "enrichr_api", return_value=_FAKE_RESULT):
+            result = tool.run(
+                {"gene_list": ["TP53", "BRCA1"], "libs": ["KEGG_2021_Human"]}
+            )
+        meta = result["metadata"]
+        self.assertEqual(meta["libraries"], ["KEGG_2021_Human"])
+        self.assertEqual(meta["gene_count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_hpo_search_terms_limit.py
+++ b/tests/unit/test_hpo_search_terms_limit.py
@@ -1,0 +1,119 @@
+"""Regression tests for HPO_search_terms result-count handling (mocked HTTP).
+
+The JAX ontology search endpoint (ontology.jax.org/api/hp/search) sizes the
+returned page with the ``limit`` query parameter. The tool previously sent
+``max``, which the API silently ignores, so every result set was capped at the
+API default of 10 regardless of the requested ``max_results`` -- a valid input
+silently returning truncated data wrapped in ``status: success``. These tests
+lock in that ``max_results`` is honored (sent as ``limit``), bounded safely,
+and that the true total match count is surfaced.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _hpo_search_tool():
+    from tooluniverse.hpo_tool import HPOTool
+
+    return HPOTool(
+        {
+            "name": "HPO_search_terms",
+            "type": "HPOTool",
+            "fields": {"endpoint": "search_terms"},
+        }
+    )
+
+
+def _search_resp(n_terms, total_count):
+    """Mock a JAX /hp/search response carrying ``n_terms`` rows."""
+    terms = [
+        {
+            "id": f"HP:{i:07d}",
+            "name": f"term {i}",
+            "definition": f"def {i}",
+            "descendantCount": i,
+            "synonyms": [],
+        }
+        for i in range(n_terms)
+    ]
+    r = MagicMock()
+    r.status_code = 200
+    r.raise_for_status.return_value = None
+    r.json.return_value = {"terms": terms, "totalCount": total_count}
+    return r
+
+
+class TestHPOSearchTermsLimit(unittest.TestCase):
+    def test_max_results_sent_as_limit_not_max(self):
+        """max_results must reach the API as ``limit`` (never the ignored ``max``)."""
+        tool = _hpo_search_tool()
+        with patch(
+            "tooluniverse.hpo_tool.requests.get",
+            return_value=_search_resp(25, 100),
+        ) as get:
+            result = tool.run({"query": "seizure", "max_results": 25})
+
+        params = get.call_args.kwargs["params"]
+        self.assertEqual(params.get("limit"), 25)
+        self.assertNotIn("max", params)
+        self.assertEqual(params.get("q"), "seizure")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(len(result["data"]), 25)
+
+    def test_total_available_surfaces_true_total(self):
+        """metadata exposes the API totalCount, not just the returned page size."""
+        tool = _hpo_search_tool()
+        with patch(
+            "tooluniverse.hpo_tool.requests.get",
+            return_value=_search_resp(10, 100),
+        ):
+            result = tool.run({"query": "seizure", "max_results": 10})
+
+        meta = result["metadata"]
+        self.assertEqual(meta["total_results"], 10)
+        self.assertEqual(meta["total_available"], 100)
+
+    def test_response_truncated_defensively(self):
+        """If upstream ever over-returns, the tool truncates to max_results."""
+        tool = _hpo_search_tool()
+        with patch(
+            "tooluniverse.hpo_tool.requests.get",
+            return_value=_search_resp(40, 100),
+        ):
+            result = tool.run({"query": "seizure", "max_results": 5})
+        self.assertEqual(len(result["data"]), 5)
+
+    def test_null_max_results_defaults_without_crashing(self):
+        """max_results=null (schema allows integer|null) must default, not crash."""
+        tool = _hpo_search_tool()
+        with patch(
+            "tooluniverse.hpo_tool.requests.get",
+            return_value=_search_resp(10, 100),
+        ) as get:
+            result = tool.run({"query": "seizure", "max_results": None})
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(get.call_args.kwargs["params"]["limit"], 10)
+
+    def test_max_results_clamped_to_bounds(self):
+        """Over-max clamps to 50; zero/negative clamps up to 1."""
+        for requested, expected_limit in [(999, 50), (0, 10), (-5, 1)]:
+            tool = _hpo_search_tool()
+            with patch(
+                "tooluniverse.hpo_tool.requests.get",
+                return_value=_search_resp(1, 100),
+            ) as get:
+                tool.run({"query": "seizure", "max_results": requested})
+            self.assertEqual(
+                get.call_args.kwargs["params"]["limit"],
+                expected_limit,
+                msg=f"max_results={requested}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Post-1.4.0 role-play bug-hunt round targeting the 436 tool wrappers newly exposed in #389 (previously registered-but-unwrapped tools that had never been through a role-play). Three researcher personas (rare-disease geneticist, clinical pharmacologist, functional genomicist) exercised ~64 tool calls across ~30 families via the CLI against the 1.4.0 code. Every reported issue was CLI-reproduced before fixing; false positives and upstream-outage artifacts were discarded.

**Net: 3 confirmed defects fixed** (1 HIGH, 2 MEDIUM), all in the "a valid input silently returns empty/wrong data as a success" class, plus a robustness hardening. The remaining ~30 families returned correct, parameter-honoring data.

## Fixes

### 1. `HPO_search_terms` silently ignored `max_results` (HIGH)
`hpo_tool.py` sent the page-size to the JAX ontology search endpoint as `max`, but that endpoint sizes pages with `limit`. The `max` key was silently ignored, so **every** search was capped at the API default of 10 regardless of the requested `max_results`, and `metadata.total_results` reported 10 even when 100 matches existed — a clinician would believe only 10 phenotype terms exist for a query.

CLI verification (live JAX API):
```
{'q':'seizure','max':3}  -> 10 terms   (ignored)
{'q':'seizure','limit':3} -> 3 terms    (honored)
{'q':'seizure','limit':50}-> 50 terms
totalCount = 100 in all cases
```
Fix: send `limit`; coerce `max_results` robustly (null / 0 / negative / over-max no longer crash or leak through — the schema allows `integer|null`); truncate defensively; and surface the true total as `metadata.total_available`.

After fix: `max_results` 3→3, 20→20, 50→50; default→10; `null`→10 (no crash); 999→50; -5→1; `total_available`=100.

### 2. `enrichr_gene_enrichment_analysis` empty `libs` returned empty as success (MEDIUM)
`libs = arguments.get("libs", DEFAULT)` — passing `libs: []` (the tool's **own documented example**) returned `[]`, so zero libraries were queried and an empty enrichment was wrapped in `status: success`. Fix: empty or omitted `libs` now falls back to the default library set (`arguments.get("libs") or DEFAULT_LIBS`), and the documented example uses a real library.

Before: documented example → `connected_paths: {}` (empty), only trivial self-loops.
After: documented example → 20 ranked connectivity paths from the 5 default libraries.

### 3. `enrichr_gene_enrichment_analysis` returned double-JSON-encoded `data` (MEDIUM)
`data` was `json.dumps(result)` — a JSON **string**, forcing every consumer to `json.loads` a second time, inconsistent with every other ToolUniverse tool; `return_schema` was merely `{"type": "string"}`, which does not describe the `{status, data}` envelope. Fix: return `data` as a structured object with a `metadata` block, and update `return_schema` to describe it (verified it validates via `jsonschema.validate(result["data"], return_schema)`, matching how `cli.py` checks it).

### 4. Enrichr request timeouts (robustness)
The `requests.get/post` calls in `enrichr_tool.py` passed no `timeout=`; a persona observed one run stall past 140s while an identical later run finished in ~8s. Added timeouts so a stalled upstream cannot hang indefinitely.

## Tests
- `tests/unit/test_hpo_search_terms_limit.py` — 5 tests: `limit` (not `max`) is sent, results honor/truncate to `max_results`, `total_available` surfaces `totalCount`, `null` defaults without crashing, bounds are clamped.
- `tests/unit/test_enrichr_empty_libs.py` — 5 tests: empty/omitted `libs` fall back to default, explicit libs pass through, `data` is a structured object, metadata reports libraries + gene count.

All 10 new tests pass; the existing HPO/Enrichr unit suites (35 tests across `test_disease_ontology_depth`, `test_hpo_phenotype_annotations`, `test_functional_enrichment_depth`, `test_enrichr_no_stdout_pollution`, `test_monarch_result_id_prefix`, `test_hpo_id_normalization`) still pass — no regressions.

## Verified false positives / not fixed (for the record)
- **Inconsistent gene-symbol param names** across families (`gene` / `gene_symbol` / `symbol`) — friction only; errors are clear and actionable. Cross-family aliasing is an anti-pattern (grows forever); left as a separate design-consistency concern.
- **EnsemblPheno / Pharos / FAERS / FDA-label errors** the personas hit were confirmed **upstream outages** (`api.fda.gov` no-route, `pharos-api.ncats.io` 502, Ensembl REST timeout), not tool defects — the tools surfaced clean errors.
- **EVA / GTEx / ClinVar / GBIF / ClinGen / PanglaoDB / ReactomeAnalysis empties** were confirmed **genuine upstream sparseness** (verified against the raw APIs / source CSVs), not silent failures.
- A `FAERS_count_*` error-as-data-row pattern and an Enrichr no-p-values output-format concern were noted but only reproduce under upstream outage / are format redesigns — deferred rather than fixed unverified.