### PR TITLE
feat: add Genomic Intelligence MCP auto-loader (15 DNA-analysis tools, keyless)

### DIFF
--- a/src/tooluniverse/data/mcp_auto_loader_gi.json
+++ b/src/tooluniverse/data/mcp_auto_loader_gi.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "mcp_auto_loader_gi",
+    "description": "Automatically discover and load Genomic Intelligence DNA sequence-analysis tools from the hosted Genomic Intelligence MCP server. Provides transformer DNA language-model predictions over six tasks (promoter, splice sites, enhancer activity, chromatin state, expression, gene annotation) plus a composite find-genes-then-predict-expression workflow, and helpers that fetch sequence from Ensembl into a reusable handle. The server is public and needs no API key; calls run against a shared, rate-limited demo quota. For research and development use, not clinical or diagnostic decisions.",
+    "type": "MCPAutoLoaderTool",
+    "tool_prefix": "gi_",
+    "server_url": "https://mcp.genomicintelligence.ai/mcp",
+    "transport": "http",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "operation": {
+          "type": "string",
+          "enum": [
+            "discover",
+            "generate_configs",
+            "call_tool"
+          ],
+          "description": "The operation to perform: discover tools, generate configs, or call a tool directly"
+        },
+        "tool_name": {
+          "type": "string",
+          "description": "Name of the MCP tool to call (required for call_tool operation)"
+        },
+        "tool_arguments": {
+          "type": "object",
+          "description": "Arguments to pass to the MCP tool (for call_tool operation)"
+        }
+      },
+      "required": [
+        "operation"
+      ]
+    },
+    "return_schema": {
+      "type": "object",
+      "description": "MCP server auto-discovered tools and their execution results. Structure varies by discovered tool (fetch_*, predict_*, find_genes*, get_job, list_jobs, list_models, store_inline_sequence).",
+      "additionalProperties": true
+    }
+  }
+]

--- a/src/tooluniverse/data/mcp_auto_loader_gi.json
+++ b/src/tooluniverse/data/mcp_auto_loader_gi.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "mcp_auto_loader_gi",
-    "description": "Automatically discover and load Genomic Intelligence DNA sequence-analysis tools from the hosted Genomic Intelligence MCP server. Provides transformer DNA language-model predictions over six tasks (promoter, splice sites, enhancer activity, chromatin state, expression, gene annotation) plus a composite find-genes-then-predict-expression workflow, and helpers that fetch sequence from Ensembl into a reusable handle. The server is public and needs no API key; calls run against a shared, rate-limited demo quota. For research and development use, not clinical or diagnostic decisions.",
+    "description": "Automatically discover and load Genomic Intelligence DNA sequence-analysis tools from the hosted Genomic Intelligence MCP server. Provides transformer DNA language-model predictions over six tasks (promoter, splice sites, enhancer activity, chromatin state, expression, gene annotation) plus a composite find-genes-then-predict-expression workflow, and helpers that turn a sequence into a reusable handle (fetched from Ensembl, loaded from a bundled demo, or pasted inline). The server is public and needs no API key; calls run against shared, rate-limited demo capacity. Bounds, fields and error codes are published at https://api.genomicintelligence.ai/v1/openapi.json. Research and development use. Not for clinical or diagnostic decisions.",
     "type": "MCPAutoLoaderTool",
     "tool_prefix": "gi_",
     "server_url": "https://mcp.genomicintelligence.ai/mcp",
@@ -33,7 +33,7 @@
     },
     "return_schema": {
       "type": "object",
-      "description": "MCP server auto-discovered tools and their execution results. Structure varies by discovered tool (fetch_*, predict_*, find_genes*, get_job, list_jobs, list_models, store_inline_sequence).",
+      "description": "MCP server auto-discovered tools and their execution results. Structure varies by discovered tool (fetch_*, predict_*, find_genes*, get_job, list_jobs, list_models, load_demo_sequence, store_inline_sequence).",
       "additionalProperties": true
     }
   }

