### PR TITLE
Fix nine tools that returned confidently wrong answers instead of failing

### DIFF
--- a/src/tooluniverse/ctg_tool.py
+++ b/src/tooluniverse/ctg_tool.py
@@ -510,13 +510,16 @@ class ClinicalTrialsSearchTool(ClinicalTrialsTool):
                 query_params[k] = arguments[k]
 
         # Add default parameters that are not shown in the schema.
-        # Skip filter.advanced when a status filter is set, because filter.advanced
-        # requires HasResults=true which excludes most RECRUITING/active trials.
-        has_status_filter = "filter.overallStatus" in query_params
+        # filter.advanced used to be skipped whenever a status filter was set,
+        # to work around its old AREA[HasResults]true clause. That clause was
+        # removed above, so the skip only disabled the documented "Limited to
+        # trials beyond phase 1" gate -- and it did so silently: adding the
+        # narrowing overall_status=COMPLETED filter to a metformin/lactic
+        # acidosis search *raised* total_count from 2 to 3 and returned a
+        # disjoint set, while a RECRUITING pembrolizumab search returned 745
+        # studies instead of 557, phase-1 trials included.
         for k, v in self.default_params_not_shown.items():
             if k not in query_params:
-                if k == "filter.advanced" and has_status_filter:
-                    continue
                 query_params[k] = v
 
         # Process list parameters that need to be joined

--- a/src/tooluniverse/data/ensembl_ld_tools.json
+++ b/src/tooluniverse/data/ensembl_ld_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "EnsemblLD_get_ld_variants",
-    "description": "Get linkage disequilibrium (LD) data for a variant from the Ensembl REST API. Returns all variants in LD with the query variant in a specified 1000 Genomes population, with r-squared and D' statistics. LD measures the non-random association of alleles at different loci, critical for GWAS interpretation and fine-mapping. Example: rs1042779 in KHV population returns 708 LD partners with r2 and D' values.",
+    "description": "Get linkage disequilibrium (LD) data for a variant from the Ensembl REST API. Returns variants in LD with the query variant in a specified 1000 Genomes population, with r-squared and D' statistics. LD measures the non-random association of alleles at different loci, critical for GWAS interpretation and fine-mapping. Results are sorted by r2 (strongest first) and capped at `limit` (default 200); `total_ld_count` always reports how many partners passed the thresholds and `truncated` flags whether any were withheld -- raise `limit` to retrieve them all. Example: rs1042779 in KHV population returns 708 LD partners with r2 and D' values.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -26,6 +26,14 @@
             "null"
           ],
           "description": "Minimum D' threshold. Default: none. Set e.g., 0.8 for high D' only."
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1,
+          "description": "Maximum number of LD partners to return, strongest r2 first. Default: 200. Increase to retrieve every partner when `truncated` is true."
         }
       },
       "required": [
@@ -62,8 +70,17 @@
                 "population": {
                   "type": "string"
                 },
+                "total_ld_count": {
+                  "type": "integer",
+                  "description": "Total LD partners passing the thresholds, before truncation"
+                },
                 "ld_count": {
-                  "type": "integer"
+                  "type": "integer",
+                  "description": "Number of LD partners actually returned in ld_variants"
+                },
+                "truncated": {
+                  "type": "boolean",
+                  "description": "True when total_ld_count exceeds ld_count; raise `limit` to retrieve the rest"
                 },
                 "ld_variants": {
                   "type": "array",

--- a/src/tooluniverse/data/gene_ontology_tools.json
+++ b/src/tooluniverse/data/gene_ontology_tools.json
@@ -329,7 +329,7 @@
   },
   {
     "name": "GO_get_genes_for_term",
-    "description": "Finds all genes/proteins associated with a specific Gene Ontology term using the Biolink API.",
+    "description": "Finds genes/proteins annotated to a Gene Ontology term, including annotations to its descendant terms (is_a/part_of closure), via the GO Solr index. Rows are collapsed to distinct genes, each carrying its evidence codes and annotation count. Supply `taxon` to restrict to one species -- omit it and genes from all species are returned together. Example: id='GO:0006915' with taxon='NCBITaxon:9606' returns human apoptosis genes.",
     "type": "GeneOntologyTool",
     "parameter": {
       "type": "object",
@@ -340,38 +340,91 @@
         },
         "taxon": {
           "type": "string",
-          "description": "Optional species filter using a NCBI taxon ID. For example, Human is 'NCBITaxon:9606', and Mouse is 'NCBITaxon:10090'."
+          "description": "Optional species filter using an NCBI taxon ID, e.g. 'NCBITaxon:9606' (human) or 'NCBITaxon:10090' (mouse). Omit to return genes from every species."
         },
         "rows": {
           "type": "integer",
-          "description": "The number of genes to return. Default is 100."
+          "minimum": 1,
+          "default": 100,
+          "description": "Maximum number of annotation rows to scan. Distinct genes returned may be fewer, since one gene can carry several annotations. Default is 100."
         }
       },
       "required": [
-        "id",
-        "taxon",
-        "rows"
+        "id"
       ]
     },
     "fields": {
-      "endpoint": "http://api.geneontology.org/api/bioentity/function/{id}",
-      "extract_path": "associations[*].subject",
+      "endpoint": "https://golr-aux.geneontology.io/solr/select?wt=json&q=*:*&fq=document_category:\"annotation\"&fq=isa_partof_closure:\"{id}\"&fq=taxon:\"{taxon}\"&rows={rows}&fl=bioentity,bioentity_label,bioentity_name,taxon,taxon_label,evidence_type",
+      "extract_path": "response.docs.genes",
       "input_description": "Input GO term ID, e.g., 'GO:0006915'.",
-      "output_description": "Returns a list of genes/proteins associated with the GO term."
+      "output_description": "Returns distinct genes/proteins annotated to the GO term or its descendants."
     },
     "test_examples": [
       {
         "id": "GO:0006915",
         "taxon": "NCBITaxon:9606",
         "rows": 10
+      },
+      {
+        "id": "GO:0006915",
+        "rows": 10
       }
     ],
     "return_schema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {}
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "bioentity": {
+                "type": "string",
+                "description": "Gene/protein identifier, e.g. 'UniProtKB:P04637'"
+              },
+              "gene_symbol": {
+                "type": "string"
+              },
+              "gene_name": {
+                "type": "string"
+              },
+              "taxon": {
+                "type": "string"
+              },
+              "taxon_label": {
+                "type": "string"
+              },
+              "evidence_types": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Distinct GO evidence codes supporting the annotation"
+              },
+              "annotation_count": {
+                "type": "integer",
+                "description": "Annotation rows collapsed into this gene"
+              }
+            },
+            "required": [
+              "bioentity"
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string"
+            },
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
     }
   },
   {

--- a/src/tooluniverse/data/gtex_v2_tools.json
+++ b/src/tooluniverse/data/gtex_v2_tools.json
@@ -2,7 +2,7 @@
   {
     "name": "GTEx_get_median_gene_expression",
     "type": "GTExV2Tool",
-    "description": "Get median gene expression levels across GTEx tissues. Returns median expression in TPM (Transcripts Per Million) for one or more genes across 54 tissue sites. Filter by specific tissues or get expression across all tissues. Defaults to GTEx V8 (2020) -- confirmed live no V11 dataset is queryable via this API (dataset_id only accepts gtex_v7/gtex_v8/gtex_v10; v10 returns empty for most endpoints, so v8 is the most complete option). Use for: tissue-specific expression profiling, identifying highly expressed genes, comparing expression patterns across tissues. Example: Get brain vs liver expression for TP53 gene.",
+    "description": "Get median gene expression levels across GTEx tissues. Returns median expression in TPM (Transcripts Per Million) for one or more genes across 54 tissue sites. Filter by specific tissues or get expression across all tissues. Defaults to GTEx V8 (2020) -- confirmed live no V11 dataset is queryable via this API (dataset_id accepts gtex_v7/gtex_v8/gtex_v10). Set dataset_id='gtex_v10' for the newer release; gene IDs are resolved to each dataset's own GENCODE version automatically, so V10 returns full results. Use for: tissue-specific expression profiling, identifying highly expressed genes, comparing expression patterns across tissues. Example: Get brain vs liver expression for TP53 gene.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -38,7 +38,7 @@
             "gtex_snrnaseq_pilot"
           ],
           "default": "gtex_v8",
-          "description": "GTEx dataset version (default: gtex_v8; v10 returns empty for most endpoints)"
+          "description": "GTEx dataset version (default: gtex_v8, the most widely cited release). gtex_v10 is the newer release (943 eQTL donors vs 838) and is fully queryable -- gene IDs are resolved to each dataset's own GENCODE version automatically."
         },
         "page": {
           "type": "integer",

--- a/src/tooluniverse/data/nhanes_tools.json
+++ b/src/tooluniverse/data/nhanes_tools.json
@@ -8,7 +8,20 @@
       "properties": {
         "year": {
           "type": "string",
-          "description": "NHANES cycle/year (e.g., '2017-2018', '2015-2016', '2013-2014')"
+          "enum": [
+            "2021-2023",
+            "2017-2018",
+            "2015-2016",
+            "2013-2014",
+            "2011-2012",
+            "2009-2010",
+            "2007-2008",
+            "2005-2006",
+            "2003-2004",
+            "2001-2002",
+            "1999-2000"
+          ],
+          "description": "NHANES cycle. Omit for the two most recent. There is no standalone 2019-2020 cycle -- COVID-19 cut that field period short and the data ship as the '2017-2020 pre-pandemic' files."
         },
         "component": {
           "type": "string",
@@ -29,44 +42,92 @@
       "return_format": "JSON"
     },
     "return_schema": {
-      "type": "object",
-      "properties": {
-        "datasets": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "Dataset name"
-              },
-              "year": {
-                "type": "string",
-                "description": "NHANES cycle"
-              },
-              "component": {
-                "type": "string"
-              },
-              "download_url": {
-                "type": "string",
-                "description": "URL to download the dataset"
-              },
-              "description": {
-                "type": "string"
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "datasets": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Dataset name"
+                      },
+                      "year": {
+                        "type": "string",
+                        "description": "NHANES cycle"
+                      },
+                      "component": {
+                        "type": "string"
+                      },
+                      "download_url": {
+                        "type": "string",
+                        "description": "CDC listing page for this component and cycle"
+                      },
+                      "description": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "count": {
+                  "type": "integer",
+                  "description": "Number of component/cycle entries returned"
+                },
+                "cycles_covered": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "The NHANES cycles these entries describe"
+                },
+                "note": {
+                  "type": "string",
+                  "description": "Information about data format and access"
+                }
               }
+            },
+            "metadata": {
+              "type": "object"
             }
-          }
+          },
+          "required": [
+            "data"
+          ]
         },
