### PR TITLE
Fix: post-1.4.0 bug-hunt + onboarding-experience gaps (consolidates #391 + #392)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,30 @@ Add to your MCP config file:
 }
 ```
 
+`--refresh` checks PyPI for the newest release on every launch. Drop it
+(`"args": ["tooluniverse"]`) to start faster from `uv`'s cache — then upgrade
+with `uv cache clean tooluniverse`.
+
 Install agent skills:
 ```bash
 npx skills add mims-harvard/ToolUniverse
 ```
 </details>
 
-**Python developers** — install the SDK:
+**Claude Code users** — one line, no config file:
 ```bash
+claude plugin marketplace add mims-harvard/ToolUniverse
+claude plugin install tooluniverse@tooluniverse
+```
+
+**Python developers** — install the SDK. Install [`uv`](https://docs.astral.sh/uv/) first and **do not use system `pip`**: on a current Mac, `pip install tooluniverse` fails with `externally-managed-environment` (PEP 668) and `python3 -m venv` can fail at `ensurepip`. `uv` manages its own Python and avoids both.
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh   # if you don't have uv
+uv venv --python 3.12 && source .venv/bin/activate
 uv pip install tooluniverse
 ```
+
+The base install covers the API and database tools. Local ML, cheminformatics, and plotting tools need extras — `uv pip install 'tooluniverse[all]'`, or a single group such as `[ml]`, `[visualization]`, `[bioinformatics]`. Note `[all]` excludes `singlecell`, `smolagents`, `client`, and `build`, which install by name. Run `tooluniverse-doctor` to see which groups are missing.
 
 **[`tu` CLI](https://zitniklab.hms.harvard.edu/ToolUniverse/guide/tu_cli.html)** — discover, inspect, run, and test tools from the terminal.
 **[Python SDK](https://zitniklab.hms.harvard.edu/ToolUniverse/guide/python_guide.html)** — programmatic access for building AI scientist systems.

--- a/docs/help/troubleshooting.rst
+++ b/docs/help/troubleshooting.rst
@@ -39,6 +39,58 @@ Run this diagnostic script to check your ToolUniverse installation:
 Installation Issues
 -------------------
 
+.. tip::
+
+   Install with `uv <https://docs.astral.sh/uv/>`_ rather than the system
+   ``pip``. It sidesteps the two errors below entirely, because it downloads and
+   manages its own Python::
+
+      curl -LsSf https://astral.sh/uv/install.sh | sh
+      uv venv --python 3.12 && source .venv/bin/activate
+      uv pip install tooluniverse
+
+error: externally-managed-environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Symptom:** ``pip install tooluniverse`` refuses to run::
+
+   error: externally-managed-environment
+   × This environment is externally managed
+
+**Cause:** PEP 668. Homebrew, Debian/Ubuntu, and Fedora mark their system
+Python as externally managed so that ``pip`` cannot modify packages the OS
+package manager owns.
+
+**Solution:** install into a virtual environment managed by ``uv``::
+
+   uv venv --python 3.12
+   source .venv/bin/activate      # Windows: .venv\Scripts\activate
+   uv pip install tooluniverse
+
+Do **not** use ``sudo pip install`` or ``pip install --break-system-packages``;
+both can leave the system Python in a broken state.
+
+python3 -m venv fails at ensurepip
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Symptom:** creating a virtual environment fails::
+
+   Error: Command '[.../bin/python3.14', '-m', 'ensurepip', '--upgrade',
+   '--default-pip']' returned non-zero exit status 1.
+
+**Cause:** some Homebrew Python builds (3.13/3.14) ship without a working
+``ensurepip``, so the standard library ``venv`` module cannot bootstrap ``pip``.
+
+**Solution:** let ``uv`` supply the interpreter instead of the system one::
+
+   uv venv --python 3.12
+   source .venv/bin/activate
+   uv pip install tooluniverse
+
+If you only need the ``tu`` command line and not the Python API::
+
+   uv tool install tooluniverse
+
 ImportError: No module named 'tooluniverse'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -112,6 +164,52 @@ Dependency conflicts
 
 Runtime Errors
 --------------
+
+A tool loads but fails when run
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Symptom:** the tool appears in ``tu list`` and ``tu status`` counts it, but
+running it raises something like ``ADMETModel requires 'admet-ai' package`` or
+``RDKit is required``.
+
+**Cause:** loading a tool registers its JSON config; it does not install the
+tool's dependencies. Tools backed by an optional extra load fine on a base
+install and only fail at call time.
+
+**Diagnosis:**
+
+.. code-block:: bash
+
+   tooluniverse-doctor
+
+The report lists every optional dependency group that is not installed.
+
+**Solution:** install the group it names::
+
+   uv pip install 'tooluniverse[ml]'              # ADMET-AI, embeddings
+   uv pip install 'tooluniverse[visualization]'   # RDKit, py3Dmol, plotting
+   uv pip install 'tooluniverse[bioinformatics]'  # Biopython, freesasa
+   uv pip install 'tooluniverse[all]'             # everything except the four below
+
+``[all]`` excludes ``singlecell``, ``smolagents``, ``client``, and ``build`` —
+install those by name.
+
+PyTorch / Lightning warnings during ML tool calls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Symptom:** ADMET-AI or other local-model tools print warnings about a missing
+GPU, PyTorch Lightning ``Trainer`` settings, or ``TypedStorage is deprecated``.
+
+**These are normal.** They come from PyTorch and PyTorch Lightning during
+ordinary CPU inference and do not affect results. Treat the call as failed only
+if the tool returns an ``error`` field or no predictions.
+
+To silence them in scripts:
+
+.. code-block:: python
+
+   import warnings
+   warnings.filterwarnings("ignore", category=UserWarning)
 
 Tool not found errors
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/reference/cli_tools.rst
+++ b/docs/reference/cli_tools.rst
@@ -215,25 +215,44 @@ Health check tool that diagnoses ToolUniverse installation and tool availability
 **What it checks**:
 
 - ToolUniverse installation and imports
-- Tool loading status (available vs unavailable)
-- Missing dependencies for specific tools
+- Tool loading status (how many tool configs registered, and which failed)
+- Which optional dependency groups (extras) are not installed
+
+.. important::
+
+   **Loaded is not the same as runnable.** Loading a tool registers its JSON
+   config; it does not install the tool's dependencies. Tools backed by an
+   optional extra (``[ml]``, ``[visualization]``, ``[bioinformatics]``, ...)
+   are counted as loaded on a base ``pip install tooluniverse`` and only fail
+   when you actually run them. ``tooluniverse-doctor`` reports both numbers so
+   a partial install is not mistaken for a complete one.
 
 **Example Output**::
 
-    Checking ToolUniverse health...
-   
-    Total tools: 1195
-    Available: 1150
-    Unavailable: 45
-   
-   ️  Unavailable tools:
-   
-      BioBERT_ner
-        Error: No module named 'transformers'
-        Fix: pip install transformers
-   
-    Bulk fix command:
-      pip install transformers torch biopython
+   Checking ToolUniverse health...
+
+   Total tools: 2599
+   Config loaded: 2599
+   Failed to load: 0
+
+   7 optional dependency group(s) not installed:
+
+     [ml] - up to 11 tool(s) may not run
+        Missing: admet-ai, sentence-transformers
+        Fix: pip install 'tooluniverse[ml]'
+
+     [bioinformatics] - up to 14 tool(s) may not run
+        Missing: biopython, freesasa
+        Fix: pip install 'tooluniverse[bioinformatics]'
+
+     Note: tool counts above are an upper bound - a few tools use these
+     packages only as an enhancement and still work without them.
+
+When nothing failed to load and every extra is installed, the report ends with
+``All tools loaded and every optional dependency group is installed!``.
+
+``tu status`` shows the same missing-extras summary in short form, and
+``tu status --json`` exposes it as a ``missing_extras`` field for scripting.
 
 **Use cases**:
 
@@ -504,14 +523,25 @@ Server won't start
 Tools not loading
 ~~~~~~~~~~~~~~~~~
 
-**Problem**: ``tooluniverse-doctor`` shows many unavailable tools.
+**Problem**: ``tooluniverse-doctor`` shows tools that failed to load, or
+optional dependency groups that are not installed.
 
 **Solution**: Install missing dependencies::
 
    # Install all optional dependencies
-   pip install tooluniverse[all]
-   
+   pip install 'tooluniverse[all]'
+
+   # Or just the group the doctor named
+   pip install 'tooluniverse[ml]'
+
    # Or follow the specific installation instructions from doctor output
+
+.. note::
+
+   ``[all]`` covers ``dev, docs, graph, visualization, space, embedding, ml,
+   bioinformatics``. It does **not** include ``singlecell``, ``smolagents``,
+   ``client``, or ``build`` — install those by name, e.g.
+   ``pip install 'tooluniverse[singlecell]'``.
 
 Command not found
 ~~~~~~~~~~~~~~~~~

--- a/plugin/skills/setup-tooluniverse/SKILL.md
+++ b/plugin/skills/setup-tooluniverse/SKILL.md
@@ -62,7 +62,7 @@ Make sure Step 2 is done, then try:
 uvx --from tooluniverse tu status              # How many tools?
 uvx --from tooluniverse tu find 'drug safety'  # Search by topic
 uvx --from tooluniverse tu info FAERS_count_death_related_by_drug  # See params
-uvx --from tooluniverse tu run FAERS_count_death_related_by_drug '{"drug_name": "metformin"}'
+uvx --from tooluniverse tu run FAERS_count_death_related_by_drug '{"medicinalproduct": "metformin"}'
 ```
 
 First run takes ~30s (downloads package), then instant. **Shortcut**: `uv tool install tooluniverse` → then just use `tu` directly.
@@ -87,11 +87,29 @@ Continue to **Step 3** (API Keys).
 
 ## SDK Setup
 
-Make sure Step 2 is done. For detailed patterns, invoke the `tooluniverse-sdk` skill.
+> **Install `uv` first (Step 2). Do not use system `pip`.** On a current Mac
+> (Homebrew Python 3.13/3.14) `pip install tooluniverse` stops with
+> `error: externally-managed-environment` (PEP 668), and `python3 -m venv` can
+> fail at `ensurepip`. `uv` avoids both because it downloads and manages its own
+> Python.
 
 ```bash
+uv venv --python 3.12          # own Python + virtualenv, ignores system pip
+source .venv/bin/activate      # Windows: .venv\Scripts\activate
 uv pip install tooluniverse
 ```
+
+`uv pip install` needs an active virtualenv — run `uv venv` first, or use
+`uv tool install tooluniverse` if you only want the `tu` command.
+
+For detailed patterns, invoke the `tooluniverse-sdk` skill.
+
+**Optional extras**: the base install covers API/database tools. Local ML,
+cheminformatics, and plotting tools need extras — `uv pip install
+'tooluniverse[ml]'`, `[visualization]`, `[bioinformatics]`, or `[all]`.
+Run `tooluniverse-doctor` to see which groups you are missing.
+Note `[all]` does **not** include `singlecell`, `smolagents`, `client`, or
+`build`; install those separately.
 
 ### Coding API — 3 calling patterns
 
@@ -124,9 +142,33 @@ Continue to **Step 3** (API Keys).
 
 ## MCP Setup (Chat Mode)
 
-Make sure Step 2 is done (`uv --version` works).
+**Offer the two low-effort paths first.** Editing JSON by hand is the fallback,
+not the recommendation — a mistyped comma is the single most common setup
+failure. Only walk through the manual path if neither option below fits.
 
-### Add ToolUniverse to your app's config
+**Path A — let an AI agent do it.** If the user already has any agent (Claude,
+Cursor, Copilot, Gemini, Codex...), they can paste this into it:
+
+```
+Read https://aiscientist.tools/setup.md and set up ToolUniverse for me.
+```
+
+The agent handles config, keys, skills, and validation. No terminal, no JSON.
+
+**Path B — Claude Code users: one-liner, no config file at all.**
+
+```bash
+claude plugin marketplace add mims-harvard/ToolUniverse
+claude plugin install tooluniverse@tooluniverse
+```
+
+Installs MCP server + 115 skills + slash commands in one step. Then see the
+`tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update"
+step so future releases apply without manual `claude plugin update`.
+
+### Manual config (fallback)
+
+Make sure Step 2 is done (`uv --version` works).
 
 **Config file help** (if user seems unfamiliar): Config files are plain text that store settings — like a preference list for the app. You don't need to understand the format; just paste exactly what's shown below. Most apps have a Settings button that opens the file for you (see table). If the file is empty, paste the entire block. If it already has content, the agent should help merge it.
 
@@ -143,14 +185,23 @@ Make sure Step 2 is done (`uv --version` works).
 }
 ```
 
-**Config file locations:**
-
-> **Claude Code users**: skip manual MCP config — use the plugin instead. Invoke the `tooluniverse-claude-code-plugin` skill or run:
+> **Paste safely.** Copy the block whole — do not retype it. If the file already
+> has an `mcpServers` block, add only the `"tooluniverse": { ... }` entry inside
+> it and put a comma after the previous entry. If the file was empty, paste the
+> whole block. Then validate before restarting the app:
 > ```bash
