### PR TITLE
Add gene liability evaluation skill

### DIFF
--- a/plugin/skills/tooluniverse-gene-liability/SKILL.md
+++ b/plugin/skills/tooluniverse-gene-liability/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: tooluniverse-gene-liability
+description: Evaluate the human safety liability of knocking down, knocking out, degrading, or pharmacologically inhibiting a gene. Use for gene safety scoring, on-target toxicity assessment, essentiality and genetic-constraint review, critical-organ expression analysis, or deciding whether a target needs partial, transient, or tissue-specific modulation.
+---
+
+# Gene Liability Evaluation
+
+Assess whether reducing a human gene's function is likely to be unsafe. Resolve the
+gene, gather independent human and model-system evidence, calculate a transparent
+0–100 liability score, and recommend an appropriate modulation strategy.
+
+Higher scores mean greater predicted liability from the stated intervention. This is
+a safety score, not a target-efficacy or druggability score.
+
+## Required Input
+
+Accept a gene symbol, name, Ensembl ID, or UniProt accession. Also capture:
+
+- intervention modality: knockout, knockdown, degrader, irreversible inhibitor,
+  reversible inhibitor, antibody, or unknown;
+- intended tissue and indication, when supplied;
+- desired inhibition depth and duration, when supplied.
+
+If modality is absent, assess complete systemic loss of function and label that
+assumption prominently. Do not silently generalize a knockout result to partial or
+tissue-restricted pharmacology.
+
+## Evidence Rules
+
+- Look up the gene before reasoning. Do not score an ambiguous identifier.
+- Use human causal evidence before animal models, screens, expression, or prediction.
+- Treat absent data as unknown, never as evidence of safety.
+- Cite every score-changing observation with the source and identifier.
+- Separate germline loss of function, somatic loss, acute pharmacology, and chronic
+  pharmacology.
+- Treat DepMap as cancer-cell essentiality, not normal-tissue essentiality.
+- Report contradictory evidence instead of averaging it away.
+
+Grade evidence as:
+
+- **T1**: human clinical outcome or replicated causal human genetics;
+- **T2**: curated human evidence, mammalian knockout phenotype, or established drug
+  class safety;
+- **T3**: functional screen, tissue expression, or single experimental study;
+- **T4**: computational prediction or catalog annotation.
+
+## Workflow
+
+### 1. Resolve the gene
+
+Use `MyGene_query_genes` with `species="human"` and request symbol, name, Ensembl,
+UniProt, and Entrez identifiers. Require an exact symbol or identifier match. If the
+query maps to multiple loci, stop and ask for clarification.
+
+Carry the approved symbol and Ensembl gene ID through every subsequent query.
+
+### 2. Gather the five scoring dimensions
+
+Run independent paths. A failed path must use its fallback or be marked unavailable.
+
+| Dimension | Weight | Primary evidence | Fallback |
+|---|---:|---|---|
+| Human genetic constraint | 25 | `gnomad_get_gene_constraints(gene_symbol=...)` | ClinVar loss-of-function variants and literature |
+| Mammalian knockout phenotype | 25 | `OpenTargets_get_biological_mouse_models_by_ensemblID(ensemblId=...)` | MGI-focused literature search |
+| Critical-organ expression | 20 | `GTEx_get_median_gene_expression(operation="get_median_gene_expression", gencode_id=...)` | `HPA_get_comprehensive_gene_details_by_ensembl_id(..., include_expression=true)` |
+| Observed on-target effects | 20 | `OpenTargets_get_target_safety_profile_by_ensemblID(ensemblId=...)` | `ClinVar_search_variants`, associated drugs, and literature |
+| Cellular essentiality and redundancy | 10 | `DepMap_get_gene_dependencies(gene_symbol=...)` | pathway, paralog, and functional-screen literature |
+
+Also query `OpenTargets_get_associated_drugs_by_target_ensemblID` to distinguish
+observed target-class toxicity from hypothetical risk. Do not interpret the mere
+existence of a drug as proof of safety.
+
+For expression, inspect heart, central nervous system, liver, kidney, lung, immune or
+marrow compartments, and reproductive tissues. Compare the gene across tissues;
+do not compare raw TPM values between unrelated genes as if they shared one threshold.
+
+### 3. Assign dimension points
+
+Use only evidence actually retrieved.
+
+#### Human genetic constraint — 0 to 25
+
+- **25**: strong loss-of-function intolerance, such as pLI at least 0.9 together
+  with LOEUF or observed/expected LoF at most 0.35;
+- **15**: one strong constraint signal or intermediate LoF constraint;
+- **5**: weak or conflicting constraint;
+- **0**: credible tolerance to loss of function.
+
+Use LOEUF when available; label observed/expected LoF as a proxy when LOEUF is absent.
+
+#### Mammalian knockout phenotype — 0 to 25
+
+- **25**: embryonic or perinatal lethality, or severe multisystem phenotype;
+- **18**: reduced survival, organ failure, severe neurologic, immune, reproductive,
+  or developmental phenotype;
+- **8**: viable knockout with a consequential but organ-limited phenotype;
+- **0**: replicated viable knockout without a consequential phenotype.
+
+#### Critical-organ expression — 0 to 20
+
+- **20**: broad high expression involving at least three critical organ systems;
+- **12**: high expression in one or two critical organs or broad moderate expression;
+- **6**: low-to-moderate critical-organ expression;
+- **0**: credible restriction to the intended or noncritical tissue with negligible
+  critical-organ expression.
+
+#### Observed on-target effects — 0 to 20
+
+- **20**: severe human disease from reduced function or consistent serious
+  target-related toxicity;
+- **12**: a credible human adverse phenotype or reproducible class effect;
+- **5**: preclinical, isolated, or mechanistically plausible safety signal;
+- **0**: human protective loss-of-function or well-tolerated target modulation with
+  no serious on-target signal at relevant exposure.
+
+Protective variants can reduce concern only when their direction, dosage, tissue,
+and lifelong-versus-acute exposure are relevant to the proposed intervention.
+
+#### Cellular essentiality and redundancy — 0 to 10
+
+- **10**: broad common-essential signal with little credible redundancy;
+- **5**: context-selective dependency or partial redundancy;
+- **0**: reproducible non-essentiality or strong functional redundancy.
+
+If DepMap returns only gene metadata without dependency scores, mark this dimension
+unavailable. Never infer essentiality from a successful lookup alone.
+
+### 4. Calculate score, coverage, and confidence
+
+For available dimensions, calculate:
+
+`liability score = 100 × points earned / available weight`
+
+Report the available weight as evidence coverage. Do not assign zero points to a
+missing dimension.
+
+- **0–24**: low liability;
+- **25–49**: moderate liability;
+- **50–74**: high liability;
+- **75–100**: very high liability.
+
+Publish a categorical score only when coverage is at least 60%. Below 60%, report
+“insufficient evidence” and list the experiments or datasets needed.
+
+Assign confidence independently:
+
+- **High**: at least 90% coverage with both T1 and independent T2 evidence;
+- **Moderate**: at least 70% coverage with T1 or T2 evidence;
+- **Low**: 60–69% coverage or evidence dominated by T3/T4;
+- **Insufficient**: below 60% coverage.
+
+### 5. Translate liability into a strategy
+
+Do not stop at a risk label. Explain whether the evidence favors:
+
+- partial rather than complete inhibition;
+- reversible or transient rather than irreversible modulation;
+- tissue-targeted delivery;
+- isoform- or domain-selective modulation;
+- biomarker-based exclusion or monitoring;
+- deprioritization until a specific safety experiment closes the key gap.
+
+## Required Output
+
+Return these sections:
+
+1. **Resolved gene and intervention assumption** — identifiers, modality, tissue,
+   inhibition depth, and duration.
+2. **Liability verdict** — score, band, evidence coverage, and confidence.
+3. **Dimension table** — evidence, points, maximum weight, tier, citation, and
+   conflicts for all five dimensions.
+4. **Key red flags and protective evidence** — list both sides explicitly.
+5. **Modulation recommendation** — full, partial, transient, tissue-specific, or
+   no-go, with rationale.
+6. **Data gaps and next experiments** — prioritize the missing evidence most likely
+   to change the verdict.
+7. **Sources** — database record links, study identifiers, and access dates.
+
+End with: “This is a research risk assessment, not a clinical safety determination.”

