### PR TITLE
Fix: silently-dropped filters, unreachable result sets, and misreported values (bug-hunt round 4)

### DIFF
--- a/src/tooluniverse/cpic_search_pairs_tool.py
+++ b/src/tooluniverse/cpic_search_pairs_tool.py
@@ -358,3 +358,87 @@ class CPICSearchPairsTool(BaseRESTTool):
 
     def _build_url(self, args: Dict[str, Any]) -> str:
         return super()._build_url(self._resolve_aliases(args))
+
+
+@register_tool("CPICGetAllelesTool")
+class CPICGetAllelesTool(BaseTool):
+    """List CPIC star alleles for a gene, with a true total and paging.
+
+    Fix-R4B-4: this tool ran as a plain BaseRESTTool over a URL template
+    carrying `limit={limit}` with a default of 50, and the only count in the
+    response was `count`, which reported the size of the returned page. So
+    `CPIC_get_alleles {"genesymbol": "CYP2D6"}` came back with 50 alleles and
+    `count: 50` -- indistinguishable from CYP2D6 genuinely having 50 alleles,
+    when CPIC actually curates 208 (confirmed live via the PostgREST
+    `Content-Range` header, `0-207/208`). A pharmacogenomics user calling
+    star alleles from that page silently loses 158 of them, and there was no
+    `offset` to walk the rest. Ask PostgREST for the exact count, report it,
+    and page explicitly.
+    """
+
+    _DEFAULT_LIMIT = 50
+    _MAX_LIMIT = 1000
+
+    def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch one page of alleles plus the gene's true allele count."""
+        gene = arguments.get("genesymbol")
+        if not gene:
+            return {"status": "error", "error": "genesymbol is required (e.g. CYP2D6)"}
+        gene = str(gene).upper()
+
+        raw_limit = arguments.get("limit")
+        limit = self._DEFAULT_LIMIT if raw_limit in (None, "") else int(raw_limit)
+        limit = max(1, min(limit, self._MAX_LIMIT))
+        offset = max(0, int(arguments.get("offset") or 0))
+
+        params = {
+            "genesymbol": f"eq.{gene}",
+            "select": "name,functionalstatus,activityvalue,clinicalfunctionalstatus",
+            "limit": limit,
+            "offset": offset,
+        }
+        try:
+            # Prefer: count=exact makes PostgREST report the unpaged total in
+            # the Content-Range response header ("0-49/208").
+            response = requests.get(
+                f"{_CPIC_API}/allele",
+                params=params,
+                headers={"Prefer": "count=exact"},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+        except requests.exceptions.RequestException as e:
+            return {"status": "error", "error": f"CPIC API error: {e}"}
+
+        total = self._total_from_content_range(response.headers.get("Content-Range"))
+        if total is None:
+            total = offset + len(data)
+
+        result: Dict[str, Any] = {
+            "status": "success",
+            "data": data,
+            "url": response.url,
+            "count": len(data),
+            "total_count": total,
+            "offset": offset,
+        }
+        if data and offset + len(data) < total:
+            result["note"] = (
+                f"Showing alleles {offset + 1}-{offset + len(data)} of {total} curated "
+                f"by CPIC for {gene}. Re-run with offset={offset + len(data)} for the "
+                f"next page, or raise 'limit' (max {self._MAX_LIMIT})."
+            )
+        elif not data and total:
+            result["note"] = (
+                f"No alleles at offset={offset}; {gene} has {total} alleles in CPIC."
+            )
+        return result
+
+    @staticmethod
+    def _total_from_content_range(header: Optional[str]) -> Optional[int]:
+        """Parse the unpaged total out of a PostgREST Content-Range header."""
+        if not header or "/" not in header:
+            return None
+        total = header.rsplit("/", 1)[1].strip()
+        return int(total) if total.isdigit() else None

--- a/src/tooluniverse/data/cpic_tools.json
+++ b/src/tooluniverse/data/cpic_tools.json
@@ -963,7 +963,7 @@
   },
   {
     "name": "CPIC_get_alleles",
-    "description": "Get pharmacogenomics alleles and their functional status for a gene from CPIC. Returns allele names, activity values, and functional status. Note: use 'clinicalfunctionalstatus' field for the active clinical classification (e.g., 'No function', 'Normal function'); the 'functionalstatus' field may be null for some genes. Critical for translating genotype to phenotype (e.g., CYP2D6 *4 = no function, CYP2D6 *1 = normal function).",
+    "description": "Get pharmacogenomics alleles and their functional status for a gene from CPIC. Returns allele names, activity values, and functional status, plus 'total_count' -- the number of alleles CPIC curates for the gene, which is often far larger than one page (CYP2D6 has 208). Returns 50 per call by default; use 'limit' (max 1000) and 'offset' to retrieve the rest. Note: use 'clinicalfunctionalstatus' field for the active clinical classification (e.g., 'No function', 'Normal function'); the 'functionalstatus' field may be null for some genes. Critical for translating genotype to phenotype (e.g., CYP2D6 *4 = no function, CYP2D6 *1 = normal function).",
     "parameter": {
       "type": "object",
       "properties": {
@@ -976,19 +976,23 @@
             "integer",
             "null"
           ],
-          "description": "Maximum number of alleles to return (default 50)",
+          "description": "Maximum number of alleles to return per call (default 50, max 1000). Compare with 'total_count' in the response to see how many exist in total.",
           "default": 50
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Zero-based index of the first allele to return, for paging through genes with more alleles than one page (e.g. offset=50 returns alleles 51-100). Default: 0.",
+          "default": 0
         }
       },
       "required": [
         "genesymbol"
       ]
     },
-    "fields": {
-      "endpoint": "https://api.cpicpgx.org/v1/allele?genesymbol=eq.{genesymbol}&select=name,functionalstatus,activityvalue,clinicalfunctionalstatus&limit={limit}",
-      "uppercase_params": ["genesymbol"]
-    },
-    "type": "BaseRESTTool",
+    "type": "CPICGetAllelesTool",
     "test_examples": [
       {
         "genesymbol": "CYP2D6",
@@ -997,32 +1001,76 @@
       {
         "genesymbol": "DPYD",
         "limit": 20
+      },
+      {
+        "genesymbol": "CYP2D6",
+        "limit": 20,
+        "offset": 50
       }
     ],
     "return_schema": {
       "oneOf": [
         {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "functionalstatus": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "activityvalue": {
-                "type": "string"
-              },
-              "clinicalfunctionalstatus": {
-                "type": "string"
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string"
+            },
+            "data": {
+              "type": "array",
+              "description": "Alleles in this page of results",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Star allele name (e.g. '*4')"
+                  },
+                  "functionalstatus": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "activityvalue": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "clinicalfunctionalstatus": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  }
+                }
               }
+            },
+            "url": {
+              "type": "string",
+              "description": "Resolved CPIC API request URL"
+            },
+            "count": {
+              "type": "integer",
+              "description": "Number of alleles in this page"
+            },
+            "total_count": {
+              "type": "integer",
+              "description": "Total alleles CPIC curates for this gene"
+            },
+            "offset": {
+              "type": "integer",
+              "description": "Zero-based index of the first allele returned"
+            },
+            "note": {
+              "type": "string",
+              "description": "Present when more alleles remain; explains how to page to them"
             }
-          }
+          },
+          "required": [
+            "data"
+          ]
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/expression_atlas_tools.json
+++ b/src/tooluniverse/data/expression_atlas_tools.json
@@ -13,6 +13,22 @@
           "type": "string",
           "description": "Species name (default: 'homo sapiens'). Also supports 'mus musculus', 'rattus norvegicus', etc.",
           "default": "homo sapiens"
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Maximum number of experiments to return (default 50, max 500). Compare with the total reported in the response to see how many exist.",
+          "default": 50
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Zero-based index of the first experiment to return, for paging through results beyond the first page (e.g. offset=50 returns 51-100). Default: 0.",
+          "default": 0
         }
       },
       "required": [
@@ -130,6 +146,22 @@
           "type": "string",
           "description": "Species name (default: 'homo sapiens')",
           "default": "homo sapiens"
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Maximum number of experiments to return (default 50, max 500). Compare with the total reported in the response to see how many exist.",
+          "default": 50
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Zero-based index of the first experiment to return, for paging through results beyond the first page (e.g. offset=50 returns 51-100). Default: 0.",
+          "default": 0
         }
       }
     },
@@ -251,6 +283,22 @@
         "species": {
           "type": "string",
           "description": "Species name (optional, e.g., 'homo sapiens')"
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Maximum number of experiments to return (default 50, max 500). Compare with the total reported in the response to see how many exist.",
+          "default": 50
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Zero-based index of the first experiment to return, for paging through results beyond the first page (e.g. offset=50 returns 51-100). Default: 0.",
+          "default": 0
         }
       }
     },

--- a/src/tooluniverse/data/gtopdb_tools.json
+++ b/src/tooluniverse/data/gtopdb_tools.json
@@ -10,7 +10,14 @@
             "string",
             "null"
           ],
-          "description": "Target name or gene symbol to search. Examples: 'dopamine', 'serotonin receptor', 'EGFR', 'beta-adrenoceptor', 'TRPV1'"
+          "description": "Target NAME substring to search. Examples: 'dopamine', 'serotonin receptor', 'beta-adrenoceptor', 'TRPV1'. This is a name/abbreviation match, not a gene lookup -- GtoPdb names targets pharmacologically ('5-HT6 receptor', 'GluN2B'), so HGNC symbols such as 'HTR6' or 'GRIN2B' return nothing here. Use 'gene_symbol' for HGNC symbols."
+        },
+        "gene_symbol": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "HGNC gene symbol for an exact target lookup. Examples: 'CHRNA7' (nicotinic acetylcholine receptor alpha7 subunit), 'GRIN2B' (GluN2B), 'HTR6' (5-HT6 receptor). Preferred over 'name' when you have a gene symbol."
         },
         "type": {
           "type": [

--- a/src/tooluniverse/data/gwas_tools.json
+++ b/src/tooluniverse/data/gwas_tools.json
@@ -922,7 +922,7 @@
   {
     "type": "GWASVariantsForTrait",
     "name": "gwas_get_variants_for_trait",
-    "description": "Search the GWAS Catalog for all genetic variants (SNPs) linked to a specific disease or trait. Accepts free-text disease/trait names (e.g., 'diabetes', 'breast cancer'), EFO ontology IDs, or EFO trait labels. Returns variant details including rsIDs, p-values, mapped genes, and genomic locations. This is the best tool for finding all GWAS variants for a disease when you do NOT already have a specific variant ID.",
+    "description": "Search the GWAS Catalog for all genetic variants (SNPs) linked to a specific disease or trait. Accepts free-text disease/trait names (e.g., 'diabetes', 'breast cancer'), EFO ontology IDs, or EFO trait labels. Returns variant details including rsIDs, p-values, mapped genes, and genomic locations. Results are sorted by p-value ascending (most significant first) by default, so the first page holds the strongest loci; override with the 'sort' and 'direction' parameters. This is the best tool for finding all GWAS variants for a disease when you do NOT already have a specific variant ID.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -957,6 +957,14 @@
         "page": {
           "type": "integer",
           "description": "Page number for pagination"
+        },
+        "sort": {
+          "type": "string",
+          "description": "Sort field (e.g., 'p_value', 'or_value'). Defaults to 'p_value' so the most significant associations appear first."
+        },
+        "direction": {
+          "type": "string",
+          "description": "Sort direction ('asc' or 'desc'). Defaults to 'asc'."
         }
       },
       "oneOf": [

--- a/src/tooluniverse/data/hlaligandatlas_tools.json
+++ b/src/tooluniverse/data/hlaligandatlas_tools.json
@@ -2,7 +2,7 @@
   {
     "name": "HLALigandAtlas_get_benign_peptides",
     "type": "HLALigandAtlasTool",
-    "description": "Retrieve benign-tissue HLA-presented peptides (immunopeptidome) from the HLA Ligand Atlas (hla-ligand-atlas.org, release 2020.12) - the curated reference of self-peptides eluted from non-malignant human tissues, used to filter self-peptides during cancer neoantigen discovery. Filter the aggregated table by peptide sequence, HLA class (HLA-I or HLA-II), presenting donor allele, and/or tissue of origin. Each row reports the peptide, HLA class, the donor-allele presentation flags (strong 'n/' or weak 'w/'), and the tissues in which it was detected. Filtering by an exact peptide sequence or a specific tissue/allele is recommended because the aggregated table is large.",
+    "description": "Retrieve benign-tissue HLA-presented peptides (immunopeptidome) from the HLA Ligand Atlas (hla-ligand-atlas.org, release 2020.12) - the curated reference of self-peptides eluted from non-malignant human tissues, used to filter self-peptides during cancer neoantigen discovery. Filter the aggregated table by peptide sequence, HLA class (HLA-I or HLA-II), presenting donor allele, and/or tissue of origin. Each row reports the peptide, HLA class, the donor-allele presentation flags, and the tissues in which it was detected. Donor alleles carry one of THREE prefixes: 's/' = strong binder, 'w/' = weak binder, 'n/' = NON-binder (the allele was typed in the donor but is not predicted to present this peptide). Only 's/' entries indicate the peptide is actually presented by that allele -- treat 'n/' as evidence AGAINST presentation, not for it. Filtering by an exact peptide sequence or a specific tissue/allele is recommended because the aggregated table is large.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -19,7 +19,7 @@
         },
         "allele": {
           "type": "string",
-          "description": "Substring of a presenting allele to match within the donor_alleles list, e.g. 'DRB1*01:01' or 'DQA1*01:03-DQB1*06:02'. Case-sensitive."
+          "description": "Substring of a presenting allele to match within the donor_alleles list, e.g. 'DRB1*01:01' or 'DQA1*01:03-DQB1*06:02'. Case-sensitive. NOTE: this is a plain substring match, so a bare allele such as 'A*02:01' also matches the 's/', 'w/' AND 'n/' prefixed entries -- including peptides that allele is predicted NOT to present. To restrict to peptides genuinely presented by the allele, include the strong-binder prefix: 's/A*02:01'."
         },
         "tissue": {
           "type": "string",

--- a/src/tooluniverse/data/iedb_tools.json
+++ b/src/tooluniverse/data/iedb_tools.json
@@ -206,7 +206,10 @@
       }
     ],
     "fields": {
-      "endpoint": "/antigen_search"
+      "endpoint": "/antigen_search",
+      "default_params": {
+        "order": "parent_source_antigen_id.asc"
+      }
     }
   },
   {
@@ -307,7 +310,10 @@
       }
     ],
     "fields": {
-      "endpoint": "/mhc_search"
+      "endpoint": "/mhc_search",
+      "default_params": {
+        "order": "elution_id.asc"
+      }
     }
   },
   {
@@ -401,7 +407,10 @@
       }
     ],
     "fields": {
-      "endpoint": "/bcell_search"
+      "endpoint": "/bcell_search",
+      "default_params": {
+        "order": "bcell_id.asc"
+      }
     }
   },
   {
@@ -495,7 +504,10 @@
       }
     ],
     "fields": {
-      "endpoint": "/reference_search"
+      "endpoint": "/reference_search",
+      "default_params": {
+        "order": "reference_id.asc"
+      }
     }
   },
   {
@@ -588,6 +600,9 @@
           "column": "structure_id",
           "op": "eq"
         }