-> claude plugin marketplace add mims-harvard/ToolUniverse
-> claude plugin install tooluniverse@tooluniverse
+> python3 -m json.tool < "<path-to-config>" > /dev/null && echo "JSON OK"
 > ```
-> This installs MCP server + 115 skills + slash commands in one step. Then see the `tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update" step so future releases apply without manual `claude plugin update`.
+> A trailing comma after the last entry, or a missing one between entries, is
+> the usual cause of "MCP server won't start".
+
+**`args` — `["tooluniverse"]` vs `["--refresh", "tooluniverse"]`**: plain is the
+default and starts fast from `uv`'s cache, but can stay on a cached older
+release until you run `uv cache clean tooluniverse`. Adding `--refresh` checks
+PyPI for the newest version on every launch — always current, a few seconds
+slower to start. Use plain unless the user specifically wants auto-updates.
+
+**Config file locations:**
 
 | Client | File | How to Access |
 |--------|------|---------------|
@@ -296,7 +347,7 @@ Skills activate automatically based on user's question. Try: "Research the drug 
 > tu info PubMed_search_articles  # Check parameters
 > tu run PubMed_search_articles '{"query": "CRISPR cancer", "max_results": 3}'
 > tu run UniProt_get_entry_by_accession '{"accession": "P12345"}'
-> tu run FAERS_count_death_related_by_drug '{"drug_name": "metformin"}'
+> tu run FAERS_count_death_related_by_drug '{"medicinalproduct": "metformin"}'
 > ```
 
 ## Write Agent Memory
@@ -346,13 +397,25 @@ NVIDIA_API_KEY=your_shared_key
 
 | Issue | Fix |
 |-------|-----|
+| `error: externally-managed-environment` (PEP 668) | System `pip` refuses to install. Use `uv` — `uv venv --python 3.12 && source .venv/bin/activate && uv pip install tooluniverse`. Never `sudo pip` or `--break-system-packages`. |
+| `python3 -m venv` fails at `ensurepip` | Homebrew Python (3.13/3.14) is missing a working `ensurepip`. Use `uv venv --python 3.12` — `uv` supplies its own Python. |
+| `uv pip install` → "No virtual environment found" | Run `uv venv` first, or use `uv tool install tooluniverse` for just the `tu` command. |
 | `requires-python >= 3.10` | `uv python install 3.12` |
 | `uvx: command not found` | Run install script from Step 2, restart terminal |
 | Context window overflow | Verify using `uvx tooluniverse` (compact mode is default) |
-| `ModuleNotFoundError` | `uv pip install tooluniverse[all]` |
-| MCP server won't start | Test: `uvx tooluniverse` in terminal. Check JSON syntax. |
+| `ModuleNotFoundError` at tool runtime | An optional extra is missing. Run `tooluniverse-doctor` to see which group, then `uv pip install 'tooluniverse[ml]'` (or `[visualization]`, `[bioinformatics]`, `[all]`). |
+| Tools listed but fail when run | Normal for extras-backed tools — `tu status` counts loaded configs, not installed dependencies. `tooluniverse-doctor` reports which groups are missing. |
+| MCP server won't start | Test: `uvx tooluniverse` in terminal. Validate config with `python3 -m json.tool < <config>`. |
 | API key 401/403 | Check key in `env` block, restart app, verify key name |
 | Upgrade needed | `uv cache clean tooluniverse` then restart app |
+
+**Health check**: `tooluniverse-doctor` reports tools that failed to load *and*
+which optional dependency groups are not installed. Use it first whenever a tool
+errors unexpectedly.
+
+**`[all]` is not everything**: it covers `dev, docs, graph, visualization,
+space, embedding, ml, bioinformatics`. `singlecell`, `smolagents`, `client`,
+and `build` must be installed by name.
 
 Still stuck? [GitHub issues](https://github.com/mims-harvard/ToolUniverse/issues) or email [Shanghua Gao](mailto:shanghuagao@gmail.com).
 

--- a/plugin/skills/tooluniverse-admet-prediction/SKILL.md
+++ b/plugin/skills/tooluniverse-admet-prediction/SKILL.md
@@ -27,6 +27,26 @@ Comprehensive pharmacokinetic and toxicity profiling integrating AI-based ADMET 
 
 **Input**: Drug name (e.g., "ibuprofen") OR SMILES string (e.g., "CC(C)Cc1ccc(cc1)C(C)C(=O)O")
 
+## Before You Run
+
+ADMETAI tools run a local model, so they need the `ml` extra:
+
+```bash
+uv pip install 'tooluniverse[ml]'
+```
+
+Without it the tools still appear in `tu list` (the config loads) but fail at
+call time with `ADMETModel requires 'admet-ai' package`. Run
+`tooluniverse-doctor` to confirm which optional groups are installed.
+
+**Expected console noise — not errors.** The first ADMETAI call loads PyTorch
+and prints warnings such as missing-GPU / `Trainer` messages from
+PyTorch Lightning, and `TypedStorage is deprecated` from PyTorch. These are
+emitted by the underlying libraries during normal CPU inference. Predictions
+are unaffected — do not report them to the user as failures and do not retry
+the call because of them. Only treat output as a failure if the tool returns an
+`error` field or no predictions.
+
 ---
 
 ## COMPUTE, DON'T DESCRIBE

--- a/plugins/tooluniverse/skills/setup-tooluniverse/SKILL.md
+++ b/plugins/tooluniverse/skills/setup-tooluniverse/SKILL.md
@@ -63,7 +63,7 @@ Make sure Step 2 is done, then try:
 uvx --from tooluniverse tu status              # How many tools?
 uvx --from tooluniverse tu find 'drug safety'  # Search by topic
 uvx --from tooluniverse tu info FAERS_count_death_related_by_drug  # See params
-uvx --from tooluniverse tu run FAERS_count_death_related_by_drug '{"drug_name": "metformin"}'
+uvx --from tooluniverse tu run FAERS_count_death_related_by_drug '{"medicinalproduct": "metformin"}'
 ```
 
 First run takes ~30s (downloads package), then instant. **Shortcut**: `uv tool install tooluniverse` → then just use `tu` directly.
@@ -88,11 +88,29 @@ Continue to **Step 3** (API Keys).
 
 ## SDK Setup
 
-Make sure Step 2 is done. For detailed patterns, invoke the `tooluniverse-sdk` skill.
+> **Install `uv` first (Step 2). Do not use system `pip`.** On a current Mac
+> (Homebrew Python 3.13/3.14) `pip install tooluniverse` stops with
+> `error: externally-managed-environment` (PEP 668), and `python3 -m venv` can
+> fail at `ensurepip`. `uv` avoids both because it downloads and manages its own
+> Python.
 
 ```bash
+uv venv --python 3.12          # own Python + virtualenv, ignores system pip
+source .venv/bin/activate      # Windows: .venv\Scripts\activate
 uv pip install tooluniverse
 ```
+
+`uv pip install` needs an active virtualenv — run `uv venv` first, or use
+`uv tool install tooluniverse` if you only want the `tu` command.
+
+For detailed patterns, invoke the `tooluniverse-sdk` skill.
+
+**Optional extras**: the base install covers API/database tools. Local ML,
+cheminformatics, and plotting tools need extras — `uv pip install
+'tooluniverse[ml]'`, `[visualization]`, `[bioinformatics]`, or `[all]`.
+Run `tooluniverse-doctor` to see which groups you are missing.
+Note `[all]` does **not** include `singlecell`, `smolagents`, `client`, or
+`build`; install those separately.
 
 ### Coding API — 3 calling patterns
 
@@ -125,9 +143,33 @@ Continue to **Step 3** (API Keys).
 
 ## MCP Setup (Chat Mode)
 
