### PR TITLE
Support return_json environment override

### DIFF
--- a/docs/reference/environment_variables.rst
+++ b/docs/reference/environment_variables.rst
@@ -164,6 +164,9 @@ Configure Large Language Model providers for agentic tools and LLM-powered featu
    * - ``TOOLUNIVERSE_LLM_TEMPERATURE``
      - (varies)
      - Temperature for LLM sampling (0.0-1.0). Higher = more creative.
+   * - ``TOOLUNIVERSE_LLM_RETURN_JSON``
+     - ``false``
+     - Request structured JSON output. Accepts ``true``/``false``, ``1``/``0``, ``yes``/``no``, or ``on``/``off``.
    * - ``TOOLUNIVERSE_LLM_MODEL_DEFAULT``
      - (provider default)
      - Default model ID when not task-specific.
@@ -183,6 +186,10 @@ Configure Large Language Model providers for agentic tools and LLM-powered featu
    
    # Adjust temperature
    export TOOLUNIVERSE_LLM_TEMPERATURE=0.2
+
+   # Force structured JSON output when environment values take priority
+   export TOOLUNIVERSE_LLM_CONFIG_MODE=env_override
+   export TOOLUNIVERSE_LLM_RETURN_JSON=true
 
 **Use cases**:
 
@@ -547,6 +554,9 @@ Complete Variable List
      - LLM
    * - ``TOOLUNIVERSE_LLM_TEMPERATURE``
      - (varies)
+     - LLM
+   * - ``TOOLUNIVERSE_LLM_RETURN_JSON``
+     - false
      - LLM
    * - ``TOOLUNIVERSE_LLM_MODEL_DEFAULT``
      - (provider default)

--- a/src/tooluniverse/agentic_tool.py
+++ b/src/tooluniverse/agentic_tool.py
@@ -34,6 +34,17 @@ class AgenticTool(BaseTool):
     STREAM_FLAG_KEY = "_tooluniverse_stream"
 
     @staticmethod