+      },
+      "default_params": {
+        "order": "structure_id.asc"
       }
     }
   },
@@ -681,6 +696,9 @@
           "column": "structure_id",
           "op": "eq"
         }
+      },
+      "default_params": {
+        "order": "elution_id.asc"
       }
     }
   },
@@ -774,6 +792,9 @@
           "column": "structure_id",
           "op": "eq"
         }
+      },
+      "default_params": {
+        "order": "reference_id.asc"
       }
     }
   }

--- a/src/tooluniverse/data/intact_tools.json
+++ b/src/tooluniverse/data/intact_tools.json
@@ -2,7 +2,7 @@
   {
     "type": "IntActRESTTool",
     "name": "intact_get_interactor",
-    "description": "Get detailed information about a specific interactor from IntAct database by IntAct identifier (e.g., 'EBI-1004115'). Note: This requires an IntAct-specific identifier, not UniProt IDs. For UniProt IDs, use intact_get_interactions instead. Returns interactor details including names, aliases, organism, and cross-references.",
+    "description": "Get detailed information about a specific interactor from IntAct database by IntAct identifier (e.g., 'EBI-1004115'). Note: This requires an IntAct-specific identifier, not UniProt IDs. For UniProt IDs, use intact_get_interactions instead. Returns interactor details including names, aliases, organism, and cross-references. Returns 25 interactions per call by default; compare 'count' with 'hitCount' in the response metadata and raise 'size' to retrieve the rest.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -13,11 +13,17 @@
         "format": {
           "type": "string",
           "enum": [
-            "json",
-            "xml"
+            "json"
           ],
           "default": "json",
-          "description": "Response format"
+          "description": "Response format. Only 'json' is produced by this endpoint."
+        },
+        "size": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Maximum number of interactions to return (default 25). IntAct entries commonly have far more -- the response reports the true total as 'hitCount', so raise 'size' to that value to retrieve them all."
         }
       },
       "required": [
@@ -47,7 +53,7 @@
   {
     "type": "IntActRESTTool",
     "name": "intact_get_interactions",
-    "description": "Get all interactions involving a specific interactor (protein or gene) by identifier. Uses EBI Search API (IntAct domain) for reliable access. Returns list of interactions with interaction IDs (e.g., 'EBI-366083-EBI-366083') in the 'interaction_ids' field. These IDs can be used with intact_get_interaction_details or intact_get_interaction_network to get detailed information. Accepts UniProt IDs, gene names, or IntAct identifiers.",
+    "description": "Get all interactions involving a specific interactor (protein or gene) by identifier. Uses EBI Search API (IntAct domain) for reliable access. Returns list of interactions with interaction IDs (e.g., 'EBI-366083-EBI-366083') in the 'interaction_ids' field. These IDs can be used with intact_get_interaction_details or intact_get_interaction_network to get detailed information. Accepts UniProt IDs, gene names, or IntAct identifiers. Returns 25 interactions per call by default; compare 'count' with 'hitCount' in the response metadata and raise 'size' to retrieve the rest.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -58,10 +64,17 @@
         "format": {
           "type": "string",
           "enum": [
-            "json",
-            "xml"
+            "json"
           ],
-          "default": "json"
+          "default": "json",
+          "description": "Response format. Only 'json' is produced by this endpoint."
+        },
+        "size": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Maximum number of interactions to return (default 25). IntAct entries commonly have far more -- the response reports the true total as 'hitCount', so raise 'size' to that value to retrieve them all."
         }
       },
       "required": [

--- a/src/tooluniverse/data/mgnify_expanded_tools.json
+++ b/src/tooluniverse/data/mgnify_expanded_tools.json
@@ -104,17 +104,13 @@
   },
   {
     "name": "MGnify_search_genomes",
-    "description": "Search the MGnify genome catalog for metagenome-assembled genomes (MAGs) and isolate genomes. Filter by taxonomy lineage or genome type. Returns quality metrics, taxonomy, and protein counts. Useful for finding reference genomes from specific microbial lineages.",
+    "description": "Search the MGnify genome catalog for metagenome-assembled genomes (MAGs) and isolate genomes. Filter by taxonomy lineage. Returns quality metrics, taxonomy, and protein counts. Useful for finding reference genomes from specific microbial lineages. Taxonomy names follow GTDB, not NCBI: use 'Bacteroidota' (not 'Bacteroidetes'), 'Bacillota' (not 'Firmicutes'), 'Pseudomonadota' (not 'Proteobacteria') -- an NCBI-style name usually returns 0 hits rather than an error.",
     "parameter": {
       "type": "object",
       "properties": {
         "taxonomy": {
           "type": "string",
-          "description": "Taxonomy lineage filter. Examples: 'Firmicutes', 'Bacteroidetes', 'Proteobacteria'."
-        },
-        "genome_type": {
-          "type": "string",
-          "description": "Filter by genome source type. Options: 'Isolate', 'MAG'."
+          "description": "GTDB taxonomy lineage filter, matched anywhere in the lineage. Examples: 'Bacteroidota' (phylum), 'Bacteroides' (genus), 'Bacillota', 'Pseudomonadota'. NCBI-style phylum names such as 'Bacteroidetes' or 'Firmicutes' return few or no hits -- use the GTDB spelling."
         },
         "page": {
           "type": "integer",

--- a/src/tooluniverse/data/pdbe_sifts_tools.json
+++ b/src/tooluniverse/data/pdbe_sifts_tools.json
@@ -1,13 +1,29 @@
 [
   {
     "name": "PDBeSIFTS_get_best_structures",
-    "description": "Get the best available PDB structures for a UniProt protein, ranked by coverage and resolution from PDBe SIFTS. Returns PDB IDs with chain mapping, resolution, experimental method (X-ray, cryo-EM, NMR), and UniProt sequence coverage. Essential for structural biologists to find the most suitable structure for a protein of interest. Example: P04637 (TP53) returns 641 structure entries, P00533 (EGFR) returns 633 entries, with X-ray and cryo-EM structures ranked by quality.",
+    "description": "Get the best available PDB structures for a UniProt protein, ranked by coverage and resolution from PDBe SIFTS. Returns PDB IDs with chain mapping, resolution, experimental method (X-ray, cryo-EM, NMR), and UniProt sequence coverage. Essential for structural biologists to find the most suitable structure for a protein of interest. Example: P04637 (TP53) returns 641 structure entries, P00533 (EGFR) returns 633 entries, with X-ray and cryo-EM structures ranked by quality. Returns 50 entries per call by default; use 'limit' (max 500) and 'offset' to page through the full ranked list, whose size is reported in the response.",
     "parameter": {
       "type": "object",
       "properties": {
         "uniprot_accession": {
           "type": "string",
           "description": "UniProt accession for the protein. Examples: 'P04637' (TP53), 'P00533' (EGFR), 'P38398' (BRCA1), 'P01308' (Insulin)."
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Maximum number of entries to return (default 50, max 500). Proteins such as P04637 (TP53) have hundreds of structure-chain entries; raise this or use 'offset' to reach past the first page.",
+          "default": 50
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Zero-based index of the first entry to return, for paging through the ranked list (e.g. offset=50 returns entries 51-100). Default: 0.",
+          "default": 0
         }
       },
       "required": [
@@ -101,11 +117,23 @@
                       }
                     }
                   },
-                  "description": "Ranked PDB structures (max 50)"
+                  "description": "Ranked PDB structures (this page)"
                 },
                 "total_structures": {
                   "type": "integer",
                   "description": "Total available structure-chain entries"
+                },
+                "returned_structures": {
+                  "type": "integer",
+                  "description": "Number of entries in this page of results"
+                },
+                "offset": {
+                  "type": "integer",
+                  "description": "Zero-based index of the first entry returned"
+                },
+                "note": {
+                  "type": "string",
+                  "description": "Present when more entries remain; explains how to page to them"
                 }
               }
             },
@@ -240,6 +268,14 @@
                           }
                         },
                         "description": "Chain-to-UniProt residue mappings"
+                      },
+                      "total_chain_mappings": {
+                        "type": "integer",
+                        "description": "Total chain mappings for this accession (chain_mappings shows at most the first 20)"
+                      },
+                      "chain_mappings_truncated": {
+                        "type": "boolean",
+                        "description": "True when total_chain_mappings exceeds the 20 returned in chain_mappings"
                       }
                     }
                   },
@@ -283,13 +319,29 @@
   },
   {
     "name": "PDBeSIFTS_get_all_structures",
-    "description": "Get all PDB structures for a UniProt protein, grouped by PDB entry with chain details, from PDBe SIFTS. Unlike best_structures which returns a flat ranked list, this groups results by PDB ID showing all chains per structure, sorted by resolution. Useful for comprehensive structural coverage analysis. Example: P04637 (TP53) has structures across hundreds of unique PDB entries covering different domains and complexes.",
+    "description": "Get all PDB structures for a UniProt protein, grouped by PDB entry with chain details, from PDBe SIFTS. Unlike best_structures which returns a flat ranked list, this groups results by PDB ID showing all chains per structure, sorted by resolution. Useful for comprehensive structural coverage analysis. Example: P04637 (TP53) has structures across hundreds of unique PDB entries covering different domains and complexes. Returns 50 entries per call by default; use 'limit' (max 500) and 'offset' to page through the full ranked list, whose size is reported in the response.",
     "parameter": {
       "type": "object",
       "properties": {
         "uniprot_accession": {
           "type": "string",
           "description": "UniProt accession for the protein. Examples: 'P04637' (TP53), 'P00533' (EGFR), 'P38398' (BRCA1)."
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Maximum number of entries to return (default 50, max 500). Proteins such as P04637 (TP53) have hundreds of structure-chain entries; raise this or use 'offset' to reach past the first page.",
+          "default": 50
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Zero-based index of the first entry to return, for paging through the ranked list (e.g. offset=50 returns entries 51-100). Default: 0.",
+          "default": 0
         }
       },
       "required": [
@@ -381,7 +433,7 @@
                       }
                     }
                   },
-                  "description": "PDB entries sorted by resolution (max 50)"
+                  "description": "PDB entries sorted by resolution (this page)"
                 },
                 "total_pdb_entries": {
                   "type": "integer",
@@ -390,6 +442,18 @@
                 "total_chain_mappings": {
                   "type": "integer",
                   "description": "Total chain-level mappings"
+                },
+                "returned_pdb_entries": {
+                  "type": "integer",
+                  "description": "Number of entries in this page of results"
+                },
+                "offset": {
+                  "type": "integer",
+                  "description": "Zero-based index of the first entry returned"
+                },
+                "note": {
+                  "type": "string",
+                  "description": "Present when more entries remain; explains how to page to them"
                 }
               }
             },

--- a/src/tooluniverse/data/rcsb_advanced_search_tools.json
+++ b/src/tooluniverse/data/rcsb_advanced_search_tools.json
@@ -49,7 +49,11 @@
         },
         "rows": {
           "type": "integer",
-          "description": "Number of results to return (default: 10, max: 50)."
+          "description": "Number of results to return per page (default: 10, max: 50). Requests above 50 are reduced to 50 and the response metadata says so -- use 'start' to retrieve the rest."
+        },
+        "start": {
+          "type": "integer",
+          "description": "Zero-based index of the first result to return, for paging through a result set larger than one page (e.g. start=50 returns results 51-100). Default: 0. The response metadata reports 'total_count' and the 'start' value to use for the next page."
         },
         "sort_by": {
           "type": [
@@ -118,6 +122,22 @@
                 },
                 "returned": {
                   "type": "integer"
+                },
+                "start": {
+                  "type": "integer",
+                  "description": "Zero-based index of the first returned result"
+                },
+                "rows": {
+                  "type": "integer",
+                  "description": "Effective page size after clamping to max_rows_per_page"
+                },
+                "max_rows_per_page": {
+                  "type": "integer",
+                  "description": "Maximum results returnable in one call"
+                },
+                "note": {
+                  "type": "string",
+                  "description": "Present when the result set was clamped or more pages remain; explains how to reach the rest"
                 }
               }
             }