-Make sure Step 2 is done (`uv --version` works).
+**Offer the two low-effort paths first.** Editing JSON by hand is the fallback,
+not the recommendation — a mistyped comma is the single most common setup
+failure. Only walk through the manual path if neither option below fits.
 
-### Add ToolUniverse to your app's config
+**Path A — let an AI agent do it.** If the user already has any agent (Claude,
+Cursor, Copilot, Gemini, Codex...), they can paste this into it:
+
+```
+Read https://aiscientist.tools/setup.md and set up ToolUniverse for me.
+```
+
+The agent handles config, keys, skills, and validation. No terminal, no JSON.
+
+**Path B — Claude Code users: one-liner, no config file at all.**
+
+```bash
+claude plugin marketplace add mims-harvard/ToolUniverse
+claude plugin install tooluniverse@tooluniverse
+```
+
+Installs MCP server + 115 skills + slash commands in one step. Then see the
+`tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update"
+step so future releases apply without manual `claude plugin update`.
+
+### Manual config (fallback)
+
+Make sure Step 2 is done (`uv --version` works).
 
 **Config file help** (if user seems unfamiliar): Config files are plain text that store settings — like a preference list for the app. You don't need to understand the format; just paste exactly what's shown below. Most apps have a Settings button that opens the file for you (see table). If the file is empty, paste the entire block. If it already has content, the agent should help merge it.
 
@@ -144,14 +186,23 @@ Make sure Step 2 is done (`uv --version` works).
 }
 ```
 
-**Config file locations:**
-
-> **Claude Code users**: skip manual MCP config — use the plugin instead. Invoke the `tooluniverse-claude-code-plugin` skill or run:
+> **Paste safely.** Copy the block whole — do not retype it. If the file already
+> has an `mcpServers` block, add only the `"tooluniverse": { ... }` entry inside
+> it and put a comma after the previous entry. If the file was empty, paste the
+> whole block. Then validate before restarting the app:
 > ```bash
-> claude plugin marketplace add mims-harvard/ToolUniverse
-> claude plugin install tooluniverse@tooluniverse
+> python3 -m json.tool < "<path-to-config>" > /dev/null && echo "JSON OK"
 > ```
-> This installs MCP server + 115 skills + slash commands in one step. Then see the `tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update" step so future releases apply without manual `claude plugin update`.
+> A trailing comma after the last entry, or a missing one between entries, is
+> the usual cause of "MCP server won't start".
+
+**`args` — `["tooluniverse"]` vs `["--refresh", "tooluniverse"]`**: plain is the
+default and starts fast from `uv`'s cache, but can stay on a cached older
+release until you run `uv cache clean tooluniverse`. Adding `--refresh` checks
+PyPI for the newest version on every launch — always current, a few seconds
+slower to start. Use plain unless the user specifically wants auto-updates.
+
+**Config file locations:**
 
 | Client | File | How to Access |
 |--------|------|---------------|
@@ -297,7 +348,7 @@ Skills activate automatically based on user's question. Try: "Research the drug 
 > tu info PubMed_search_articles  # Check parameters
 > tu run PubMed_search_articles '{"query": "CRISPR cancer", "max_results": 3}'
 > tu run UniProt_get_entry_by_accession '{"accession": "P12345"}'
-> tu run FAERS_count_death_related_by_drug '{"drug_name": "metformin"}'
+> tu run FAERS_count_death_related_by_drug '{"medicinalproduct": "metformin"}'
 > ```
 
 ## Write Agent Memory
@@ -347,13 +398,25 @@ NVIDIA_API_KEY=your_shared_key
 
 | Issue | Fix |
 |-------|-----|
+| `error: externally-managed-environment` (PEP 668) | System `pip` refuses to install. Use `uv` — `uv venv --python 3.12 && source .venv/bin/activate && uv pip install tooluniverse`. Never `sudo pip` or `--break-system-packages`. |
+| `python3 -m venv` fails at `ensurepip` | Homebrew Python (3.13/3.14) is missing a working `ensurepip`. Use `uv venv --python 3.12` — `uv` supplies its own Python. |
+| `uv pip install` → "No virtual environment found" | Run `uv venv` first, or use `uv tool install tooluniverse` for just the `tu` command. |
 | `requires-python >= 3.10` | `uv python install 3.12` |
 | `uvx: command not found` | Run install script from Step 2, restart terminal |
 | Context window overflow | Verify using `uvx tooluniverse` (compact mode is default) |
-| `ModuleNotFoundError` | `uv pip install tooluniverse[all]` |
-| MCP server won't start | Test: `uvx tooluniverse` in terminal. Check JSON syntax. |
+| `ModuleNotFoundError` at tool runtime | An optional extra is missing. Run `tooluniverse-doctor` to see which group, then `uv pip install 'tooluniverse[ml]'` (or `[visualization]`, `[bioinformatics]`, `[all]`). |
+| Tools listed but fail when run | Normal for extras-backed tools — `tu status` counts loaded configs, not installed dependencies. `tooluniverse-doctor` reports which groups are missing. |
+| MCP server won't start | Test: `uvx tooluniverse` in terminal. Validate config with `python3 -m json.tool < <config>`. |
 | API key 401/403 | Check key in `env` block, restart app, verify key name |
 | Upgrade needed | `uv cache clean tooluniverse` then restart app |
+
+**Health check**: `tooluniverse-doctor` reports tools that failed to load *and*
+which optional dependency groups are not installed. Use it first whenever a tool
+errors unexpectedly.
+
+**`[all]` is not everything**: it covers `dev, docs, graph, visualization,
+space, embedding, ml, bioinformatics`. `singlecell`, `smolagents`, `client`,
+and `build` must be installed by name.
 
 Still stuck? [GitHub issues](https://github.com/mims-harvard/ToolUniverse/issues) or email [Shanghua Gao](mailto:shanghuagao@gmail.com).
 

--- a/plugins/tooluniverse/skills/tooluniverse-admet-prediction/SKILL.md
+++ b/plugins/tooluniverse/skills/tooluniverse-admet-prediction/SKILL.md
@@ -27,6 +27,26 @@ Comprehensive pharmacokinetic and toxicity profiling integrating AI-based ADMET 
 
 **Input**: Drug name (e.g., "ibuprofen") OR SMILES string (e.g., "CC(C)Cc1ccc(cc1)C(C)C(=O)O")
 
+## Before You Run
+
+ADMETAI tools run a local model, so they need the `ml` extra:
+
+```bash
+uv pip install 'tooluniverse[ml]'
+```
+
+Without it the tools still appear in `tu list` (the config loads) but fail at
+call time with `ADMETModel requires 'admet-ai' package`. Run
+`tooluniverse-doctor` to confirm which optional groups are installed.
+
+**Expected console noise — not errors.** The first ADMETAI call loads PyTorch
+and prints warnings such as missing-GPU / `Trainer` messages from
+PyTorch Lightning, and `TypedStorage is deprecated` from PyTorch. These are
+emitted by the underlying libraries during normal CPU inference. Predictions
+are unaffected — do not report them to the user as failures and do not retry
+the call because of them. Only treat output as a failure if the tool returns an
+`error` field or no predictions.
+
 ---
 
 ## COMPUTE, DON'T DESCRIBE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,13 @@ dependencies = [
     "aiohttp",
     "beautifulsoup4>=4.12.0",
     "python-dotenv>=1.0.0",
+    # markitdown[all] (~32 MB: SpeechRecognition, youtube-transcript-api, pydub,
+    # azure-ai-documentintelligence). The [all] marker is deliberate: the
+    # convert_to_markdown tool takes an arbitrary http/https/file/data URI with no
+    # format allowlist, so every converter dropped here becomes a silent runtime
+    # failure for that input type. markitdown is also imported unconditionally at
+    # module scope by unified_guideline_tools.py, so it cannot move to an extra
+    # without guarding that import. Narrow only alongside those two changes.
     "markitdown[all]>=0.1.0",
     "psutil>=5.9.0",
     "ddgs>=9.0.0",

--- a/skills/setup-tooluniverse/SKILL.md
+++ b/skills/setup-tooluniverse/SKILL.md
@@ -62,7 +62,7 @@ Make sure Step 2 is done, then try:
 uvx --from tooluniverse tu status              # How many tools?
 uvx --from tooluniverse tu find 'drug safety'  # Search by topic
 uvx --from tooluniverse tu info FAERS_count_death_related_by_drug  # See params
-uvx --from tooluniverse tu run FAERS_count_death_related_by_drug '{"drug_name": "metformin"}'
+uvx --from tooluniverse tu run FAERS_count_death_related_by_drug '{"medicinalproduct": "metformin"}'
 ```
 
 First run takes ~30s (downloads package), then instant. **Shortcut**: `uv tool install tooluniverse` → then just use `tu` directly.
@@ -87,11 +87,29 @@ Continue to **Step 3** (API Keys).
 
 ## SDK Setup
 
-Make sure Step 2 is done. For detailed patterns, invoke the `tooluniverse-sdk` skill.
+> **Install `uv` first (Step 2). Do not use system `pip`.** On a current Mac
+> (Homebrew Python 3.13/3.14) `pip install tooluniverse` stops with
+> `error: externally-managed-environment` (PEP 668), and `python3 -m venv` can
+> fail at `ensurepip`. `uv` avoids both because it downloads and manages its own
+> Python.
 
 ```bash
+uv venv --python 3.12          # own Python + virtualenv, ignores system pip
+source .venv/bin/activate      # Windows: .venv\Scripts\activate
 uv pip install tooluniverse
 ```
+
+`uv pip install` needs an active virtualenv — run `uv venv` first, or use
+`uv tool install tooluniverse` if you only want the `tu` command.
+
+For detailed patterns, invoke the `tooluniverse-sdk` skill.
+
+**Optional extras**: the base install covers API/database tools. Local ML,
+cheminformatics, and plotting tools need extras — `uv pip install
+'tooluniverse[ml]'`, `[visualization]`, `[bioinformatics]`, or `[all]`.
+Run `tooluniverse-doctor` to see which groups you are missing.
+Note `[all]` does **not** include `singlecell`, `smolagents`, `client`, or
+`build`; install those separately.
 
 ### Coding API — 3 calling patterns
 
@@ -124,9 +142,33 @@ Continue to **Step 3** (API Keys).
 
 ## MCP Setup (Chat Mode)
 
-Make sure Step 2 is done (`uv --version` works).
+**Offer the two low-effort paths first.** Editing JSON by hand is the fallback,
+not the recommendation — a mistyped comma is the single most common setup
+failure. Only walk through the manual path if neither option below fits.
 
-### Add ToolUniverse to your app's config
+**Path A — let an AI agent do it.** If the user already has any agent (Claude,
+Cursor, Copilot, Gemini, Codex...), they can paste this into it:
+
+```
+Read https://aiscientist.tools/setup.md and set up ToolUniverse for me.
+```
+
+The agent handles config, keys, skills, and validation. No terminal, no JSON.
+
+**Path B — Claude Code users: one-liner, no config file at all.**
+
+```bash
+claude plugin marketplace add mims-harvard/ToolUniverse
+claude plugin install tooluniverse@tooluniverse
+```
+
+Installs MCP server + 115 skills + slash commands in one step. Then see the
+`tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update"
+step so future releases apply without manual `claude plugin update`.
+
+### Manual config (fallback)
+
+Make sure Step 2 is done (`uv --version` works).
 
 **Config file help** (if user seems unfamiliar): Config files are plain text that store settings — like a preference list for the app. You don't need to understand the format; just paste exactly what's shown below. Most apps have a Settings button that opens the file for you (see table). If the file is empty, paste the entire block. If it already has content, the agent should help merge it.
 
@@ -143,14 +185,23 @@ Make sure Step 2 is done (`uv --version` works).
 }
 ```
 
-**Config file locations:**
-
-> **Claude Code users**: skip manual MCP config — use the plugin instead. Invoke the `tooluniverse-claude-code-plugin` skill or run:
+> **Paste safely.** Copy the block whole — do not retype it. If the file already
+> has an `mcpServers` block, add only the `"tooluniverse": { ... }` entry inside
+> it and put a comma after the previous entry. If the file was empty, paste the
+> whole block. Then validate before restarting the app:
 > ```bash
