### PR TITLE
Fix 11 tools returning confidently wrong answers instead of failing (bug-hunt round 6)

### DIFF
--- a/src/tooluniverse/alphamissense_tool.py
+++ b/src/tooluniverse/alphamissense_tool.py
@@ -26,6 +26,9 @@ from .tool_registry import register_tool
 ALPHAMISSENSE_BASE_URL = "https://alphamissense.hegelab.org"
 UNIPROT_FASTA_URL = "https://rest.uniprot.org/uniprotkb/{accession}.fasta"
 
+# The 20 standard amino acids, in one-letter code.
+_AMINO_ACIDS = frozenset("ACDEFGHIKLMNPQRSTVWY")
+
 
 @register_tool("AlphaMissenseTool")
 class AlphaMissenseTool(BaseTool):
@@ -75,6 +78,32 @@ class AlphaMissenseTool(BaseTool):
             return "benign"
         else:
             return "ambiguous"
+
+    @staticmethod
+    def _class_members(raw: Any) -> List[str]:
+        """Parse a hotspot class field of the form ``"5:M,P,Q,R,V"``.
+
+        Returns the one-letter residues in that class; an empty list when the
+        field is absent, empty or malformed.
+        """
+        if not isinstance(raw, str) or not raw.strip():
+            return []
+        residues = raw.split(":", 1)[1] if ":" in raw else raw
+        return [r.strip() for r in residues.split(",") if r.strip()]
+
+    def _classify_substitution(self, data: Dict[str, Any], alt_aa: str):
+        """Locate ``alt_aa`` in the residue's AlphaMissense class lists.
+
+        Prefers the SNV-accessible lists (``benign``/``ambiguous``/``pathogenic``)
+        and falls back to the all-substitutions lists (``*_all``). Returns
+        ``(classification, substitution_set)``; classification is ``None`` when
+        the substitution appears in neither.
+        """
+        for suffix, set_name in (("", "snv_accessible"), ("_all", "all_substitutions")):
+            for label in ("pathogenic", "ambiguous", "benign"):
+                if alt_aa in self._class_members(data.get(f"{label}{suffix}")):
+                    return label, set_name
+        return None, None
 
     def _fetch_protein_length(self, uniprot_id: str) -> Optional[int]:
         """Get protein length from UniProt FASTA."""
@@ -275,6 +304,31 @@ class AlphaMissenseTool(BaseTool):
             position = int(match.group(2))
             alt_aa = match.group(3)
 
+            if alt_aa not in _AMINO_ACIDS:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"Invalid substituted amino acid {alt_aa!r} in {variant}. "
+                        f"Expected one of: {''.join(sorted(_AMINO_ACIDS))}"
+                    ),
+                }
+            if ref_aa not in _AMINO_ACIDS:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"Invalid reference amino acid {ref_aa!r} in {variant}. "
+                        f"Expected one of: {''.join(sorted(_AMINO_ACIDS))}"
+                    ),
+                }
+            if ref_aa == alt_aa:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"{variant} is synonymous (reference and substituted residue "
+                        "are both {0}); AlphaMissense scores missense variants only."
+                    ).format(ref_aa),
+                }
+
             # Query the API
             url = f"{ALPHAMISSENSE_BASE_URL}/hotspotapi"
             params = {"uid": uniprot_id, "resi": position}
@@ -291,48 +345,75 @@ class AlphaMissenseTool(BaseTool):
             response.raise_for_status()
             data = response.json()
 
-            # Look for the specific variant in the response
-            score = None
-            if isinstance(data, dict):
-                # API may return different formats
-                scores = data.get("scores", data.get("data", {}))
-                if isinstance(scores, dict):
-                    score = scores.get(alt_aa)
-                elif isinstance(scores, list):
-                    for item in scores:
-                        if item.get("aa") == alt_aa or item.get("variant") == alt_aa:
-                            score = item.get("score", item.get("am_pathogenicity"))
-                            break
-
-            if score is not None:
-                classification = self._classify_score(score)
+            if not isinstance(data, dict):
                 return {
-                    "status": "success",
-                    "data": {
-                        "uniprot_id": uniprot_id,
-                        "variant": f"p.{ref_aa}{position}{alt_aa}",
-                        "position": position,
-                        "reference_aa": ref_aa,
-                        "variant_aa": alt_aa,
-                        "pathogenicity_score": score,
-                        "classification": classification,
-                        "thresholds": {
-                            "pathogenic": f"> {self.PATHOGENIC_THRESHOLD}",
-                            "ambiguous": f"{self.BENIGN_THRESHOLD} - {self.PATHOGENIC_THRESHOLD}",
-                            "benign": f"< {self.BENIGN_THRESHOLD}",
+                    "status": "error",
+                    "error": (
+                        "Unexpected AlphaMissense response shape for "
+                        f"{uniprot_id} position {position}"
+                    ),
+                }
+
+            # Guard against a position/isoform mismatch: the endpoint answers for
+            # whatever residue sits at `resi`, so a wrong reference residue means
+            # the caller is querying a different sequence than they think.
+            api_ref_aa = data.get("aa")
+            if api_ref_aa and api_ref_aa != ref_aa:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"Reference residue mismatch: {variant} expects {ref_aa} at "
+                        f"position {position}, but {uniprot_id} has {api_ref_aa} there. "
+                        "Check the variant notation and the isoform/accession."
+                    ),
+                }
+
+            # The hotspot endpoint does not expose per-substitution scores. It
+            # reports, per residue, which substitutions fall in each AlphaMissense
+            # class as "<count>:<comma-separated residues>", once for the
+            # SNV-accessible substitutions and once (the *_all fields) for all 19.
+            classification, substitution_set = self._classify_substitution(data, alt_aa)
+
+            return {
+                "status": "success",
+                "data": {
+                    "uniprot_id": uniprot_id,
+                    "variant": f"p.{ref_aa}{position}{alt_aa}",
+                    "position": position,
+                    "reference_aa": ref_aa,
+                    "variant_aa": alt_aa,
+                    "classification": classification,
+                    "substitution_set": substitution_set,
+                    # This endpoint publishes class membership, not per-variant
+                    # scores. Reporting the residue mean here would look like a
+                    # score for this substitution, so it is named for what it is.
+                    "pathogenicity_score": None,
+                    "score_available": False,
+                    "residue_mean_score_snv_accessible": data.get("mean"),
+                    "residue_mean_score_all_substitutions": data.get("mean_all"),
+                    "residue_class_counts": {
+                        "snv_accessible": {
+                            "benign": self._class_members(data.get("benign")),
+                            "ambiguous": self._class_members(data.get("ambiguous")),
+                            "pathogenic": self._class_members(data.get("pathogenic")),
+                        },
+                        "all_substitutions": {
+                            "benign": self._class_members(data.get("benign_all")),
+                            "ambiguous": self._class_members(data.get("ambiguous_all")),
+                            "pathogenic": self._class_members(
+                                data.get("pathogenic_all")
+                            ),
                         },
                     },
-                }
-            else:
-                return {
-                    "status": "success",
-                    "data": {
-                        "uniprot_id": uniprot_id,
-                        "variant": f"p.{ref_aa}{position}{alt_aa}",
-                        "raw_response": data,
-                        "message": "Score extraction requires parsing API response format",
-                    },
-                }
+                    "note": (
+                        "AlphaMissense hotspot API returns per-residue class "
+                        "membership, not a numeric score per substitution. "
+                        "`classification` is this substitution's class; the mean "
+                        "fields are residue-level averages, not this variant's "
+                        "score."
+                    ),
+                },
+            }
         except requests.exceptions.Timeout:
             return {
                 "status": "error",

--- a/src/tooluniverse/data/alphamissense_tools.json
+++ b/src/tooluniverse/data/alphamissense_tools.json
@@ -96,7 +96,7 @@
     },
     {
         "name": "AlphaMissense_get_variant_score",
-        "description": "Get AlphaMissense pathogenicity score for a specific missense variant. Input: UniProt ID and variant (e.g., 'p.R123H'). Returns score and classification (pathogenic/ambiguous/benign). State-of-the-art for VUS interpretation.",
+        "description": "Classify a specific missense variant with AlphaMissense. Input: UniProt ID and variant (e.g., 'p.R123H'). Returns the variant's AlphaMissense class (pathogenic/ambiguous/benign) and whether it came from the SNV-accessible or the all-substitutions set. NOTE: the upstream hotspot API publishes per-residue class membership, not a numeric score per substitution, so `pathogenicity_score` is null and `score_available` is false; the `residue_mean_score_*` fields are residue-level averages, NOT this variant's score. For a numeric per-variant score use GenomeNexus_annotate_variant.",
         "parameter": {
             "type": "object",
             "properties": {
@@ -134,8 +134,17 @@
                     "properties": {
                         "uniprot_id": {"type": "string"},
                         "variant": {"type": "string"},
-                        "pathogenicity_score": {"type": "number"},
-                        "classification": {"type": "string", "enum": ["pathogenic", "ambiguous", "benign"]}
+                        "position": {"type": "integer"},
+                        "reference_aa": {"type": "string"},
+                        "variant_aa": {"type": "string"},
+                        "pathogenicity_score": {"type": ["number", "null"], "description": "Always null: the upstream hotspot API exposes no per-substitution score."},
+                        "score_available": {"type": "boolean"},
+                        "classification": {"type": ["string", "null"], "enum": ["pathogenic", "ambiguous", "benign", null]},
+                        "substitution_set": {"type": ["string", "null"], "enum": ["snv_accessible", "all_substitutions", null]},
+                        "residue_mean_score_snv_accessible": {"type": ["number", "null"]},
+                        "residue_mean_score_all_substitutions": {"type": ["number", "null"]},
+                        "residue_class_counts": {"type": "object"},
+                        "note": {"type": "string"}
                     }
                 },
                 "error": {"type": "string"}
@@ -149,7 +158,7 @@
     },
     {
         "name": "AlphaMissense_get_residue_scores",
-        "description": "Get AlphaMissense scores for all 20 possible amino acid substitutions at a specific protein position. Useful for saturation mutagenesis analysis and identifying pathogenic hotspots.",
+        "description": "Get the AlphaMissense class breakdown for substitutions at a specific protein position: which residues fall in each class (benign/ambiguous/pathogenic), reported separately for the SNV-accessible substitutions and for all 19, plus the residue mean scores. NOTE: the upstream hotspot API does not expose a numeric score per individual substitution, so this returns class membership rather than 20 scores.",
         "parameter": {
             "type": "object",
             "properties": {

--- a/src/tooluniverse/data/cbioportal_tools.json
+++ b/src/tooluniverse/data/cbioportal_tools.json
@@ -194,17 +194,18 @@
   {
     "type": "CBioPortalRESTTool",
     "name": "cBioPortal_get_samples",
-    "description": "Get all samples in a cancer study",
+    "description": "Get all samples in a cancer study. Returns the full cohort by default; the response is a bare array with no truncation marker, so lower `page_size` only when you deliberately want a sample. Use this count as the denominator for mutation-frequency calculations.",
     "parameter": {
       "type": "object",
       "properties": {
         "study_id": {"type": "string", "description": "Cancer study ID"},
-        "page_size": {"type": "integer", "default": 100, "description": "Number of samples to return"}
+        "page_size": {"type": "integer", "default": 100000, "description": "Maximum number of samples to return. Defaults high enough to return every sample in a study; a smaller value silently truncates the cohort, which will corrupt any frequency denominator computed from it."},
+        "page_number": {"type": "integer", "default": 0, "description": "0-based page index, used with `page_size` to page through very large studies."}
       },
       "required": ["study_id"]
     },
     "fields": {
-      "endpoint": "https://www.cbioportal.org/api/studies/{study_id}/samples?pageSize={page_size}",
+      "endpoint": "https://www.cbioportal.org/api/studies/{study_id}/samples?pageSize={page_size}&pageNumber={page_number}",
       "return_format": "JSON"
     },
     "return_schema": {
@@ -227,17 +228,18 @@
   {
     "type": "CBioPortalRESTTool",
     "name": "cBioPortal_get_patients",
-    "description": "Get all patients in a cancer study",
+    "description": "Get all patients in a cancer study. Returns the full cohort by default; the response is a bare array with no truncation marker, so lower `page_size` only when you deliberately want a sample. Use this count as the denominator for mutation-frequency calculations.",
     "parameter": {
       "type": "object",
       "properties": {
         "study_id": {"type": "string", "description": "Cancer study ID"},
-        "page_size": {"type": "integer", "default": 100, "description": "Number of patients to return"}
+        "page_size": {"type": "integer", "default": 100000, "description": "Maximum number of patients to return. Defaults high enough to return every patient in a study; a smaller value silently truncates the cohort, which will corrupt any frequency denominator computed from it."},
+        "page_number": {"type": "integer", "default": 0, "description": "0-based page index, used with `page_size` to page through very large studies."}
       },
       "required": ["study_id"]
     },
     "fields": {
-      "endpoint": "https://www.cbioportal.org/api/studies/{study_id}/patients?pageSize={page_size}",
+      "endpoint": "https://www.cbioportal.org/api/studies/{study_id}/patients?pageSize={page_size}&pageNumber={page_number}",
       "return_format": "JSON"
     },
     "return_schema": {

--- a/src/tooluniverse/data/igsr_tools.json
+++ b/src/tooluniverse/data/igsr_tools.json
@@ -43,7 +43,12 @@
           "type": "object",
           "properties": {
             "total": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Total number of matching records in IGSR, independent of the `limit` page size."
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number of records included in this response (at most `limit`)."
             },
             "populations": {
               "type": "array",
@@ -161,7 +166,12 @@
           "type": "object",
           "properties": {
             "total": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Total number of matching records in IGSR, independent of the `limit` page size."
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number of records included in this response (at most `limit`)."
             },
             "samples": {
               "type": "array",
@@ -261,7 +271,12 @@
           "type": "object",
           "properties": {
             "total": {
-              "type": "integer"
+              "type": "integer",
+              "description": "Total number of matching records in IGSR, independent of the `limit` page size."
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number of records included in this response (at most `limit`)."
             },
             "collections": {
               "type": "array",

--- a/src/tooluniverse/data/jaspar_tools.json
+++ b/src/tooluniverse/data/jaspar_tools.json
@@ -597,7 +597,7 @@
         },
         "species": {
           "type": "string",
-          "description": "Filter by NCBI taxonomy ID (e.g., '9606' for human)."
+          "description": "Filter by NCBI taxonomy ID (e.g., '9606' for human). Sent to JASPAR as its `tax_id` query parameter."
         },
         "page": {
           "type": "integer",
@@ -615,7 +615,10 @@
     "fields": {
       "endpoint": "https://jaspar.elixir.no/api/v1/matrix/",
       "return_format": "JSON",
-      "use_params": true
+      "use_params": true,
+      "param_map": {
+        "species": "tax_id"
+      }
     },
     "return_schema": {
       "type": "object",

--- a/src/tooluniverse/data/proteomicsdb_tools.json
+++ b/src/tooluniverse/data/proteomicsdb_tools.json
@@ -95,14 +95,14 @@
                   "number",
                   "null"
                 ],
-                "description": "Log10 normalized intensity (main value)"
+                "description": "Log10 NORMALIZED intensity - the main, cross-tissue-comparable value, and the one bounded by min_expression/max_expression"
               },
-              "median_expression": {
+              "unnormalized_intensity": {
                 "type": [
                   "number",
                   "null"
                 ],
-                "description": "Median log10 normalized intensity"
+                "description": "Log10 un-normalized intensity, as reported upstream. Not comparable across tissues; do not rank on this."
               },
               "min_expression": {
                 "type": [
@@ -322,7 +322,7 @@
                   "null"
                 ]
               },
-              "median_expression": {
+              "unnormalized_intensity": {
                 "type": [
                   "number",
                   "null"

--- a/src/tooluniverse/data/rhea_tools.json
+++ b/src/tooluniverse/data/rhea_tools.json
@@ -14,7 +14,14 @@
             "integer",
             "null"
           ],
-          "description": "Maximum number of results (default 20, max 50)."
+          "description": "Maximum number of reactions to return per page (default 20, max 1000). This caps the page only; `metadata.total_results` reports the full result-set size."
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of matching reactions to skip before returning a page (default 0). Combine with `limit` and `metadata.has_more` to page through large result sets."
         }
       },
       "required": [
@@ -78,7 +85,27 @@
                   "type": "string"
                 },
                 "total_results": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "Total number of matching Rhea reactions, independent of `limit`. Null if the count query failed."
+                },
+                "returned": {
+                  "type": "integer",
+                  "description": "Number of reactions in this response (at most `limit`)."
+                },
+                "offset": {
                   "type": "integer"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "has_more": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
                 }
               }
             }
@@ -116,7 +143,14 @@
             "integer",
             "null"
           ],
-          "description": "Maximum number of results (default 20, max 50)."
+          "description": "Maximum number of reactions to return per page (default 20, max 1000). This caps the page only; `metadata.total_results` reports the full result-set size."
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of matching reactions to skip before returning a page (default 0). Combine with `limit` and `metadata.has_more` to page through large result sets."
         }
       },
       "required": [
@@ -177,7 +211,27 @@
                   "type": "string"
                 },
                 "total_results": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "Total number of matching Rhea reactions, independent of `limit`. Null if the count query failed."
+                },
+                "returned": {
+                  "type": "integer",
+                  "description": "Number of reactions in this response (at most `limit`)."
+                },
+                "offset": {
                   "type": "integer"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "has_more": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
                 }
               }
             }
@@ -215,7 +269,14 @@
             "integer",
             "null"
           ],
-          "description": "Maximum number of results (default 20, max 50)."
+          "description": "Maximum number of reactions to return per page (default 20, max 1000). This caps the page only; `metadata.total_results` reports the full result-set size."
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of matching reactions to skip before returning a page (default 0). Combine with `limit` and `metadata.has_more` to page through large result sets."
         }
       },
       "required": [
@@ -282,7 +343,27 @@
                   "type": "string"
                 },
                 "total_results": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "Total number of matching Rhea reactions, independent of `limit`. Null if the count query failed."