@@ -161,7 +181,11 @@
         },
         "rows": {
           "type": "integer",
-          "description": "Number of results to return (default: 10, max: 50)."
+          "description": "Number of results to return per page (default: 10, max: 50). Requests above 50 are reduced to 50 and the response metadata says so -- use 'start' to retrieve the rest."
+        },
+        "start": {
+          "type": "integer",
+          "description": "Zero-based index of the first result to return, for paging through a result set larger than one page (e.g. start=50 returns results 51-100). Default: 0. The response metadata reports 'total_count' and the 'start' value to use for the next page."
         }
       },
       "required": [
@@ -236,6 +260,22 @@
                 },
                 "returned": {
                   "type": "integer"
+                },
+                "start": {
+                  "type": "integer",
+                  "description": "Zero-based index of the first returned result"
+                },
+                "rows": {
+                  "type": "integer",
+                  "description": "Effective page size after clamping to max_rows_per_page"
+                },
+                "max_rows_per_page": {
+                  "type": "integer",
+                  "description": "Maximum results returnable in one call"
+                },
+                "note": {
+                  "type": "string",
+                  "description": "Present when the result set was clamped or more pages remain; explains how to reach the rest"
                 },
                 "pattern": {
                   "type": "string"

--- a/src/tooluniverse/dgidb_tool.py
+++ b/src/tooluniverse/dgidb_tool.py
@@ -49,10 +49,26 @@ class DGIdbTool(BaseTool):
             return {"status": "error", "error": payload["errors"]}
         inner = payload.get("data", {}) or {}
         nodes = (inner.get(collection) or {}).get("nodes", []) or []
+
+        # Fix-R4A-8: `total` counted top-level nodes, which for the
+        # interactions tools are GENES, not interactions. Querying PDCD1
+        # reported total=1 beside a payload holding 68 drug-gene interactions,
+        # and three genes reported total=3 against 140 -- a number that reads
+        # as a truncation warning and is the one figure most likely to be
+        # quoted in a summary. Name what is actually counted and add the
+        # interaction total alongside it.
+        interaction_total = sum(
+            len(node.get("interactions") or [])
+            for node in nodes
+            if isinstance(node, dict)
+        )
+        metadata = {"total": len(nodes), f"{collection}_returned": len(nodes)}
+        if interaction_total:
+            metadata["interactions_total"] = interaction_total
         return {
             "status": "success",
             "data": inner,
-            "metadata": {"total": len(nodes)},
+            "metadata": metadata,
         }
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/tooluniverse/expression_atlas_tool.py
+++ b/src/tooluniverse/expression_atlas_tool.py
@@ -92,6 +92,32 @@ class ExpressionAtlasTool(BaseTool):
             f"gene-specific result set."
         )
 
+    @staticmethod
+    def _page(records, arguments):
+        """Slice a result list to the caller's window and describe the slice.
+
+        Fix-R4A-10: these lists were cut to a hard-coded [:50] with no limit or
+        offset parameter declared, so the tail was unreachable -- confirmed
+        live that condition="cancer" reports total_count 241 and returns 50.
+        The lists are ranked (by assay count, or gene-mention then assay
+        count), so the truncated tail is the weakest end, but 191 of 241
+        experiments simply could not be retrieved.
+        """
+        raw_limit = arguments.get("limit")
+        limit = 50 if raw_limit in (None, "") else int(raw_limit)
+        limit = max(1, min(limit, 500))
+        offset = max(0, int(arguments.get("offset") or 0))
+
+        page = records[offset : offset + limit]
+        note = None
+        if page and offset + len(page) < len(records):
+            note = (
+                f"Showing {offset + 1}-{offset + len(page)} of {len(records)}. "
+                f"Re-run with offset={offset + len(page)} for the next page, or "
+                "raise 'limit' (max 500)."
+            )
+        return page, offset, note
+
     def _get_baseline_expression(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """
         List baseline expression experiments for a species.
@@ -156,14 +182,18 @@ class ExpressionAtlasTool(BaseTool):
                 for exp in baseline_exps
             ]
             results.sort(key=lambda x: -(x.get("num_assays") or 0))
+            _page, _offset, _note = self._page(results, arguments)
 
             return {
                 "status": "success",
                 "data": {
                     "gene": gene,
                     "species": species,
-                    "baseline_experiments": results[:50],
+                    "baseline_experiments": _page,
                     "total_baseline": len(baseline_exps),
+                    "returned_baseline": len(_page),
+                    "offset": _offset,
+                    **({"page_note": _note} if _note else {}),
                 },
                 "note": (
                     f"This lists baseline experiments for '{species}'; it does "
@@ -270,12 +300,16 @@ class ExpressionAtlasTool(BaseTool):
                     )
                 )
 
+            _page, _offset, _note = self._page(experiments, arguments)
             result_data = {
                 "gene": gene,
                 "condition": condition,
                 "species": species,
-                "experiments": experiments[:50],
+                "experiments": _page,
                 "experiment_count": len(experiments),
+                "returned_experiments": len(_page),
+                "offset": _offset,
+                **({"page_note": _note} if _note else {}),
             }
             if gene:
                 result_data["warning"] = self._gene_filter_warning(gene)
@@ -375,13 +409,17 @@ class ExpressionAtlasTool(BaseTool):
                     )
                 )
 
+            _page, _offset, _note = self._page(experiments, arguments)
             result_data = {
                 "gene": gene,
                 "condition": condition,
                 "species": species,
-                "experiments": experiments[:50],
+                "experiments": _page,
                 "total_count": len(experiments),
+                "returned_experiments": len(_page),
+                "offset": _offset,
                 "gene_specific_count": len(gene_exp_ids),
+                **({"page_note": _note} if _note else {}),
             }
             if gene:
                 result_data["warning"] = self._gene_filter_warning(gene)

--- a/src/tooluniverse/gtopdb_tool.py
+++ b/src/tooluniverse/gtopdb_tool.py
@@ -138,6 +138,17 @@ class GtoPdbRESTTool(BaseTool):
                 "min_affinity": "affinity",
                 "approved_only": "approved",
                 "query": "name",  # alias: query → name (GtoPdb API uses ?name=)
+                # Fix-R4A-3: gene_symbol was not in this map, so it was passed
+                # through verbatim as ?gene_symbol=, which GtoPdb ignores --
+                # GtoPdb_search_targets returned the identical unfiltered
+                # first-50 target list ("12R-LOX", "12S-LOX", ...) for
+                # gene_symbol=CHRNA7, gene_symbol=GRIN2B and no arguments at
+                # all. GtoPdb does index targets by gene symbol under
+                # ?geneSymbol= (CHRNA7 -> target 468, GRIN2B -> 457,
+                # HTR6 -> 11), which the sibling GtoPdb_get_interactions
+                # already uses.
+                "gene_symbol": "geneSymbol",
+                "gene": "geneSymbol",
             }
 
             api_params = {}
@@ -386,9 +397,17 @@ class GtoPdbRESTTool(BaseTool):
         # Feature-46A-04: gene_symbol convenience parameter for GtoPdb_get_interactions.
         # Auto-resolve gene symbol → targetId so users don't need a separate
         # GtoPdb_search_targets call before querying interactions.
+        # Fix-R4A-3: this resolution is only meaningful for the interactions
+        # endpoints, which are addressed as /targets/{targetId}/interactions.
+        # On the plain /targets endpoint the resolved targetId becomes a query
+        # parameter that GtoPdb ignores, and `gene_symbol` was popped on the
+        # way -- so GtoPdb_search_targets silently dropped the filter and
+        # returned the unfiltered first 50 targets. There, `gene_symbol` maps
+        # directly to GtoPdb's own ?geneSymbol= instead (see _build_url).
         gene_symbol = arguments.get("gene_symbol")
         if (
             gene_symbol
+            and endpoint.endswith("/interactions")
             and not arguments.get("targetId")
             and not arguments.get("target_id")
         ):

--- a/src/tooluniverse/gwas_tool.py
+++ b/src/tooluniverse/gwas_tool.py
@@ -501,9 +501,21 @@ class GWASVariantsForTrait(GWASRESTTool):
         page_size = (
             self._coerce_int(arguments.get("size") or arguments.get("limit")) or 200
         )
+        # Fix-R4B-1: /v2/associations returns associations UNSORTED, and this
+        # tool never asked for a sort -- so the first page was an arbitrary
+        # slice of the trait's associations rather than its strongest loci.
+        # Confirmed live: efo_id=MONDO_0004979 (asthma, 3219 associations)
+        # returned p-values 2e-06 .. 2e-24 here, while the sibling
+        # GWASAssociationsForTrait -- same endpoint, but sending
+        # sort=p_value&direction=asc -- returned 7e-288, 8e-223, 2e-156 ...
+        # A user reading the top of this tool's page therefore missed every
+        # genome-wide-significant hit. Default to significance order and let
+        # callers override, matching the sibling tools.
         params: Dict[str, Any] = {
             "size": page_size,
             "page": self._coerce_int(arguments.get("page")) or 0,
+            "sort": self._coerce_str(arguments.get("sort")) or "p_value",
+            "direction": self._coerce_str(arguments.get("direction")) or "asc",
         }
         if efo_id:
             params["efo_id"] = efo_id

--- a/src/tooluniverse/hpa_tool.py
+++ b/src/tooluniverse/hpa_tool.py
@@ -249,7 +249,22 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
             "single_cell": "rnascm",  # RNA single cell type specific nTPM
         }
 
-        # Map expected API response field names for each source type
+        # Fix-R4A-2: the aggregate "*specific nTPM" columns above are populated
+        # only for genes HPA classifies as enriched in that source type, and
+        # "rnabrm" is not a valid HPA column at all -- HPA silently drops
+        # unknown columns, so every brain query returned "N/A" with
+        # status "success". Confirmed live: ?columns=g,rnabrm returns
+        # {"Gene":"GFAP"} with no data column, while
+        # ?columns=g,brain_RNA_thalamus returns 14782.4 nTPM. HPA exposes a
+        # per-source column for each source name; query that first and only
+        # fall back to the aggregate column if it yields nothing.
+        self.source_column_prefixes = {
+            "tissue": "t_RNA_",
+            "blood": "blood_RNA_",
+            "brain": "brain_RNA_",
+            "single_cell": "sc_RNA_",
+        }
+
         self.api_response_fields = {
             "tissue": "RNA tissue specific nTPM",
             "blood": "RNA blood lineage specific nTPM",
@@ -341,6 +356,64 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
             },
         }
 
+    @staticmethod
+    def _categorize_expression(expression_value):
+        """Bucket an nTPM/nCPM value into a coarse expression level."""
+        if expression_value in (None, "N/A"):
+            return "unknown"
+        try:
+            val = float(expression_value)
+        except (ValueError, TypeError):
+            return "unknown"
+        if val > 50:
+            return "very high"
+        if val > 10:
+            return "high"
+        if val > 1:
+            return "medium"
+        if val > 0.1:
+            return "low"
+        return "very low"
+
+    def _query_source_column(self, gene_name, source_type, candidate_names):
+        """Fetch a single source's value from its dedicated HPA column.
+
+        Returns (value, column_label) or (None, None) when HPA has no such
+        column or no value for this gene.
+        """
+        prefix = self.source_column_prefixes.get(source_type)
+        if not prefix:
+            return None, None
+
+        for candidate in candidate_names:
+            if not candidate:
+                continue
+            column = prefix + str(candidate).strip().replace(" ", "_")
+            try:
+                response = self._make_api_request(gene_name, f"g,{column}")
+            except Exception:
+                continue
+            if not response or isinstance(response, dict):
+                continue
+
+            # HPA's search matches synonyms too (search=GFAP also returns
+            # HGFAC), so pick the row whose Gene actually equals the query.
+            row = next(
+                (
+                    r
+                    for r in response
+                    if str(r.get("Gene", "")).upper() == gene_name.upper()
+                ),
+                response[0],
+            )
+            for key, value in row.items():
+                # HPA labels the column e.g. "Brain RNA - thalamus [nTPM]".
+                if " RNA - " not in key:
+                    continue
+                if value not in (None, "", "N/A"):
+                    return value, key
+        return None, None
+
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         gene_name = arguments.get("gene_name")
         source_type = arguments.get("source_type", "").lower()
@@ -423,6 +496,27 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
             return {"status": "error", "data": {"error": error_msg}}
 
         try:
+            # Prefer HPA's dedicated per-source column -- it carries a value
+            # for every gene, not just the ones enriched in this source type.
+            candidates = list(self.source_name_mappings[source_type][source_name])
+            candidates.append(source_name.replace("_", " "))
+            direct_value, direct_label = self._query_source_column(
+                gene_name, source_type, candidates
+            )
+            if direct_value is not None:
+                return {
+                    "status": "success",
+                    "data": {
+                        "gene_name": gene_name,
+                        "source_type": source_type,
+                        "source_name": source_name,
+                        "expression_value": direct_value,
+                        "expression_level": self._categorize_expression(direct_value),
+                        "column_queried": direct_label,
+                        "status": "ok",
+                    },
+                }
+
             # Get the correct API column
             api_column = self.source_column_mappings[source_type]
             columns = f"g,gs,{api_column}"
@@ -485,23 +579,7 @@ class HPAGetRnaExpressionBySourceTool(HPASearchApiTool):
                         if expression_value != "N/A":
                             break
 
-            # Categorize expression level
-            expression_level = "unknown"
-            if expression_value != "N/A":
-                try:
-                    val = float(expression_value)
-                    if val > 50:
-                        expression_level = "very high"
-                    elif val > 10:
-                        expression_level = "high"
-                    elif val > 1:
-                        expression_level = "medium"
-                    elif val > 0.1:
-                        expression_level = "low"
-                    else:
-                        expression_level = "very low"
-                except (ValueError, TypeError):
-                    expression_level = "unknown"
+            expression_level = self._categorize_expression(expression_value)
 
             result = {
                 "gene_name": gene_data.get("Gene", gene_name),

--- a/src/tooluniverse/mgnify_expanded_tool.py
+++ b/src/tooluniverse/mgnify_expanded_tool.py
@@ -146,11 +146,30 @@ class MGnifyExpandedTool(BaseTool):
         params["page"] = page
         params["page_size"] = page_size
 
-        if "taxonomy" in arguments:
-            params["lineage"] = arguments["taxonomy"]
+        # Fix-R4A-1: the /genomes endpoint filters on `taxon_lineage`, not
+        # `lineage`. MGnify drops unknown query params rather than erroring, so
+        # sending `lineage` returned the ENTIRE unfiltered catalogue as a
+        # success -- confirmed live that taxonomy="Bacteroides",
+        # taxonomy="COMPLETELY_BOGUS_XYZ" and no taxonomy at all all returned
+        # the same 56,782 genomes, while ?taxon_lineage=Bacteroides upstream
+        # returns the correct 136.
+        if arguments.get("taxonomy"):
+            params["taxon_lineage"] = arguments["taxonomy"]
 
-        if "genome_type" in arguments:
-            params["genome_type"] = arguments["genome_type"]
+        # ...and `genome_type` has no working equivalent on this endpoint at
+        # all: ?genome_type=, ?type= and ?genome-type= each return the full
+        # 56,782. Rather than accept the filter and ignore it, fail closed and
+        # point at the per-genome `type` field callers can filter on instead.
+        if arguments.get("genome_type"):
+            return {
+                "status": "error",
+                "error": (
+                    "The MGnify /genomes endpoint does not support filtering by "
+                    "genome_type; passing it would silently return the entire "
+                    "unfiltered catalogue. Omit genome_type and filter the "
+                    "returned records on their 'type' field instead."
+                ),
+            }
 
         url = f"{MGNIFY_BASE_URL}/genomes"
         response = requests.get(url, params=params, timeout=self.timeout)

--- a/src/tooluniverse/neuromorpho_tool.py
+++ b/src/tooluniverse/neuromorpho_tool.py
@@ -125,6 +125,22 @@ class NeuroMorphoTool(BaseTool):
             "metadata": {"total_results": 1},
         }
 
+    @staticmethod
+    def _lucene_term(value: Any) -> str:
+        """Quote a multi-word query value so it stays a single search term.
+
+        Fix-R4A-4: NeuroMorpho's Solr-style endpoint splits an unquoted
+        multi-word value on whitespace and matches only the trailing token, so
+        query_value="entorhinal cortex" was executed as "cortex". Confirmed
+        live that it returned the identical 872 hits as query_value="cortex"
+        -- topped by zebra-finch song-nucleus neurons -- while the quoted form
+        returns the correct 3431 entorhinal-cortex reconstructions.
+        """
+        text = str(value).strip()
+        if not text or (text.startswith('"') and text.endswith('"')):
+            return text
+        return f'"{text}"' if any(c.isspace() for c in text) else text
+
     def _search_neurons(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Search neurons by field criteria."""
         query_field = arguments.get("query_field", "species")
@@ -142,14 +158,14 @@ class NeuroMorphoTool(BaseTool):
 
         url = f"{NEUROMORPHO_BASE_URL}/neuron/select"
         params = {
-            "q": f"{query_field}:{query_value}",
+            "q": f"{query_field}:{self._lucene_term(query_value)}",
             "page": page,
             "size": size,
         }
 
         # Add filter query if specified
         if filter_field and filter_value:
-            params["fq"] = f"{filter_field}:{filter_value}"
+            params["fq"] = f"{filter_field}:{self._lucene_term(filter_value)}"
 
         response = requests.get(url, params=params, timeout=self.timeout)
         response.raise_for_status()
@@ -213,7 +229,7 @@ class NeuroMorphoTool(BaseTool):
 
         url = f"{NEUROMORPHO_BASE_URL}/literature/select"
         params = {
-            "q": f"{query_field}:{query_value}",
+            "q": f"{query_field}:{self._lucene_term(query_value)}",
             "page": page,
             "size": size,
         }

--- a/src/tooluniverse/pdbe_sifts_tool.py
+++ b/src/tooluniverse/pdbe_sifts_tool.py
@@ -17,6 +17,14 @@ from .tool_registry import register_tool
 
 PDBE_API_BASE_URL = "https://www.ebi.ac.uk/pdbe/api"
 
+# Fix-R4B-3: the structure lists were sliced to a hard-coded first 50 with no
+# parameter able to reach past it -- P04637 (TP53) has 676 structure-chain
+# entries and only the first 50 were obtainable, at any resolution or method.
+# `limit`/`offset` make the whole ranked list reachable; DEFAULT_PAGE_SIZE
+# preserves the previous default response size for existing callers.
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 500
+
 
 @register_tool("PDBeSIFTSTool")
 class PDBeSIFTSTool(BaseTool):
@@ -74,6 +82,29 @@ class PDBeSIFTSTool(BaseTool):
                 "error": f"Unexpected error querying PDBe SIFTS API: {str(e)}",
             }
 