+    def _parse_bool_env(value: Optional[str]) -> Optional[bool]:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+        raise ValueError(f"Expected boolean environment value, got: {value!r}")
+
+    @staticmethod
     def has_any_api_keys() -> bool:
         """
         Check if any API keys are available across all supported API types.
@@ -91,6 +102,10 @@ class AgenticTool(BaseTool):
             elif key == "temperature":
                 temp_str = os.getenv("TOOLUNIVERSE_LLM_TEMPERATURE")
                 env_value = float(temp_str) if temp_str else None
+            elif key == "return_json":
+                env_value = self._parse_bool_env(
+                    os.getenv("TOOLUNIVERSE_LLM_RETURN_JSON")
+                )
 
             mode = os.getenv("TOOLUNIVERSE_LLM_CONFIG_MODE", "default")
 

--- a/tests/unit/test_agentic_tool_env_vars.py
+++ b/tests/unit/test_agentic_tool_env_vars.py
@@ -450,9 +450,40 @@ class TestAgenticToolEnvironmentVariables:
             assert tool._api_type == "CHATGPT"  # Built-in default
             assert tool._temperature == 1.0  # Built-in default
 
-    def test_return_json_env_override(self):
+    @pytest.mark.parametrize(
+        ("env_value", "tool_value", "expected"),
+        [
+            ("true", False, True),
+            ("1", False, True),
+            ("false", True, False),
+            ("off", True, False),
+        ],
+    )
+    def test_return_json_env_override(self, env_value, tool_value, expected):
         """Test that TOOLUNIVERSE_LLM_RETURN_JSON can override tool config."""
         os.environ["TOOLUNIVERSE_LLM_CONFIG_MODE"] = "env_override"
+        os.environ["TOOLUNIVERSE_LLM_RETURN_JSON"] = env_value
+
+        tool_config = {
+            "name": "test_tool",
+            "prompt": "Test prompt: {input}",
+            "input_arguments": ["input"],
+            "parameter": {
+                "type": "object",
+                "properties": {"input": {"type": "string"}},
+                "required": ["input"],
+            },
+            "return_json": tool_value,
+        }
+
+        with patch.object(AgenticTool, "_try_initialize_api"):
+            tool = AgenticTool(tool_config)
+
+        assert tool._return_json is expected
+
+    def test_return_json_tool_config_wins_in_default_mode(self):
+        """Default mode keeps an explicit tool setting ahead of the environment."""
+        os.environ["TOOLUNIVERSE_LLM_CONFIG_MODE"] = "default"
         os.environ["TOOLUNIVERSE_LLM_RETURN_JSON"] = "true"
 
         tool_config = {
@@ -467,10 +498,29 @@ class TestAgenticToolEnvironmentVariables:
             "return_json": False,
         }
 
-        with patch.object(AgenticTool, '_try_initialize_api'):
+        with patch.object(AgenticTool, "_try_initialize_api"):
             tool = AgenticTool(tool_config)
 
-            assert tool._return_json is True
+        assert tool._return_json is False
+
+    def test_invalid_return_json_env_value_fails_fast(self):
+        """Reject ambiguous boolean values instead of silently enabling JSON mode."""
+        os.environ["TOOLUNIVERSE_LLM_RETURN_JSON"] = "sometimes"
+
+        tool_config = {
+            "name": "test_tool",
+            "prompt": "Test prompt: {input}",
+            "input_arguments": ["input"],
+            "parameter": {
+                "type": "object",
+                "properties": {"input": {"type": "string"}},
+                "required": ["input"],
+            },
+        }
+
+        with patch.object(AgenticTool, "_try_initialize_api"):
+            with pytest.raises(ValueError, match="Expected boolean environment value"):
+                AgenticTool(tool_config)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_agentic_tool_env_vars.py
+++ b/tests/unit/test_agentic_tool_env_vars.py
@@ -26,6 +26,7 @@ class TestAgenticToolEnvironmentVariables:
             "TOOLUNIVERSE_LLM_DEFAULT_PROVIDER",
             "TOOLUNIVERSE_LLM_MODEL_DEFAULT",
             "TOOLUNIVERSE_LLM_TEMPERATURE",
+            "TOOLUNIVERSE_LLM_RETURN_JSON",
             "TOOLUNIVERSE_LLM_MAX_TOKENS",
             "TOOLUNIVERSE_LLM_CONFIG_MODE",
             "GEMINI_MODEL_ID",
@@ -448,6 +449,28 @@ class TestAgenticToolEnvironmentVariables:
             # In fallback mode with no tool config, should use built-in defaults
             assert tool._api_type == "CHATGPT"  # Built-in default
             assert tool._temperature == 1.0  # Built-in default
+
+    def test_return_json_env_override(self):
+        """Test that TOOLUNIVERSE_LLM_RETURN_JSON can override tool config."""
+        os.environ["TOOLUNIVERSE_LLM_CONFIG_MODE"] = "env_override"
+        os.environ["TOOLUNIVERSE_LLM_RETURN_JSON"] = "true"
+
+        tool_config = {
+            "name": "test_tool",
+            "prompt": "Test prompt: {input}",
+            "input_arguments": ["input"],
+            "parameter": {
+                "type": "object",
+                "properties": {"input": {"type": "string"}},
+                "required": ["input"],
+            },
+            "return_json": False,
+        }
+
+        with patch.object(AgenticTool, '_try_initialize_api'):
+            tool = AgenticTool(tool_config)
+
+            assert tool._return_json is True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- preserve SufianTA's original #275 implementation and commit
- allow `TOOLUNIVERSE_LLM_RETURN_JSON` to participate in the existing LLM configuration precedence rules
- accept explicit common boolean spellings and reject ambiguous values
- document the environment variable and add precedence/error regression tests

## Why

Agentic tools already support provider, model, and temperature environment settings, but structured JSON output could only be configured per tool. This adds the missing environment-level control without changing the default behavior: tool configuration still wins in `default` mode, while the environment wins only in `env_override` mode.

## Validation

- 44 AgenticTool, temperature-default, and Gemini unit tests passed
- 6 ToolSpace integration tests passed
- Ruff lint and format checks passed
- `git diff --check` passed
- cleanly based on current `main` after #406 and #407

## Attribution

This supersedes #275 while preserving SufianTA's original commit `7687ab3b` and authorship.