-> claude plugin marketplace add mims-harvard/ToolUniverse
-> claude plugin install tooluniverse@tooluniverse
+> python3 -m json.tool < "<path-to-config>" > /dev/null && echo "JSON OK"
 > ```
-> This installs MCP server + 115 skills + slash commands in one step. Then see the `tooluniverse-claude-code-plugin` skill's "Recommended: turn on auto-update" step so future releases apply without manual `claude plugin update`.
+> A trailing comma after the last entry, or a missing one between entries, is
+> the usual cause of "MCP server won't start".
+
+**`args` — `["tooluniverse"]` vs `["--refresh", "tooluniverse"]`**: plain is the
+default and starts fast from `uv`'s cache, but can stay on a cached older
+release until you run `uv cache clean tooluniverse`. Adding `--refresh` checks
+PyPI for the newest version on every launch — always current, a few seconds
+slower to start. Use plain unless the user specifically wants auto-updates.
+
+**Config file locations:**
 
 | Client | File | How to Access |
 |--------|------|---------------|
@@ -296,7 +347,7 @@ Skills activate automatically based on user's question. Try: "Research the drug 
 > tu info PubMed_search_articles  # Check parameters
 > tu run PubMed_search_articles '{"query": "CRISPR cancer", "max_results": 3}'
 > tu run UniProt_get_entry_by_accession '{"accession": "P12345"}'
-> tu run FAERS_count_death_related_by_drug '{"drug_name": "metformin"}'
+> tu run FAERS_count_death_related_by_drug '{"medicinalproduct": "metformin"}'
 > ```
 
 ## Write Agent Memory
@@ -346,13 +397,25 @@ NVIDIA_API_KEY=your_shared_key
 
 | Issue | Fix |
 |-------|-----|
+| `error: externally-managed-environment` (PEP 668) | System `pip` refuses to install. Use `uv` — `uv venv --python 3.12 && source .venv/bin/activate && uv pip install tooluniverse`. Never `sudo pip` or `--break-system-packages`. |
+| `python3 -m venv` fails at `ensurepip` | Homebrew Python (3.13/3.14) is missing a working `ensurepip`. Use `uv venv --python 3.12` — `uv` supplies its own Python. |
+| `uv pip install` → "No virtual environment found" | Run `uv venv` first, or use `uv tool install tooluniverse` for just the `tu` command. |
 | `requires-python >= 3.10` | `uv python install 3.12` |
 | `uvx: command not found` | Run install script from Step 2, restart terminal |
 | Context window overflow | Verify using `uvx tooluniverse` (compact mode is default) |
-| `ModuleNotFoundError` | `uv pip install tooluniverse[all]` |
-| MCP server won't start | Test: `uvx tooluniverse` in terminal. Check JSON syntax. |
+| `ModuleNotFoundError` at tool runtime | An optional extra is missing. Run `tooluniverse-doctor` to see which group, then `uv pip install 'tooluniverse[ml]'` (or `[visualization]`, `[bioinformatics]`, `[all]`). |
+| Tools listed but fail when run | Normal for extras-backed tools — `tu status` counts loaded configs, not installed dependencies. `tooluniverse-doctor` reports which groups are missing. |
+| MCP server won't start | Test: `uvx tooluniverse` in terminal. Validate config with `python3 -m json.tool < <config>`. |
 | API key 401/403 | Check key in `env` block, restart app, verify key name |
 | Upgrade needed | `uv cache clean tooluniverse` then restart app |
+
+**Health check**: `tooluniverse-doctor` reports tools that failed to load *and*
+which optional dependency groups are not installed. Use it first whenever a tool
+errors unexpectedly.
+
+**`[all]` is not everything**: it covers `dev, docs, graph, visualization,
+space, embedding, ml, bioinformatics`. `singlecell`, `smolagents`, `client`,
+and `build` must be installed by name.
 
 Still stuck? [GitHub issues](https://github.com/mims-harvard/ToolUniverse/issues) or email [Shanghua Gao](mailto:shanghuagao@gmail.com).
 

--- a/skills/tooluniverse-admet-prediction/SKILL.md
+++ b/skills/tooluniverse-admet-prediction/SKILL.md
@@ -27,6 +27,26 @@ Comprehensive pharmacokinetic and toxicity profiling integrating AI-based ADMET 
 
 **Input**: Drug name (e.g., "ibuprofen") OR SMILES string (e.g., "CC(C)Cc1ccc(cc1)C(C)C(=O)O")
 
+## Before You Run
+
+ADMETAI tools run a local model, so they need the `ml` extra:
+
+```bash
+uv pip install 'tooluniverse[ml]'
+```
+
+Without it the tools still appear in `tu list` (the config loads) but fail at
+call time with `ADMETModel requires 'admet-ai' package`. Run
+`tooluniverse-doctor` to confirm which optional groups are installed.
+
+**Expected console noise — not errors.** The first ADMETAI call loads PyTorch
+and prints warnings such as missing-GPU / `Trainer` messages from
+PyTorch Lightning, and `TypedStorage is deprecated` from PyTorch. These are
+emitted by the underlying libraries during normal CPU inference. Predictions
+are unaffected — do not report them to the user as failures and do not retry
+the call because of them. Only treat output as a failure if the tool returns an
+`error` field or no predictions.
+
 ---
 
 ## COMPUTE, DON'T DESCRIBE

--- a/src/tooluniverse/cli.py
+++ b/src/tooluniverse/cli.py
@@ -635,6 +635,19 @@ def _render_status(d: dict) -> str:
         lines.append("\ntop categories:")
         for cat, cnt in top.items():
             lines.append(f"  {cat:<20} {cnt}")
+    # "tools loaded" counts registered configs, not runnable tools. Flag any
+    # optional dependency group that is missing so a partial install is visible.
+    gaps = d.get("missing_extras") or {}
+    if gaps:
+        lines.append(
+            f"\noptional deps:   {len(gaps)} group(s) not installed "
+            "(tools needing them will fail at runtime)"
+        )
+        for extra, packages in gaps.items():
+            lines.append(
+                f"  [{extra}]{'':<{max(0, 14 - len(extra))}} missing: {', '.join(packages)}"
+            )
+        lines.append("  run `tooluniverse-doctor` for details")
     return "\n".join(lines)
 
 
@@ -1289,6 +1302,9 @@ def cmd_status(args: argparse.Namespace) -> None:
             cat = _get_tool_category(tool, tool_name, tu)
             category_counts[cat] = category_counts.get(cat, 0) + 1
         gated_count = _count_gated_tools(tu)
+        from tooluniverse.extras import runtime_readiness
+
+        readiness = runtime_readiness(tu.all_tools)
     status = {
         "total_tools": len(tu.all_tools),
         "categories": len(category_counts),
@@ -1299,6 +1315,7 @@ def cmd_status(args: argparse.Namespace) -> None:
         ),
         "version": _TU_VERSION,
         "gated_tools_count": gated_count,
+        "missing_extras": readiness["missing_extras"],
     }
     _print_result(status, args, _render_status)
 

--- a/src/tooluniverse/data/enrichr_tools.json
+++ b/src/tooluniverse/data/enrichr_tools.json
@@ -19,7 +19,7 @@
           "items": {
             "type": "string"
           },
-          "description": "List of enrichment libraries to use for analysis.",
+          "description": "List of Enrichr enrichment libraries to query (e.g. 'KEGG_2021_Human', 'GO_Biological_Process_2023'). Omitting this or passing an empty list uses a broad default set of pathway/ontology libraries.",
           "default": [
             "WikiPathways_2024_Human",
             "Reactome_Pathways_2024",
@@ -40,11 +40,26 @@
           "BRCA1",
           "EGFR"
         ],
-        "libs": []
+        "libs": [
+          "KEGG_2021_Human"
+        ]
       }
     ],
     "return_schema": {
-      "type": "string"
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "connected_paths": {
+          "type": "object",
+          "description": "Ranked weighted paths between the first two genes routed through shared enrichment terms."
+        },
+        "connections": {
+          "type": "object",
+          "description": "Per gene-to-term connectivity paths found in the enrichment graph."
+        }
+      }
     }
   }
 ]

--- a/src/tooluniverse/doctor.py
+++ b/src/tooluniverse/doctor.py
@@ -1,6 +1,48 @@
 #!/usr/bin/env python3
 """ToolUniverse health checker."""
 