+    @staticmethod
+    def _page_window(arguments: Dict[str, Any]) -> Dict[str, int]:
+        """Resolve the limit/offset window for a truncated result list."""
+        raw_limit = arguments.get("limit")
+        limit = DEFAULT_PAGE_SIZE if raw_limit in (None, "") else int(raw_limit)
+        limit = max(1, min(limit, MAX_PAGE_SIZE))
+        offset = max(0, int(arguments.get("offset") or 0))
+        return {"limit": limit, "offset": offset}
+
+    @staticmethod
+    def _page_note(window: Dict[str, int], total: int, returned: int) -> str:
+        """Describe the slice returned, and how to reach the rest of it."""
+        if not returned:
+            return ""
+        first = window["offset"] + 1
+        last = window["offset"] + returned
+        if last >= total:
+            return ""
+        return (
+            f"Showing {first}-{last} of {total}. Re-run with offset={last} for the "
+            f"next page, or raise 'limit' (max {MAX_PAGE_SIZE})."
+        )
+
     def _query(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Route to appropriate endpoint."""
         if self.endpoint == "best_structures":
@@ -102,9 +133,10 @@ class PDBeSIFTSTool(BaseTool):
         data = response.json()
 
         entries = data.get(accession, [])
+        window = self._page_window(arguments)
 
         structures = []
-        for e in entries[:50]:
+        for e in entries[window["offset"] : window["offset"] + window["limit"]]:
             structures.append(
                 {
                     "pdb_id": e.get("pdb_id"),
@@ -118,18 +150,24 @@ class PDBeSIFTSTool(BaseTool):
                 }
             )
 
-        return {
+        result = {
             "status": "success",
             "data": {
                 "uniprot_accession": accession,
                 "structures": structures,
                 "total_structures": len(entries),
+                "returned_structures": len(structures),
+                "offset": window["offset"],
             },
             "metadata": {
                 "source": "PDBe SIFTS - Best Structures",
                 "accession": accession,
             },
         }
+        note = self._page_note(window, len(entries), len(structures))
+        if note:
+            result["data"]["note"] = note
+        return result
 
     def _get_pdb_to_uniprot(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Map PDB entry chains to UniProt accessions."""
@@ -151,8 +189,9 @@ class PDBeSIFTSTool(BaseTool):
 
         proteins = []
         for acc, info in uniprot_data.items():
+            all_mappings = info.get("mappings", [])
             chain_mappings = []
-            for m in info.get("mappings", [])[:20]:
+            for m in all_mappings[:20]:
                 chain_mappings.append(
                     {
                         "chain_id": m.get("chain_id"),
@@ -163,11 +202,17 @@ class PDBeSIFTSTool(BaseTool):
                     }
                 )
 
+            # Fix-R4B-3: this 20-mapping truncation was entirely silent --
+            # `total_proteins` counts proteins, not mappings, so a viral or
+            # ribosomal entry with dozens of chains per accession looked
+            # complete at 20. Report the real count alongside the slice.
             proteins.append(
                 {
                     "uniprot_accession": acc,
                     "name": info.get("identifier"),
                     "chain_mappings": chain_mappings,
+                    "total_chain_mappings": len(all_mappings),
+                    "chain_mappings_truncated": len(all_mappings) > len(chain_mappings),
                 }
             )
 
@@ -300,12 +345,17 @@ class PDBeSIFTSTool(BaseTool):
             key=lambda x: x.get("resolution") or 999,
         )
 
-        return {
+        window = self._page_window(arguments)
+        page = sorted_entries[window["offset"] : window["offset"] + window["limit"]]
+
+        result = {
             "status": "success",
             "data": {
                 "uniprot_accession": accession,
-                "pdb_entries": sorted_entries[:50],
+                "pdb_entries": page,
                 "total_pdb_entries": len(pdb_entries),
+                "returned_pdb_entries": len(page),
+                "offset": window["offset"],
                 "total_chain_mappings": len(entries),
             },
             "metadata": {
@@ -313,3 +363,7 @@ class PDBeSIFTSTool(BaseTool):
                 "accession": accession,
             },
         }
+        note = self._page_note(window, len(pdb_entries), len(page))
+        if note:
+            result["data"]["note"] = note
+        return result

--- a/src/tooluniverse/pubchem_tool.py
+++ b/src/tooluniverse/pubchem_tool.py
@@ -296,6 +296,34 @@ class PubChemRESTTool(BaseTool):
             },
         }
 
+    @staticmethod
+    def _cid_not_found(payload):
+        """Turn PubChem's CID-0 not-found sentinel into a real error.
+
+        Fix-R4A-9: a structure PubChem does not hold is answered at HTTP 200
+        with {"IdentifierList": {"CID": [0]}}. CID 0 is a sentinel, not a
+        compound, so the wrapper reported status "success" and callers chained
+        it forward -- PubChem_get_compound_properties_by_CID({"cid": 0}) then
+        died with an opaque "Invalid ID, must be positive integer" two steps
+        later. Novel or proprietary analogues are exactly the inputs that hit
+        this. The name-based sibling already reports a clean HTTP 404 /
+        "No CID found", so match that behaviour.
+        """
+        if not isinstance(payload, dict):
+            return None
+        cids = (payload.get("IdentifierList") or {}).get("CID")
+        if isinstance(cids, list) and cids and all(c == 0 for c in cids):
+            return {
+                "status": "error",
+                "error": "No CID found",
+                "detail": (
+                    "PubChem has no compound record matching this structure "
+                    "(it returned the CID 0 not-found sentinel). The structure "
+                    "may be novel, or the input notation may need correcting."
+                ),
+            }
+        return None
+
     def run(self, arguments: dict):
         # Substance (SID, depositor-level) record lookup is handled separately:
         # it parses the raw PC_Substances payload and merges linked CIDs.
@@ -370,7 +398,11 @@ class PubChemRESTTool(BaseTool):
 
         if out_fmt == "JSON":
             try:
-                return {"status": "success", "data": resp.json()}
+                payload = resp.json()
+                sentinel = self._cid_not_found(payload)
+                if sentinel:
+                    return sentinel
+                return {"status": "success", "data": payload}
             except ValueError:
                 ct = resp.headers.get("content-type", "")
                 return {

--- a/src/tooluniverse/rcsb_advanced_search_tool.py
+++ b/src/tooluniverse/rcsb_advanced_search_tool.py
@@ -18,6 +18,14 @@ from .tool_registry import register_tool
 
 RCSB_SEARCH_URL = "https://search.rcsb.org/rcsbsearch/v2/query"
 
+# Fix-R4B-2: `rows` was clamped to 50 and the paginate window start was
+# hard-coded to 0, so results 51+ were structurally unreachable -- a search
+# matching 81,865 entries could only ever expose its first 50, and a caller
+# asking for rows=200 silently got 50 back with nothing in the response
+# saying the request had been reduced. `start` makes the rest of the result
+# set reachable; _paginate() reports the clamp instead of hiding it.
+MAX_ROWS_PER_PAGE = 50
+
 
 @register_tool("RCSBAdvancedSearchTool")
 class RCSBAdvancedSearchTool(BaseTool):
@@ -57,6 +65,54 @@ class RCSBAdvancedSearchTool(BaseTool):
         except Exception as e:
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}
 
+    @staticmethod
+    def _paginate(arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve the paginate window, reporting any clamp applied to `rows`.
+
+        Returns the RCSB `paginate` block plus the bookkeeping needed to tell
+        the caller how much of the result set they actually received.
+        """
+        requested_rows = (
+            arguments.get("rows")
+            or arguments.get("limit")
+            or arguments.get("max_results")
+            or 10
+        )
+        requested_rows = max(1, int(requested_rows))
+        rows = min(requested_rows, MAX_ROWS_PER_PAGE)
+        start = max(0, int(arguments.get("start") or arguments.get("offset") or 0))
+
+        clamped = None
+        if requested_rows > rows:
+            clamped = (
+                f"Requested rows={requested_rows} exceeds the per-page maximum of "
+                f"{MAX_ROWS_PER_PAGE}; returned {rows}. Use 'start' to page through "
+                "the remaining results."
+            )
+        return {"start": start, "rows": rows, "clamp_note": clamped}
+
+    @staticmethod
+    def _pagination_metadata(window: Dict[str, Any], total: int, returned: int) -> Dict:
+        """Build the metadata block describing this page of the result set."""
+        meta: Dict[str, Any] = {
+            "total_count": total,
+            "returned": returned,
+            "start": window["start"],
+            "rows": window["rows"],
+            "max_rows_per_page": MAX_ROWS_PER_PAGE,
+        }
+
+        notes = [n for n in (window["clamp_note"],) if n]
+        next_start = window["start"] + returned
+        if returned and next_start < total:
+            notes.append(
+                f"Showing results {window['start'] + 1}-{next_start} of {total}. "
+                f"Re-run with start={next_start} for the next page."
+            )
+        if notes:
+            meta["note"] = " ".join(notes)
+        return meta
+
     def _query(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Route to appropriate endpoint."""
         if self.endpoint == "advanced_search":
@@ -74,13 +130,7 @@ class RCSBAdvancedSearchTool(BaseTool):
         experimental_method = arguments.get("experimental_method")
         polymer_description = arguments.get("polymer_description")
         min_deposition_date = arguments.get("min_deposition_date")
-        rows = min(
-            arguments.get("rows")
-            or arguments.get("limit")
-            or arguments.get("max_results")
-            or 10,
-            50,
-        )
+        window = self._paginate(arguments)
         sort_by = arguments.get("sort_by") or "resolution"
 
         nodes = []
@@ -192,7 +242,7 @@ class RCSBAdvancedSearchTool(BaseTool):
             "query": query,
             "return_type": "entry",
             "request_options": {
-                "paginate": {"start": 0, "rows": rows},
+                "paginate": {"start": window["start"], "rows": window["rows"]},
                 "sort": [{"sort_by": sort_field, "direction": sort_direction}],
             },
         }
@@ -210,8 +260,7 @@ class RCSBAdvancedSearchTool(BaseTool):
                 "data": [],
                 "metadata": {
                     "source": "RCSB PDB Advanced Search",
-                    "total_count": 0,
-                    "returned": 0,
+                    **self._pagination_metadata(window, 0, 0),
                 },
             }
 
@@ -232,8 +281,9 @@ class RCSBAdvancedSearchTool(BaseTool):
             "data": results,
             "metadata": {
                 "source": "RCSB PDB Advanced Search",
-                "total_count": data.get("total_count", 0),
-                "returned": len(results),
+                **self._pagination_metadata(
+                    window, data.get("total_count", 0), len(results)
+                ),
             },
         }
 
