### PR TITLE
Fix Round 140 R2: five newly-wrapped tools returning empty/wrong data as success

### DIFF
--- a/src/tooluniverse/data/massive_tools.json
+++ b/src/tooluniverse/data/massive_tools.json
@@ -94,13 +94,13 @@
     },
     {
         "name": "MassIVE_get_protein_identifications",
-        "description": "Identification-level access to MassIVE datasets via the ProXI standard API. MassIVE's other tools return only dataset metadata; this tool exposes the actual protein identifications. Three modes: (1) per-dataset protein summaries - pass 'accession' (e.g. 'PXD000561') to get identified proteins with countPSM/countPeptides/countPeptidoforms/countDatasets; (2) cross-dataset protein lookup - pass 'protein_accession' (e.g. 'A2M_MOUSE') to find how many MassIVE datasets identified a protein; (3) peptide-spectrum matches - set result_type='psms' with a dataset 'accession' to get PSMs (peptide sequence + charge). Returns a structured success/error envelope.",
+        "description": "Identification-level access to MassIVE datasets via the ProXI standard API. Keyed on 'protein_accession' (e.g. 'A2M_MOUSE'): with result_type='proteins' (default) it returns that protein's cross-dataset identification counts (countPSM/countPeptides/countPeptidoforms/countDatasets); with result_type='psms' it returns that protein's peptide-spectrum matches (peptide sequence + charge). Note: the MassIVE ProXI proteins/psms endpoints do not filter by dataset 'accession' (they return the same global summary regardless), so per-dataset identification listing is not supported here - use MassIVE_get_dataset for dataset-level metadata. Returns a structured success/error envelope.",
         "parameter": {
             "type": "object",
             "properties": {
                 "accession": {
                     "type": ["string", "null"],
-                    "description": "Dataset accession (ProteomeXchange PXD or MassIVE MSV, e.g. 'PXD000561'). Required for per-dataset protein summaries and for PSM lookups."
+                    "description": "Optional dataset accession (ProteomeXchange PXD or MassIVE MSV). NOTE: the MassIVE ProXI endpoints ignore this as a filter, so it does not restrict results to a dataset. Use 'protein_accession' to query; use MassIVE_get_dataset for dataset metadata."
                 },
                 "protein_accession": {
                     "type": ["string", "null"],
@@ -110,7 +110,7 @@
                     "type": "string",
                     "enum": ["proteins", "psms"],
                     "default": "proteins",
-                    "description": "'proteins' (default) for protein identification summaries, or 'psms' for peptide-spectrum matches (use with a dataset 'accession')."
+                    "description": "'proteins' (default) for cross-dataset protein identification summaries, or 'psms' for that protein's peptide-spectrum matches. Both require 'protein_accession'."
                 }
             },
             "required": []
@@ -121,13 +121,10 @@
         "type": "MassIVETool",
         "test_examples": [
             {
-                "accession": "PXD000561"
-            },
-            {
                 "protein_accession": "A2M_MOUSE"
             },
             {
-                "accession": "PXD000561",
+                "protein_accession": "A2M_MOUSE",
                 "result_type": "psms"
             }
         ],

--- a/src/tooluniverse/fda_gsrs_tool.py
+++ b/src/tooluniverse/fda_gsrs_tool.py
@@ -137,7 +137,10 @@ class FDAGSRSTool(BaseTool):
                 "error": "Provide 'query' (name, UNII, InChIKey, or formula).",
             }
 
-        params: Dict[str, Any] = {"q": query.strip(), "top": limit}
+        # ``view=full`` inlines each result's codes/names arrays; without it the
+        # search records carry only link stubs, so xrefs and synonyms come back
+        # empty for every hit.
+        params: Dict[str, Any] = {"q": query.strip(), "top": limit, "view": "full"}
         if substance_class:
             params["fdim"] = f"substanceClass:{substance_class}"
 
@@ -174,7 +177,13 @@ class FDAGSRSTool(BaseTool):
                 "error": "Provide 'unii' (e.g., 'R16CO5Y76E' for aspirin).",
             }
 