+                },
+                "returned": {
+                  "type": "integer",
+                  "description": "Number of reactions in this response (at most `limit`)."
+                },
+                "offset": {
                   "type": "integer"
+                },
+                "limit": {
+                  "type": "integer"
+                },
+                "has_more": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
                 }
               }
             }

--- a/src/tooluniverse/data/tcdb_tools.json
+++ b/src/tooluniverse/data/tcdb_tools.json
@@ -89,7 +89,11 @@
         },
         "limit": {
           "type": "integer",
-          "description": "Maximum number of families to return (default 20, max 100)."
+          "description": "Maximum number of families to return per page (default 20, max 100). This caps the page only; `total_matches` reports the full result-set size."
+        },
+        "offset": {
+          "type": "integer",
+          "description": "Number of matching families to skip before returning a page (default 0). Combine with `limit` to page through result sets larger than 100."
         }
       },
       "required": []
@@ -103,6 +107,9 @@
               "type": "object",
               "properties": {
                 "total_matches": {"type": "integer"},
+                "returned": {"type": "integer"},
+                "offset": {"type": "integer"},
+                "has_more": {"type": "boolean"},
                 "families": {
                   "type": "array",
                   "items": {
@@ -157,7 +164,11 @@
         },
         "limit": {
           "type": "integer",
-          "description": "Maximum number of results to return (default 20, max 100)."
+          "description": "Maximum number of transporters to return per page (default 20, max 100). This caps the page only; `total_matches` reports the full result-set size."
+        },
+        "offset": {
+          "type": "integer",
+          "description": "Number of matching transporters to skip before returning a page (default 0). Combine with `limit` to page through result sets larger than 100."
         }
       },
       "required": ["substrate_name"]
@@ -171,6 +182,9 @@
               "type": "object",
               "properties": {
                 "total_matches": {"type": "integer"},
+                "returned": {"type": "integer"},
+                "offset": {"type": "integer"},
+                "has_more": {"type": "boolean"},
                 "transporters": {
                   "type": "array",
                   "items": {

--- a/src/tooluniverse/data/worms_tools.json
+++ b/src/tooluniverse/data/worms_tools.json
@@ -2,58 +2,84 @@
   {
     "type": "WoRMSRESTTool",
     "name": "WoRMS_search_species",
-    "description": "Search marine species in World Register of Marine Species",
+    "description": "Search marine species in the World Register of Marine Species (WoRMS) by name. Returns up to `limit` matching taxon records; WoRMS serves 50 records per request, so larger pages are assembled automatically. `has_more` indicates whether further records exist beyond the returned page \u2014 use `offset` to retrieve them.",
     "parameter": {
       "type": "object",
       "properties": {
         "query": {"type": "string", "description": "Species name or search term"},
-        "limit": {"type": "integer", "default": 20, "description": "Number of results"}
+        "limit": {"type": "integer", "default": 20, "description": "Maximum number of taxon records to return (default 20). Pages larger than 50 are assembled from multiple WoRMS requests."},
+        "offset": {"type": "integer", "default": 1, "description": "1-based index of the first record to return (default 1). Use with `limit` and `has_more` to page through large result sets."}
       },
       "required": ["query"]
     },
     "fields": {
-      "endpoint": "https://www.marinespecies.org/rest/AphiaIDByName/{query}",
+      "endpoint": "https://www.marinespecies.org/rest/AphiaRecordsByName/{query}",
       "return_format": "JSON"
     },
     "return_schema": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "AphiaID": {"type": "integer"},
-          "url": {"type": "string"},
-          "scientificname": {"type": "string"},
-          "authority": {"type": ["string", "null"]},
-          "status": {"type": "string"},
-          "unacceptreason": {"type": ["string", "null"]},
-          "taxonRankID": {"type": "integer"},
-          "rank": {"type": "string"},
-          "valid_AphiaID": {"type": "integer"},
-          "valid_name": {"type": "string"},
-          "valid_authority": {"type": ["string", "null"]},
-          "parentNameUsageID": {"type": "integer"},
-          "originalNameUsageID": {"type": ["integer", "null"]},
-          "kingdom": {"type": "string"},
-          "phylum": {"type": "string"},
-          "class": {"type": "string"},
-          "order": {"type": "string"},
-          "family": {"type": ["string", "null"]},
-          "genus": {"type": ["string", "null"]},
-          "citation": {"type": "string"},
-          "lsid": {"type": "string"},
-          "isMarine": {"type": ["integer", "null"]},
-          "isBrackish": {"type": ["integer", "null"]},
-          "isFreshwater": {"type": ["integer", "null"]},
-          "isTerrestrial": {"type": ["integer", "null"]},
-          "isExtinct": {"type": ["integer", "null"]},
-          "match_type": {"type": "string"},
-          "modified": {"type": "string"}
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["status", "data"],
+          "properties": {
+            "status": {"type": "string"},
+            "count": {"type": "integer", "description": "Number of records in this response (at most `limit`)."},
+            "offset": {"type": "integer"},
+            "limit": {"type": "integer"},
+            "has_more": {"type": "boolean", "description": "True when further matching records exist beyond this page."},
+            "url": {"type": "string"},
+            "message": {"type": "string"},
+            "data": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "AphiaID": {"type": "integer"},
+                  "url": {"type": "string"},
+                  "scientificname": {"type": "string"},
+                  "authority": {"type": ["string", "null"]},
+                  "status": {"type": "string"},
+                  "unacceptreason": {"type": ["string", "null"]},
+                  "taxonRankID": {"type": "integer"},
+                  "rank": {"type": "string"},
+                  "valid_AphiaID": {"type": "integer"},
+                  "valid_name": {"type": "string"},
+                  "valid_authority": {"type": ["string", "null"]},
+                  "parentNameUsageID": {"type": "integer"},
+                  "originalNameUsageID": {"type": ["integer", "null"]},
+                  "kingdom": {"type": "string"},
+                  "phylum": {"type": "string"},
+                  "class": {"type": "string"},
+                  "order": {"type": "string"},
+                  "family": {"type": ["string", "null"]},
+                  "genus": {"type": ["string", "null"]},
+                  "citation": {"type": "string"},
+                  "lsid": {"type": "string"},
+                  "isMarine": {"type": ["integer", "null"]},
+                  "isBrackish": {"type": ["integer", "null"]},
+                  "isFreshwater": {"type": ["integer", "null"]},
+                  "isTerrestrial": {"type": ["integer", "null"]},
+                  "isExtinct": {"type": ["integer", "null"]},
+                  "match_type": {"type": "string"},
+                  "modified": {"type": "string"}
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["error"],
+          "properties": {
+            "status": {"type": "string"},
+            "error": {"type": "string"}
+          }
         }
-      }
+      ]
     },
     "test_examples": [
       {"query": "Actinia equina", "limit": 5},
-      {"query": "Scleractinia", "limit": 10}
+      {"query": "Gadus", "limit": 10, "offset": 1}
     ]
   },
   {

--- a/src/tooluniverse/igsr_tool.py
+++ b/src/tooluniverse/igsr_tool.py
@@ -86,6 +86,18 @@ class IGSRTool(BaseTool):
         response.raise_for_status()
         return response.json()
 
+    @staticmethod
+    def _total_hits(raw: Dict[str, Any]) -> int:
+        """Number of documents matching the query, independent of page size.
+
+        Elasticsearch reports this either as a bare integer or as
+        ``{"value": N, "relation": ...}`` depending on server version.
+        """
+        total = raw.get("hits", {}).get("total", 0)
+        if isinstance(total, dict):
+            total = total.get("value", 0)
+        return total or 0
+
     def _search_populations(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Search 1000 Genomes populations by superpopulation or name."""
         superpopulation = arguments.get("superpopulation")
@@ -139,12 +151,17 @@ class IGSRTool(BaseTool):
                     "longitude": src.get("longitude"),
                 }
             )
+        # `total` is the size of the matching result set, not of the page. When the
+        # superpopulation filter is applied client-side the Elasticsearch hit count
+        # ignores it, so the post-filter length is the authoritative total there.
+        total = len(populations) if superpopulation else self._total_hits(raw)
         populations = populations[:limit]
 
         return {
             "status": "success",
             "data": {
-                "total": len(populations),
+                "total": total,
+                "returned": len(populations),
                 "populations": populations,
             },
             "metadata": {
@@ -202,7 +219,8 @@ class IGSRTool(BaseTool):
         return {
             "status": "success",
             "data": {
-                "total": raw.get("hits", {}).get("total", 0),
+                "total": self._total_hits(raw),
+                "returned": len(samples),
                 "samples": samples,
             },
             "metadata": {
@@ -237,7 +255,8 @@ class IGSRTool(BaseTool):
         return {
             "status": "success",
             "data": {
-                "total": raw.get("hits", {}).get("total", 0),
+                "total": self._total_hits(raw),
+                "returned": len(collections),
                 "collections": collections,
             },
             "metadata": {

--- a/src/tooluniverse/jaspar_tool.py
+++ b/src/tooluniverse/jaspar_tool.py
@@ -39,6 +39,14 @@ class JASPARRESTTool(BaseTool):
                         url = url.replace(ph, str(v))
                         params.pop(k, None)
 
+                # Some JASPAR query parameters are named differently upstream than
+                # in our parameter schema (e.g. the taxonomy filter is `tax_id`).
+                # JASPAR ignores unrecognised query parameters instead of
+                # rejecting them, so an unmapped name silently drops the filter
+                # and returns the unfiltered result set as a success.
+                param_map = fields_cfg.get("param_map") or {}
+                params = {param_map.get(k, k): v for k, v in params.items()}
+
                 response = self.session.get(url, params=params, timeout=self.timeout)
             else:
                 url = self._build_url(arguments)

--- a/src/tooluniverse/metabolite_tool.py
+++ b/src/tooluniverse/metabolite_tool.py
@@ -50,6 +50,15 @@ def _cas_from_synonyms(synonyms: List[str]) -> Optional[str]:
     return None
 
 
+class CTDBackendUnavailable(RuntimeError):
+    """The CTD mirror could not be reached or is no longer served.
+
+    Raised so that "the backend is gone" is never reported as "this compound has
+    no disease associations" -- the two are indistinguishable to a caller once
+    an empty list is returned as a success.
+    """
+
+
 @register_tool("MetaboliteTool")
 class MetaboliteTool(BaseTool):
     """
@@ -189,9 +198,15 @@ class MetaboliteTool(BaseTool):
                 timeout=self.timeout,
             )
             r.raise_for_status()
+        except requests.RequestException as exc:
+            raise CTDBackendUnavailable(
+                f"CTD mirror (automat.renci.org/ctd) is unavailable: {exc}"
+            ) from exc
+        try:
             payload = r.json()
             curie = payload["results"][0]["data"][0]["row"][0]
-        except (requests.RequestException, KeyError, IndexError, TypeError, ValueError):
+        except (KeyError, IndexError, TypeError, ValueError):
+            # Query succeeded but this term is not a node in the graph.
             return []
 
         # 2) Fetch the SmallMolecule → Disease edges
@@ -202,8 +217,13 @@ class MetaboliteTool(BaseTool):
                 timeout=self.timeout,
             )
             r.raise_for_status()
+        except requests.RequestException as exc:
+            raise CTDBackendUnavailable(
+                f"CTD mirror (automat.renci.org/ctd) is unavailable: {exc}"
+            ) from exc
+        try:
             edges = r.json()
-        except (requests.RequestException, ValueError):
+        except ValueError:
             return []
         if not isinstance(edges, list):
             return []
@@ -459,5 +479,7 @@ class MetaboliteTool(BaseTool):
                     "pubchem_url": f"https://pubchem.ncbi.nlm.nih.gov/compound/{cid}",
                 },
             }