+import sys
+
+
+def _report_optional_dependencies(tool_configs) -> bool:
+    """Print the optional-dependency section. Returns True if everything is installed.
+
+    Loading a tool only registers its config; tools backed by an optional
+    dependency group stay listed as "available" but fail when run. Report those
+    groups so a partial install is not mistaken for a complete one.
+    """
+    try:
+        from .extras import runtime_readiness
+
+        readiness = runtime_readiness(tool_configs)
+    except Exception as exc:  # never let diagnostics break the health check
+        print(f"⚠️  Could not check optional dependencies: {exc}\n")
+        return True
+
+    if readiness["ready"]:
+        return True
+
+    gaps = readiness["missing_extras"]
+    affected = readiness["affected_tools"]
+    print(f"⚠️  {len(gaps)} optional dependency group(s) not installed:\n")
+    for extra, packages in gaps.items():
+        count = affected.get(extra)
+        scope = (
+            f"up to {count} tool(s) may not run"
+            if count
+            else "no currently-loaded tool needs it"
+        )
+        print(f"  📦 [{extra}] — {scope}")
+        print(f"     Missing: {', '.join(packages)}")
+        print(f"     Fix: pip install 'tooluniverse[{extra}]'")
+        print()
+
+    print(
+        "   Note: tool counts above are an upper bound — a few tools use these\n"
+        "   packages only as an enhancement and still work without them.\n"
+    )
+    return False
+
 
 def main() -> int:
     """Run ToolUniverse health checks and print a diagnostic report."""
@@ -18,32 +60,34 @@ def main() -> int:
         return 1
 
     print(f"📊 Total tools: {health['total']}")
-    print(f"✅ Available: {health['available']}")
-    print(f"❌ Unavailable: {health['unavailable']}\n")
+    print(f"✅ Config loaded: {health['available']}")
+    print(f"❌ Failed to load: {health['unavailable']}\n")
 
-    if health["unavailable"] == 0:
-        print("🎉 All tools loaded successfully!")
-        return 0
+    if health["unavailable"]:
+        print("⚠️  Tools that failed to load:\n")
 
-    print("⚠️  Unavailable tools:\n")
+        packages = set()
+        for tool_name in health["unavailable_list"]:
+            details = health["details"].get(tool_name, {})
+            print(f"  ❌ {tool_name}")
+            print(f"     Error: {details.get('error', 'Unknown')[:80]}")
+            if details.get("missing_package"):
+                pkg = details["missing_package"]
+                print(f"     Fix: pip install {pkg}")
+                packages.add(pkg)
+            print()
 
-    packages = set()
-    for tool_name in health["unavailable_list"]:
-        details = health["details"].get(tool_name, {})
-        print(f"  ❌ {tool_name}")
-        print(f"     Error: {details.get('error', 'Unknown')[:80]}")
-        if details.get("missing_package"):
-            pkg = details["missing_package"]
-            print(f"     Fix: pip install {pkg}")
-            packages.add(pkg)
-        print()
+        if packages:
+            print("💡 Bulk fix command:")
+            print(f"   pip install {' '.join(sorted(packages))}\n")
 
-    if packages:
-        print("💡 Bulk fix command:")
-        print(f"   pip install {' '.join(sorted(packages))}")
+    deps_ok = _report_optional_dependencies(getattr(tu, "all_tools", None))
+
+    if not health["unavailable"] and deps_ok:
+        print("🎉 All tools loaded and every optional dependency group is installed!")
 
     return 0
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/src/tooluniverse/enrichr_tool.py
+++ b/src/tooluniverse/enrichr_tool.py
@@ -15,6 +15,16 @@ class EnrichrTool(BaseTool):
     Tool to perform gene enrichment analysis using Enrichr.
     """
 
+    # Default enrichment libraries used when the caller does not specify any
+    # (or passes an empty list).
+    DEFAULT_LIBS = [
+        "WikiPathways_2024_Human",
+        "Reactome_Pathways_2024",
+        "MSigDB_Hallmark_2020",
+        "GO_Molecular_Function_2023",
+        "GO_Biological_Process_2023",
+    ]
+
     def __init__(self, tool_config):
         super().__init__(tool_config)
         # Constants
@@ -24,22 +34,24 @@ class EnrichrTool(BaseTool):
     def run(self, arguments):
         """Main entry point for the tool."""
         genes = arguments.get("gene_list")
-        libs = arguments.get(
-            "libs",
-            [
-                "WikiPathways_2024_Human",
-                "Reactome_Pathways_2024",
-                "MSigDB_Hallmark_2020",
-                "GO_Molecular_Function_2023",
-                "GO_Biological_Process_2023",
-            ],
-        )
+        # ``libs`` defaults to a broad set of pathway/ontology libraries. An
+        # explicitly-supplied empty list (e.g. ``"libs": []``) is treated as
+        # "use the default" rather than "query nothing" -- otherwise a valid
+        # call would silently return an empty enrichment wrapped in success.
+        libs = arguments.get("libs") or self.DEFAULT_LIBS
         connected_path, connections = self.enrichr_api(genes, libs)
-        # Convert to JSON string for schema compatibility
-        import json
-
-        result = {"connected_paths": connected_path, "connections": connections}
-        return {"status": "success", "data": json.dumps(result, indent=2)}
+        return {
+            "status": "success",
+            "data": {
+                "connected_paths": connected_path,
+                "connections": connections,
+            },
+            "metadata": {
+                "source": "Enrichr (maayanlab.cloud)",
+                "libraries": list(libs),
+                "gene_count": len(genes) if genes else 0,
+            },
+        }
 
     def get_official_gene_name(self, gene_name):
         """
@@ -55,7 +67,7 @@ class EnrichrTool(BaseTool):
         encoded_gene_name = urllib.parse.quote(gene_name)
         url = f"https://mygene.info/v3/query?q={encoded_gene_name}&fields=symbol,alias&species=human"
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         if response.status_code != 200:
             return f"Error querying MyGene.info API: {response.status_code}"
 
@@ -110,7 +122,7 @@ class EnrichrTool(BaseTool):
             "list": (None, gene_list),
             "description": (None, f"Gene list for {gene_list}"),
         }
-        response = requests.post(self.enrichr_url, files=payload)
+        response = requests.post(self.enrichr_url, files=payload, timeout=30)
 
         if not response.ok:
             return "Error submitting gene list to Enrichr"
@@ -129,7 +141,7 @@ class EnrichrTool(BaseTool):
             dict: The enrichment results.
         """
         query_string = f"?userListId={user_list_id}&backgroundType={library}"
-        response = requests.get(self.enrichment_url + query_string)
+        response = requests.get(self.enrichment_url + query_string, timeout=60)
 
         if not response.ok:
             return f"Error fetching enrichment results for {library}"

--- a/src/tooluniverse/extras.py
+++ b/src/tooluniverse/extras.py
@@ -1,0 +1,205 @@
+"""Introspection for ToolUniverse optional dependency groups ("extras").
+
+A tool being *loaded* is not the same as a tool being *runnable*.  Tool configs
+are registered from JSON at load time, so ``tu status`` and
+``tooluniverse-doctor`` happily count tools whose implementation needs an
+optional dependency that is not installed.  Those tools only fail later, when
+the user actually runs them.
+
+This module reports which optional dependency groups declared in
+``pyproject.toml`` are importable in the current environment, so the CLI can
+distinguish "config-loaded" from "runtime-ready".
+
+Keys are *import* names (what ``import x`` needs); values are the PyPI
+distribution names shown to users.  The mapping is kept in sync with
+``[project.optional-dependencies]`` by ``tests/unit/test_extras.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+# Optional dependency groups that gate *tool runtime*.  Packaging-only extras
+# (dev, docs, build) and the aggregate ``all`` extra are intentionally absent —
+# missing them says nothing about whether a tool can run.
+EXTRA_PACKAGES: dict[str, dict[str, str]] = {
+    "ml": {
+        "admet_ai": "admet-ai",
+        "sentence_transformers": "sentence-transformers",
+        "faiss": "faiss-cpu",
+        "huggingface_hub": "huggingface_hub",
+    },
+    "embedding": {
+        "sentence_transformers": "sentence-transformers",
+        "faiss": "faiss-cpu",
+        "huggingface_hub": "huggingface_hub",
+    },
+    "visualization": {
+        "py3Dmol": "py3Dmol",
+        "rdkit": "rdkit",
+        "plotly": "plotly",
+        "kaleido": "kaleido",
+        "scipy": "scipy",
+        "matplotlib": "matplotlib",
+        "networkx": "networkx",
+    },
+    "graph": {
+        "flask": "flask",
+        "matplotlib": "matplotlib",
+        "plotly": "plotly",
+        "scipy": "scipy",
+        "pydot": "pydot",
+        "pygraphviz": "pygraphviz",
+        "jinja2": "jinja2",
+        "werkzeug": "werkzeug",
+    },
+    "bioinformatics": {
+        "Bio": "biopython",
+        "freesasa": "freesasa",
+    },
+    "singlecell": {
+        "cellxgene_census": "cellxgene-census",
+        "tiledbsoma": "tiledbsoma",
+    },
+    "smolagents": {
+        "smolagents": "smolagents",
+        "gradio": "gradio",
+    },
+}
+
+# Extras NOT covered by ``tooluniverse[all]`` — worth telling users about,
+# because "all" reads like it means all.
+EXTRAS_NOT_IN_ALL = ("singlecell", "smolagents", "client", "build")
+
+
+def _is_importable(import_name: str) -> bool:
+    """Return True if *import_name* can be located without importing it."""
+    try:
+        return importlib.util.find_spec(import_name) is not None
+    except (ImportError, ValueError, AttributeError):
+        # A partially-installed or shadowed package can raise here; treat it
+        # as unavailable rather than crashing the health check.
+        return False
+
+
+def missing_packages() -> dict[str, str]:
+    """Map every missing import name to its PyPI distribution name."""
+    missing: dict[str, str] = {}
+    for packages in EXTRA_PACKAGES.values():
+        for import_name, pypi_name in packages.items():
+            if import_name not in missing and not _is_importable(import_name):
+                missing[import_name] = pypi_name
+    return missing
+
+
+def missing_extras() -> dict[str, list[str]]:
+    """Map each incompletely-installed extra to its missing PyPI names.
+
+    Extras whose dependencies are all importable are omitted, so an empty
+    result means every runtime extra is satisfied.
+    """
+    absent = missing_packages()
+    result: dict[str, list[str]] = {}
+    for extra, packages in EXTRA_PACKAGES.items():
+        gaps = sorted(
+            pypi_name
+            for import_name, pypi_name in packages.items()
+            if import_name in absent
+        )
+        if gaps:
+            result[extra] = gaps
+    return result
+
+
+def _module_source_path(module_name: str) -> Path | None:
+    """Resolve a ``tooluniverse``-relative module name to its source file."""
+    try:
+        import tooluniverse
+
+        root = Path(tooluniverse.__file__).parent
+    except (ImportError, AttributeError, TypeError):
+        return None
+    candidate = root / (module_name.replace(".", "/") + ".py")
+    return candidate if candidate.is_file() else None
+
+
+def tools_needing_missing_packages(
+    tool_configs: Iterable[dict],
+    absent: dict[str, str] | None = None,
+) -> dict[str, int]:
+    """Count loaded tools whose implementation module imports a missing package.
+
+    Returns a mapping of extra name to the number of affected tools.  This is
+    an **upper bound**: a handful of tools import an optional package only as
+    an enhancement and still work without it (for example the DNA tools fall
+    back to a built-in restriction-enzyme table when Biopython is absent).
+    Callers should present the number as "may not run", never as a failure
+    count.
+
+    Returns an empty mapping when nothing is missing, so the (cheap) source
+    scan is skipped entirely on a fully-installed environment.
+    """
+    if absent is None:
+        absent = missing_packages()
+    if not absent:
+        return {}
+
+    from .tool_registry import _lazy_registry
+
+    pattern = re.compile(
+        r"^\s*(?:import|from)\s+(" + "|".join(map(re.escape, absent)) + r")\b",
+        re.MULTILINE,
+    )
+
+    scanned: dict[str, frozenset] = {}
+
+    def packages_used(module_name: str) -> frozenset:
+        if module_name not in scanned:
+            path = _module_source_path(module_name)
+            found: frozenset = frozenset()
+            if path is not None:
+                try:
+                    found = frozenset(pattern.findall(path.read_text(encoding="utf-8")))
+                except (OSError, UnicodeDecodeError):
+                    found = frozenset()
+            scanned[module_name] = found
+        return scanned[module_name]
+
+    counts: dict[str, int] = {}
+    for config in tool_configs:
+        module_name = _lazy_registry.get(config.get("type"))
+        if not module_name:
+            continue
+        for import_name in packages_used(module_name):
+            for extra, packages in EXTRA_PACKAGES.items():
+                if import_name in packages:
+                    counts[extra] = counts.get(extra, 0) + 1
+    return counts
+
+
+def runtime_readiness(tool_configs: Iterable[dict] | None = None) -> dict:
+    """Summarize whether optional tool dependencies are installed.
+
+    Args:
+        tool_configs: Loaded tool config dicts. When supplied, the result
+            includes per-extra counts of tools that may not run.
+
+    Returns a dict with ``ready`` (bool), ``missing_extras`` (extra -> missing
+    PyPI names), ``affected_tools`` (extra -> upper-bound tool count), and
+    ``install_hints`` (pip install strings).
+    """
+    gaps = missing_extras()
+    affected = (
+        tools_needing_missing_packages(tool_configs)
+        if (tool_configs is not None and gaps)
+        else {}
+    )
+    return {
+        "ready": not gaps,
+        "missing_extras": gaps,
+        "affected_tools": affected,
+        "install_hints": [f"pip install 'tooluniverse[{extra}]'" for extra in gaps],
+    }