-        result = self._api_get(f"{GSRS_BASE}/substances/{unii.strip().upper()}")
+        # ``?view=full`` is required for GSRS to inline the codes/names/references
+        # arrays; the default view returns only link stubs (``_codes``/``_names``),
+        # so without it the cross-references and synonyms come back empty.
+        result = self._api_get(
+            f"{GSRS_BASE}/substances/{unii.strip().upper()}",
+            params={"view": "full"},
+        )
         if not result["ok"]:
             result.pop("ok", None)
             return {"status": "error", **result}
@@ -224,7 +233,10 @@ class FDAGSRSTool(BaseTool):
                     "smiles": structure.get("smiles", ""),
                     "formula": structure.get("formula", ""),
                     "molfile": structure.get("molfile", ""),
-                    "inchiKey": structure.get("inchiKey", ""),
+                    # GSRS exposes the InChIKey under ``_inchiKey`` in the full
+                    # view; keep the plain key as a fallback.
+                    "inchiKey": structure.get("_inchiKey")
+                    or structure.get("inchiKey", ""),
                     "charge": structure.get("charge", ""),
                     "mwt": structure.get("mwt", ""),
                 },

--- a/src/tooluniverse/imgt_tool.py
+++ b/src/tooluniverse/imgt_tool.py
@@ -195,12 +195,11 @@ class IMGTTool(BaseTool):
 
         fmt = arguments.get("format", "fasta")
 