+        except CTDBackendUnavailable as e:
+            return {"status": "error", "error": str(e)}
         except requests.exceptions.RequestException as e:
             return {"status": "error", "error": f"Request failed: {str(e)}"}

--- a/src/tooluniverse/ols_tool.py
+++ b/src/tooluniverse/ols_tool.py
@@ -34,16 +34,30 @@ def _expand_short_term_id(term_id: str) -> str:
     """
     if not term_id or term_id.startswith("http"):
         return term_id
-    if ":" in term_id:
-        prefix, local = term_id.split(":", 1)
-        return f"http://purl.obolibrary.org/obo/{prefix}_{local}"
+    # OBO PURLs are case-sensitive and always upper-case the prefix, so a
+    # well-formed but differently-cased CURIE ('mondo:0005180', the canonical
+    # Bioregistry spelling) must be normalized. Forwarding the caller's casing
+    # verbatim produced a valid-looking PURL that OLS resolves to nothing,
+    # which is indistinguishable from a genuine leaf term.
+    separator = ":" if ":" in term_id else ("_" if "_" in term_id else "")
+    if separator:
+        prefix, local = term_id.split(separator, 1)
+        return f"http://purl.obolibrary.org/obo/{prefix.upper()}_{local}"
     return term_id
 
 
 def _infer_ontology_from_term_id(term_id: str) -> str:
-    """Infer OLS ontology identifier from a CURIE prefix (e.g. 'HP:0001234' → 'hp')."""
-    if term_id and ":" in term_id and not term_id.startswith("http"):
-        return term_id.split(":", 1)[0].lower()
+    """Infer OLS ontology identifier from a CURIE prefix (e.g. 'HP:0001234' → 'hp').
+
+    Accepts both the colon CURIE and the underscore form used in OBO IRIs
+    ('MONDO_0005180'), which these tools emit themselves in their `iri` and
+    `shortForm` fields.
+    """
+    if not term_id or term_id.startswith("http"):
+        return ""
+    for separator in (":", "_"):
+        if separator in term_id:
+            return term_id.split(separator, 1)[0].lower()
     return ""
 
 
@@ -623,7 +637,12 @@ class OLSTool(BaseTool):
                             elements = candidates[0]
 
         if not elements:
-            return data if isinstance(data, dict) else {"items": data}
+            # Keep the success shape stable for empty result sets. Returning the
+            # raw upstream envelope here meant a leaf term answered with
+            # `totalElements`/`elements` while a non-leaf answered with
+            # `total_items`/`terms`, so callers reading `data["terms"]` broke on
+            # exactly the queries that legitimately have no children.
+            return {"terms": [], "total_items": 0, "showing": 0}
 
         limited = elements[:size]
         term_models = [self._build_term_model(item) for item in limited]

--- a/src/tooluniverse/openfda_tool.py
+++ b/src/tooluniverse/openfda_tool.py
@@ -257,7 +257,12 @@ def search_openfda(
                 print("Invalid search_keyword_option. Please use 'AND' or 'OR'.")
         del params["search_fields"]
     if search_query:
-        params["search"] = "+".join(search_query)
+        # Join the per-field clauses with an explicit AND. A bare "+" decodes to a
+        # space, and openFDA's Lucene parser defaults to OR between clauses, so
+        # every multi-field search returned the UNION of its filters: adding a
+        # second filter increased the result count and admitted records matching
+        # neither the first field nor, necessarily, having that field at all.
+        params["search"] = "+AND+".join(search_query)
         params["search"] = "(" + params["search"] + ")"
 
     def _normalize_indication_terms(text: str) -> list[str]:
@@ -537,6 +542,15 @@ def search_openfda(
         is_name_based = bool(
             {"openfda.brand_name", "openfda.generic_name"} & orig_fields_flat
         )
+        # The broadening stages below exist to tolerate typos and synonyms in a
+        # single lookup term: they OR the terms across several fields and use only
+        # the FIRST filter's text. Applied to a query that supplied more than one
+        # filter, they silently drop the other filters and re-introduce the union
+        # semantics this function is meant to avoid -- so a deliberately narrow
+        # two-filter query would come back with thousands of non-matching records
+        # instead of the correct empty result. With multiple filters, NOT_FOUND is
+        # the right answer.
+        is_multi_filter = len(orig_search_fields) > 1
 
         # Return-field fallback mapping (generic):
         # If NOT_FOUND is likely caused by `_exists_:{primary}` for a requested
@@ -568,6 +582,7 @@ def search_openfda(
         # Stage A: phrase -> terms within the same search field(s)
         if (
             not used_generic_fallback
+            and not is_multi_filter
             and fallback_terms
             and isinstance(response_data, dict)
             and response_data.get("error", {}).get("code") == "NOT_FOUND"
@@ -593,7 +608,8 @@ def search_openfda(
 
         # Stage B: expand to label-text fields (robust when openfda is empty or name mismatched)
         if (
-            fallback_terms
+            not is_multi_filter
+            and fallback_terms
             and isinstance(response_data, dict)
             and response_data.get("error", {}).get("code") == "NOT_FOUND"
         ):

--- a/src/tooluniverse/proteomicsdb_tool.py
+++ b/src/tooluniverse/proteomicsdb_tool.py
@@ -225,9 +225,17 @@ class ProteomicsDBTool(BaseTool):
                     "tissue_category": t[3] or "",
                 }
 
-        # Build expression records
-        # mapdata format: [protein_id, tissue_id, val1, val2, val3, val4]
-        # val1 appears to be the main normalized expression value (log10 iBAQ)
+        # Build expression records.
+        #
+        # mapdata rows mirror ProteomicsDB's documented proteinexpression.xsodata
+        # columns, in this order:
+        #   [protein_id, tissue_id, UNNORMALIZED_INTENSITY, NORMALIZED_INTENSITY,
+        #    MIN_NORMALIZED_INTENSITY, MAX_NORMALIZED_INTENSITY]
+        # `expression_value` must be the NORMALIZED intensity: it is the value the
+        # tool documents, the one comparable across tissues, and the only one that
+        # lies inside the min/max interval reported alongside it. Using the
+        # un-normalized column put every value outside its own error bars and
+        # reordered the tissue ranking.
         records = []
         for row in mapdata:
             if len(row) < 3:
@@ -239,18 +247,17 @@ class ProteomicsDBTool(BaseTool):
                 "tissue_name": tissue_info.get("tissue_name", ""),
                 "tissue_group": tissue_info.get("tissue_group", ""),
                 "tissue_category": tissue_info.get("tissue_category", ""),
-                "expression_value": row[2] if len(row) > 2 else None,
+                "expression_value": row[3] if len(row) > 3 else None,
+                "unnormalized_intensity": row[2],
             }
             # Add additional quantification values if present
-            if len(row) > 3:
-                rec["median_expression"] = row[3]
             if len(row) > 4:
                 rec["min_expression"] = row[4]
             if len(row) > 5:
                 rec["max_expression"] = row[5]
             records.append(rec)
 
-        # Sort by expression value descending
+        # Sort by normalized expression value descending
         records.sort(key=lambda r: r.get("expression_value") or 0, reverse=True)
 
         # Get protein info

--- a/src/tooluniverse/rhea_tool.py
+++ b/src/tooluniverse/rhea_tool.py
@@ -12,12 +12,18 @@ Returns TSV format which is parsed to JSON by this tool.
 No authentication required. Free public access.
 """
 
+import re
+
 import requests
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 RHEA_BASE_URL = "https://www.rhea-db.org/rhea"
+
+# Rhea's REST API honours `limit` but ignores `offset`, so paging is done
+# client-side by fetching offset+limit rows and slicing.
+MAX_ROWS_PER_REQUEST = 1000
 
 
 @register_tool("RheaTool")
@@ -71,6 +77,97 @@ class RheaTool(BaseTool):
         else:
             return {"status": "error", "error": f"Unknown endpoint: {self.endpoint}"}
 
