### PR TITLE
Add reviewed dynamic REST runtime

### DIFF
--- a/docs/dev_docs/VSD_DYNAMIC_REST_VALIDATION.md
+++ b/docs/dev_docs/VSD_DYNAMIC_REST_VALIDATION.md
@@ -1,0 +1,45 @@
+# VSD Reviewed Dynamic REST Runtime
+
+## Scope
+
+This phase restores the useful execution portion of PR #32 without restoring
+arbitrary URL execution or automatic publication. An administrator-reviewed
+operation can be attached to one `ToolUniverse` instance and invoked through
+`run_one_function()`. Nothing is loaded by default and nothing is persisted by
+this phase.
+
+The runtime deliberately supports only public, read-only HTTPS JSON `GET`
+operations. Authenticated or mutating APIs require a dedicated integration with
+source-specific security review.
+
+## Enforced Contract
+
+- Exact-host allowlisting and public DNS resolution before every request.
+- Connection to one pinned public IP while preserving TLS hostname validation.
+- No redirects, proxy inheritance, credentials, nonstandard ports, or URL query
+  strings in operation definitions.
+- One shared wall-clock deadline and a one-megabyte undecoded response limit.
+- Strict JSON media type, UTF-8 decoding, and finite JSON numbers.
+- JSON Schema validation for tool arguments and provider responses.
+- Exact argument-to-path/query mapping; every declared argument must be used.
+- Percent encoding for path arguments and credential-name rejection for query
+  parameters.
+- Stable SHA-256 digests for both the reviewed operation and returned payload.
+
+## End-to-End Proof
+
+`examples/vsd/dynamic_rest_als_case_study.py` defines two independent reviewed
+operations backed by ClinicalTrials.gov. It registers both into one real
+`ToolUniverse` instance, searches active or upcoming US studies for amyotrophic
+lateral sclerosis, chooses one returned identifier deterministically, and calls
+the second operation to retrieve that record. The case fails if either provider
+schema drifts or the detail identifier differs from the search result.
+
+Artifacts are written to:
+
+- `examples/vsd/artifacts/dynamic_rest_als_snapshot.json`
+- `examples/vsd/artifacts/dynamic_rest_als_snapshot.md`
+
+The result is an execution and record-consistency proof. It is not a patient
+matching system, eligibility assessment, scientific endorsement, or treatment
+recommendation.

