### PR TITLE
Validate LLM temperature environment values

### DIFF
--- a/src/tooluniverse/agentic_tool.py
+++ b/src/tooluniverse/agentic_tool.py
@@ -45,6 +45,17 @@ class AgenticTool(BaseTool):
         raise ValueError(f"Expected boolean environment value, got: {value!r}")
 
     @staticmethod
+    def _parse_float_env(value: Optional[str]) -> Optional[float]:
+        if value is None or value == "":
+            return None
+        try:
+            return float(value)
+        except ValueError as exc:
+            raise ValueError(
+                f"Expected numeric TOOLUNIVERSE_LLM_TEMPERATURE, got: {value!r}"
+            ) from exc
+
+    @staticmethod
     def has_any_api_keys() -> bool:
         """
         Check if any API keys are available across all supported API types.
@@ -100,8 +111,9 @@ class AgenticTool(BaseTool):
                     "TOOLUNIVERSE_LLM_MODEL_DEFAULT"
                 )
             elif key == "temperature":
-                temp_str = os.getenv("TOOLUNIVERSE_LLM_TEMPERATURE")
-                env_value = float(temp_str) if temp_str else None
+                env_value = self._parse_float_env(
+                    os.getenv("TOOLUNIVERSE_LLM_TEMPERATURE")
+                )
             elif key == "return_json":
                 env_value = self._parse_bool_env(
                     os.getenv("TOOLUNIVERSE_LLM_RETURN_JSON")

--- a/src/tooluniverse/agentic_tool.py
+++ b/src/tooluniverse/agentic_tool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import json
+import math
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
@@ -49,11 +50,16 @@ class AgenticTool(BaseTool):
         if value is None or value == "":
             return None
         try:
-            return float(value)
-        except ValueError as exc:
+            parsed = float(value)
+        except (TypeError, ValueError) as exc:
             raise ValueError(
                 f"Expected numeric TOOLUNIVERSE_LLM_TEMPERATURE, got: {value!r}"
             ) from exc
+        if not math.isfinite(parsed):
+            raise ValueError(
+                f"Expected finite numeric TOOLUNIVERSE_LLM_TEMPERATURE, got: {value!r}"
+            )
+        return parsed
 
     @staticmethod
     def has_any_api_keys() -> bool:

--- a/tests/unit/test_agentic_tool_env_vars.py
+++ b/tests/unit/test_agentic_tool_env_vars.py
@@ -522,6 +522,25 @@ class TestAgenticToolEnvironmentVariables:
             with pytest.raises(ValueError, match="Expected boolean environment value"):
                 AgenticTool(tool_config)
 
+    def test_invalid_temperature_env_var_fails_fast(self):
+        """Invalid temperature env values should fail with a clear error."""
+        os.environ["TOOLUNIVERSE_LLM_TEMPERATURE"] = "not-a-number"
+
+        tool_config = {
+            "name": "test_tool",
+            "prompt": "Test prompt: {input}",
+            "input_arguments": ["input"],
+            "parameter": {
+                "type": "object",
+                "properties": {"input": {"type": "string"}},
+                "required": ["input"],
+            },
+        }
+
+        with patch.object(AgenticTool, "_try_initialize_api"):
+            with pytest.raises(ValueError, match="TOOLUNIVERSE_LLM_TEMPERATURE"):
+                AgenticTool(tool_config)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/unit/test_agentic_tool_env_vars.py
+++ b/tests/unit/test_agentic_tool_env_vars.py
@@ -541,6 +541,26 @@ class TestAgenticToolEnvironmentVariables:
             with pytest.raises(ValueError, match="TOOLUNIVERSE_LLM_TEMPERATURE"):
                 AgenticTool(tool_config)
 
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf"])
+    def test_non_finite_temperature_env_var_fails_fast(self, value):
+        """Reject non-finite floats before they reach a provider client."""
+        os.environ["TOOLUNIVERSE_LLM_TEMPERATURE"] = value
+
+        tool_config = {
+            "name": "test_tool",
+            "prompt": "Test prompt: {input}",
+            "input_arguments": ["input"],
+            "parameter": {
+                "type": "object",
+                "properties": {"input": {"type": "string"}},
+                "required": ["input"],
+            },
+        }
+
+        with patch.object(AgenticTool, "_try_initialize_api"):
+            with pytest.raises(ValueError, match="finite numeric"):
+                AgenticTool(tool_config)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Summary

This supersedes #276 with the original contributor commit preserved on the current `main` implementation.

- parse `TOOLUNIVERSE_LLM_TEMPERATURE` through a dedicated validation helper
- provide a clear error for invalid values before provider initialization
- reject `NaN` and positive/negative infinity, which Python's `float()` otherwise accepts
- keep validation provider-neutral: finite values are accepted, while the existing recommended `[0, 2]` range remains a warning rather than a provider-specific hard limit
- add regression coverage for valid, malformed, missing, empty, and non-finite values

## Merge notes

- #410 is merged and this branch has been synchronized with its merge commit on `main`.
- The original SufianTA commit (`68cfb6a8`) is retained. Please use **Create a merge commit**, not squash merge, to preserve that contribution record.
- Keep #276 open until this replacement lands.

## Validation on latest `main`

- GitHub `Run Tests (3.12)` — passed
- `pytest -q --no-cov --tb=short tests/unit/test_agentic_tool_env_vars.py tests/unit/test_agentic_tool_temperature_defaults.py` — 31 passed
- `pytest -q --no-cov --tb=short tests/unit` — passed with 11 documented environment/resource skips
- `ruff check` — passed
- `ruff format --check` for the two changed files — passed
- `git diff --check origin/main...HEAD` — passed
- real CLI smoke test, forced to import this worktree via `PYTHONPATH=src`, confirms `nan` fails immediately with a finite-numeric validation error before provider initialization