-        try:
-            # Use EBI DBFetch to retrieve IMGT sequences
-            response = requests.get(
+        def _dbfetch(db):
+            return requests.get(
                 EBI_DBFETCH_URL,
                 params={
-                    "db": "imgt",
+                    "db": db,
                     "id": accession,
                     "format": fmt,
                     "style": "raw",
@@ -209,21 +208,25 @@ class IMGTTool(BaseTool):
                 headers={"User-Agent": "ToolUniverse/IMGT"},
             )
 
-            if response.status_code == 404 or "not found" in response.text.lower():
-                # Try EMBL database as fallback
-                response = requests.get(
-                    EBI_DBFETCH_URL,
-                    params={
-                        "db": "embl",
-                        "id": accession,
-                        "format": fmt,
-                        "style": "raw",
-                    },
-                    timeout=self.timeout,
-                    headers={"User-Agent": "ToolUniverse/IMGT"},
-                )
+        def _dbfetch_failed(resp):
+            # DBFetch reports failures (unknown database, no entries found) as an
+            # HTTP 200 whose body begins with "ERROR <n> ...", so a status-code
+            # check alone would let that error text through as a "sequence".
+            if resp.status_code == 404:
+                return True
+            body = resp.text.lstrip()
+            return body.startswith("ERROR ") or "not found" in body.lower()
 
-            if response.status_code == 404:
+        try:
+            # IMGT/LIGM-DB is the native IMGT nucleotide database for IG/TR gene
+            # sequences; fall back to EMBL/ENA for accessions not mirrored there.
+            # (The old "imgt" slug is not a valid DBFetch database, so every
+            # request returned "ERROR 1 Unknown database [imgt]." as the result.)
+            response = _dbfetch("imgtligm")
+            if _dbfetch_failed(response):
+                response = _dbfetch("embl")
+
+            if _dbfetch_failed(response):
                 return {"status": "error", "error": f"Sequence not found: {accession}"}
 
             response.raise_for_status()

--- a/src/tooluniverse/massive_tool.py
+++ b/src/tooluniverse/massive_tool.py
@@ -212,30 +212,37 @@ class MassIVETool(BaseTool):
     def _get_protein_identifications(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Identification-level access to MassIVE via ProXI.
 
-        Three sub-modes (auto-selected by which argument is present):
-          - per-dataset proteins:  accession=PXD000561 -> protein summaries
-          - cross-dataset protein:  protein_accession=A2M_MOUSE -> dataset counts
-          - peptide-spectrum matches: result_type='psms' with a dataset accession
+        Keyed on ``protein_accession`` (e.g. 'A2M_MOUSE'):
+          - proteins (default): cross-dataset PSM / peptide / dataset counts
+          - psms (result_type='psms'): peptide-spectrum matches for the protein
+
+        The MassIVE ProXI proteins/psms endpoints do NOT honor a dataset
+        ``accession`` filter -- they return the same global summary regardless of
+        it -- so per-dataset identification listing is not offered here; use
+        MassIVE_get_dataset for dataset-level metadata.
         """
         accession = arguments.get("accession")
         protein_accession = arguments.get("protein_accession")
         result_type = arguments.get("result_type", "proteins")
 
-        if not accession and not protein_accession:
+        if not protein_accession:
             return {
                 "status": "error",
                 "error": (
-                    "Provide 'accession' (dataset, e.g. 'PXD000561') for per-dataset "
-                    "identifications, or 'protein_accession' (e.g. 'A2M_MOUSE') for a "
-                    "cross-dataset protein lookup."
+                    "'protein_accession' is required (e.g. 'A2M_MOUSE'). The MassIVE "
+                    "ProXI proteins/psms endpoints ignore a dataset 'accession' filter "
+                    "and return a global summary, so identifications cannot be listed "
+                    "per dataset; use MassIVE_get_dataset for dataset metadata."
                 ),
             }
 
-        params: Dict[str, Any] = {"resultType": "compact"}
-        if accession:
-            params["accession"] = accession
-        if protein_accession:
-            params["proteinAccession"] = protein_accession
+        # `accession` (dataset) is intentionally NOT sent to the endpoint: it is
+        # ignored upstream, and including it would imply a per-dataset filter that
+        # does not actually work.
+        params: Dict[str, Any] = {
+            "resultType": "compact",
+            "proteinAccession": protein_accession,
+        }
 
         endpoint = "psms" if result_type == "psms" else "proteins"
         result = self._proxi_get(endpoint, params)

--- a/src/tooluniverse/mavedb_tool.py
+++ b/src/tooluniverse/mavedb_tool.py
@@ -79,14 +79,24 @@ class MaveDBTool(BaseTool):
             }
 
         data = resp.json()
-        score_sets = data.get("scoreSets", [])[:limit]
+        all_score_sets = data.get("scoreSets", [])
+        score_sets = all_score_sets[:limit]
         results = []
         for ss in score_sets:
+            target_genes = [
+                g.get("name")
+                for g in (ss.get("targetGenes") or [])
+                if isinstance(g, dict) and g.get("name")
+            ]
             results.append(
                 {
                     "urn": ss.get("urn"),
                     "title": ss.get("title"),
                     "short_description": ss.get("shortDescription"),
+                    # Expose the target gene(s) so a full-text hit on a different
+                    # gene (e.g. query "BRCA1" matching "BRCA1-Associated Protein
+                    # 1"/BAP1) is visible rather than silently taken for the query.
+                    "target_genes": target_genes,
                     "num_variants": ss.get("numVariants"),
                     "published_date": ss.get("publishedDate"),
                 }
@@ -95,7 +105,10 @@ class MaveDBTool(BaseTool):
             "status": "success",
             "data": results,
             "metadata": {
-                "total_results": len(score_sets),
+                # True number of matches (MaveDB returns them all in one page),
+                # computed before truncation so callers know more may exist.
+                "total_results": len(all_score_sets),
+                "returned_results": len(results),
                 "query": query,
             },
         }
@@ -284,6 +297,21 @@ class MaveDBTool(BaseTool):
         }
 
     @staticmethod
+    def _is_genomic_reference(summary: Optional[Dict[str, Any]]) -> bool:
+        """True when a summarized VRS allele is anchored on a genomic sequence.
+
+        MaveDB maps protein-level DMS constructs onto protein (NP_/XP_) or
+        transcript (NM_/XM_/NR_) RefSeqs, which carry no genomic coordinates;
+        only chromosome/gene-region RefSeqs (NC_/NT_/NW_/NG_) are genomic.
+        Counting any non-null postMapped as "genomic" over-reports variants that
+        cannot actually be cross-referenced to ClinVar/dbSNP by position.
+        """
+        if not summary:
+            return False
+        label = (summary.get("sequence_reference_label") or "").upper()
+        return label.startswith(("NC_", "NT_", "NW_", "NG_"))
+
+    @staticmethod
     def _parse_limit(raw_limit: Any) -> Optional[int]:
         """Coerce a user-supplied ``limit`` to a positive int, else None (no cap)."""
         if raw_limit is None:
@@ -349,7 +377,7 @@ class MaveDBTool(BaseTool):
             post = self._summarize_vrs_allele(entry.get("postMapped"))
             pre = self._summarize_vrs_allele(entry.get("preMapped"))
             clingen = entry.get("clingenAlleleId")
-            if post:
+            if self._is_genomic_reference(post):
                 n_with_genomic += 1
             if clingen:
                 n_with_clingen += 1

--- a/tests/unit/test_fda_gsrs_full_view.py
+++ b/tests/unit/test_fda_gsrs_full_view.py
@@ -1,0 +1,93 @@
+"""Regression tests for FDA GSRS full-view enrichment (mocked HTTP).
+
+GSRS returns codes/names/references as link stubs (``_codes``/``_names``) in the
+default view and only inlines the real arrays with ``?view=full``. The tools
+fetched substances without ``view=full`` and read ``codes``/``names``, which
+were therefore always empty -- so cross-references and synonyms (the primary
+value of a GSRS lookup) were silently dropped under ``status: success``. These
+tests lock in that both the single-substance and search paths request the full
+view and surface the enriched fields.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(operation):
+    from tooluniverse.fda_gsrs_tool import FDAGSRSTool
+
+    return FDAGSRSTool(
+        {"name": "t", "type": "FDAGSRSTool", "fields": {"operation": operation}}
+    )
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.status_code = 200
+    r.raise_for_status.return_value = None
+    r.json.return_value = json_body
+    return r
+
+
+# A full-view substance record: codes/names inlined, InChIKey under _inchiKey.
+_FULL = {
+    "uuid": "u1",
+    "approvalID": "3G6A5W338E",
+    "_name": "CAFFEINE",
+    "substanceClass": "chemical",
+    "status": "approved",
+    "codes": [
+        {"codeSystem": "CAS", "code": "58-08-2", "type": "PRIMARY"},
+        {"codeSystem": "MESH", "code": "D002110", "type": "PRIMARY"},
+    ],
+    "names": [
+        {"name": "CAFFEINE", "type": "of", "preferred": True},
+        {"name": "1,3,7-TRIMETHYLXANTHINE", "type": "cn", "preferred": False},
+    ],
+    "structure": {
+        "formula": "C8H10N4O2",
+        "smiles": "Cn1cnc2c1c(=O)n(C)c(=O)n2C",
+        "_inchiKey": "RYYVLZVUVIJVGH-UHFFFAOYSA-N",
+        "mwt": 194.19,
+    },
+}
+
+
+class TestGetSubstanceFullView(unittest.TestCase):
+    def test_get_substance_requests_full_view_and_parses_arrays(self):
+        """get_substance asks for view=full and surfaces codes/names/InChIKey."""
+        tool = _tool("get_substance")
+        with patch(
+            "tooluniverse.fda_gsrs_tool.requests.get", return_value=_resp(_FULL)
+        ) as get:
+            result = tool._get_substance({"unii": "3G6A5W338E"})
+        self.assertEqual(get.call_args.kwargs["params"], {"view": "full"})
+        data = result["data"]
+        self.assertEqual(len(data["codes"]), 2)
+        self.assertEqual(len(data["names"]), 2)
+        self.assertEqual(
+            data["structure"]["inchiKey"], "RYYVLZVUVIJVGH-UHFFFAOYSA-N"
+        )
+
+
+class TestSearchFullView(unittest.TestCase):
+    def test_search_requests_full_view_and_populates_xrefs(self):
+        """search asks for view=full so xrefs/synonyms are non-empty."""
+        tool = _tool("search_substances")
+        body = {"content": [_FULL], "total": 1}
+        with patch(
+            "tooluniverse.fda_gsrs_tool.requests.get", return_value=_resp(body)
+        ) as get:
+            result = tool._search_substances({"query": "caffeine", "limit": 1})
+        self.assertEqual(get.call_args.kwargs["params"].get("view"), "full")
+        substance = result["data"][0]
+        self.assertIn("CAS", substance["xrefs"])
+        self.assertTrue(substance["synonyms"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_imgt_get_sequence_dbfetch.py
+++ b/tests/unit/test_imgt_get_sequence_dbfetch.py
@@ -1,0 +1,85 @@
+"""Regression tests for IMGT_get_sequence DBFetch handling (mocked HTTP).
+
+The tool fetched sequences from EBI DBFetch with ``db=imgt`` -- not a valid
+DBFetch database. DBFetch answers an unknown database with HTTP 200 and a body
+of ``ERROR 1 Unknown database [imgt].``, so the old status-code-only check let
+that error text through as the returned ``sequence`` under ``status: success``
+(a valid input silently returning wrong data as success -- the documented
+example M12950 was 100% broken). The fix queries the real ``imgtligm`` database,
+detects DBFetch's HTTP-200 ``ERROR ...`` bodies, falls back to EMBL, and returns
+a structured error when nothing resolves.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    from tooluniverse.imgt_tool import IMGTTool
+
+    return IMGTTool({"name": "IMGT_get_sequence", "type": "IMGTTool"})
+
+
+def _resp(text, status=200):
+    r = MagicMock()
+    r.status_code = status
+    r.text = text
+    r.raise_for_status.return_value = None
+    return r
+
+
+_REAL_FASTA = ">IMGTLIGM:M12950 M12950.1 Human TCR gamma V-region\ngagattctta\n"
+_DBFETCH_ERR = "ERROR 1 Unknown database [imgt].\n"
+
+
+class TestIMGTGetSequenceDBFetch(unittest.TestCase):
+    def test_primary_query_uses_imgtligm_not_imgt(self):
+        """The first DBFetch request must target the valid imgtligm database."""
+        tool = _tool()
+        with patch(
+            "tooluniverse.imgt_tool.requests.get", return_value=_resp(_REAL_FASTA)
+        ) as get:
+            result = tool._get_sequence({"accession": "M12950", "format": "fasta"})
+        self.assertEqual(get.call_args_list[0].kwargs["params"]["db"], "imgtligm")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"]["sequence"], _REAL_FASTA)
+
+    def test_dbfetch_error_body_is_not_returned_as_sequence(self):
+        """An HTTP-200 'ERROR ...' body must never surface as a success/sequence."""
+        tool = _tool()
+        # Both imgtligm and the embl fallback answer with DBFetch error bodies.
+        with patch(
+            "tooluniverse.imgt_tool.requests.get",
+            side_effect=[_resp(_DBFETCH_ERR), _resp("ERROR 12 No entries found.\n")],
+        ):
+            result = tool._get_sequence({"accession": "BOGUS", "format": "fasta"})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("BOGUS", result["error"])
+
+    def test_falls_back_to_embl_when_imgtligm_misses(self):
+        """imgtligm ERROR body triggers the EMBL fallback, which then succeeds."""
+        tool = _tool()
+        with patch(
+            "tooluniverse.imgt_tool.requests.get",
+            side_effect=[_resp(_DBFETCH_ERR), _resp(_REAL_FASTA)],
+        ) as get:
+            result = tool._get_sequence({"accession": "M12950", "format": "fasta"})
+        self.assertEqual(get.call_args_list[1].kwargs["params"]["db"], "embl")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"]["sequence"], _REAL_FASTA)
+
+    def test_missing_accession_errors_without_network(self):
+        """No accession -> structured error and no HTTP call."""
+        tool = _tool()
+        with patch("tooluniverse.imgt_tool.requests.get") as get:
+            result = tool._get_sequence({})
+        self.assertEqual(result["status"], "error")
+        get.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_mavedb_search_genomic.py
+++ b/tests/unit/test_mavedb_search_genomic.py
@@ -1,0 +1,104 @@
+"""Regression tests for MaveDB search totals and genomic-location counting.
+
+Two confirmed defects (mocked HTTP):
+
+* ``MaveDB_search_score_sets`` computed ``total_results`` from the post-``limit``
+  slice, so a query understated how many matches exist (5 shown when 62 exist),
+  and it exposed no target-gene field -- a full-text hit on a different gene
+  (query "BRCA1" matching "BRCA1-Associated Protein 1"/BAP1) looked on-target.
+* ``MaveDB_get_mapped_variants`` counted any non-null postMapped as
+  ``n_with_genomic_location``; protein-anchored (NP_/NM_) mappings, which have no
+  genomic coordinates, inflated the count for protein-level DMS score sets.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _mavedb():
+    from tooluniverse.mavedb_tool import MaveDBTool
+
+    return MaveDBTool({"name": "t", "type": "MaveDBTool"})
+
+
+def _resp(status, json_body):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = json_body
+    return r
+
+
+class TestMaveDBSearchTotals(unittest.TestCase):
+    def test_total_results_is_true_total_before_truncation(self):
+        """total_results reflects all matches, not just the returned page."""
+        tool = _mavedb()
+        body = {
+            "scoreSets": [
+                {"urn": f"urn:{i}", "title": f"t{i}", "targetGenes": [{"name": "BAP1"}]}
+                for i in range(10)
+            ]
+        }
+        with patch.object(tool.session, "post", return_value=_resp(200, body)):
+            out = tool._search({"query": "BRCA1", "limit": 3})
+        self.assertEqual(len(out["data"]), 3)
+        self.assertEqual(out["metadata"]["total_results"], 10)
+        self.assertEqual(out["metadata"]["returned_results"], 3)
+
+    def test_search_exposes_target_genes(self):
+        """Each result carries its target gene(s) so off-target hits are visible."""
+        tool = _mavedb()
+        body = {
+            "scoreSets": [
+                {"urn": "urn:1", "title": "x", "targetGenes": [{"name": "BAP1"}]}
+            ]
+        }
+        with patch.object(tool.session, "post", return_value=_resp(200, body)):
+            out = tool._search({"query": "BRCA1", "limit": 5})
+        self.assertEqual(out["data"][0]["target_genes"], ["BAP1"])
+
+
+class TestMaveDBGenomicCount(unittest.TestCase):
+    def test_protein_mapping_not_counted_as_genomic(self):
+        """NP_ (protein) postMapped is excluded; only NC_ (genomic) is counted."""
+        tool = _mavedb()
+        body = [
+            {
+                "variantUrn": "v1",
+                "postMapped": {
+                    "id": "a",
+                    "state": {"sequence": "M"},
+                    "location": {
+                        "start": 1,
+                        "end": 2,
+                        "sequenceReference": {"label": "NP_203524.1"},
+                    },
+                },
+                "clingenAlleleId": None,
+            },
+            {
+                "variantUrn": "v2",
+                "postMapped": {
+                    "id": "b",
+                    "state": {"sequence": "A"},
+                    "location": {
+                        "start": 100,
+                        "end": 101,
+                        "sequenceReference": {"label": "NC_000017.11"},
+                    },
+                },
+                "clingenAlleleId": "CA1",
+            },
+        ]
+        with patch.object(tool.session, "get", return_value=_resp(200, body)):
+            out = tool._get_mapped_variants({"urn": "urn:mavedb:x"})
+        data = out["data"]
+        self.assertEqual(data["total_mapped_variants"], 2)
+        self.assertEqual(data["n_with_genomic_location"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_proteomics_depth.py
+++ b/tests/unit/test_proteomics_depth.py
@@ -284,38 +284,26 @@ def _massive_tool():
     )
 
 
-def test_massive_proteins_parse(monkeypatch):
-    """MassIVE per-dataset proteins parse and coerce counts to int."""
+def test_massive_dataset_only_accession_errors(monkeypatch):
+    """A dataset-only accession fails closed instead of returning global data.
+
+    The MassIVE ProXI proteins/psms endpoints ignore the dataset filter (they
+    return the same global summary regardless), so per-dataset identification
+    listing is not offered; protein_accession is required and the guard fires
+    before any HTTP call.
+    """
     tool = _massive_tool()
-    payload = [
-        {
-            "proteinAccession": "A2MP_MOUSE",
-            "countPSM": "87187",
-            "countPeptides": "58",
-            "countPeptidoforms": "82",
-            "countDatasets": "5",
-        },
-        {
-            "proteinAccession": "A2M_MOUSE",
-            "countPSM": "146131",
-            "countPeptides": "106",
-            "countPeptidoforms": "234",
-            "countDatasets": "4",
-        },
-    ]
-    monkeypatch.setattr(
-        massive_mod.requests, "get", lambda *a, **k: _resp(200, payload)
-    )
+    called = {"n": 0}
+
+    def fake_get(*a, **k):
+        called["n"] += 1
+        return _resp(200, [])
+
+    monkeypatch.setattr(massive_mod.requests, "get", fake_get)
     out = tool.run({"accession": "PXD000561"})
-    assert out["status"] == "success"
-    data = out["data"]
-    assert data["result_type"] == "proteins"
-    assert data["count"] == 2
-    first = data["proteins"][0]
-    assert first["proteinAccession"] == "A2MP_MOUSE"
-    # count strings coerced to int
-    assert first["countPSM"] == 87187
-    assert first["countDatasets"] == 5
+    assert out["status"] == "error"
+    assert "protein_accession" in out["error"]
+    assert called["n"] == 0
 
 
 def test_massive_cross_dataset_parse(monkeypatch):
@@ -361,7 +349,7 @@ def test_massive_psms_parse(monkeypatch):
         return _resp(200, payload)
 
     monkeypatch.setattr(massive_mod.requests, "get", fake_get)
-    out = tool.run({"accession": "PXD000561", "result_type": "psms"})
+    out = tool.run({"protein_accession": "A2M_MOUSE", "result_type": "psms"})
     assert out["status"] == "success"
     assert out["data"]["result_type"] == "psms"
     assert out["data"]["count"] == 2
@@ -388,7 +376,7 @@ def test_massive_http_error(monkeypatch):
         raise requests.exceptions.ConnectionError("down")
 
     monkeypatch.setattr(massive_mod.requests, "get", boom)
-    out = tool.run({"accession": "PXD000561"})
+    out = tool.run({"protein_accession": "A2M_MOUSE"})
     assert out["status"] == "error"
 
 


### PR DESCRIPTION
## Summary

Round 2 of the post-1.4.0 role-play bug-hunt, branched off the current main (which already carries round 1 via #393). Three fresh researcher personas (precision-oncology genomicist, structural biologist / immunoinformatics, metabolomics / lipidomics chemist) exercised ~60 tool calls across a different slice of the #389-added surface — MaveDB, GDC, GenomeNexus, InterPro, ELM, IPD/IMGT, MassBank, SwissLipids, LipidMaps, FDA GSRS, MassIVE, and more. Every reported issue was CLI-reproduced (and cross-checked against the live upstream APIs) before fixing; false positives and upstream-outage artifacts were discarded.

**Net: 5 defects fixed (3 HIGH, 2 MEDIUM)**, all in the "a valid input silently returns empty/wrong data as a success" class.

## Fixes

### 1. `IMGT_get_sequence` returned an error string as the sequence (HIGH)
Queried EBI DBFetch with `db=imgt`, which is not a valid DBFetch database. DBFetch answers an unknown database with **HTTP 200 + body `ERROR 1 Unknown database [imgt].`**, and the status-code-only check returned that error text as the `sequence` under `status:success` — the documented example `M12950` was 100% broken. Fixed by querying the real `imgtligm` (IMGT/LIGM-DB) database, detecting DBFetch's HTTP-200 `ERROR ...` bodies so the EMBL fallback actually fires, and returning a structured error on a genuine miss. CLI-verified: `M12950` → real sequence; bogus accession → `Error: Sequence not found`.

### 2. `MassIVE_get_protein_identifications` ignored the dataset filter (HIGH)
The MassIVE ProXI `/proteins` **and** `/psms` endpoints ignore the dataset `accession` filter — `PXD000561`, `PXD000865`, and even the nonexistent `PXD999999` all returned byte-identical global data (100 mouse proteins) as success. CLI + curl verified the endpoint returns the same result with or without `accession`. Fixed by requiring `protein_accession` (the filter the endpoint actually honors), failing closed on dataset-only queries with a clear message, and correcting the misleading description/parameter/examples.

### 3. `FDAGSRS_get_substance` / `FDAGSRS_search_substances` dropped cross-refs & synonyms (HIGH)
Read `codes`/`names` without `?view=full`; GSRS returns only link stubs in the default view, so cross-references and synonyms — the primary value of a GSRS lookup — came back empty for every substance. Live GSRS `?view=full` for caffeine has **45 codes / 59 names**. Fixed by requesting the full view on both the single-substance and search paths and reading the InChIKey from `_inchiKey`. CLI-verified: caffeine → codes#45, xrefs#33, InChIKey `RYYVLZVUVIJVGH-UHFFFAOYSA-N` (all previously empty).

### 4. `MaveDB_search_score_sets` understated totals and hid the target gene (MEDIUM)
`total_results` was computed from the post-`limit` slice (5 shown when 62 exist), and no target-gene field was exposed — so a query like `BRCA1` that full-text-matches "BRCA1-Associated Protein 1"/**BAP1** looked on-target. Fixed by counting before truncation, adding `returned_results`, and surfacing `target_genes` per row. CLI-verified: `BRCA1` → `total_results=62`, and the top rows now visibly show `target_genes=['BAP1']`.

### 5. `MaveDB_get_mapped_variants` over-counted genomic locations (MEDIUM)
Counted any non-null `postMapped` as `n_with_genomic_location`; protein/transcript-anchored (`NP_`/`NM_`) mappings — common for protein-level DMS score sets — have no genomic coordinates. Fixed to count only chromosome/gene-region references (`NC_`/`NT_`/`NW_`/`NG_`). CLI-verified: `urn:mavedb:00000115-a-7` (all `NP_203524.1`) → `n_with_genomic_location` `3553 → 0`, consistent with `n_with_clingen_allele_id=0`.

## Tests
- New: `tests/unit/test_imgt_get_sequence_dbfetch.py`, `tests/unit/test_fda_gsrs_full_view.py`, `tests/unit/test_mavedb_search_genomic.py`.
- Updated `tests/unit/test_proteomics_depth.py` — the MassIVE tests that encoded the old (buggy) per-dataset behavior now assert the fail-closed error and drive the parse tests via `protein_accession`.
- **89 tests pass** across the new tests plus the existing IMGT / MaveDB / MassIVE / FDAGSRS suites — no regressions.

## Verified false positives / not fixed (for the record)
- Persona-reported items confirmed as **upstream** (not tool defects): MaveDB read-timeouts / HTTP 504 on large score sets; Pharos 502; `api.fda.gov` no-route; IMGT GENElect scrape read-timeout; a multi-allelic dbSNP rsID that GenomeNexus resolves to one allele.
- Confirmed **working** (parameters honored, no silent-ignore): MassBank advanced-search filters (each narrows correctly), GDC `project_id`/`size`, GTEx tissue filters, InterPro/ELM/IUPred3/AlphaFill/IPD/MHCMotifAtlas, ClassyFire, SwissLipids, LipidMaps by-formula/id/xref, FooDB.
- Deferred (noted, not fixed here): `LipidMaps_search_by_name` sn-position chain notation returning empty (needs an `abbrev_chains` endpoint fallback); `MassBank_search_records_advanced` empty-result shape inconsistency (LOW); `ESM2` "keyless" description drift (upstream HF auth change); `InterPro` gene-symbol-vs-accession error message (LOW).