+    @staticmethod
+    def _normalize_prefixed_id(value: str, prefix: str) -> str:
+        """Normalize an identifier to Rhea's ``PREFIX:local`` query form.
+
+        Accepts the spellings that appear in OWL/OBO files, spreadsheets and
+        papers -- ``CHEBI_15724``, ``chebi:15724``, ``EC 1.1.1.1``, a bare
+        ``15724`` -- and returns ``CHEBI:15724`` / ``EC:1.1.1.1``. Previously the
+        check was a case-sensitive ``startswith``, so ``CHEBI_15724`` became
+        ``CHEBI:CHEBI_15724`` (0 results reported as a success) and lowercase
+        prefixes produced an upstream HTTP 500.
+        """
+        text = str(value).strip()
+        local = re.sub(rf"^{re.escape(prefix)}\s*[:_ ]?\s*", "", text, flags=re.I)
+        return f"{prefix}:{local.strip()}"
+
+    def _total_for_query(self, query: str) -> Optional[int]:
+        """Number of Rhea reactions matching `query`, independent of page size.
+
+        Rhea exposes no count endpoint, so this fetches the single ``rhea-id``
+        column unlimited -- cheap, and the only way to report a real total
+        rather than echoing back the requested ``limit``.
+        """
+        try:
+            response = requests.get(
+                RHEA_BASE_URL,
+                params={"query": query, "columns": "rhea-id", "format": "tsv"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except requests.RequestException:
+            return None
+        return len(self._parse_tsv(response.text))
+
+    def _paged_search(
+        self,
+        query: str,
+        columns: str,
+        arguments: Dict[str, Any],
+        extra_metadata: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Run a Rhea search, reporting an honest total and supporting paging."""
+        try:
+            limit = int(arguments.get("limit", 20))
+            offset = int(arguments.get("offset", 0))
+        except (TypeError, ValueError):
+            return {
+                "status": "error",
+                "error": (
+                    "limit and offset must be integers, got "
+                    f"limit={arguments.get('limit')!r}, "
+                    f"offset={arguments.get('offset')!r}"
+                ),
+            }
+        if limit < 1:
+            return {"status": "error", "error": f"limit must be >= 1, got {limit}"}
+        offset = max(offset, 0)
+
+        total = self._total_for_query(query)
+
+        # Rhea ignores `offset`, so fetch through the requested window and slice.
+        fetch = min(offset + limit, MAX_ROWS_PER_REQUEST)
+        response = requests.get(
+            RHEA_BASE_URL,
+            params={
+                "query": query,
+                "columns": columns,
+                "format": "tsv",
+                "limit": fetch,
+            },
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+
+        page = self._parse_tsv(response.text)[offset : offset + limit]
+
+        metadata = {
+            "source": "Rhea (SIB)",
+            # Size of the whole matching result set, not of this page.
+            "total_results": total,
+            "returned": len(page),
+            "offset": offset,
+            "limit": limit,
+            "has_more": (
+                offset + len(page) < total if isinstance(total, int) else None
+            ),
+            "max_rows_per_request": MAX_ROWS_PER_REQUEST,
+        }
+        metadata.update(extra_metadata)
+
+        return {"status": "success", "data": page, "metadata": metadata}
+
     def _parse_tsv(self, text: str) -> List[Dict[str, str]]:
         """Parse TSV response into list of dicts."""
         lines = text.strip().split("\n")
@@ -112,29 +209,12 @@ class RheaTool(BaseTool):
                 "error": "query parameter is required (e.g., 'glucose', 'ATP', 'kinase')",
             }
 
-        limit = arguments.get("limit", 20)
-
-        params = {
-            "query": query,
-            "columns": "rhea-id,equation,ec",
-            "format": "tsv",
-            "limit": min(limit, 50),
-        }
-
-        response = requests.get(RHEA_BASE_URL, params=params, timeout=self.timeout)
-        response.raise_for_status()
-
-        results = self._parse_tsv(response.text)
-
-        return {
-            "status": "success",
-            "data": results,
-            "metadata": {
-                "source": "Rhea (SIB)",
-                "query": query,
-                "total_results": len(results),
-            },
-        }
+        return self._paged_search(
+            query=query,
+            columns="rhea-id,equation,ec",
+            arguments=arguments,
+            extra_metadata={"query": query},
+        )
 
     def _search_by_ec(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Search for reactions by EC (Enzyme Commission) number."""
@@ -145,33 +225,14 @@ class RheaTool(BaseTool):
                 "error": "ec_number parameter is required (e.g., 'EC:1.1.1.1', '3.5.1.50')",
             }
 
-        # Normalize EC number format
-        if not ec_number.startswith("EC:"):
-            ec_number = f"EC:{ec_number}"
+        ec_number = self._normalize_prefixed_id(ec_number, "EC")
 
-        limit = arguments.get("limit", 20)
-
-        params = {
-            "query": ec_number,
-            "columns": "rhea-id,equation,ec",
-            "format": "tsv",
-            "limit": min(limit, 50),
-        }
-
-        response = requests.get(RHEA_BASE_URL, params=params, timeout=self.timeout)
-        response.raise_for_status()
-
-        results = self._parse_tsv(response.text)
-
-        return {
-            "status": "success",
-            "data": results,
-            "metadata": {
-                "source": "Rhea (SIB)",
-                "ec_number": ec_number,
-                "total_results": len(results),
-            },
-        }
+        return self._paged_search(
+            query=ec_number,
+            columns="rhea-id,equation,ec",
+            arguments=arguments,
+            extra_metadata={"ec_number": ec_number},
+        )
 
     def _search_by_chebi(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Search for reactions involving a specific ChEBI compound."""
@@ -182,30 +243,11 @@ class RheaTool(BaseTool):
                 "error": "chebi_id parameter is required (e.g., 'CHEBI:17234' for glucose)",
             }
 
-        # Normalize ChEBI ID format
-        if not chebi_id.startswith("CHEBI:"):
-            chebi_id = f"CHEBI:{chebi_id}"
+        chebi_id = self._normalize_prefixed_id(chebi_id, "CHEBI")
 
-        limit = arguments.get("limit", 20)
-
-        params = {
-            "query": chebi_id,
-            "columns": "rhea-id,equation,chebi-id,ec",
-            "format": "tsv",
-            "limit": min(limit, 50),
-        }
-
-        response = requests.get(RHEA_BASE_URL, params=params, timeout=self.timeout)
-        response.raise_for_status()
-
-        results = self._parse_tsv(response.text)
-
-        return {
-            "status": "success",
-            "data": results,
-            "metadata": {
-                "source": "Rhea (SIB)",
-                "chebi_id": chebi_id,
-                "total_results": len(results),
-            },
-        }
+        return self._paged_search(
+            query=chebi_id,
+            columns="rhea-id,equation,chebi-id,ec",
+            arguments=arguments,
+            extra_metadata={"chebi_id": chebi_id},
+        )

--- a/src/tooluniverse/string_tool.py
+++ b/src/tooluniverse/string_tool.py
@@ -7,6 +7,11 @@ from .tool_registry import register_tool
 
 STRING_BASE_URL = "https://string-db.org/api"
 
+# Categories whose STRING label differs from the value our schema advertises.
+# Every other enum value ('Process', 'Component', 'Function', 'KEGG',
+# 'WikiPathways', 'COMPARTMENTS', 'TISSUES', 'DISEASES') matches STRING exactly.
+_STRING_CATEGORY_LABELS = {"Reactome": "RCTM"}
+
 
 @register_tool("STRINGRESTTool")
 class STRINGRESTTool(BaseTool):
@@ -121,6 +126,14 @@ class STRINGRESTTool(BaseTool):
         # Apply client-side filter when category is specified.
         category_filter = arguments.get("category")
         if category_filter:
+            # STRING labels its own categories differently from our enum for
+            # Reactome ('RCTM'). Comparing the enum value verbatim matched no
+            # row, so a declared and schema-validated category returned zero
+            # enriched terms as a success -- indistinguishable from "this gene
+            # set has no Reactome enrichment".
+            category_filter = _STRING_CATEGORY_LABELS.get(
+                category_filter, category_filter
+            )
             if isinstance(api_response, list):
                 api_response = [
                     r for r in api_response if r.get("category") == category_filter

--- a/src/tooluniverse/tcdb_tool.py
+++ b/src/tooluniverse/tcdb_tool.py
@@ -234,6 +234,7 @@ class TCDBTool(BaseTool):
         family_id = (arguments.get("family_id") or "").strip()
         family_name = (arguments.get("family_name") or "").strip()
         limit = min(int(arguments.get("limit", 20)), 100)
+        offset = max(int(arguments.get("offset", 0)), 0)
 
         if not family_id and not family_name:
             return {
@@ -262,13 +263,19 @@ class TCDBTool(BaseTool):
             )
 
         matches.sort(key=lambda x: x["family_id"])
-        matches = matches[:limit]
+        # `total_matches` counts every family matching the query. It must be taken
+        # before paging, otherwise it just echoes `limit` back to the caller.
+        total_matches = len(matches)
+        page = matches[offset : offset + limit]
 
         return {
             "status": "success",
             "data": {
-                "total_matches": len(matches),
-                "families": matches,
+                "total_matches": total_matches,
+                "returned": len(page),
+                "offset": offset,
+                "has_more": offset + len(page) < total_matches,
+                "families": page,
                 "query": {
                     "family_id": family_id or None,
                     "family_name": family_name or None,
@@ -282,6 +289,7 @@ class TCDBTool(BaseTool):
             arguments.get("substrate_name") or arguments.get("substrate") or ""
         ).strip()
         limit = min(int(arguments.get("limit", 20)), 100)
+        offset = max(int(arguments.get("offset", 0)), 0)
 
         if not substrate_name:
             return {
@@ -308,12 +316,18 @@ class TCDBTool(BaseTool):
                     }
                 )
 
-        matches = matches[:limit]
+        # Count every transporter carrying the substrate before paging, so
+        # `total_matches` reports the size of the result set rather than `limit`.
+        total_matches = len(matches)
+        page = matches[offset : offset + limit]
         return {
             "status": "success",
             "data": {
-                "total_matches": len(matches),
-                "transporters": matches,
+                "total_matches": total_matches,
+                "returned": len(page),
+                "offset": offset,
+                "has_more": offset + len(page) < total_matches,
+                "transporters": page,
                 "query": substrate_name,
             },
         }

--- a/src/tooluniverse/worms_tool.py
+++ b/src/tooluniverse/worms_tool.py
@@ -17,6 +17,9 @@ _APHIA_OPERATIONS = {
 
 @register_tool("WoRMSRESTTool")
 class WoRMSRESTTool(BaseTool):
+    # Maximum number of records WoRMS returns from a single AphiaRecordsByName call.
+    _PAGE_SIZE = 50
+
     def __init__(self, tool_config: Dict):
         super().__init__(tool_config)
         self.base_url = "https://www.marinespecies.org/rest"
@@ -72,32 +75,73 @@ class WoRMSRESTTool(BaseTool):
         if not query:
             return {"status": "error", "error": "Query parameter is required"}
 
-        encoded_query = urllib.parse.quote(query)
-        url = f"{self.base_url}/AphiaRecordsByName/{encoded_query}"
         try:
-            response = self.session.get(url, timeout=self.timeout)
-            response.raise_for_status()
-            if not response.text.strip():
-                return {
-                    "status": "success",
-                    "data": [],
-                    "url": url,
-                    "message": "No results found for this query",
-                }
-            data = response.json()
-        except Exception as e:
-            return {"status": "error", "error": f"WoRMS API error: {str(e)}"}
+            limit = int(arguments.get("limit", 20))
+            offset = int(arguments.get("offset", 1))
+        except (TypeError, ValueError):
+            return {
+                "status": "error",
+                "error": (
+                    "limit and offset must be integers, got "
+                    f"limit={arguments.get('limit')!r}, "
+                    f"offset={arguments.get('offset')!r}"
+                ),
+            }
+        if limit < 1:
+            return {"status": "error", "error": f"limit must be >= 1, got {limit}"}
+        offset = max(offset, 1)
 
-        if isinstance(data, list) and len(data) > 0:
-            limited_data = data[:5]
+        encoded_query = urllib.parse.quote(query)
+        base_url = f"{self.base_url}/AphiaRecordsByName/{encoded_query}"
+        first_url = f"{base_url}?offset={offset}"
+
+        # WoRMS caps every AphiaRecordsByName response at _PAGE_SIZE records and
+        # pages with a 1-based `offset`. Walk pages until the caller's `limit` is
+        # satisfied, fetching one record beyond it so `has_more` can be reported
+        # without enumerating the entire result set.
+        records: list = []
+        page_offset = offset
+        while len(records) <= limit:
+            url = f"{base_url}?offset={page_offset}"
+            try:
+                response = self.session.get(url, timeout=self.timeout)
+                # 204 / empty body = no (further) records for this query.
+                if response.status_code == 204 or not response.text.strip():
+                    break
+                response.raise_for_status()
+                page = response.json()
+            except Exception as e:
+                return {"status": "error", "error": f"WoRMS API error: {str(e)}"}
+            if not isinstance(page, list) or not page:
+                break
+            records.extend(page)
+            if len(page) < self._PAGE_SIZE:
+                break
+            page_offset += self._PAGE_SIZE
+
+        if not records:
             return {
                 "status": "success",
-                "data": limited_data,
-                "url": url,
-                "count": len(limited_data),
-                "total_found": len(data),
+                "data": [],
+                "url": first_url,
+                "count": 0,
+                "offset": offset,
+                "limit": limit,
+                "has_more": False,
+                "message": "No results found for this query",
             }
-        return {"status": "success", "data": data, "url": url}
+
+        has_more = len(records) > limit
+        page = records[:limit]
+        return {
+            "status": "success",
+            "data": page,
+            "url": first_url,
+            "count": len(page),
+            "offset": offset,
+            "limit": limit,
+            "has_more": has_more,
+        }
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         operation = self._operation()

--- a/tests/unit/test_confidently_wrong_answers_r6.py
+++ b/tests/unit/test_confidently_wrong_answers_r6.py
@@ -1,0 +1,546 @@
+"""Regression tests for round-6 tools that returned confidently wrong answers.
+
+Each case below returned ``status: success`` with a plausible-looking but wrong
+value, rather than failing visibly:
+
+* ``jaspar``/``WoRMS``/``TCDB``/``IGSR`` are covered in their own modules.
+* ``openfda`` OR'd multi-field filters, so a *narrowing* filter increased the
+  result count and admitted records matching neither field.
+* ``STRING_functional_enrichment`` compared the enum value ``Reactome`` against
+  STRING's own label ``RCTM``, so a declared category always yielded 0 terms.
+* ``AlphaMissense_get_variant_score`` discarded the substituted amino acid, so
+  every substitution at a residue returned identical output -- including
+  invalid ones.
+* ``ProteomicsDB`` reported the un-normalized intensity as ``expression_value``
+  and sorted on it, putting every value outside its own min/max interval.
+* ``Rhea`` echoed ``limit`` back as ``total_results`` and mangled ID spellings.
+* ``ols`` forwarded CURIE casing verbatim into case-sensitive OBO PURLs.
+* ``Metabolite_get_diseases`` reported a dead CTD backend as "0 diseases".
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+DATA = REPO / "src" / "tooluniverse" / "data"
+
+
+# ---------------------------------------------------------------- openFDA ---
+
+
+def test_openfda_joins_multiple_filters_with_and():
+    """A second filter must intersect, not union."""
+    from tooluniverse.openfda_tool import search_openfda
+
+    captured = {}
+
+    def fake_get(url, *a, **k):
+        captured["url"] = url
+        response = MagicMock()
+        response.json.return_value = {"meta": {"results": {"total": 1}}, "results": []}
+        return response
+
+    with patch("tooluniverse.openfda_tool.requests.get", side_effect=fake_get):
+        search_openfda(
+            params={
+                "search_fields": {
+                    "drug_interactions": "fluconazole",
+                    "indications_and_usage": "Hypertension",
+                }
+            },
+            endpoint_url="https://api.fda.gov/drug/label.json",
+            return_fields=["openfda.brand_name"],
+        )
+
+    import urllib.parse
+
+    raw = captured["url"]
+    assert "+AND+" in raw, "clauses must be AND'd (literal '+AND+' in the URL)"
+    search = urllib.parse.unquote(raw)
+    assert 'drug_interactions:"fluconazole"' in search
+    assert 'indications_and_usage:"Hypertension"' in search
+    # The clauses must not be separated by a bare '+', which decodes to a space
+    # and which openFDA's Lucene parser reads as OR.
+    assert 'fluconazole"+indications' not in search
+
+
+def test_openfda_single_filter_still_builds_a_query():
+    from tooluniverse.openfda_tool import search_openfda
+
+    captured = {}
+
+    def fake_get(url, *a, **k):
+        captured["url"] = url
+        response = MagicMock()
+        response.json.return_value = {"meta": {"results": {"total": 1}}, "results": []}
+        return response
+
+    with patch("tooluniverse.openfda_tool.requests.get", side_effect=fake_get):
+        search_openfda(
+            params={"search_fields": {"drug_interactions": "fluconazole"}},
+            endpoint_url="https://api.fda.gov/drug/label.json",
+            return_fields=["openfda.brand_name"],
+        )
+    import urllib.parse
+
+    assert 'drug_interactions:"fluconazole"' in urllib.parse.unquote(captured["url"])
+
+
+def test_openfda_multi_filter_not_found_is_not_broadened():
+    """With several filters, NOT_FOUND is the answer -- never an OR'd retry."""
+    from tooluniverse.openfda_tool import search_openfda
+
+    urls = []
+
+    def fake_get(url, *a, **k):
+        urls.append(url)
+        response = MagicMock()
+        response.json.return_value = {
+            "error": {"code": "NOT_FOUND", "message": "No matches found!"}
+        }
+        return response
+
+    with patch("tooluniverse.openfda_tool.requests.get", side_effect=fake_get):
+        search_openfda(
+            params={
+                "search_fields": {
+                    "boxed_warning": "bleeding",
+                    "indications_and_usage": "ZZZQQNOTANINDICATION",
+                }
+            },
+            endpoint_url="https://api.fda.gov/drug/label.json",
+            return_fields=["openfda.brand_name"],
+        )
+
+    # The broadening stages OR terms across fields; none of them may run here.
+    import urllib.parse
+
+    urls = [urllib.parse.unquote(u) for u in urls]
+    assert not any("+OR+" in u and "boxed_warning:(" in u for u in urls), (
+        "multi-filter NOT_FOUND must not fall back to an OR'd term search"
+    )
+
+
+# ----------------------------------------------------------------- STRING ---
+
+
+def test_string_reactome_category_maps_to_rctm():
+    from tooluniverse.string_tool import _STRING_CATEGORY_LABELS
+
+    assert _STRING_CATEGORY_LABELS["Reactome"] == "RCTM"
+
+
+@pytest.mark.parametrize(
+    "requested,expected_rows",
+    [("Reactome", 2), ("KEGG", 1), ("Process", 1)],
+)
+def test_string_enrichment_category_filter(requested, expected_rows):
+    from tooluniverse.string_tool import STRINGRESTTool
+
+    rows = [
+        {"category": "RCTM", "term": "R-HSA-1", "description": "DSB repair"},
+        {"category": "RCTM", "term": "R-HSA-2", "description": "Stabilization of p53"},
+        {"category": "KEGG", "term": "hsa04110", "description": "Cell cycle"},
+        {"category": "Process", "term": "GO:1", "description": "DNA repair"},
+    ]
+    config = {
+        "type": "STRINGRESTTool",
+        "name": "STRING_functional_enrichment",
+        "description": "enrichment",
+        "parameter": {"type": "object", "properties": {}},
+        "fields": {"endpoint": "enrichment", "output_format": "json"},
+    }
+    tool = STRINGRESTTool(config)
+    with patch.object(tool, "_make_request", return_value=list(rows)):
+        result = tool.run(
+            {
+                "protein_ids": ["TP53", "MDM2"],
+                "species": 9606,
+                "category": requested,
+            }
+        )
+    data = result.get("data")
+    data = data if isinstance(data, list) else data.get("data", [])
+    assert len(data) == expected_rows
+
+
+# ---------------------------------------------------------- AlphaMissense ---
+
+
+def _alphamissense_tool():
+    from tooluniverse.alphamissense_tool import AlphaMissenseTool
+
+    cfg = {
+        "type": "AlphaMissenseTool",
+        "name": "AlphaMissense_get_variant_score",
+        "description": "score",
+        "parameter": {"type": "object", "properties": {}},
+        "fields": {"operation": "get_variant_score"},
+    }
+    return AlphaMissenseTool(cfg)
+
+
+HOTSPOT_858 = {
+    "uid": "P00533",
+    "aa": "L",
+    "resi": 858,
+    "benign": "",
+    "ambiguous": "",
+    "pathogenic": "5:M,P,Q,R,V",
+    "mean": 0.97394,
+    "benign_all": None,
+    "ambiguous_all": None,
+    "pathogenic_all": "19:A,C,D,E,F,G,H,I,K,M,N,P,Q,R,S,T,V,W,Y",
+    "mean_all": 0.98727,
+}
+
+
+def _run_variant(variant, payload=None):
+    tool = _alphamissense_tool()
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = payload if payload is not None else HOTSPOT_858
+    response.raise_for_status.return_value = None
+    with patch("tooluniverse.alphamissense_tool.requests.get", return_value=response):
+        return tool.run({"uniprot_id": "P00533", "variant": variant})
+
+
+def test_alphamissense_class_list_parsing():
+    from tooluniverse.alphamissense_tool import AlphaMissenseTool
+
+    assert AlphaMissenseTool._class_members("5:M,P,Q,R,V") == ["M", "P", "Q", "R", "V"]
+    assert AlphaMissenseTool._class_members("") == []
+    assert AlphaMissenseTool._class_members(None) == []
+    assert AlphaMissenseTool._class_members("A,B") == ["A", "B"]
+
+
+def test_alphamissense_distinguishes_substitutions():
+    """R is SNV-accessible at L858; W is only in the all-substitutions set."""
+    r = _run_variant("p.L858R")["data"]
+    w = _run_variant("p.L858W")["data"]
+    assert r["classification"] == "pathogenic"
+    assert r["substitution_set"] == "snv_accessible"
+    assert w["substitution_set"] == "all_substitutions"
+    assert r != w, "different substitutions must not return identical payloads"
+
+
+def test_alphamissense_rejects_invalid_amino_acid():
+    result = _run_variant("p.L858Z")
+    assert result["status"] == "error"
+    assert "Z" in result["error"]
+
+
+def test_alphamissense_rejects_synonymous_variant():
+    result = _run_variant("p.L858L")
+    assert result["status"] == "error"
+    assert "synonymous" in result["error"]
+
+
+def test_alphamissense_rejects_reference_residue_mismatch():
+    """Catches a wrong position or a different isoform."""
+    result = _run_variant("p.A858V")
+    assert result["status"] == "error"
+    assert "mismatch" in result["error"].lower()
+
+
+def test_alphamissense_does_not_present_residue_mean_as_a_variant_score():
+    data = _run_variant("p.L858R")["data"]
+    assert data["pathogenicity_score"] is None
+    assert data["score_available"] is False
+    assert data["residue_mean_score_snv_accessible"] == pytest.approx(0.97394)
+    assert "note" in data
+
+
+def test_alphamissense_no_todo_message_ships():
+    data = _run_variant("p.L858R")["data"]
+    assert "Score extraction requires parsing" not in json.dumps(data)
+
+
+# ------------------------------------------------------------ ProteomicsDB ---
+
+
+def test_proteomicsdb_uses_normalized_intensity_and_ranks_on_it():
+    from tooluniverse.proteomicsdb_tool import ProteomicsDBTool
+
+    cfg = {
+        "type": "ProteomicsDBTool",
+        "name": "ProteomicsDB_get_protein_expression",
+        "description": "expression",
+        "parameter": {"type": "object", "properties": {}},
+        "fields": {"operation": "get_protein_expression"},
+    }
+    tool = ProteomicsDBTool(cfg)
+    # [protein_id, tissue_id, UNNORM, NORM, MIN_NORM, MAX_NORM]
+    mapdata = [
+        [1, "BTO:0001086", 6.40, 3.82, 2.98, 4.39],  # embryonic stem cell
+        [1, "BTO:0000149", 5.49, 5.13, 5.13, 5.13],  # breast
+    ]
+    tissue_lookup = {
+        "BTO:0001086": {"tissue_name": "embryonic stem cell"},
+        "BTO:0000149": {"tissue_name": "breast"},
+    }
+    with patch.object(
+        tool,
+        "_fetch_expression_payload",
+        return_value=(mapdata, tissue_lookup),
+        create=True,
+    ):
+        pass  # helper name may differ; the record builder is exercised below
+
+    # Exercise the record-building logic directly through the public operation
+    # by faking the HTTP layer.
+    payload = {"mapdata": mapdata}
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+
+    with patch("tooluniverse.proteomicsdb_tool.requests.get", return_value=response):
+        result = tool.run(
+            {
+                "operation": "get_protein_expression",
+                "uniprot_id": "P04637",
+                "tissue_category": "tissue",
+            }
+        )
+
+    records = (result.get("data") or {}).get("expression_records")
+    if not records:
+        pytest.skip("expression payload shape not reproducible offline")
+    for rec in records:
+        if rec.get("min_expression") is None:
+            continue
+        assert rec["min_expression"] <= rec["expression_value"] <= rec["max_expression"]
+
+
+def test_proteomicsdb_config_documents_normalized_value():
+    cfg = json.loads((DATA / "proteomicsdb_tools.json").read_text())
+    text = json.dumps(cfg)
+    assert "unnormalized_intensity" in text
+    assert "NORMALIZED" in text
+
+
+# ------------------------------------------------------------------- Rhea ---
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("CHEBI:15724", "CHEBI:15724"),
+        ("15724", "CHEBI:15724"),
+        ("CHEBI_15724", "CHEBI:15724"),
+        ("chebi:15724", "CHEBI:15724"),
+        ("ChEBI:15724", "CHEBI:15724"),
+        ("  CHEBI:15724  ", "CHEBI:15724"),
+    ],
+)
+def test_rhea_normalizes_chebi_spellings(raw, expected):
+    from tooluniverse.rhea_tool import RheaTool
+
+    assert RheaTool._normalize_prefixed_id(raw, "CHEBI") == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("1.14.13.148", "EC:1.14.13.148"),
+        ("EC:1.14.13.148", "EC:1.14.13.148"),
+        ("EC 1.14.13.148", "EC:1.14.13.148"),
+        ("ec:1.14.13.148", "EC:1.14.13.148"),
+    ],
+)
+def test_rhea_normalizes_ec_spellings(raw, expected):
+    from tooluniverse.rhea_tool import RheaTool
+
+    assert RheaTool._normalize_prefixed_id(raw, "EC") == expected
+
+
+def _rhea_tool(operation="search_by_chebi"):
+    from tooluniverse.rhea_tool import RheaTool
+
+    return RheaTool(
+        {
+            "type": "RheaTool",
+            "name": f"Rhea_{operation}",
+            "description": "rhea",
+            "parameter": {"type": "object", "properties": {}},
+            "fields": {"endpoint": operation},
+        }
+    )
+
+
+def _rhea_tsv(n):
+    header = "Reaction identifier\tEquation\tChEBI identifier\tEC number"
+    rows = [f"RHEA:{1000 + i}\tA = B\tCHEBI:1\tEC:1.1.1.1" for i in range(n)]
+    return "\n".join([header] + rows)
+
+
+def test_rhea_total_is_independent_of_limit():
+    tool = _rhea_tool()
+
+    def fake_get(url, params=None, timeout=None):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        if params.get("columns") == "rhea-id" and "limit" not in params:
+            response.text = _rhea_tsv(1384)  # the count query
+        else:
+            response.text = _rhea_tsv(min(params.get("limit", 20), 1384))
+        return response
+
+    with patch("tooluniverse.rhea_tool.requests.get", side_effect=fake_get):
+        for limit in (5, 20, 50, 200):
+            result = tool.run({"chebi_id": "CHEBI:30616", "limit": limit})
+            assert result["metadata"]["total_results"] == 1384
+            assert result["metadata"]["returned"] == limit
+            assert result["metadata"]["has_more"] is True
+
+
+def test_rhea_limit_is_not_capped_at_fifty():
+    tool = _rhea_tool()
+
+    def fake_get(url, params=None, timeout=None):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.text = _rhea_tsv(
+            1384 if "limit" not in params else min(params["limit"], 1384)
+        )
+        return response
+
+    with patch("tooluniverse.rhea_tool.requests.get", side_effect=fake_get):
+        result = tool.run({"chebi_id": "CHEBI:30616", "limit": 200})
+    assert len(result["data"]) == 200
+
+
+def test_rhea_offset_pages_client_side():
+    tool = _rhea_tool()
+
+    def fake_get(url, params=None, timeout=None):
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.text = _rhea_tsv(
+            1384 if "limit" not in params else min(params["limit"], 1384)
+        )
+        return response
+
+    with patch("tooluniverse.rhea_tool.requests.get", side_effect=fake_get):
+        first = tool.run({"chebi_id": "CHEBI:30616", "limit": 5, "offset": 0})
+        second = tool.run({"chebi_id": "CHEBI:30616", "limit": 5, "offset": 5})
+    a = [r["rhea_id"] for r in first["data"]]
+    b = [r["rhea_id"] for r in second["data"]]
+    assert len(a) == len(b) == 5
+    assert not set(a) & set(b)
+
+
+def test_rhea_rejects_bad_limit():
+    tool = _rhea_tool()
+    result = tool.run({"chebi_id": "CHEBI:30616", "limit": "abc"})
+    assert result["status"] == "error"
+
+
+def test_rhea_config_declares_offset():
+    cfg = json.loads((DATA / "rhea_tools.json").read_text())
+    for tool in cfg:
+        if tool.get("type") == "RheaTool":
+            assert "offset" in tool["parameter"]["properties"], tool["name"]
+
+
+# -------------------------------------------------------------------- OLS ---
+
+
+@pytest.mark.parametrize(
+    "term_id",
+    ["MONDO:0005180", "mondo:0005180", "Mondo:0005180", "MONDO_0005180"],
+)
+def test_ols_curie_casing_normalizes_to_the_obo_purl(term_id):
+    from tooluniverse.ols_tool import _expand_short_term_id
+
+    assert (
+        _expand_short_term_id(term_id) == "http://purl.obolibrary.org/obo/MONDO_0005180"
+    )
+
+
+def test_ols_full_iri_is_passed_through():
+    from tooluniverse.ols_tool import _expand_short_term_id
+
+    iri = "http://purl.obolibrary.org/obo/MONDO_0005180"
+    assert _expand_short_term_id(iri) == iri
+
+
+@pytest.mark.parametrize(
+    "term_id,expected",
+    [
+        ("MONDO:0005180", "mondo"),
+        ("mondo:0005180", "mondo"),
+        ("MONDO_0005180", "mondo"),
+        ("HP:0001234", "hp"),
+        ("http://purl.obolibrary.org/obo/MONDO_0005180", ""),
+    ],
+)
+def test_ols_infers_ontology_from_both_curie_forms(term_id, expected):
+    from tooluniverse.ols_tool import _infer_ontology_from_term_id
+
+    assert _infer_ontology_from_term_id(term_id) == expected
+
+
+# ------------------------------------------------------------- Metabolite ---
+
+
+def test_metabolite_dead_ctd_backend_is_an_error_not_zero_diseases():
+    import requests as _requests
+    from tooluniverse.metabolite_tool import CTDBackendUnavailable, MetaboliteTool
+
+    tool = MetaboliteTool(
+        {
+            "type": "MetaboliteTool",
+            "name": "Metabolite_get_diseases",
+            "description": "diseases",
+            "parameter": {"type": "object", "properties": {}},
+            "fields": {"operation": "get_diseases"},
+        }
+    )
+
+    response = MagicMock()
+    response.raise_for_status.side_effect = _requests.HTTPError("404 Client Error")
+    with patch("tooluniverse.metabolite_tool.requests.post", return_value=response):
+        with pytest.raises(CTDBackendUnavailable):
+            tool._ctd_diseases("cholesterol")
+
+
+def test_metabolite_unknown_term_still_returns_empty_not_an_error():
+    """A reachable backend that simply has no node for the term is not a failure."""
+    from tooluniverse.metabolite_tool import MetaboliteTool
+
+    tool = MetaboliteTool(
+        {
+            "type": "MetaboliteTool",
+            "name": "Metabolite_get_diseases",
+            "description": "diseases",
+            "parameter": {"type": "object", "properties": {}},
+            "fields": {"operation": "get_diseases"},
+        }
+    )
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"results": [{"data": []}]}
+    with patch("tooluniverse.metabolite_tool.requests.post", return_value=response):
+        assert tool._ctd_diseases("zzzz") == []
+
+
+# ------------------------------------------------------------- cBioPortal ---
+
+
+@pytest.mark.parametrize("name", ["cBioPortal_get_samples", "cBioPortal_get_patients"])
+def test_cbioportal_returns_whole_cohort_by_default(name):
+    cfg = {
+        t["name"]: t for t in json.loads((DATA / "cbioportal_tools.json").read_text())
+    }
+    props = cfg[name]["parameter"]["properties"]
+    assert props["page_size"]["default"] >= 100000, (
+        "the default must cover a whole study; a truncated cohort silently "
+        "corrupts every mutation-frequency denominator"
+    )
+    assert "page_number" in props
+    assert "pageNumber=" in cfg[name]["fields"]["endpoint"]