--- a/src/tooluniverse/default_config.py
+++ b/src/tooluniverse/default_config.py
@@ -352,6 +352,7 @@ default_tool_files = {
     "mcp_auto_loader_esm": os.path.join(
         current_dir, "data", "mcp_auto_loader_esm.json"
     ),
+    "mcp_auto_loader_gi": os.path.join(current_dir, "data", "mcp_auto_loader_gi.json"),
     "cryoet": os.path.join(current_dir, "data", "cryoet_tools.json"),
     "esm": os.path.join(current_dir, "data", "esm_tools.json"),
     "structure_annotation": os.path.join(


### PR DESCRIPTION
## Summary

Adds one `MCPAutoLoaderTool` config pointing at the hosted **Genomic
Intelligence** MCP server, so ToolUniverse auto-discovers a set of DNA
sequence-analysis tools with no new Python and no API key.

Genomic Intelligence serves transformer DNA language models over hosted
inference. Discovery currently yields **15 tools**, namespaced `gi_` by
`tool_prefix`:

- **Prediction:** `gi_predict_promoter`, `gi_predict_splice`,
  `gi_predict_enhancer`, `gi_predict_chromatin`, `gi_predict_expression`
- **Composite:** `gi_find_genes`, `gi_find_genes_and_predict_expression`
  (annotate a region, then predict each gene's expression)
- **Sequence acquisition (handles, so long sequences stay out of context):**
  `gi_fetch_ensembl_sequence`, `gi_fetch_region`, `gi_fetch_gene_for_expression`,
  `gi_load_demo_sequence`, `gi_store_inline_sequence`
- **Jobs and metadata:** `gi_get_job`, `gi_list_jobs`, `gi_list_models`

## Dependency on #401

This is the first auto-loader that is active by default (see "One deliberate
difference" below), so it is the first config that constructs an
`MCPAutoLoaderTool` during normal startup. On current `main` that construction
writes diagnostics to stdout via `print()`, which corrupts the JSON-RPC stream
in stdio mode and fails the `test_stdio_*` integration tests. That is a
pre-existing issue in `mcp_client_tool.py`, not something this config
introduces, and it is fixed independently in #401 (which routes those prints
through the package logger to stderr).

Because of that, the stdio integration tests on this PR will stay red until #401
merges. I kept the two changes in separate PRs so the logging fix can be
reviewed on its own merits. If you would prefer them combined, I am happy to do
that instead.

## Changes

Two files:

- `src/tooluniverse/data/mcp_auto_loader_gi.json` (new)
- `src/tooluniverse/default_config.py`, one entry in `default_tool_files`

Nothing else. `api_keys_catalog.json`, `.env.template`, `src/tooluniverse/tools/`
and `docs/tools/` are generated, so they are left to their generators.

## Why it fits

- **Uses the existing MCP path.** Same mechanism as
  `mcp_auto_loader_esm.json`, `boltz_mcp_loader_tools.json`,
  `txagent_client_tools.json`, `expert_feedback_tools.json` and
  `uspto_downloader_tools.json`. Zero new code to review or maintain; if the
  server gains a tool, ToolUniverse picks it up on the next `load_tools()`.
- **Fills a gap.** The registry's existing sequence-to-function DNA models are
  key-gated: `alphagenome_tools.json` requires `ALPHA_GENOME_API_KEY` and
  `evo2_variant_effect_tools.json` requires `NVIDIA_API_KEY`. This one runs with
  nothing set.

## One deliberate difference from the existing loaders

All five current `MCPAutoLoaderTool` configs point at self-hosted servers and
name a `${...}` host or URL variable in `required_api_keys`, so with the variable
unset the config is filtered out in `_filter_and_deduplicate_tools` and the
loader never runs. Genomic Intelligence has a fixed public URL and no key
requirement, so **this is the first auto-loader that is active by default**:
`load_tools()` will make one `tools/list` round trip to
`mcp.genomicintelligence.ai`.

That is the point (15 tools with zero setup), but the cost is real for offline
users. The config sets no `timeout`, so `MCPAutoLoaderTool.__init__` passes
`tool_config.get("timeout", 5)` to `BaseMCPClient` and the HTTP client is bounded
at 5 s; the outer `asyncio.wait_for` in `_process_mcp_auto_loaders` reads the
same field with its own fallback of 30 s, so in the pathological case where the
client does not raise first that is the ceiling. A timeout there is caught and
downgraded to a warning, and any other discovery error is caught by the
surrounding handler, so a failed or offline discovery does not break
`load_tools()`. Proxy tools generated by the loader inherit neither value:
`generate_proxy_tool_configs` does not emit a `timeout`, so they keep
`MCPClientTool`'s 600 s default and long-running predictions are unaffected.
If you would rather have one explicit bound, I am happy to add `"timeout": 5`
to the config, which sets both.

**If you would rather it be opt-in**, say so and I will switch it to the ESM
shape in a follow-up commit on this branch: `"server_url":
"${GI_MCP_SERVER_URL}"` with `"required_api_keys": ["GI_MCP_SERVER_URL"]` and an
`api_key_info` block of `type: "endpoint"` (which also updates the generated
catalog and `.env.template`). Happy either way.

## On API keys

No key is declared, on purpose. The hosted server is reachable **with no
credentials at all**: an anonymous `initialize` followed by `tools/list` against
`https://mcp.genomicintelligence.ai/mcp` returns the full tool list, and the
`predict_*` tools return real results, with nothing set in the environment. Usage
runs against a shared, rate-limited public demo quota. On top of that,
`BaseMCPClient` in `mcp_client_tool.py` calls
`streamablehttp_client(endpoint, timeout=...)` without a `headers` argument, so
there is currently no way for a tool config to send an `Authorization` header to
an MCP server. Declaring an optional key would put a row in
`api_keys_catalog.json` and `.env.template` that nothing could act on.

Consequently `python3 scripts/gen_api_key_catalog.py` produces byte-identical
output before and after this change, and the `sync-api-keys` workflow has
nothing to sync.

If per-user keys for authenticated MCP servers are interesting to you, the
general fix is small: thread an optional `headers` dict from the tool config
through `BaseMCPClient._make_mcp_request` into `streamablehttp_client`, which the
MCP SDK already supports. Happy to send that as a separate PR; it would help any
authenticated MCP server, not just this one.

## How it was verified

Checked directly against this branch:

- `default_tool_files["mcp_auto_loader_gi"]` resolves and the JSON loads with
  `type == "MCPAutoLoaderTool"` and `tool_prefix == "gi_"`.
- `python3 scripts/gen_api_key_catalog.py` leaves
  `src/tooluniverse/data/api_keys_catalog.json` and `.env.template` unchanged
  (identical checksum before and after).
- `ruff format --check src/tooluniverse/default_config.py` passes.
- Live keyless discovery against `https://mcp.genomicintelligence.ai/mcp`
  returns the 15 tools listed above with no credentials set.

The network-marked tests are excluded from the CI selection, so the live
discovery above is a manual check rather than an automated one. I did not run
the full integration suite locally; as noted under "Dependency on #401", the
stdio integration tests need that fix to pass. Glad to add a unit test asserting
the config is registered and well formed if you would like one in the suite.

## Notes

- For research and development use, not clinical or diagnostic decisions; the
  server states this in its MCP `instructions` and it is repeated in the tool
  description.
- No model IDs are pinned; `gi_list_models` reports what is live and the server
  resolves defaults.
- Docs: <https://docs.genomicintelligence.ai>