--- a/plugin/skills/tooluniverse/SKILL.md
+++ b/plugin/skills/tooluniverse/SKILL.md
@@ -106,6 +106,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "research", "profile", "**drug**", "medication", "therapeutic agent", "tell me about [drug]" | `Skill(skill="tooluniverse-drug-research")` |
 | "**literature review**", "papers about", "publications on", "research articles", "recent studies" | `Skill(skill="tooluniverse-literature-deep-research")` |
 | "research", "profile", "**target**", "protein target", "gene target", "target validation" | `Skill(skill="tooluniverse-target-research")` |
+| "**gene liability**", "gene safety score", "knockout safety", "knockdown safety", "on-target toxicity", "safe to inhibit [gene]" | `Skill(skill="tooluniverse-gene-liability")` |
 | "**peptide target**", "**deorphanize**", "deorphanization", "**peptide off-target**", "what does [peptide] bind", "target of a peptide", "orphan peptide", "peptide doesn't bind [target]", "binds in [species] but not", "find the receptor for [peptide]" | `Skill(skill="tooluniverse-peptide-target-deorphanization")` |
 
 ### 3. Clinical Decision Support

--- a/plugins/tooluniverse/skills/tooluniverse-gene-liability/SKILL.md
+++ b/plugins/tooluniverse/skills/tooluniverse-gene-liability/SKILL.md
@@ -1,0 +1,180 @@
+---
+
+name: tooluniverse-gene-liability
+description: "Evaluate the human safety liability of knocking down, knocking out, degrading, or pharmacologically inhibiting a gene. Use for gene safety scoring, on-target toxicity assessment, essentiality and genetic-constraint review, critical-organ expression analysis, or deciding whether a target needs partial, transient, or tissue-specific modulation."
+---
+
+# Gene Liability Evaluation
+
+Assess whether reducing a human gene's function is likely to be unsafe. Resolve the
+gene, gather independent human and model-system evidence, calculate a transparent
+0–100 liability score, and recommend an appropriate modulation strategy.
+
+Higher scores mean greater predicted liability from the stated intervention. This is
+a safety score, not a target-efficacy or druggability score.
+
+## Required Input
+
+Accept a gene symbol, name, Ensembl ID, or UniProt accession. Also capture:
+
+- intervention modality: knockout, knockdown, degrader, irreversible inhibitor,
+  reversible inhibitor, antibody, or unknown;
+- intended tissue and indication, when supplied;
+- desired inhibition depth and duration, when supplied.
+
+If modality is absent, assess complete systemic loss of function and label that
+assumption prominently. Do not silently generalize a knockout result to partial or
+tissue-restricted pharmacology.
+
+## Evidence Rules
+
+- Look up the gene before reasoning. Do not score an ambiguous identifier.
+- Use human causal evidence before animal models, screens, expression, or prediction.
+- Treat absent data as unknown, never as evidence of safety.
+- Cite every score-changing observation with the source and identifier.
+- Separate germline loss of function, somatic loss, acute pharmacology, and chronic
+  pharmacology.
+- Treat DepMap as cancer-cell essentiality, not normal-tissue essentiality.
+- Report contradictory evidence instead of averaging it away.
+
+Grade evidence as:
+
+- **T1**: human clinical outcome or replicated causal human genetics;
+- **T2**: curated human evidence, mammalian knockout phenotype, or established drug
+  class safety;
+- **T3**: functional screen, tissue expression, or single experimental study;
+- **T4**: computational prediction or catalog annotation.
+
+## Workflow
+
+### 1. Resolve the gene
+
+Use `MyGene_query_genes` with `species="human"` and request symbol, name, Ensembl,
+UniProt, and Entrez identifiers. Require an exact symbol or identifier match. If the
+query maps to multiple loci, stop and ask for clarification.
+
+Carry the approved symbol and Ensembl gene ID through every subsequent query.
+
+### 2. Gather the five scoring dimensions
+
+Run independent paths. A failed path must use its fallback or be marked unavailable.
+
+| Dimension | Weight | Primary evidence | Fallback |
+|---|---:|---|---|
+| Human genetic constraint | 25 | `gnomad_get_gene_constraints(gene_symbol=...)` | ClinVar loss-of-function variants and literature |
+| Mammalian knockout phenotype | 25 | `OpenTargets_get_biological_mouse_models_by_ensemblID(ensemblId=...)` | MGI-focused literature search |
+| Critical-organ expression | 20 | `GTEx_get_median_gene_expression(operation="get_median_gene_expression", gencode_id=...)` | `HPA_get_comprehensive_gene_details_by_ensembl_id(..., include_expression=true)` |
+| Observed on-target effects | 20 | `OpenTargets_get_target_safety_profile_by_ensemblID(ensemblId=...)` | `ClinVar_search_variants`, associated drugs, and literature |
+| Cellular essentiality and redundancy | 10 | `DepMap_get_gene_dependencies(gene_symbol=...)` | pathway, paralog, and functional-screen literature |
+
+Also query `OpenTargets_get_associated_drugs_by_target_ensemblID` to distinguish
+observed target-class toxicity from hypothetical risk. Do not interpret the mere
+existence of a drug as proof of safety.
+
+For expression, inspect heart, central nervous system, liver, kidney, lung, immune or
+marrow compartments, and reproductive tissues. Compare the gene across tissues;
+do not compare raw TPM values between unrelated genes as if they shared one threshold.
+
+### 3. Assign dimension points
+
+Use only evidence actually retrieved.
+
+#### Human genetic constraint — 0 to 25
+
+- **25**: strong loss-of-function intolerance, such as pLI at least 0.9 together
+  with LOEUF or observed/expected LoF at most 0.35;
+- **15**: one strong constraint signal or intermediate LoF constraint;
+- **5**: weak or conflicting constraint;
+- **0**: credible tolerance to loss of function.
+
+Use LOEUF when available; label observed/expected LoF as a proxy when LOEUF is absent.
+
+#### Mammalian knockout phenotype — 0 to 25
+
+- **25**: embryonic or perinatal lethality, or severe multisystem phenotype;
+- **18**: reduced survival, organ failure, severe neurologic, immune, reproductive,
+  or developmental phenotype;
+- **8**: viable knockout with a consequential but organ-limited phenotype;
+- **0**: replicated viable knockout without a consequential phenotype.
+
+#### Critical-organ expression — 0 to 20
+
+- **20**: broad high expression involving at least three critical organ systems;
+- **12**: high expression in one or two critical organs or broad moderate expression;
+- **6**: low-to-moderate critical-organ expression;
+- **0**: credible restriction to the intended or noncritical tissue with negligible
+  critical-organ expression.
+
+#### Observed on-target effects — 0 to 20
+
+- **20**: severe human disease from reduced function or consistent serious
+  target-related toxicity;
+- **12**: a credible human adverse phenotype or reproducible class effect;
+- **5**: preclinical, isolated, or mechanistically plausible safety signal;
+- **0**: human protective loss-of-function or well-tolerated target modulation with
+  no serious on-target signal at relevant exposure.
+
+Protective variants can reduce concern only when their direction, dosage, tissue,
+and lifelong-versus-acute exposure are relevant to the proposed intervention.
+
+#### Cellular essentiality and redundancy — 0 to 10
+
+- **10**: broad common-essential signal with little credible redundancy;
+- **5**: context-selective dependency or partial redundancy;
+- **0**: reproducible non-essentiality or strong functional redundancy.
+
+If DepMap returns only gene metadata without dependency scores, mark this dimension
+unavailable. Never infer essentiality from a successful lookup alone.
+
+### 4. Calculate score, coverage, and confidence
+
+For available dimensions, calculate:
+
+`liability score = 100 × points earned / available weight`
+
+Report the available weight as evidence coverage. Do not assign zero points to a
+missing dimension.
+
+- **0–24**: low liability;
+- **25–49**: moderate liability;
+- **50–74**: high liability;
+- **75–100**: very high liability.
+
+Publish a categorical score only when coverage is at least 60%. Below 60%, report
+“insufficient evidence” and list the experiments or datasets needed.
+
+Assign confidence independently:
+
+- **High**: at least 90% coverage with both T1 and independent T2 evidence;
+- **Moderate**: at least 70% coverage with T1 or T2 evidence;
+- **Low**: 60–69% coverage or evidence dominated by T3/T4;
+- **Insufficient**: below 60% coverage.
+
+### 5. Translate liability into a strategy
+
+Do not stop at a risk label. Explain whether the evidence favors:
+
+- partial rather than complete inhibition;
+- reversible or transient rather than irreversible modulation;
+- tissue-targeted delivery;
+- isoform- or domain-selective modulation;
+- biomarker-based exclusion or monitoring;
+- deprioritization until a specific safety experiment closes the key gap.
+
+## Required Output
+
+Return these sections:
+
+1. **Resolved gene and intervention assumption** — identifiers, modality, tissue,
+   inhibition depth, and duration.
+2. **Liability verdict** — score, band, evidence coverage, and confidence.
+3. **Dimension table** — evidence, points, maximum weight, tier, citation, and
+   conflicts for all five dimensions.
+4. **Key red flags and protective evidence** — list both sides explicitly.
+5. **Modulation recommendation** — full, partial, transient, tissue-specific, or
+   no-go, with rationale.
+6. **Data gaps and next experiments** — prioritize the missing evidence most likely
+   to change the verdict.
+7. **Sources** — database record links, study identifiers, and access dates.
+
+End with: “This is a research risk assessment, not a clinical safety determination.”

