### PR TITLE
Add hardened OpenAI-compatible agentic provider

### DIFF
--- a/docs/guide/agentic_tools_tutorial.rst
+++ b/docs/guide/agentic_tools_tutorial.rst
@@ -54,7 +54,12 @@ Step 2: Choose Your LLM Provider
 
 ToolUniverse supports these AI providers:
 
-**OpenAI/Azure OpenAI**
+**OpenAI-Compatible**
+ - Models: GPT-5, GPT-4o, and compatible provider model IDs
+ - Configuration: Set ``OPENAI_API_KEY`` and optional ``OPENAI_BASE_URL``
+ - See :doc:`../guide/openai_compatible_support` for details
+
+**Azure OpenAI**
  - Models: GPT-4, GPT-4o, o1-mini, o1-preview
  - Configuration: Set ``AZURE_OPENAI_API_KEY`` and ``AZURE_OPENAI_ENDPOINT``
 
@@ -185,7 +190,7 @@ Set up AI model settings:
 
 **Configuration Options**:
 
-- ``api_type``: "CHATGPT", "GEMINI", "OPENROUTER", or "VLLM"
+- ``api_type``: "CHATGPT", "OPENAI", "GEMINI", "OPENROUTER", or "VLLM"
 - ``model_id``: Choose your model (see Step 2)
  - For vLLM: Must match the model name loaded on your vLLM server
  - Set ``VLLM_SERVER_URL`` environment variable when using vLLM

--- a/docs/guide/api_keys.rst
+++ b/docs/guide/api_keys.rst
@@ -393,7 +393,7 @@ Environment Variables
 
 .. code-block:: bash
 
-   # Default LLM provider (OPENAI, AZURE_OPENAI, GEMINI, VLLM)
+   # Default LLM provider (CHATGPT, OPENAI, OPENROUTER, GEMINI, VLLM)
    TOOLUNIVERSE_LLM_DEFAULT_PROVIDER=OPENAI
 
    # Model configuration per task
@@ -408,7 +408,7 @@ Environment Variables
    TOOLUNIVERSE_LLM_CONFIG_MODE=default
 
    # Custom fallback chain (JSON array of {api_type, model_id} objects)
-   AGENTIC_TOOL_FALLBACK_CHAIN='[{"api_type":"OPENAI","model_id":"gpt-4"},{"api_type":"GEMINI","model_id":"gemini-pro"}]'
+   AGENTIC_TOOL_FALLBACK_CHAIN='[{"api_type":"OPENAI","model_id":"gpt-4o-mini"},{"api_type":"GEMINI","model_id":"gemini-pro"}]'
 
 Configuration Modes
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -38,6 +38,7 @@ LLM Providers
 
 * **vLLM Support** → :doc:`vllm_support` - Use self-hosted LLM models with vLLM for high-performance inference
 * **OpenRouter Support** → :doc:`openrouter_support` - Access multiple LLM providers through OpenRouter API
+* **OpenAI-Compatible Support** -> :doc:`openai_compatible_support` - Use OpenAI and compatible chat-completions endpoints
 
 Advanced Features
 -----------------

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -38,7 +38,7 @@ LLM Providers
 
 * **vLLM Support** → :doc:`vllm_support` - Use self-hosted LLM models with vLLM for high-performance inference
 * **OpenRouter Support** → :doc:`openrouter_support` - Access multiple LLM providers through OpenRouter API
-* **OpenAI-Compatible Support** -> :doc:`openai_compatible_support` - Use OpenAI and compatible chat-completions endpoints
+* **OpenAI-Compatible Support** → :doc:`openai_compatible_support` - Use OpenAI and compatible chat-completions endpoints
 
 Advanced Features
 -----------------

--- a/docs/guide/openai_compatible_support.rst
+++ b/docs/guide/openai_compatible_support.rst
@@ -1,0 +1,66 @@
+OpenAI-Compatible Provider Support
+==================================
+
+ToolUniverse agentic tools support a generic ``OPENAI`` provider backed by the
+OpenAI Python SDK. Use it for OpenAI directly or for OpenAI-compatible hosted
+endpoints.
+
+Configuration
+-------------
+
+Set an API key:
+
+.. code-block:: bash
+
+   export OPENAI_API_KEY=your_key_here
+
+For OpenAI-compatible endpoints, also set a base URL:
+
+.. code-block:: bash
+
+   export OPENAI_BASE_URL=https://your-provider.example/v1
+
+Then configure an agentic tool with ``api_type: "OPENAI"``:
+
+.. code-block:: json
+
+   {
+     "name": "openai_compatible_reasoning_tool",
+     "type": "AgenticTool",
+     "prompt": "Answer this question: {question}",
+     "input_arguments": ["question"],
+     "api_type": "OPENAI",
+     "model_id": "gpt-4o-mini",
+     "parameter": {
+       "type": "object",
+       "properties": {
+         "question": {"type": "string"}
+       },
+       "required": ["question"]
+     }
+   }
+
+Environment Variables
+---------------------
+
+``OPENAI_API_KEY``
+   Required API key for the selected endpoint.
+
+``OPENAI_BASE_URL``
+   Optional OpenAI-compatible API base URL. If unset, the OpenAI SDK default is
+   used.
+
+``OPENAI_MAX_TOKENS_BY_MODEL``
+   Optional JSON mapping of model ID or model prefix to default max output
+   tokens. Example: ``{"gpt-4o": 4096}``.
+
+``OPENAI_DEFAULT_MODEL_LIMITS``
+   Optional JSON mapping that extends or overrides ToolUniverse's built-in
+   model-family defaults.
+
+Provider Notes
+--------------
+
+Use ``OPENAI`` for OpenAI-compatible chat completions endpoints. Use
+``OPENROUTER`` when you want OpenRouter-specific headers and model naming, and
+use ``VLLM`` for self-hosted vLLM servers.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -237,6 +237,7 @@ Community & Support
    guide/streaming_tools
    guide/openrouter_support
    guide/vllm_support