--- a/tests/unit/test_jaspar_species_tax_id_mapping.py
+++ b/tests/unit/test_jaspar_species_tax_id_mapping.py
@@ -1,0 +1,139 @@
+"""Regression test: jaspar_search_matrices must send its species filter as `tax_id`.
+
+JASPAR names the taxonomy filter ``tax_id``; the tool declared it as ``species``
+and forwarded that name verbatim. JASPAR ignores unrecognised query parameters
+rather than rejecting them, so the filter was dropped and the *unfiltered* result
+set came back as a success:
+
+    species=9606     -> count 215   (all species)
+    species=9999999  -> count 215   (identical: proof the filter was ignored)
+
+After the fix the same queries return 156 and 0 respectively.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tooluniverse.jaspar_tool import JASPARRESTTool
+
+
+CONFIG_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "tooluniverse"
+    / "data"
+    / "jaspar_tools.json"
+)
+CONFIGS = {t["name"]: t for t in json.loads(CONFIG_PATH.read_text())}
+
+
+def _tool_with_capture(name):
+    tool = JASPARRESTTool(dict(CONFIGS[name]))
+    captured = {}
+
+    def get(url, params=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params or {}
+        response = MagicMock()
+        response.status_code = 200
+        response.url = url
+        response.json.return_value = {"count": 0, "results": []}
+        response.raise_for_status.return_value = None
+        return response
+
+    session = MagicMock()
+    session.get.side_effect = get
+    tool.session = session
+    return tool, captured
+
+
+def test_species_is_sent_as_tax_id():
+    tool, captured = _tool_with_capture("jaspar_search_matrices")
+    result = tool.run({"search": "FOX", "species": "9606", "page_size": 5})
+    assert result["status"] == "success"
+    assert captured["params"].get("tax_id") == "9606"
+    assert "species" not in captured["params"], (
+        "JASPAR ignores unknown params, so a leftover `species` key silently "
+        "drops the taxonomy filter"
+    )
+
+
+def test_other_filters_keep_their_names():
+    tool, captured = _tool_with_capture("jaspar_search_matrices")
+    tool.run(
+        {
+            "search": "FOX",
+            "name": "FOXA1",
+            "collection": "CORE",
+            "tax_group": "vertebrates",
+            "page": 2,
+            "page_size": 5,
+        }
+    )
+    params = captured["params"]
+    assert params["search"] == "FOX"
+    assert params["name"] == "FOXA1"
+    assert params["collection"] == "CORE"
+    assert params["tax_group"] == "vertebrates"
+    assert params["page"] == 2
+    assert params["page_size"] == 5
+
+
+def test_config_declares_the_param_map():
+    fields = CONFIGS["jaspar_search_matrices"]["fields"]
+    assert fields.get("param_map", {}).get("species") == "tax_id"
+
+
+def test_config_description_records_the_upstream_name():
+    prop = CONFIGS["jaspar_search_matrices"]["parameter"]["properties"]["species"]
+    assert "tax_id" in prop["description"]
+
+
+def test_path_placeholders_still_resolve_before_mapping():
+    tool, captured = _tool_with_capture("jaspar_get_matrix_versions")
+    tool.run({"base_id": "MA0002", "page_size": 5})
+    assert "MA0002" in captured["url"]
+    assert "base_id" not in captured["params"]
+    assert captured["params"]["page_size"] == 5
+
+
+def test_tools_without_a_param_map_are_unchanged():
+    tool, captured = _tool_with_capture("JASPAR_get_transcription_factors")
+    tool.run({"collection": "CORE", "page_size": 3})
+    assert captured["params"] == {"collection": "CORE", "page_size": 3}
+
+
+def test_none_valued_arguments_are_dropped():
+    tool, captured = _tool_with_capture("jaspar_search_matrices")
+    tool.run({"search": "FOX", "species": None})
+    assert "tax_id" not in captured["params"]
+    assert "species" not in captured["params"]
+
+
+def test_non_param_mode_tool_still_uses_path_substitution():
+    tool, captured = _tool_with_capture("jaspar_get_matrix")
+    result = tool.run({"matrix_id": "MA0002.1"})
+    assert result["status"] == "success"
+    assert captured["url"].endswith("MA0002.1")
+
+
+def test_upstream_error_is_reported_not_raised():
+    tool = JASPARRESTTool(dict(CONFIGS["jaspar_search_matrices"]))
+    session = MagicMock()
+    session.get.side_effect = RuntimeError("boom")
+    tool.session = session
+    result = tool.run({"search": "FOX"})
+    assert result["status"] == "error"
+    assert "JASPAR API error" in result["error"]
+
+
+@pytest.mark.parametrize(
+    "name", ["jaspar_search_matrices", "JASPAR_get_transcription_factors"]
+)
+def test_configs_remain_valid_json_schema_shape(name):
+    cfg = CONFIGS[name]
+    assert cfg["fields"]["use_params"] is True
+    assert "properties" in cfg["parameter"]

--- a/tests/unit/test_result_set_totals_not_page_size.py
+++ b/tests/unit/test_result_set_totals_not_page_size.py
@@ -1,0 +1,326 @@
+"""Regression tests: reported totals must describe the result set, not the page.
+
+Three search tools computed their "total" field from the list they had already
+truncated to ``limit``, so the number they reported was simply the page size:
+
+* ``TCDB_search_family`` reported ``total_matches: 100`` for a query with 165
+  matches, and ``total_matches: 5`` for the same query at ``limit=5``.
+* ``TCDB_search_by_substrate`` did the same (126 true matches for "glucose").
+* ``IGSR_search_populations`` reported ``total: 3`` at ``limit=3`` although the
+  Elasticsearch response carried the true hit count of 212.
+
+Both TCDB searches also capped ``limit`` at 100 with no offset, so the rest of
+the result set was unreachable.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tooluniverse.igsr_tool import IGSRTool
+from tooluniverse.tcdb_tool import TCDBTool
+
+
+# --------------------------------------------------------------------------
+# TCDB
+# --------------------------------------------------------------------------
+
+FAMILY_CONFIG = {
+    "type": "TCDBTool",
+    "name": "TCDB_search_family",
+    "description": "Search TCDB families",
+    "parameter": {"type": "object", "properties": {}},
+    "fields": {"operation": "search_family"},
+}
+
+SUBSTRATE_CONFIG = {
+    "type": "TCDBTool",
+    "name": "TCDB_search_by_substrate",
+    "description": "Search TCDB by substrate",
+    "parameter": {"type": "object", "properties": {}},
+    "fields": {"operation": "search_by_substrate"},
+}
+
+# 165 families under the "1.A" prefix, mirroring the live TCDB numbers.
+FAMILIES = {f"1.A.{i}": f"Channel family {i}" for i in range(1, 166)}
+FAMILIES.update({f"2.A.{i}": f"Porter family {i}" for i in range(1, 31)})
+
+
+def _family_tool():
+    tool = TCDBTool(dict(FAMILY_CONFIG))
+    tool._get_families = lambda: FAMILIES
+    tool._get_acc2tcid = lambda: {"P00001": ["1.A.1.1.1"]}
+    return tool
+
+
+def _substrate_tool(n_matches=126):
+    tool = TCDBTool(dict(SUBSTRATE_CONFIG))
+    entries = [
+        {"tc_number": f"2.A.1.{i}", "substrates": [{"name": "D-glucose"}]}
+        for i in range(n_matches)
+    ]
+    entries += [
+        {"tc_number": f"3.A.1.{i}", "substrates": [{"name": "sodium"}]}
+        for i in range(40)
+    ]
+    tool._get_substrates = lambda: entries
+    tool._get_families = lambda: {}
+    tool._family_for_tc = lambda tc, fams: "family"
+    return tool
+
+
+@pytest.mark.parametrize("limit", [5, 20, 100])
+def test_family_total_is_independent_of_limit(limit):
+    result = _family_tool().run({"family_id": "1.A", "limit": limit})
+    data = result["data"]
+    assert data["total_matches"] == 165, "total must count all matches, not the page"
+    assert data["returned"] == limit
+    assert len(data["families"]) == limit
+    assert data["has_more"] is True
+
+
+@pytest.mark.parametrize("limit", [5, 100])
+def test_substrate_total_is_independent_of_limit(limit):
+    result = _substrate_tool().run({"substrate_name": "glucose", "limit": limit})
+    data = result["data"]
+    assert data["total_matches"] == 126
+    assert data["returned"] == limit
+    assert data["has_more"] is True
+
+
+def test_family_offset_reaches_results_beyond_the_limit_cap():
+    """`limit` is capped at 100; `offset` must make the tail reachable."""
+    result = _family_tool().run({"family_id": "1.A", "offset": 160, "limit": 100})
+    data = result["data"]
+    assert data["total_matches"] == 165
+    assert data["returned"] == 5
+    assert data["has_more"] is False
+    # The page is the tail of the (lexicographically) sorted match list.
+    expected_tail = sorted(f for f in FAMILIES if f.startswith("1.A"))[160:]
+    assert [f["family_id"] for f in data["families"]] == expected_tail
+
+
+def test_family_offset_pages_are_disjoint():
+    first = _family_tool().run({"family_id": "1.A", "limit": 50, "offset": 0})
+    second = _family_tool().run({"family_id": "1.A", "limit": 50, "offset": 50})
+    ids_a = {f["family_id"] for f in first["data"]["families"]}
+    ids_b = {f["family_id"] for f in second["data"]["families"]}
+    assert len(ids_a) == 50 and len(ids_b) == 50
+    assert not ids_a & ids_b
+
+
+def test_substrate_offset_reaches_the_tail():
+    result = _substrate_tool().run(
+        {"substrate_name": "glucose", "offset": 120, "limit": 100}
+    )
+    data = result["data"]
+    assert data["total_matches"] == 126
+    assert data["returned"] == 6
+    assert data["has_more"] is False
+
+
+def test_family_name_filter_total_is_also_untruncated():
+    result = _family_tool().run({"family_name": "Porter", "limit": 5})
+    assert result["data"]["total_matches"] == 30
+    assert result["data"]["returned"] == 5
+
+
+def test_family_requires_a_query():
+    result = _family_tool().run({})
+    assert result["status"] == "error"
+
+
+def test_substrate_requires_a_query():
+    result = _substrate_tool().run({})
+    assert result["status"] == "error"
+
+
+def test_family_empty_result_set_has_no_more():
+    result = _family_tool().run({"family_id": "9.Z", "limit": 10})
+    data = result["data"]
+    assert data["total_matches"] == 0
+    assert data["returned"] == 0
+    assert data["has_more"] is False
+
+
+# --------------------------------------------------------------------------
+# IGSR
+# --------------------------------------------------------------------------
+
+POPULATION_CONFIG = {
+    "type": "IGSRTool",
+    "name": "IGSR_search_populations",
+    "description": "Search IGSR populations",
+    "parameter": {
+        "type": "object",
+        "properties": {"operation": {"default": "search_populations"}},
+    },
+}
+
+
+def _population_hits(n, superpop="EUR"):
+    return [
+        {
+            "_source": {
+                "code": f"POP{i}",
+                "name": f"Population {i}",
+                "description": "",
+                "samples": {"count": 100},
+                "superpopulation": {"code": superpop, "name": superpop},
+            }
+        }
+        for i in range(n)
+    ]
+
+
+def _igsr_tool(hits, total):
+    tool = IGSRTool(dict(POPULATION_CONFIG))
+    tool._es_search = lambda index, body: {
+        "hits": {"total": total, "hits": hits[: body.get("size", 10)]}
+    }
+    return tool
+
+
+@pytest.mark.parametrize("limit", [3, 25, 100])
+def test_population_total_comes_from_elasticsearch_not_the_page(limit):
+    tool = _igsr_tool(_population_hits(300), total=212)
+    result = tool.run({"limit": limit})
+    data = result["data"]
+    assert data["total"] == 212, "total must be the ES hit count, not the page size"
+    assert data["returned"] == min(limit, 212)
+
+
+def test_population_total_handles_elasticsearch7_total_object():
+    tool = _igsr_tool(_population_hits(300), total={"value": 212, "relation": "eq"})
+    result = tool.run({"limit": 3})
+    assert result["data"]["total"] == 212
+
+
+def test_population_superpopulation_total_counts_filtered_matches():
+    """The superpopulation filter runs client-side, so the ES count is wrong there."""
+    hits = _population_hits(5, superpop="EUR") + _population_hits(20, superpop="AFR")
+    tool = _igsr_tool(hits, total=212)
+    result = tool.run({"superpopulation": "EUR", "limit": 3})
+    data = result["data"]
+    assert data["total"] == 5, "must count EUR matches, not all 212 populations"
+    assert data["returned"] == 3
+
+
+def test_population_superpopulation_total_stable_across_limits():
+    hits = _population_hits(5, superpop="EUR") + _population_hits(20, superpop="AFR")
+    totals = {
+        limit: _igsr_tool(hits, total=212).run(
+            {"superpopulation": "EUR", "limit": limit}
+        )["data"]["total"]
+        for limit in (1, 3, 100)
+    }
+    assert set(totals.values()) == {5}
+
+
+def test_population_returned_never_exceeds_available():
+    tool = _igsr_tool(_population_hits(4), total=4)
+    result = tool.run({"limit": 100})
+    assert result["data"]["total"] == 4
+    assert result["data"]["returned"] == 4
+
+
+def test_samples_and_collections_totals_survive_total_object_form():
+    """The shared helper must not regress the siblings that were already correct."""
+    for operation, key in (
+        ("search_samples", "samples"),
+        ("list_data_collections", "collections"),
+    ):
+        config = dict(POPULATION_CONFIG)
+        config["parameter"] = {
+            "type": "object",
+            "properties": {"operation": {"default": operation}},
+        }
+        tool = IGSRTool(config)
+        tool._es_search = lambda index, body: {
+            "hits": {
+                "total": {"value": 3202, "relation": "eq"},
+                "hits": [{"_source": {}} for _ in range(2)],
+            }
+        }
+        result = tool.run({"limit": 2})
+        assert result["data"]["total"] == 3202
+        assert result["data"]["returned"] == 2
+        assert len(result["data"][key]) == 2
+
+
+def test_igsr_unknown_operation_is_an_error():
+    tool = IGSRTool(dict(POPULATION_CONFIG))
+    result = tool.run({"operation": "not_a_real_operation"})
+    assert result["status"] == "error"
+
+
+def test_igsr_es_failure_surfaces_as_error():
+    tool = IGSRTool(dict(POPULATION_CONFIG))
+
+    def boom(index, body):
+        raise RuntimeError("es down")
+
+    tool._es_search = boom
+    result = tool.run({"limit": 5})
+    assert result["status"] == "error"
+
+
+def test_tcdb_config_declares_offset_and_new_schema_fields():
+    import json
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "tooluniverse"
+        / "data"
+        / "tcdb_tools.json"
+    )
+    tools = {t["name"]: t for t in json.loads(path.read_text())}
+    for name in ("TCDB_search_family", "TCDB_search_by_substrate"):
+        props = tools[name]["parameter"]["properties"]
+        assert "offset" in props, f"{name} must document offset"
+        schema = json.dumps(tools[name]["return_schema"])
+        assert "has_more" in schema and "returned" in schema
+
+
+def test_igsr_config_documents_total_semantics():
+    import json
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "tooluniverse"
+        / "data"
+        / "igsr_tools.json"
+    )
+    tools = {t["name"]: t for t in json.loads(path.read_text())}
+    schema = json.dumps(tools["IGSR_search_populations"]["return_schema"])
+    assert "returned" in schema
+    assert "independent of the `limit`" in schema
+
+
+def test_igsr_es_search_is_untouched_by_helper():
+    """_total_hits must be a pure read of the response, not a request."""
+    assert IGSRTool._total_hits({"hits": {"total": 7}}) == 7
+    assert IGSRTool._total_hits({"hits": {"total": {"value": 7}}}) == 7
+    assert IGSRTool._total_hits({}) == 0
+    assert IGSRTool._total_hits({"hits": {}}) == 0
+
+
+def test_tcdb_get_transporter_operation_unaffected():
+    """Only the two search operations changed; lookup must still route normally."""
+    config = dict(FAMILY_CONFIG)
+    config["fields"] = {"operation": "get_transporter"}
+    tool = TCDBTool(config)
+    result = tool.run({})
+    # No accession supplied -> a clean error, not a crash.
+    assert result["status"] == "error"
+    assert isinstance(result.get("error"), str)
+
+
+def test_magicmock_not_leaking_into_results():
+    """Guard against mocks silently standing in for real data in these tests."""
+    result = _family_tool().run({"family_id": "1.A", "limit": 2})
+    assert not isinstance(result["data"]["total_matches"], MagicMock)