--- a/examples/vsd/artifacts/dynamic_rest_als_snapshot.json
+++ b/examples/vsd/artifacts/dynamic_rest_als_snapshot.json
@@ -1,0 +1,1833 @@
+{
+  "case": {
+    "condition": "Amyotrophic Lateral Sclerosis",
+    "interpretation_boundary": "This is an API execution and record-consistency proof, not trial matching, eligibility assessment, or treatment advice.",
+    "location_query": "AREA[LocationCountry]United States",
+    "question": "Which active or upcoming US ALS studies are returned by the reviewed ClinicalTrials.gov search, and can a second generated operation retrieve the selected study consistently?",
+    "status_filter": [
+      "RECRUITING",
+      "NOT_YET_RECRUITING",
+      "ACTIVE_NOT_RECRUITING",
+      "ENROLLING_BY_INVITATION"
+    ]
+  },
+  "detail_follow_up": {
+    "identifier_matches_search": true,
+    "provenance": {
+      "content_type": "application/json",
+      "endpoint": "https://clinicaltrials.gov/api/v2/studies/NCT01772602",
+      "http_status": 200,
+      "method": "GET",
+      "operation_sha256": "3b4dd7f5717bd0f2dcf1d50c85a09a71c1b00ba44c7bccbfcf339bf0a53dbfa6",
+      "payload_sha256": "4dd3ccee9977ba69c9e8c35c179fdc25f212d39b101cc0c9e0a8e8fd7ca30c44",
+      "provider": "clinicaltrials.gov",
+      "query_params": {
+        "format": "json"
+      },
+      "redirects": 0,
+      "response_bytes": 4743,
+      "retrieved_at": "2026-08-01T01:07:10.720661+00:00"
+    },
+    "selected_nct_id": "NCT01772602",
+    "selection_rule": "Lexicographically smallest returned valid NCT identifier",
+    "study": {
+      "conditions": [
+        "Amyotrophic Lateral Sclerosis"
+      ],
+      "interventions": [],
+      "lead_sponsor": "Centers for Disease Control and Prevention",
+      "nct_id": "NCT01772602",
+      "overall_status": "RECRUITING",
+      "phases": [],
+      "study_type": "OBSERVATIONAL",
+      "title": "The National Amyotrophic Lateral Sclerosis Registry",
+      "us_locations": [
+        {
+          "city": "Atlanta",
+          "facility": "CDC",
+          "state": "Georgia",
+          "status": "RECRUITING"
+        }
+      ]
+    }
+  },
+  "search": {
+    "has_next_page": true,
+    "intervention_type_counts": {
+      "BEHAVIORAL": 2,
+      "BIOLOGICAL": 1,
+      "COMBINATION_PRODUCT": 1,
+      "DEVICE": 4,
+      "DIETARY_SUPPLEMENT": 1,
+      "DRUG": 14,
+      "GENETIC": 1,
+      "OTHER": 6
+    },
+    "phase_counts": {
+      "NA": 4,
+      "NOT_APPLICABLE": 8,
+      "PHASE1": 4,
+      "PHASE2": 3,
+      "PHASE3": 2
+    },
+    "provenance": {
+      "content_type": "application/json",
+      "endpoint": "https://clinicaltrials.gov/api/v2/studies",
+      "http_status": 200,
+      "method": "GET",
+      "operation_sha256": "79852cdcc0dc7695b4e430313b1574721303fb78b0dff1cd3eadcbcd66c9be1c",
+      "payload_sha256": "dbefbe106f242d10a0b52277d89cd4264b7fe52851b6f50ffbe65efcf23da6a9",
+      "provider": "clinicaltrials.gov",
+      "query_params": {
+        "countTotal": "true",
+        "filter.overallStatus": "RECRUITING|NOT_YET_RECRUITING|ACTIVE_NOT_RECRUITING|ENROLLING_BY_INVITATION",
+        "format": "json",
+        "pageSize": 20,
+        "query.cond": "Amyotrophic Lateral Sclerosis",
+        "query.locn": "AREA[LocationCountry]United States"
+      },
+      "redirects": 0,
+      "response_bytes": 336328,
+      "retrieved_at": "2026-08-01T01:07:10.515764+00:00"
+    },
+    "provider_total_count": 113,
+    "returned_records": 20,
+    "status_counts": {
+      "ACTIVE_NOT_RECRUITING": 5,
+      "NOT_YET_RECRUITING": 3,
+      "RECRUITING": 12
+    },
+    "studies": [
+      {
+        "conditions": [
+          "Frontotemporal Degeneration(FTD)",
+          "Primary Progressive Aphasia(PPA)",
+          "Familial Frontotemporal Lobar Degeneration (fFTLD)",
+          "Amyotrophic Lateral Sclerosis(ALS)",
+          "Lewy Body Disease(LBD)",
+          "Progressive Supranuclear Palsy(PSP)",
+          "Corticobasal Syndrome(CBS)",
+          "Posterior Cortical Atrophy(PCA)",
+          "Alzheimer's Disease(AD)"
+        ],
+        "interventions": [
+          {
+            "name": "No intervention",
+            "type": "OTHER"
+          }
+        ],
+        "lead_sponsor": "University of Pennsylvania",
+        "nct_id": "NCT04715399",
+        "overall_status": "RECRUITING",
+        "phases": [],
+        "study_type": "OBSERVATIONAL",
+        "title": "UPenn Observational Research Repository on Neurodegenerative Disease",
+        "us_locations": [
+          {
+            "city": "Philadelphia",
+            "facility": "University of Pennsylvania",
+            "state": "Pennsylvania",
+            "status": "RECRUITING"
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis"
+        ],
+        "interventions": [],
+        "lead_sponsor": "Centers for Disease Control and Prevention",
+        "nct_id": "NCT01772602",
+        "overall_status": "RECRUITING",
+        "phases": [],
+        "study_type": "OBSERVATIONAL",
+        "title": "The National Amyotrophic Lateral Sclerosis Registry",
+        "us_locations": [
+          {
+            "city": "Atlanta",
+            "facility": "CDC",
+            "state": "Georgia",
+            "status": "RECRUITING"
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis",
+          "Motor Neuron Disease"
+        ],
+        "interventions": [
+          {
+            "name": "Acamprosate calcium",
+            "type": "DRUG"
+          }
+        ],
+        "lead_sponsor": "National Institute of Neurological Disorders and Stroke (NINDS)",
+        "nct_id": "NCT07204977",
+        "overall_status": "ACTIVE_NOT_RECRUITING",
+        "phases": [
+          "PHASE1"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "Acamprosate in C9orf72 Hexanucleotide Repeat Expansion Amyotrophic Lateral Sclerosis (ACALS)",
+        "us_locations": [
+          {
+            "city": "Bethesda",
+            "facility": "National Institutes of Health Clinical Center",
+            "state": "Maryland",
+            "status": null
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "C9orf72 Amyotrophic Lateral Sclerosis (ALS)",
+          "Frontotemporal Dementia"
+        ],
+        "interventions": [
+          {
+            "name": "Metformin",
+            "type": "DRUG"
+          }
+        ],
+        "lead_sponsor": "University of Florida",
+        "nct_id": "NCT04220021",
+        "overall_status": "ACTIVE_NOT_RECRUITING",
+        "phases": [
+          "PHASE2"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "Safety and Therapeutic Potential of the FDA-approved Drug Metformin for C9orf72 ALS/FTD",
+        "us_locations": [
+          {
+            "city": "Gainesville",
+            "facility": "UF Health at the University of Florida",
+            "state": "Florida",
+            "status": null
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis",
+          "Primary Lateral Sclerosis"
+        ],
+        "interventions": [],
+        "lead_sponsor": "University of Minnesota",
+        "nct_id": "NCT02567136",
+        "overall_status": "RECRUITING",
+        "phases": [],
+        "study_type": "OBSERVATIONAL",
+        "title": "Imaging Biomarkers in ALS",
+        "us_locations": [
+          {
+            "city": "Minneapolis",
+            "facility": "University of Minnesota",
+            "state": "Minnesota",
+            "status": "RECRUITING"
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis",
+          "Movement Disorders",
+          "Degenerative Disorder",
+          "Motor Neuron Disease"
+        ],
+        "interventions": [],
+        "lead_sponsor": "Target ALS Foundation, Inc.",
+        "nct_id": "NCT05137665",
+        "overall_status": "RECRUITING",
+        "phases": [],
+        "study_type": "OBSERVATIONAL",
+        "title": "Target ALS Biomarker Study; Longitudinal Biofluids, Clinical Measures, and At Home Measures",
+        "us_locations": [
+          {
+            "city": "Phoenix",
+            "facility": "Barrow Neurological Institute",
+            "state": "Arizona",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "San Diego",
+            "facility": "University of California San Diego",
+            "state": "California",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Georgetown",
+            "facility": "Georgetown University",
+            "state": "District of Columbia",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Jacksonville",
+            "facility": "Mayo Clinic",
+            "state": "Florida",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Chicago",
+            "facility": "Northwestern University",
+            "state": "Illinois",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Boston",
+            "facility": "Massachusetts General Hospital",
+            "state": "Massachusetts",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "St Louis",
+            "facility": "Washington University",
+            "state": "Missouri",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "New York",
+            "facility": "Columbia University",
+            "state": "New York",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Houston",
+            "facility": "Baylor College of Medicine",
+            "state": "Texas",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Seattle",
+            "facility": "University of Washington",
+            "state": "Washington",
+            "status": "RECRUITING"
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Tetraplegia/Tetraparesis",
+          "Quadriplegia",
+          "Cervical Spinal Cord Injury",
+          "Amyotrophic Lateral Sclerosis",
+          "Quadriplegia/Tetraplegia",
+          "Tetraplegic; Paralysis",
+          "Stroke"
+        ],
+        "interventions": [
+          {
+            "name": "N1 Implant",
+            "type": "DEVICE"
+          },
+          {
+            "name": "R1 Robot",
+            "type": "DEVICE"
+          }
+        ],
+        "lead_sponsor": "Neuralink Corp",
+        "nct_id": "NCT07224256",
+        "overall_status": "RECRUITING",
+        "phases": [
+          "NA"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "VOICE: An Early Feasibility Study of a Precise Robotically Implanted Brain-Computer Interface for Communication Restoration",
+        "us_locations": [
+          {
+            "city": "Dallas",
+            "facility": "The University of Texas Southwestern Medical Center",
+            "state": "Texas",
+            "status": "RECRUITING"
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis (ALS)"
+        ],
+        "interventions": [
+          {
+            "name": "Antioxidants",
+            "type": "COMBINATION_PRODUCT"
+          }
+        ],
+        "lead_sponsor": "Dallas VA Medical Center",
+        "nct_id": "NCT04244630",
+        "overall_status": "RECRUITING",
+        "phases": [
+          "PHASE2"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "Mitochondrial Capacity Boost in ALS (MICABO-ALS) Trial",
+        "us_locations": [
+          {
+            "city": "Dallas",
+            "facility": "VA North Texas Health Care System",
+            "state": "Texas",
+            "status": "RECRUITING"
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis",
+          "Hereditary Spastic Paraplegia",
+          "Primary Lateral Sclerosis",
+          "Progressive Muscular Atrophy",
+          "Frontotemporal Dementia"
+        ],
+        "interventions": [],
+        "lead_sponsor": "University of Miami",
+        "nct_id": "NCT04875416",
+        "overall_status": "ACTIVE_NOT_RECRUITING",
+        "phases": [],
+        "study_type": "OBSERVATIONAL",
+        "title": "Phenotype, Genotype and Biomarkers 2",
+        "us_locations": [
+          {
+            "city": "Miami",
+            "facility": "University of Miami",
+            "state": "Florida",
+            "status": null
+          },
+          {
+            "city": "Kansas City",
+            "facility": "University of Kansas Medical Center",
+            "state": "Kansas",
+            "status": null
+          },
+          {
+            "city": "Philadelphia",
+            "facility": "University of Pennsylvania",
+            "state": "Pennsylvania",
+            "status": null
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis ALS"
+        ],
+        "interventions": [
+          {
+            "name": "\u03b2-hydroxy-\u03b2-methylbutyrate (HMB)",
+            "type": "DRUG"
+          }
+        ],
+        "lead_sponsor": "Duke University",
+        "nct_id": "NCT07589764",
+        "overall_status": "NOT_YET_RECRUITING",
+        "phases": [
+          "PHASE1"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "A Widely Inclusive, Hybrid-Decentralized Pilot Trial Utilizing \u03b2-hydroxy-\u03b2-methylbutyrate to Lower IGFBP7 Levels in People With ALS",
+        "us_locations": [
+          {
+            "city": "Durham",
+            "facility": "Duke University Medical Center",
+            "state": "North Carolina",
+            "status": null
+          },
+          {
+            "city": "Philadelphia",
+            "facility": "Temple University",
+            "state": "Pennsylvania",
+            "status": null
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis"
+        ],
+        "interventions": [],
+        "lead_sponsor": "St. Joseph's Hospital and Medical Center, Phoenix",
+        "nct_id": "NCT06581861",
+        "overall_status": "RECRUITING",
+        "phases": [],
+        "study_type": "OBSERVATIONAL",
+        "title": "PREVENT ALL ALS Study",
+        "us_locations": [
+          {
+            "city": "Birmingham",
+            "facility": "University of Alabama Birmingham",
+            "state": "Alabama",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Phoenix",
+            "facility": "Barrow Neurological Institute",
+            "state": "Arizona",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "La Jolla",
+            "facility": "University of California San Diego",
+            "state": "California",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Orange",
+            "facility": "University of California Irvine",
+            "state": "California",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "San Francisco",
+            "facility": "University of California, San Francisco",
+            "state": "California",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Aurora",
+            "facility": "University of Colorado Anschutz Medical Campus",
+            "state": "Colorado",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "New Britain",
+            "facility": "Hospital for Special Care",
+            "state": "Connecticut",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Washington D.C.",
+            "facility": "Georgetown University",
+            "state": "District of Columbia",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Jacksonville",
+            "facility": "Mayo Clinic",
+            "state": "Florida",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Boise",
+            "facility": "Saint Alphonsus Regional Medical Center",
+            "state": "Idaho",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Chicago",
+            "facility": "Northwestern University",
+            "state": "Illinois",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Indianapolis",
+            "facility": "Indiana University",
+            "state": "Indiana",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Baltimore",
+            "facility": "John Hopkins University",
+            "state": "Maryland",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Bethesda",
+            "facility": "Nih/Ninds",
+            "state": "Maryland",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Boston",
+            "facility": "Massachusetts General Brigham",
+            "state": "Massachusetts",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Ann Arbor",
+            "facility": "University of Michigan",
+            "state": "Michigan",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Detroit",
+            "facility": "Henry Ford Health",
+            "state": "Michigan",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Minneapolis",
+            "facility": "University of Minnesota",
+            "state": "Minnesota",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "St Louis",
+            "facility": "Washington University",
+            "state": "Missouri",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Omaha",
+            "facility": "University of Nebraska Medical Center",
+            "state": "Nebraska",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Lebanon",
+            "facility": "Dartmouth Hitchcock Medical Center",
+            "state": "New Hampshire",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "New York",
+            "facility": "Columbia University",
+            "state": "New York",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Durham",
+            "facility": "Duke University",
+            "state": "North Carolina",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Columbus",
+            "facility": "Ohio State University",
+            "state": "Ohio",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Portland",
+            "facility": "Providence ALS Center",
+            "state": "Oregon",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Hershey",
+            "facility": "Penn State Health",
+            "state": "Pennsylvania",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Philadelphia",
+            "facility": "Temple University",
+            "state": "Pennsylvania",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Dallas",
+            "facility": "Texas Neurology",
+            "state": "Texas",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Salt Lake City",
+            "facility": "University of Utah",
+            "state": "Utah",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Richmond",
+            "facility": "Virginia Commonwealth University",
+            "state": "Virginia",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Seattle",
+            "facility": "University of Washington",
+            "state": "Washington",
+            "status": "RECRUITING"
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis"
+        ],
+        "interventions": [
+          {
+            "name": "Zilucoplan",
+            "type": "DRUG"
+          },
+          {
+            "name": "Verdiperstat",
+            "type": "DRUG"
+          },
+          {
+            "name": "CNM-Au8",
+            "type": "DRUG"
+          },
+          {
+            "name": "Pridopidine",
+            "type": "DRUG"
+          },
+          {
+            "name": "SLS-005 Trehalose",
+            "type": "DRUG"
+          },
+          {
+            "name": "ABBV-CLS-7262",
+            "type": "DRUG"
+          },
+          {
+            "name": "DNL343",
+            "type": "DRUG"
+          },
+          {
+            "name": "NUZ-001",
+            "type": "DRUG"
+          }
+        ],
+        "lead_sponsor": "Merit E. Cudkowicz, MD",
+        "nct_id": "NCT04297683",
+        "overall_status": "ACTIVE_NOT_RECRUITING",
+        "phases": [
+          "PHASE2",
+          "PHASE3"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "HEALEY ALS Platform Trial - Master Protocol",
+        "us_locations": [
+          {
+            "city": "Phoenix",
+            "facility": "Barrow Neurological Institute",
+            "state": "Arizona",
+            "status": null
+          },
+          {
+            "city": "Scottsdale",
+            "facility": "Mayo Clinic Scottsdale",
+            "state": "Arizona",
+            "status": null
+          },
+          {
+            "city": "Little Rock",
+            "facility": "University of Arkansas for Medical Sciences",
+            "state": "Arkansas",
+            "status": null
+          },
+          {
+            "city": "La Jolla",
+            "facility": "UC San Diego",
+            "state": "California",
+            "status": null
+          },
+          {
+            "city": "Loma Linda",
+            "facility": "Loma Linda University Health",
+            "state": "California",
+            "status": null
+          },
+          {
+            "city": "Los Angeles",
+            "facility": "Kaiser Permanente Los Angeles Medical Center",
+            "state": "California",
+            "status": null
+          },
+          {
+            "city": "Los Angeles",
+            "facility": "University of Southern California",
+            "state": "California",
+            "status": null
+          },
+          {
+            "city": "Los Angeles",
+            "facility": "Cedars-Sinai Medical Center",
+            "state": "California",
+            "status": null
+          },
+          {
+            "city": "Orange",
+            "facility": "University of California, Irvine",
+            "state": "California",
+            "status": null
+          },
+          {
+            "city": "San Francisco",
+            "facility": "Forbes Norris MDA/ALS Research Center, California Pacific Medical Center",
+            "state": "California",
+            "status": null
+          },
+          {
+            "city": "San Francisco",
+            "facility": "University of California, San Francisco",
+            "state": "California",
+            "status": null
+          },
+          {
+            "city": "Aurora",
+            "facility": "University of Colorado",
+            "state": "Colorado",
+            "status": null
+          },
+          {
+            "city": "New Britain",
+            "facility": "Hospital for Special Care",
+            "state": "Connecticut",
+            "status": null
+          },
+          {
+            "city": "New Haven",
+            "facility": "Yale University",
+            "state": "Connecticut",
+            "status": null
+          },
+          {
+            "city": "Washington D.C.",
+            "facility": "Georgetown University",
+            "state": "District of Columbia",
+            "status": null
+          },
+          {
+            "city": "Washington D.C.",
+            "facility": "George Washington University",
+            "state": "District of Columbia",
+            "status": null
+          },
+          {
+            "city": "Davie",
+            "facility": "Nova Southeastern University",
+            "state": "Florida",
+            "status": null
+          },
+          {
+            "city": "Gainesville",
+            "facility": "University of Florida",
+            "state": "Florida",
+            "status": null
+          },
+          {
+            "city": "Jacksonville",
+            "facility": "Mayo Clinic Florida",
+            "state": "Florida",
+            "status": null
+          },
+          {
+            "city": "Miami",
+            "facility": "University of Miami",
+            "state": "Florida",
+            "status": null
+          },
+          {
+            "city": "Tampa",
+            "facility": "University of South Florida",
+            "state": "Florida",
+            "status": null
+          },
+          {
+            "city": "Augusta",
+            "facility": "Augusta University",
+            "state": "Georgia",
+            "status": null
+          },
+          {
+            "city": "Boise",
+            "facility": "Saint Alphonsus Regional Medical Center",
+            "state": "Idaho",
+            "status": null
+          },
+          {
+            "city": "Chicago",
+            "facility": "Northwestern University",
+            "state": "Illinois",
+            "status": null
+          },
+          {
+            "city": "Chicago",
+            "facility": "University of Chicago",
+            "state": "Illinois",
+            "status": null
+          },
+          {
+            "city": "Indianapolis",
+            "facility": "Indiana University Health",
+            "state": "Indiana",
+            "status": null
+          },
+          {
+            "city": "Iowa City",
+            "facility": "University of Iowa Hospitals and Clinics",
+            "state": "Iowa",
+            "status": null
+          },
+          {
+            "city": "Fairway",
+            "facility": "University of Kansas Medical Center",
+            "state": "Kansas",
+            "status": null
+          },
+          {
+            "city": "Lexington",
+            "facility": "University of Kentucky",
+            "state": "Kentucky",
+            "status": null
+          },
+          {
+            "city": "New Orleans",
+            "facility": "Ochsner Health System",
+            "state": "Louisiana",
+            "status": null
+          },
+          {
+            "city": "Baltimore",
+            "facility": "Johns Hopkins University",
+            "state": "Maryland",
+            "status": null
+          },
+          {
+            "city": "Boston",
+            "facility": "Massachusetts General Hospital",
+            "state": "Massachusetts",
+            "status": null
+          },
+          {
+            "city": "Boston",
+            "facility": "Beth Israel Deaconess Medical Center",
+            "state": "Massachusetts",
+            "status": null
+          },
+          {
+            "city": "Burlington",
+            "facility": "Lahey Hospital and Medical Center",
+            "state": "Massachusetts",
+            "status": null
+          },
+          {
+            "city": "North Worcester",
+            "facility": "University of Massachusetts Medical School",
+            "state": "Massachusetts",
+            "status": null
+          },
+          {
+            "city": "Ann Arbor",
+            "facility": "University of Michigan",
+            "state": "Michigan",
+            "status": null
+          },
+          {
+            "city": "Detroit",
+            "facility": "Henry Ford Health System",
+            "state": "Michigan",
+            "status": null
+          },
+          {
+            "city": "Grand Rapids",
+            "facility": "Spectrum Health/Corewell Health",
+            "state": "Michigan",
+            "status": null
+          },
+          {
+            "city": "Duluth",
+            "facility": "Essentia Health",
+            "state": "Minnesota",
+            "status": null
+          },
+          {
+            "city": "Minneapolis",
+            "facility": "University of Minnesota Medical School",
+            "state": "Minnesota",
+            "status": null
+          },
+          {
+            "city": "Rochester",
+            "facility": "Mayo Clinic - Rochester",
+            "state": "Minnesota",
+            "status": null
+          },
+          {
+            "city": "Columbia",
+            "facility": "University of Missouri Health Care",
+            "state": "Missouri",
+            "status": null
+          },
+          {
+            "city": "St Louis",
+            "facility": "Saint Louis University",
+            "state": "Missouri",
+            "status": null
+          },
+          {
+            "city": "St Louis",
+            "facility": "Washington University School of Medicine",
+            "state": "Missouri",
+            "status": null
+          },
+          {
+            "city": "Lincoln",
+            "facility": "Neurology Associates, P.C./Somnos Clinical Research",
+            "state": "Nebraska",
+            "status": null
+          },
+          {
+            "city": "Omaha",
+            "facility": "University of Nebraska Medical Center",
+            "state": "Nebraska",
+            "status": null
+          },
+          {
+            "city": "Lebanon",
+            "facility": "Dartmouth-Hitchcock Medical Center",
+            "state": "New Hampshire",
+            "status": null
+          },
+          {
+            "city": "Hackensack",
+            "facility": "Hackensack University Medical Center",
+            "state": "New Jersey",
+            "status": null
+          },
+          {
+            "city": "Amherst",
+            "facility": "Dent Neurologic Institute",
+            "state": "New York",
+            "status": null
+          },
+          {
+            "city": "New York",
+            "facility": "Mount Sinai",
+            "state": "New York",
+            "status": null
+          },
+          {
+            "city": "New York",
+            "facility": "Columbia University",
+            "state": "New York",
+            "status": null
+          },
+          {
+            "city": "Rochester",
+            "facility": "University of Rochester",
+            "state": "New York",
+            "status": null
+          },
+          {
+            "city": "Stony Brook",
+            "facility": "Stony Brook University Hospital",
+            "state": "New York",
+            "status": null
+          },
+          {
+            "city": "Syracuse",
+            "facility": "SUNY Upstate",
+            "state": "New York",
+            "status": null
+          },
+          {
+            "city": "Chapel Hill",
+            "facility": "University of North Carolina",
+            "state": "North Carolina",
+            "status": null
+          },
+          {
+            "city": "Charlotte",
+            "facility": "Atrium Health",
+            "state": "North Carolina",
+            "status": null
+          },
+          {
+            "city": "Durham",
+            "facility": "Duke University",
+            "state": "North Carolina",
+            "status": null
+          },
+          {
+            "city": "Winston-Salem",
+            "facility": "Wake Forest Health Science",
+            "state": "North Carolina",
+            "status": null
+          },
+          {
+            "city": "Cincinnati",
+            "facility": "University of Cincinnati",
+            "state": "Ohio",
+            "status": null
+          },
+          {
+            "city": "Cleveland",
+            "facility": "Cleveland Clinic",
+            "state": "Ohio",
+            "status": null
+          },
+          {
+            "city": "Columbus",
+            "facility": "The Ohio State University",
+            "state": "Ohio",
+            "status": null
+          },
+          {
+            "city": "Westerville",
+            "facility": "OhioHealth Research Institute",
+            "state": "Ohio",
+            "status": null
+          },
+          {
+            "city": "Portland",
+            "facility": "Providence Brain and Spine Institute ALS Center",
+            "state": "Oregon",
+            "status": null
+          },
+          {
+            "city": "Allentown",
+            "facility": "Lehigh Valley Health Network",
+            "state": "Pennsylvania",
+            "status": null
+          },
+          {
+            "city": "Hershey",
+            "facility": "Penn State Hershey",
+            "state": "Pennsylvania",
+            "status": null
+          },
+          {
+            "city": "Philadelphia",
+            "facility": "Jefferson Weinberg ALS Center, Thomas Jefferson University",
+            "state": "Pennsylvania",
+            "status": null
+          },
+          {
+            "city": "Philadelphia",
+            "facility": "University of Pennsylvania",
+            "state": "Pennsylvania",
+            "status": null
+          },
+          {
+            "city": "Philadelphia",
+            "facility": "Lewis Katz School of Medicine at Temple University",
+            "state": "Pennsylvania",
+            "status": null
+          },
+          {
+            "city": "Pittsburgh",
+            "facility": "University of Pittsburg Medical Center",
+            "state": "Pennsylvania",
+            "status": null
+          },
+          {
+            "city": "Nashville",
+            "facility": "Vanderbilt University Medical Center",
+            "state": "Tennessee",
+            "status": null
+          },
+          {
+            "city": "Austin",
+            "facility": "Austin Neuromuscular Clinic",
+            "state": "Texas",
+            "status": null
+          },
+          {
+            "city": "Dallas",
+            "facility": "Texas Neurology",
+            "state": "Texas",
+            "status": null
+          },
+          {
+            "city": "Houston",
+            "facility": "Baylor College of Medicine",
+            "state": "Texas",
+            "status": null
+          },
+          {
+            "city": "Houston",
+            "facility": "Houston Methodist",
+            "state": "Texas",
+            "status": null
+          },
+          {
+            "city": "San Antonio",
+            "facility": "UTHSCSA",
+            "state": "Texas",
+            "status": null
+          },
+          {
+            "city": "Salt Lake City",
+            "facility": "University of Utah",
+            "state": "Utah",
+            "status": null
+          },
+          {
+            "city": "Charlottesville",
+            "facility": "University of Virginia",
+            "state": "Virginia",
+            "status": null
+          },
+          {
+            "city": "Henrico",
+            "facility": "Virginia Commonwealth University",
+            "state": "Virginia",
+            "status": null
+          },
+          {
+            "city": "Seattle",
+            "facility": "Swedish Medical Center",
+            "state": "Washington",
+            "status": null
+          },
+          {
+            "city": "Seattle",
+            "facility": "University of Washington",
+            "state": "Washington",
+            "status": null
+          },
+          {
+            "city": "Milwaukee",
+            "facility": "Medical College of Wisconsin",
+            "state": "Wisconsin",
+            "status": null
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis"
+        ],
+        "interventions": [],
+        "lead_sponsor": "St. Joseph's Hospital and Medical Center, Phoenix",
+        "nct_id": "NCT06578195",
+        "overall_status": "RECRUITING",
+        "phases": [],
+        "study_type": "OBSERVATIONAL",
+        "title": "ASSESS ALL ALS Study",
+        "us_locations": [
+          {
+            "city": "Birmingham",
+            "facility": "University of Alabama Birmingham",
+            "state": "Alabama",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Phoenix",
+            "facility": "Barrow Neurological Institute",
+            "state": "Arizona",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Irvine",
+            "facility": "University of California, Irvine",
+            "state": "California",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "La Jolla",
+            "facility": "University of California San Diego",
+            "state": "California",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Los Angeles",
+            "facility": "University of California, Los Angeles",
+            "state": "California",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "San Francisco",
+            "facility": "University of California, San Francisco",
+            "state": "California",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Aurora",
+            "facility": "University of Colorado Anschutz Medical Campus",
+            "state": "Colorado",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "New Britain",
+            "facility": "Hospital For Special Care",
+            "state": "Connecticut",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Washington D.C.",
+            "facility": "Georgetown University",
+            "state": "District of Columbia",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Davie",
+            "facility": "Nova Southeastern University",
+            "state": "Florida",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Jacksonville",
+            "facility": "Mayo Clinic",
+            "state": "Florida",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Boise",
+            "facility": "Saint Alphonsus Regional Medical Center",
+            "state": "Idaho",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Chicago",
+            "facility": "Northwestern University",
+            "state": "Illinois",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Chicago",
+            "facility": "Synapticure (Remote Participation Only)",
+            "state": "Illinois",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Indianapolis",
+            "facility": "Indiana University",
+            "state": "Indiana",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Baltimore",
+            "facility": "John Hopkins University",
+            "state": "Maryland",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Bethseda",
+            "facility": "Nih/Ninds",
+            "state": "Maryland",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Boston",
+            "facility": "Massachusetts General Brigham",
+            "state": "Massachusetts",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Ann Arbor",
+            "facility": "University of Michigan",
+            "state": "Michigan",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Detroit",
+            "facility": "Henry Ford Health",
+            "state": "Michigan",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Minneapolis",
+            "facility": "University of Minnesota",
+            "state": "Minnesota",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "St Louis",
+            "facility": "Washington University",
+            "state": "Missouri",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Omaha",
+            "facility": "University of Nebraska Medical Center",
+            "state": "Nebraska",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Lebanon",
+            "facility": "Dartmouth Hitchcock Medical Center",
+            "state": "New Hampshire",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "New York",
+            "facility": "Columbia University",
+            "state": "New York",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Durham",
+            "facility": "Duke University",
+            "state": "North Carolina",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Colombus",
+            "facility": "Ohio State University",
+            "state": "Ohio",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Portland",
+            "facility": "Providence ALS Center",
+            "state": "Oregon",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Hershey",
+            "facility": "Penn State Health",
+            "state": "Pennsylvania",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Philadelphia",
+            "facility": "University of Pennsylvania",
+            "state": "Pennsylvania",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Philadelphia",
+            "facility": "Temple University",
+            "state": "Pennsylvania",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Nashville",
+            "facility": "Vanderbilt University Medical Center",
+            "state": "Tennessee",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Dallas",
+            "facility": "Texas Neurology",
+            "state": "Texas",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Salt Lake City",
+            "facility": "University of Utah",
+            "state": "Utah",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Richmond",
+            "facility": "Virginia Commonwealth University",
+            "state": "Virginia",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Seattle",
+            "facility": "University of Washington",
+            "state": "Washington",
+            "status": "RECRUITING"
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis (ALS)",
+          "Emotional Distress"
+        ],
+        "interventions": [
+          {
+            "name": "Resilient Together ALS",
+            "type": "BEHAVIORAL"
+          }
+        ],
+        "lead_sponsor": "Massachusetts General Hospital",
+        "nct_id": "NCT06968468",
+        "overall_status": "NOT_YET_RECRUITING",
+        "phases": [
+          "NA"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "Resiliency Intervention for Patients With ALS and Their Care-Partners",
+        "us_locations": [
+          {
+            "city": "Boston",
+            "facility": "Massachusetts General Hospital",
+            "state": "Massachusetts",
+            "status": null
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis"
+        ],
+        "interventions": [
+          {
+            "name": "INS1202",
+            "type": "GENETIC"
+          }
+        ],
+        "lead_sponsor": "Insmed Gene Therapy LLC",
+        "nct_id": "NCT07290062",
+        "overall_status": "RECRUITING",
+        "phases": [
+          "PHASE1"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "A Study to Investigate the Safety and Pharmacodynamics of a Single Intrathecal Injection (IT) of INS1202 in Participants With Amyotrophic Lateral Sclerosis (ALS)",
+        "us_locations": [
+          {
+            "city": "La Jolla",
+            "facility": "USA004",
+            "state": "California",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Palo Alto",
+            "facility": "USA002",
+            "state": "California",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Columbia",
+            "facility": "USA001",
+            "state": "Missouri",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Columbus",
+            "facility": "USA007",
+            "state": "Ohio",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Philadelphia",
+            "facility": "USA006",
+            "state": "Pennsylvania",
+            "status": "RECRUITING"
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Anarthria",
+          "Dysarthria",
+          "Tetraplegia",
+          "Spinal Cord Injuries",
+          "Amyotrophic Lateral Sclerosis",
+          "Brain Stem Infarctions",
+          "Locked-in Syndrome",
+          "Muscular Dystrophies"
+        ],
+        "interventions": [
+          {
+            "name": "BrainGate Neural Interface System",
+            "type": "DEVICE"
+          }
+        ],
+        "lead_sponsor": "Leigh R. Hochberg, MD, PhD.",
+        "nct_id": "NCT06094205",
+        "overall_status": "RECRUITING",
+        "phases": [
+          "NA"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "Feasibility of the BrainGate2 Neural Interface System in Persons With Tetraplegia (BG-Speech-02)",
+        "us_locations": [
+          {
+            "city": "Sacramento",
+            "facility": "University of California, Davis",
+            "state": "California",
+            "status": "RECRUITING"
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "ALS (Amyotrophic Lateral Sclerosis)",
+          "TBI Traumatic Brain Injury",
+          "SCI - Spinal Cord Injury",
+          "Stroke"
+        ],
+        "interventions": [
+          {
+            "name": "Cognixion + Apple Vision Pro",
+            "type": "DEVICE"
+          }
+        ],
+        "lead_sponsor": "Cognixion",
+        "nct_id": "NCT07209943",
+        "overall_status": "NOT_YET_RECRUITING",
+        "phases": [
+          "NA"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "Augmented Reality BCI Longitudinal Study for Persons With ALS, Stroke, TBI and SCI Utilizing Cognixion + Apple Vision Pro",
+        "us_locations": [
+          {
+            "city": "Santa Barbara",
+            "facility": "Cognixion HQ",
+            "state": "California",
+            "status": null
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis (ALS)",
+          "Motor Neuron Disease (MND)",
+          "Primary Lateral Sclerosis (PLS)"
+        ],
+        "interventions": [
+          {
+            "name": "Education about treatment options",
+            "type": "OTHER"
+          },
+          {
+            "name": "Dietary Supplements: Vitamins, Minerals, Herbs, etc.",
+            "type": "DIETARY_SUPPLEMENT"
+          },
+          {
+            "name": "Meditation, Prayer, Talk Therapy, Affirmations, Journaling, etc.",
+            "type": "BEHAVIORAL"
+          },
+          {
+            "name": "Diet, various diets will be observed",
+            "type": "OTHER"
+          },
+          {
+            "name": "Exercise, physical therapy, occupational therapy, speech therapy, sauna, EMS, massage and other therapies",
+            "type": "OTHER"
+          },
+          {
+            "name": "ALS medications and other medications",
+            "type": "DRUG"
+          },
+          {
+            "name": "Physical and emotional support",
+            "type": "OTHER"
+          }
+        ],
+        "lead_sponsor": "Healing Advocates Registry and Ministry",
+        "nct_id": "NCT07233148",
+        "overall_status": "RECRUITING",
+        "phases": [],
+        "study_type": "OBSERVATIONAL",
+        "title": "Healing ALS Registry Observational Study (HAROS)",
+        "us_locations": [
+          {
+            "city": "Park City",
+            "facility": "Virtual",
+            "state": "Utah",
+            "status": "RECRUITING"
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis"
+        ],
+        "interventions": [
+          {
+            "name": "CK0803",
+            "type": "BIOLOGICAL"
+          },
+          {
+            "name": "Excipient",
+            "type": "OTHER"
+          }
+        ],
+        "lead_sponsor": "Cellenkos, Inc.",
+        "nct_id": "NCT05695521",
+        "overall_status": "ACTIVE_NOT_RECRUITING",
+        "phases": [
+          "PHASE1"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "Regulatory T Cells for Amyotrophic Lateral Sclerosis",
+        "us_locations": [
+          {
+            "city": "New York",
+            "facility": "Columbia University Irving Medical Center",
+            "state": "New York",
+            "status": null
+          },
+          {
+            "city": "Houston",
+            "facility": "Baylor College of Medicine",
+            "state": "Texas",
+            "status": null
+          },
+          {
+            "city": "Houston",
+            "facility": "Michael E. DeBakey Veterans Affairs Medical Center",
+            "state": "Texas",
+            "status": null
+          }
+        ]
+      },
+      {
+        "conditions": [
+          "Amyotrophic Lateral Sclerosis"
+        ],
+        "interventions": [
+          {
+            "name": "Pridopidine",
+            "type": "DRUG"
+          },
+          {
+            "name": "Placebo",
+            "type": "DRUG"
+          }
+        ],
+        "lead_sponsor": "Prilenia",
+        "nct_id": "NCT07322003",
+        "overall_status": "RECRUITING",
+        "phases": [
+          "PHASE3"
+        ],
+        "study_type": "INTERVENTIONAL",
+        "title": "Pridopidine Phase 3 Study to Evaluate Efficacy and Safety in ALS",
+        "us_locations": [
+          {
+            "city": "Phoenix",
+            "facility": "Barrow Neurological Institute",
+            "state": "Arizona",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "San Francisco",
+            "facility": "California Pacific Medical Center",
+            "state": "California",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Aurora",
+            "facility": "University of Colorado CU Anschutz Neurology",
+            "state": "Colorado",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Jacksonville",
+            "facility": "Mayo Clinic",
+            "state": "Florida",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Tampa",
+            "facility": "University of South Florida",
+            "state": "Florida",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Atlanta",
+            "facility": "Emory University",
+            "state": "Georgia",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Chicago",
+            "facility": "Northwestern University",
+            "state": "Illinois",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Fairway",
+            "facility": "University of Kansas",
+            "state": "Kansas",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Baltimore",
+            "facility": "Johns Hopkins University",
+            "state": "Maryland",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Boston",
+            "facility": "Sean M. Healey & AMG Center for ALS",
+            "state": "Massachusetts",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "St Louis",
+            "facility": "Washington University",
+            "state": "Missouri",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Lincoln",
+            "facility": "Somnos Clinical Research",
+            "state": "Nebraska",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "New York",
+            "facility": "Eleanor and Lou Gehrig ALS Center at Columbia University",
+            "state": "New York",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Philadelphia",
+            "facility": "Neuroscience Department at LKSM at Temple University",
+            "state": "Pennsylvania",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Dallas",
+            "facility": "Texas Neurology",
+            "state": "Texas",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Houston",
+            "facility": "Baylor College of Medicine; McNair Medical Campus",
+            "state": "Texas",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Seattle",
+            "facility": "Swedish Medical Center",
+            "state": "Washington",
+            "status": "RECRUITING"
+          },
+          {
+            "city": "Seattle",
+            "facility": "University of Washington",
+            "state": "Washington",
+            "status": "RECRUITING"
+          }
+        ]
+      }
+    ],
+    "top_location_states": [
+      [
+        "California",
+        21
+      ],
+      [
+        "Pennsylvania",
+        16
+      ],
+      [
+        "Texas",
+        14
+      ],
+      [
+        "Florida",
+        13
+      ],
+      [
+        "New York",
+        11
+      ],
+      [
+        "Massachusetts",
+        9
+      ],
+      [
+        "Missouri",
+        8
+      ],
+      [
+        "Maryland",
+        7
+      ],
+      [
+        "Illinois",
+        7
+      ],
+      [
+        "Washington",
+        7
+      ]
+    ]
+  },
+  "tool_contracts": [
+    {
+      "endpoint": "https://clinicaltrials.gov/api/v2/studies",
+      "name": "VSDReviewedClinicalTrialsSearch",
+      "operation_sha256": "79852cdcc0dc7695b4e430313b1574721303fb78b0dff1cd3eadcbcd66c9be1c"
+    },
+    {
+      "endpoint": "https://clinicaltrials.gov/api/v2/studies/{nctId}",
+      "name": "VSDReviewedClinicalTrialDetails",
+      "operation_sha256": "3b4dd7f5717bd0f2dcf1d50c85a09a71c1b00ba44c7bccbfcf339bf0a53dbfa6"
+    }
+  ]
+}

--- a/examples/vsd/artifacts/dynamic_rest_als_snapshot.md
+++ b/examples/vsd/artifacts/dynamic_rest_als_snapshot.md
@@ -1,0 +1,57 @@
+# Reviewed Dynamic REST ALS Validation
+
+## Decision Question
+
+Which active or upcoming US ALS studies are returned by the reviewed ClinicalTrials.gov search, and can a second generated operation retrieve the selected study consistently?
+
+## Result
+
+- Returned records: **20**
+- Provider total matching records: **113**
+- Additional page available: **yes**
+- Deterministic follow-up record: **NCT01772602**
+- Detail identifier matched search: **true**
+
+## Cohort Summary
+
+- Statuses: `{"ACTIVE_NOT_RECRUITING": 5, "NOT_YET_RECRUITING": 3, "RECRUITING": 12}`
+- Phases: `{"NA": 4, "NOT_APPLICABLE": 8, "PHASE1": 4, "PHASE2": 3, "PHASE3": 2}`
+- Intervention types: `{"BEHAVIORAL": 2, "BIOLOGICAL": 1, "COMBINATION_PRODUCT": 1, "DEVICE": 4, "DIETARY_SUPPLEMENT": 1, "DRUG": 14, "GENETIC": 1, "OTHER": 6}`
+- Most represented US states: `[["California", 21], ["Pennsylvania", 16], ["Texas", 14], ["Florida", 13], ["New York", 11], ["Massachusetts", 9], ["Missouri", 8], ["Maryland", 7], ["Illinois", 7], ["Washington", 7]]`
+
+## Returned Studies
+
+| NCT ID | Status | Phase | Title | US locations |
+| --- | --- | --- | --- | ---: |
+| NCT04715399 | RECRUITING | N/A | UPenn Observational Research Repository on Neurodegenerative Disease | 1 |
+| NCT01772602 | RECRUITING | N/A | The National Amyotrophic Lateral Sclerosis Registry | 1 |
+| NCT07204977 | ACTIVE_NOT_RECRUITING | PHASE1 | Acamprosate in C9orf72 Hexanucleotide Repeat Expansion Amyotrophic Lateral Sclerosis (ACALS) | 1 |
+| NCT04220021 | ACTIVE_NOT_RECRUITING | PHASE2 | Safety and Therapeutic Potential of the FDA-approved Drug Metformin for C9orf72 ALS/FTD | 1 |
+| NCT02567136 | RECRUITING | N/A | Imaging Biomarkers in ALS | 1 |
+| NCT05137665 | RECRUITING | N/A | Target ALS Biomarker Study; Longitudinal Biofluids, Clinical Measures, and At Home Measures | 10 |
+| NCT07224256 | RECRUITING | NA | VOICE: An Early Feasibility Study of a Precise Robotically Implanted Brain-Computer Interface for Communication Restoration | 1 |
+| NCT04244630 | RECRUITING | PHASE2 | Mitochondrial Capacity Boost in ALS (MICABO-ALS) Trial | 1 |
+| NCT04875416 | ACTIVE_NOT_RECRUITING | N/A | Phenotype, Genotype and Biomarkers 2 | 3 |
+| NCT07589764 | NOT_YET_RECRUITING | PHASE1 | A Widely Inclusive, Hybrid-Decentralized Pilot Trial Utilizing β-hydroxy-β-methylbutyrate to Lower IGFBP7 Levels in People With ALS | 2 |
+| NCT06581861 | RECRUITING | N/A | PREVENT ALL ALS Study | 31 |
+| NCT04297683 | ACTIVE_NOT_RECRUITING | PHASE2, PHASE3 | HEALEY ALS Platform Trial - Master Protocol | 81 |
+| NCT06578195 | RECRUITING | N/A | ASSESS ALL ALS Study | 36 |
+| NCT06968468 | NOT_YET_RECRUITING | NA | Resiliency Intervention for Patients With ALS and Their Care-Partners | 1 |
+| NCT07290062 | RECRUITING | PHASE1 | A Study to Investigate the Safety and Pharmacodynamics of a Single Intrathecal Injection (IT) of INS1202 in Participants With Amyotrophic Lateral Sclerosis (ALS) | 5 |
+| NCT06094205 | RECRUITING | NA | Feasibility of the BrainGate2 Neural Interface System in Persons With Tetraplegia (BG-Speech-02) | 1 |
+| NCT07209943 | NOT_YET_RECRUITING | NA | Augmented Reality BCI Longitudinal Study for Persons With ALS, Stroke, TBI and SCI Utilizing Cognixion + Apple Vision Pro | 1 |
+| NCT07233148 | RECRUITING | N/A | Healing ALS Registry Observational Study (HAROS) | 1 |
+| NCT05695521 | ACTIVE_NOT_RECRUITING | PHASE1 | Regulatory T Cells for Amyotrophic Lateral Sclerosis | 3 |
+| NCT07322003 | RECRUITING | PHASE3 | Pridopidine Phase 3 Study to Evaluate Efficacy and Safety in ALS | 18 |
+
+## Execution Evidence
+
+- `VSDReviewedClinicalTrialsSearch`: `79852cdcc0dc7695b4e430313b1574721303fb78b0dff1cd3eadcbcd66c9be1c`
+- `VSDReviewedClinicalTrialDetails`: `3b4dd7f5717bd0f2dcf1d50c85a09a71c1b00ba44c7bccbfcf339bf0a53dbfa6`
+- Search payload: `dbefbe106f242d10a0b52277d89cd4264b7fe52851b6f50ffbe65efcf23da6a9`
+- Detail payload: `4dd3ccee9977ba69c9e8c35c179fdc25f212d39b101cc0c9e0a8e8fd7ca30c44`
+- Both calls used HTTPS GET, zero redirects, bounded JSON decoding, pinned DNS, schema validation, and the ToolUniverse `run_one_function()` path.
+
+## Interpretation Boundary
+
+This is an API execution and record-consistency proof, not trial matching, eligibility assessment, or treatment advice.

--- a/examples/vsd/dynamic_rest_als_case_study.py
+++ b/examples/vsd/dynamic_rest_als_case_study.py
@@ -1,0 +1,384 @@
+"""End-to-end proof for reviewed dynamic REST execution through ToolUniverse."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from tooluniverse import ToolUniverse
+from tooluniverse.vsd_dynamic_rest import (
+    operation_digest,
+    register_reviewed_rest_tool,
+)
+
+ACTIVE_STATUSES = (
+    "RECRUITING|NOT_YET_RECRUITING|ACTIVE_NOT_RECRUITING|ENROLLING_BY_INVITATION"
+)
+
+SEARCH_TOOL = {
+    "name": "VSDReviewedClinicalTrialsSearch",
+    "type": "VSDDynamicRESTTool",
+    "description": (
+        "Search a reviewed ClinicalTrials.gov operation for active or upcoming "
+        "studies by condition and location expression."
+    ),
+    "category": "special_tools",
+    "cacheable": False,
+    "mcp_annotations": {"readOnlyHint": True, "destructiveHint": False},
+    "parameter": {
+        "type": "object",
+        "properties": {
+            "condition": {"type": "string", "minLength": 2, "maxLength": 200},
+            "location_query": {
+                "type": "string",
+                "minLength": 2,
+                "maxLength": 500,
+            },
+            "page_size": {"type": "integer", "minimum": 1, "maximum": 20},
+        },
+        "required": ["condition", "location_query", "page_size"],
+        "additionalProperties": False,
+    },
+    "vsd_operation": {
+        "version": 1,
+        "method": "GET",
+        "endpoint": "https://clinicaltrials.gov/api/v2/studies",
+        "path_arguments": {},
+        "query_arguments": {
+            "condition": "query.cond",
+            "location_query": "query.locn",
+            "page_size": "pageSize",
+        },
+        "fixed_query": {
+            "format": "json",
+            "countTotal": "true",
+            "filter.overallStatus": ACTIVE_STATUSES,
+        },
+        "timeout_seconds": 30,
+        "auth": {"type": "none"},
+        "response_schema": {
+            "type": "object",
+            "properties": {
+                "studies": {"type": "array", "maxItems": 20},
+                "totalCount": {"type": "integer", "minimum": 0},
+                "nextPageToken": {"type": "string"},
+            },
+            "required": ["studies"],
+            "additionalProperties": True,
+        },
+    },
+}
+
+DETAIL_TOOL = {
+    "name": "VSDReviewedClinicalTrialDetails",
+    "type": "VSDDynamicRESTTool",
+    "description": (
+        "Retrieve one reviewed ClinicalTrials.gov study record by its validated "
+        "NCT identifier."
+    ),
+    "category": "special_tools",
+    "cacheable": False,
+    "mcp_annotations": {"readOnlyHint": True, "destructiveHint": False},
+    "parameter": {
+        "type": "object",
+        "properties": {"nct_id": {"type": "string", "pattern": "^NCT[0-9]{8}$"}},
+        "required": ["nct_id"],
+        "additionalProperties": False,
+    },
+    "vsd_operation": {
+        "version": 1,
+        "method": "GET",
+        "endpoint": "https://clinicaltrials.gov/api/v2/studies/{nctId}",
+        "path_arguments": {"nct_id": "nctId"},
+        "query_arguments": {},
+        "fixed_query": {"format": "json"},
+        "timeout_seconds": 30,
+        "auth": {"type": "none"},
+        "response_schema": {
+            "type": "object",
+            "properties": {"protocolSection": {"type": "object"}},
+            "required": ["protocolSection"],
+            "additionalProperties": True,
+        },
+    },
+}
+
+
+def _module(study: dict[str, Any], name: str) -> dict[str, Any]:
+    protocol = study.get("protocolSection") or {}
+    value = protocol.get(name) or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _clean_provider_text(value: Any) -> Any:
+    """Repair common UTF-8-as-Latin-1 text and normalize whitespace."""
+    if isinstance(value, dict):
+        return {key: _clean_provider_text(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_clean_provider_text(item) for item in value]
+    if not isinstance(value, str):
+        return value
+    repaired = value
+    if any(marker in value for marker in ("\u00c2", "\u00c3", "\u00ce", "\u00e2")):
+        try:
+            repaired = value.encode("latin-1").decode("utf-8")
+        except (UnicodeEncodeError, UnicodeDecodeError):
+            repaired = value
+    return re.sub(r"\s+", " ", repaired).strip()
+
+
+def _study_summary(study: dict[str, Any]) -> dict[str, Any]:
+    identification = _module(study, "identificationModule")
+    status = _module(study, "statusModule")
+    design = _module(study, "designModule")
+    contacts = _module(study, "contactsLocationsModule")
+    conditions = _module(study, "conditionsModule")
+    arms = _module(study, "armsInterventionsModule")
+    sponsor = _module(study, "sponsorCollaboratorsModule")
+    locations = contacts.get("locations") or []
+    interventions = arms.get("interventions") or []
+    return _clean_provider_text(
+        {
+            "nct_id": identification.get("nctId"),
+            "title": identification.get("briefTitle"),
+            "overall_status": status.get("overallStatus"),
+            "phases": design.get("phases") or [],
+            "study_type": design.get("studyType"),
+            "conditions": conditions.get("conditions") or [],
+            "lead_sponsor": (sponsor.get("leadSponsor") or {}).get("name"),
+            "interventions": [
+                {"name": item.get("name"), "type": item.get("type")}
+                for item in interventions
+                if isinstance(item, dict)
+            ],
+            "us_locations": [
+                {
+                    "facility": item.get("facility"),
+                    "city": item.get("city"),
+                    "state": item.get("state"),
+                    "status": item.get("status"),
+                }
+                for item in locations
+                if isinstance(item, dict) and item.get("country") == "United States"
+            ],
+        }
+    )
+
+
+def _must_succeed(result: Any, tool_name: str) -> dict[str, Any]:
+    if not isinstance(result, dict) or result.get("status") != "success":
+        raise RuntimeError(
+            f"{tool_name} did not return a successful result: {result!r}"
+        )
+    data = result.get("data")
+    if not isinstance(data, dict) or "result" not in data or "provenance" not in data:
+        raise RuntimeError(f"{tool_name} returned an incomplete evidence envelope")
+    return data
+
+
+def run_case() -> dict[str, Any]:
+    """Run two reviewed operations from one API through one ToolUniverse instance."""
+    tooluniverse = ToolUniverse()
+    try:
+        for config in (SEARCH_TOOL, DETAIL_TOOL):
+            register_reviewed_rest_tool(tooluniverse, config)
+
+        search_data = _must_succeed(
+            tooluniverse.run_one_function(
+                {
+                    "name": SEARCH_TOOL["name"],
+                    "arguments": {
+                        "condition": "Amyotrophic Lateral Sclerosis",
+                        "location_query": "AREA[LocationCountry]United States",
+                        "page_size": 20,
+                    },
+                },
+                use_cache=False,
+            ),
+            SEARCH_TOOL["name"],
+        )
+        studies = search_data["result"].get("studies") or []
+        summaries = [_study_summary(study) for study in studies]
+        summaries = [summary for summary in summaries if summary.get("nct_id")]
+        if not summaries:
+            raise RuntimeError("The reviewed ALS search returned no usable NCT records")
+        selected_nct_id = sorted(summary["nct_id"] for summary in summaries)[0]
+
+        detail_data = _must_succeed(
+            tooluniverse.run_one_function(
+                {
+                    "name": DETAIL_TOOL["name"],
+                    "arguments": {"nct_id": selected_nct_id},
+                },
+                use_cache=False,
+            ),
+            DETAIL_TOOL["name"],
+        )
+        detailed_summary = _study_summary(detail_data["result"])
+        if detailed_summary.get("nct_id") != selected_nct_id:
+            raise RuntimeError("The detail operation returned a different NCT record")
+
+        statuses = Counter(
+            item.get("overall_status") or "UNKNOWN" for item in summaries
+        )
+        phases = Counter(
+            phase
+            for item in summaries
+            for phase in (item.get("phases") or ["NOT_APPLICABLE"])
+        )
+        intervention_types = Counter(
+            intervention.get("type") or "UNKNOWN"
+            for item in summaries
+            for intervention in item.get("interventions") or []
+        )
+        states = Counter(
+            location.get("state") or "UNSPECIFIED"
+            for item in summaries
+            for location in item.get("us_locations") or []
+        )
+        return {
+            "case": {
+                "question": (
+                    "Which active or upcoming US ALS studies are returned by the "
+                    "reviewed ClinicalTrials.gov search, and can a second generated "
+                    "operation retrieve the selected study consistently?"
+                ),
+                "condition": "Amyotrophic Lateral Sclerosis",
+                "location_query": "AREA[LocationCountry]United States",
+                "status_filter": ACTIVE_STATUSES.split("|"),
+                "interpretation_boundary": (
+                    "This is an API execution and record-consistency proof, not trial "
+                    "matching, eligibility assessment, or treatment advice."
+                ),
+            },
+            "tool_contracts": [
+                {
+                    "name": config["name"],
+                    "endpoint": config["vsd_operation"]["endpoint"],
+                    "operation_sha256": operation_digest(config),
+                }
+                for config in (SEARCH_TOOL, DETAIL_TOOL)
+            ],
+            "search": {
+                "returned_records": len(summaries),
+                "provider_total_count": search_data["result"].get("totalCount"),
+                "has_next_page": bool(search_data["result"].get("nextPageToken")),
+                "status_counts": dict(sorted(statuses.items())),
+                "phase_counts": dict(sorted(phases.items())),
+                "intervention_type_counts": dict(sorted(intervention_types.items())),
+                "top_location_states": states.most_common(10),
+                "studies": summaries,
+                "provenance": search_data["provenance"],
+            },
+            "detail_follow_up": {
+                "selection_rule": "Lexicographically smallest returned valid NCT identifier",
+                "selected_nct_id": selected_nct_id,
+                "identifier_matches_search": any(
+                    item["nct_id"] == detailed_summary["nct_id"] for item in summaries
+                ),
+                "study": detailed_summary,
+                "provenance": detail_data["provenance"],
+            },
+        }
+    finally:
+        tooluniverse.close()
+
+
+def render_markdown(evidence: dict[str, Any]) -> str:
+    """Render a compact analyst-facing report from the evidence ledger."""
+    case = evidence["case"]
+    search = evidence["search"]
+    follow_up = evidence["detail_follow_up"]
+    lines = [
+        "# Reviewed Dynamic REST ALS Validation",
+        "",
+        "## Decision Question",
+        "",
+        case["question"],
+        "",
+        "## Result",
+        "",
+        f"- Returned records: **{search['returned_records']}**",
+        f"- Provider total matching records: **{search['provider_total_count']}**",
+        f"- Additional page available: **{'yes' if search['has_next_page'] else 'no'}**",
+        f"- Deterministic follow-up record: **{follow_up['selected_nct_id']}**",
+        f"- Detail identifier matched search: **{str(follow_up['identifier_matches_search']).lower()}**",
+        "",
+        "## Cohort Summary",
+        "",
+        f"- Statuses: `{json.dumps(search['status_counts'], sort_keys=True)}`",
+        f"- Phases: `{json.dumps(search['phase_counts'], sort_keys=True)}`",
+        f"- Intervention types: `{json.dumps(search['intervention_type_counts'], sort_keys=True)}`",
+        f"- Most represented US states: `{json.dumps(search['top_location_states'])}`",
+        "",
+        "## Returned Studies",
+        "",
+        "| NCT ID | Status | Phase | Title | US locations |",
+        "| --- | --- | --- | --- | ---: |",
+    ]
+    for study in search["studies"]:
+        title = str(study.get("title") or "").replace("|", "\\|")
+        phases = ", ".join(study.get("phases") or ["N/A"])
+        lines.append(
+            f"| {study['nct_id']} | {study.get('overall_status') or 'N/A'} | "
+            f"{phases} | {title} | {len(study.get('us_locations') or [])} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Execution Evidence",
+            "",
+        ]
+    )
+    for contract in evidence["tool_contracts"]:
+        lines.append(f"- `{contract['name']}`: `{contract['operation_sha256']}`")
+    lines.extend(
+        [
+            f"- Search payload: `{search['provenance']['payload_sha256']}`",
+            f"- Detail payload: `{follow_up['provenance']['payload_sha256']}`",
+            "- Both calls used HTTPS GET, zero redirects, bounded JSON decoding, "
+            "pinned DNS, schema validation, and the ToolUniverse `run_one_function()` path.",
+            "",
+            "## Interpretation Boundary",
+            "",
+            case["interpretation_boundary"],
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_artifacts(evidence: dict[str, Any], output_dir: Path) -> tuple[Path, Path]:
+    """Write machine-readable and human-readable evidence artifacts."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "dynamic_rest_als_snapshot.json"
+    markdown_path = output_dir / "dynamic_rest_als_snapshot.md"
+    json_path.write_text(
+        json.dumps(evidence, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(render_markdown(evidence), encoding="utf-8")
+    return json_path, markdown_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(__file__).with_name("artifacts"),
+    )
+    arguments = parser.parse_args(argv)
+    evidence = run_case()
+    json_path, markdown_path = write_artifacts(evidence, arguments.output_dir)
+    print(f"Wrote {json_path}")
+    print(f"Wrote {markdown_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tooluniverse/vsd_dynamic_rest.py
+++ b/src/tooluniverse/vsd_dynamic_rest.py
@@ -1,0 +1,288 @@
+"""Validated runtime execution for explicitly reviewed public JSON operations.
+
+This module intentionally does not discover, persist, approve, or automatically
+load tools.  It provides the execution boundary used after an administrator has
+reviewed an operation definition.  Only HTTPS GET operations are supported so a
+generated tool cannot mutate an upstream service or transmit credentials.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import quote, urlsplit
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError, ValidationError
+
+from .base_tool import BaseTool
+from .tool_registry import register_tool
+from .vsd_tool import VSDPolicyError, _safe_get_json, _validated_params
+
+_TOOL_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,127}$")
+_ARGUMENT_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+_PATH_TOKEN_RE = re.compile(r"\{([A-Za-z][A-Za-z0-9_]{0,63})\}")
+_QUERY_NAME_RE = re.compile(r"^[A-Za-z0-9_.\[\]-]{1,128}$")
+
+
+class VSDDynamicRESTError(VSDPolicyError):
+    """Raised when an operation or provider result violates its reviewed contract."""
+
+
+def _schema_validator(schema: Any, *, field: str) -> Draft202012Validator:
+    if not isinstance(schema, dict):
+        raise VSDDynamicRESTError(f"{field} must be a JSON Schema object")
+    try:
+        encoded = json.dumps(schema, allow_nan=False, ensure_ascii=True)
+    except (TypeError, ValueError) as exc:
+        raise VSDDynamicRESTError(f"{field} must be finite JSON") from exc
+    if len(encoded.encode("utf-8")) > 65_536:
+        raise VSDDynamicRESTError(f"{field} exceeds the 64 KiB schema limit")
+
+    pending: list[Any] = [schema]
+    while pending:
+        node = pending.pop()
+        if isinstance(node, dict):
+            reference = node.get("$ref")
+            if isinstance(reference, str) and not reference.startswith("#/"):
+                raise VSDDynamicRESTError(
+                    f"{field} cannot resolve an external JSON Schema reference"
+                )
+            pending.extend(node.values())
+        elif isinstance(node, list):
+            pending.extend(node)
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError as exc:
+        raise VSDDynamicRESTError(f"{field} is not a valid JSON Schema") from exc
+    return Draft202012Validator(schema)
+
+
+def _validated_operation_config(config: Any) -> dict[str, Any]:
+    if not isinstance(config, dict):
+        raise VSDDynamicRESTError("Tool configuration must be an object")
+    normalized = copy.deepcopy(config)
+    name = normalized.get("name")
+    if not isinstance(name, str) or not _TOOL_NAME_RE.fullmatch(name):
+        raise VSDDynamicRESTError("Tool name must be a stable identifier")
+    description = normalized.get("description")
+    if (
+        not isinstance(description, str)
+        or not description.strip()
+        or len(description) > 2000
+    ):
+        raise VSDDynamicRESTError("Tool description must contain 1-2000 characters")
+    if normalized.get("type") != "VSDDynamicRESTTool":
+        raise VSDDynamicRESTError("Tool type must be VSDDynamicRESTTool")
+
+    input_schema = normalized.get("parameter")
+    _schema_validator(input_schema, field="parameter")
+    if input_schema.get("type") != "object":
+        raise VSDDynamicRESTError("parameter must describe an object")
+    if input_schema.get("additionalProperties") is not False:
+        raise VSDDynamicRESTError("parameter must reject additional properties")
+
+    operation = normalized.get("vsd_operation")
+    if not isinstance(operation, dict):
+        raise VSDDynamicRESTError("vsd_operation must be an object")
+    if operation.get("version") != 1:
+        raise VSDDynamicRESTError("vsd_operation.version must be 1")
+    if operation.get("method") != "GET":
+        raise VSDDynamicRESTError(
+            "Dynamic VSD operations are read-only HTTPS GET calls"
+        )
+    endpoint = operation.get("endpoint")
+    if not isinstance(endpoint, str) or not endpoint:
+        raise VSDDynamicRESTError("vsd_operation.endpoint must be a non-empty string")
+    parsed = urlsplit(endpoint)
+    if parsed.scheme.lower() != "https" or not parsed.hostname:
+        raise VSDDynamicRESTError("vsd_operation.endpoint must be an HTTPS URL")
+    if parsed.query or parsed.fragment or parsed.username or parsed.password:
+        raise VSDDynamicRESTError(
+            "vsd_operation.endpoint cannot contain credentials, a query, or a fragment"
+        )
+
+    properties = input_schema.get("properties")
+    if not isinstance(properties, dict):
+        raise VSDDynamicRESTError("parameter.properties must be an object")
+    path_arguments = operation.get("path_arguments", {})
+    query_arguments = operation.get("query_arguments", {})
+    fixed_query = operation.get("fixed_query", {})
+    if not isinstance(path_arguments, dict) or not isinstance(query_arguments, dict):
+        raise VSDDynamicRESTError("Argument mappings must be objects")
+    for argument, target in (*path_arguments.items(), *query_arguments.items()):
+        if (
+            not isinstance(argument, str)
+            or not _ARGUMENT_NAME_RE.fullmatch(argument)
+            or argument not in properties
+        ):
+            raise VSDDynamicRESTError(
+                f"Mapped argument {argument!r} is not declared by parameter.properties"
+            )
+        if not isinstance(target, str) or not _QUERY_NAME_RE.fullmatch(target):
+            raise VSDDynamicRESTError(
+                f"Invalid provider parameter name for {argument!r}"
+            )
+    overlap = set(path_arguments) & set(query_arguments)
+    if overlap:
+        raise VSDDynamicRESTError(
+            f"Arguments cannot be both path and query values: {sorted(overlap)!r}"
+        )
+    tokens = _PATH_TOKEN_RE.findall(parsed.path)
+    if len(tokens) != len(set(tokens)) or set(tokens) != set(path_arguments.values()):
+        raise VSDDynamicRESTError(
+            "Endpoint path placeholders must exactly match path_arguments targets"
+        )
+    mapped_arguments = set(path_arguments) | set(query_arguments)
+    unmapped = set(properties) - mapped_arguments
+    if unmapped:
+        raise VSDDynamicRESTError(
+            f"Every input must map to the request; unmapped inputs: {sorted(unmapped)!r}"
+        )
+    if not isinstance(fixed_query, dict):
+        raise VSDDynamicRESTError("fixed_query must be an object")
+    try:
+        fixed_query = _validated_params(fixed_query)
+    except VSDPolicyError as exc:
+        raise VSDDynamicRESTError(str(exc)) from exc
+    conflicting = set(fixed_query) & set(query_arguments.values())
+    if conflicting:
+        raise VSDDynamicRESTError(
+            f"Fixed and argument query parameters overlap: {sorted(conflicting)!r}"
+        )
+    operation["fixed_query"] = fixed_query
+    operation["timeout_seconds"] = operation.get("timeout_seconds", 20)
+    timeout = operation["timeout_seconds"]
+    if (
+        isinstance(timeout, bool)
+        or not isinstance(timeout, (int, float))
+        or not 1 <= timeout <= 60
+    ):
+        raise VSDDynamicRESTError("timeout_seconds must be between 1 and 60")
+    operation["response_schema"] = operation.get("response_schema", {})
+    _schema_validator(operation["response_schema"], field="response_schema")
+    if operation.get("auth") not in (None, {"type": "none"}):
+        raise VSDDynamicRESTError(
+            "Dynamic VSD operations cannot carry credentials; use a dedicated tool"
+        )
+    return normalized
+
+
+def operation_digest(config: dict[str, Any]) -> str:
+    """Return the stable review digest for one normalized operation."""
+    normalized = _validated_operation_config(config)
+    encoded = json.dumps(
+        normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _provider_request(
+    config: dict[str, Any], arguments: dict[str, Any]
+) -> tuple[str, dict[str, Any]]:
+    operation = config["vsd_operation"]
+    endpoint = operation["endpoint"]
+    path_arguments = operation.get("path_arguments", {})
+    for argument, placeholder in path_arguments.items():
+        value = arguments[argument]
+        if isinstance(value, (dict, list)) or value is None:
+            raise VSDDynamicRESTError(
+                f"Path argument {argument!r} must be a non-null scalar"
+            )
+        endpoint = endpoint.replace("{" + placeholder + "}", quote(str(value), safe=""))
+
+    query = dict(operation.get("fixed_query", {}))
+    for argument, parameter_name in operation.get("query_arguments", {}).items():
+        if argument in arguments and arguments[argument] is not None:
+            query[parameter_name] = arguments[argument]
+    try:
+        return endpoint, _validated_params(query)
+    except VSDPolicyError as exc:
+        raise VSDDynamicRESTError(str(exc)) from exc
+
+
+@register_tool("VSDDynamicRESTTool")
+class VSDDynamicRESTTool(BaseTool):
+    """Execute one already-reviewed, read-only JSON API operation."""
+
+    def __init__(self, tool_config):
+        super().__init__(_validated_operation_config(tool_config))
+        self._input_validator = _schema_validator(
+            self.tool_config["parameter"], field="parameter"
+        )
+        self._response_validator = _schema_validator(
+            self.tool_config["vsd_operation"]["response_schema"],
+            field="response_schema",
+        )
+        self._operation_digest = operation_digest(self.tool_config)
+
+    def run(self, arguments=None, **_: Any):
+        values = {} if arguments is None else arguments
+        if not isinstance(values, dict):
+            raise VSDDynamicRESTError("Tool arguments must be an object")
+        try:
+            self._input_validator.validate(values)
+        except ValidationError as exc:
+            raise VSDDynamicRESTError(
+                f"Tool arguments failed the reviewed schema: {exc.message}"
+            ) from exc
+
+        endpoint, query = _provider_request(self.tool_config, values)
+        operation = self.tool_config["vsd_operation"]
+        payload, request = _safe_get_json(
+            endpoint,
+            query,
+            timeout=float(operation["timeout_seconds"]),
+        )
+        try:
+            self._response_validator.validate(payload)
+        except ValidationError as exc:
+            raise VSDDynamicRESTError(
+                f"Provider response failed the reviewed schema: {exc.message}"
+            ) from exc
+        canonical = json.dumps(
+            payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+        return {
+            "status": "success",
+            "data": {
+                "result": payload,
+                "provenance": {
+                    "provider": urlsplit(endpoint).hostname,
+                    "endpoint": endpoint,
+                    "method": "GET",
+                    "query_params": query,
+                    "retrieved_at": datetime.now(timezone.utc).isoformat(),
+                    "http_status": request["status_code"],
+                    "content_type": request["content_type"],
+                    "response_bytes": request["response_bytes"],
+                    "redirects": request["redirects"],
+                    "payload_sha256": hashlib.sha256(canonical).hexdigest(),
+                    "operation_sha256": self._operation_digest,
+                },
+            },
+        }
+
+
+def register_reviewed_rest_tool(tooluniverse, config: dict[str, Any]) -> str:
+    """Register one reviewed operation into a specific ToolUniverse instance."""
+    normalized = _validated_operation_config(config)
+    instance = VSDDynamicRESTTool(normalized)
+    return tooluniverse.register_custom_tool(
+        tool_class=VSDDynamicRESTTool,
+        tool_name=normalized["name"],
+        tool_config=normalized,
+        tool_instance=instance,
+    )
+
+
+__all__ = [
+    "VSDDynamicRESTError",
+    "VSDDynamicRESTTool",
+    "operation_digest",
+    "register_reviewed_rest_tool",
+]

--- a/tests/unit/test_vsd_dynamic_rest.py
+++ b/tests/unit/test_vsd_dynamic_rest.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from tooluniverse import ToolUniverse
+from tooluniverse import vsd_dynamic_rest
+
+pytestmark = pytest.mark.unit
+
+
+def _search_config() -> dict:
+    return {
+        "name": "ReviewedTrialSearch",
+        "type": "VSDDynamicRESTTool",
+        "description": "Search a reviewed public clinical-trial endpoint.",
+        "category": "special_tools",
+        "cacheable": False,
+        "parameter": {
+            "type": "object",
+            "properties": {
+                "condition": {"type": "string", "minLength": 2, "maxLength": 100},
+                "page_size": {"type": "integer", "minimum": 1, "maximum": 20},
+            },
+            "required": ["condition"],
+            "additionalProperties": False,
+        },
+        "vsd_operation": {
+            "version": 1,
+            "method": "GET",
+            "endpoint": "https://clinicaltrials.gov/api/v2/studies",
+            "path_arguments": {},
+            "query_arguments": {
+                "condition": "query.cond",
+                "page_size": "pageSize",
+            },
+            "fixed_query": {"format": "json", "countTotal": "true"},
+            "timeout_seconds": 20,
+            "auth": {"type": "none"},
+            "response_schema": {
+                "type": "object",
+                "properties": {"studies": {"type": "array"}},
+                "required": ["studies"],
+            },
+        },
+    }
+
+
+def test_rejects_mutating_or_authenticated_operations():
+    """Mutating methods and embedded credentials never reach the network."""
+    config = _search_config()
+    config["vsd_operation"]["method"] = "POST"
+    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match="read-only"):
+        vsd_dynamic_rest.VSDDynamicRESTTool(config)
+
+    config = _search_config()
+    config["vsd_operation"]["auth"] = {
+        "type": "api_key",
+        "value": "must-not-be-embedded",
+    }
+    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match="credentials"):
+        vsd_dynamic_rest.VSDDynamicRESTTool(config)
+
+
+def test_rejects_external_schema_references():
+    """Provider-controlled schemas cannot trigger a second network fetch."""
+    config = _search_config()
+    config["vsd_operation"]["response_schema"] = {
+        "$ref": "https://example.com/provider-schema.json"
+    }
+    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match="external"):
+        vsd_dynamic_rest.VSDDynamicRESTTool(config)
+
+
+@pytest.mark.parametrize(
+    "mutation, message",
+    [
+        (lambda c: c["parameter"].update(additionalProperties=True), "additional"),
+        (
+            lambda c: c["vsd_operation"]["query_arguments"].update(
+                missing="query.term"
+            ),
+            "not declared",
+        ),
+        (
+            lambda c: c["vsd_operation"]["fixed_query"].update(api_key="secret"),
+            "Credential-like",
+        ),
+        (
+            lambda c: c["vsd_operation"].update(
+                endpoint="https://clinicaltrials.gov/api/v2/studies?x=1"
+            ),
+            "query",
+        ),
+    ],
+)
+def test_rejects_ambiguous_or_unsafe_contracts(mutation, message):
+    """Malformed mappings, endpoints, and fixed parameters fail closed."""
+    config = _search_config()
+    mutation(config)
+    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match=message):
+        vsd_dynamic_rest.VSDDynamicRESTTool(config)
+
+
+def test_validates_arguments_and_provider_schema(monkeypatch):
+    """Both request arguments and provider data follow reviewed schemas."""
+    tool = vsd_dynamic_rest.VSDDynamicRESTTool(_search_config())
+    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match="reviewed schema"):
+        tool.run({"condition": "ALS", "page_size": 100})
+
+    monkeypatch.setattr(
+        vsd_dynamic_rest,
+        "_safe_get_json",
+        lambda *args, **kwargs: (
+            {"unexpected": []},
+            {
+                "status_code": 200,
+                "content_type": "application/json",
+                "response_bytes": 17,
+                "redirects": 0,
+            },
+        ),
+    )
+    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match="Provider response"):
+        tool.run({"condition": "ALS", "page_size": 5})
+
+
+def test_path_values_are_encoded_and_every_argument_reaches_request(monkeypatch):
+    """Path data cannot escape its placeholder and query mappings are exact."""
+    config = _search_config()
+    config["name"] = "ReviewedTrialDetails"
+    config["parameter"] = {
+        "type": "object",
+        "properties": {"nct_id": {"type": "string"}},
+        "required": ["nct_id"],
+        "additionalProperties": False,
+    }
+    config["vsd_operation"].update(
+        endpoint="https://clinicaltrials.gov/api/v2/studies/{nctId}",
+        path_arguments={"nct_id": "nctId"},
+        query_arguments={},
+        fixed_query={"format": "json"},
+        response_schema={"type": "object"},
+    )
+    request = {}
+
+    def fake_get(url, params, *, timeout):
+        request.update(url=url, params=params, timeout=timeout)
+        return {}, {
+            "status_code": 200,
+            "content_type": "application/json",
+            "response_bytes": 2,
+            "redirects": 0,
+        }
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", fake_get)
+    result = vsd_dynamic_rest.VSDDynamicRESTTool(config).run({"nct_id": "NCT/123"})
+
+    assert request["url"].endswith("/NCT%2F123")
+    assert request["params"] == {"format": "json"}
+    assert result["data"]["provenance"]["method"] == "GET"
+    assert len(result["data"]["provenance"]["operation_sha256"]) == 64
+
+
+def test_register_and_execute_through_real_tooluniverse(monkeypatch):
+    """One reviewed runtime tool executes through ToolUniverse end to end."""
+    requests = []
+
+    def fake_get(url, params, *, timeout):
+        requests.append((url, params, timeout))
+        return {"studies": [{"protocolSection": {}}], "totalCount": 1}, {
+            "status_code": 200,
+            "content_type": "application/json; charset=utf-8",
+            "response_bytes": 59,
+            "redirects": 0,
+        }
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", fake_get)
+    tooluniverse = ToolUniverse()
+    try:
+        name = vsd_dynamic_rest.register_reviewed_rest_tool(
+            tooluniverse, deepcopy(_search_config())
+        )
+        result = tooluniverse.run_one_function(
+            {
+                "name": name,
+                "arguments": {
+                    "condition": "amyotrophic lateral sclerosis",
+                    "page_size": 5,
+                },
+            },
+            use_cache=False,
+        )
+    finally:
+        tooluniverse.close()
+
+    assert result["status"] == "success"
+    assert result["data"]["result"]["totalCount"] == 1
+    assert requests[0][1]["query.cond"] == "amyotrophic lateral sclerosis"
+
+
+def test_digest_changes_when_reviewed_contract_changes():
+    """Any reviewed-contract change invalidates its stable digest."""
+    first = _search_config()
+    second = deepcopy(first)
+    second["vsd_operation"]["fixed_query"]["countTotal"] = "false"
+    assert vsd_dynamic_rest.operation_digest(
+        first
+    ) != vsd_dynamic_rest.operation_digest(second)

--- a/tests/unit/test_vsd_dynamic_rest_case_study.py
+++ b/tests/unit/test_vsd_dynamic_rest_case_study.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from examples.vsd import dynamic_rest_als_case_study as study
+from tooluniverse import vsd_dynamic_rest
+
+pytestmark = pytest.mark.unit
+
+
+def _request_metadata(size: int = 100) -> dict:
+    return {
+        "status_code": 200,
+        "content_type": "application/json",
+        "response_bytes": size,
+        "redirects": 0,
+    }
+
+
+def _trial(nct_id: str, *, status: str, state: str) -> dict:
+    return {
+        "protocolSection": {
+            "identificationModule": {"nctId": nct_id, "briefTitle": f"Study {nct_id}"},
+            "statusModule": {"overallStatus": status},
+            "designModule": {"phases": ["PHASE2"], "studyType": "INTERVENTIONAL"},
+            "conditionsModule": {"conditions": ["Amyotrophic Lateral Sclerosis"]},
+            "armsInterventionsModule": {
+                "interventions": [{"name": "Investigational therapy", "type": "DRUG"}]
+            },
+            "sponsorCollaboratorsModule": {"leadSponsor": {"name": "Research center"}},
+            "contactsLocationsModule": {
+                "locations": [
+                    {
+                        "facility": "ALS Center",
+                        "city": "Boston",
+                        "state": state,
+                        "country": "United States",
+                        "status": "RECRUITING",
+                    }
+                ]
+            },
+        }
+    }
+
+
+def test_case_runs_two_real_tooluniverse_calls_and_writes_artifacts(
+    monkeypatch, tmp_path: Path
+):
+    """The study searches, follows an ID, summarizes, and writes stable evidence."""
+    trials = [
+        _trial("NCT00000002", status="RECRUITING", state="Massachusetts"),
+        _trial("NCT00000001", status="NOT_YET_RECRUITING", state="California"),
+    ]
+    calls = []
+
+    def fake_get(url, params, *, timeout):
+        calls.append((url, params, timeout))
+        if url.endswith("/studies"):
+            return {
+                "studies": trials,
+                "totalCount": 9,
+                "nextPageToken": "next",
+            }, _request_metadata()
+        assert url.endswith("/studies/NCT00000001")
+        return trials[1], _request_metadata()
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", fake_get)
+    evidence = study.run_case()
+    json_path, markdown_path = study.write_artifacts(evidence, tmp_path)
+
+    assert len(calls) == 2
+    assert calls[0][1]["query.cond"] == "Amyotrophic Lateral Sclerosis"
+    assert evidence["detail_follow_up"]["selected_nct_id"] == "NCT00000001"
+    assert evidence["detail_follow_up"]["identifier_matches_search"] is True
+    assert evidence["search"]["status_counts"] == {
+        "NOT_YET_RECRUITING": 1,
+        "RECRUITING": 1,
+    }
+    assert (
+        json.loads(json_path.read_text(encoding="utf-8"))["search"]["returned_records"]
+        == 2
+    )
+    report = markdown_path.read_text(encoding="utf-8")
+    assert "Reviewed Dynamic REST ALS Validation" in report
+    assert "NCT00000001" in report
+    assert "not trial matching" in report

--- a/tests/unit/test_vsd_dynamic_rest_case_study.py
+++ b/tests/unit/test_vsd_dynamic_rest_case_study.py
@@ -15,7 +15,9 @@ pytestmark = pytest.mark.unit
 MODULE_PATH = (
     Path(__file__).parents[2] / "examples" / "vsd" / "dynamic_rest_als_case_study.py"
 )
-SPEC = importlib.util.spec_from_file_location("vsd_dynamic_rest_case_study", MODULE_PATH)
+SPEC = importlib.util.spec_from_file_location(
+    "vsd_dynamic_rest_case_study", MODULE_PATH
+)
 assert SPEC and SPEC.loader
 study = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = study

--- a/tests/unit/test_vsd_dynamic_rest_case_study.py
+++ b/tests/unit/test_vsd_dynamic_rest_case_study.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
+import importlib.util
 import json
+import sys
 from pathlib import Path
 
 import pytest
 
-from examples.vsd import dynamic_rest_als_case_study as study
 from tooluniverse import vsd_dynamic_rest
 
 pytestmark = pytest.mark.unit
+
+
+MODULE_PATH = (
+    Path(__file__).parents[2] / "examples" / "vsd" / "dynamic_rest_als_case_study.py"
+)
+SPEC = importlib.util.spec_from_file_location("vsd_dynamic_rest_case_study", MODULE_PATH)
+assert SPEC and SPEC.loader
+study = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = study
+SPEC.loader.exec_module(study)
 
 
 def _request_metadata(size: int = 100) -> dict:


### PR DESCRIPTION
## Summary

This is phase 2 of the PR #32 replacement and is stacked on #416. It restores dynamic REST execution without restoring arbitrary URL execution, automatic publication, or agent-controlled registration.

- adds an administrator-reviewed, read-only HTTPS JSON runtime
- validates every tool argument and provider response with self-contained JSON Schema
- maps every declared argument to one exact path or query location
- reuses the pinned-DNS, exact-host, zero-redirect, one-megabyte, total-deadline VSD transport
- prohibits credentials, mutating methods, external schema references, and automatic persistence
- records stable operation and payload SHA-256 digests with request provenance

## End-to-end case

The checked ALS case registers two reviewed operations from one ClinicalTrials.gov source into a real `ToolUniverse` instance. It searches active or upcoming US ALS records, deterministically selects one returned NCT identifier, and retrieves the same record through a second operation using `run_one_function()`.

The live run returned 20 records from 113 provider matches and confirmed the follow-up identifier. Human-readable and JSON evidence are checked in under `examples/vsd/artifacts/dynamic_rest_als_snapshot.*`.

This is an API execution and record-consistency proof, not patient matching, eligibility assessment, or treatment advice.

## Validation

- 78 VSD foundation and runtime tests passed together
- 11 focused runtime and case-study tests passed after final schema hardening
- pinned Ruff 0.14.5 check and formatting passed
- live ClinicalTrials.gov search and follow-up completed successfully
- `git diff --check` passed

## Stack

- Base: #416
- Next: demand-driven API discovery and ranking