-        "note": {
-          "type": "string",
-          "description": "Information about data format and access"
+        {
+          "type": "object",
+          "properties": {
+            "status": {
+              "type": "string"
+            },
+            "error": {
+              "type": "string",
+              "description": "Reason the request failed, e.g. an unrecognised NHANES cycle"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     },
     "test_examples": [
       {
         "year": "2017-2018",
         "component": "Demographics"
+      },
+      {
+        "year": "2021-2023",
+        "component": "Laboratory"
       }
     ]
   },

--- a/src/tooluniverse/data/wikipathways_ext_tools.json
+++ b/src/tooluniverse/data/wikipathways_ext_tools.json
@@ -1,18 +1,20 @@
 [
     {
         "name": "WikiPathways_get_pathway_genes",
-        "description": "Get all genes (as gene symbols) involved in a WikiPathways pathway. Returns the list of HGNC gene symbols for human pathways, or equivalent organism-specific gene identifiers. Useful for extracting gene sets from curated pathways for enrichment analysis or network building. Example: WP254 (Apoptosis) returns 88 genes including AKT1, APAF1, BAD, BAK1, BAX, BCL2, BCL2L1, BID, CASP3, CASP8, CASP9, CFLAR, CYCS, DIABLO, FADD, FAS, NFKB1, TP53, TRAF1, XIAP, and more.",
+        "description": "Get the genes involved in a WikiPathways pathway. `gene_count` counts distinct gene products; `genes` lists every symbol label WikiPathways records for them, which is larger because one gene product carries several aliases (AKT, AKT1, Akt1 are one node) and occasionally an unrelated symbol -- use `gene_products` for node-level identifiers and their exact labels. By default every gene product is returned regardless of which database annotated it; set `code` only when you need genes cross-referenced to one identifier system, and note most pathways are annotated from Entrez Gene or Ensembl rather than HGNC. Useful for extracting gene sets from curated pathways for enrichment analysis or network building. Example: WP254 (Apoptosis) has 87 gene products (139 labels) including AKT1, APAF1, BAD, BAK1, BAX, BCL2, BCL2L1, BID, CASP3, CASP8, CASP9, CFLAR, CYCS, DIABLO, FADD, FAS, NFKB1, TP53, TRAF1, XIAP.",
         "parameter": {
             "type": "object",
             "properties": {
                 "pathway_id": {
                     "type": "string",
-                    "description": "WikiPathways pathway identifier. Examples: 'WP254' (Apoptosis, 88 genes), 'WP179' (Cell cycle, 100+ genes), 'WP4216' (Chromosomal and microsatellite instability), 'WP1584' (Type II diabetes mellitus)."
+                    "description": "WikiPathways pathway identifier. Examples: 'WP254' (Apoptosis, 87 gene products), 'WP179' (Cell cycle), 'WP4216' (Chromosomal and microsatellite instability), 'WP1584' (Type II diabetes mellitus)."
                 },
                 "code": {
-                    "type": "string",
-                    "description": "Identifier system code for returned genes. Options: 'H' (HGNC symbols, default), 'En' (Ensembl), 'S' (UniProt), 'L' (Entrez Gene), 'Ce' (ChEBI for metabolites).",
-                    "default": "H"
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "description": "Optional filter restricting results to gene products annotated from one identifier system: 'H' (HGNC), 'En' (Ensembl), 'S' (UniProt), 'L' (Entrez Gene), 'Ce' (ChEBI, metabolites). Omit to return every gene product in the pathway. Most pathways are annotated from Entrez Gene or Ensembl and carry no HGNC-sourced entries, so filtering can legitimately return 0."
                 }
             },
             "required": [
@@ -46,17 +48,39 @@
                                 },
                                 "gene_count": {
                                     "type": "integer",
-                                    "description": "Total number of genes in the pathway"
+                                    "description": "Number of distinct gene products in the pathway"
+                                },
+                                "label_count": {
+                                    "type": "integer",
+                                    "description": "Number of distinct symbol labels across those gene products; exceeds gene_count because one gene product carries several aliases"
                                 },
                                 "identifier_type": {
                                     "type": "string",
-                                    "description": "Type of gene identifiers returned (HGNC, Ensembl, etc.)"
+                                    "description": "Identifier system results were filtered to, or 'All sources' when unfiltered"
                                 },
                                 "genes": {
                                     "type": "array",
-                                    "description": "List of gene identifiers",
+                                    "description": "Every symbol label recorded for the pathway's gene products",
                                     "items": {
                                         "type": "string"
+                                    }
+                                },
+                                "gene_products": {
+                                    "type": "array",
+                                    "description": "Node-level truth: one entry per gene product with its identifier and exact labels",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "identifier": {
+                                                "type": "string"
+                                            },
+                                            "labels": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/src/tooluniverse/ebi_proteins_interactions_tool.py
+++ b/src/tooluniverse/ebi_proteins_interactions_tool.py
@@ -18,6 +18,23 @@ from .tool_registry import register_tool
 EBI_PROTEINS_BASE_URL = "https://www.ebi.ac.uk/proteins/api"
 
 
+def _entries_for_accession(data: Any, accession: str) -> list:
+    """Keep only the payload entries describing `accession` itself.
+
+    /proteins/interaction/{acc} answers with the queried protein followed by
+    its neighbours, so an entry's own `accession` is the only thing that ties
+    an interaction list to the protein it belongs to.
+    """
+    if not isinstance(data, list):
+        return []
+    wanted = accession.upper()
+    return [
+        entry
+        for entry in data
+        if isinstance(entry, dict) and str(entry.get("accession", "")).upper() == wanted
+    ]
+
+
 @register_tool("EBIProteinsInteractionsTool")
 class EBIProteinsInteractionsTool(BaseTool):
     """
@@ -86,27 +103,30 @@ class EBIProteinsInteractionsTool(BaseTool):
         response.raise_for_status()
         data = response.json()
 
-        # Data is a list of entries, each with interactions
+        # The endpoint returns the queried protein *plus* ~100 neighbour
+        # proteins, each carrying its own full interaction list. Pooling them
+        # attributed other proteins' partners to the query: 44 of the 50 rows
+        # returned for TP53 were pairs like AXIN1-GSK3B and BRCA2-RAD51, and
+        # the total read 3258 instead of TP53's own few hundred.
         all_interactions = []
-        if isinstance(data, list):
-            for entry in data:
-                for interaction in entry.get("interactions", []):
-                    partner_acc = interaction.get(
-                        "accession2", interaction.get("accession1")
-                    )
-                    # Skip self-interactions
-                    if partner_acc == accession:
-                        partner_acc = interaction.get("accession1")
-                    all_interactions.append(
-                        {
-                            "partner_accession": partner_acc,
-                            "gene_name": interaction.get("gene"),
-                            "experiments": interaction.get("experiments", 0),
-                            "organism_differ": interaction.get("organismDiffer", False),
-                            "intact_id_a": interaction.get("interactor1"),
-                            "intact_id_b": interaction.get("interactor2"),
-                        }
-                    )
+        for entry in _entries_for_accession(data, accession):
+            for interaction in entry.get("interactions", []):
+                partner_acc = interaction.get(
+                    "accession2", interaction.get("accession1")
+                )
+                # Skip self-interactions
+                if partner_acc == accession:
+                    partner_acc = interaction.get("accession1")
+                all_interactions.append(
+                    {
+                        "partner_accession": partner_acc,
+                        "gene_name": interaction.get("gene"),
+                        "experiments": interaction.get("experiments", 0),
+                        "organism_differ": interaction.get("organismDiffer", False),
+                        "intact_id_a": interaction.get("interactor1"),
+                        "intact_id_b": interaction.get("interactor2"),
+                    }
+                )
 
         # Deduplicate by partner accession, keep highest experiment count
         seen = {}
@@ -159,8 +179,10 @@ class EBIProteinsInteractionsTool(BaseTool):
                 "error": f"No interaction data found for {accession}",
             }
 
-        # Extract protein metadata from first entry
-        first_entry = data[0]
+        # Metadata must come from the queried protein's own entry, not merely
+        # the first one in the payload.
+        own_entries = _entries_for_accession(data, accession)
+        first_entry = own_entries[0] if own_entries else data[0]
         # Feature-66B-008a: "accession" returns the accession again; use "name" for protein name
         protein_name = first_entry.get("name", accession)
         protein_existence = first_entry.get("proteinExistence")
@@ -176,7 +198,9 @@ class EBIProteinsInteractionsTool(BaseTool):
         diseases = set()
         locations = set()
 
-        for entry in data:
+        # Same scoping as the interactions tool: neighbour entries describe
+        # their own partners, not this protein's.
+        for entry in own_entries:
             for interaction in entry.get("interactions", []):
                 partner_acc = interaction.get(
                     "accession2", interaction.get("accession1")

--- a/src/tooluniverse/ensembl_ld_tool.py
+++ b/src/tooluniverse/ensembl_ld_tool.py
@@ -21,6 +21,10 @@ from .tool_registry import register_tool
 ENSEMBL_BASE_URL = "https://rest.ensembl.org"
 ENSEMBL_HEADERS = {"User-Agent": "ToolUniverse/1.0", "Accept": "application/json"}
 
+# Default number of LD partners returned, strongest r2 first. Overridable via
+# the `limit` parameter; the full total is always reported as total_ld_count.
+DEFAULT_LD_VARIANT_LIMIT = 200
+
 
 @register_tool("EnsemblLDTool")
 class EnsemblLDTool(BaseTool):
@@ -86,6 +90,9 @@ class EnsemblLDTool(BaseTool):
         population = arguments.get("population", "")
         r2_threshold = arguments.get("r2_threshold", None)
         d_prime_threshold = arguments.get("d_prime_threshold", None)
+        limit = arguments.get("limit")
+        if limit is None:
+            limit = DEFAULT_LD_VARIANT_LIMIT
 
         if not variant_id:
             return {
@@ -137,13 +144,18 @@ class EnsemblLDTool(BaseTool):
         # Sort by r2 descending
         ld_variants.sort(key=lambda x: x["r2"], reverse=True)
 
-        # Limit to top 200
-        ld_variants = ld_variants[:200]
+        # Keep the strongest `limit` partners, but report the true total: a count
+        # taken after truncation reads as "this variant has 200 LD partners" and
+        # hides that the weakest returned r2 is far above the requested threshold.
+        total_ld_count = len(ld_variants)
+        ld_variants = ld_variants[:limit]
 
         result = {
             "query_variant": variant_id,
             "population": population,
+            "total_ld_count": total_ld_count,
             "ld_count": len(ld_variants),
+            "truncated": total_ld_count > len(ld_variants),
             "ld_variants": ld_variants,
         }
 

--- a/src/tooluniverse/epigenomics_tool.py
+++ b/src/tooluniverse/epigenomics_tool.py
@@ -34,6 +34,22 @@ _RETRY_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 _MAX_RETRIES = 3
 
 
+def _encode_empty_result_note(biosample: Any = None) -> str:
+    """Explain a genuinely empty ENCODE result, hinting at ontology spelling."""
+    note = (
+        "No matching ENCODE experiments. The filters are applied as given -- "
+        "this is a real zero-result answer, not a dropped filter."
+    )
+    if biosample:
+        note += (
+            f" ENCODE requires exact ontology names, so check biosample='{biosample}' "
+            "(e.g. 'K562', 'HepG2', 'liver', 'brain', 'breast epithelium', 'MCF-7'; "
+            "'breast' must be spelled 'breast epithelium' or 'mammary gland'). "
+            "Use GEO_search_chipseq_datasets for disease-based searches."
+        )
+    return note
+
+
 def _inject_ncbi_api_key(params: Dict[str, Any]) -> Dict[str, Any]:
     """If NCBI_API_KEY is set, append it to the params dict. 3→10 req/sec.
 
@@ -168,7 +184,16 @@ class EpigenomicsTool(BaseTool):
     # =========================================================================
 
     def _encode_search(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        """Generic ENCODE search helper."""
+        """Generic ENCODE search helper.
+
+        ENCODE answers a facet combination that matches nothing with HTTP 404
+        carrying a perfectly valid body ({"total": 0, "@graph": [],
+        "notification": "No results found"}). Treating that as a transport
+        error made callers either retry with a filter removed -- returning
+        another species' experiments under the requested organism -- or report
+        a genuine zero-result query as "API HTTP error: 404". Parse the body,
+        as encode_tool.py::_http_get already does.
+        """
         url = f"{ENCODE_BASE_URL}/search/"
         params["format"] = "json"
         response = _request_with_backoff(
@@ -177,6 +202,14 @@ class EpigenomicsTool(BaseTool):
             headers={"Accept": "application/json"},
             timeout=self.timeout,
         )
+        if response.status_code == 404:
+            try:
+                body = response.json()
+            except ValueError:
+                response.raise_for_status()
+            else:
+                if isinstance(body, dict) and "@graph" in body:
+                    return body
         response.raise_for_status()
         return response.json()
 
@@ -223,36 +256,23 @@ class EpigenomicsTool(BaseTool):
         limit = arguments.get("limit", 25)
         params["limit"] = min(int(limit), 100)
 
-        # Feature-70A-003: ambiguous/non-leaf biosample terms (e.g. "heart") combined with
-        # the organism filter can produce HTTP 404 from ENCODE. Fall back without
-        # the organism filter in that case.
-        # Feature-79E: if biosample_term_name is not a valid ENCODE ontology term
-        # (e.g. disease names like "AML"), both attempts 404; return empty with hint.
-        try:
-            raw = self._encode_search(params)
-        except Exception:
-            fallback_params = {
-                k: v
-                for k, v in params.items()
-                if k != "replicates.library.biosample.organism.scientific_name"
+        # A zero-result combination now comes back as total 0 rather than an
+        # exception. Retrying without the organism filter used to answer
+        # "human midbrain H3K4me3" with four Mus musculus embryo experiments
+        # while still reporting organism="Homo sapiens", so no filter is
+        # dropped here -- an empty answer is reported as empty.
+        raw = self._encode_search(params)
+        if not raw.get("@graph"):
+            return {
+                "status": "success",
+                "data": [],
+                "metadata": {
+                    "source": "ENCODE",
+                    "total": 0,
+                    "organism": organism,
+                    "note": _encode_empty_result_note(biosample),
+                },
             }
-            try:
-                raw = self._encode_search(fallback_params)
-            except Exception:
-                return {
-                    "status": "success",
-                    "data": [],
-                    "metadata": {
-                        "source": "ENCODE",
-                        "total": 0,
-                        "note": f"No results for biosample='{biosample}'. "
-                        "ENCODE requires exact ontology names for cell lines or tissues "
-                        "(e.g., 'K562', 'HepG2', 'liver', 'brain', 'breast epithelium', 'MCF-7'). "
-                        "Common anatomy terms like 'breast' must be spelled as ENCODE uses them "
-                        "(try 'breast epithelium', 'mammary gland', or a cell line like 'MCF-7'). "
-                        "Use GEO_search_chipseq_datasets for disease-based searches.",
-                    },
-                }
 
         experiments = []
         for exp in raw.get("@graph", []):
@@ -370,30 +390,19 @@ class EpigenomicsTool(BaseTool):
         limit = arguments.get("limit", 25)
         params["limit"] = min(int(limit), 100)
 
-        # Feature-70A-003: biosample+organism combos can 404; fall back without organism.
-        try:
-            raw = self._encode_search(params)
-        except Exception:
-            fallback_params = {
-                k: v
-                for k, v in params.items()
-                if k != "replicates.library.biosample.organism.scientific_name"
+        # No filter is dropped on an empty result -- see _encode_search.
+        raw = self._encode_search(params)
+        if not raw.get("@graph"):
+            return {
+                "status": "success",
+                "data": [],
+                "metadata": {
+                    "source": "ENCODE",
+                    "total": 0,
+                    "organism": organism,
+                    "note": _encode_empty_result_note(biosample),
+                },
             }
-            try:
-                raw = self._encode_search(fallback_params)
-            except Exception:
-                return {
-                    "status": "success",
-                    "data": [],
-                    "metadata": {
-                        "source": "ENCODE",
-                        "total": 0,
-                        "note": f"No results for biosample='{biosample}'. "
-                        "ENCODE requires exact ontology names for cell lines or tissues "
-                        "(e.g., 'K562', 'HepG2', 'liver', 'brain', 'breast epithelium', 'MCF-7'). "
-                        "Use GEO_search_atacseq_datasets for disease-based searches.",
-                    },
-                }
 
         experiments = []
         for exp in raw.get("@graph", []):
@@ -875,29 +884,8 @@ class EpigenomicsTool(BaseTool):
             params["replicates.library.biosample.organism.scientific_name"] = organism
         params["limit"] = min(int(limit), 100)
 
-        try:
-            raw = self._encode_search(params)
-        except Exception:
-            # Fall back without organism filter (mirrors histone search fix)
-            fallback = {
-                k: v
-                for k, v in params.items()
-                if k != "replicates.library.biosample.organism.scientific_name"
-            }
-            try:
-                raw = self._encode_search(fallback)
-            except Exception:
-                return {
-                    "status": "success",
-                    "data": {"total": 0, "experiments": []},
-                    "metadata": {
-                        "source": "ENCODE",
-                        "note": (
-                            f"No results for biosample='{biosample}'. "
-                            "ENCODE requires exact ontology names (e.g., 'K562', 'HepG2', 'liver')."
-                        ),
-                    },
-                }
+        # No filter is dropped on an empty result -- see _encode_search.
+        raw = self._encode_search(params)
 
         # If no results and assay was 'total RNA-seq', retry with 'polyA plus RNA-seq'
         # Some cell lines (e.g. HeLa-S3) have no total RNA-seq but have polyA plus RNA-seq.

--- a/src/tooluniverse/gene_ontology_tool.py
+++ b/src/tooluniverse/gene_ontology_tool.py
@@ -4,6 +4,27 @@ from urllib.parse import quote
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
+# Defaults applied to GOlr URL templates when the caller omits the parameter.
+_GOLR_TEMPLATE_DEFAULTS = {"rows": 100}
+
+
+def _drop_unfilled_query_segments(url: str) -> str:
+    """Remove query segments still holding an unsubstituted {placeholder}.
+
+    An optional filter the caller omitted must not be sent as the literal
+    string "{taxon}" -- Solr would then match nothing and the tool would report
+    an empty result set as though the term genuinely had no genes.
+    """
+    if "{" not in url or "?" not in url:
+        return url
+    base, _, query = url.partition("?")
+    kept = [
+        segment
+        for segment in query.split("&")
+        if not ("{" in segment and "}" in segment)
+    ]
+    return f"{base}?{'&'.join(kept)}" if kept else base
+
 
 @register_tool("GeneOntologyTool")
 class GeneOntologyTool(BaseTool):
@@ -49,21 +70,34 @@ class GeneOntologyTool(BaseTool):
             docs = response.get("docs", [])
             return docs
 
-        elif extract_path == "associations[*].subject":
-            # Extract gene/protein information from Biolink associations
-            result = []
-            # Handle both dict with associations and direct list from Biolink API
-            if isinstance(data, list):
-                # Direct list of associations from Biolink API
-                associations = data
-            else:
-                # Dictionary response with associations key
-                associations = data.get("associations", [])
-
-            for assoc in associations:
-                subject = assoc.get("subject", {})
-                result.append(subject)
-            return result
+        elif extract_path == "response.docs.genes":
+            # Collapse GOlr annotation rows into distinct genes. GOlr returns one
+            # row per annotation, so a gene backed by several evidence codes
+            # appears many times; counting rows would overstate the gene count.
+            response = data.get("response", {})
+            docs = response.get("docs", [])
+            genes = {}
+            for doc in docs:
+                bioentity = doc.get("bioentity")
+                if not bioentity:
+                    continue
+                gene = genes.setdefault(
+                    bioentity,
+                    {
+                        "bioentity": bioentity,
+                        "gene_symbol": doc.get("bioentity_label"),
+                        "gene_name": doc.get("bioentity_name"),
+                        "taxon": doc.get("taxon"),
+                        "taxon_label": doc.get("taxon_label"),
+                        "evidence_types": [],
+                        "annotation_count": 0,
+                    },
+                )
+                gene["annotation_count"] += 1
+                evidence = doc.get("evidence_type")
+                if evidence and evidence not in gene["evidence_types"]:
+                    gene["evidence_types"].append(evidence)
+            return list(genes.values())
 
         # For simple paths, try direct access
         try:
@@ -124,8 +158,13 @@ class GeneOntologyTool(BaseTool):
         if "?" in self.endpoint:
             # This is a complete URL with query parameters (GOlr format)
             url = self.endpoint
-            for key, value in arguments.items():
+            template_args = dict(arguments)
+            for key, default in _GOLR_TEMPLATE_DEFAULTS.items():
+                if f"{{{key}}}" in url and key not in template_args:
+                    template_args[key] = default
+            for key, value in template_args.items():
                 url = url.replace(f"{{{key}}}", quote(str(value)))
+            url = _drop_unfilled_query_segments(url)
             params = {}
         else:
             # This is a template URL (Biolink format)

--- a/src/tooluniverse/gtex_tool.py
+++ b/src/tooluniverse/gtex_tool.py
@@ -3,6 +3,10 @@ from typing import Any, Dict
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from tooluniverse.gtex_v2_tool import (
+    DATASET_GENCODE_VERSION,
+    DEFAULT_GENCODE_VERSION,
+)
 from tooluniverse.tool_registry import register_tool
 
 
@@ -31,16 +35,22 @@ def _extract_data_list(api_response: Any) -> list:
     return api_response if isinstance(api_response, list) else []
 
 
-def _resolve_gene_id(gene_input: str, base_url: str, timeout: int) -> str:
+def _resolve_gene_id(
+    gene_input: str, base_url: str, timeout: int, dataset_id: str = "gtex_v8"
+) -> str:
     """Resolve a gene symbol or unversioned Ensembl ID to a versioned GENCODE ID.
 
-    Queries GTEx /reference/gene to resolve to the correct GENCODE v26 version.
-    If a user-provided versioned ID (e.g., ENSG00000142192.21) doesn't match
-    GENCODE v26, strip the version and re-resolve.
+    Queries GTEx /reference/gene for the GENCODE version `dataset_id` is
+    annotated against. Resolving against the wrong version yields an empty but
+    HTTP 200 response, which reads as "no data for this gene" rather than as an
+    ID mismatch, so the dataset drives the version rather than a fixed v26.
     """
+    gencode_version = DATASET_GENCODE_VERSION.get(dataset_id, DEFAULT_GENCODE_VERSION)
     # Try resolving the input (versioned or not) via the reference API
     query_id = gene_input.split(".")[0] if gene_input.startswith("ENS") else gene_input
-    url = f"{base_url}/reference/gene?geneId={query_id}&gencodeVersion=v26"
+    url = (
+        f"{base_url}/reference/gene?geneId={query_id}&gencodeVersion={gencode_version}"
+    )
     try:
         data = _http_get(url, headers={"Accept": "application/json"}, timeout=timeout)
         genes = data.get("data", [])
@@ -205,11 +215,12 @@ class GTExEQTLTool:
                     "(e.g. 'ENSG00000197708'), or 'gene' to query eQTLs."
                 ),
             }
-        gencode_id = _resolve_gene_id(gene_input, base, timeout)
+        dataset_id = arguments.get("dataset_id", "gtex_v8")
+        gencode_id = _resolve_gene_id(gene_input, base, timeout, dataset_id)
 
         query: Dict[str, Any] = {
             "gencodeId": gencode_id,
-            "datasetId": arguments.get("dataset_id", "gtex_v8"),
+            "datasetId": dataset_id,
         }
         # Pass tissue filter if provided (tissueSiteDetailId is case-sensitive, e.g. 'Brain_Cortex')
         tissue = arguments.get("tissue_id") or arguments.get("tissue")

--- a/src/tooluniverse/gtex_v2_tool.py
+++ b/src/tooluniverse/gtex_v2_tool.py
@@ -17,23 +17,41 @@ from .tool_registry import register_tool
 
 GTEX_BASE_URL = "https://gtexportal.org/api/v2"
 
+# Each GTEx dataset is annotated against a different GENCODE release, and the
+# API only matches gene IDs carrying that release's version suffix. The values
+# below are the `gencodeVersion` fields reported by /metadata/dataset.
+DATASET_GENCODE_VERSION = {
+    "gtex_v7": "v19",
+    "gtex_v8": "v26",
+    "gtex_v10": "v39",
+    "gtex_snrnaseq_pilot": "v26",
+    "kids_first_harmonization": "v26",
+}
+DEFAULT_GENCODE_VERSION = "v26"
 
-def _resolve_gencode_id(gene_input: str, timeout: int = 30) -> str:
-    """Resolve a gene symbol or unversioned Ensembl ID to a versioned GENCODE ID.
 
-    GTEx API requires versioned GENCODE IDs (e.g. ENSG00000141510.18 for TP53).
-    If already versioned (contains '.'), returns as-is.
-    Otherwise queries /reference/gene with gencodeVersion=v26 (used by gtex_v8).
+def _resolve_gencode_id(
+    gene_input: str, dataset_id: str = "gtex_v8", timeout: int = 30
+) -> str:
+    """Resolve a gene symbol or Ensembl ID to the GENCODE ID `dataset_id` uses.
+
+    GTEx requires versioned GENCODE IDs, and the version differs per dataset
+    (TP53 is ENSG00000141510.16 in gtex_v8/GENCODE v26 but .18 in
+    gtex_v10/GENCODE v39). Resolving against the wrong version makes the API
+    return an empty -- but HTTP 200 -- result set, which reads as "no data for
+    this gene" rather than as the ID mismatch it actually is. Any version
+    suffix on the input is therefore stripped and re-resolved against the
+    target dataset's GENCODE release.
     """
     if not gene_input:
         return gene_input
-    # Strip version suffix so versioned IDs (e.g. ENSG00000012048.23) resolve to correct v26 ID
+    gencode_version = DATASET_GENCODE_VERSION.get(dataset_id, DEFAULT_GENCODE_VERSION)
     base_id = gene_input.split(".")[0] if "." in gene_input else gene_input
     url = f"{GTEX_BASE_URL}/reference/gene"
     try:
         resp = requests.get(
             url,
-            params={"geneId": base_id, "gencodeVersion": "v26"},
+            params={"geneId": base_id, "gencodeVersion": gencode_version},
             timeout=timeout,
         )
         if resp.status_code == 200:
@@ -135,12 +153,14 @@ class GTExV2Tool(BaseTool):
             }
         if isinstance(gencode_ids, str):
             gencode_ids = [gencode_ids]
-        # Resolve gene symbols/unversioned IDs to versioned GENCODE IDs
-        gencode_ids = [_resolve_gencode_id(gid) for gid in (gencode_ids or [])]
-
-        # Feature-69A-002: gtex_v10 returns empty results for medianGeneExpression.
-        # Default to gtex_v8 which is stable and returns correct tissue expression.
+        # gtex_v8 stays the default because it is the most widely cited release;
+        # gtex_v10 is fully queryable once IDs are resolved against GENCODE v39.
         dataset_id = arguments.get("dataset_id", "gtex_v8")
+        # Resolve gene symbols/Ensembl IDs to the GENCODE version this dataset uses
+        gencode_ids = [
+            _resolve_gencode_id(gid, dataset_id) for gid in (gencode_ids or [])
+        ]
+
         tissue_ids = arguments.get("tissue_site_detail_id")
         if tissue_ids is None:
             tissue_ids = arguments.get("tissue_id") or []
@@ -197,11 +217,12 @@ class GTExV2Tool(BaseTool):
         gencode_ids = arguments.get("gencode_id")
         if isinstance(gencode_ids, str):
             gencode_ids = [gencode_ids]
-        # Resolve gene symbols/unversioned IDs to versioned GENCODE IDs
-        gencode_ids = [_resolve_gencode_id(gid) for gid in (gencode_ids or [])]
-
-        # Feature-69A-002: gtex_v10 returns empty for geneExpression; use gtex_v8
         dataset_id = arguments.get("dataset_id", "gtex_v8")
+        # Resolve gene symbols/Ensembl IDs to the GENCODE version this dataset uses
+        gencode_ids = [
+            _resolve_gencode_id(gid, dataset_id) for gid in (gencode_ids or [])
+        ]
+
         tissue_ids = arguments.get("tissue_site_detail_id", [])
         attribute_subset = arguments.get("attribute_subset")
 
@@ -295,7 +316,7 @@ class GTExV2Tool(BaseTool):
     def _get_eqtl_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get eQTL genes (eGenes) with significant cis-eQTLs."""
         tissue_ids = arguments.get("tissue_site_detail_id", [])
-        # Feature-69A-002: gtex_v10 returns empty for eQTL endpoints; use gtex_v8
+        # gtex_v8 is the default release; gtex_v10 is also fully queryable here.
         dataset_id = arguments.get("dataset_id", "gtex_v8")
 
         if isinstance(tissue_ids, str):
@@ -334,13 +355,12 @@ class GTExV2Tool(BaseTool):
         gencode_ids = arguments.get("gencode_id") or []
         variant_ids = arguments.get("variant_id") or []
         tissue_ids = arguments.get("tissue_site_detail_id") or []
-        # Feature-69A-002: gtex_v10 returns empty for eQTL endpoints; use gtex_v8
         dataset_id = arguments.get("dataset_id", "gtex_v8")
 
         if isinstance(gencode_ids, str):
             gencode_ids = [gencode_ids]
-        # Resolve gene symbols/unversioned IDs to versioned GENCODE IDs
-        gencode_ids = [_resolve_gencode_id(gid) for gid in gencode_ids]
+        # Resolve gene symbols/Ensembl IDs to the GENCODE version this dataset uses
+        gencode_ids = [_resolve_gencode_id(gid, dataset_id) for gid in gencode_ids]
         if isinstance(variant_ids, str):
             variant_ids = [variant_ids]
         if isinstance(tissue_ids, str):
@@ -387,10 +407,10 @@ class GTExV2Tool(BaseTool):
     def _get_multi_tissue_eqtls(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get multi-tissue eQTL Metasoft results."""
         gencode_id = arguments.get("gencode_id")
-        if gencode_id:
-            gencode_id = _resolve_gencode_id(gencode_id)
-        variant_id = arguments.get("variant_id")
         dataset_id = arguments.get("dataset_id", "gtex_v8")
+        if gencode_id:
+            gencode_id = _resolve_gencode_id(gencode_id, dataset_id)
+        variant_id = arguments.get("variant_id")
 
         if not gencode_id:
             return {
@@ -429,11 +449,11 @@ class GTExV2Tool(BaseTool):
     def _calculate_eqtl(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Calculate dynamic eQTL for gene-variant pair."""
         gencode_id = arguments.get("gencode_id")
+        dataset_id = arguments.get("dataset_id", "gtex_v8")
         if gencode_id:
-            gencode_id = _resolve_gencode_id(gencode_id)
+            gencode_id = _resolve_gencode_id(gencode_id, dataset_id)
         variant_id = arguments.get("variant_id")
         tissue_id = arguments.get("tissue_site_detail_id")
-        dataset_id = arguments.get("dataset_id", "gtex_v8")
 
         if not all([gencode_id, variant_id, tissue_id]):
             return {
@@ -469,7 +489,7 @@ class GTExV2Tool(BaseTool):
 
     def _get_sample_info(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get sample information and metadata."""
-        # Feature-69A-002: gtex_v10 returns empty; use gtex_v8
+        # gtex_v8 is the default release; gtex_v10 is also fully queryable here.
         dataset_id = arguments.get("dataset_id", "gtex_v8")
         sample_ids = arguments.get("sample_id", [])
         subject_ids = arguments.get("subject_id", [])
@@ -524,7 +544,7 @@ class GTExV2Tool(BaseTool):
     def _get_top_expressed_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get top expressed genes for a tissue."""
         tissue_id = arguments.get("tissue_site_detail_id")
-        # Feature-69A-002: gtex_v10 returns empty; use gtex_v8
+        # gtex_v8 is the default release; gtex_v10 is also fully queryable here.
         dataset_id = arguments.get("dataset_id", "gtex_v8")
         filter_mt = arguments.get("filter_mt_genes", True)
 
@@ -586,7 +606,7 @@ class GTExV2Tool(BaseTool):
             gencode_ids = arguments.get("gencode_id") or []
             if isinstance(gencode_ids, str):
                 gencode_ids = [gencode_ids]
-            gencode_ids = [_resolve_gencode_id(gid) for gid in gencode_ids]
+            gencode_ids = [_resolve_gencode_id(gid, dataset_id) for gid in gencode_ids]
             variant_ids = arguments.get("variant_id") or []
             if isinstance(variant_ids, str):
                 variant_ids = [variant_ids]
@@ -633,9 +653,9 @@ class GTExV2Tool(BaseTool):
             }
         if isinstance(gencode_ids, str):
             gencode_ids = [gencode_ids]
-        gencode_ids = [_resolve_gencode_id(gid) for gid in gencode_ids]
-
         dataset_id = arguments.get("dataset_id", "gtex_v8")
+        gencode_ids = [_resolve_gencode_id(gid, dataset_id) for gid in gencode_ids]
+
         tissue_ids = arguments.get("tissue_site_detail_id") or []
         if isinstance(tissue_ids, str):
             tissue_ids = [tissue_ids]
@@ -686,10 +706,10 @@ class GTExV2Tool(BaseTool):
             }
         if isinstance(gencode_ids, str):
             gencode_ids = [gencode_ids]
-        gencode_ids = [_resolve_gencode_id(gid) for gid in gencode_ids]
-
         # snRNA-seq data lives only in the pilot dataset.
         dataset_id = arguments.get("dataset_id", "gtex_snrnaseq_pilot")
+        gencode_ids = [_resolve_gencode_id(gid, dataset_id) for gid in gencode_ids]
+
         tissue_ids = arguments.get("tissue_site_detail_id") or []
         if isinstance(tissue_ids, str):
             tissue_ids = [tissue_ids]
@@ -745,9 +765,9 @@ class GTExV2Tool(BaseTool):
             }
         if isinstance(gencode_id, list):
             gencode_id = gencode_id[0] if gencode_id else None
-        gencode_id = _resolve_gencode_id(gencode_id)
-
         dataset_id = arguments.get("dataset_id", "gtex_v8")
+        gencode_id = _resolve_gencode_id(gencode_id, dataset_id)
+
         tissue_ids = arguments.get("tissue_site_detail_id") or []
         if isinstance(tissue_ids, str):
             tissue_ids = [tissue_ids]

--- a/src/tooluniverse/nhanes_tool.py
+++ b/src/tooluniverse/nhanes_tool.py
@@ -25,65 +25,81 @@ class NHANESTool(BaseTool):
         super().__init__(tool_config)
         self.endpoint = tool_config["fields"]["endpoint"]
 
+    # Published NHANES continuous cycles, newest first. Each is a real CDC
+    # release; note there is no standalone 2019-2020 cycle -- field work was
+    # cut short by COVID-19 and those data ship as the "2017-2020 pre-pandemic"
+    # files instead.
+    _CYCLES = [
+        "2021-2023",
+        "2017-2018",
+        "2015-2016",
+        "2013-2014",
+        "2011-2012",
+        "2009-2010",
+        "2007-2008",
+        "2005-2006",
+        "2003-2004",
+        "2001-2002",
+        "1999-2000",
+    ]
+
+    _COMPONENTS = [
+        "Demographics",
+        "Dietary",
+        "Examination",
+        "Laboratory",
+        "Questionnaire",
+    ]
+
+    @staticmethod
+    def _datapage_url(component: str, cycle: str) -> str:
+        """Build the CDC data-listing URL for a component within a cycle."""
+        return (
+            "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx"
+            f"?Component={component}&CycleBeginYear={cycle.split('-')[0]}"
+        )
+
     def _get_dataset_info(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get NHANES dataset information."""
         year = arguments.get("year")
         component = arguments.get("component")
 
-        base_url = "https://wwwn.cdc.gov/Nchs/Nhanes"
+        # An unrecognised cycle used to fall through to the two most recent
+        # ones, so asking for 2021-2023 returned rows labelled 2017-2018 under
+        # status "success". Reject it instead of answering about another year.
+        if year and year not in self._CYCLES:
+            return {
+                "status": "error",
+                "error": (
+                    f"Unknown NHANES cycle '{year}'. Valid cycles: "
+                    f"{', '.join(self._CYCLES)}. NHANES has no standalone "
+                    "2019-2020 cycle; those data are published as the "
+                    "'2017-2020 pre-pandemic' files."
+                ),
+            }
 
-        # Common NHANES cycles
-        cycles = [
-            "2017-2018",
-            "2015-2016",
-            "2013-2014",
-            "2011-2012",
-            "2009-2010",
-            "2007-2008",
+        cycles_to_show = [year] if year else self._CYCLES[:2]
+        components = [component] if component else self._COMPONENTS
+
+        datasets = [
+            {
+                "name": f"NHANES {comp} - {cycle}",
+                "year": cycle,
+                "component": comp,
+                "download_url": self._datapage_url(comp, cycle),
+                "description": f"NHANES {comp} data for {cycle}",
+            }
+            for cycle in cycles_to_show
+            for comp in components
         ]
-
-        datasets = []
-
-        if year:
-            cycles_to_show = [year] if year in cycles else cycles[:2]
-        else:
-            cycles_to_show = cycles[:2]  # Show most recent
-
-        for cycle in cycles_to_show:
-            if component:
-                datasets.append(
-                    {
-                        "name": f"NHANES {component} - {cycle}",
-                        "year": cycle,
-                        "component": component,
-                        "download_url": f"{base_url}/{cycle}/{component.lower()}_{cycle}.aspx",
-                        "description": f"NHANES {component} data for {cycle}",
-                    }
-                )
-            else:
-                # Show all components
-                for comp in [
-                    "Demographics",
-                    "Dietary",
-                    "Examination",
-                    "Laboratory",
-                    "Questionnaire",
-                ]:
-                    datasets.append(
-                        {
-                            "name": f"NHANES {comp} - {cycle}",
-                            "year": cycle,
-                            "component": comp,
-                            "download_url": f"{base_url}/{cycle}/{comp.lower()}_{cycle}.aspx",
-                            "description": f"NHANES {comp} data for {cycle}",
-                        }
-                    )
 
         return {
             "status": "success",
             "data": {
-                "datasets": datasets[:20],  # Limit results
-                "note": "NHANES data is available as downloadable files (SAS, XPT formats) from the CDC website. Visit the download URLs to access datasets. Files may require SAS or conversion tools to read.",
+                "datasets": datasets,
+                "count": len(datasets),
+                "cycles_covered": cycles_to_show,
+                "note": "download_url opens the CDC listing of data files for that component and cycle. Files are XPT (SAS transport); use NHANES_download_and_parse to fetch and parse one directly.",
             },
             "metadata": {
                 "source": "CDC NHANES",

--- a/src/tooluniverse/pubchem_tox_tool.py
+++ b/src/tooluniverse/pubchem_tox_tool.py
@@ -135,21 +135,28 @@ class PubChemToxTool(BaseTool):
     def _extract_info_from_sections(
         self, sections: List[Dict], heading: str
     ) -> List[Dict]:
-        """Find sections matching heading recursively and extract their Information entries."""
+        """Find sections matching heading recursively and extract their Information entries.
+
+        PubChem packs every statement of one notification group into a single
+        Information entry holding N StringWithMarkup elements, so reading only
+        element 0 dropped the rest. Because GHS codes are ordered numerically
+        and physical hazards (H2xx) sort ahead of health hazards (H3xx), that
+        systematically discarded carcinogenicity and mutagenicity: benzene came
+        back as H225/H401 -- flammable and toxic to aquatic life -- with H350
+        "May cause cancer" among the fourteen statements silently lost.
+        """
         matched = self._find_sections_recursive(sections, heading)
         results = []
         for section in matched:
             for info in section.get("Information", []):
                 name = info.get("Name", "")
                 val = info.get("Value", {})
-                sws = val.get("StringWithMarkup", [])
-                if sws:
-                    text = sws[0].get("String", "")
-                    markups = sws[0].get("Markup", [])
+                for sw in val.get("StringWithMarkup", []):
+                    markups = sw.get("Markup", [])
                     extras = [m.get("Extra", "") for m in markups if m.get("Extra")]
                     entry = {
                         "name": name,
-                        "value": self._strip_html(text),
+                        "value": self._strip_html(sw.get("String", "")),
                     }
                     if extras:
                         entry["pictogram_labels"] = extras

--- a/src/tooluniverse/wikipathways_ext_tool.py
+++ b/src/tooluniverse/wikipathways_ext_tool.py
@@ -100,9 +100,22 @@ class WikiPathwaysExtTool(BaseTool):
                 "error": "pathway_id parameter is required (e.g., 'WP254')",
             }
 
-        code = arguments.get("code", "H")
-        id_type_name = CODE_TO_NAME.get(code, code)
-        source_substr = _CODE_TO_SOURCE_SUBSTR.get(code, code)
+        # `code` used to default to "H" (HGNC), but WikiPathways' RDF store
+        # annotates gene products with the database they were drawn from, and
+        # HGNC is rare there -- WP254's 87 gene products are sourced from
+        # Entrez Gene (84) and Ensembl (3), none from HGNC. The default filter
+        # therefore matched nothing and the tool reported "0 genes" for its own
+        # documented 88-gene example. `code` is now an optional filter.
+        code = arguments.get("code")
+        id_type_name = CODE_TO_NAME.get(code, code) if code else "All sources"
+
+        source_filter = ""
+        if code:
+            source_substr = _CODE_TO_SOURCE_SUBSTR.get(code, code)
+            # Case-insensitive: the store writes "UniProtKB", not "Uniprot".
+            source_filter = (
+                f'\n  FILTER(CONTAINS(LCASE(STR(?src)), "{source_substr.lower()}"))'
+            )
 
         identifier_uri = f"https://identifiers.org/wikipathways/{pathway_id}"
         sparql = f"""
@@ -110,33 +123,43 @@ PREFIX wp: <http://vocabularies.wikipathways.org/wp#>
 PREFIX dc: <http://purl.org/dc/elements/1.1/>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-SELECT DISTINCT ?gene_id ?gene_label WHERE {{
+SELECT DISTINCT ?gene ?gene_label WHERE {{
   ?gene dcterms:isPartOf ?pathway ;
         a wp:GeneProduct ;
-        dc:identifier ?gene_id ;
         rdfs:label ?gene_label ;
         dc:source ?src .
-  ?pathway dc:identifier <{identifier_uri}> .
-  FILTER(CONTAINS(STR(?src), "{source_substr}"))
-}} LIMIT 500
+  ?pathway dc:identifier <{identifier_uri}> .{source_filter}
+}} LIMIT 2000
 """
         data = _sparql(sparql, timeout=self.timeout)
-        # SPARQL returns the gene URI in ?gene_id; flatten to the bare label
-        # so callers see the same {gene_count, genes:[symbol]} shape as before.
-        symbols = sorted(
-            {
-                _val(b, "gene_label")
-                for b in data.get("results", {}).get("bindings", [])
-                if _val(b, "gene_label")
-            }
-        )
+        # One gene product carries several rdfs:label aliases, so counting
+        # labels overstated the gene set -- WP254 read as 134 genes against 87
+        # actual gene products. Count the nodes instead. The aliases are not
+        # reliable enough to pick a single symbol from (WikiPathways attaches
+        # "PIK3CA" to the AKT1 node among others), so every label is reported
+        # rather than one being guessed at.
+        labels_by_gene: Dict[str, set] = {}
+        for binding in data.get("results", {}).get("bindings", []):
+            gene_uri = _val(binding, "gene")
+            label = _val(binding, "gene_label")
+            if not gene_uri or not label:
+                continue
+            labels_by_gene.setdefault(gene_uri, set()).add(label)
+
+        symbols = sorted({lbl for labels in labels_by_gene.values() for lbl in labels})
+        gene_products = [
+            {"identifier": uri, "labels": sorted(labels)}
+            for uri, labels in sorted(labels_by_gene.items())
+        ]
         return {
             "status": "success",
             "data": {
                 "pathway_id": pathway_id,
-                "gene_count": len(symbols),
+                "gene_count": len(labels_by_gene),
+                "label_count": len(symbols),
                 "identifier_type": id_type_name,
                 "genes": symbols,
+                "gene_products": gene_products,
             },
             "metadata": {
                 "source": "WikiPathways SPARQL",

--- a/tests/unit/test_ctg_phase_gate_with_status.py
+++ b/tests/unit/test_ctg_phase_gate_with_status.py
@@ -1,0 +1,92 @@
+"""search_clinical_trials dropped its phase>=2 gate whenever a status filter was set.
+
+The tool documents "Limited to trials beyond phase 1" and implements it with a
+hidden ``filter.advanced=(AREA[Phase]PHASE2 OR ... PHASE4)`` default. That
+default was skipped whenever ``filter.overallStatus`` was present, guarded by a
+comment about an ``AREA[HasResults]true`` clause that an earlier fix had already
+deleted -- so the workaround outlived its reason and silently disabled the gate.
+
+Confirmed live: adding the *narrowing* ``overall_status=["COMPLETED"]`` to a
+metformin/lactic-acidosis search raised total_count from 2 to 3 and returned a
+disjoint set of studies, and a RECRUITING pembrolizumab search returned 745
+studies instead of 557 -- 188 of them phase 1 or early phase 1.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.ctg_tool import ClinicalTrialsSearchTool
+
+_PHASE_GATE = "(AREA[Phase]PHASE2 OR AREA[Phase]PHASE3 OR AREA[Phase]PHASE4)"
+_CONFIG = (
+    Path(__file__).resolve().parents[2]
+    / "src/tooluniverse/data/clinicaltrials_gov_tools.json"
+)
+
+
+@pytest.fixture
+def tool():
+    # Use the shipped config so the test tracks the real query_schema.
+    configs = json.loads(_CONFIG.read_text())
+    cfg = next(c for c in configs if c["name"] == "search_clinical_trials")
+    return ClinicalTrialsSearchTool(cfg)
+
+
+def _captured_params(tool, arguments):
+    captured = {}
+
+    def fake_query(endpoint_url, variables):
+        captured.update(variables)
+        return {"studies": [{"protocolSection": {}}], "totalCount": 1}
+
+    with patch("tooluniverse.ctg_tool.execute_RESTful_query", side_effect=fake_query):
+        with patch.object(tool, "_simplify_output", side_effect=lambda r: r):
+            tool.run(dict(arguments))
+    return captured
+
+
+def test_phase_gate_applied_without_status_filter(tool):
+    params = _captured_params(tool, {"condition": "diabetes"})
+
+    assert params["filter.advanced"] == _PHASE_GATE
+
+
+def test_phase_gate_still_applied_with_status_filter(tool):
+    params = _captured_params(
+        tool, {"condition": "diabetes", "overall_status": ["COMPLETED"]}
+    )
+
+    assert params["filter.advanced"] == _PHASE_GATE
+    assert "COMPLETED" in str(params["filter.overallStatus"])
+
+
+def test_phase_gate_applied_for_every_status_value(tool):
+    for status in ("RECRUITING", "COMPLETED", "TERMINATED", "WITHDRAWN"):
+        params = _captured_params(
+            tool, {"condition": "diabetes", "overall_status": [status]}
+        )
+        assert params["filter.advanced"] == _PHASE_GATE, status
+
+
+def test_status_alias_does_not_bypass_the_gate(tool):
+    # `status` is mapped onto filter.overallStatus by the param-name mapper.
+    params = _captured_params(tool, {"condition": "diabetes", "status": ["RECRUITING"]})
+
+    assert params["filter.advanced"] == _PHASE_GATE
+
+
+def test_status_filter_only_adds_a_constraint(tool):
+    # Adding a status filter must narrow the query, never trade one filter for
+    # another -- that swap is what let the result count grow from 2 to 3.
+    without = _captured_params(tool, {"condition": "diabetes"})
+    with_status = _captured_params(
+        tool, {"condition": "diabetes", "overall_status": ["COMPLETED"]}
+    )
+
+    assert set(without) <= set(with_status)
+    for key, value in without.items():
+        assert with_status[key] == value, key
+    assert "filter.overallStatus" in with_status

--- a/tests/unit/test_ebi_interactions_scoped_to_query.py
+++ b/tests/unit/test_ebi_interactions_scoped_to_query.py
@@ -1,0 +1,173 @@
+"""EBI interaction tools attributed neighbours' partners to the query protein.
+
+/proteins/interaction/{acc} answers with the queried protein *plus* about a
+hundred neighbour proteins, each carrying its own complete interaction list.
+Pooling every entry's interactions turned unrelated pairs into partners of the
+query.
+
+Confirmed live before the fix: TP53 (P04637) reported total_interactions 3258
+against a true 185, and 44 of the 50 rows on the default page were not TP53
+interactions at all -- AXIN1-GSK3B, BRCA2-RAD51 and PIK3CA-PIK3R1 among them.
+Insulin (P01308) reported 735 partners against a true 9, listing huntingtin and
+ataxin-1 -- partners of a chaperone hub in the same payload -- as insulin
+binders.
+"""
+
+from unittest.mock import patch
+
+from tooluniverse.ebi_proteins_interactions_tool import (
+    EBIProteinsInteractionsTool,
+    _entries_for_accession,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+# Entry 0 is the query protein; entries 1-2 are neighbours whose own
+# interactions must never be attributed to it.
+_PAYLOAD = [
+    {
+        "accession": "P04637",
+        "name": "P53_HUMAN",
+        "interactions": [
+            {
+                "accession1": "P04637",
+                "accession2": "Q00987",
+                "gene": "MDM2",
+                "experiments": 117,
+                "interactor1": "EBI-366083",
+                "interactor2": "EBI-389668",
+            },
+            {
+                "accession1": "P04637",
+                "accession2": "O15151",
+                "gene": "MDM4",
+                "experiments": 27,
+                "interactor1": "EBI-366083",
+                "interactor2": "EBI-398437",
+            },
+        ],
+        "diseases": [{"diseaseId": "Li-Fraumeni syndrome"}],
+        "subcellularLocations": [{"locations": [{"location": {"value": "Nucleus"}}]}],
+    },
+    {
+        "accession": "O15169",
+        "interactions": [
+            {
+                "accession1": "O15169",
+                "accession2": "P49841",
+                "gene": "GSK3B",
+                "experiments": 52,
+                "interactor1": "EBI-373586",
+                "interactor2": "EBI-710484",
+            }
+        ],
+        "diseases": [{"diseaseId": "SHOULD NOT APPEAR"}],
+    },
+    {
+        "accession": "P51587",
+        "interactions": [
+            {
+                "accession1": "P51587",
+                "accession2": "Q06609",
+                "gene": "RAD51",
+                "experiments": 46,
+                "interactor1": "EBI-297202",
+                "interactor2": "EBI-79792",
+            }
+        ],
+    },
+]
+
+
+def _make(operation):
+    return EBIProteinsInteractionsTool(
+        {
+            "name": f"EBIProteins_{operation}",
+            "type": "EBIProteinsInteractionsTool",
+            "fields": {"operation": operation},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+def _run(operation, arguments):
+    tool = _make(operation)
+    with patch(
+        "tooluniverse.ebi_proteins_interactions_tool.requests.get",
+        return_value=_FakeResponse(_PAYLOAD),
+    ):
+        return tool.run(arguments)
+
+
+def test_entries_helper_keeps_only_the_query_protein():
+    entries = _entries_for_accession(_PAYLOAD, "P04637")
+
+    assert [e["accession"] for e in entries] == ["P04637"]
+
+
+def test_entries_helper_is_case_insensitive():
+    assert len(_entries_for_accession(_PAYLOAD, "p04637")) == 1
+
+
+def test_only_the_query_proteins_partners_are_returned():
+    result = _run("get_interactions", {"accession": "P04637"})
+    genes = {i["gene_name"] for i in result["data"]["interactions"]}
+
+    assert genes == {"MDM2", "MDM4"}
+    assert "GSK3B" not in genes
+    assert "RAD51" not in genes
+
+
+def test_total_counts_only_the_query_proteins_interactions():
+    result = _run("get_interactions", {"accession": "P04637"})
+
+    assert result["metadata"]["total_interactions"] == 2
+
+
+def test_every_returned_row_involves_the_query_proteins_intact_id():
+    result = _run("get_interactions", {"accession": "P04637"})
+
+    for interaction in result["data"]["interactions"]:
+        assert "EBI-366083" in (
+            interaction["intact_id_a"],
+            interaction["intact_id_b"],
+        )
+
+
+def test_sorting_by_experiment_count_is_preserved():
+    result = _run("get_interactions", {"accession": "P04637"})
+    counts = [i["experiments"] for i in result["data"]["interactions"]]
+
+    assert counts == sorted(counts, reverse=True)
+
+
+def test_interaction_details_is_scoped_the_same_way():
+    result = _run("get_interaction_details", {"accession": "P04637"})
+    payload = result["data"]
+    genes = {i["gene_name"] for i in payload["interactions"]}
+
+    assert genes == {"MDM2", "MDM4"}
+    assert "SHOULD NOT APPEAR" not in str(payload.get("diseases"))
+
+
+def test_details_metadata_comes_from_the_query_protein_even_if_not_first():
+    reordered = [_PAYLOAD[1], _PAYLOAD[0], _PAYLOAD[2]]
+    tool = _make("get_interaction_details")
+    with patch(
+        "tooluniverse.ebi_proteins_interactions_tool.requests.get",
+        return_value=_FakeResponse(reordered),
+    ):
+        result = tool.run({"accession": "P04637"})
+
+    genes = {i["gene_name"] for i in result["data"]["interactions"]}
+    assert genes == {"MDM2", "MDM4"}

--- a/tests/unit/test_encode_404_is_zero_results.py
+++ b/tests/unit/test_encode_404_is_zero_results.py
@@ -1,0 +1,152 @@
+"""ENCODE searches answered a zero-result query with another species' data.
+
+ENCODE returns HTTP 404 carrying a valid body ({"total": 0, "@graph": [],
+"notification": "No results found"}) when a facet combination matches nothing.
+``_encode_search`` treated that as a transport error, and callers reacted in one
+of two wrong ways:
+
+* the histone / chromatin-accessibility / RNA-seq searches retried with the
+  organism filter deleted, so "H3K4me3 in human midbrain" -- which ENCODE does
+  not have -- came back as four *Mus musculus* embryo experiments while
+  metadata still said organism "Homo sapiens". The bogus-value control was
+  arithmetic: Homo sapiens 431 + Mus musculus 97 = 528, exactly what a
+  nonsense organism returned;
+* five other searches surfaced the same 404 as "API HTTP error: 404", turning a
+  legitimately empty answer into a fake outage.
+
+Both symptoms come from the one misread status code.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.epigenomics_tool import EpigenomicsTool
+
+_ORGANISM_KEY = "replicates.library.biosample.organism.scientific_name"
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+_EMPTY_404 = {"total": 0, "@graph": [], "notification": "No results found"}
+
+
+def _make(endpoint):
+    return EpigenomicsTool(
+        {
+            "name": f"ENCODE_{endpoint}",
+            "type": "EpigenomicsTool",
+            "fields": {"endpoint": endpoint},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+def test_encode_search_reads_the_404_body_as_zero_results():
+    tool = _make("histone_chipseq")
+    with patch(
+        "tooluniverse.epigenomics_tool._request_with_backoff",
+        return_value=_FakeResponse(404, _EMPTY_404),
+    ):
+        raw = tool._encode_search({"type": "Experiment"})
+
+    assert raw["total"] == 0
+    assert raw["@graph"] == []
+
+
+def test_a_real_404_without_a_body_still_raises():
+    tool = _make("histone_chipseq")
+    with patch(
+        "tooluniverse.epigenomics_tool._request_with_backoff",
+        return_value=_FakeResponse(404, None),
+    ):
+        with pytest.raises(RuntimeError):
+            tool._encode_search({"type": "Experiment"})
+
+
+@pytest.mark.parametrize(
+    "endpoint,arguments",
+    [
+        (
+            "histone_chipseq",
+            {"histone_mark": "H3K4me3", "biosample_term_name": "midbrain"},
+        ),
+        (
+            "chromatin_accessibility",
+            {"biosample_term_name": "midbrain"},
+        ),
+    ],
+)
+def test_empty_result_never_retries_without_the_organism_filter(endpoint, arguments):
+    tool = _make(endpoint)
+    calls = []
+
+    def fake_request(url, params=None, **kwargs):
+        calls.append(dict(params or {}))
+        return _FakeResponse(404, _EMPTY_404)
+
+    with patch(
+        "tooluniverse.epigenomics_tool._request_with_backoff",
+        side_effect=fake_request,
+    ):
+        result = tool.run(dict(arguments, organism="Homo sapiens", limit=4))
+
+    assert len(calls) == 1, "the organism filter must not be dropped and retried"
+    assert calls[0][_ORGANISM_KEY] == "Homo sapiens"
+
+    assert result["status"] == "success"
+    assert result["metadata"]["total"] == 0
+    assert result["metadata"]["organism"] == "Homo sapiens"
+    assert result["data"] == []
+
+
+def test_empty_result_is_not_reported_as_an_api_outage():
+    tool = _make("encode_microrna")
+    with patch(
+        "tooluniverse.epigenomics_tool._request_with_backoff",
+        return_value=_FakeResponse(404, _EMPTY_404),
+    ):
+        result = tool.run({"biosample_term_name": "liver", "limit": 2})
+
+    assert result["status"] == "success"
+    assert "404" not in str(result)
+    assert result["data"]["total"] == 0
+
+
+def test_non_empty_results_still_flow_through():
+    tool = _make("histone_chipseq")
+    payload = {
+        "total": 1,
+        "@graph": [
+            {
+                "accession": "ENCSR914QOK",
+                "target": {"label": "H3K27me3"},
+                "lab": {"title": "Some Lab"},
+                "biosample_summary": "Homo sapiens K562",
+            }
+        ],
+    }
+    with patch(
+        "tooluniverse.epigenomics_tool._request_with_backoff",
+        return_value=_FakeResponse(200, payload),
+    ):
+        result = tool.run(
+            {"histone_mark": "H3K27me3", "biosample_term_name": "K562", "limit": 5}
+        )
+
+    assert result["status"] == "success"
+    accessions = [e["accession"] for e in result["data"]["experiments"]]
+    assert accessions == ["ENCSR914QOK"]

--- a/tests/unit/test_ensembl_ld_truncation_count.py
+++ b/tests/unit/test_ensembl_ld_truncation_count.py
@@ -1,0 +1,113 @@
+"""EnsemblLD_get_ld_variants counted its LD partners after truncating them.
+
+The handler sorted partners by r2, sliced to the top 200, then reported
+``ld_count = len(<truncated list>)``. Two things were wrong at once: the count
+read as the number of partners the variant has, and the returned set stopped
+far above the requested r2 threshold. Confirmed live: rs1042779 in
+1000GENOMES:phase_3:CEU at r2_threshold=0.05 returned ``ld_count: 200`` with a
+weakest r2 of 0.792, while the Ensembl endpoint returned 735 partners reaching
+down to 0.052. The tool description compounded it by promising "all variants in
+LD", and there was no parameter to reach past the cap.
+
+The handler now reports ``total_ld_count`` (pre-truncation), keeps ``ld_count``
+as what was actually returned, sets ``truncated``, and accepts ``limit``.
+"""
+
+from unittest.mock import patch
+
+from tooluniverse.ensembl_ld_tool import DEFAULT_LD_VARIANT_LIMIT, EnsemblLDTool
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+def _make():
+    cfg = {
+        "name": "EnsemblLD_get_ld_variants",
+        "type": "EnsemblLDTool",
+        "fields": {"endpoint_type": "ld_variants"},
+        "parameter": {"type": "object", "properties": {}},
+    }
+    return EnsemblLDTool(cfg)
+
+
+def _fake_partners(n):
+    """n partners with descending r2 from just under 1.0 down toward 0.05."""
+    return [
+        {
+            "variation1": "rs1042779",
+            "variation2": f"rs{100000 + i}",
+            "r2": str(round(0.99 - (i * 0.9 / n), 6)),
+            "d_prime": "0.99",
+            "population_name": "1000GENOMES:phase_3:CEU",
+        }
+        for i in range(n)
+    ]
+
+
+def _run(arguments, n_partners=735):
+    tool = _make()
+    with patch(
+        "tooluniverse.ensembl_ld_tool.requests.get",
+        return_value=_FakeResponse(_fake_partners(n_partners)),
+    ):
+        return tool.run(arguments)
+
+
+_BASE = {
+    "variant_id": "rs1042779",
+    "population": "1000GENOMES:phase_3:CEU",
+    "r2_threshold": 0.05,
+}
+
+
+def test_total_count_is_reported_before_truncation():
+    data = _run(dict(_BASE))["data"]
+
+    assert data["total_ld_count"] == 735
+    assert data["ld_count"] == DEFAULT_LD_VARIANT_LIMIT
+    assert len(data["ld_variants"]) == DEFAULT_LD_VARIANT_LIMIT
+    assert data["truncated"] is True
+
+
+def test_limit_reaches_the_partners_beyond_the_default_cap():
+    data = _run(dict(_BASE, limit=5000))["data"]
+
+    assert data["total_ld_count"] == 735
+    assert data["ld_count"] == 735
+    assert data["truncated"] is False
+    # The weakest partner is now visible instead of being cut off at r2~0.79.
+    assert min(v["r2"] for v in data["ld_variants"]) < 0.1
+
+
+def test_not_flagged_truncated_when_everything_fits():
+    data = _run(dict(_BASE), n_partners=12)["data"]
+
+    assert data["total_ld_count"] == 12
+    assert data["ld_count"] == 12
+    assert data["truncated"] is False
+
+
+def test_explicit_limit_smaller_than_default_is_honoured():
+    data = _run(dict(_BASE, limit=5))["data"]
+
+    assert data["ld_count"] == 5
+    assert data["total_ld_count"] == 735
+    assert data["truncated"] is True
+
+
+def test_results_remain_sorted_by_descending_r2():
+    data = _run(dict(_BASE, limit=50))["data"]
+
+    r2_values = [v["r2"] for v in data["ld_variants"]]
+    assert r2_values == sorted(r2_values, reverse=True)

--- a/tests/unit/test_go_genes_for_term.py
+++ b/tests/unit/test_go_genes_for_term.py
@@ -1,0 +1,140 @@
+"""GO_get_genes_for_term returned N empty objects and ignored its taxon filter.
+
+Two defects compounded. The tool read the Biolink endpoint with
+``extract_path: "associations[*].subject"``, but that API now answers with a
+flat list of annotation records keyed ``bioentity_label`` / ``taxon`` and no
+``subject`` key at all -- so ``assoc.get("subject", {})`` produced ``{}`` for
+every row and ``rows=10`` returned ten empty dicts as a successful result. The
+declared ``return_schema`` was ``array of objects with no properties``, so
+nothing caught it.
+
+Second, ``taxon`` was a *required* parameter that the endpoint silently ignored:
+requesting NCBITaxon:10090 returned Homo sapiens and Caenorhabditis elegans
+rows, and a nonsense taxon returned the same 50 records. The tool now queries
+the GO Solr index, which honours the filter (human 1257, mouse 2034, bogus 0)
+and returns real gene fields.
+"""
+
+import json
+from pathlib import Path
+
+from tooluniverse.gene_ontology_tool import (
+    GeneOntologyTool,
+    _drop_unfilled_query_segments,
+)
+
+_CONFIG = (
+    Path(__file__).resolve().parents[2]
+    / "src/tooluniverse/data/gene_ontology_tools.json"
+)
+
+
+def _config():
+    configs = json.loads(_CONFIG.read_text())
+    return next(c for c in configs if c["name"] == "GO_get_genes_for_term")
+
+
+def _tool():
+    return GeneOntologyTool(_config())
+
+
+_SOLR_DOCS = {
+    "response": {
+        "numFound": 1257,
+        "docs": [
+            {
+                "bioentity": "UniProtKB:P01375",
+                "bioentity_label": "TNF",
+                "bioentity_name": "Tumor necrosis factor",
+                "taxon": "NCBITaxon:9606",
+                "taxon_label": "Homo sapiens",
+                "evidence_type": "IDA",
+            },
+            {
+                "bioentity": "UniProtKB:P01375",
+                "bioentity_label": "TNF",
+                "bioentity_name": "Tumor necrosis factor",
+                "taxon": "NCBITaxon:9606",
+                "taxon_label": "Homo sapiens",
+                "evidence_type": "IEA",
+            },
+            {
+                "bioentity": "UniProtKB:P04637",
+                "bioentity_label": "TP53",
+                "bioentity_name": "Cellular tumor antigen p53",
+                "taxon": "NCBITaxon:9606",
+                "taxon_label": "Homo sapiens",
+                "evidence_type": "TAS",
+            },
+        ],
+    }
+}
+
+
+def test_genes_carry_real_fields_not_empty_objects():
+    genes = _tool()._extract_data(_SOLR_DOCS, "response.docs.genes")
+
+    assert len(genes) == 2
+    assert all(g["bioentity"] for g in genes)
+    assert {g["gene_symbol"] for g in genes} == {"TNF", "TP53"}
+    assert all(g != {} for g in genes)
+
+
+def test_annotation_rows_are_collapsed_to_distinct_genes():
+    genes = _tool()._extract_data(_SOLR_DOCS, "response.docs.genes")
+    tnf = next(g for g in genes if g["gene_symbol"] == "TNF")
+
+    # Three rows, two genes; TNF's two evidence codes fold into one entry.
+    assert tnf["annotation_count"] == 2
+    assert sorted(tnf["evidence_types"]) == ["IDA", "IEA"]
+
+
+def test_taxon_is_carried_through():
+    genes = _tool()._extract_data(_SOLR_DOCS, "response.docs.genes")
+
+    assert {g["taxon_label"] for g in genes} == {"Homo sapiens"}
+
+
+def test_rows_without_a_bioentity_are_skipped():
+    payload = {"response": {"docs": [{"bioentity_label": "orphan"}]}}
+
+    assert _tool()._extract_data(payload, "response.docs.genes") == []
+
+
+def test_taxon_is_no_longer_required():
+    # It was required while being silently ignored by the old endpoint.
+    assert _config()["parameter"]["required"] == ["id"]
+
+
+def test_endpoint_filters_on_taxon_and_term_closure():
+    endpoint = _config()["fields"]["endpoint"]
+
+    assert "golr" in endpoint
+    assert 'isa_partof_closure:"{id}"' in endpoint
+    assert 'taxon:"{taxon}"' in endpoint
+
+
+def test_return_schema_declares_the_gene_fields():
+    schema = _config()["return_schema"]
+
+    assert "oneOf" in schema
+    props = schema["oneOf"][0]["items"]["properties"]
+    assert "gene_symbol" in props
+    assert "bioentity" in props
+
+
+def test_omitted_optional_filter_is_dropped_from_the_url():
+    url = _drop_unfilled_query_segments(
+        'https://x/solr/select?q=*:*&fq=isa_partof_closure:"GO:0006915"'
+        '&fq=taxon:"{taxon}"&rows=100'
+    )
+
+    assert "{taxon}" not in url
+    assert 'isa_partof_closure:"GO:0006915"' in url
+    assert "rows=100" in url
+
+
+def test_url_without_placeholders_is_untouched():
+    url = "https://x/solr/select?q=*:*&rows=10"
+
+    assert _drop_unfilled_query_segments(url) == url

--- a/tests/unit/test_gtex_dataset_gencode_version.py
+++ b/tests/unit/test_gtex_dataset_gencode_version.py
@@ -1,0 +1,178 @@
+"""GTEx resolved every gene ID against GENCODE v26, whatever dataset was asked for.
+
+Each GTEx dataset is annotated against a different GENCODE release and the API
+only matches IDs carrying that release's version suffix (TP53 is
+ENSG00000141510.16 in gtex_v8/v26 but .18 in gtex_v10/v39). The resolver
+hardcoded ``gencodeVersion=v26``, so selecting ``dataset_id="gtex_v10"`` -- a
+documented enum value -- sent v26 IDs to a v39 dataset and the API answered
+HTTP 200 with an empty list. That surfaced as ``status: "success"`` with
+``num_results: 0``, i.e. "this gene has no expression in V10" rather than an ID
+mismatch. Confirmed live: median expression for TP53 in gtex_v10 returned 0
+rows via the tool but 54 tissues via the API with the .18 ID, and ERAP2/Liver
+eQTLs returned 0 via the tool but 250 via the API with the .17 ID.
+
+The resolver also stripped and re-resolved any supplied version suffix, so a
+caller who passed the correct v39 ID had it downgraded back to v26 -- there was
+no workaround from the outside.
+"""
+
+from unittest.mock import patch
+
+from tooluniverse.gtex_v2_tool import (
+    DATASET_GENCODE_VERSION,
+    GTExV2Tool,
+    _resolve_gencode_id,
+)
+
+# gencodeVersion -> versioned ID, as returned by /reference/gene
+_TP53_BY_VERSION = {
+    "v19": "ENSG00000141510.11",
+    "v26": "ENSG00000141510.16",
+    "v39": "ENSG00000141510.18",
+}
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _fake_reference_gene(url, params=None, timeout=None):
+    """Stand in for GET /reference/gene, honouring the requested gencodeVersion."""
+    version = (params or {}).get("gencodeVersion")
+    return _FakeResponse({"data": [{"gencodeId": _TP53_BY_VERSION[version]}]})
+
+
+def _make(operation):
+    cfg = {
+        "name": f"GTEx_{operation}",
+        "type": "GTExV2Tool",
+        "parameter": {
+            "type": "object",
+            "properties": {"operation": {"enum": [operation]}},
+        },
+    }
+    return GTExV2Tool(cfg)
+
+
+def test_dataset_gencode_map_matches_api_metadata():
+    # Values reported by GTEx /metadata/dataset.
+    assert DATASET_GENCODE_VERSION["gtex_v7"] == "v19"
+    assert DATASET_GENCODE_VERSION["gtex_v8"] == "v26"
+    assert DATASET_GENCODE_VERSION["gtex_v10"] == "v39"
+    assert DATASET_GENCODE_VERSION["gtex_snrnaseq_pilot"] == "v26"
+
+
+def test_resolver_uses_the_datasets_own_gencode_version():
+    with patch("tooluniverse.gtex_v2_tool.requests.get", _fake_reference_gene):
+        assert _resolve_gencode_id("TP53", "gtex_v8") == "ENSG00000141510.16"
+        assert _resolve_gencode_id("TP53", "gtex_v10") == "ENSG00000141510.18"
+        assert _resolve_gencode_id("TP53", "gtex_v7") == "ENSG00000141510.11"
+
+
+def test_resolver_defaults_to_v26_for_unknown_dataset():
+    with patch("tooluniverse.gtex_v2_tool.requests.get", _fake_reference_gene):
+        assert _resolve_gencode_id("TP53", "some_future_dataset") == (
+            "ENSG00000141510.16"
+        )
+
+
+def test_supplied_version_suffix_is_retargeted_not_preserved_blindly():
+    # A v26 ID asked for against v10 must come back as the v10 ID, and vice
+    # versa -- previously both directions collapsed to .16.
+    with patch("tooluniverse.gtex_v2_tool.requests.get", _fake_reference_gene):
+        assert (
+            _resolve_gencode_id("ENSG00000141510.16", "gtex_v10")
+            == "ENSG00000141510.18"
+        )
+        assert (
+            _resolve_gencode_id("ENSG00000141510.18", "gtex_v8") == "ENSG00000141510.16"
+        )
+
+
+def test_median_expression_sends_v39_id_when_dataset_is_v10():
+    tool = _make("get_median_gene_expression")
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        if url.endswith("/reference/gene"):
+            return _fake_reference_gene(url, params, timeout)
+        captured["url"] = url
+        captured["params"] = params
+        return _FakeResponse({"medianGeneExpression": [{"median": 22.65}]})
+
+    with patch("tooluniverse.gtex_v2_tool.requests.get", fake_get):
+        res = tool.run(
+            {"operation": "get_median_gene_expression", "gencode_id": "TP53",
+             "dataset_id": "gtex_v10"}
+        )
+
+    assert res["status"] == "success"
+    assert captured["params"]["gencodeId"] == ["ENSG00000141510.18"]
+    assert captured["params"]["datasetId"] == "gtex_v10"
+    assert res["num_results"] == 1
+
+
+def test_median_expression_still_sends_v26_id_by_default():
+    tool = _make("get_median_gene_expression")
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        if url.endswith("/reference/gene"):
+            return _fake_reference_gene(url, params, timeout)
+        captured["params"] = params
+        return _FakeResponse({"medianGeneExpression": []})
+
+    with patch("tooluniverse.gtex_v2_tool.requests.get", fake_get):
+        tool.run({"operation": "get_median_gene_expression", "gencode_id": "TP53"})
+
+    assert captured["params"]["gencodeId"] == ["ENSG00000141510.16"]
+    assert captured["params"]["datasetId"] == "gtex_v8"
+
+
+def test_single_tissue_eqtl_resolves_against_requested_dataset():
+    tool = _make("get_single_tissue_eqtls")
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        if url.endswith("/reference/gene"):
+            return _fake_reference_gene(url, params, timeout)
+        captured["params"] = params
+        return _FakeResponse({"data": []})
+
+    with patch("tooluniverse.gtex_v2_tool.requests.get", fake_get):
+        tool.run(
+            {
+                "operation": "get_single_tissue_eqtls",
+                "gencode_id": ["TP53"],
+                "tissue_site_detail_id": ["Liver"],
+                "dataset_id": "gtex_v10",
+            }
+        )
+
+    assert captured["params"]["gencodeId"] == ["ENSG00000141510.18"]
+
+
+def test_single_nucleus_defaults_to_pilot_dataset_gencode_version():
+    tool = _make("get_single_nucleus_expression")
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        if url.endswith("/reference/gene"):
+            return _fake_reference_gene(url, params, timeout)
+        captured["params"] = params
+        return _FakeResponse({"data": []})
+
+    with patch("tooluniverse.gtex_v2_tool.requests.get", fake_get):
+        tool.run(
+            {"operation": "get_single_nucleus_expression", "gencode_id": "TP53"}
+        )
+
+    # snRNA-seq pilot is GENCODE v26, so the .16 ID is the correct one here.
+    assert captured["params"]["datasetId"] == "gtex_snrnaseq_pilot"
+    assert captured["params"]["gencodeId"] == ["ENSG00000141510.16"]

--- a/tests/unit/test_nhanes_cycle_fallback.py
+++ b/tests/unit/test_nhanes_cycle_fallback.py
@@ -1,0 +1,102 @@
+"""nhanes_get_dataset_info answered about a different survey cycle than asked.
+
+An unrecognised ``year`` fell through to ``cycles[:2]``, so asking for the real
+2021-2023 cycle returned rows labelled 2017-2018 and 2015-2016 under
+``status: "success"`` -- the wrong years presented as the answer, with nothing
+to signal the substitution. The hardcoded cycle list was also stale (it began
+at 2007-2008 and stopped at 2017-2018, omitting six earlier published cycles
+and the current one), and every ``download_url`` was assembled from a template
+that does not exist: confirmed live,
+``.../Nchs/Nhanes/2017-2018/laboratory_2017-2018.aspx`` redirects to CDC's
+ErrorPage.aspx, while the datapage form now emitted returns HTTP 200.
+"""
+
+import pytest
+
+from tooluniverse.nhanes_tool import NHANESTool
+
+
+def _make():
+    cfg = {
+        "name": "nhanes_get_dataset_info",
+        "type": "NHANESTool",
+        "fields": {"endpoint": "dataset_info"},
+        "parameter": {"type": "object", "properties": {}},
+    }
+    return NHANESTool(cfg)
+
+
+def _info(**arguments):
+    return _make()._get_dataset_info(arguments)
+
+
+def test_unknown_cycle_is_rejected_not_silently_substituted():
+    res = _info(year="2021-2022", component="Laboratory")
+
+    assert res["status"] == "error"
+    assert "2021-2022" in res["error"]
+    # The caller is told what it can ask for instead of getting other years.
+    assert "2017-2018" in res["error"]
+
+
+def test_no_2019_2020_cycle_is_advertised():
+    # Field work was cut short by COVID-19; those data ship as the
+    # "2017-2020 pre-pandemic" files, and DEMO_K.XPT is a live 404.
+    assert "2019-2020" not in NHANESTool._CYCLES
+    assert _info(year="2019-2020")["status"] == "error"
+
+
+def test_current_cycle_is_available():
+    res = _info(year="2021-2023", component="Laboratory")
+
+    assert res["status"] == "success"
+    assert res["data"]["cycles_covered"] == ["2021-2023"]
+    assert [d["year"] for d in res["data"]["datasets"]] == ["2021-2023"]
+
+
+def test_earlier_published_cycles_are_available():
+    for cycle in ("1999-2000", "2003-2004", "2005-2006"):
+        res = _info(year=cycle, component="Demographics")
+        assert res["status"] == "success", cycle
+        assert res["data"]["datasets"][0]["year"] == cycle
+
+
+def test_requested_year_is_the_year_returned():
+    for cycle in NHANESTool._CYCLES:
+        res = _info(year=cycle, component="Laboratory")
+        assert res["status"] == "success", cycle
+        assert {d["year"] for d in res["data"]["datasets"]} == {cycle}
+
+
+def test_download_url_uses_the_live_cdc_datapage_form():
+    res = _info(year="2017-2018", component="Laboratory")
+    url = res["data"]["datasets"][0]["download_url"]
+
+    assert url == (
+        "https://wwwn.cdc.gov/nchs/nhanes/search/datapage.aspx"
+        "?Component=Laboratory&CycleBeginYear=2017"
+    )
+    # The old template pointed at a path CDC redirects to its error page.
+    assert "laboratory_2017-2018.aspx" not in url
+
+
+def test_omitting_year_covers_the_two_most_recent_cycles():
+    res = _info(component="Demographics")
+
+    assert res["data"]["cycles_covered"] == ["2021-2023", "2017-2018"]
+
+
+def test_omitting_component_lists_every_component():
+    res = _info(year="2017-2018")
+
+    components = {d["component"] for d in res["data"]["datasets"]}
+    assert components == set(NHANESTool._COMPONENTS)
+    assert res["data"]["count"] == len(NHANESTool._COMPONENTS)
+
+
+@pytest.mark.parametrize("cycle", NHANESTool._CYCLES)
+def test_every_advertised_cycle_builds_a_datapage_url(cycle):
+    res = _info(year=cycle, component="Examination")
+    url = res["data"]["datasets"][0]["download_url"]
+
+    assert url.endswith(f"CycleBeginYear={cycle.split('-')[0]}")

--- a/tests/unit/test_pubchem_tox_all_hazard_statements.py
+++ b/tests/unit/test_pubchem_tox_all_hazard_statements.py
@@ -1,0 +1,150 @@
+"""PubChemTox kept only the first string of each PubChem Information entry.
+
+PubChem packs every statement of one notification group into a single
+Information entry holding N StringWithMarkup elements. Reading ``sws[0]`` and
+discarding the rest was not a random sample: GHS codes are ordered numerically
+and physical hazards (H2xx) sort ahead of health hazards (H3xx), so the health
+hazard was dropped whenever a physical one existed.
+
+Confirmed live before the fix: benzene (CID 241) returned H225 and H401 only --
+"highly flammable" and "toxic to aquatic life" -- while PubChem lists 16 codes
+including H350 "May cause cancer", H340 and H372. Vinyl chloride, formaldehyde
+and arsenic trioxide behaved the same way; all four are IARC Group 1 human
+carcinogens. The same truncation made the carcinogen tool cite the withdrawn
+1987 IARC monograph and drop the current 2012 one.
+"""
+
+from tooluniverse.pubchem_tox_tool import PubChemToxTool
+
+
+def _make():
+    return PubChemToxTool(
+        {
+            "name": "PubChemTox_get_ghs_classification",
+            "type": "PubChemToxTool",
+            "fields": {"operation": "get_ghs_classification"},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+def _sections(strings, name="GHS Hazard Statements"):
+    return [
+        {
+            "TOCHeading": "GHS Classification",
+            "Information": [
+                {
+                    "Name": name,
+                    "Value": {
+                        "StringWithMarkup": [{"String": s} for s in strings]
+                    },
+                }
+            ],
+        }
+    ]
+
+
+_BENZENE = [
+    "H225: Highly Flammable liquid and vapor",
+    "H304: May be fatal if swallowed and enters airways",
+    "H315: Causes skin irritation",
+    "H340: May cause genetic defects",
+    "H350: May cause cancer",
+    "H372: Causes damage to organs",
+]
+
+
+def test_every_hazard_statement_is_returned():
+    entries = _make()._extract_info_from_sections(
+        _sections(_BENZENE), "GHS Classification"
+    )
+
+    assert [e["value"] for e in entries] == _BENZENE
+
+
+def test_the_carcinogenicity_statement_survives():
+    entries = _make()._extract_info_from_sections(
+        _sections(_BENZENE), "GHS Classification"
+    )
+    values = " ".join(e["value"] for e in entries)
+
+    assert "H350" in values
+    assert "May cause cancer" in values
+    assert "H340" in values
+
+
+def test_health_hazards_are_not_lost_behind_a_physical_hazard():
+    # H2xx sorts first, which is exactly why reading element 0 hid H3xx.
+    entries = _make()._extract_info_from_sections(
+        _sections(["H220: Extremely flammable gas", "H350: May cause cancer"]),
+        "GHS Classification",
+    )
+
+    assert len(entries) == 2
+    assert entries[0]["value"].startswith("H220")
+    assert entries[1]["value"].startswith("H350")
+
+
+def test_the_group_name_is_carried_onto_every_statement():
+    entries = _make()._extract_info_from_sections(
+        _sections(_BENZENE, name="GHS Hazard Statements"), "GHS Classification"
+    )
+
+    assert {e["name"] for e in entries} == {"GHS Hazard Statements"}
+
+
+def test_multiple_iarc_monographs_are_all_kept():
+    monographs = [
+        "Volume Sup 7: Overall Evaluations, 1987 (out of print)",
+        "Volume 62: (1995) Wood Dust and Formaldehyde",
+        "Volume 88: (2006) Formaldehyde, 2-Butoxyethanol",
+        "Volume 100F: (2012) Chemical Agents and Related Occupations",
+    ]
+    entries = _make()._extract_info_from_sections(
+        _sections(monographs, name="IARC Monographs"), "GHS Classification"
+    )
+
+    assert len(entries) == 4
+    assert any("100F" in e["value"] for e in entries)
+
+
+def test_pictogram_markup_is_kept_per_statement():
+    sections = [
+        {
+            "TOCHeading": "GHS Classification",
+            "Information": [
+                {
+                    "Name": "Pictogram(s)",
+                    "Value": {
+                        "StringWithMarkup": [
+                            {
+                                "String": "Flammable",
+                                "Markup": [{"Extra": "Flammable"}],
+                            },
+                            {
+                                "String": "Health Hazard",
+                                "Markup": [{"Extra": "Health Hazard"}],
+                            },
+                        ]
+                    },
+                }
+            ],
+        }
+    ]
+    entries = _make()._extract_info_from_sections(sections, "GHS Classification")
+
+    assert [e["pictogram_labels"] for e in entries] == [
+        ["Flammable"],
+        ["Health Hazard"],
+    ]
+
+
+def test_entry_without_strings_is_skipped():
+    sections = [
+        {
+            "TOCHeading": "GHS Classification",
+            "Information": [{"Name": "Table pointer", "Value": {}}],
+        }
+    ]
+
+    assert _make()._extract_info_from_sections(sections, "GHS Classification") == []

--- a/tests/unit/test_wikipathways_pathway_genes.py
+++ b/tests/unit/test_wikipathways_pathway_genes.py
@@ -1,0 +1,131 @@
+"""WikiPathways_get_pathway_genes returned 0 genes for its own documented example.
+
+``code`` defaulted to "H" (HGNC), which becomes a SPARQL filter on the
+``dc:source`` database that annotated each gene product. WikiPathways rarely
+records HGNC there: WP254's 87 gene products come from Entrez Gene (84) and
+Ensembl (3), and none from HGNC. So the default answered "0 genes" -- with
+status success -- for the pathway the tool's own description says returns 88.
+
+Two smaller defects rode along: the "S" code mapped to the substring "Uniprot"
+while the store writes "UniProtKB", and SPARQL CONTAINS is case-sensitive, so
+that filter was permanently dead (WP3594 has 206 UniProt-sourced gene products
+and returned 0). And gene_count deduplicated on rdfs:label, but one gene
+product carries several alias labels (AKT, AKT1, Akt1), inflating WP254 from 87
+genes to 134.
+"""
+
+from unittest.mock import patch
+
+from tooluniverse.wikipathways_ext_tool import WikiPathwaysExtTool
+
+
+def _make():
+    return WikiPathwaysExtTool(
+        {
+            "name": "WikiPathways_get_pathway_genes",
+            "type": "WikiPathwaysExtTool",
+            "fields": {"endpoint": "get_pathway_genes"},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+def _bindings(rows):
+    return {
+        "results": {
+            "bindings": [
+                {"gene": {"value": g}, "gene_label": {"value": lbl}}
+                for g, lbl in rows
+            ]
+        }
+    }
+
+
+# One gene product with three alias labels, plus two ordinary ones.
+_ROWS = [
+    ("http://identifiers.org/ncbigene/207", "AKT"),
+    ("http://identifiers.org/ncbigene/207", "AKT1"),
+    ("http://identifiers.org/ncbigene/207", "Akt1"),
+    ("http://identifiers.org/ncbigene/317", "APAF1"),
+    ("http://identifiers.org/ncbigene/7157", "TP53"),
+]
+
+
+def _run(arguments, rows=_ROWS):
+    captured = {}
+
+    def fake_sparql(query, timeout=30):
+        captured["query"] = query
+        return _bindings(rows)
+
+    with patch(
+        "tooluniverse.wikipathways_ext_tool._sparql", side_effect=fake_sparql
+    ):
+        result = _make().run(arguments)
+    return result, captured.get("query", "")
+
+
+def test_default_applies_no_source_filter():
+    result, query = _run({"pathway_id": "WP254"})
+
+    assert "FILTER(CONTAINS" not in query
+    assert result["data"]["gene_count"] == 3
+    assert result["data"]["identifier_type"] == "All sources"
+
+
+def test_gene_count_counts_gene_products_not_alias_labels():
+    result, _ = _run({"pathway_id": "WP254"})
+    data = result["data"]
+
+    # Five rows, three gene products, five distinct labels.
+    assert data["gene_count"] == 3
+    assert data["label_count"] == 5
+
+
+def test_every_alias_is_still_reported_rather_than_one_being_guessed():
+    # WikiPathways attaches unrelated symbols to a node (PIK3CA sits on the
+    # AKT1 node), so picking a single label would fabricate a gene.
+    result, _ = _run({"pathway_id": "WP254"})
+
+    assert "AKT1" in result["data"]["genes"]
+    assert "AKT" in result["data"]["genes"]
+
+
+def test_gene_products_expose_node_level_truth():
+    result, _ = _run({"pathway_id": "WP254"})
+    products = result["data"]["gene_products"]
+
+    assert len(products) == 3
+    akt = next(p for p in products if p["identifier"].endswith("/207"))
+    assert akt["labels"] == ["AKT", "AKT1", "Akt1"]
+
+
+def test_uniprot_code_matches_the_stores_uniprotkb_spelling():
+    _, query = _run({"pathway_id": "WP3594", "code": "S"})
+
+    assert 'LCASE(STR(?src)), "uniprot"' in query
+
+
+def test_source_filter_is_case_insensitive_for_every_code():
+    for code in ("H", "En", "S", "L", "Ce"):
+        _, query = _run({"pathway_id": "WP254", "code": code})
+        assert "LCASE(STR(?src))" in query, code
+
+
+def test_explicit_code_is_still_applied_and_labelled():
+    result, query = _run({"pathway_id": "WP254", "code": "L"})
+
+    assert 'LCASE(STR(?src)), "entrez gene"' in query
+    assert result["data"]["identifier_type"] == "Entrez Gene"
+
+
+def test_empty_result_stays_empty():
+    result, _ = _run({"pathway_id": "WP254", "code": "S"}, rows=[])
+
+    assert result["status"] == "success"
+    assert result["data"]["gene_count"] == 0
+    assert result["data"]["genes"] == []
+
+
+def test_missing_pathway_id_is_an_error():
+    assert _make().run({})["status"] == "error"


### PR DESCRIPTION
Round 5 of the role-play bug hunt. Four researcher personas (cancer epigenetics, clinical pharmacology/pharmacovigilance, pathway systems biology, computational toxicology/structural biology) worked in tool families untouched by earlier rounds. They reported 40 candidates; each was re-verified against the live API before any code was touched, running the tool **with and without** the input in question plus a **bogus-value control**. 9 were fixed here, and the discards are listed at the bottom.

Every fix targets the same failure mode: **the tool accepts an input or reports a number and answers confidently wrong, rather than erroring**. That is the dangerous case — a scientist has no signal that anything went wrong.

No overlap with the open PRs #395, #396 or #397 (file lists checked before editing).

## Fixes

### 1. GTEx resolved every gene ID against GENCODE v26 regardless of dataset
`gtex_v2_tool.py`, `gtex_tool.py`, `data/gtex_v2_tools.json`

Each GTEx dataset is annotated against a different GENCODE release. TP53 is `ENSG00000141510.16` in gtex_v8 (v26) but `.18` in gtex_v10 (v39). The resolver hardcoded `gencodeVersion=v26`, so selecting `dataset_id="gtex_v10"` — a documented enum value — sent v26 IDs to a v39 dataset. The API answered HTTP 200 with an empty list, surfacing as `status: "success"`, `num_results: 0`: *"this gene has no expression in V10"*. The resolver also stripped and re-resolved any supplied version suffix, so a caller passing the correct v39 ID had it downgraded back to v26 — there was no workaround from outside.

| query | before | after |
|---|---|---|
| TP53 median expression, `gtex_v10` | 0 | **54 tissues** |
| ERAP2/Liver eQTLs, `gtex_v10` | 0 | **250** |
| anything on `gtex_v8` | unchanged | unchanged |

The per-dataset GENCODE map is taken from the API's own `/metadata/dataset`. This also means the code comments and tool descriptions asserting *"v10 returns empty for most endpoints"* were documenting this bug — verified false for expression, eQTL, sample and top-expressed-gene endpoints, and corrected. `gtex_v8` remains the default.

### 2. ENCODE searches answered a zero-result query with another species' experiments
`epigenomics_tool.py`

ENCODE returns **HTTP 404 carrying a valid body** (`{"total": 0, "@graph": [], "notification": "No results found"}`) when a facet combination matches nothing. `_encode_search` treated that as a transport error, and callers reacted in one of two wrong ways:

- three searches retried with the organism filter **deleted**. "H3K4me3 in human midbrain" — which ENCODE does not have — returned four *Mus musculus* embryo experiments, with `metadata.organism` still reading `"Homo sapiens"`.
- five others reported a legitimately empty query as `"API HTTP error: 404"`, a fake outage.

The bogus-value control was arithmetic: `Homo sapiens` 431 + `Mus musculus` 97 = **528**, exactly what a nonsense organism returned. After the fix a nonsense organism returns 0, real organisms are unchanged, and `sibling encode_tool.py::_http_get` already handled the 404 this way — the two modules now agree.

### 3. PubChem toxicology dropped the carcinogenicity of every carcinogen tested
`pubchem_tox_tool.py`

PubChem packs every statement of one notification group into a single `Information` entry holding N `StringWithMarkup` elements. Only element 0 was read. This was not a random sample: GHS codes are emitted in ascending numeric order and physical hazards (H2xx) sort ahead of health hazards (H3xx), so the health hazard was discarded whenever a physical one existed.

Benzene (IARC Group 1) returned **H225 + H401** — "highly flammable", "toxic to aquatic life" — while PubChem lists 16 codes including **H350 "May cause cancer"**, H340 and H372. Verified identically for vinyl chloride, formaldehyde and arsenic trioxide; all four now report H350. The same truncation had `PubChemTox_get_carcinogen_classification` citing the withdrawn 1987 IARC monograph while dropping the current 2012 Volume 100F.

This helper backs all eight `PubChemTox_*` tools, so their outputs are now longer.

### 4. EBI Proteins reported other proteins' interactions as the query protein's
`ebi_proteins_interactions_tool.py`

`/proteins/interaction/{acc}` returns the queried protein **plus ~100 neighbour proteins**, each carrying its own full interaction list. All were pooled.

| protein | reported | true | wrong rows on default page |
|---|---|---|---|
| TP53 (P04637) | 3258 | **185** | **44 of 50** |
| Insulin (P01308) | 735 | **9** | — |

TP53's "partners" included AXIN1–GSK3B, BRCA2–RAD51 and PIK3CA–PIK3R1 pairs. Insulin's included huntingtin and ataxin-1 — partners of a chaperone hub in the same payload. Entries are now scoped by their own `accession`; the same scoping is applied to `_get_interaction_details`, whose metadata also no longer assumes the query protein is `data[0]`. The file already contained a comment diagnosing this exact pooling problem for diseases/locations; the reasoning is now applied to interactions too.

### 5. ClinicalTrials.gov silently disabled its phase filter when a status filter was set
`ctg_tool.py`

`search_clinical_trials` documents *"Limited to trials beyond phase 1"* and implements it with a hidden `filter.advanced` default. That default was skipped whenever `filter.overallStatus` was present — guarded by a comment describing an `AREA[HasResults]true` clause that an earlier fix had **already deleted**. The workaround outlived its reason.

The signature was logically impossible: adding the *narrowing* `overall_status=["COMPLETED"]` to a metformin/lactic-acidosis search **raised** `total_count` from 2 to 3 and returned a disjoint set. A RECRUITING pembrolizumab search returned **745** studies instead of **557** — 188 wrongly included, with pure `PHASE1` and `EARLY_PHASE1` trials on page 1.

### 6. GO_get_genes_for_term returned N empty objects, and its taxon filter did nothing
`gene_ontology_tool.py`, `data/gene_ontology_tools.json`

Two defects compounded. The extract path `associations[*].subject` keyed on a field the Biolink API no longer returns — it now answers with flat annotation records (`bioentity_label`, `taxon`, `evidence_type`) and **no `subject` key** — so `assoc.get("subject", {})` produced `{}` for every row. `rows=10` returned ten empty dicts as a success. The declared `return_schema` was `array of objects with no properties`, so nothing could catch it.

Second, `taxon` was a **required** parameter the endpoint silently ignored: `NCBITaxon:10090` (mouse) returned human and *C. elegans* rows, and a nonsense taxon returned the same 50 records.

Now queries the GO Solr index, which honours the filter (human 1257, mouse 2034, bogus **0**) and returns real genes. Annotation rows are collapsed to distinct genes with their evidence codes, `taxon` becomes a genuine optional filter, and the `return_schema` gains a `oneOf` envelope describing the actual fields.

### 7. WikiPathways returned 0 genes for its own documented example
`wikipathways_ext_tool.py`, `data/wikipathways_ext_tools.json`

`code` defaulted to `"H"` (HGNC), which filters on the *database that annotated each gene product*. WikiPathways rarely records HGNC there — WP254's 87 gene products come from Entrez Gene (84) and Ensembl (3), **none** from HGNC. So the default answered "0 genes", with `status: success`, for the pathway the tool's own description says returns 88.

Two smaller defects rode along: the `"S"` code matched the substring `"Uniprot"` against a store that writes `"UniProtKB"` under a case-sensitive SPARQL `CONTAINS`, so it was permanently dead (WP3594 has 206 UniProt-sourced gene products, returned 0); and counts deduplicated on `rdfs:label`, but one gene product carries several aliases, inflating WP254 from 87 to 134.

`code` is now an optional, case-insensitive filter; WP254 returns 87 gene products by default and `code="S"` on WP3594 returns 206. A bogus code still returns 0 (fails closed).

**Note on labels:** I deliberately did *not* collapse each gene product to one "primary" symbol. WikiPathways attaches unrelated symbols to a node — the AKT1 node (`ncbigene/207`) carries `AKT, AKT1, Akt1, PIK3CA, PKB, PKB/Akt` — so any heuristic would fabricate a gene. Instead `gene_count` counts gene products, `label_count` counts labels, `genes` keeps every label, and a new `gene_products` field gives node-level identifiers with their exact labels.

### 8. Ensembl LD counted its partners after truncating them
`ensembl_ld_tool.py`, `data/ensembl_ld_tools.json`

`ld_count` was computed on the post-truncation list. For rs1042779 in CEU at `r2_threshold=0.05` the tool reported **200 partners** when Ensembl returned **735**, and the returned set stopped at r2 **0.79** despite the requested 0.05 — wrong on both the count and the range, while the description promised *"all variants in LD"* and cited 708 partners. There was no parameter to reach past the cap.

Now reports `total_ld_count` (pre-truncation) alongside `ld_count`, sets `truncated`, and accepts `limit`. This follows the precedent already set by `ensembl_overlap_tool.py` in this repo, which correctly reports `total_features` and `returned`.

### 9. NHANES answered about a different survey cycle than requested
`nhanes_tool.py`, `data/nhanes_tools.json`

An unrecognised `year` fell through to `cycles[:2]`, so asking for **2021-2023** (a real, published cycle) returned rows labelled **2017-2018** and **2015-2016** under `status: success`, with nothing signalling the substitution. The hardcoded list was also stale — it began at 2007-2008 and omitted six earlier published cycles plus the current one — and every `download_url` was assembled from a template that does not exist: `.../Nchs/Nhanes/2017-2018/laboratory_2017-2018.aspx` redirects to CDC's `ErrorPage.aspx`.

Now rejects an unknown cycle (naming the valid ones), lists all published cycles including 2021-2023, notes that no standalone 2019-2020 cycle exists (COVID-19 cut that field period short; `DEMO_K.XPT` is a live 404), and emits the CDC datapage URL form, which returns 200. `return_schema` gains the required `oneOf` envelope.

## Testing

- **76 new regression tests** across 9 files, all offline (HTTP layer mocked), each documenting the live evidence in its module docstring.
- Full unit suite: **3337 tests, 0 failures** (only pre-existing environmental skips — no scanpy, lazy-load cache).
- `import tooluniverse.tools` works.
- Every fix was CLI-verified against the live API before and after the change.

## For the maintainer — convention decisions I did not make unilaterally

1. **GTEx default release.** `gtex_v8` is kept as the default because it is the most widely cited and changing it would move every existing answer. But `gtex_v10` is the current release (943 eQTL donors vs 838) and is now fully queryable. Worth deciding whether the default should move.
2. **`PubChemTox_*` output shape.** Fix 3 makes these tools return substantially more entries. Any downstream consumer assuming one string per Information entry will see more rows, and the `*_count` fields grow correspondingly.
3. **Count-that-is-really-a-page-size is systemic.** Beyond the two fixed here, the pathway persona independently found the same shape in `ReactomeContent_search` (reports 10, true 584), `ReactomeInteractors_get_protein_interactors` (20 vs 249), `WikiPathways_find_pathways_by_gene` (100 vs 172) and four KEGG search tools (25 vs 739). In every case the true total is available upstream for free, and `PathwayCommons_search` already does it right (`total_hits` + `page`). This deserves one convention applied across the repo rather than nine separate patches, so I have left them for a dedicated pass.
4. **`WikiPathways_get_pathway_genes` output.** Adding `label_count` and `gene_products` changes the response shape. If the project would rather keep the response flat, the alternative is to return only `gene_products` and drop `genes` — but that breaks callers using it as a gene set.

## Verified and discarded (not fixed)

Roughly half of the raw persona reports did not survive verification, plus several real findings deliberately deferred:

- **`ensembl_overlap_tool.py` truncation** — flagged by a static scan; it already reports `total_features` pre-truncation and `returned`. Correct as written.
- **GTEx `sex` / `age_bracket` filters** — suspected dropped; both genuinely filter (Liver+male returns only male, bogus sex is rejected with a 422 enum error).
- **`gtex_tool.py` hardcoded `datasetId`** — the v1 expression tool declares no `dataset_id` parameter, so hardcoding v8 matches its own resolver. Not a bug; the undocumented back-door in the sibling eQTL tool was made dataset-aware for consistency only.
- **NHANES `_search_datasets` / `NHANES_download_and_parse`** — both build working URLs, and the download path already handles CDC's HTML-error-page-with-200. Only `_get_dataset_info` was defective.
- **BLAST** — persona confirmed it polls to completion, `expect`/`hitlist_size`/`database` all reach the API, and "no hits" is distinguishable from a running job. The dead `max_wait_time`/`timeout` attributes are real but cosmetic; deferred.
- **AlphaFold confidence semantics** — checked specifically for inverted pLDDT/PAE. Pure pass-through, nothing relabelled or thresholded. Correct.
- **LD50 units/route/species** — checked for the classic unit-mixing hazard. Preserved faithfully, including heterogeneous units (µg/kg, g/kg). Correct.
- **ClinicalTrials `totalCount`** — top suspicion for a page-size-as-total bug; `countTotal=true` is sent and totals match the raw API exactly. Clean.
- **FAERS disproportionality** — 2×2 recomputed independently from openFDA; ROR matched to three decimals.
- **KEGG flat-file parsing** — checked for continuation-line truncation; `hsa04110`'s 158 genes and `hsa04910`'s 138 come back intact.
- **`geo_search_datasets` invalid field tags** — the code sends `[study_type]`/`[platform]` where the real tags are `GTYP`/`RGPL`, and NCBI silently downgrades both to `[All Fields]`. Latent fragility, but no wrong answer could be produced (counts and records matched the correct query), so it is recorded rather than patched.
- **DailyMed `drug_name` resolution, date filters, and section counts; Reactome literature bare-int drops; ENCODE biosample organism path; GEO GSM→Series substitution; UCSC track truncation** — all verified real, all outside the nine shipped here. They are self-contained and well-characterised; I stopped at nine to keep this PR reviewable rather than expanding scope further.