--- a/src/tooluniverse/hpo_tool.py
+++ b/src/tooluniverse/hpo_tool.py
@@ -306,18 +306,29 @@ class HPOTool(BaseTool):
         if not query:
             return {"status": "error", "error": "query parameter is required"}
 
-        max_results = arguments.get("max_results", 10)
-        if max_results > 50:
-            max_results = 50
+        # Coerce max_results robustly: the schema allows integer|null, so a
+        # caller may omit it, pass null, or pass an out-of-range value. Using
+        # the raw value directly would crash on None (None > 50) and let
+        # negatives/zero through.
+        try:
+            max_results = int(arguments.get("max_results") or 10)
+        except (TypeError, ValueError):
+            max_results = 10
+        max_results = max(1, min(max_results, 50))
 
         url = f"{HPO_BASE_URL}/search"
-        params = {"q": query, "max": max_results}
+        # The JAX ontology search endpoint sizes the page with `limit`. The
+        # previous `max` key was silently ignored, capping every result set at
+        # the API default of 10 regardless of the requested count.
+        params = {"q": query, "limit": max_results}
 
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
         data = response.json()
 
-        terms = data.get("terms", [])
+        # Defensive truncation in case an upstream change ever returns more
+        # rows than requested.
+        terms = data.get("terms", [])[:max_results]
         results = []
         for term in terms:
             results.append(
@@ -337,6 +348,10 @@ class HPOTool(BaseTool):
                 "source": "HPO (JAX Ontology)",
                 "query": query,
                 "total_results": len(results),
+                # Total matches available across all pages (the API reports this
+                # as `totalCount`), so callers can see more terms exist beyond
+                # the returned page instead of assuming this page is exhaustive.
+                "total_available": data.get("totalCount", len(results)),
             },
         }
 