--- a/tests/unit/test_worms_search_pagination.py
+++ b/tests/unit/test_worms_search_pagination.py
@@ -1,0 +1,202 @@
+"""Regression tests for WoRMS_search_species paging.
+
+The search used to hard-code ``data[:5]``: the declared ``limit`` parameter was
+ignored entirely, and ``total_found`` reported the size of the single upstream
+page (WoRMS caps every AphiaRecordsByName response at 50 records) rather than
+the size of the result set. A search for "Gadus" returned 5 records and claimed
+``total_found: 50`` when 129 records actually match.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.worms_tool import WoRMSRESTTool
+
+
+SEARCH_CONFIG = {
+    "type": "WoRMSRESTTool",
+    "name": "WoRMS_search_species",
+    "description": "Search marine species in WoRMS",
+    "parameter": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "limit": {"type": "integer"},
+            "offset": {"type": "integer"},
+        },
+        "required": ["query"],
+    },
+    "fields": {"return_format": "JSON"},
+}
+
+
+def _record(i):
+    return {"AphiaID": 1000 + i, "scientificname": f"Gadus species{i}"}
+
+
+def _fake_session(total_records):
+    """Session whose AphiaRecordsByName pages 50 records at a time like WoRMS."""
+    records = [_record(i) for i in range(total_records)]
+
+    def get(url, timeout=None):
+        offset = 1
+        if "offset=" in url:
+            offset = int(url.split("offset=")[1].split("&")[0])
+        page = records[offset - 1 : offset - 1 + WoRMSRESTTool._PAGE_SIZE]
+        response = MagicMock()
+        if not page:
+            response.status_code = 204
+            response.text = ""
+            response.json.return_value = []
+            return response
+        response.status_code = 200
+        response.text = "[...]"
+        response.json.return_value = page
+        return response
+
+    session = MagicMock()
+    session.get.side_effect = get
+    return session
+
+
+def _run(arguments, total_records=129):
+    tool = WoRMSRESTTool(dict(SEARCH_CONFIG))
+    tool.session = _fake_session(total_records)
+    return tool.run(arguments)
+
+
+@pytest.mark.parametrize("limit", [3, 25, 60])
+def test_limit_is_honored(limit):
+    """The declared limit drives the page size instead of a hard-coded 5."""
+    result = _run({"query": "Gadus", "limit": limit})
+    assert result["status"] == "success"
+    assert result["count"] == limit
+    assert len(result["data"]) == limit
+    assert result["has_more"] is True
+
+
+def test_limit_spans_upstream_page_boundary():
+    """A limit above the 50-record upstream page size assembles several pages."""
+    result = _run({"query": "Gadus", "limit": 60})
+    assert len(result["data"]) == 60
+    # Distinct records, not the first page repeated.
+    assert len({r["AphiaID"] for r in result["data"]}) == 60
+
+
+def test_full_result_set_is_reachable():
+    """A large limit returns every match, not the first upstream page of 50."""
+    result = _run({"query": "Gadus", "limit": 500})
+    assert result["count"] == 129
+    assert result["has_more"] is False
+
+
+def test_offset_pages_to_the_tail():
+    result = _run({"query": "Gadus", "limit": 50, "offset": 101})
+    assert result["count"] == 29
+    assert result["has_more"] is False
+    assert result["offset"] == 101
+
+
+def test_default_limit_is_twenty_not_five():
+    result = _run({"query": "Gadus"})
+    assert result["count"] == 20
+    assert result["limit"] == 20
+
+
+def test_no_stale_total_found_field():
+    """The old `total_found` reported the upstream page size, so it is gone."""
+    result = _run({"query": "Gadus", "limit": 5})
+    assert "total_found" not in result
+
+
+def test_exact_limit_at_end_reports_no_more():
+    result = _run({"query": "Gadus", "limit": 129})
+    assert result["count"] == 129
+    assert result["has_more"] is False
+
+
+def test_empty_result_set():
+    result = _run({"query": "Zzzz"}, total_records=0)
+    assert result["status"] == "success"
+    assert result["data"] == []
+    assert result["count"] == 0
+    assert result["has_more"] is False
+
+
+def test_non_integer_limit_is_reported_as_error():
+    result = _run({"query": "Gadus", "limit": "abc"})
+    assert result["status"] == "error"
+    assert "integer" in result["error"]
+
+
+def test_zero_limit_is_rejected():
+    result = _run({"query": "Gadus", "limit": 0})
+    assert result["status"] == "error"
+
+
+def test_upstream_failure_surfaces_as_error():
+    tool = WoRMSRESTTool(dict(SEARCH_CONFIG))
+    session = MagicMock()
+    session.get.side_effect = RuntimeError("boom")
+    tool.session = session
+    result = tool.run({"query": "Gadus"})
+    assert result["status"] == "error"
+    assert "WoRMS API error" in result["error"]
+
+
+def test_config_declares_offset_and_envelope_schema():
+    """The shipped config must document `offset` and use a oneOf envelope."""
+    import json
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "tooluniverse"
+        / "data"
+        / "worms_tools.json"
+    )
+    tools = {t["name"]: t for t in json.loads(path.read_text())}
+    search = tools["WoRMS_search_species"]
+    assert "offset" in search["parameter"]["properties"]
+    assert "oneOf" in search["return_schema"]
+    # The endpoint recorded in the config must be the one the code actually calls.
+    assert "AphiaRecordsByName" in search["fields"]["endpoint"]
+
+
+def test_search_does_not_disturb_aphia_operations():
+    """Enrichment operations keyed by AphiaID are unaffected by the paging change."""
+    config = dict(SEARCH_CONFIG)
+    config["fields"] = {"operation": "classification"}
+    tool = WoRMSRESTTool(config)
+    response = MagicMock()
+    response.status_code = 200
+    response.text = "{}"
+    response.json.return_value = {"AphiaID": 126436, "rank": "Species"}
+    session = MagicMock()
+    session.get.return_value = response
+    tool.session = session
+    result = tool.run({"AphiaID": 126436})
+    assert result["status"] == "success"
+    assert result["data"]["rank"] == "Species"
+
+
+def test_aphia_operation_requires_id():
+    config = dict(SEARCH_CONFIG)
+    config["fields"] = {"operation": "synonyms"}
+    tool = WoRMSRESTTool(config)
+    result = tool.run({})
+    assert result["status"] == "error"
+    assert "AphiaID" in result["error"]
+
+
+@patch("tooluniverse.worms_tool.requests")
+def test_search_requests_use_offset_query_parameter(_requests):
+    """Paging must go through WoRMS's 1-based offset parameter."""
+    tool = WoRMSRESTTool(dict(SEARCH_CONFIG))
+    tool.session = _fake_session(129)
+    tool.run({"query": "Gadus", "limit": 60})
+    called = [c.args[0] for c in tool.session.get.call_args_list]
+    assert any("offset=1" in u for u in called)
+    assert any("offset=51" in u for u in called)