--- a/plugins/tooluniverse/skills/tooluniverse/SKILL.md
+++ b/plugins/tooluniverse/skills/tooluniverse/SKILL.md
@@ -107,6 +107,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "research", "profile", "**drug**", "medication", "therapeutic agent", "tell me about [drug]" | `Skill(skill="tooluniverse-drug-research")` |
 | "**literature review**", "papers about", "publications on", "research articles", "recent studies" | `Skill(skill="tooluniverse-literature-deep-research")` |
 | "research", "profile", "**target**", "protein target", "gene target", "target validation" | `Skill(skill="tooluniverse-target-research")` |
+| "**gene liability**", "gene safety score", "knockout safety", "knockdown safety", "on-target toxicity", "safe to inhibit [gene]" | `Skill(skill="tooluniverse-gene-liability")` |
 | "**peptide target**", "**deorphanize**", "deorphanization", "**peptide off-target**", "what does [peptide] bind", "target of a peptide", "orphan peptide", "peptide doesn't bind [target]", "binds in [species] but not", "find the receptor for [peptide]" | `Skill(skill="tooluniverse-peptide-target-deorphanization")` |
 
 ### 3. Clinical Decision Support

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
 # ToolUniverse Skills
 
-68 pre-built research skills for AI agents. Skills are automatically available — just ask naturally.
+69 pre-built research skills for AI agents. Skills are automatically available — just ask naturally.
 
 ```
 "Find the E. coli K-12 genome"           → tooluniverse-sequence-retrieval
@@ -41,6 +41,7 @@ npx skills add mims-harvard/ToolUniverse
 | `tooluniverse-epigenomics` | Epigenomics and gene regulation (ENCODE, JASPAR, methylation) |
 | `tooluniverse-expression-data-retrieval` | Gene expression datasets from ArrayExpress and BioStudies |
 | `tooluniverse-gene-enrichment` | Gene enrichment and pathway analysis (gseapy, PANTHER, STRING, etc.) |
+| `tooluniverse-gene-liability` | Human safety liability scoring for gene inhibition or loss of function |
 | `tooluniverse-gwas-drug-discovery` | GWAS signals to drug targets and repurposing opportunities |
 | `tooluniverse-gwas-finemapping` | Causal variant prioritization via statistical fine-mapping |
 | `tooluniverse-gwas-snp-interpretation` | Genetic variant interpretation from GWAS studies |

--- a/skills/README.md
+++ b/skills/README.md
@@ -112,4 +112,7 @@ skill-name/
 1. Create `skill-name/SKILL.md` with proper frontmatter
 2. Keep SKILL.md concise (<500 lines)
 3. Add examples for common use cases
-4. See `create-tooluniverse-skill` for the full workflow
+4. Keep canonical skills host-agnostic. Do not add client-specific metadata such
+   as `agents/openai.yaml`; generate host-specific files in the corresponding
+   plugin packaging layer instead.
+5. See `create-tooluniverse-skill` for the full workflow

--- a/skills/tooluniverse-gene-liability/SKILL.md
+++ b/skills/tooluniverse-gene-liability/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: tooluniverse-gene-liability
+description: Evaluate the human safety liability of knocking down, knocking out, degrading, or pharmacologically inhibiting a gene. Use for gene safety scoring, on-target toxicity assessment, essentiality and genetic-constraint review, critical-organ expression analysis, or deciding whether a target needs partial, transient, or tissue-specific modulation.
+---
+
+# Gene Liability Evaluation
+
+Assess whether reducing a human gene's function is likely to be unsafe. Resolve the
+gene, gather independent human and model-system evidence, calculate a transparent
+0–100 liability score, and recommend an appropriate modulation strategy.
+
+Higher scores mean greater predicted liability from the stated intervention. This is
+a safety score, not a target-efficacy or druggability score.
+
+## Required Input
+
+Accept a gene symbol, name, Ensembl ID, or UniProt accession. Also capture:
+
+- intervention modality: knockout, knockdown, degrader, irreversible inhibitor,
+  reversible inhibitor, antibody, or unknown;
+- intended tissue and indication, when supplied;
+- desired inhibition depth and duration, when supplied.
+
+If modality is absent, assess complete systemic loss of function and label that
+assumption prominently. Do not silently generalize a knockout result to partial or
+tissue-restricted pharmacology.
+
+## Evidence Rules
+
+- Look up the gene before reasoning. Do not score an ambiguous identifier.
+- Use human causal evidence before animal models, screens, expression, or prediction.
+- Treat absent data as unknown, never as evidence of safety.
+- Cite every score-changing observation with the source and identifier.
+- Separate germline loss of function, somatic loss, acute pharmacology, and chronic
+  pharmacology.
+- Treat DepMap as cancer-cell essentiality, not normal-tissue essentiality.
+- Report contradictory evidence instead of averaging it away.
+
+Grade evidence as:
+
+- **T1**: human clinical outcome or replicated causal human genetics;
+- **T2**: curated human evidence, mammalian knockout phenotype, or established drug
+  class safety;
+- **T3**: functional screen, tissue expression, or single experimental study;
+- **T4**: computational prediction or catalog annotation.
+
+## Workflow
+
+### 1. Resolve the gene
+
+Use `MyGene_query_genes` with `species="human"` and request symbol, name, Ensembl,
+UniProt, and Entrez identifiers. Require an exact symbol or identifier match. If the
+query maps to multiple loci, stop and ask for clarification.
+
+Carry the approved symbol and Ensembl gene ID through every subsequent query.
+
+### 2. Gather the five scoring dimensions
+
+Run independent paths. A failed path must use its fallback or be marked unavailable.
+
+| Dimension | Weight | Primary evidence | Fallback |
+|---|---:|---|---|
+| Human genetic constraint | 25 | `gnomad_get_gene_constraints(gene_symbol=...)` | ClinVar loss-of-function variants and literature |
+| Mammalian knockout phenotype | 25 | `OpenTargets_get_biological_mouse_models_by_ensemblID(ensemblId=...)` | MGI-focused literature search |
+| Critical-organ expression | 20 | `GTEx_get_median_gene_expression(operation="get_median_gene_expression", gencode_id=...)` | `HPA_get_comprehensive_gene_details_by_ensembl_id(..., include_expression=true)` |
+| Observed on-target effects | 20 | `OpenTargets_get_target_safety_profile_by_ensemblID(ensemblId=...)` | `ClinVar_search_variants`, associated drugs, and literature |
+| Cellular essentiality and redundancy | 10 | `DepMap_get_gene_dependencies(gene_symbol=...)` | pathway, paralog, and functional-screen literature |
+
+Also query `OpenTargets_get_associated_drugs_by_target_ensemblID` to distinguish
+observed target-class toxicity from hypothetical risk. Do not interpret the mere
+existence of a drug as proof of safety.
+
+For expression, inspect heart, central nervous system, liver, kidney, lung, immune or
+marrow compartments, and reproductive tissues. Compare the gene across tissues;
+do not compare raw TPM values between unrelated genes as if they shared one threshold.
+
+### 3. Assign dimension points
+
+Use only evidence actually retrieved.
+
+#### Human genetic constraint — 0 to 25
+
+- **25**: strong loss-of-function intolerance, such as pLI at least 0.9 together
+  with LOEUF or observed/expected LoF at most 0.35;
+- **15**: one strong constraint signal or intermediate LoF constraint;
+- **5**: weak or conflicting constraint;
+- **0**: credible tolerance to loss of function.
+
+Use LOEUF when available; label observed/expected LoF as a proxy when LOEUF is absent.
+
+#### Mammalian knockout phenotype — 0 to 25
+
+- **25**: embryonic or perinatal lethality, or severe multisystem phenotype;
+- **18**: reduced survival, organ failure, severe neurologic, immune, reproductive,
+  or developmental phenotype;
+- **8**: viable knockout with a consequential but organ-limited phenotype;
+- **0**: replicated viable knockout without a consequential phenotype.
+
+#### Critical-organ expression — 0 to 20
+
+- **20**: broad high expression involving at least three critical organ systems;
+- **12**: high expression in one or two critical organs or broad moderate expression;
+- **6**: low-to-moderate critical-organ expression;
+- **0**: credible restriction to the intended or noncritical tissue with negligible
+  critical-organ expression.
+
+#### Observed on-target effects — 0 to 20
+
+- **20**: severe human disease from reduced function or consistent serious
+  target-related toxicity;
+- **12**: a credible human adverse phenotype or reproducible class effect;
+- **5**: preclinical, isolated, or mechanistically plausible safety signal;
+- **0**: human protective loss-of-function or well-tolerated target modulation with
+  no serious on-target signal at relevant exposure.
+
+Protective variants can reduce concern only when their direction, dosage, tissue,
+and lifelong-versus-acute exposure are relevant to the proposed intervention.
+
+#### Cellular essentiality and redundancy — 0 to 10
+
+- **10**: broad common-essential signal with little credible redundancy;
+- **5**: context-selective dependency or partial redundancy;
+- **0**: reproducible non-essentiality or strong functional redundancy.
+
+If DepMap returns only gene metadata without dependency scores, mark this dimension
+unavailable. Never infer essentiality from a successful lookup alone.
+
+### 4. Calculate score, coverage, and confidence
+
+For available dimensions, calculate:
+
+`liability score = 100 × points earned / available weight`
+
+Report the available weight as evidence coverage. Do not assign zero points to a
+missing dimension.
+
+- **0–24**: low liability;
+- **25–49**: moderate liability;
+- **50–74**: high liability;
+- **75–100**: very high liability.
+
+Publish a categorical score only when coverage is at least 60%. Below 60%, report
+“insufficient evidence” and list the experiments or datasets needed.
+
+Assign confidence independently:
+
+- **High**: at least 90% coverage with both T1 and independent T2 evidence;
+- **Moderate**: at least 70% coverage with T1 or T2 evidence;
+- **Low**: 60–69% coverage or evidence dominated by T3/T4;
+- **Insufficient**: below 60% coverage.
+
+### 5. Translate liability into a strategy
+
+Do not stop at a risk label. Explain whether the evidence favors:
+
+- partial rather than complete inhibition;
+- reversible or transient rather than irreversible modulation;
+- tissue-targeted delivery;
+- isoform- or domain-selective modulation;
+- biomarker-based exclusion or monitoring;
+- deprioritization until a specific safety experiment closes the key gap.
+
+## Required Output
+
+Return these sections:
+
+1. **Resolved gene and intervention assumption** — identifiers, modality, tissue,
+   inhibition depth, and duration.
+2. **Liability verdict** — score, band, evidence coverage, and confidence.
+3. **Dimension table** — evidence, points, maximum weight, tier, citation, and
+   conflicts for all five dimensions.
+4. **Key red flags and protective evidence** — list both sides explicitly.
+5. **Modulation recommendation** — full, partial, transient, tissue-specific, or
+   no-go, with rationale.
+6. **Data gaps and next experiments** — prioritize the missing evidence most likely
+   to change the verdict.
+7. **Sources** — database record links, study identifiers, and access dates.
+
+End with: “This is a research risk assessment, not a clinical safety determination.”

--- a/skills/tooluniverse-gene-liability/agents/openai.yaml
+++ b/skills/tooluniverse-gene-liability/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gene Liability Evaluation"
+  short_description: "Score safety risks of inhibiting a human gene"
+  default_prompt: "Use $tooluniverse-gene-liability to evaluate the safety liability of inhibiting TP53."

--- a/skills/tooluniverse-gene-liability/agents/openai.yaml
+++ b/skills/tooluniverse-gene-liability/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Gene Liability Evaluation"
-  short_description: "Score safety risks of inhibiting a human gene"
-  default_prompt: "Use $tooluniverse-gene-liability to evaluate the safety liability of inhibiting TP53."

--- a/skills/tooluniverse-gene-liability/test_skill.py
+++ b/skills/tooluniverse-gene-liability/test_skill.py
@@ -1,0 +1,77 @@
+"""Contract tests for the gene-liability skill's documented tools."""
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.tools.ClinVar_search_variants import ClinVar_search_variants
+from tooluniverse.tools.DepMap_get_gene_dependencies import (
+    DepMap_get_gene_dependencies,
+)
+from tooluniverse.tools.GTEx_get_median_gene_expression import (
+    GTEx_get_median_gene_expression,
+)
+from tooluniverse.tools.HPA_get_comprehensive_gene_details_by_ensembl_id import (
+    HPA_get_comprehensive_gene_details_by_ensembl_id,
+)
+from tooluniverse.tools.MyGene_query_genes import MyGene_query_genes
+from tooluniverse.tools.OpenTargets_get_associated_drugs_by_target_ensemblID import (
+    OpenTargets_get_associated_drugs_by_target_ensemblID,
+)
+from tooluniverse.tools.OpenTargets_get_biological_mouse_models_by_ensemblID import (
+    OpenTargets_get_biological_mouse_models_by_ensemblID,
+)
+from tooluniverse.tools.OpenTargets_get_target_safety_profile_by_ensemblID import (
+    OpenTargets_get_target_safety_profile_by_ensemblID,
+)
+from tooluniverse.tools.gnomad_get_gene_constraints import gnomad_get_gene_constraints
+
+
+pytestmark = pytest.mark.unit
+
+_SKILL_TEXT = (Path(__file__).parent / "SKILL.md").read_text()
+
+
+@pytest.mark.parametrize(
+    ("tool", "parameter"),
+    [
+        (MyGene_query_genes, "query"),
+        (gnomad_get_gene_constraints, "gene_symbol"),
+        (OpenTargets_get_biological_mouse_models_by_ensemblID, "ensemblId"),
+        (GTEx_get_median_gene_expression, "gencode_id"),
+        (HPA_get_comprehensive_gene_details_by_ensembl_id, "ensembl_id"),
+        (OpenTargets_get_target_safety_profile_by_ensemblID, "ensemblId"),
+        (OpenTargets_get_associated_drugs_by_target_ensemblID, "ensemblId"),
+        (ClinVar_search_variants, "gene"),
+        (DepMap_get_gene_dependencies, "gene_symbol"),
+    ],
+)
+def test_documented_tool_parameter_contracts(tool, parameter):
+    assert parameter in inspect.signature(tool).parameters
+
+
+def test_gtex_uses_the_supported_operation_name():
+    assert 'operation="get_median_gene_expression"' in _SKILL_TEXT
+    assert 'operation="median"' not in _SKILL_TEXT
+
+
+def test_score_weights_cover_the_full_liability_model():
+    for dimension, weight in [
+        ("Human genetic constraint", 25),
+        ("Mammalian knockout phenotype", 25),
+        ("Critical-organ expression", 20),
+        ("Observed on-target effects", 20),
+        ("Cellular essentiality and redundancy", 10),
+    ]:
+        assert dimension in _SKILL_TEXT
+        assert f"| {weight} |" in _SKILL_TEXT
+
+    assert sum([25, 25, 20, 20, 10]) == 100
+
+
+def test_skill_does_not_treat_missing_evidence_as_safe():
+    normalized_text = " ".join(_SKILL_TEXT.split())
+
+    assert "Do not assign zero points to a missing dimension" in normalized_text
+    assert "DepMap as cancer-cell essentiality" in _SKILL_TEXT

--- a/skills/tooluniverse-gene-liability/test_skill.py
+++ b/skills/tooluniverse-gene-liability/test_skill.py
@@ -33,6 +33,12 @@ pytestmark = pytest.mark.unit
 _SKILL_TEXT = (Path(__file__).parent / "SKILL.md").read_text()
 
 
+def test_skill_has_no_host_specific_metadata():
+    skill_dir = Path(__file__).parent
+
+    assert not (skill_dir / "agents" / "openai.yaml").exists()
+
+
 @pytest.mark.parametrize(
     ("tool", "parameter"),
     [

--- a/skills/tooluniverse/SKILL.md
+++ b/skills/tooluniverse/SKILL.md
@@ -106,6 +106,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "research", "profile", "**drug**", "medication", "therapeutic agent", "tell me about [drug]" | `Skill(skill="tooluniverse-drug-research")` |
 | "**literature review**", "papers about", "publications on", "research articles", "recent studies" | `Skill(skill="tooluniverse-literature-deep-research")` |
 | "research", "profile", "**target**", "protein target", "gene target", "target validation" | `Skill(skill="tooluniverse-target-research")` |
+| "**gene liability**", "gene safety score", "knockout safety", "knockdown safety", "on-target toxicity", "safe to inhibit [gene]" | `Skill(skill="tooluniverse-gene-liability")` |
 | "**peptide target**", "**deorphanize**", "deorphanization", "**peptide off-target**", "what does [peptide] bind", "target of a peptide", "orphan peptide", "peptide doesn't bind [target]", "binds in [species] but not", "find the receptor for [peptide]" | `Skill(skill="tooluniverse-peptide-target-deorphanization")` |
 
 ### 3. Clinical Decision Support


### PR DESCRIPTION
## Summary

- add a dedicated `tooluniverse-gene-liability` skill
- score inhibition liability across human constraint, mammalian knockout phenotypes, critical-organ expression, observed on-target effects, and cellular essentiality
- report evidence coverage and confidence separately so missing data is never interpreted as safety
- distinguish complete knockout from partial, transient, tissue-specific, and pharmacological modulation
- route gene-liability queries through the main ToolUniverse skill and update the skill catalog
- keep the canonical skill host-agnostic and sync it into both the Claude and Codex plugin packages
- add contract and portability tests

## Why

The existing target-research workflow contains safety evidence, but it does not provide the focused one-gene liability score and modulation recommendation requested in the issue.

ToolUniverse skills are shared across multiple agent hosts. Host-specific metadata therefore belongs in a plugin packaging layer, not in the canonical `skills/` source tree.

## Validation

- `pytest skills/tooluniverse-gene-liability/test_skill.py -q --no-cov` — 13 passed
- `ruff check skills/tooluniverse-gene-liability/test_skill.py` — passed
- `plugin/sync-skills.sh` — copied 140 skills into both plugin packages
- verified no `agents/openai.yaml` or dependency-file diff remains
- live TP53 smoke tests against MyGene, gnomAD, Open Targets safety/mouse/drug endpoints, GTEx, HPA, DepMap, and ClinVar
- corrected the GTEx contract to the currently accepted `operation="get_median_gene_expression"`

Closes #384.