+   guide/openai_compatible_support
    guide/euhealth_tools_tutorial
 
 .. toctree::

--- a/docs/reference/environment_variables.rst
+++ b/docs/reference/environment_variables.rst
@@ -157,7 +157,7 @@ Configure Large Language Model providers for agentic tools and LLM-powered featu
      - Description
    * - ``TOOLUNIVERSE_LLM_DEFAULT_PROVIDER``
      - (none)
-     - Default LLM provider: ``openai``, ``azure``, ``gemini``, ``anthropic``
+     - Default LLM provider: ``CHATGPT``, ``OPENAI``, ``OPENROUTER``, ``GEMINI``, ``VLLM``
    * - ``TOOLUNIVERSE_LLM_CONFIG_MODE``
      - ``default``
      - LLM configuration mode. Use ``default`` or custom profiles.
@@ -174,7 +174,7 @@ Configure Large Language Model providers for agentic tools and LLM-powered featu
 **Examples**::
 
    # Use OpenAI for all LLM tasks
-   export TOOLUNIVERSE_LLM_DEFAULT_PROVIDER=openai
+   export TOOLUNIVERSE_LLM_DEFAULT_PROVIDER=OPENAI
    export TOOLUNIVERSE_LLM_MODEL_DEFAULT=gpt-4o-mini
    
    # Task-specific models
@@ -191,6 +191,28 @@ Configure Large Language Model providers for agentic tools and LLM-powered featu
 - **Custom Tools**: Your own tools that leverage LLM capabilities
 
 **See also**: Provider-specific API keys in :doc:`../guide/api_keys`.
+
+OpenAI-compatible variables:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Variable
+     - Default
+     - Description
+   * - ``OPENAI_API_KEY``
+     - (none)
+     - API key for OpenAI or an OpenAI-compatible endpoint.
+   * - ``OPENAI_BASE_URL``
+     - SDK default
+     - Optional OpenAI-compatible API base URL.
+   * - ``OPENAI_MAX_TOKENS_BY_MODEL``
+     - (none)
+     - JSON mapping of model IDs or prefixes to default max output tokens.
+   * - ``OPENAI_DEFAULT_MODEL_LIMITS``
+     - built-in
+     - JSON mapping that extends or overrides built-in model-family defaults.
 
 Performance & System
 --------------------
@@ -553,6 +575,15 @@ Complete Variable List
      - LLM
    * - ``TOOLUNIVERSE_LLM_MODEL_{TASK}``
      - (none)
+     - LLM
+   * - ``OPENAI_BASE_URL``
+     - SDK default
+     - LLM
+   * - ``OPENAI_MAX_TOKENS_BY_MODEL``
+     - (none)
+     - LLM
+   * - ``OPENAI_DEFAULT_MODEL_LIMITS``
+     - built-in
      - LLM
    * - ``TOOLUNIVERSE_THREAD_POOL_SIZE``
      - 20

--- a/src/tooluniverse/agentic_tool.py
+++ b/src/tooluniverse/agentic_tool.py
@@ -8,7 +8,13 @@ from typing import Any, Callable, Dict, List, Optional
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 from .logging_config import get_logger
-from .llm_clients import AzureOpenAIClient, GeminiClient, OpenRouterClient, VLLMClient
+from .llm_clients import (
+    AzureOpenAIClient,
+    GeminiClient,
+    OpenAICompatibleClient,
+    OpenRouterClient,
+    VLLMClient,
+)
 
 
 # Global default fallback configuration