### PR DESCRIPTION
Round 6 of the role-play bug-hunt. Five researcher personas (precision oncology, systems/pathway biology, clinical pharmacogenomics, structural bioinformatics/proteomics, metabolomics/ontology curation) worked real questions end-to-end against tool families rounds 1-5 had not stressed.

**11 fixes, all CLI-verified against the live APIs before any code was touched.** Every candidate was run with and without the input in question plus a bogus-value control, and cross-checked against upstream ground truth. Roughly half of the raw persona reports were discarded as false positives.

Zero file overlap with the four open PRs (#395, #396, #397, #398).

## The recurring theme: a plausible number that is wrong

Every fix here is a tool that returned `status: success` with an authoritative-looking answer that was incorrect — not a tool that broke visibly.

### Silently dropped or inverted filters

**openFDA multi-field searches OR'd their filters instead of AND'ing them** — the highest-impact find of the round, affecting the **47 `FDADrugLabel` tools** that declare more than one search field. Clauses were joined with a bare `+`, which decodes to a space, and openFDA's Lucene parser defaults to OR. The signature was unmistakable: *adding a narrowing filter increased the result count.*

| query | before | after | upstream truth |
|---|---|---|---|
| `drug_interactions:fluconazole` | 1766 | 1766 | — |
| ` + indication:Hypertension` | **5758** | **317** | 317 |
| ` + indication:ZZZQQNOTAN` (bogus) | **1766** | **0** | 0 |

Set arithmetic on the raw API confirms the union: clause A 4325 + clause B 11824 − intersection 833 = 15316, exactly the observed total. A clinician asking "which antidepressants list an MAOI contraindication?" was getting lamotrigine and olanzapine as top hits — neither has one.

A second code path had to be closed too: the typo/synonym broadening fallback ORs terms across fields and uses only the *first* filter's text, so on a multi-filter query it silently dropped the other filters and restored the union. It is now gated to single-filter lookups, where it belongs.

**`jaspar_search_matrices` `species` filter was inert** — the tool sent `species=`, JASPAR's parameter is `tax_id`, and JASPAR ignores unknown query params rather than rejecting them. `species=9606` and `species=9999999` both returned the same 215 FOX matrices. Now 156 and 0. The parameter description already documented it as "NCBI taxonomy ID", so the intent was never in doubt.

**`STRING_functional_enrichment` category `Reactome` always returned 0 terms** — a declared, documented, schema-validated enum value compared against STRING's own label, which is `RCTM`. A gene set with 37 enriched Reactome pathways (including *DNA Double-Strand Break Repair*) reported none. The other eight enum values match STRING exactly and are untouched.

### Counts that meant something other than their name

Four tools computed a "total" from the list they had already truncated, so the number simply echoed `limit` back:

| tool | reported | true |
|---|---|---|
| `TCDB_search_family` (`1.A`) | 5 / 20 / 100 (tracked `limit`) | **165** |
| `TCDB_search_by_substrate` (glucose) | tracked `limit` | **126** |
| `IGSR_search_populations` | 3 at `limit=3` | **212** |
| `Rhea_search_by_chebi` (ATP) | 50 (capped) | **1384** |

`IGSR`'s own sibling operations already read the true Elasticsearch hit count — this aligns `_search_populations` with them. TCDB and Rhea additionally had no pagination escape (`limit` capped at 100 and 50 respectively); both now take an `offset`, and Rhea's limit reaches 1000.

**`WoRMS_search_species`** ignored its declared `limit` entirely and hard-coded `data[:5]`, while `total_found` reported the size of one upstream page. A search for *Gadus* returned 5 records claiming `total_found: 50`; **129** actually match. Pages larger than WoRMS's 50-record cap are now assembled across requests, `offset` pages, and `has_more` replaces the misleading total.

**`cBioPortal_get_samples`/`get_patients`** defaulted to `page_size: 100` while described as "Get all samples", returning 100 of 594 for a TCGA study — as a bare array with no truncation marker. That is the denominator for every mutation-frequency calculation: the same study reports 314 TP53-mutated patients, which against 100 samples is arithmetically impossible.

### Wrong values and wrong identifiers

**`ProteomicsDB` reported the un-normalized intensity as `expression_value` and ranked tissues on it.** All 9 TP53 tissue records fell outside their own `min`/`max` interval — the value and its error bars came from different normalization scales. The tissue ranking was wrong:

| | before | after (correct) |
|---|---|---|
| 1 | embryonic stem cell 6.40 | **breast 5.13** |
| 2 | blood platelet 5.86 | rectum 4.75 |

Verified against ProteomicsDB's documented `proteinexpression.xsodata` columns. Out-of-range records: 9/9 → 0/9.

**`AlphaMissense_get_variant_score` discarded the substituted amino acid.** It read a `scores` key the hotspot API does not have, so `p.L858R` (a canonical oncogenic driver), `p.L858Q`, `p.L858W` and even the invalid `p.L858Z` returned byte-identical payloads — no score, no classification, and a shipped `"Score extraction requires parsing API response format"` TODO. It now classifies from the API's class-membership lists, distinguishes SNV-accessible from all-substitution sets, and rejects invalid, synonymous, and reference-mismatched variants. Since the endpoint genuinely publishes no per-substitution score, `pathogenicity_score` is explicitly `null` with `score_available: false` rather than letting the residue mean stand in for it.

**`Rhea` mangled ID spellings.** A case-sensitive `startswith` check turned `CHEBI_15724` into `CHEBI:CHEBI_15724` — 0 results, reported as success — while `chebi:15724` produced an upstream HTTP 500. All common spellings (`CHEBI:x`, `chebi:x`, `CHEBI_x`, bare `x`, `EC 1.1.1.1`) now normalize; TMAO returns its 7 reactions from every one.

**`ols_get_term_children`/`ancestors` forwarded CURIE casing into case-sensitive OBO PURLs.** `mondo:0005180` — the canonical Bioregistry spelling — returned an empty result byte-identical to a nonexistent term, though Parkinson disease has 6 children. A curator would conclude it is a leaf. The `MONDO_0005180` underscore form, which these tools emit themselves in their own `iri` and `shortForm` fields, errored as a missing parameter. Empty results also returned the raw upstream envelope instead of the normalized shape, so callers reading `data["terms"]` broke on exactly the leaf terms that legitimately have none.

### A dead backend reported as "no data"

**`Metabolite_get_diseases`/`HMDB_get_diseases`** swallowed the CTD mirror's HTTP 404 into an empty list and reported `disease_count: 0` for *every* compound — cholesterol included. The `ctd` backend has been de-registered from `automat.renci.org` entirely. The sibling `CTD_get_chemical_diseases` already surfaces the same 404 as an error; this makes the two consistent.

## Testing

- **100 new regression tests** across 4 files, all offline/mocked.
- **Full unit suite: 3351 passed, 10 skipped, 0 failed.**
- `import tooluniverse.tools` verified.

## Notes for the maintainer

**A convention decision worth making repo-wide.** "A truncated list's length reported as the total" turned up **eight independent times** this round across unrelated families (TCDB ×2, IGSR, Rhea, WoRMS, plus — reported but not fixed here — `ReactomeContent_search`, `ReactomeInteractors_get_protein_interactors`, `PANTHER_enrichment`, `WikiPathways_search`, `RxClass` ×2). This is the single most common defect shape in the codebase. A `grep` for `"total.*": len(` checked against whether the list was already sliced would likely find more. Good in-tree templates already exist: `SIGNOR_get_interactions`, `ComplexPortal_search_complexes`, `Harmonizome_get_gene_set_members` and `PathwayCommons_search` all report `{total, returned}` correctly.

**Verified but deliberately not fixed here**, to keep this PR reviewable and conflict-free — each is independently reproducible from the persona reports:

- `ReactomeAnalysis_*` hardcodes `"page": 1` in all five handlers; a 379-pathway result set is capped at the top 50 with no escape.
- `PANTHER_enrichment` hardcodes `enriched[:50]` and calls it `result_count` (true significant count for a DDR set: 295).
- `WikiPathways_search` is capped at 20 by a `limit` parameter that exists in the code but is absent from the config, so it is undiscoverable (`limit=1000` reveals the true 63).
- `PathwayCommons_get_neighborhood` counts every node in the neighbourhood *subgraph* as a partner of the query gene — CDK2 reports 14,248 partners against a true 1,440, and 19 of 20 returned rows do not involve CDK2 at all.
- `FDA_OrangeBook_check_generic_availability` counts the brand-name reference drug among its own generics (COUMADIN: 21 vs 18 true ANDAs); `FDA_OrangeBook_get_te_code` inherits an undeclared `limit=10` that drops 3 of 8 warfarin ANDAs.
- `DepMap_get_gene_dependencies` returns no dependency scores at all and silently ignores `model_id`; `DepMap_get_cell_lines` accepts `tissue`/`cancer_type` filters that are inert (bogus and real values return identical rows).
- `COSMIC_get_mutations_by_gene` has a hard ~193-result ceiling against `total_count: 10000`, so no canonical TP53 hotspot (R175H, R248Q, R273H) is reachable.
- `SABIO_RK_search_reactions`/`BRENDA_get_enzyme_kinetics` read Solr fields that do not exist, so kinetic *values* are always empty although the numbers sit unparsed in the same document.
- `OmniPath` crashes with `'list' object has no attribute 'get'` on an HTTP-200 JSON error body whose message is actionable.
- `InterPro_search_entries` never requests `extra_fields=counters`, so the `protein_count`/`structure_count`/`taxa_count` its description promises are unconditionally null.

**One code-evident issue left unfixed because it could not be CLI-verified:** `SwissTargetPrediction_predict` computes `total_targets` after applying `top_n`. The tool cannot currently run — its own description records that upstream job-URL extraction is non-deterministic — so no live before/after was possible and no unverifiable change was shipped.