--- a/tests/unit/test_enrichr_empty_libs.py
+++ b/tests/unit/test_enrichr_empty_libs.py
@@ -1,0 +1,101 @@
+"""Regression tests for enrichr_gene_enrichment_analysis input/output handling.
+
+Two confirmed defects in the freshly-wrapped 1.4.0 tool:
+
+* An explicit empty ``libs`` list (which is the tool's own documented example,
+  ``{"gene_list": [...], "libs": []}``) queried zero libraries and returned an
+  empty enrichment wrapped in ``status: success`` -- the "valid input silently
+  returns empty as success" class. Empty/omitted ``libs`` must fall back to the
+  default library set.
+* ``data`` was a double-JSON-encoded string (``json.dumps(result)``), forcing
+  every consumer to ``json.loads`` a second time, inconsistent with every other
+  ToolUniverse tool. ``data`` must be a structured object.
+
+These are unit-level (``run`` logic) and mock out the network via ``enrichr_api``.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    from tooluniverse.enrichr_tool import EnrichrTool
+
+    return EnrichrTool(
+        {"name": "enrichr_gene_enrichment_analysis", "type": "EnrichrTool"}
+    )
+
+
+_FAKE_RESULT = (
+    {"Path: ['TP53', 'term', 'BRCA1']": "Total Weight: 12.0"},
+    {"Connectivity: TP53 - term": [[["TP53", "term"], 1]]},
+)
+
+
+class TestEnrichrLibsFallback(unittest.TestCase):
+    def test_empty_libs_falls_back_to_default(self):
+        """libs=[] must query the default library set, not zero libraries."""
+        from tooluniverse.enrichr_tool import EnrichrTool
+
+        tool = _tool()
+        with patch.object(
+            type(tool), "enrichr_api", return_value=_FAKE_RESULT
+        ) as api:
+            tool.run({"gene_list": ["TP53", "BRCA1"], "libs": []})
+        called_libs = api.call_args.args[1]
+        self.assertEqual(called_libs, EnrichrTool.DEFAULT_LIBS)
+
+    def test_omitted_libs_falls_back_to_default(self):
+        """Omitting libs also uses the default set."""
+        from tooluniverse.enrichr_tool import EnrichrTool
+
+        tool = _tool()
+        with patch.object(
+            type(tool), "enrichr_api", return_value=_FAKE_RESULT
+        ) as api:
+            tool.run({"gene_list": ["TP53", "BRCA1"]})
+        self.assertEqual(api.call_args.args[1], EnrichrTool.DEFAULT_LIBS)
+
+    def test_explicit_libs_used_verbatim(self):
+        """A non-empty libs list is passed through unchanged."""
+        tool = _tool()
+        with patch.object(
+            type(tool), "enrichr_api", return_value=_FAKE_RESULT
+        ) as api:
+            tool.run(
+                {"gene_list": ["TP53", "BRCA1"], "libs": ["KEGG_2021_Human"]}
+            )
+        self.assertEqual(api.call_args.args[1], ["KEGG_2021_Human"])
+
+
+class TestEnrichrOutputShape(unittest.TestCase):
+    def test_data_is_structured_object_not_string(self):
+        """data must be a dict with connected_paths/connections, not a JSON string."""
+        tool = _tool()
+        with patch.object(type(tool), "enrichr_api", return_value=_FAKE_RESULT):
+            result = tool.run({"gene_list": ["TP53", "BRCA1"], "libs": ["X"]})
+        self.assertEqual(result["status"], "success")
+        data = result["data"]
+        self.assertIsInstance(data, dict)
+        self.assertIn("connected_paths", data)
+        self.assertIn("connections", data)
+        self.assertIsInstance(data["connected_paths"], dict)
+
+    def test_metadata_reports_libraries_and_gene_count(self):
+        """metadata surfaces the libraries queried and the gene count."""
+        tool = _tool()
+        with patch.object(type(tool), "enrichr_api", return_value=_FAKE_RESULT):
+            result = tool.run(
+                {"gene_list": ["TP53", "BRCA1"], "libs": ["KEGG_2021_Human"]}
+            )
+        meta = result["metadata"]
+        self.assertEqual(meta["libraries"], ["KEGG_2021_Human"])
+        self.assertEqual(meta["gene_count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_extras.py
+++ b/tests/unit/test_extras.py
@@ -1,0 +1,290 @@
+"""Tests for optional-dependency ("extras") reporting.
+
+Covers the distinction between a tool being *config-loaded* and being
+*runtime-ready*: tools backed by an uninstalled optional dependency register
+fine and only fail when run, so the health check must not report an all-clear.
+"""
+
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse import extras
+from tooluniverse.extras import (
+    EXTRA_PACKAGES,
+    EXTRAS_NOT_IN_ALL,
+    missing_extras,
+    missing_packages,
+    runtime_readiness,
+    tools_needing_missing_packages,
+)
+
+PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _raw_pyproject_extras():
+    """Return the raw {extra: [requirement strings]} table from pyproject.toml."""
+    try:
+        import tomllib
+    except ImportError:  # Python < 3.11
+        pytest.skip("tomllib unavailable")
+    with open(PYPROJECT, "rb") as fh:
+        data = tomllib.load(fh)
+    return data["project"]["optional-dependencies"]
+
+
+def _load_pyproject_extras():
+    """Return {extra: [normalized pypi names]} from pyproject.toml."""
+    result = {}
+    for extra, requirements in _raw_pyproject_extras().items():
+        names = []
+        for requirement in requirements:
+            # Strip version specifiers / markers / extras: "faiss-cpu==1.12.0"
+            name = re.split(r"[<>=!~;\[]", requirement, maxsplit=1)[0].strip()
+            names.append(name.lower().replace("_", "-"))
+        result[extra] = names
+    return result
+
+
+def _extras_included_in_all():
+    """Return the set of extras that ``tooluniverse[all]`` pulls in.
+
+    ``all`` is declared as a self-referential requirement,
+    ``tooluniverse[dev,docs,...]``, so the extra names live inside the
+    brackets rather than in separate list entries.
+    """
+    included = set()
+    for requirement in _raw_pyproject_extras()["all"]:
+        match = re.search(r"\[([^\]]+)\]", requirement)
+        if match:
+            included.update(part.strip() for part in match.group(1).split(","))
+    return included
+
+
+def _normalize(name: str) -> str:
+    return name.lower().replace("_", "-")
+
+
+class TestExtrasMatchPyproject:
+    """EXTRA_PACKAGES must stay in sync with [project.optional-dependencies]."""
+
+    def test_every_extra_is_declared(self):
+        declared = _load_pyproject_extras()
+        for extra in EXTRA_PACKAGES:
+            assert extra in declared, f"'{extra}' is not declared in pyproject.toml"
+
+    def test_every_package_is_declared_in_its_extra(self):
+        declared = _load_pyproject_extras()
+        for extra, packages in EXTRA_PACKAGES.items():
+            for pypi_name in packages.values():
+                assert _normalize(pypi_name) in declared[extra], (
+                    f"'{pypi_name}' is mapped to extra '{extra}' but is not "
+                    f"listed under that extra in pyproject.toml"
+                )
+
+    def test_extras_not_in_all_is_accurate(self):
+        """`[all]` is a misnomer; verify the documented exclusion list."""
+        declared = _load_pyproject_extras()
+        included = _extras_included_in_all()
+        assert included, "could not parse the [all] extra"
+        for extra in EXTRAS_NOT_IN_ALL:
+            assert extra in declared, f"'{extra}' is not a real extra"
+            assert extra not in included, (
+                f"'{extra}' IS covered by [all]; remove it from EXTRAS_NOT_IN_ALL"
+            )
+
+    def test_all_covers_everything_else(self):
+        """Any extra absent from [all] must be documented in EXTRAS_NOT_IN_ALL."""
+        declared = _load_pyproject_extras()
+        included = _extras_included_in_all()
+        for extra in declared:
+            if extra == "all" or extra in included:
+                continue
+            assert extra in EXTRAS_NOT_IN_ALL, (
+                f"'{extra}' is not covered by [all] and is not listed in "
+                f"EXTRAS_NOT_IN_ALL"
+            )
+
+
+class TestMissingDetection:
+    def test_nothing_missing_when_all_importable(self):
+        with patch.object(extras, "_is_importable", return_value=True):
+            assert missing_packages() == {}
+            assert missing_extras() == {}
+
+    def test_all_missing_when_none_importable(self):
+        with patch.object(extras, "_is_importable", return_value=False):
+            gaps = missing_extras()
+        assert set(gaps) == set(EXTRA_PACKAGES)
+        assert "biopython" in gaps["bioinformatics"]
+
+    def test_single_missing_package_flags_only_its_extras(self):
+        def only_rdkit_missing(name):
+            return name != "rdkit"
+
+        with patch.object(extras, "_is_importable", side_effect=only_rdkit_missing):
+            gaps = missing_extras()
+        assert gaps == {"visualization": ["rdkit"]}
+
+    def test_shared_package_flags_every_extra_that_needs_it(self):
+        def only_matplotlib_missing(name):
+            return name != "matplotlib"
+
+        with patch.object(
+            extras, "_is_importable", side_effect=only_matplotlib_missing
+        ):
+            gaps = missing_extras()
+        assert set(gaps) == {"visualization", "graph"}
+
+    def test_importable_check_survives_broken_package(self):
+        with patch(
+            "importlib.util.find_spec", side_effect=ValueError("broken __spec__")
+        ):
+            assert extras._is_importable("anything") is False
+
+
+class TestRuntimeReadiness:
+    def test_ready_when_nothing_missing(self):
+        with patch.object(extras, "_is_importable", return_value=True):
+            readiness = runtime_readiness([])
+        assert readiness["ready"] is True
+        assert readiness["missing_extras"] == {}
+        assert readiness["install_hints"] == []
+
+    def test_not_ready_when_something_missing(self):
+        with patch.object(extras, "_is_importable", return_value=False):
+            readiness = runtime_readiness(None)
+        assert readiness["ready"] is False
+        assert readiness["missing_extras"]
+        assert "pip install 'tooluniverse[ml]'" in readiness["install_hints"]
+
+    def test_affected_tools_skipped_without_configs(self):
+        with patch.object(extras, "_is_importable", return_value=False):
+            readiness = runtime_readiness(None)
+        assert readiness["affected_tools"] == {}
+
+
+class TestToolCounting:
+    def test_no_scan_when_nothing_missing(self):
+        configs = [{"name": "T", "type": "ADMETAITool"}]
+        assert tools_needing_missing_packages(configs, absent={}) == {}
+
+    def test_counts_tools_whose_module_imports_missing_package(self):
+        configs = [
+            {"name": "A", "type": "ADMETAITool"},
+            {"name": "B", "type": "ADMETAITool"},
+        ]
+        counts = tools_needing_missing_packages(
+            configs, absent={"admet_ai": "admet-ai"}
+        )
+        assert counts.get("ml") == 2
+
+    def test_ignores_tools_with_unknown_type(self):
+        configs = [{"name": "X", "type": "NoSuchToolTypeAnywhere"}]
+        counts = tools_needing_missing_packages(
+            configs, absent={"admet_ai": "admet-ai"}
+        )
+        assert counts == {}
+
+    def test_ignores_tools_not_using_the_missing_package(self):
+        """A plain REST tool must not be blamed on a missing ML package."""
+        configs = [{"name": "R", "type": "RESTTool"}]
+        counts = tools_needing_missing_packages(
+            configs, absent={"admet_ai": "admet-ai"}
+        )
+        assert counts == {}
+
+
+class TestDoctorOutput:
+    """The regression this fixes: a false all-clear on a partial install."""
+
+    def _run_doctor(self, health, importable):
+        from tooluniverse import doctor
+
+        class FakeTU:
+            all_tools = [{"name": "A", "type": "ADMETAITool"}]
+
+            def load_tools(self):
+                pass
+
+            def get_tool_health(self):
+                return health
+
+        with (
+            patch("tooluniverse.ToolUniverse", return_value=FakeTU()),
+            patch.object(extras, "_is_importable", side_effect=importable),
+        ):
+            import io
+            from contextlib import redirect_stdout
+
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                code = doctor.main()
+            return code, buffer.getvalue()
+
+    HEALTHY = {
+        "total": 100,
+        "available": 100,
+        "unavailable": 0,
+        "unavailable_list": [],
+        "details": {},
+    }
+
+    def test_no_false_all_clear_when_extra_missing(self):
+        code, output = self._run_doctor(
+            self.HEALTHY, importable=lambda name: name != "admet_ai"
+        )
+        assert code == 0
+        assert "optional dependency group(s) not installed" in output
+        assert "pip install 'tooluniverse[ml]'" in output
+        assert "All tools loaded and every optional dependency" not in output
+
+    def test_all_clear_only_when_fully_installed(self):
+        code, output = self._run_doctor(self.HEALTHY, importable=lambda name: True)
+        assert code == 0
+        assert "All tools loaded and every optional dependency group is installed!" in (
+            output
+        )
+        assert "not installed" not in output
+
+    def test_load_failures_still_reported(self):
+        health = {
+            "total": 100,
+            "available": 99,
+            "unavailable": 1,
+            "unavailable_list": ["BrokenTool"],
+            "details": {
+                "BrokenTool": {
+                    "error": "No module named 'torch'",
+                    "missing_package": "torch",
+                }
+            },
+        }
+        code, output = self._run_doctor(health, importable=lambda name: True)
+        assert code == 0
+        assert "BrokenTool" in output
+        assert "pip install torch" in output
+        assert "All tools loaded and every optional dependency" not in output
+
+    def test_reports_both_failures_and_missing_extras(self):
+        health = {
+            "total": 100,
+            "available": 99,
+            "unavailable": 1,
+            "unavailable_list": ["BrokenTool"],
+            "details": {"BrokenTool": {"error": "boom", "missing_package": None}},
+        }
+        code, output = self._run_doctor(
+            health, importable=lambda name: name != "admet_ai"
+        )
+        assert code == 0
+        assert "BrokenTool" in output
+        assert "[ml]" in output
+
+    def test_initialization_failure_returns_1(self):
+        from tooluniverse import doctor
+
+        with patch("tooluniverse.ToolUniverse", side_effect=Exception("nope")):
+            assert doctor.main() == 1

--- a/tests/unit/test_hpo_search_terms_limit.py
+++ b/tests/unit/test_hpo_search_terms_limit.py
@@ -1,0 +1,119 @@
+"""Regression tests for HPO_search_terms result-count handling (mocked HTTP).
+
+The JAX ontology search endpoint (ontology.jax.org/api/hp/search) sizes the
+returned page with the ``limit`` query parameter. The tool previously sent
+``max``, which the API silently ignores, so every result set was capped at the
+API default of 10 regardless of the requested ``max_results`` -- a valid input
+silently returning truncated data wrapped in ``status: success``. These tests
+lock in that ``max_results`` is honored (sent as ``limit``), bounded safely,
+and that the true total match count is surfaced.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _hpo_search_tool():
+    from tooluniverse.hpo_tool import HPOTool
+
+    return HPOTool(
+        {
+            "name": "HPO_search_terms",
+            "type": "HPOTool",
+            "fields": {"endpoint": "search_terms"},
+        }
+    )
+
+
+def _search_resp(n_terms, total_count):
+    """Mock a JAX /hp/search response carrying ``n_terms`` rows."""
+    terms = [
+        {
+            "id": f"HP:{i:07d}",
+            "name": f"term {i}",
+            "definition": f"def {i}",
+            "descendantCount": i,
+            "synonyms": [],
+        }
+        for i in range(n_terms)
+    ]
+    r = MagicMock()
+    r.status_code = 200
+    r.raise_for_status.return_value = None
+    r.json.return_value = {"terms": terms, "totalCount": total_count}
+    return r
+
+
+class TestHPOSearchTermsLimit(unittest.TestCase):
+    def test_max_results_sent_as_limit_not_max(self):
+        """max_results must reach the API as ``limit`` (never the ignored ``max``)."""
+        tool = _hpo_search_tool()
+        with patch(
+            "tooluniverse.hpo_tool.requests.get",
+            return_value=_search_resp(25, 100),
+        ) as get:
+            result = tool.run({"query": "seizure", "max_results": 25})
+
+        params = get.call_args.kwargs["params"]
+        self.assertEqual(params.get("limit"), 25)
+        self.assertNotIn("max", params)
+        self.assertEqual(params.get("q"), "seizure")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(len(result["data"]), 25)
+
+    def test_total_available_surfaces_true_total(self):
+        """metadata exposes the API totalCount, not just the returned page size."""
+        tool = _hpo_search_tool()
+        with patch(
+            "tooluniverse.hpo_tool.requests.get",
+            return_value=_search_resp(10, 100),
+        ):
+            result = tool.run({"query": "seizure", "max_results": 10})
+
+        meta = result["metadata"]
+        self.assertEqual(meta["total_results"], 10)
+        self.assertEqual(meta["total_available"], 100)
+
+    def test_response_truncated_defensively(self):
+        """If upstream ever over-returns, the tool truncates to max_results."""
+        tool = _hpo_search_tool()
+        with patch(
+            "tooluniverse.hpo_tool.requests.get",
+            return_value=_search_resp(40, 100),
+        ):
+            result = tool.run({"query": "seizure", "max_results": 5})
+        self.assertEqual(len(result["data"]), 5)
+
+    def test_null_max_results_defaults_without_crashing(self):
+        """max_results=null (schema allows integer|null) must default, not crash."""
+        tool = _hpo_search_tool()
+        with patch(
+            "tooluniverse.hpo_tool.requests.get",
+            return_value=_search_resp(10, 100),
+        ) as get:
+            result = tool.run({"query": "seizure", "max_results": None})
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(get.call_args.kwargs["params"]["limit"], 10)
+
+    def test_max_results_clamped_to_bounds(self):
+        """Over-max clamps to 50; zero/negative clamps up to 1."""
+        for requested, expected_limit in [(999, 50), (0, 10), (-5, 1)]:
+            tool = _hpo_search_tool()
+            with patch(
+                "tooluniverse.hpo_tool.requests.get",
+                return_value=_search_resp(1, 100),
+            ) as get:
+                tool.run({"query": "seizure", "max_results": requested})
+            self.assertEqual(
+                get.call_args.kwargs["params"]["limit"],
+                expected_limit,
+                msg=f"max_results={requested}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Consolidates two independently-reviewed, green post-1.4.0 branches into a single PR so the merge is one action instead of two. The two source branches touch **zero overlapping files**, so this is a straight union of their changes — each commit is preserved verbatim and every file matches its source branch byte-for-byte.

**Supersedes #391 and #392.**

---

# Section 1 — Bug-hunt fixes (from #391)

Post-1.4.0 role-play round targeting the 436 tool wrappers newly exposed in #389 (previously registered-but-unwrapped tools that had never been through a role-play). Three researcher personas (rare-disease geneticist, clinical pharmacologist, functional genomicist) exercised ~64 tool calls across ~30 families via the CLI. Every reported issue was CLI-reproduced before being fixed; false positives and upstream-outage artifacts were discarded.

**Net: 3 confirmed defects fixed** (1 HIGH, 2 MEDIUM), all in the "a valid input silently returns empty/wrong data as a success" class, plus a robustness hardening.

### 1. `HPO_search_terms` silently ignored `max_results` (HIGH)

`hpo_tool.py` sent the page size to the JAX ontology search endpoint as `max`, but that endpoint sizes pages with `limit`. The `max` key was silently ignored, so **every** search was capped at the API default of 10 regardless of the requested `max_results`, and `metadata.total_results` reported 10 even when 100 matches existed — a clinician would believe only 10 phenotype terms exist for a query.

CLI verification (live JAX API):

```
{'q':'seizure','max':3}   -> 10 terms  (ignored)
{'q':'seizure','limit':3} -> 3 terms   (honored)
{'q':'seizure','limit':50}-> 50 terms
totalCount = 100 in all cases
```

Fix: send `limit`; coerce `max_results` robustly (null / 0 / negative / over-max no longer crash or leak through); truncate defensively; surface the true total as `metadata.total_available`.

After fix: `max_results` 3→3, 20→20, 50→50; default→10; `null`→10 (no crash); 999→50; -5→1; `total_available`=100.

### 2. `enrichr_gene_enrichment_analysis` empty `libs` returned empty as success (MEDIUM)

`libs = arguments.get("libs", DEFAULT)` — passing `libs: []` (the tool's **own documented example**) returned `[]`, so zero libraries were queried and an empty enrichment was wrapped in `status: success`. Fix: empty or omitted `libs` now falls back to the default library set, and the documented example uses a real library.

Before: documented example → `connected_paths: {}`, only trivial self-loops. After: 20 ranked connectivity paths from the 5 default libraries.

### 3. `enrichr_gene_enrichment_analysis` returned double-JSON-encoded `data` (MEDIUM)

`data` was `json.dumps(result)` — a JSON **string**, forcing every consumer to `json.loads` a second time, inconsistent with every other ToolUniverse tool; `return_schema` was merely `{"type": "string"}`, which does not describe the `{status, data}` envelope. Fix: return `data` as a structured object with a `metadata` block, and update `return_schema` to describe it.

### 4. Enrichr request timeouts (robustness)

The `requests.get/post` calls in `enrichr_tool.py` passed no `timeout=`; a persona observed one run stall past 140s while an identical later run finished in ~8s. Added timeouts so a stalled upstream cannot hang indefinitely.

### Verified false positives / not fixed (for the record)

- Inconsistent gene-symbol param names across families (`gene` / `gene_symbol` / `symbol`) — friction only; errors are clear and actionable. Cross-family aliasing is an anti-pattern; left as a separate design-consistency concern.
- EnsemblPheno / Pharos / FAERS / FDA-label errors were confirmed **upstream outages**, not tool defects — the tools surfaced clean errors.
- EVA / GTEx / ClinVar / GBIF / ClinGen / PanglaoDB / ReactomeAnalysis empties were confirmed **genuine upstream sparseness**, verified against the raw APIs.

---

# Section 2 — Onboarding fixes (from #392)

Fixes the papercuts a non-CS user hits between `pip install` and a first working tool call. Each finding was reproduced on the current tree before being fixed.

### 1. The setup guide's first example used the wrong parameter

`skills/setup-tooluniverse/SKILL.md` (and its two mirrors) told users to run `FAERS_count_death_related_by_drug` with `drug_name`, but the tool's config requires `medicinalproduct`:

```
$ tu run FAERS_count_death_related_by_drug '{"drug_name": "metformin"}'
Error: Parameter validation failed for 'root': 'medicinalproduct' is a required property

$ tu run FAERS_count_death_related_by_drug '{"medicinalproduct": "metformin"}'
{"result": [{"term": "alive", "count": 110696}, {"term": "death", "count": 37537}]}
```

Fixed all 6 occurrences across `skills/`, `plugin/skills/`, and `plugins/tooluniverse/skills/`. This was the scripted "it works!" moment, so it errored for everyone who followed the guide verbatim.

### 2. `tooluniverse-doctor` / `tu status` falsely reported an all-clear

Loading a tool registers its JSON config; it does not install the tool's dependencies. Tools backed by an optional extra were counted as available and only failed at call time — the report said `Available: 2599 / Unavailable: 0` while `ADMETAI_predict_BBB_penetrance` failed with `ADMETModel requires 'admet-ai' package`.

A new `tooluniverse.extras` module resolves each declared extra against the environment. The all-clear now prints only when nothing failed to load **and** every group is installed; the report names each missing group with its install command. `tu status` shows the same summary, and `tu status --json` exposes a `missing_extras` field.

Verified against a real install, not just mocks — installing `biopython` + `freesasa` moved the report from 7 groups to 6, with `[bioinformatics]` dropping out. Counts are deliberately framed as an upper bound, since a few tools import an optional package only as an enhancement.

### 3. Naive `pip install` is a trap on a modern Mac

Both symptoms reproduce on a current macOS box (Homebrew Python 3.14.6): `python3 -m venv` fails with `ensurepip ... returned non-zero exit status 1`, and `pip install` hits PEP 668 `externally-managed-environment`. `uv` is now an explicit, loud prerequisite on the SDK/Python-developer install line in both the README and the setup skill, with `uv venv --python 3.12` shown. Added troubleshooting entries for both errors plus the "loads but fails when run" case.

### 4. The "no-code" chat path led with hand-editing JSON

Reframed so the two genuinely low-friction paths come first — asking an existing AI agent to read `setup.md`, and the Claude Code plugin one-liner — with manual JSON demoted to a documented fallback. The manual path is kept, now with a copy-paste-safe snippet and a `python3 -m json.tool` validation step, since "JSON syntax error" is a top reported failure.

### 5. Base-install bloat — documented, not changed

`markitdown[all]` does pull in ~32 MB. **Deliberately not narrowed:** `convert_to_markdown` accepts an arbitrary URI with no format allowlist, so every converter dropped from `[all]` becomes a silent runtime failure rather than a clean error; and `markitdown` is imported unconditionally at module scope by `unified_guideline_tools.py`, so it cannot move to an extra without guarding that import first. Both constraints are recorded as a comment in `pyproject.toml`. Narrowing is a real opportunity but needs its own change with format coverage tests.

### Minor

- `[all]` is a misnomer — it excludes `singlecell`, `smolagents`, `client`, and `build`. Noted wherever `[all]` is recommended, with a test asserting the exclusion list stays accurate against `pyproject.toml`.
- Reconciled README's `["--refresh", "tooluniverse"]` against the setup skill's `["tooluniverse"]` by documenting the tradeoff in both places.
- Added a note that PyTorch Lightning warnings during ADMET calls are normal, not failures.

---

# Consolidation verification

- **File set is exactly the 19-file union** of the two branches (5 from #391 + 14 from #392), confirmed against `git diff --name-only origin/main...HEAD`. No third-branch content, no `src/tooluniverse/tools/` wrapper churn, no `uv.lock` drift.
- **Content is byte-identical to each source branch**: `git diff <source-branch> HEAD -- <that branch's files>` is empty for both.
- **No conflicts** — the two file sets are disjoint.
- All 6 touched `SKILL.md` files retain intact frontmatter (checked explicitly against the folded-`description` corruption mode fixed in #390).

## Testing

`tests/unit` on the combined tree: **3251 passed, 10 skipped, 11 deselected, 0 failed** (exit 0, 138s).

Includes both branches' new tests — `test_hpo_search_terms_limit.py` (5), `test_enrichr_empty_libs.py` (5), `test_extras.py` (21).

`import tooluniverse.tools` verified working on the combined tree.