@@ -21,6 +27,7 @@ DEFAULT_FALLBACK_CHAIN = [
 # API key environment variable mapping
 API_KEY_ENV_VARS = {
     "CHATGPT": ["AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"],
+    "OPENAI": ["OPENAI_API_KEY"],
     "OPENROUTER": ["OPENROUTER_API_KEY"],
     "GEMINI": ["GEMINI_API_KEY"],
     "VLLM": ["VLLM_SERVER_URL"],
@@ -272,6 +279,8 @@ class AgenticTool(BaseTool):
         try:
             if api_type == "CHATGPT":
                 self._llm_client = AzureOpenAIClient(model_id, None, self.logger)
+            elif api_type == "OPENAI":
+                self._llm_client = OpenAICompatibleClient(model_id, self.logger)
             elif api_type == "OPENROUTER":
                 self._llm_client = OpenRouterClient(model_id, self.logger)
             elif api_type == "GEMINI":
@@ -315,7 +324,7 @@ class AgenticTool(BaseTool):
 
     # ------------------------------------------------------------------ LLM utilities -----------
     def _validate_model_config(self):
-        supported_api_types = ["CHATGPT", "OPENROUTER", "GEMINI", "VLLM"]
+        supported_api_types = ["CHATGPT", "OPENAI", "OPENROUTER", "GEMINI", "VLLM"]
         if self._api_type not in supported_api_types:
             raise ValueError(
                 f"Unsupported API type: {self._api_type}. Supported types: {supported_api_types}"
@@ -602,6 +611,8 @@ class AgenticTool(BaseTool):
         try:
             if self._api_type == "CHATGPT":
                 self._llm_client = AzureOpenAIClient(self._model_id, None, self.logger)
+            elif self._api_type == "OPENAI":
+                self._llm_client = OpenAICompatibleClient(self._model_id, self.logger)
             elif self._api_type == "OPENROUTER":
                 self._llm_client = OpenRouterClient(self._model_id, self.logger)
             elif self._api_type == "GEMINI":

--- a/src/tooluniverse/execute_function.py
+++ b/src/tooluniverse/execute_function.py
@@ -1308,7 +1308,8 @@ class ToolUniverse:
                         f"Skipping agentic tool '{tool_name}' due to missing LLM API keys"
                     )
                     all_missing_keys.add(
-                        "LLM API keys (AZURE_OPENAI_API_KEY, OPENROUTER_API_KEY, or GEMINI_API_KEY)"
+                        "LLM API keys (AZURE_OPENAI_API_KEY, OPENAI_API_KEY, "
+                        "OPENROUTER_API_KEY, GEMINI_API_KEY, or VLLM_SERVER_URL)"
                     )
                     continue
 

--- a/src/tooluniverse/llm_clients.py
+++ b/src/tooluniverse/llm_clients.py
@@ -650,7 +650,9 @@ class OpenAICompatibleClient(BaseLLMClient):
             raise ValueError("OPENAI_API_KEY not set")
 
         base_url = os.getenv("OPENAI_BASE_URL")
-        client_kwargs: Dict[str, Any] = {"api_key": api_key}
+        # Keep retries in this adapter so its max_retries/retry_delay arguments
+        # are authoritative instead of multiplying the SDK's own retries.
+        client_kwargs: Dict[str, Any] = {"api_key": api_key, "max_retries": 0}
         if base_url:
             client_kwargs["base_url"] = base_url
         self.client = self._OpenAI(**client_kwargs)
@@ -782,6 +784,24 @@ class OpenAICompatibleClient(BaseLLMClient):
             return "".join(fragments) or None
         return None
 
+    def _is_retryable_error(self, error: Exception) -> bool:
+        retryable_types = tuple(
+            error_type
+            for error_type in (
+                getattr(self._openai, "RateLimitError", None),
+                getattr(self._openai, "APIConnectionError", None),
+                getattr(self._openai, "APITimeoutError", None),
+            )
+            if isinstance(error_type, type)
+        )
+        if retryable_types and isinstance(error, retryable_types):
+            return True
+
+        status_code = getattr(error, "status_code", None)
+        return status_code in (408, 409, 429) or (
+            isinstance(status_code, int) and status_code >= 500
+        )
+
     def test_api(self) -> None:
         test_messages = [{"role": "user", "content": "ping"}]
         token_attempts = [1, 4, 16, 32]
@@ -858,15 +878,18 @@ class OpenAICompatibleClient(BaseLLMClient):
                 if custom_format is not None:
                     return resp.choices[0].message.parsed.model_dump()
                 return resp.choices[0].message.content
-            except self._openai.RateLimitError:  # type: ignore[attr-defined]
-                self.logger.warning(
-                    f"Rate limit exceeded. Retrying in {retry_delay} seconds..."
-                )
-                retries += 1
-                time.sleep(retry_delay * retries)
             except Exception as e:  # noqa: BLE001
-                self.logger.error(f"OpenAI-compatible error: {e}")
-                break
+                if not self._is_retryable_error(e):
+                    self.logger.error(f"OpenAI-compatible error: {e}")
+                    return None
+                retries += 1
+                if retries < max_retries:
+                    delay = retry_delay * retries
+                    self.logger.warning(
+                        f"Transient OpenAI-compatible error: {e}. "
+                        f"Retrying in {delay} seconds..."
+                    )
+                    time.sleep(delay)
 
         self.logger.error("Max retries exceeded for OpenAI-compatible request")
         return None
@@ -918,16 +941,18 @@ class OpenAICompatibleClient(BaseLLMClient):
                     if text:
                         yield text
                 return
-            except self._openai.RateLimitError:  # type: ignore[attr-defined]
-                self.logger.warning(
-                    f"Rate limit exceeded. Retrying in {retry_delay} seconds..."
-                )
+            except Exception as e:  # noqa: BLE001
+                if not self._is_retryable_error(e):
+                    self.logger.error(f"OpenAI-compatible streaming error: {e}")
+                    return
                 retries += 1
                 if retries < max_retries:
-                    time.sleep(retry_delay * retries)
-            except Exception as e:  # noqa: BLE001
-                self.logger.error(f"OpenAI-compatible streaming error: {e}")
-                break
+                    delay = retry_delay * retries
+                    self.logger.warning(
+                        f"Transient OpenAI-compatible streaming error: {e}. "
+                        f"Retrying in {delay} seconds..."
+                    )
+                    time.sleep(delay)
 
         self.logger.error(
             "Max retries exceeded for OpenAI-compatible streaming request"

--- a/src/tooluniverse/llm_clients.py
+++ b/src/tooluniverse/llm_clients.py
@@ -551,6 +551,186 @@ class GeminiClient(BaseLLMClient):
         )
 
 
+class OpenAICompatibleClient(BaseLLMClient):
+    """
+    Generic OpenAI-compatible chat completions client.
+
+    Supports OpenAI directly and compatible endpoints configured with
+    OPENAI_BASE_URL.
+    """
+
+    DEFAULT_MODEL_LIMITS: Dict[str, Dict[str, int]] = {
+        "gpt-5": {"max_output": 128_000, "context_window": 400_000},
+        "gpt-4.1": {"max_output": 32768, "context_window": 1_047_576},
+        "gpt-4o": {"max_output": 16384, "context_window": 128_000},
+        "o4-mini": {"max_output": 100_000, "context_window": 200_000},
+        "o3-mini": {"max_output": 100_000, "context_window": 200_000},
+    }
+
+    def __init__(self, model_id: str, logger):
+        try:
+            from openai import OpenAI as _OpenAI  # type: ignore
+            import openai as _openai  # type: ignore
+        except Exception as e:  # pragma: no cover
+            raise RuntimeError("openai client is not available") from e
+
+        self._OpenAI = _OpenAI
+        self._openai = _openai
+        self.model_name = model_id
+        self.logger = logger
+
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY not set")
+
+        base_url = os.getenv("OPENAI_BASE_URL")
+        client_kwargs: Dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self.client = self._OpenAI(**client_kwargs)
+
+        env_limits_raw = os.getenv("OPENAI_DEFAULT_MODEL_LIMITS")
+        self._default_limits: Dict[str, Dict[str, int]] = (
+            self.DEFAULT_MODEL_LIMITS.copy()
+        )
+        if env_limits_raw:
+            try:
+                env_limits = _json.loads(env_limits_raw)
+                for k, v in env_limits.items():
+                    if isinstance(v, dict):
+                        base = self._default_limits.get(k, {}).copy()
+                        base.update(
+                            {
+                                kk: int(vv)
+                                for kk, vv in v.items()
+                                if isinstance(vv, (int, float, str))
+                            }
+                        )
+                        self._default_limits[k] = base
+            except Exception:
+                pass
+
+    def _resolve_default_max_tokens(self, model_id: str) -> Optional[int]:
+        mapping_raw = os.getenv("OPENAI_MAX_TOKENS_BY_MODEL")
+        mapping: Dict[str, Any] = {}
+        if mapping_raw:
+            try:
+                mapping = _json.loads(mapping_raw)
+            except Exception:
+                mapping = {}
+
+        if model_id in mapping:
+            try:
+                return int(mapping[model_id])
+            except Exception:
+                pass
+
+        for k, v in mapping.items():
+            try:
+                if model_id.startswith(k):
+                    return int(v)
+            except Exception:
+                continue
+
+        if model_id in self._default_limits:
+            return int(self._default_limits[model_id].get("max_output", 0)) or None
+
+        for k, v in self._default_limits.items():
+            try:
+                if model_id.startswith(k):
+                    return int(v.get("max_output", 0)) or None
+            except Exception:
+                continue
+
+        return None
+
+    def test_api(self) -> None:
+        test_messages = [{"role": "user", "content": "ping"}]
+        token_attempts = [1, 4, 16, 32]
+        last_error: Optional[Exception] = None
+
+        for tok in token_attempts:
+            try:
+                self.client.chat.completions.create(
+                    model=self.model_name,
+                    messages=test_messages,
+                    max_tokens=tok,
+                    temperature=0,
+                )
+                return
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                msg = str(e).lower()
+                if (
+                    "max_tokens" in msg
+                    or "model output limit" in msg
+                    or "finish the message" in msg
+                ) and tok != token_attempts[-1]:
+                    continue
+                break
+
+        if last_error:
+            raise ValueError(f"OpenAI-compatible API test failed: {last_error}")
+        raise ValueError("OpenAI-compatible API test failed: unknown error")
+
+    def infer(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float],
+        max_tokens: Optional[int],
+        return_json: bool,
+        custom_format: Any = None,
+        max_retries: int = 5,
+        retry_delay: int = 5,
+    ) -> Optional[str]:
+        retries = 0
+        call_fn = (
+            self.client.chat.completions.parse
+            if custom_format is not None
+            else self.client.chat.completions.create
+        )
+        response_format = (
+            custom_format
+            if custom_format is not None
+            else ({"type": "json_object"} if return_json else None)
+        )
+        eff_max = (
+            max_tokens
+            if max_tokens is not None
+            else self._resolve_default_max_tokens(self.model_name)
+        )
+
+        while retries < max_retries:
+            try:
+                kwargs: Dict[str, Any] = {
+                    "model": self.model_name,
+                    "messages": messages,
+                }
+                if response_format is not None:
+                    kwargs["response_format"] = response_format
+                if temperature is not None:
+                    kwargs["temperature"] = temperature
+                if eff_max is not None:
+                    kwargs["max_tokens"] = eff_max
+
+                resp = call_fn(**kwargs)
+                if custom_format is not None:
+                    return resp.choices[0].message.parsed.model_dump()
+                return resp.choices[0].message.content
+            except self._openai.RateLimitError:  # type: ignore[attr-defined]
+                self.logger.warning(
+                    f"Rate limit exceeded. Retrying in {retry_delay} seconds..."
+                )
+                retries += 1
+                time.sleep(retry_delay * retries)
+            except Exception as e:  # noqa: BLE001
+                self.logger.error(f"OpenAI-compatible error: {e}")
+                break
+
+        self.logger.error("Max retries exceeded for OpenAI-compatible request")
+        return None
+
+
 class OpenRouterClient(BaseLLMClient):
     """
     OpenRouter client using OpenAI SDK with custom base URL.

--- a/src/tooluniverse/llm_clients.py
+++ b/src/tooluniverse/llm_clients.py
@@ -685,29 +685,101 @@ class OpenAICompatibleClient(BaseLLMClient):
             except Exception:
                 mapping = {}
 
-        if model_id in mapping:
-            try:
-                return int(mapping[model_id])
-            except Exception:
-                pass
+        model_ids = (model_id, self._model_family(model_id))
+        for candidate in model_ids:
+            if candidate in mapping:
+                try:
+                    return int(mapping[candidate])
+                except Exception:
+                    pass
 
         for k, v in mapping.items():
             try:
-                if model_id.startswith(k):
+                if any(candidate.startswith(k) for candidate in model_ids):
                     return int(v)
             except Exception:
                 continue
 
-        if model_id in self._default_limits:
-            return int(self._default_limits[model_id].get("max_output", 0)) or None
+        for candidate in model_ids:
+            if candidate in self._default_limits:
+                return int(self._default_limits[candidate].get("max_output", 0)) or None
 
         for k, v in self._default_limits.items():
             try:
-                if model_id.startswith(k):
+                if any(candidate.startswith(k) for candidate in model_ids):
                     return int(v.get("max_output", 0)) or None
             except Exception:
                 continue
 
+        return None
+
+    @staticmethod
+    def _model_family(model_id: str) -> str:
+        """Return the provider-independent model portion of a model ID."""
+        return model_id.rsplit("/", 1)[-1].lower()
+
+    @classmethod
+    def _uses_max_completion_tokens(cls, model_id: str) -> bool:
+        family = cls._model_family(model_id)
+        return family.startswith(("gpt-5", "o1", "o3", "o4"))
+
+    @classmethod
+    def _normalize_temperature(
+        cls, model_id: str, temperature: Optional[float]
+    ) -> Optional[float]:
+        family = cls._model_family(model_id)
+        if family.startswith(("o1", "o3", "o4")):
+            return None
+        return temperature
+
+    @classmethod
+    def _set_token_limit(
+        cls, kwargs: Dict[str, Any], model_id: str, token_limit: Optional[int]
+    ) -> None:
+        if token_limit is None:
+            return
+        key = (
+            "max_completion_tokens"
+            if cls._uses_max_completion_tokens(model_id)
+            else "max_tokens"
+        )
+        kwargs[key] = token_limit
+
+    @staticmethod
+    def _extract_text_from_chunk(chunk: Any) -> Optional[str]:
+        if isinstance(chunk, dict):
+            choices = chunk.get("choices", [])
+        else:
+            choices = getattr(chunk, "choices", [])
+        if not choices:
+            return None
+
+        first = choices[0]
+        delta = (
+            first.get("delta")
+            if isinstance(first, dict)
+            else getattr(first, "delta", None)
+        )
+        if delta is None:
+            return None
+        content = (
+            delta.get("content")
+            if isinstance(delta, dict)
+            else getattr(delta, "content", None)
+        )
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            fragments = []
+            for part in content:
+                text = (
+                    part.get("text")
+                    if isinstance(part, dict)
+                    else getattr(part, "text", None)
+                )
+                if text:
+                    fragments.append(text)
+            return "".join(fragments) or None
         return None
 
     def test_api(self) -> None:
@@ -717,12 +789,15 @@ class OpenAICompatibleClient(BaseLLMClient):
 
         for tok in token_attempts:
             try:
-                self.client.chat.completions.create(
-                    model=self.model_name,
-                    messages=test_messages,
-                    max_tokens=tok,
-                    temperature=0,
-                )
+                kwargs: Dict[str, Any] = {
+                    "model": self.model_name,
+                    "messages": test_messages,
+                }
+                self._set_token_limit(kwargs, self.model_name, tok)
+                temperature = self._normalize_temperature(self.model_name, 0)
+                if temperature is not None:
+                    kwargs["temperature"] = temperature
+                self.client.chat.completions.create(**kwargs)
                 return
             except Exception as e:  # noqa: BLE001
                 last_error = e
@@ -765,6 +840,7 @@ class OpenAICompatibleClient(BaseLLMClient):
             if max_tokens is not None
             else self._resolve_default_max_tokens(self.model_name)
         )
+        eff_temp = self._normalize_temperature(self.model_name, temperature)
 
         while retries < max_retries:
             try:
@@ -774,10 +850,9 @@ class OpenAICompatibleClient(BaseLLMClient):
                 }
                 if response_format is not None:
                     kwargs["response_format"] = response_format
-                if temperature is not None:
-                    kwargs["temperature"] = temperature
-                if eff_max is not None:
-                    kwargs["max_tokens"] = eff_max
+                if eff_temp is not None:
+                    kwargs["temperature"] = eff_temp
+                self._set_token_limit(kwargs, self.model_name, eff_max)
 
                 resp = call_fn(**kwargs)
                 if custom_format is not None:
@@ -795,6 +870,68 @@ class OpenAICompatibleClient(BaseLLMClient):
 
         self.logger.error("Max retries exceeded for OpenAI-compatible request")
         return None
+
+    def infer_stream(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float],
+        max_tokens: Optional[int],
+        return_json: bool,
+        custom_format: Any = None,
+        max_retries: int = 5,
+        retry_delay: int = 5,
+    ):
+        if return_json or custom_format is not None:
+            yield from super().infer_stream(
+                messages,
+                temperature,
+                max_tokens,
+                return_json,
+                custom_format,
+                max_retries,
+                retry_delay,
+            )
+            return
+
+        eff_max = (
+            max_tokens
+            if max_tokens is not None
+            else self._resolve_default_max_tokens(self.model_name)
+        )
+        eff_temp = self._normalize_temperature(self.model_name, temperature)
+        retries = 0
+
+        while retries < max_retries:
+            try:
+                kwargs: Dict[str, Any] = {
+                    "model": self.model_name,
+                    "messages": messages,
+                    "stream": True,
+                }
+                if eff_temp is not None:
+                    kwargs["temperature"] = eff_temp
+                self._set_token_limit(kwargs, self.model_name, eff_max)
+
+                stream = self.client.chat.completions.create(**kwargs)
+                for chunk in stream:
+                    text = self._extract_text_from_chunk(chunk)
+                    if text:
+                        yield text
+                return
+            except self._openai.RateLimitError:  # type: ignore[attr-defined]
+                self.logger.warning(
+                    f"Rate limit exceeded. Retrying in {retry_delay} seconds..."
+                )
+                retries += 1
+                if retries < max_retries:
+                    time.sleep(retry_delay * retries)
+            except Exception as e:  # noqa: BLE001
+                self.logger.error(f"OpenAI-compatible streaming error: {e}")
+                break
+
+        self.logger.error(
+            "Max retries exceeded for OpenAI-compatible streaming request"
+        )
 
 
 class OpenRouterClient(BaseLLMClient):

--- a/tests/unit/test_agentic_tool_env_vars.py
+++ b/tests/unit/test_agentic_tool_env_vars.py
@@ -31,6 +31,8 @@ class TestAgenticToolEnvironmentVariables:
             "GEMINI_MODEL_ID",
             "AGENTIC_TOOL_FALLBACK_CHAIN",
             "VLLM_SERVER_URL",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
         ]
         for var in env_vars_to_clear:
             if var in os.environ:
@@ -287,6 +289,29 @@ class TestAgenticToolEnvironmentVariables:
             # Verify the VLLM server URL was correctly read
             # This is tested indirectly through the VLLM client initialization
             assert os.getenv("VLLM_SERVER_URL") == "http://localhost:8000"
+
+    def test_openai_provider_is_supported(self):
+        """Test that OpenAI-compatible provider config is accepted."""
+        os.environ["OPENAI_API_KEY"] = "test-key"
+
+        tool_config = {
+            "name": "test_tool",
+            "prompt": "Test prompt: {input}",
+            "input_arguments": ["input"],
+            "parameter": {
+                "type": "object",
+                "properties": {"input": {"type": "string"}},
+                "required": ["input"],
+            },
+            "api_type": "OPENAI",
+            "model_id": "gpt-4o-mini",
+        }
+
+        with patch.object(AgenticTool, "_try_initialize_api"):
+            tool = AgenticTool(tool_config)
+
+            assert tool._api_type == "OPENAI"
+            assert AgenticTool.has_any_api_keys() is True
 
     def test_task_specific_model_env_var(self):
         """Test that task-specific model environment variables work."""

--- a/tests/unit/test_openai_compatible_client.py
+++ b/tests/unit/test_openai_compatible_client.py
@@ -1,0 +1,91 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from tooluniverse.llm_clients import OpenAICompatibleClient
+
+
+class FakeRateLimitError(Exception):
+    pass
+
+
+class FakeCompletions:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+
+class FakeOpenAIClient:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.completions = FakeCompletions()
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(
+                create=self.completions.create,
+                parse=self.completions.create,
+            )
+        )
+        FakeOpenAIClient.instances.append(self)
+
+
+@pytest.fixture(autouse=True)
+def fake_openai(monkeypatch):
+    FakeOpenAIClient.instances = []
+    monkeypatch.setitem(
+        sys.modules,
+        "openai",
+        SimpleNamespace(OpenAI=FakeOpenAIClient, RateLimitError=FakeRateLimitError),
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+
+def test_openai_compatible_client_uses_base_url(monkeypatch):
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://example.test/v1")
+
+    client = OpenAICompatibleClient(
+        "provider/model",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+
+    assert FakeOpenAIClient.instances[0].kwargs == {
+        "api_key": "test-key",
+        "base_url": "https://example.test/v1",
+    }
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=0,
+        max_tokens=16,
+        return_json=True,
+        max_retries=1,
+        retry_delay=0,
+    )
+    assert result == "ok"
+
+
+def test_openai_compatible_default_max_tokens_from_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_MAX_TOKENS_BY_MODEL", '{"gpt-4o": 123}')
+    client = OpenAICompatibleClient(
+        "gpt-4o-mini",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=None,
+        max_tokens=None,
+        return_json=False,
+        max_retries=1,
+        retry_delay=0,
+    )
+
+    assert result == "ok"
+    assert FakeOpenAIClient.instances[0].completions.calls[0]["max_tokens"] == 123

--- a/tests/unit/test_openai_compatible_client.py
+++ b/tests/unit/test_openai_compatible_client.py
@@ -16,6 +16,15 @@ class FakeCompletions:
 
     def create(self, **kwargs):
         self.calls.append(kwargs)
+        if kwargs.get("stream"):
+            return [
+                SimpleNamespace(
+                    choices=[SimpleNamespace(delta=SimpleNamespace(content="hel"))]
+                ),
+                SimpleNamespace(
+                    choices=[SimpleNamespace(delta=SimpleNamespace(content="lo"))]
+                ),
+            ]
         return SimpleNamespace(
             choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
         )
@@ -89,3 +98,49 @@ def test_openai_compatible_default_max_tokens_from_env(monkeypatch):
 
     assert result == "ok"
     assert FakeOpenAIClient.instances[0].completions.calls[0]["max_tokens"] == 123
+
+
+def test_openai_reasoning_model_uses_completion_tokens(monkeypatch):
+    monkeypatch.setenv("OPENAI_MAX_TOKENS_BY_MODEL", '{"o4-mini": 321}')
+    client = OpenAICompatibleClient(
+        "provider/o4-mini",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=0.7,
+        max_tokens=None,
+        return_json=False,
+        max_retries=1,
+        retry_delay=0,
+    )
+
+    assert result == "ok"
+    call = FakeOpenAIClient.instances[0].completions.calls[0]
+    assert call["max_completion_tokens"] == 321
+    assert "max_tokens" not in call
+    assert "temperature" not in call
+
+
+def test_openai_compatible_streaming():
+    client = OpenAICompatibleClient(
+        "provider/model",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+
+    chunks = list(
+        client.infer_stream(
+            messages=[{"role": "user", "content": "ping"}],
+            temperature=0,
+            max_tokens=16,
+            return_json=False,
+            max_retries=1,
+            retry_delay=0,
+        )
+    )
+
+    assert chunks == ["hel", "lo"]
+    call = FakeOpenAIClient.instances[0].completions.calls[0]
+    assert call["stream"] is True
+    assert call["max_tokens"] == 16

--- a/tests/unit/test_openai_compatible_client.py
+++ b/tests/unit/test_openai_compatible_client.py
@@ -68,6 +68,7 @@ def test_openai_compatible_client_uses_base_url(monkeypatch):
     assert FakeOpenAIClient.instances[0].kwargs == {
         "api_key": "test-key",
         "base_url": "https://example.test/v1",
+        "max_retries": 0,
     }
     result = client.infer(
         messages=[{"role": "user", "content": "ping"}],
@@ -78,6 +79,9 @@ def test_openai_compatible_client_uses_base_url(monkeypatch):
         retry_delay=0,
     )
     assert result == "ok"
+    assert FakeOpenAIClient.instances[0].completions.calls[0]["response_format"] == {
+        "type": "json_object"
+    }
 
 
 def test_openai_compatible_default_max_tokens_from_env(monkeypatch):
@@ -144,3 +148,183 @@ def test_openai_compatible_streaming():
     call = FakeOpenAIClient.instances[0].completions.calls[0]
     assert call["stream"] is True
     assert call["max_tokens"] == 16
+
+
+def test_openai_compatible_rate_limit_does_not_sleep_after_final_attempt(
+    monkeypatch,
+):
+    client = OpenAICompatibleClient(
+        "provider/model",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+    completions = FakeOpenAIClient.instances[0].completions
+    attempts = []
+
+    def always_rate_limited(**kwargs):
+        attempts.append(kwargs)
+        raise FakeRateLimitError
+
+    client.client.chat.completions.create = always_rate_limited
+    sleeps = []
+    monkeypatch.setattr("tooluniverse.llm_clients.time.sleep", sleeps.append)
+
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=0,
+        max_tokens=16,
+        return_json=False,
+        max_retries=2,
+        retry_delay=3,
+    )
+
+    assert result is None
+    assert len(attempts) == 2
+    assert sleeps == [3]
+    assert completions.calls == []
+
+
+def test_openai_compatible_non_retryable_error_is_not_reported_as_exhausted():
+    errors = []
+    client = OpenAICompatibleClient(
+        "provider/model",
+        logger=SimpleNamespace(warning=lambda *_: None, error=errors.append),
+    )
+
+    def fail_once(**kwargs):
+        raise ValueError("invalid request")
+
+    client.client.chat.completions.create = fail_once
+
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=0,
+        max_tokens=16,
+        return_json=False,
+        max_retries=3,
+        retry_delay=0,
+    )
+
+    assert result is None
+    assert errors == ["OpenAI-compatible error: invalid request"]
+
+
+def test_openai_compatible_retries_server_errors(monkeypatch):
+    client = OpenAICompatibleClient(
+        "provider/model",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+    attempts = []
+
+    class ServiceUnavailableError(Exception):
+        status_code = 503
+
+    def fail_then_succeed(**kwargs):
+        attempts.append(kwargs)
+        if len(attempts) == 1:
+            raise ServiceUnavailableError
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+    client.client.chat.completions.create = fail_then_succeed
+    sleeps = []
+    monkeypatch.setattr("tooluniverse.llm_clients.time.sleep", sleeps.append)
+
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=0,
+        max_tokens=16,
+        return_json=False,
+        max_retries=2,
+        retry_delay=3,
+    )
+
+    assert result == "ok"
+    assert len(attempts) == 2
+    assert sleeps == [3]
+
+
+def test_openai_compatible_stream_retries_before_first_chunk(monkeypatch):
+    client = OpenAICompatibleClient(
+        "provider/model",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+    attempts = []
+
+    def create_stream(**kwargs):
+        attempts.append(kwargs)
+        if len(attempts) == 1:
+            raise FakeRateLimitError
+        return [
+            SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content="ok"))]
+            )
+        ]
+
+    client.client.chat.completions.create = create_stream
+    sleeps = []
+    monkeypatch.setattr("tooluniverse.llm_clients.time.sleep", sleeps.append)
+
+    chunks = list(
+        client.infer_stream(
+            messages=[{"role": "user", "content": "ping"}],
+            temperature=0,
+            max_tokens=16,
+            return_json=False,
+            max_retries=2,
+            retry_delay=3,
+        )
+    )
+
+    assert chunks == ["ok"]
+    assert len(attempts) == 2
+    assert sleeps == [3]
+
+
+def test_openai_compatible_custom_format_uses_parse_and_returns_dumped_model():
+    client = OpenAICompatibleClient(
+        "provider/model",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+    calls = []
+    response_format = object()
+
+    def parse(**kwargs):
+        calls.append(kwargs)
+        parsed = SimpleNamespace(model_dump=lambda: {"answer": 42})
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(parsed=parsed))]
+        )
+
+    client.client.chat.completions.parse = parse
+
+    result = client.infer(
+        messages=[{"role": "user", "content": "Return a structured answer"}],
+        temperature=0,
+        max_tokens=16,
+        return_json=False,
+        custom_format=response_format,
+        max_retries=1,
+        retry_delay=0,
+    )
+
+    assert result == {"answer": 42}
+    assert calls[0]["response_format"] is response_format
+
+
+def test_openai_compatible_extracts_list_content_from_dict_chunk():
+    chunk = {
+        "choices": [
+            {
+                "delta": {
+                    "content": [
+                        {"text": "hel"},
+                        {"text": "lo"},
+                        {"type": "ignored"},
+                    ]
+                }
+            }
+        ]
+    }
+
+    assert OpenAICompatibleClient._extract_text_from_chunk(chunk) == "hello"


### PR DESCRIPTION
## Summary

This is a current-main replacement for #184 that preserves SufianTA’s original contribution commit (`4776416e`) and adds compatibility hardening.

- adds a generic OpenAI-compatible protocol adapter configurable with `OPENAI_BASE_URL`
- keeps the feature provider-neutral; no provider-specific skill or YAML is introduced
- adds actual SSE streaming support
- uses `max_completion_tokens` for current reasoning-model families while retaining `max_tokens` for compatible chat models
- omits unsupported temperature settings for o-series reasoning models
- makes model-family overrides work with provider-prefixed model IDs
- includes the provider page in the Sphinx documentation tree

## Validation

- 46 related unit tests passed
- Ruff lint and format checks passed
- Sphinx includes the new provider page (the full docs build retains 210 unrelated baseline warnings)
- end-to-end protocol test against a local OpenAI-compatible HTTP server using OpenAI Python SDK 1.107.2 passed:
  - buffered `/v1/chat/completions` request with auth, JSON mode, and `max_tokens`
  - SSE stream yielding `hel` + `lo`
  - `provider/o4-mini` request using `max_completion_tokens: 7` and omitting `temperature`

This deliberately does not auto-close #8: that issue asks for broader multi-provider support, while this PR adds only the generic OpenAI-compatible adapter.

After this replacement is merged, #184 can be closed with thanks to the original contributor.