@@ -245,13 +295,7 @@ class RCSBAdvancedSearchTool(BaseTool):
 
         pattern_type = arguments.get("pattern_type") or "prosite"
         sequence_type = arguments.get("sequence_type") or "protein"
-        rows = min(
-            arguments.get("rows")
-            or arguments.get("limit")
-            or arguments.get("max_results")
-            or 10,
-            50,
-        )
+        window = self._paginate(arguments)
 
         request_body = {
             "query": {
@@ -264,7 +308,9 @@ class RCSBAdvancedSearchTool(BaseTool):
                 },
             },
             "return_type": "polymer_entity",
-            "request_options": {"paginate": {"start": 0, "rows": rows}},
+            "request_options": {
+                "paginate": {"start": window["start"], "rows": window["rows"]}
+            },
         }
 
         response = requests.post(
@@ -280,8 +326,7 @@ class RCSBAdvancedSearchTool(BaseTool):
                 "data": [],
                 "metadata": {
                     "source": "RCSB PDB Motif Search",
-                    "total_count": 0,
-                    "returned": 0,
+                    **self._pagination_metadata(window, 0, 0),
                     "pattern": pattern,
                     "pattern_type": pattern_type,
                 },
@@ -310,8 +355,9 @@ class RCSBAdvancedSearchTool(BaseTool):
             "data": results,
             "metadata": {
                 "source": "RCSB PDB Motif Search",
-                "total_count": data.get("total_count", 0),
-                "returned": len(results),
+                **self._pagination_metadata(
+                    window, data.get("total_count", 0), len(results)
+                ),
                 "pattern": pattern,
                 "pattern_type": pattern_type,
             },

--- a/src/tooluniverse/rdkit_cheminfo_tool.py
+++ b/src/tooluniverse/rdkit_cheminfo_tool.py
@@ -61,12 +61,27 @@ _PHARM_SMARTS: Dict[str, list] = {
         "[CX4H1]",  # methine carbons
     ],
     # Single recursive SMARTS — must not be split
+    #
+    # Fix-R4A-7: the previous pattern excluded only [OH,OX1] neighbours, so it
+    # never excluded nitrogen bonded to a carbonyl (i.e. amides), and it
+    # explicitly matched $([n;H0;+0]) -- every neutral aromatic nitrogen.
+    # That made acetamide, acetanilide and pyridine each report 1 basic centre
+    # and imatinib report 7 (its whole nitrogen count) where RDKit's own
+    # BaseFeatures.fdef gives 0, 0, 0 and 2. Amide/anilide N and pyridine
+    # (pKaH 5.2) / pyrimidine (pKaH 1.3) N are not protonated at pH 7.4, and
+    # amides are near-universal in drug-like molecules, so the false positive
+    # hit almost every query. Require sp3 amine nitrogen whose neighbours are
+    # not carbonyl/sulfonyl carbon, plus already-cationic nitrogen and
+    # amidine/guanidine carbon.
     "PosIonizable": [
-        "[$([NH2;+0;$(N-[!$([OH,OX1])])]),"
-        "$([NH;+0;$(N(-[!$([OH,OX1])])-[!$([OH,OX1])])]),"
-        "$([N;H0;+0;$(N(-[!$([OH,OX1])])"
-        "(-[!$([OH,OX1])])-[!$([OH,OX1])])]),"
-        "$([n;H0;+0]),$([NH;+]),$([NH2;+])]"
+        "[$([NX3;H2;+0;!$(N[!#6]);!$(N=*);"
+        "!$(N-[C,S]=[O,S,N]);$(N-[CX4])]),"
+        "$([NX3;H1;+0;!$(N[!#6]);!$(N=*);"
+        "!$(N-[C,S]=[O,S,N]);$(N(-[CX4])-[CX4])]),"
+        "$([NX3;H0;+0;!$(N[!#6]);!$(N=*);"
+        "!$(N-[C,S]=[O,S,N]);$(N(-[CX4])(-[CX4])-[CX4])]),"
+        "$([NX4;+]),$([NH;+]),$([NH2;+]),$([NH3;+]),"
+        "$([$([CX3](=N)(-N)-N)]),$([$([CX3](=N)-N)])]"
     ],
     # Single recursive SMARTS — must not be split
     "NegIonizable": [
@@ -122,8 +137,15 @@ class RDKitCheminfoTool(BaseTool):
         return mol, None
 
     def _get_descriptors(self, mol) -> Dict[str, Any]:
+        # Fix-R4A-6: "MW" was ExactMolWt -- the monoisotopic mass, not the
+        # average molecular weight that "MW" and "Da" denote. Imatinib came
+        # back as 493.26 where PubChem, ChEMBL, SwissADME and SMILES_verify
+        # all report 493.6, and the gap widens with halogens (bromoacetanilide
+        # 212.98 vs the true 214.06), so Ro5 cutoffs and mg->mmol maths were
+        # computed off the wrong number. Report both, correctly labelled.
         return {
-            "MW": round(Descriptors.ExactMolWt(mol), 2),
+            "MW": round(Descriptors.MolWt(mol), 2),
+            "exact_mass": round(Descriptors.ExactMolWt(mol), 4),
             "cLogP": round(Descriptors.MolLogP(mol), 3),
             "HBD": int(rdMolDescriptors.CalcNumHBD(mol)),
             "HBA": int(rdMolDescriptors.CalcNumHBA(mol)),
@@ -199,10 +221,36 @@ class RDKitCheminfoTool(BaseTool):
         except Exception:
             pass
 
-        n_hbd = feature_counts.get("HBD", 0)
-        n_hba = feature_counts.get("HBA", 0)
-        n_arom = feature_counts.get("Aromatic", 0)
-        n_hydro = feature_counts.get("Hydrophobic", 0)
+        # Fix-R4A-5: these used `.get(name, 0)`, so a feature the caller
+        # filtered out via include_features was reported as a hard 0 rather
+        # than "not computed". include_features=["HBD"] on imatinib returned
+        # HBA_count 0, aromatic_atom_count 0 and hydrophobic_atom_count 0 --
+        # a chemically false profile (the true values are 6, 24 and 28) with
+        # status "success". Report None for anything that was not requested.
+        def counted(name):
+            return feature_counts.get(name) if name in features_found else None
+
+        n_hbd = counted("HBD")
+        n_hba = counted("HBA")
+        n_arom = counted("Aromatic")
+        n_hydro = counted("Hydrophobic")
+
+        note = (
+            "3D feature centers computed from MMFF conformer."
+            if feature_centers_3d
+            else "3D conformer generation failed; 2D feature counts provided."
+        )
+        if n_hydro is not None and n_hba is not None:
+            note = (
+                "High hydrophobic + low HBA may indicate poor aqueous solubility. "
+                "HBD/HBA ratio influences membrane permeability (Ro5). " + note
+            )
+        skipped = [f for f in _PHARM_SMARTS if f not in features_found]
+        if skipped:
+            note += (
+                " Values reported as null were excluded by include_features"
+                f" and were not computed: {', '.join(sorted(skipped))}."
+            )
 
         return {
             "status": "success",
@@ -216,17 +264,11 @@ class RDKitCheminfoTool(BaseTool):
                     "HBA_count": n_hba,
                     "aromatic_atom_count": n_arom,
                     "hydrophobic_atom_count": n_hydro,
-                    "hbd_hba_ratio": round(n_hbd / n_hba, 2) if n_hba > 0 else None,
-                    "3d_available": feature_centers_3d is not None,
-                    "note": (
-                        "High hydrophobic + low HBA may indicate poor aqueous solubility. "
-                        "HBD/HBA ratio influences membrane permeability (Ro5). "
-                        + (
-                            "3D feature centers computed from MMFF conformer."
-                            if feature_centers_3d
-                            else "3D conformer generation failed; 2D feature counts provided."
-                        )
+                    "hbd_hba_ratio": (
+                        round(n_hbd / n_hba, 2) if n_hbd is not None and n_hba else None
                     ),
+                    "3d_available": feature_centers_3d is not None,
+                    "note": note,
                 },
             },
             "metadata": {

--- a/tests/unit/test_gwas_variants_for_trait_sort.py
+++ b/tests/unit/test_gwas_variants_for_trait_sort.py
@@ -1,0 +1,72 @@
+"""Regression guard for Fix-R4B-1: gwas_get_variants_for_trait returned an
+UNSORTED page.
+
+GWASVariantsForTrait and GWASAssociationsForTrait hit the same
+/v2/associations endpoint, but only the latter sent sort=p_value&direction=asc.
+The GWAS Catalog returns associations unsorted, so the variants tool handed
+back an arbitrary slice: confirmed live that efo_id=MONDO_0004979 (asthma,
+3219 associations) yielded p-values 2e-06 .. 2e-24 from this tool while the
+sibling returned 7e-288, 8e-223, 2e-156 for the identical query. Every
+genome-wide-significant locus was missing from the first page.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.gwas_tool import GWASAssociationsForTrait, GWASVariantsForTrait
+
+pytestmark = pytest.mark.unit
+
+
+def _params_for(cls, name, arguments):
+    """Run the tool with the network stubbed and return the query params sent."""
+    captured = {}
+
+    def fake_request(endpoint, params):
+        captured["params"] = params
+        return {"_embedded": {"associations": []}, "page": {"totalElements": 0}}
+
+    with patch.object(cls, "_make_request", side_effect=fake_request):
+        cls({"name": name}).run(arguments)
+    return captured["params"]
+
+
+def _variant_params(arguments):
+    return _params_for(
+        GWASVariantsForTrait, "gwas_get_variants_for_trait", arguments
+    )
+
+
+def test_defaults_to_significance_order():
+    params = _variant_params({"efo_id": "MONDO_0004979"})
+    assert params["sort"] == "p_value"
+    assert params["direction"] == "asc"
+
+
+def test_explicit_sort_and_direction_are_respected():
+    params = _variant_params(
+        {"efo_id": "MONDO_0004979", "sort": "or_value", "direction": "desc"}
+    )
+    assert params["sort"] == "or_value"
+    assert params["direction"] == "desc"
+
+
+def test_matches_sibling_tool_ordering_for_the_same_trait():
+    """The two trait tools query one endpoint; they must not disagree on order."""
+    variants = _variant_params({"efo_id": "MONDO_0004979"})
+    associations = _params_for(
+        GWASAssociationsForTrait,
+        "gwas_get_associations_for_trait",
+        {"efo_id": "MONDO_0004979"},
+    )
+    assert (variants["sort"], variants["direction"]) == (
+        associations["sort"],
+        associations["direction"],
+    )
+
+
+def test_paging_and_size_still_pass_through():
+    params = _variant_params({"efo_id": "MONDO_0004979", "size": 25, "page": 3})
+    assert params["size"] == 25
+    assert params["page"] == 3

--- a/tests/unit/test_result_cap_pagination.py
+++ b/tests/unit/test_result_cap_pagination.py
@@ -304,3 +304,35 @@ def test_cpic_missing_gene_is_an_error_not_an_exception():
     result = CPICGetAllelesTool({"name": "CPIC_get_alleles"}).run({})
     assert result["status"] == "error"
     assert "genesymbol" in result["error"]
+
+
+# --------------------------------------------------------------------------
+# Expression Atlas
+# --------------------------------------------------------------------------
+
+
+def test_expression_atlas_pages_beyond_the_old_fifty_cap():
+    """241 experiments matched 'cancer' but only the first 50 were reachable."""
+    from tooluniverse.expression_atlas_tool import ExpressionAtlasTool
+
+    records = [{"experiment_accession": f"E-{i:04d}"} for i in range(241)]
+
+    first, offset, note = ExpressionAtlasTool._page(records, {})
+    assert len(first) == 50 and offset == 0
+    assert "241" in note and "offset=50" in note
+
+    tail, offset, note = ExpressionAtlasTool._page(records, {"limit": 10, "offset": 200})
+    assert [r["experiment_accession"] for r in tail][0] == "E-0200"
+    assert offset == 200
+
+    everything, _, note = ExpressionAtlasTool._page(records, {"limit": 300})
+    assert len(everything) == 241
+    assert note is None, "no next-page note once the list is exhausted"
+
+
+def test_expression_atlas_limit_is_capped_and_offset_floored():
+    from tooluniverse.expression_atlas_tool import ExpressionAtlasTool
+
+    records = [{"i": i} for i in range(600)]
+    assert len(ExpressionAtlasTool._page(records, {"limit": 9999})[0]) == 500
+    assert ExpressionAtlasTool._page(records, {"offset": -5})[1] == 0

--- a/tests/unit/test_result_cap_pagination.py
+++ b/tests/unit/test_result_cap_pagination.py
@@ -1,0 +1,306 @@
+"""Regression guards for Fix-R4B-2/3/4: undocumented result caps with no escape.
+
+Three tools truncated their result list to a hard-coded page and gave the
+caller no way to reach the rest -- and in two cases no way to even tell that
+truncation had happened:
+
+* RCSBAdvSearch_search_structures clamped `rows` to 50 and hard-coded the
+  paginate window to start=0. A search matching 6,705 entries could only ever
+  expose its first 50, and rows=200 silently returned 50.
+* PDBeSIFTS_get_best_structures / _get_all_structures sliced to entries[:50]
+  with no limit/offset parameter at all (P04637 has 676 entries), and
+  PDBeSIFTS_get_pdb_to_uniprot cut chain mappings at 20 with no count.
+* CPIC_get_alleles defaulted to limit=50 and reported only `count` -- the size
+  of the returned page -- so CYP2D6 looked like it had 50 alleles when CPIC
+  curates 208.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.cpic_search_pairs_tool import CPICGetAllelesTool
+from tooluniverse.pdbe_sifts_tool import PDBeSIFTSTool
+from tooluniverse.rcsb_advanced_search_tool import (
+    MAX_ROWS_PER_PAGE,
+    RCSBAdvancedSearchTool,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# RCSB advanced search
+# --------------------------------------------------------------------------
+
+
+def _rcsb_tool(endpoint="advanced_search"):
+    return RCSBAdvancedSearchTool(
+        {"name": "RCSBAdvSearch_search_structures", "fields": {"endpoint": endpoint}}
+    )
+
+
+def _rcsb_response(n_hits, total):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.content = b"{}"
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {
+        "result_set": [{"identifier": f"{i:04d}", "score": 1.0} for i in range(n_hits)],
+        "total_count": total,
+    }
+    return resp
+
+
+def _run_rcsb(arguments, n_hits=50, total=6705, endpoint="advanced_search"):
+    with patch("requests.post", return_value=_rcsb_response(n_hits, total)) as post:
+        result = _rcsb_tool(endpoint).run(arguments)
+    return result, post.call_args.kwargs["json"]
+
+
+def test_rcsb_start_reaches_beyond_the_first_page():
+    _, body = _run_rcsb({"organism": "Homo sapiens", "rows": 50, "start": 50})
+    assert body["request_options"]["paginate"] == {"start": 50, "rows": 50}
+
+
+def test_rcsb_offset_is_accepted_as_an_alias_for_start():
+    _, body = _run_rcsb({"organism": "Homo sapiens", "offset": 120})
+    assert body["request_options"]["paginate"]["start"] == 120
+
+
+def test_rcsb_start_defaults_to_zero():
+    _, body = _run_rcsb({"organism": "Homo sapiens"})
+    assert body["request_options"]["paginate"]["start"] == 0
+
+
+def test_rcsb_rows_over_the_cap_is_reported_not_silently_reduced():
+    result, body = _run_rcsb({"organism": "Homo sapiens", "rows": 200})
+    assert body["request_options"]["paginate"]["rows"] == MAX_ROWS_PER_PAGE
+    note = result["metadata"]["note"]
+    assert "200" in note and str(MAX_ROWS_PER_PAGE) in note
+    assert result["metadata"]["max_rows_per_page"] == MAX_ROWS_PER_PAGE
+
+
+def test_rcsb_metadata_points_at_the_next_page():
+    result, _ = _run_rcsb({"organism": "Homo sapiens", "rows": 50}, n_hits=50)
+    assert result["metadata"]["total_count"] == 6705
+    assert result["metadata"]["returned"] == 50
+    assert "start=50" in result["metadata"]["note"]
+
+
+def test_rcsb_no_next_page_note_when_everything_was_returned():
+    result, _ = _run_rcsb({"organism": "rare"}, n_hits=3, total=3)
+    assert "note" not in result["metadata"]
+
+
+def test_rcsb_motif_search_pages_too():
+    _, body = _run_rcsb(
+        {"pattern": "C-x(2,4)-C", "rows": 200, "start": 50}, endpoint="motif_search"
+    )
+    assert body["request_options"]["paginate"] == {
+        "start": 50,
+        "rows": MAX_ROWS_PER_PAGE,
+    }
+
+
+# --------------------------------------------------------------------------
+# PDBe SIFTS
+# --------------------------------------------------------------------------
+
+
+def _sifts_tool(endpoint):
+    return PDBeSIFTSTool({"name": "PDBeSIFTS", "fields": {"endpoint": endpoint}})
+
+
+def _sifts_entries(n):
+    return [
+        {
+            "pdb_id": f"e{i:03d}",
+            "chain_id": "A",
+            "resolution": 1.0 + i,
+            "experimental_method": "X-ray diffraction",
+            "coverage": 0.9,
+        }
+        for i in range(n)
+    ]
+
+
+def _run_sifts(endpoint, payload, arguments):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = payload
+    with patch("requests.get", return_value=resp):
+        return _sifts_tool(endpoint).run(arguments)
+
+
+def test_sifts_best_structures_default_page_is_unchanged():
+    result = _run_sifts(
+        "best_structures", {"P04637": _sifts_entries(676)}, {"uniprot_accession": "P04637"}
+    )
+    assert len(result["data"]["structures"]) == 50
+    assert result["data"]["total_structures"] == 676
+    assert result["data"]["returned_structures"] == 50
+
+
+def test_sifts_best_structures_offset_returns_a_different_slice():
+    payload = {"P04637": _sifts_entries(676)}
+    first = _run_sifts(
+        "best_structures", payload, {"uniprot_accession": "P04637", "limit": 5}
+    )
+    second = _run_sifts(
+        "best_structures",
+        payload,
+        {"uniprot_accession": "P04637", "limit": 5, "offset": 50},
+    )
+    assert [s["pdb_id"] for s in first["data"]["structures"]] != [
+        s["pdb_id"] for s in second["data"]["structures"]
+    ]
+    assert second["data"]["structures"][0]["pdb_id"] == "e050"
+    assert second["data"]["offset"] == 50
+
+
+def test_sifts_best_structures_limit_reaches_past_the_old_cap():
+    result = _run_sifts(
+        "best_structures",
+        {"P04637": _sifts_entries(676)},
+        {"uniprot_accession": "P04637", "limit": 400},
+    )
+    assert result["data"]["returned_structures"] == 400
+
+
+def test_sifts_best_structures_notes_the_remaining_entries():
+    result = _run_sifts(
+        "best_structures", {"P04637": _sifts_entries(676)}, {"uniprot_accession": "P04637"}
+    )
+    assert "676" in result["data"]["note"]
+    assert "offset=50" in result["data"]["note"]
+
+
+def test_sifts_note_absent_when_the_whole_list_fits():
+    result = _run_sifts(
+        "best_structures", {"P01308": _sifts_entries(7)}, {"uniprot_accession": "P01308"}
+    )
+    assert "note" not in result["data"]
+    assert result["data"]["returned_structures"] == 7
+
+
+def test_sifts_all_structures_pages_as_well():
+    entries = [
+        {"pdb_id": f"e{i:03d}", "chain_id": "A", "resolution": 1.0 + i}
+        for i in range(120)
+    ]
+    result = _run_sifts(
+        "uniprot_to_pdb",
+        {"P04637": entries},
+        {"uniprot_accession": "P04637", "limit": 10, "offset": 100},
+    )
+    assert result["data"]["returned_pdb_entries"] == 10
+    assert result["data"]["offset"] == 100
+    assert result["data"]["total_pdb_entries"] == 120
+
+
+def test_sifts_pdb_to_uniprot_reports_truncated_chain_mappings():
+    """The 20-mapping cut was previously invisible: total_proteins counts
+    proteins, not mappings."""
+    mappings = [
+        {
+            "chain_id": chr(65 + (i % 26)),
+            "start": {"residue_number": 1},
+            "end": {"residue_number": 100},
+            "unp_start": 1,
+            "unp_end": 100,
+        }
+        for i in range(37)
+    ]
+    result = _run_sifts(
+        "pdb_to_uniprot",
+        {"1tup": {"UniProt": {"P04637": {"identifier": "P53_HUMAN", "mappings": mappings}}}},
+        {"pdb_id": "1TUP"},
+    )
+    protein = result["data"]["proteins"][0]
+    assert len(protein["chain_mappings"]) == 20
+    assert protein["total_chain_mappings"] == 37
+    assert protein["chain_mappings_truncated"] is True
+
+
+def test_sifts_pdb_to_uniprot_not_flagged_when_complete():
+    mappings = [
+        {"chain_id": "A", "start": {}, "end": {}, "unp_start": 1, "unp_end": 10}
+    ]
+    result = _run_sifts(
+        "pdb_to_uniprot",
+        {"1abc": {"UniProt": {"P00000": {"identifier": "X", "mappings": mappings}}}},
+        {"pdb_id": "1abc"},
+    )
+    protein = result["data"]["proteins"][0]
+    assert protein["total_chain_mappings"] == 1
+    assert protein["chain_mappings_truncated"] is False
+
+
+# --------------------------------------------------------------------------
+# CPIC alleles
+# --------------------------------------------------------------------------
+
+
+def _cpic_response(n_rows, content_range):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = [{"name": f"*{i}"} for i in range(n_rows)]
+    resp.headers = {"Content-Range": content_range} if content_range else {}
+    resp.url = "https://api.cpicpgx.org/v1/allele"
+    return resp
+
+
+def _run_cpic(arguments, n_rows=50, content_range="0-49/208"):
+    with patch(
+        "requests.get", return_value=_cpic_response(n_rows, content_range)
+    ) as get:
+        result = CPICGetAllelesTool({"name": "CPIC_get_alleles"}).run(arguments)
+    return result, get.call_args
+
+
+def test_cpic_reports_the_true_allele_total_not_the_page_size():
+    result, _ = _run_cpic({"genesymbol": "CYP2D6"})
+    assert result["count"] == 50
+    assert result["total_count"] == 208
+    assert "208" in result["note"]
+
+
+def test_cpic_requests_an_exact_count_from_postgrest():
+    _, call = _run_cpic({"genesymbol": "CYP2D6"})
+    assert call.kwargs["headers"]["Prefer"] == "count=exact"
+
+
+def test_cpic_offset_is_sent_upstream():
+    _, call = _run_cpic({"genesymbol": "CYP2D6", "offset": 200}, n_rows=8)
+    assert call.kwargs["params"]["offset"] == 200
+    assert call.kwargs["params"]["limit"] == 50
+
+
+def test_cpic_gene_symbol_is_uppercased_for_the_eq_filter():
+    _, call = _run_cpic({"genesymbol": "cyp2d6"})
+    assert call.kwargs["params"]["genesymbol"] == "eq.CYP2D6"
+
+
+def test_cpic_limit_is_capped_but_far_above_the_old_default():
+    _, call = _run_cpic({"genesymbol": "CYP2D6", "limit": 99999})
+    assert call.kwargs["params"]["limit"] == CPICGetAllelesTool._MAX_LIMIT
+
+
+def test_cpic_no_note_once_the_last_page_is_reached():
+    result, _ = _run_cpic(
+        {"genesymbol": "CYP2D6", "offset": 200}, n_rows=8, content_range="200-207/208"
+    )
+    assert result["total_count"] == 208
+    assert "note" not in result
+
+
+def test_cpic_falls_back_when_the_count_header_is_missing():
+    result, _ = _run_cpic({"genesymbol": "TPMT"}, n_rows=12, content_range=None)
+    assert result["total_count"] == 12
+
+
+def test_cpic_missing_gene_is_an_error_not_an_exception():
+    result = CPICGetAllelesTool({"name": "CPIC_get_alleles"}).run({})
+    assert result["status"] == "error"
+    assert "genesymbol" in result["error"]

--- a/tests/unit/test_silently_dropped_filters.py
+++ b/tests/unit/test_silently_dropped_filters.py
@@ -1,0 +1,248 @@
+"""Regression guards for filters and lookups that were silently dropped.
+
+Each tool below accepted an input, ignored it, and returned an unfiltered or
+wrong result as a success:
+
+* MGnify_search_genomes sent ?lineage= where /genomes filters on
+  ?taxon_lineage=, so every taxonomy value returned the whole 56,782-genome
+  catalogue; its genome_type filter has no upstream equivalent at all.
+* NeuroMorpho_search_neurons left multi-word values unquoted, so
+  brain_region="entorhinal cortex" was executed as "cortex".
+* GtoPdb_search_targets rewrote gene_symbol into a targetId query parameter
+  that the /targets endpoint ignores.
+* HPA_get_rna_expression_by_source queried a column name HPA does not have.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.gtopdb_tool import GtoPdbRESTTool
+from tooluniverse.hpa_tool import HPAGetRnaExpressionBySourceTool
+from tooluniverse.mgnify_expanded_tool import MGnifyExpandedTool
+from tooluniverse.neuromorpho_tool import NeuroMorphoTool
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------
+# MGnify genome search
+# --------------------------------------------------------------------------
+
+
+def _mgnify_tool():
+    return MGnifyExpandedTool(
+        {"name": "MGnify_search_genomes", "fields": {"endpoint_type": "genomes"}}
+    )
+
+
+def _mgnify_params(arguments):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"data": [], "meta": {"pagination": {"count": 0}}}
+    with patch("requests.get", return_value=resp) as get:
+        result = _mgnify_tool()._genome_search(arguments)
+    return result, (get.call_args.kwargs.get("params") if get.call_args else None)
+
+
+def test_mgnify_taxonomy_uses_taxon_lineage_not_lineage():
+    _, params = _mgnify_params({"taxonomy": "Bacteroides"})
+    assert params["taxon_lineage"] == "Bacteroides"
+    assert "lineage" not in params
+
+
+def test_mgnify_no_taxonomy_sends_no_taxon_filter():
+    _, params = _mgnify_params({"page_size": 3})
+    assert "taxon_lineage" not in params
+
+
+def test_mgnify_genome_type_fails_closed_instead_of_returning_everything():
+    result, params = _mgnify_params({"genome_type": "Isolate"})
+    assert result["status"] == "error"
+    assert "genome_type" in result["error"]
+    assert params is None, "must not issue an unfiltered request"
+
+
+def test_mgnify_page_size_is_still_capped():
+    _, params = _mgnify_params({"taxonomy": "Bacteroides", "page_size": 5000})
+    assert params["page_size"] == 100
+
+
+# --------------------------------------------------------------------------
+# NeuroMorpho query quoting
+# --------------------------------------------------------------------------
+
+
+def _neuromorpho_query(arguments):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"_embedded": {"neuronResources": []}, "page": {}}
+    tool = NeuroMorphoTool(
+        {
+            "name": "NeuroMorpho_search_neurons",
+            "fields": {"endpoint_type": "neuron", "query_mode": "search"},
+        }
+    )
+    with patch("requests.get", return_value=resp) as get:
+        tool.run(arguments)
+    return get.call_args.kwargs["params"]
+
+
+def test_neuromorpho_quotes_multi_word_query_value():
+    params = _neuromorpho_query(
+        {"query_field": "brain_region", "query_value": "entorhinal cortex"}
+    )
+    assert params["q"] == 'brain_region:"entorhinal cortex"'
+
+
+def test_neuromorpho_leaves_single_word_unquoted():
+    params = _neuromorpho_query({"query_field": "brain_region", "query_value": "cortex"})
+    assert params["q"] == "brain_region:cortex"
+
+
+def test_neuromorpho_does_not_double_quote():
+    params = _neuromorpho_query(
+        {"query_field": "brain_region", "query_value": '"entorhinal cortex"'}
+    )
+    assert params["q"] == 'brain_region:"entorhinal cortex"'
+
+
+def test_neuromorpho_quotes_the_filter_query_too():
+    params = _neuromorpho_query(
+        {
+            "query_field": "species",
+            "query_value": "mouse",
+            "filter_field": "cell_type",
+            "filter_value": "pyramidal cell",
+        }
+    )
+    assert params["fq"] == 'cell_type:"pyramidal cell"'
+
+
+# --------------------------------------------------------------------------
+# GtoPdb gene symbol routing
+# --------------------------------------------------------------------------
+
+
+def _gtopdb_tool(endpoint):
+    return GtoPdbRESTTool(
+        {"name": "GtoPdb_test", "fields": {"endpoint": endpoint, "params": {}}}
+    )
+
+
+def test_gtopdb_target_search_maps_gene_symbol_to_gene_symbol_query():
+    url = _gtopdb_tool(
+        "https://www.guidetopharmacology.org/services/targets"
+    )._build_url({"gene_symbol": "CHRNA7"})
+    assert url.endswith("targets?geneSymbol=CHRNA7")
+
+
+def test_gtopdb_target_search_still_supports_name():
+    url = _gtopdb_tool(
+        "https://www.guidetopharmacology.org/services/targets"
+    )._build_url({"name": "dopamine"})
+    assert "name=dopamine" in url
+    assert "geneSymbol" not in url
+
+
+def test_gtopdb_target_search_does_not_resolve_gene_symbol_to_targetid():
+    """The targetId rewrite is only meaningful for /interactions endpoints."""
+    tool = _gtopdb_tool("https://www.guidetopharmacology.org/services/targets")
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = []
+    with patch("tooluniverse.gtopdb_tool.request_with_retry", return_value=resp) as req:
+        tool.run({"gene_symbol": "CHRNA7"})
+    called = [c.args[2] for c in req.call_args_list if len(c.args) > 2]
+    assert not any("targetId=" in u for u in called)
+
+
+# --------------------------------------------------------------------------
+# HPA per-source expression columns
+# --------------------------------------------------------------------------
+
+
+def _hpa_tool():
+    return HPAGetRnaExpressionBySourceTool({"name": "HPA_get_rna_expression_by_source"})
+
+
+def test_hpa_brain_uses_per_region_column_not_rnabrm():
+    tool = _hpa_tool()
+    requested = []
+
+    def fake_request(gene, columns, format_type="json"):
+        requested.append(columns)
+        if "brain_RNA_" in columns:
+            return [{"Gene": "GFAP", "Brain RNA - thalamus [nTPM]": "14782.4"}]
+        return []
+
+    with patch.object(tool, "_make_api_request", side_effect=fake_request):
+        result = tool.run(
+            {"gene_name": "GFAP", "source_type": "brain", "source_name": "thalamus"}
+        )
+
+    assert result["data"]["expression_value"] == "14782.4"
+    assert result["data"]["expression_level"] == "very high"
+    assert any("brain_RNA_thalamus" in c for c in requested)
+    assert not any(c.endswith("rnabrm") for c in requested)
+
+
+def test_hpa_tissue_uses_per_tissue_column():
+    tool = _hpa_tool()
+
+    def fake_request(gene, columns, format_type="json"):
+        if "t_RNA_liver" in columns:
+            return [{"Gene": "TP53", "Tissue RNA - liver [nTPM]": "15.6"}]
+        return []
+
+    with patch.object(tool, "_make_api_request", side_effect=fake_request):
+        result = tool.run(
+            {"gene_name": "TP53", "source_type": "tissue", "source_name": "liver"}
+        )
+    assert result["data"]["expression_value"] == "15.6"
+
+
+def test_hpa_picks_the_queried_gene_not_a_synonym_hit():
+    """HPA's search matches synonyms, so search=GFAP also returns HGFAC."""
+    tool = _hpa_tool()
+
+    def fake_request(gene, columns, format_type="json"):
+        return [
+            {"Gene": "HGFAC", "Brain RNA - thalamus [nTPM]": "1.6"},
+            {"Gene": "GFAP", "Brain RNA - thalamus [nTPM]": "14782.4"},
+        ]
+
+    with patch.object(tool, "_make_api_request", side_effect=fake_request):
+        result = tool.run(
+            {"gene_name": "GFAP", "source_type": "brain", "source_name": "thalamus"}
+        )
+    assert result["data"]["expression_value"] == "14782.4"
+
+
+def test_hpa_falls_back_to_aggregate_column_when_no_per_source_value():
+    tool = _hpa_tool()
+    requested = []
+
+    def fake_request(gene, columns, format_type="json"):
+        requested.append(columns)
+        if columns.endswith("rnabrm"):
+            return [{"Gene": "GFAP"}]
+        return [{"Gene": "GFAP"}]
+
+    with patch.object(tool, "_make_api_request", side_effect=fake_request):
+        result = tool.run(
+            {"gene_name": "GFAP", "source_type": "brain", "source_name": "thalamus"}
+        )
+    assert result["status"] == "success"
+    assert any(c.endswith("rnabrm") for c in requested)
+
+
+def test_hpa_expression_level_buckets():
+    categorize = HPAGetRnaExpressionBySourceTool._categorize_expression
+    assert categorize("14782.4") == "very high"
+    assert categorize("15.6") == "high"
+    assert categorize("1.5") == "medium"
+    assert categorize("0.5") == "low"
+    assert categorize("0.05") == "very low"
+    assert categorize("N/A") == "unknown"
+    assert categorize(None) == "unknown"

--- a/tests/unit/test_wrong_values_and_counts.py
+++ b/tests/unit/test_wrong_values_and_counts.py
@@ -1,0 +1,230 @@
+"""Regression guards for values, counts and sentinels that misreported reality.
+
+* RDKit_matched_molecular_pair labelled ExactMolWt (monoisotopic mass) as "MW"
+  and formatted deltas in Da, so imatinib read 493.26 against the 493.6 every
+  other tool in the suite reports.
+* RDKit_pharmacophore_features counted amide, anilide and every neutral
+  aromatic nitrogen as PosIonizable (imatinib: 7, RDKit's own reference: 2),
+  and reported filtered-out features as a hard 0 rather than "not computed".
+* PubChem_get_CID_by_SMILES passed through PubChem's CID-0 not-found sentinel
+  as a success.
+* DGIdb interaction tools reported metadata.total as the GENE count.
+* Five IEDB tools declared an `offset` that always failed, because PostgREST
+  rejects offset without order.
+* intact_get_interactions truncated to 25 of 87 with the working `size`
+  parameter undeclared.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.dgidb_tool import DGIdbTool
+from tooluniverse.pubchem_tool import PubChemRESTTool
+
+pytestmark = pytest.mark.unit
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "src" / "tooluniverse" / "data"
+
+
+def _config(filename, tool_name):
+    for tool in json.loads((DATA_DIR / filename).read_text()):
+        if tool.get("name") == tool_name:
+            return tool
+    raise AssertionError(f"{tool_name} not found in {filename}")
+
+
+# --------------------------------------------------------------------------
+# RDKit descriptors and pharmacophore features
+# --------------------------------------------------------------------------
+
+rdkit = pytest.importorskip("rdkit", reason="rdkit not installed")
+
+IMATINIB = "Cc1ccc(NC(=O)c2ccc(CN3CCN(C)CC3)cc2)cc1Nc1nccc(-c2cccnc2)n1"
+
+
+def _cheminfo(endpoint):
+    from tooluniverse.rdkit_cheminfo_tool import RDKitCheminfoTool
+
+    return RDKitCheminfoTool({"name": "rdkit", "fields": {"endpoint": endpoint}})
+
+
+def test_mw_is_average_molecular_weight_not_monoisotopic():
+    from rdkit import Chem
+    from rdkit.Chem import Descriptors
+
+    mol = Chem.MolFromSmiles(IMATINIB)
+    descriptors = _cheminfo("matched_molecular_pair")._get_descriptors(mol)
+
+    assert descriptors["MW"] == round(Descriptors.MolWt(mol), 2) == 493.62
+    assert descriptors["MW"] != round(Descriptors.ExactMolWt(mol), 2)
+
+
+def test_exact_mass_is_reported_separately():
+    from rdkit import Chem
+
+    mol = Chem.MolFromSmiles(IMATINIB)
+    descriptors = _cheminfo("matched_molecular_pair")._get_descriptors(mol)
+    assert descriptors["exact_mass"] == pytest.approx(493.259, abs=0.01)
+
+
+def test_halogen_mw_matches_average_mass():
+    """The monoisotopic/average gap is widest for heavy halogens."""
+    from rdkit import Chem
+
+    descriptors = _cheminfo("matched_molecular_pair")._get_descriptors(
+        Chem.MolFromSmiles("CC(=O)Nc1ccc(Br)cc1")
+    )
+    assert descriptors["MW"] == pytest.approx(214.06, abs=0.01)
+
+
+@pytest.mark.parametrize(
+    "name,smiles,expected",
+    [
+        ("acetamide", "CC(N)=O", 0),
+        ("acetanilide", "CC(=O)Nc1ccccc1", 0),
+        ("pyridine", "c1ccncc1", 0),
+        ("aniline", "Nc1ccccc1", 0),
+        ("sulfanilamide", "Nc1ccc(S(N)(=O)=O)cc1", 0),
+        ("triethylamine", "CCN(CC)CC", 1),
+        ("benzylamine", "NCc1ccccc1", 1),
+        ("piperazine", "C1CNCCN1", 2),
+        ("imatinib", IMATINIB, 2),
+    ],
+)
+def test_posionizable_matches_rdkit_reference_definitions(name, smiles, expected):
+    """Counts must agree with RDKit's own BaseFeatures.fdef."""
+    from rdkit import Chem
+    from tooluniverse.rdkit_cheminfo_tool import _PHARM_SMARTS
+
+    mol = Chem.MolFromSmiles(smiles)
+    matched = set()
+    for smarts in _PHARM_SMARTS["PosIonizable"]:
+        pattern = Chem.MolFromSmarts(smarts)
+        assert pattern is not None, f"PosIonizable SMARTS failed to parse: {smarts}"
+        for hit in mol.GetSubstructMatches(pattern):
+            matched.update(hit)
+    assert len(matched) == expected, name
+
+
+def test_filtered_out_features_report_null_not_zero():
+    result = _cheminfo("pharmacophore_features").run(
+        {"smiles": IMATINIB, "include_features": ["HBD"]}
+    )
+    interpretation = result["data"]["interpretation"]
+    assert interpretation["HBD_count"] == 2
+    assert interpretation["HBA_count"] is None
+    assert interpretation["aromatic_atom_count"] is None
+    assert interpretation["hydrophobic_atom_count"] is None
+    assert "include_features" in interpretation["note"]
+
+
+def test_unfiltered_request_still_reports_every_count():
+    result = _cheminfo("pharmacophore_features").run({"smiles": IMATINIB})
+    interpretation = result["data"]["interpretation"]
+    assert interpretation["HBA_count"] == 6
+    assert interpretation["aromatic_atom_count"] == 24
+    assert interpretation["hydrophobic_atom_count"] == 28
+    assert result["data"]["feature_counts"]["PosIonizable"] == 2
+
+
+# --------------------------------------------------------------------------
+# PubChem CID-0 sentinel
+# --------------------------------------------------------------------------
+
+
+def test_cid_zero_sentinel_becomes_an_error():
+    result = PubChemRESTTool._cid_not_found({"IdentifierList": {"CID": [0]}})
+    assert result is not None
+    assert result["status"] == "error"
+    assert "No CID found" in result["error"]
+
+
+def test_real_cid_is_not_treated_as_not_found():
+    assert PubChemRESTTool._cid_not_found({"IdentifierList": {"CID": [2244]}}) is None
+
+
+def test_mixed_cid_list_is_not_treated_as_not_found():
+    assert PubChemRESTTool._cid_not_found({"IdentifierList": {"CID": [0, 2244]}}) is None
+
+
+def test_non_cid_payloads_pass_through():
+    assert PubChemRESTTool._cid_not_found({"PropertyTable": {}}) is None
+    assert PubChemRESTTool._cid_not_found([1, 2, 3]) is None
+
+
+# --------------------------------------------------------------------------
+# DGIdb counts
+# --------------------------------------------------------------------------
+
+
+def test_dgidb_reports_interaction_total_alongside_gene_count():
+    payload = {
+        "data": {
+            "genes": {
+                "nodes": [
+                    {"name": "PDCD1", "interactions": [{}] * 68},
+                    {"name": "CD274", "interactions": [{}] * 36},
+                    {"name": "CTLA4", "interactions": [{}] * 36},
+                ]
+            }
+        }
+    }
+    result = DGIdbTool._envelope(payload, "genes")
+    assert result["metadata"]["genes_returned"] == 3
+    assert result["metadata"]["interactions_total"] == 140
+
+
+def test_dgidb_errors_still_propagate():
+    result = DGIdbTool._envelope({"errors": [{"message": "boom"}]}, "genes")
+    assert result["status"] == "error"
+
+
+# --------------------------------------------------------------------------
+# Config-level declarations
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "iedb_search_antigens",
+        "iedb_search_mhc",
+        "iedb_search_bcell",
+        "iedb_search_references",
+        "iedb_get_epitope_antigens",
+        "iedb_get_epitope_mhc",
+        "iedb_get_epitope_references",
+    ],
+)
+def test_iedb_tools_declare_a_default_order_so_offset_works(tool_name):
+    """PostgREST rejects offset without order; every offset-bearing tool needs one."""
+    config = _config("iedb_tools.json", tool_name)
+    order = (config.get("fields") or {}).get("default_params", {}).get("order")
+    assert order, f"{tool_name} declares offset but has no default order"
+    assert order.endswith((".asc", ".desc"))
+
+
+@pytest.mark.parametrize(
+    "tool_name", ["intact_get_interactions", "intact_get_interactor"]
+)
+def test_intact_declares_the_size_parameter_it_already_honours(tool_name):
+    config = _config("intact_tools.json", tool_name)
+    assert "size" in config["parameter"]["properties"]
+
+
+def test_intact_format_enum_does_not_advertise_xml_it_cannot_produce():
+    config = _config("intact_tools.json", "intact_get_interactions")
+    assert config["parameter"]["properties"]["format"]["enum"] == ["json"]
+
+
+def test_hla_ligand_atlas_documents_all_three_binder_flags():
+    """s/ = strong, w/ = weak, n/ = NON-binder -- the docs had n/ as 'strong'."""
+    description = _config(
+        "hlaligandatlas_tools.json", "HLALigandAtlas_get_benign_peptides"
+    )["description"]
+    assert "'s/' = strong binder" in description
+    assert "'n/' = NON-binder" in description
+    assert "strong 'n/'" not in description


### PR DESCRIPTION
Round 4 of the role-play bug hunt. Four researcher personas worked real end-to-end
questions in domains earlier rounds had not touched — neuroscience, immunology,
medicinal chemistry / cheminformatics, and microbiome / systems biology — plus
follow-up on four result-cap problems CLI-flagged during round 3.

**29 candidates reported → 19 CLI-verified → 17 fixed → 3 discarded as false positives.**
Every fix was reproduced against the live upstream API before the change and
re-verified after it. Nothing here was taken on a persona's word.

The theme that emerged is narrower than "bugs": **a tool accepts an input or reports
a number, and the answer it gives back is confidently wrong rather than obviously
broken.** A silently-dropped filter, a cap with no escape, a count that means
something other than what it is named — each one returns `status: success` and looks
like a real answer.

---

## What was broken, and how wrong it was

### Filters that were accepted and then ignored

| Tool | Asked for | Actually returned |
|---|---|---|
| `MGnify_search_genomes` | `taxonomy="Bacteroides"` | all **56,782** genomes (correct: 136) |
| `HPA_get_rna_expression_by_source` | GFAP in thalamus | `"N/A"` for **every gene, every brain region** |
| `NeuroMorpho_search_neurons` | `brain_region="entorhinal cortex"` | 872 **zebra-finch song-nucleus** neurons (correct: 3,431 entorhinal) |
| `GtoPdb_search_targets` | `gene_symbol="CHRNA7"` | the unfiltered first 50 targets, alphabetically |

`MGnify_search_genomes` sent `?lineage=` where the endpoint filters on
`?taxon_lineage=`; MGnify drops unknown query params rather than erroring, so
`taxonomy="Bacteroides"`, `taxonomy="COMPLETELY_BOGUS_XYZ"` and no taxonomy at all
all returned the identical full catalogue. Its `genome_type` filter has no working
upstream equivalent at all (`?genome_type=`, `?type=`, `?genome-type=` each return
all 56,782), so it now **fails closed** instead of silently returning everything.
The description also advertised NCBI phylum names against a GTDB catalogue —
`Bacteroidetes` returns 0 where `Bacteroidota` returns 6,895.

`HPA_get_rna_expression_by_source` queried column `rnabrm`, which is not a valid HPA
column — HPA silently drops unknown columns. The whole brain mode was dead, and the
`tissue` mode used an aggregate column populated only for tissue-enriched genes, so
even the tool's own documented example (TP53 / liver) came back empty. Now:
GFAP/thalamus 14782.4 nTPM, GFAP/cerebellum 9332.2, APP/cerebral cortex 669.1,
TP53/liver 15.6.

`GtoPdb_search_targets` had a `gene_symbol`→`targetId` resolution step meant for
`/targets/{id}/interactions` firing on the plain `/targets` endpoint, where
`targetId` is just an ignored query param — and `gene_symbol` was popped on the way.
CHRNA7, GRIN2B and HTR6 now each resolve to their one correct target.

### Result caps with no way past them

| Tool | Returned | Actually available | Escape before |
|---|---|---|---|
| `RCSBAdvSearch_search_structures` | 50 | 81,865 | none — `start` hard-coded to 0 |
| `PDBeSIFTS_get_best_structures` | 50 | 676 (TP53) | none — no limit/offset param |
| `ExpressionAtlas_search_experiments` | 50 | 241 | none |
| `CPIC_get_alleles` | 50 | **208** CYP2D6 alleles | `limit` worked but total was hidden |
| `intact_get_interactions` | 25 | 87 | `size` worked but was **undeclared** |

`RCSBAdvSearch_search_structures` also silently reduced `rows=200` to 50 with nothing
in the response saying so. It now reports the clamp and the `start` value for the
next page. `PDBeSIFTS_get_pdb_to_uniprot` additionally cut chain mappings at 20 with
*no count at all* — `total_proteins` counts proteins, not mappings — so a
multi-chain entry looked complete at 20.

`CPIC_get_alleles` reported only `count`, the size of the returned page, so CYP2D6
looked like it had 50 star alleles when CPIC curates 208. A pharmacogenomics user
calling star alleles silently lost 158 of them. It now asks PostgREST for an exact
count and accepts `offset`.

`intact_get_interactions` honoured a `size` parameter it never declared — an MCP
client seeing only the schema had no way to reach 62 of PD-1's 87 interactors.

### Numbers and labels that misreported the data

**`RDKit_matched_molecular_pair` reported the monoisotopic mass as "MW".** Imatinib
came back as 493.26 where PubChem, ChEMBL, SwissADME and `SMILES_verify` all say
493.6, and the error grows with halogens (bromoacetanilide 212.98 vs the true
214.06). MW is the denominator for ligand efficiency, the Ro5 ≤500 cutoff and
mg→mmol dosing. Now average MW, with `exact_mass` reported separately.

**`RDKit_pharmacophore_features` counted every amide nitrogen as a basic centre.**
Its SMARTS excluded only hydroxyl/oxide neighbours and explicitly matched all neutral
aromatic N, giving acetamide, acetanilide and pyridine one basic centre each and
imatinib seven — its entire nitrogen count — where RDKit's own `BaseFeatures.fdef`
gives 0, 0, 0 and 2. Amides are near-universal in drug-like molecules, so the false
positive hit almost every query. The replacement pattern agrees with RDKit's
reference on all 13 molecules tested, including morphine, propranolol and
sulfanilamide. Separately, `include_features=["HBD"]` reported imatinib as having
zero H-bond acceptors and zero aromatic atoms; filtered-out features now report
`null` with a note.

**`HLALigandAtlas_get_benign_peptides` had its binder flags documented backwards.**
The docs said the flags were "strong `n/` or weak `w/`"; the data carries three
prefixes. Matching peptides against canonical anchor motifs for three alleles with
distinct motifs settles it without needing a predictor:

| flag | B\*07:02 (P2=P, C-term=L/F) | B\*44:03 (P2=E, C-term=Y/F) | A\*03:01 (C-term=K/R) |
|---|---|---|---|
| `s/` | **71%** | **69%** | **73%** |
| `w/` | 0% | 7% | 13% |
| `n/` | **0%** | **0%** | **0%** |

So `s/` is the strong binder and `n/` is a NON-binder. This tool exists to exclude
self-peptides from neoantigen candidates, so reading `n/` as "strongly presented"
inverts the safety call — you drop safe candidates and keep unsafe ones. The `allele`
filter is also a plain substring match, so `A*02:01` matches `n/A*02:01` too; both
facts are now documented.

**`DGIdb` reported `metadata.total` as the gene count.** Querying PDCD1 returned
`total: 1` beside 68 drug-gene interactions; three genes reported 3 against 140. Next
to a 68-row payload, `total: 1` reads as a truncation warning.

**`PubChem_get_CID_by_SMILES` passed through the CID-0 not-found sentinel as a
success.** A structure PubChem does not hold returned `{"CID": [0]}` at HTTP 200;
callers chained it into `PubChem_get_compound_properties_by_CID`, which died two
steps later with "Invalid ID, must be positive integer". Novel and proprietary
analogues are exactly the inputs that hit this. The name-based sibling already
reports a clean "No CID found"; now this one matches.

### Ordering and pagination

**`gwas_get_variants_for_trait` returned an unsorted page.** It and
`gwas_get_associations_for_trait` query the same `/v2/associations` endpoint, but only
the sibling sent `sort=p_value&direction=asc`, and the GWAS Catalog returns
associations unsorted. For asthma (3,219 associations) this tool returned p-values
2e-06 … 2e-24 while the sibling returned 7e-288, 8e-223, 2e-156 — so the first page
held **none** of the genome-wide-significant loci a user asking "which variants are
associated with this trait" is looking for.

**Seven IEDB tools declared an `offset` that always failed**, because PostgREST
rejects `offset` without `order`. Only `iedb_search_epitopes` carried a default
order; pagination was 100% broken on the rest.

---

## Fixes shipped (17)

1. `gwas_get_variants_for_trait` — default to p-value order, matching its sibling; expose `sort`/`direction`
2. `RCSBAdvSearch_search_structures` / `_search_by_motif` — add `start`/`offset`; report the `rows` clamp and next page
3. `PDBeSIFTS_get_best_structures` / `_get_all_structures` — add `limit` (max 500) and `offset`
4. `PDBeSIFTS_get_pdb_to_uniprot` — report `total_chain_mappings` and a truncation flag
5. `CPIC_get_alleles` — exact `total_count` via PostgREST `Content-Range`, plus `offset`
6. `MGnify_search_genomes` — `taxon_lineage` filter; `genome_type` fails closed; GTDB naming documented
7. `HPA_get_rna_expression_by_source` — query HPA's real per-source columns
8. `NeuroMorpho_search_neurons` — quote multi-word values in `q` and `fq`
9. `GtoPdb_search_targets` — route `gene_symbol` to `?geneSymbol=`; declare it; stop `name` claiming gene-symbol support
10. `RDKit_matched_molecular_pair` — `MW` is average mass; `exact_mass` added
11. `RDKit_pharmacophore_features` — PosIonizable SMARTS matched to RDKit's reference definitions
12. `RDKit_pharmacophore_features` — filtered-out features report `null`, not `0`
13. `PubChem_get_CID_by_SMILES` — CID-0 sentinel becomes "No CID found"
14. DGIdb interaction tools — count named for what it holds; `interactions_total` added
15. Seven IEDB tools — default `order` so the declared `offset` works
16. `intact_get_interactions` / `_get_interactor` — declare `size`; drop the unreachable `xml` enum option
17. `ExpressionAtlas_get_baseline` / `_search_differential` / `_search_experiments` — add `limit`/`offset`

Defaults are unchanged throughout: existing callers get the same records, plus the
new count and paging fields.

## Tests

76 new regression tests across four files. All touched tests pass and
`import tooluniverse.tools` works.

- `tests/unit/test_result_cap_pagination.py`
- `tests/unit/test_gwas_variants_for_trait_sort.py`
- `tests/unit/test_silently_dropped_filters.py`
- `tests/unit/test_wrong_values_and_counts.py`

The PosIonizable test asserts agreement with RDKit's own `BaseFeatures.fdef` rather
than hard-coding this implementation's answers, so it stays honest if the SMARTS is
revised again.

## Discarded as false positives (3)

- **`ClinGen_search_gene_validity` 100-row cap** — the tool requires `gene`, and
  per-gene result sets are tiny (BRCA1 returns 2 of 2). The cap never bites.
- **`GtoPdb` "500-element truncation"** — both sites are `response.text[:500]` error
  message truncation, not result caps.
- **A repo-wide scan for hard-coded slices** flagged 95 modules; spot-checking showed
  most are string truncation (`str(e)[:200]`) or already report a true total. Not
  treated as a bug class.

---

## For a maintainer decision — not fixed here

### 1. Pagination vocabulary drift

**926 of 2,570 tools expose a paging parameter, across 39 distinct vocabularies.**

```
 334  limit                 61  size                 19  start
 164  limit+skip            56  max_results          18  page+page_size
  76  limit+offset          44  page_size            16  limit+page
  22  page+size             22  page                 15  pageSize
                                                      7  rows
```

The four tools in this PR alone used `limit`/`offset`, `rows`/`start`, `size`/`page`
and `size`. Picking one vocabulary is a project-wide convention call, not something
to normalise unilaterally — the same reasoning that kept round 3 from touching the
response-envelope drift (~9 distinct top-level shapes), which is still open and still
worth a decision.

### 2. What a "count" field means

Two independent bugs this round were the same ambiguity: `count` and `total` are used
for both *records returned* and *records available*, and the surrounding fields
(`hitCount`, `totalElements`, `total_count`, `total_results`, `experiment_count`)
don't disambiguate either. A convention — say, `returned` always means this page and
`total_count` always means the full result set — would make this class of bug
mechanically detectable instead of one-by-one.

### 3. Verified but not fixed

Real, reproduced, left alone to keep this PR reviewable. Each is a genuine
user-facing problem:

- `OpenTargets_get_target_expression_by_ensemblID` — reports `count: 1474`, returns 25
  rows across 3 tissues, no paging parameter. For APP the answer is "pancreas and
  pituitary" with zero brain rows. Its sibling in the same family exposes `size`/`index`.
- `AllenBrain_get_structure_expression_values` — 50 of 2,407 regions in arbitrary
  order; upstream supports `order=expression_energy$desc`.
- `IPD_search_hla_alleles` — `total: 512`, only 100 reachable; the upstream `next`
  cursor is discarded.
- `MGnify_search_studies` / `MGnify_list_analyses` — no `page` parameter and the
  upstream `count`/`pages` are dropped (590 gut studies, 100 visible). Sibling MGnify
  tools do expose `page`.
- `NCBIDatasets_list_genomes_by_taxon` — honest `total_available: 2077`, clamps to
  100, discards the `next_page_token` the API hands it.
- `NCBIDatasets_suggest_taxonomy` — `total_results: 20` is the upstream cap, not a total.
- `STRING_get_enrichment` — 230 terms in category-blocked order, not p-value order;
  the most significant term sits at index 69. Sibling enrichment tools rank properly.
- `OrthoDB_search_groups` — `data.orthodb.org/v12/search` returns a Postgres error at
  HTTP 404 while v11 search and every other v12 endpoint work. It is the only way to
  obtain a `group_id`, so the whole OrthoDB family is unreachable.
- `IEDB_predict_mhci_binding` — injects `score: 0.0` for every peptide on the three
  methods where upstream returns no score column; `ic50` is a string with no unit.
- `GtoPdb_get_interactions` — its own truncation message names a `limit` parameter
  that works but is undeclared, and passing it drops the pagination metadata.
