### PR TITLE
Add reviewed tool promotion pipeline

### DIFF
--- a/docs/dev_docs/VSD_TOOL_PROMOTION_VALIDATION.md
+++ b/docs/dev_docs/VSD_TOOL_PROMOTION_VALIDATION.md
@@ -1,0 +1,108 @@
+# VSD Reviewed Tool Promotion
+
+This phase turns one **reviewed** discovery candidate into one or more narrow,
+read-only ToolUniverse tools. It does not make discovery results executable and
+does not let an agent approve or publish a tool.
+
+## Boundary
+
+The pipeline has four explicit administrator actions:
+
+1. `draft-socrata` generates a bounded GET contract from reviewed candidate fields.
+2. `verify` executes the draft through a real `ToolUniverse` instance against 3-20 cases.
+3. `approve` records a reviewer and decision against the exact draft and evidence hashes.
+4. `publish` atomically writes the approved contract. Loading remains a separate, explicit call.
+
+Draft, evidence, approval, and publication artifacts are SHA-256 linked. A changed
+artifact fails closed. Generated filters are mandatory, the record limit is fixed,
+credentials are forbidden, provider responses must match the reviewed schema, and
+published tools cannot replace a tool already loaded in the process.
+
+The hashes detect accidental or out-of-band modification; they are not digital
+signatures. Write access to the promotion workspace is therefore an administrative
+trust boundary. Loading validates every publication before registering any of them,
+so one malformed record cannot leave a partially loaded set.
+
+Socrata arbitrary-precision `Number` and `Money` fields are modeled as bounded
+numeric strings because that is their documented JSON wire representation. Object
+fields may be returned, but the generator refuses to expose them as direct equality
+filters. Field and tool-name limits also match the dynamic runtime and ToolUniverse's
+MCP-compatible name ceiling.
+
+Provider reference: https://dev.socrata.com/docs/datatypes/number.html
+
+This is a technical review boundary. It does not establish that a dataset is
+scientifically correct, clinically appropriate, current enough for care, or endorsed
+by ToolUniverse.
+
+## Administrator CLI
+
+The CLI accepts either a standalone discovery candidate or the checked discovery
+case-study snapshot:
+
+```console
+tooluniverse-vsd-promote --workspace .tooluniverse/vsd draft-socrata discovery.json \
+  --tool-name CancerTrialsBySite \
+  --description "Query the reviewed cancer-trial dataset by exact primary site." \
+  --filter-fields primary_site \
+  --return-fields protocol,primary_site,study_phase,title \
+  --max-records 25
+
+tooluniverse-vsd-promote --workspace .tooluniverse/vsd verify DRAFT_ID cases.json
+tooluniverse-vsd-promote --workspace .tooluniverse/vsd approve DRAFT_ID \
+  --reviewed-by REVIEWER \
+  --decision-note "Technical approval after contract review and live verification."
+tooluniverse-vsd-promote --workspace .tooluniverse/vsd publish DRAFT_ID
+tooluniverse-vsd-promote --workspace .tooluniverse/vsd list
+```
+
+Applications opt in to published records explicitly:
+
+```python
+from tooluniverse import ToolUniverse
+from tooluniverse.vsd_promotion import load_published_tools
+
+tu = ToolUniverse()
+loaded_names = load_published_tools(tu, workspace=".tooluniverse/vsd")
+```
+
+There is no startup scan, background publication, or agent-facing approval action.
+
+## End-to-End Cancer-Trial Case
+
+The checked case starts with the candidate selected by the preceding Socrata catalog
+study: New York State dataset `2ig8-yxf8`, "Current Active Clinical Trials - Roswell
+Park Cancer Institute." It deliberately creates **two tools from one source**:
+
+- `VSDGeneratedCancerTrialsBySite`, requiring an exact `primary_site`.
+- `VSDGeneratedCancerTrialsByPhase`, requiring an exact `study_phase`.
+
+The site tool verifies Brain and Nervous System, Breast, and Prostate. The phase tool
+verifies phases I, II, and III. After publication, a fresh ToolUniverse instance loads
+both records and repeats independent Breast and phase III queries.
+
+Run it from the repository root:
+
+```console
+PYTHONPATH=src python examples/vsd/tool_promotion_cancer_case_study.py
+```
+
+Review the concise report at
+`examples/vsd/artifacts/tool_promotion_snapshot.md`, the machine-readable summary at
+`examples/vsd/artifacts/tool_promotion_snapshot.json`, and the complete audit chain
+under `examples/vsd/artifacts/promotion_workspace/`.
+
+## Verification Commands
+
+```console
+PYTHONPATH=src python -m pytest \
+  tests/unit/test_vsd_promotion.py \
+  tests/unit/test_vsd_promotion_cli.py -q
+
+uvx --from ruff==0.14.5 ruff check \
+  src/tooluniverse/vsd_promotion.py \
+  src/tooluniverse/vsd_promotion_cli.py \
+  tests/unit/test_vsd_promotion.py \
+  tests/unit/test_vsd_promotion_cli.py \
+  examples/vsd/tool_promotion_cancer_case_study.py
+```

--- a/docs/dev_docs/VSD_TOOL_PROMOTION_VALIDATION.md
+++ b/docs/dev_docs/VSD_TOOL_PROMOTION_VALIDATION.md
@@ -92,17 +92,53 @@ Review the concise report at
 `examples/vsd/artifacts/tool_promotion_snapshot.json`, and the complete audit chain
 under `examples/vsd/artifacts/promotion_workspace/`.
 
+## Complete VSD Pipeline Case
+
+The oncology source-governance case is the integration proof for all four VSD
+phases. Unlike the focused examples, it does not begin from a checked discovery
+snapshot. It performs live administrative source inspection, reviewed source
+execution, reviewed dynamic REST search and detail calls, demand-driven catalog
+discovery, candidate screening, draft generation, six live verification calls,
+approval, publication, explicit loading into a fresh ToolUniverse instance, and
+two post-publication calls in one run.
+
+The run fails closed unless all 12 cross-stage assertions pass. Those assertions
+cover catalog cleanup, control-plane isolation, identity consistency, candidate
+non-executability, required discovery fields, verification outcomes, all five
+promotion hashes per tool, absence before explicit loading, exact loaded names,
+and exact-filter runtime results. A final SHA-256 digest binds the provider,
+operation, discovery, promotion, and runtime evidence hashes into one audit
+record.
+
+The live search originally exceeded the 1 MB transport ceiling when requesting
+twenty full ClinicalTrials.gov protocols. The contract was narrowed to an
+explicit ten-field projection, producing the same bounded record count in about
+372 KB. This is an important validation result: the integration adapted its data
+contract instead of relaxing the transport policy.
+
+```console
+PYTHONPATH=src python examples/vsd/complete_pipeline_case_study.py
+```
+
+- Detailed report: `examples/vsd/artifacts/complete_pipeline_snapshot.md`
+- Machine ledger: `examples/vsd/artifacts/complete_pipeline_snapshot.json`
+- Promotion chain: `examples/vsd/artifacts/complete_pipeline_workspace/promotion/`
+- Isolated final catalog: `examples/vsd/artifacts/complete_pipeline_workspace/catalog/sources.json`
+
 ## Verification Commands
 
 ```console
 PYTHONPATH=src python -m pytest \
   tests/unit/test_vsd_promotion.py \
-  tests/unit/test_vsd_promotion_cli.py -q
+  tests/unit/test_vsd_promotion_cli.py \
+  tests/unit/test_vsd_complete_pipeline_case_study.py -q
 
 uvx --from ruff==0.14.5 ruff check \
   src/tooluniverse/vsd_promotion.py \
   src/tooluniverse/vsd_promotion_cli.py \
   tests/unit/test_vsd_promotion.py \
   tests/unit/test_vsd_promotion_cli.py \
+  tests/unit/test_vsd_complete_pipeline_case_study.py \
+  examples/vsd/complete_pipeline_case_study.py \
   examples/vsd/tool_promotion_cancer_case_study.py
 ```

--- a/examples/vsd/README.md
+++ b/examples/vsd/README.md
@@ -1,4 +1,52 @@
-# ToolUniverse VSD Heart-Health Evidence Dossier
+# ToolUniverse VSD Validation Case Studies
+
+## Complete Oncology Source-Governance Pipeline
+
+`complete_pipeline_case_study.py` exercises the entire VSD stack in one
+continuous workflow. It starts with a breast-cancer evidence need and crosses
+each trust boundary explicitly:
+
+1. The administrator CLI registers, probes, lists, queries, and removes a
+   temporary openFDA tamoxifen source in an isolated catalog.
+2. A real ToolUniverse instance confirms that the administrative operations are
+   absent, discovers the packaged openFDA integration offline, and retrieves the
+   same label through the fixed `VSDOpenFDALabelBySetId` contract.
+3. Two reviewed dynamic REST operations search active or upcoming New York
+   breast-cancer studies and retrieve one deterministic NCT record.
+4. `VSDDiscoverAPICandidates` searches the fixed Socrata catalog for a source
+   with six demanded trial fields. The selected candidate remains explicitly
+   non-executable.
+5. The administrator creates two narrow drafts from that candidate, runs three
+   live cases per draft, approves the exact evidence hashes, and publishes the
+   approved records.
+6. A fresh ToolUniverse instance proves the new tools were absent before the
+   explicit load, loads both publications, and executes independent site and
+   phase queries.
+
+The first live attempt was rejected because twenty unprojected ClinicalTrials.gov
+records exceeded the transport's 1 MB response ceiling. The reviewed search
+contract was corrected to request only the ten fields used by the study; the
+successful response retained twenty records while shrinking to roughly 372 KB.
+The safety limit was not weakened.
+
+Run the complete case from the repository root:
+
+```console
+PYTHONPATH=src python examples/vsd/complete_pipeline_case_study.py
+```
+
+The checked live run passed all 12 end-to-end assertions, six promotion cases,
+two post-publication executions, catalog cleanup, search/detail identity, and
+the final cross-stage audit digest. Review the detailed report at
+`artifacts/complete_pipeline_snapshot.md`, the complete machine-readable ledger
+at `artifacts/complete_pipeline_snapshot.json`, and the draft/evidence/approval/
+publication records under `artifacts/complete_pipeline_workspace/promotion/`.
+
+The report is a software-governance and public-record retrieval proof. It does
+not match patients, establish trial eligibility, compare treatments, or join
+the state and national registries at record level.
+
+## Heart-Health Evidence Dossier
 
 This example builds a reproducible population-health screening dossier for
 Autauga County, Alabama. It asks which census tracts show concurrent modeled
@@ -11,7 +59,7 @@ The output is designed for an analyst deciding what to investigate next. It is
 not a neighborhood ranking, patient-risk model, causal analysis, clinical
 recommendation, or resource-allocation algorithm.
 
-## Workflow
+### Workflow
 
 The script creates one `ToolUniverse` instance, selectively loads six tools, and
 executes all work through the documented `run_one_function()` API with caching
@@ -43,7 +91,7 @@ inactivity, obesity, lack of insurance, and routine checkups. It validates the
 measure IDs and names, county, unique tract-measure pairs, percentage bounds,
 and confidence-interval ordering before returning data.
 
-## Analysis
+### Analysis
 
 The live Autauga query is expected to form a complete 17-tract by 8-measure grid.
 The script refuses to build a dossier if the response reaches its record limit or
@@ -73,7 +121,7 @@ point estimates and each context measure. These are diagnostics only: they do
 not use confidence intervals or adjust for shared model inputs, demographics, or
 spatial dependence.
 
-## Run And Artifacts
+### Run And Artifacts
 
 From the repository root:
 
@@ -99,7 +147,7 @@ size, redirect count, and raw-payload SHA-256. PubMed and ClinicalTrials.gov are
 supporting ToolUniverse integrations and do not inherit the VSD transport or
 provenance contract.
 
-## Scientific Boundaries
+### Scientific Boundaries
 
 CDC PLACES estimates are modeled aggregates derived from BRFSS and Census inputs,
 not patient observations. CDC cautions against using the estimates to rank the

--- a/examples/vsd/artifacts/complete_pipeline_snapshot.json
+++ b/examples/vsd/artifacts/complete_pipeline_snapshot.json
@@ -1,0 +1,1071 @@
+{
+  "administrative_source_lifecycle": {
+    "boundary": "Registration and generic querying occurred only through the administrator CLI. They did not publish an agent-facing tool.",
+    "catalog_restored": true,
+    "endpoint": "https://api.fda.gov/drug/label.json",
+    "final_source_ids": [],
+    "initial_source_ids": [],
+    "listed_source_ids": [
+      "openfda_tamoxifen_review"
+    ],
+    "preexisting_source_removed": false,
+    "query": {
+      "content_type": "application/json; charset=utf-8",
+      "default_params": {
+        "limit": 1,
+        "search": "openfda.generic_name:\"tamoxifen\""
+      },
+      "http_status": 200,
+      "normalized_payload_sha256": "2c0606a1fceec256c19de248ff4eae11fe3b677487e6792542feec89dc34c018",
+      "provider_total_records": 14,
+      "redirects": 0,
+      "response_bytes": 171971,
+      "returned_records": 1,
+      "selected_set_id": "1e6ff055-590c-41e6-9530-1fdf04cdbd02"
+    },
+    "registered": true,
+    "registration_probe": {
+      "content_type": "application/json; charset=utf-8",
+      "peer_ip": "2600:1f12:18a:7d00:e3f9:f180:329:aeba",
+      "redirects": 0,
+      "response_bytes": 171971,
+      "result_type": "dict",
+      "status_code": 200,
+      "url": "https://api.fda.gov/drug/label.json"
+    },
+    "removed": true,
+    "source_id": "openfda_tamoxifen_review"
+  },
+  "audit_chain": {
+    "inputs": {
+      "admin_query_payload": "2c0606a1fceec256c19de248ff4eae11fe3b677487e6792542feec89dc34c018",
+      "discovery_payload": "4cdc9fcc7d7c494b259af4af4209b7d6a70b46fb3830e3c96b92eedafbea2ed7",
+      "dynamic_contracts": [
+        "6f4f8cba84e65c6432da167929386a18d4b137a89065678fbdad274c72f8880c",
+        "77c4c98fd5977836777fb792767a331995a69b39b024a9424f0e48e4bed9ef1d"
+      ],
+      "dynamic_payloads": [
+        "8344bbd862b6d367d93adc81145b249bb84bfe875dfd84b6cde35ca10bdeb161",
+        "9301d45041fa287bc00dd47ae55320bc0f8a0a064f63f441ab7230b21b799afe"
+      ],
+      "promotion_chains": [
+        {
+          "approval_sha256": "f54da18517d7960ed1308531bd5cea0b93e708dcaffbefead9e1e46c021f44c0",
+          "draft_sha256": "28bfd3429e704ebaeb16038f199491536822fe1098ac6b1619013c81934cd770",
+          "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+          "publication_sha256": "74ca9fe294424567af57f5da4e6cb3c6e325bd4b8caa0c01440140735e4e03bc",
+          "verification_sha256": "318d81ea17d38bcf3094d92855d87785533ebfeb8fec74d639e841a3a8221d05"
+        },
+        {
+          "approval_sha256": "8b917cb80250323d0cb704024c4cfe9a357a141e2dd6437fe0a27aabf31860d6",
+          "draft_sha256": "1118f91aaa25b923cebbb0e4de34954570409faf0d45bdb3410ce26d30aae86f",
+          "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+          "publication_sha256": "0a78f46737d17fd414645d13287e46a9241a311af177cb091091a32556b494aa",
+          "verification_sha256": "2ce8b64fbf79cc1ad747ecbf28dd222dd8a6399a4d2b51f85374f1b04475d790"
+        }
+      ],
+      "reviewed_label_payload": "adfd73ae9a40c8fae86c31cc30bed62c88a7d232cae237f9c0aba2fa6541d6d9",
+      "runtime_payloads": [
+        "5562338d7fdf189fa5ec3eecbfedadcb579778970ac266b82400116b84adb90f",
+        "322b0476c5a33b91b7eae1117283468bac557db1ac748bbf8645b4d2d8a7795d"
+      ],
+      "selected_candidate": "31dcb2ce74f62d7c"
+    },
+    "sha256": "0530702a8466da09286370a3303fbf68361074ea6543f8d86ef57d2aa7a6ebc6"
+  },
+  "case": "complete_vsd_oncology_source_governance",
+  "decision_question": "Can ToolUniverse start from an oncology evidence need, keep generic source administration outside the agent boundary, execute reviewed contracts, discover an unknown API without executing it, and promote only verified narrow tools with a complete audit chain?",
+  "demand_discovery": {
+    "boundary": "Candidates are untrusted catalog metadata. They are not approved, probed, executable, or scientific endorsements.",
+    "candidates": [
+      {
+        "approval_state": "unreviewed_candidate",
+        "candidate_id": "31dcb2ce74f62d7c",
+        "catalog_domain": "data.ny.gov",
+        "dataset_id": "2ig8-yxf8",
+        "execution_allowed": false,
+        "field_count": 7,
+        "matched_required_fields": [
+          "date_opened",
+          "primary_site",
+          "principal_investigator",
+          "protocol",
+          "study_phase",
+          "title"
+        ],
+        "missing_required_fields": [],
+        "name": "Current Active Clinical Trials - Roswell Park Cancer Institute",
+        "score": 0.9,
+        "selected_for_contract_review": true
+      },
+      {
+        "approval_state": "unreviewed_candidate",
+        "candidate_id": "2139c3a85291e320",
+        "catalog_domain": "data.texas.gov",
+        "dataset_id": "6pm5-am5m",
+        "execution_allowed": false,
+        "field_count": 23,
+        "matched_required_fields": [],
+        "missing_required_fields": [
+          "date_opened",
+          "primary_site",
+          "principal_investigator",
+          "protocol",
+          "study_phase",
+          "title"
+        ],
+        "name": "Texas Commission on Environmental Quality - Water Quality General Permits Active/Pending",
+        "score": 0.5563,
+        "selected_for_contract_review": false
+      },
+      {
+        "approval_state": "unreviewed_candidate",
+        "candidate_id": "997796d9182291ff",
+        "catalog_domain": "data.texas.gov",
+        "dataset_id": "7fq8-wig2",
+        "execution_allowed": false,
+        "field_count": 22,
+        "matched_required_fields": [],
+        "missing_required_fields": [
+          "date_opened",
+          "primary_site",
+          "principal_investigator",
+          "protocol",
+          "study_phase",
+          "title"
+        ],
+        "name": "Texas Commission on Environmental Quality - Water Quality Individual Permits Active/Pending",
+        "score": 0.5563,
+        "selected_for_contract_review": false
+      },
+      {
+        "approval_state": "unreviewed_candidate",
+        "candidate_id": "6794128cb5ecab13",
+        "catalog_domain": "data.pa.gov",
+        "dataset_id": "e7ip-7qrs",
+        "execution_allowed": false,
+        "field_count": 45,
+        "matched_required_fields": [],
+        "missing_required_fields": [
+          "date_opened",
+          "primary_site",
+          "principal_investigator",
+          "protocol",
+          "study_phase",
+          "title"
+        ],
+        "name": "Emissions Inventory System (EIS) Facilities 2017 - Current County Environmental Protection",
+        "score": 0.4875,
+        "selected_for_contract_review": false
+      },
+      {
+        "approval_state": "unreviewed_candidate",
+        "candidate_id": "d89303e87d4b1139",
+        "catalog_domain": "data.wa.gov",
+        "dataset_id": "i3e8-j9am",
+        "execution_allowed": false,
+        "field_count": 45,
+        "matched_required_fields": [],
+        "missing_required_fields": [
+          "date_opened",
+          "primary_site",
+          "principal_investigator",
+          "protocol",
+          "study_phase",
+          "title"
+        ],
+        "name": "Public Health Activities and Services - 2014",
+        "score": 0.4875,
+        "selected_for_contract_review": false
+      },
+      {
+        "approval_state": "unreviewed_candidate",
+        "candidate_id": "76614a72b918e8da",
+        "catalog_domain": "cos-data.seattle.gov",
+        "dataset_id": "fg6z-cn3y",
+        "execution_allowed": false,
+        "field_count": 20,
+        "matched_required_fields": [],
+        "missing_required_fields": [
+          "date_opened",
+          "primary_site",
+          "principal_investigator",
+          "protocol",
+          "study_phase",
+          "title"
+        ],
+        "name": "Public Life Data - Locations",
+        "score": 0.4875,
+        "selected_for_contract_review": false
+      },
+      {
+        "approval_state": "unreviewed_candidate",
+        "candidate_id": "63d28a35d1881a25",
+        "catalog_domain": "data.cityofchicago.org",
+        "dataset_id": "6q3z-9maq",
+        "execution_allowed": false,
+        "field_count": 16,
+        "matched_required_fields": [],
+        "missing_required_fields": [
+          "date_opened",
+          "primary_site",
+          "principal_investigator",
+          "protocol",
+          "study_phase",
+          "title"
+        ],
+        "name": "COVID-19 Vaccination Locations - Historical",
+        "score": 0.4375,
+        "selected_for_contract_review": false
+      },
+      {
+        "approval_state": "unreviewed_candidate",
+        "candidate_id": "3c8b7b124fd86ee8",
+        "catalog_domain": "data.cityofnewyork.us",
+        "dataset_id": "usc3-8zwd",
+        "execution_allowed": false,
+        "field_count": 50,
+        "matched_required_fields": [],
+        "missing_required_fields": [
+          "date_opened",
+          "primary_site",
+          "principal_investigator",
+          "protocol",
+          "study_phase",
+          "title"
+        ],
+        "name": "Energy and Water Data Disclosure for Local Law 84 2021 (Data for Calendar Year 2020)",
+        "score": 0.4375,
+        "selected_for_contract_review": false
+      },
+      {
+        "approval_state": "unreviewed_candidate",
+        "candidate_id": "e011e60455228196",
+        "catalog_domain": "data.cityofnewyork.us",
+        "dataset_id": "7x5e-2fxh",
+        "execution_allowed": false,
+        "field_count": 50,
+        "matched_required_fields": [],
+        "missing_required_fields": [
+          "date_opened",
+          "primary_site",
+          "principal_investigator",
+          "protocol",
+          "study_phase",
+          "title"
+        ],
+        "name": "Energy and Water Data Disclosure for Local Law 84 2022 (Data for Calendar Year 2021)",
+        "score": 0.4375,
+        "selected_for_contract_review": false
+      },
+      {
+        "approval_state": "unreviewed_candidate",
+        "candidate_id": "5a7c28ed3d4c3f59",
+        "catalog_domain": "data.princegeorgescountymd.gov",
+        "dataset_id": "qzrv-2tnv",
+        "execution_allowed": false,
+        "field_count": 50,
+        "matched_required_fields": [],
+        "missing_required_fields": [
+          "date_opened",
+          "primary_site",
+          "principal_investigator",
+          "protocol",
+          "study_phase",
+          "title"
+        ],
+        "name": "Property",
+        "score": 0.4188,
+        "selected_for_contract_review": false
+      }
+    ],
+    "catalog_result_count": 13,
+    "loaded_agent_tools_after_dynamic_registration": [
+      "VSDDiscoverAPICandidates",
+      "VSDDiscoverSources",
+      "VSDOpenFDALabelBySetId",
+      "VSDTotalClinicalTrialDetails",
+      "VSDTotalClinicalTrialsSearch"
+    ],
+    "provenance": {
+      "content_type": "application/json;charset=utf-8",
+      "endpoint": "https://api.us.socrata.com/api/catalog/v1",
+      "http_status": 200,
+      "payload_sha256": "4cdc9fcc7d7c494b259af4af4209b7d6a70b46fb3830e3c96b92eedafbea2ed7",
+      "provider": "Socrata Open Data API Catalog",
+      "query_params": {
+        "limit": 30,
+        "only": "datasets",
+        "q": "active cancer clinical trials primary site phase protocol"
+      },
+      "redirects": 0,
+      "response_bytes": 586386,
+      "retrieved_at": "2026-08-01T04:31:32.923536+00:00"
+    },
+    "query": "active cancer clinical trials primary site phase protocol",
+    "returned_candidate_count": 10,
+    "selected_candidate": {
+      "api_endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+      "approval_state": "unreviewed_candidate",
+      "candidate_id": "31dcb2ce74f62d7c",
+      "catalog_domain": "data.ny.gov",
+      "dataset_id": "2ig8-yxf8",
+      "description": "List of active studies submitted by Roswell Park Cancer Institute (RPCI) to National Cancer Institute (NCI) annually as part of the Cancer Center Report Grant reporting. It includes the primary site, protocol, principal investigator, date opened, phase and study name.",
+      "documentation_url": "https://data.ny.gov/d/2ig8-yxf8",
+      "execution_allowed": false,
+      "fields": [
+        {
+          "description": "The unique identifier for this study. For both national and externally",
+          "field": "protocol",
+          "json_type": "string",
+          "label": "Protocol",
+          "provider_type": "Text"
+        },
+        {
+          "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or ",
+          "field": "study_phase",
+          "json_type": "string",
+          "label": "Study Phase",
+          "provider_type": "Text"
+        },
+        {
+          "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+          "field": "primary_site",
+          "json_type": "string",
+          "label": "Primary Site",
+          "provider_type": "Text"
+        },
+        {
+          "description": "The name of the Principal Investigator from Center who is responsible for the Clinical Research Study",
+          "field": "principal_investigator",
+          "json_type": "string",
+          "label": "Principal Investigator",
+          "provider_type": "Text"
+        },
+        {
+          "description": "The official start date (activation) of a trial",
+          "field": "date_opened",
+          "json_type": "string",
+          "label": "Date Opened",
+          "provider_type": "Calendar date"
+        },
+        {
+          "description": "The date the clinical research study closed to accrual. If the study is still open, this field will be blank.",
+          "field": "date_closed",
+          "json_type": "string",
+          "label": "Date Closed",
+          "provider_type": "Calendar date"
+        },
+        {
+          "description": "Name of the protocol provided by the study's principal investigator",
+          "field": "title",
+          "json_type": "string",
+          "label": "Title",
+          "provider_type": "Text"
+        }
+      ],
+      "metadata_trust": "untrusted_catalog_metadata",
+      "name": "Current Active Clinical Trials - Roswell Park Cancer Institute",
+      "provenance_label": "official",
+      "score": {
+        "api_ready": 1.0,
+        "exact_phrase": 0.0,
+        "government_domain": 1.0,
+        "official_catalog_label": 1.0,
+        "query_coverage": 1.0,
+        "total": 0.9
+      },
+      "tags": [
+        "cancer study",
+        "nci",
+        "rpci"
+      ],
+      "updated_at": "2026-04-14T21:08:58.000Z"
+    },
+    "selection_rule": "Require non-executable unreviewed state, an official government API-ready catalog record, and all six demanded fields; then choose the highest score with candidate ID as the stable tie-breaker."
+  },
+  "end_to_end_assertions": {
+    "administrative_catalog_restored": true,
+    "administrative_tools_not_agent_facing": true,
+    "discovery_candidate_has_required_fields": true,
+    "discovery_candidate_remained_non_executable": true,
+    "dynamic_search_detail_identifier_match": true,
+    "fixed_adapter_matches_admin_record": true,
+    "promoted_tools_absent_before_explicit_load": true,
+    "promotion_hash_chain_complete": true,
+    "published_runtime_filters_exact": true,
+    "published_tools_loaded_explicitly": true,
+    "reviewed_source_discovered_offline": true,
+    "six_live_promotion_cases_passed": true
+  },
+  "generated_at": "2026-08-01T04:31:36.578274+00:00",
+  "interpretation_boundary": "This is a software-governance and public-record retrieval demonstration. It does not match patients to trials, establish eligibility, compare treatments, or provide medical advice. The state and national registries are independent and are not joined at record level.",
+  "reviewed_dynamic_rest": {
+    "detail_follow_up": {
+      "identifier_matches_search": true,
+      "provenance": {
+        "content_type": "application/json",
+        "endpoint": "https://clinicaltrials.gov/api/v2/studies/NCT01766297",
+        "http_status": 200,
+        "method": "GET",
+        "operation_sha256": "77c4c98fd5977836777fb792767a331995a69b39b024a9424f0e48e4bed9ef1d",
+        "payload_sha256": "9301d45041fa287bc00dd47ae55320bc0f8a0a064f63f441ab7230b21b799afe",
+        "provider": "clinicaltrials.gov",
+        "query_params": {
+          "format": "json"
+        },
+        "redirects": 0,
+        "response_bytes": 13339,
+        "retrieved_at": "2026-08-01T04:31:32.069853+00:00"
+      },
+      "selected_nct_id": "NCT01766297",
+      "selection_rule": "Lexicographically smallest valid returned NCT ID",
+      "study": {
+        "conditions": [
+          "Breast Cancer",
+          "Breast Neoplasm",
+          "Breast Tumor",
+          "Cancer of the Breast"
+        ],
+        "nct_id": "NCT01766297",
+        "new_york_locations": [
+          {
+            "city": "New York",
+            "facility": "New York Proton Center",
+            "status": "RECRUITING"
+          }
+        ],
+        "overall_status": "RECRUITING",
+        "phases": [
+          "PHASE2"
+        ],
+        "title": "Phase II Protocol of Proton Therapy for Partial Breast Irradiation in Early Stage Breast Cancer"
+      }
+    },
+    "search": {
+      "arguments": {
+        "condition": "Breast Cancer",
+        "location_query": "AREA[LocationState]New York",
+        "page_size": 20
+      },
+      "phase_counts": {
+        "NA": 2,
+        "NOT_APPLICABLE": 1,
+        "PHASE1": 2,
+        "PHASE2": 11,
+        "PHASE3": 5
+      },
+      "provenance": {
+        "content_type": "application/json",
+        "endpoint": "https://clinicaltrials.gov/api/v2/studies",
+        "http_status": 200,
+        "method": "GET",
+        "operation_sha256": "6f4f8cba84e65c6432da167929386a18d4b137a89065678fbdad274c72f8880c",
+        "payload_sha256": "8344bbd862b6d367d93adc81145b249bb84bfe875dfd84b6cde35ca10bdeb161",
+        "provider": "clinicaltrials.gov",
+        "query_params": {
+          "countTotal": "true",
+          "fields": "NCTId,BriefTitle,OverallStatus,Phase,Condition,LocationFacility,LocationCity,LocationState,LocationCountry,LocationStatus",
+          "filter.overallStatus": "RECRUITING|NOT_YET_RECRUITING|ACTIVE_NOT_RECRUITING|ENROLLING_BY_INVITATION",
+          "format": "json",
+          "pageSize": 20,
+          "query.cond": "Breast Cancer",
+          "query.locn": "AREA[LocationState]New York"
+        },
+        "redirects": 0,
+        "response_bytes": 371748,
+        "retrieved_at": "2026-08-01T04:31:31.869941+00:00"
+      },
+      "provider_total_count": 546,
+      "returned_nct_ids": [
+        "NCT05059444",
+        "NCT03384914",
+        "NCT06682793",
+        "NCT01766297",
+        "NCT04683679",
+        "NCT05104866",
+        "NCT06954337",
+        "NCT05238922",
+        "NCT04379570",
+        "NCT05382286",
+        "NCT02513394",
+        "NCT07007559",
+        "NCT03414970",
+        "NCT06840483",
+        "NCT02750358",
+        "NCT04589468",
+        "NCT05374915",
+        "NCT07483307",
+        "NCT04001829",
+        "NCT03344965"
+      ],
+      "returned_records": 20,
+      "sample_studies": [
+        {
+          "conditions": [
+            "Bladder Carcinoma",
+            "Ureter Carcinoma",
+            "Renal Pelvis Carcinoma",
+            "Non-small Cell Lung Cancer",
+            "Invasive Breast Carcinoma",
+            "Cutaneous Melanoma",
+            "Esophageal Carcinoma",
+            "Gastroesophageal Junction Carcinoma",
+            "Gastric Adenocarcinoma",
+            "Pancreatic Adenocarcinoma",
+            "Squamous Cell Carcinoma of the Head and Neck",
+            "Epithelial Ovarian Carcinoma",
+            "Fallopian Tube Carcinoma",
+            "Endometrial Carcinoma",
+            "Renal Cell Carcinoma",
+            "Rectal Adenocarcinoma"
+          ],
+          "nct_id": "NCT05059444",
+          "new_york_locations": [
+            {
+              "city": "New York",
+              "facility": "Icahn School of Medicine at Mount Sinai",
+              "status": "TERMINATED"
+            }
+          ],
+          "overall_status": "RECRUITING",
+          "phases": [],
+          "title": "ORACLE: Observation of ResiduAl Cancer With Liquid Biopsy Evaluation"
+        },
+        {
+          "conditions": [
+            "Breast Cancer Female",
+            "Breast Cancer, Male",
+            "Breast Cancer Stage I",
+            "Breast Cancer Stage II",
+            "Breast Cancer Stage III",
+            "Residual Disease",
+            "HER2-positive Breast Cancer",
+            "HER2 Positive Breast Carcinoma"
+          ],
+          "nct_id": "NCT03384914",
+          "new_york_locations": [
+            {
+              "city": "Buffalo",
+              "facility": "Roswell Park Comprehensive Cancer Center",
+              "status": null
+            }
+          ],
+          "overall_status": "ACTIVE_NOT_RECRUITING",
+          "phases": [
+            "PHASE2"
+          ],
+          "title": "Vaccine to Prevent Recurrence in Patients With HER-2 Positive Breast Cancer"
+        },
+        {
+          "conditions": [
+            "Solid Tumor, Adult",
+            "Colorectal Cancer",
+            "Non-Small Cell Lung",
+            "NSCLC (Non-small Cell Lung Cancer)",
+            "Cancer",
+            "Colon Cancer",
+            "Rectal Cancer",
+            "Lung Cancer",
+            "CRC",
+            "Head and Neck Squamous Cell Cancer",
+            "HNSCC",
+            "Renal Cell Carcinoma",
+            "RCC",
+            "Kidney Cancer",
+            "Triple Negative Breast Cancer",
+            "TNBC",
+            "Colorectal Adenocarcinoma"
+          ],
+          "nct_id": "NCT06682793",
+          "new_york_locations": [
+            {
+              "city": "New York",
+              "facility": "NYU Langone Health",
+              "status": "RECRUITING"
+            }
+          ],
+          "overall_status": "RECRUITING",
+          "phases": [
+            "PHASE1",
+            "PHASE2"
+          ],
+          "title": "A Study to Evaluate the Safety and Efficacy of A2B395, an Allogeneic Logic-gated CAR T, in Participants With Solid Tumors That Express EGFR and Have Lost HLA-A*02 Expression"
+        },
+        {
+          "conditions": [
+            "Breast Cancer",
+            "Breast Neoplasm",
+            "Breast Tumor",
+            "Cancer of the Breast"
+          ],
+          "nct_id": "NCT01766297",
+          "new_york_locations": [
+            {
+              "city": "New York",
+              "facility": "New York Proton Center",
+              "status": "RECRUITING"
+            }
+          ],
+          "overall_status": "RECRUITING",
+          "phases": [
+            "PHASE2"
+          ],
+          "title": "Phase II Protocol of Proton Therapy for Partial Breast Irradiation in Early Stage Breast Cancer"
+        },
+        {
+          "conditions": [
+            "Triple Negative Breast Cancer",
+            "TNBC - Triple-Negative Breast Cancer",
+            "Breast Cancer",
+            "Metastatic Breast Cancer"
+          ],
+          "nct_id": "NCT04683679",
+          "new_york_locations": [
+            {
+              "city": "Commack",
+              "facility": "Memorial Sloan Kettering Commack (Limited Protocol Activities)",
+              "status": "RECRUITING"
+            },
+            {
+              "city": "Harrison",
+              "facility": "Memorial Sloan Kettering Westchester (Limited Protocol Activities)",
+              "status": "RECRUITING"
+            },
+            {
+              "city": "New York",
+              "facility": "Memorial Sloan Kettering Cancer Center (All Protocol Activities)",
+              "status": "RECRUITING"
+            },
+            {
+              "city": "Uniondale",
+              "facility": "Memorial Sloan Kettering Nassau (All Protocol Activities)",
+              "status": "RECRUITING"
+            }
+          ],
+          "overall_status": "RECRUITING",
+          "phases": [
+            "PHASE2"
+          ],
+          "title": "A Study of Radiation Therapy With Pembrolizumab and Olaparib or Other Radiosensitizers in Women Who Have Triple-Negative or Hormone-Receptor Positive/Her2 Negative Breast Cancer"
+        }
+      ],
+      "status_counts": {
+        "ACTIVE_NOT_RECRUITING": 13,
+        "RECRUITING": 7
+      }
+    },
+    "tool_contracts": [
+      {
+        "endpoint": "https://clinicaltrials.gov/api/v2/studies",
+        "name": "VSDTotalClinicalTrialsSearch",
+        "operation_sha256": "6f4f8cba84e65c6432da167929386a18d4b137a89065678fbdad274c72f8880c"
+      },
+      {
+        "endpoint": "https://clinicaltrials.gov/api/v2/studies/{nctId}",
+        "name": "VSDTotalClinicalTrialDetails",
+        "operation_sha256": "77c4c98fd5977836777fb792767a331995a69b39b024a9424f0e48e4bed9ef1d"
+      }
+    ]
+  },
+  "reviewed_promotion": {
+    "loaded_tools": [
+      "VSDTotalCancerTrialsByPhase",
+      "VSDTotalCancerTrialsBySite"
+    ],
+    "promoted_tools_present_before_explicit_load": [],
+    "promotion_state": {
+      "approvals": [
+        "vsdtotalcancertrialsbyphase_df24873e96db",
+        "vsdtotalcancertrialsbysite_86a7b6f8e4f5"
+      ],
+      "approved": [
+        "VSDTotalCancerTrialsByPhase",
+        "VSDTotalCancerTrialsBySite"
+      ],
+      "drafts": [
+        "vsdtotalcancertrialsbyphase_df24873e96db",
+        "vsdtotalcancertrialsbysite_86a7b6f8e4f5"
+      ],
+      "evidence": [
+        "vsdtotalcancertrialsbyphase_df24873e96db",
+        "vsdtotalcancertrialsbysite_86a7b6f8e4f5"
+      ]
+    },
+    "promotions": [
+      {
+        "all_cases_passed": true,
+        "approval_sha256": "f54da18517d7960ed1308531bd5cea0b93e708dcaffbefead9e1e46c021f44c0",
+        "case_count": 3,
+        "cases": [
+          {
+            "arguments": {
+              "primary_site": "Brain and Nervous System"
+            },
+            "case_index": 0,
+            "expect": {
+              "equals": {
+                "primary_site": "Brain and Nervous System"
+              },
+              "max_items": 25,
+              "min_items": 1,
+              "required_fields": [
+                "protocol",
+                "title",
+                "primary_site"
+              ]
+            },
+            "http_status": 200,
+            "observed_fields": [
+              "date_closed",
+              "date_opened",
+              "primary_site",
+              "principal_investigator",
+              "protocol",
+              "study_phase",
+              "title"
+            ],
+            "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+            "payload_sha256": "177c396cab0849392b328bfb23a9cd648df0f4435c3d22920260f2c98a7454be",
+            "redirects": 0,
+            "retrieved_at": "2026-08-01T04:31:33.467679+00:00",
+            "row_count": 19
+          },
+          {
+            "arguments": {
+              "primary_site": "Breast"
+            },
+            "case_index": 1,
+            "expect": {
+              "equals": {
+                "primary_site": "Breast"
+              },
+              "max_items": 25,
+              "min_items": 1,
+              "required_fields": [
+                "protocol",
+                "title",
+                "primary_site"
+              ]
+            },
+            "http_status": 200,
+            "observed_fields": [
+              "date_closed",
+              "date_opened",
+              "primary_site",
+              "principal_investigator",
+              "protocol",
+              "study_phase",
+              "title"
+            ],
+            "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+            "payload_sha256": "5562338d7fdf189fa5ec3eecbfedadcb579778970ac266b82400116b84adb90f",
+            "redirects": 0,
+            "retrieved_at": "2026-08-01T04:31:33.887712+00:00",
+            "row_count": 23
+          },
+          {
+            "arguments": {
+              "primary_site": "Prostate"
+            },
+            "case_index": 2,
+            "expect": {
+              "equals": {
+                "primary_site": "Prostate"
+              },
+              "max_items": 25,
+              "min_items": 1,
+              "required_fields": [
+                "protocol",
+                "title",
+                "primary_site"
+              ]
+            },
+            "http_status": 200,
+            "observed_fields": [
+              "date_closed",
+              "date_opened",
+              "primary_site",
+              "principal_investigator",
+              "protocol",
+              "study_phase",
+              "title"
+            ],
+            "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+            "payload_sha256": "1dec38172ecdc0658609492f56125b67f2d0010c74509268a3019da6663af842",
+            "redirects": 0,
+            "retrieved_at": "2026-08-01T04:31:34.315035+00:00",
+            "row_count": 20
+          }
+        ],
+        "draft_id": "vsdtotalcancertrialsbysite_86a7b6f8e4f5",
+        "draft_sha256": "28bfd3429e704ebaeb16038f199491536822fe1098ac6b1619013c81934cd770",
+        "filter_field": "primary_site",
+        "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+        "publication_sha256": "74ca9fe294424567af57f5da4e6cb3c6e325bd4b8caa0c01440140735e4e03bc",
+        "tool_name": "VSDTotalCancerTrialsBySite",
+        "verification_sha256": "318d81ea17d38bcf3094d92855d87785533ebfeb8fec74d639e841a3a8221d05"
+      },
+      {
+        "all_cases_passed": true,
+        "approval_sha256": "8b917cb80250323d0cb704024c4cfe9a357a141e2dd6437fe0a27aabf31860d6",
+        "case_count": 3,
+        "cases": [
+          {
+            "arguments": {
+              "study_phase": "I"
+            },
+            "case_index": 0,
+            "expect": {
+              "equals": {
+                "study_phase": "I"
+              },
+              "max_items": 25,
+              "min_items": 1,
+              "required_fields": [
+                "protocol",
+                "title",
+                "study_phase"
+              ]
+            },
+            "http_status": 200,
+            "observed_fields": [
+              "date_closed",
+              "date_opened",
+              "primary_site",
+              "principal_investigator",
+              "protocol",
+              "study_phase",
+              "title"
+            ],
+            "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+            "payload_sha256": "7de1c8fb37ce5a26b9a25de4e6d12fc6b639735d8a221bdf3ecdc2912501893a",
+            "redirects": 0,
+            "retrieved_at": "2026-08-01T04:31:34.786244+00:00",
+            "row_count": 25
+          },
+          {
+            "arguments": {
+              "study_phase": "II"
+            },
+            "case_index": 1,
+            "expect": {
+              "equals": {
+                "study_phase": "II"
+              },
+              "max_items": 25,
+              "min_items": 1,
+              "required_fields": [
+                "protocol",
+                "title",
+                "study_phase"
+              ]
+            },
+            "http_status": 200,
+            "observed_fields": [
+              "date_closed",
+              "date_opened",
+              "primary_site",
+              "principal_investigator",
+              "protocol",
+              "study_phase",
+              "title"
+            ],
+            "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+            "payload_sha256": "7898177fe582799b118a98de9de2bd4603d9d60589e46d488af43a342812026a",
+            "redirects": 0,
+            "retrieved_at": "2026-08-01T04:31:35.235030+00:00",
+            "row_count": 25
+          },
+          {
+            "arguments": {
+              "study_phase": "III"
+            },
+            "case_index": 2,
+            "expect": {
+              "equals": {
+                "study_phase": "III"
+              },
+              "max_items": 25,
+              "min_items": 1,
+              "required_fields": [
+                "protocol",
+                "title",
+                "study_phase"
+              ]
+            },
+            "http_status": 200,
+            "observed_fields": [
+              "date_closed",
+              "date_opened",
+              "primary_site",
+              "principal_investigator",
+              "protocol",
+              "study_phase",
+              "title"
+            ],
+            "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+            "payload_sha256": "322b0476c5a33b91b7eae1117283468bac557db1ac748bbf8645b4d2d8a7795d",
+            "redirects": 0,
+            "retrieved_at": "2026-08-01T04:31:35.639377+00:00",
+            "row_count": 25
+          }
+        ],
+        "draft_id": "vsdtotalcancertrialsbyphase_df24873e96db",
+        "draft_sha256": "1118f91aaa25b923cebbb0e4de34954570409faf0d45bdb3410ce26d30aae86f",
+        "filter_field": "study_phase",
+        "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+        "publication_sha256": "0a78f46737d17fd414645d13287e46a9241a311af177cb091091a32556b494aa",
+        "tool_name": "VSDTotalCancerTrialsByPhase",
+        "verification_sha256": "2ce8b64fbf79cc1ad747ecbf28dd222dd8a6399a4d2b51f85374f1b04475d790"
+      }
+    ],
+    "runtime_checks": [
+      {
+        "arguments": {
+          "primary_site": "Breast"
+        },
+        "provenance": {
+          "content_type": "application/json;charset=utf-8",
+          "endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+          "http_status": 200,
+          "method": "GET",
+          "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+          "payload_sha256": "5562338d7fdf189fa5ec3eecbfedadcb579778970ac266b82400116b84adb90f",
+          "provider": "data.ny.gov",
+          "query_params": {
+            "$limit": 25,
+            "$select": "date_opened,protocol,primary_site,study_phase,title,date_closed,principal_investigator",
+            "primary_site": "Breast"
+          },
+          "redirects": 0,
+          "response_bytes": 7415,
+          "retrieved_at": "2026-08-01T04:31:36.149413+00:00"
+        },
+        "row_count": 23,
+        "sample_rows": [
+          {
+            "date_opened": "2020-08-05T00:00:00.000",
+            "primary_site": "Breast",
+            "principal_investigator": "Ambrosone, C",
+            "protocol": "I-724220",
+            "study_phase": "N/A",
+            "title": "The North-South Breast Cancer Study (NSBCS)"
+          },
+          {
+            "date_opened": "2018-10-18T00:00:00.000",
+            "primary_site": "Breast",
+            "principal_investigator": "Bonaccio, E",
+            "protocol": "I-60217",
+            "study_phase": "N/A",
+            "title": "Photoacoustic Imaging of Human Breast"
+          },
+          {
+            "date_closed": "2025-03-20T00:00:00.000",
+            "date_opened": "2021-09-16T00:00:00.000",
+            "primary_site": "Breast",
+            "principal_investigator": "Fung-Kee-Fung, S",
+            "protocol": "N-1764921",
+            "study_phase": "III",
+            "title": "NRG-BR007: A PHASE III CLINICAL TRIAL EVALUATING DE-ESCALATION OF BREAST RADIATION FOR CONSERVATIVE TREATMENT OF STAGE I, HORMONE SENSITIVE, HER2-NEGATIVE, ONCOTYPE RECURRENCE SCORE &#8804; 18 BREAST CANCER"
+          }
+        ],
+        "tool_name": "VSDTotalCancerTrialsBySite"
+      },
+      {
+        "arguments": {
+          "study_phase": "III"
+        },
+        "provenance": {
+          "content_type": "application/json;charset=utf-8",
+          "endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+          "http_status": 200,
+          "method": "GET",
+          "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+          "payload_sha256": "322b0476c5a33b91b7eae1117283468bac557db1ac748bbf8645b4d2d8a7795d",
+          "provider": "data.ny.gov",
+          "query_params": {
+            "$limit": 25,
+            "$select": "date_opened,protocol,primary_site,study_phase,title,date_closed,principal_investigator",
+            "study_phase": "III"
+          },
+          "redirects": 0,
+          "response_bytes": 10230,
+          "retrieved_at": "2026-08-01T04:31:36.576671+00:00"
+        },
+        "row_count": 25,
+        "sample_rows": [
+          {
+            "date_opened": "2021-07-19T00:00:00.000",
+            "primary_site": "Brain and Nervous System",
+            "principal_investigator": "Barth, M",
+            "protocol": "N-1385821",
+            "study_phase": "III",
+            "title": "(ACNS1931) A Phase 3 Study of Selumetinib (NSC# 748727, IND# 77782) or Selumetinib in Combination with Vinblastine for non-NF1, non-TSC Patients with Recurrent or Progressive Low-Grade Gliomas (LGGs) Lacking BRAFV600E or IDH1 Mutations"
+          },
+          {
+            "date_opened": "2020-01-06T00:00:00.000",
+            "primary_site": "Brain and Nervous System",
+            "principal_investigator": "Barth, M",
+            "protocol": "N-564119",
+            "study_phase": "III",
+            "title": "(ACNS1831) A Phase 3 Randomized Study of Selumetinib (IND # 77782) Versus Carboplatin/Vincristine in Newly Diagnosed or Previously Untreated Neurofibromatosis Type 1 (NF1) Associated Low-Grade Glioma (LGG)"
+          },
+          {
+            "date_opened": "2020-02-26T00:00:00.000",
+            "primary_site": "Brain and Nervous System",
+            "principal_investigator": "Barth, M",
+            "protocol": "N-632820",
+            "study_phase": "III",
+            "title": "(ACNS1833) A Phase 3 Randomized Non-Inferiority Study of Carboplatin and Vincristine versus Selumetinib (NSC# 748727, IND# 77782) in Newly Diagnosed or Previously Untreated Low-Grade Glioma (LGG) not associated with BRAFV600E Mutations or Systemic Neurofibromatosis Type 1 (NF1)"
+          }
+        ],
+        "tool_name": "VSDTotalCancerTrialsByPhase"
+      }
+    ],
+    "verification_case_count": 6
+  },
+  "reviewed_source_adapter": {
+    "administrative_tools_loaded": [],
+    "label": {
+      "brand_name": "SOLTAMOX",
+      "effective_time": "20211129",
+      "generic_name": "TAMOXIFEN CITRATE",
+      "route": "ORAL",
+      "set_id": "1e6ff055-590c-41e6-9530-1fdf04cdbd02",
+      "warning_section_count": 0,
+      "warning_sections_sha256": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    "loaded_agent_tools_before_dynamic_registration": [
+      "VSDDiscoverAPICandidates",
+      "VSDDiscoverSources",
+      "VSDOpenFDALabelBySetId"
+    ],
+    "matched_source": {
+      "default_params": {
+        "limit": 5
+      },
+      "description": "FDA drug labeling records, warnings, and indications.",
+      "endpoint": "https://api.fda.gov/drug/label.json",
+      "name": "openFDA Drug Labels",
+      "review_scope": "Transport and response adapter reviewed; not scientific endorsement.",
+      "source_id": "openfda_labels",
+      "tool_name": "VSDOpenFDALabelBySetId"
+    },
+    "offline_query": "drug label",
+    "provenance": {
+      "content_type": "application/json; charset=utf-8",
+      "endpoint": "https://api.fda.gov/drug/label.json",
+      "http_status": 200,
+      "payload_sha256": "adfd73ae9a40c8fae86c31cc30bed62c88a7d232cae237f9c0aba2fa6541d6d9",
+      "provider": "openFDA Drug Labels",
+      "query_params": {
+        "limit": 1,
+        "search": "set_id:\"1e6ff055-590c-41e6-9530-1fdf04cdbd02\""
+      },
+      "redirects": 0,
+      "response_bytes": 171970,
+      "retrieved_at": "2026-08-01T04:31:31.451512+00:00"
+    }
+  }
+}

--- a/examples/vsd/artifacts/complete_pipeline_snapshot.md
+++ b/examples/vsd/artifacts/complete_pipeline_snapshot.md
@@ -1,0 +1,100 @@
+# Complete VSD Oncology Source-Governance Case Study
+
+## Decision Question
+
+Can ToolUniverse start from an oncology evidence need, keep generic source administration outside the agent boundary, execute reviewed contracts, discover an unknown API without executing it, and promote only verified narrow tools with a complete audit chain?
+
+## End-to-End Result
+
+| Stage | Boundary exercised | Live proof |
+| ---: | --- | --- |
+| 1 | Administrator-only source catalog | Registered, probed, listed, queried, removed, and restored the temporary catalog |
+| 2 | Packaged reviewed adapter | Discovered openFDA offline and retrieved the same tamoxifen label through a fixed typed tool |
+| 3 | Reviewed dynamic REST | Searched active/upcoming New York breast-cancer studies and retrieved one deterministic NCT record |
+| 4 | Demand-driven discovery | Searched the fixed Socrata catalog and kept the selected API non-executable pending review |
+| 5 | Reviewed promotion | Ran six live verification cases, approved hash-bound drafts, and published two bounded tools |
+| 6 | Explicit runtime loading | Loaded both publications into a fresh ToolUniverse instance and executed exact-filter queries |
+
+## 1. Administrative Source Lifecycle
+
+- Source: `openfda_tamoxifen_review` at `https://api.fda.gov/drug/label.json`
+- Probe HTTP status: **200**
+- Query records: **1** of **14** provider matches
+- Selected label set ID: `1e6ff055-590c-41e6-9530-1fdf04cdbd02`
+- Removed after inspection: **true**
+- Catalog restored: **true**
+- Boundary: Registration and generic querying occurred only through the administrator CLI. They did not publish an agent-facing tool.
+
+## 2. Reviewed Source Adapter
+
+- Offline source: **openFDA Drug Labels**
+- Agent-facing tool: `VSDOpenFDALabelBySetId`
+- Label: **SOLTAMOX** (`TAMOXIFEN CITRATE`)
+- Effective time: `20211129`
+- Route: `ORAL`
+- Administrative operations present in the agent runtime: **0**
+- Provider payload: `adfd73ae9a40c8fae86c31cc30bed62c88a7d232cae237f9c0aba2fa6541d6d9`
+
+The generic administrative query established a record identifier only. The agent-facing call used the fixed openFDA endpoint, UUID input contract, source-specific response validation, and typed provenance.
+
+## 3. Reviewed Dynamic REST
+
+- National registry matches: **546**
+- Bounded records returned: **20**
+- Status counts: `{"ACTIVE_NOT_RECRUITING": 13, "RECRUITING": 7}`
+- Phase counts: `{"NA": 2, "NOT_APPLICABLE": 1, "PHASE1": 2, "PHASE2": 11, "PHASE3": 5}`
+- Deterministic detail record: `NCT01766297`
+- Search/detail ID match: **true**
+
+Both operations are reviewed HTTPS GET contracts with exact argument mappings, bounded schemas, no credentials, zero redirects, pinned public destinations, response limits, and operation/payload hashes.
+
+## 4. Demand-Driven API Discovery
+
+- Demand query: `active cancer clinical trials primary site phase protocol`
+- Catalog matches: **13**
+- Candidates reviewed: **10**
+- Selected dataset: **Current Active Clinical Trials - Roswell Park Cancer Institute** (`2ig8-yxf8`)
+- Proposed endpoint: `https://data.ny.gov/resource/2ig8-yxf8.json`
+- Required fields present: **6/6**
+- Execution allowed before review: **false**
+- Selection rule: Require non-executable unreviewed state, an official government API-ready catalog record, and all six demanded fields; then choose the highest score with candidate ID as the stable tie-breaker.
+
+## 5. Promotion And Fresh Runtime
+
+| Tool | Required filter | Verification rows | Runtime query | Runtime rows |
+| --- | --- | --- | --- | ---: |
+| `VSDTotalCancerTrialsBySite` | `primary_site` | 19, 23, 20 | `primary_site=Breast` | 23 |
+| `VSDTotalCancerTrialsByPhase` | `study_phase` | 25, 25, 25 | `study_phase=III` | 25 |
+
+- Live verification cases: **6**
+- Promoted tools present before explicit load: **0**
+- Explicitly loaded publications: `VSDTotalCancerTrialsByPhase`, `VSDTotalCancerTrialsBySite`
+
+Every draft, verification result, approval, and publication is bound to the preceding SHA-256 records. Loading is a separate explicit call; discovery alone never executes or publishes a candidate.
+
+## End-to-End Assertions
+
+| Assertion | Result |
+| --- | --- |
+| `administrative_catalog_restored` | PASS |
+| `administrative_tools_not_agent_facing` | PASS |
+| `discovery_candidate_has_required_fields` | PASS |
+| `discovery_candidate_remained_non_executable` | PASS |
+| `dynamic_search_detail_identifier_match` | PASS |
+| `fixed_adapter_matches_admin_record` | PASS |
+| `promoted_tools_absent_before_explicit_load` | PASS |
+| `promotion_hash_chain_complete` | PASS |
+| `published_runtime_filters_exact` | PASS |
+| `published_tools_loaded_explicitly` | PASS |
+| `reviewed_source_discovered_offline` | PASS |
+| `six_live_promotion_cases_passed` | PASS |
+
+## Reproducibility And Audit Chain
+
+- End-to-end evidence-chain SHA-256: `0530702a8466da09286370a3303fbf68361074ea6543f8d86ef57d2aa7a6ebc6`
+- Generated at: `2026-08-01T04:31:36.578274+00:00`
+- The JSON artifact contains provider payload hashes, reviewed operation hashes, promotion hashes, exact arguments, bounded samples, and every assertion used to accept the run.
+
+## Interpretation Boundary
+
+This is a software-governance and public-record retrieval demonstration. It does not match patients to trials, establish eligibility, compare treatments, or provide medical advice. The state and national registries are independent and are not joined at record level.

--- a/examples/vsd/artifacts/complete_pipeline_workspace/.gitignore
+++ b/examples/vsd/artifacts/complete_pipeline_workspace/.gitignore
@@ -1,0 +1,3 @@
+.runtime/
+catalog/.sources.json.lock
+promotion/.promotion.lock

--- a/examples/vsd/artifacts/complete_pipeline_workspace/catalog/sources.json
+++ b/examples/vsd/artifacts/complete_pipeline_workspace/catalog/sources.json
@@ -1,0 +1,4 @@
+{
+  "sources": {},
+  "version": 1
+}

--- a/examples/vsd/artifacts/complete_pipeline_workspace/promotion/approvals/vsdtotalcancertrialsbyphase_df24873e96db.json
+++ b/examples/vsd/artifacts/complete_pipeline_workspace/promotion/approvals/vsdtotalcancertrialsbyphase_df24873e96db.json
@@ -1,0 +1,13 @@
+{
+  "approval_sha256": "8b917cb80250323d0cb704024c4cfe9a357a141e2dd6437fe0a27aabf31860d6",
+  "approved_at": "2026-08-01T04:31:35.664103+00:00",
+  "decision": "approved",
+  "decision_note": "Technical approval after field-contract review and three live provider cases; not scientific or clinical endorsement.",
+  "draft_id": "vsdtotalcancertrialsbyphase_df24873e96db",
+  "draft_sha256": "1118f91aaa25b923cebbb0e4de34954570409faf0d45bdb3410ce26d30aae86f",
+  "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+  "reviewed_by": "SufianTA",
+  "tool_name": "VSDTotalCancerTrialsByPhase",
+  "verification_sha256": "2ce8b64fbf79cc1ad747ecbf28dd222dd8a6399a4d2b51f85374f1b04475d790",
+  "version": 1
+}

--- a/examples/vsd/artifacts/complete_pipeline_workspace/promotion/approvals/vsdtotalcancertrialsbysite_86a7b6f8e4f5.json
+++ b/examples/vsd/artifacts/complete_pipeline_workspace/promotion/approvals/vsdtotalcancertrialsbysite_86a7b6f8e4f5.json
@@ -1,0 +1,13 @@
+{
+  "approval_sha256": "f54da18517d7960ed1308531bd5cea0b93e708dcaffbefead9e1e46c021f44c0",
+  "approved_at": "2026-08-01T04:31:34.338268+00:00",
+  "decision": "approved",
+  "decision_note": "Technical approval after field-contract review and three live provider cases; not scientific or clinical endorsement.",
+  "draft_id": "vsdtotalcancertrialsbysite_86a7b6f8e4f5",
+  "draft_sha256": "28bfd3429e704ebaeb16038f199491536822fe1098ac6b1619013c81934cd770",
+  "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+  "reviewed_by": "SufianTA",
+  "tool_name": "VSDTotalCancerTrialsBySite",
+  "verification_sha256": "318d81ea17d38bcf3094d92855d87785533ebfeb8fec74d639e841a3a8221d05",
+  "version": 1
+}

--- a/examples/vsd/artifacts/complete_pipeline_workspace/promotion/approved/VSDTotalCancerTrialsByPhase.json
+++ b/examples/vsd/artifacts/complete_pipeline_workspace/promotion/approved/VSDTotalCancerTrialsByPhase.json
@@ -1,0 +1,136 @@
+{
+  "approval_sha256": "8b917cb80250323d0cb704024c4cfe9a357a141e2dd6437fe0a27aabf31860d6",
+  "config": {
+    "cacheable": false,
+    "category": "special_tools",
+    "description": "Query the reviewed Roswell Park active cancer-trial dataset by an exact study phase.",
+    "mcp_annotations": {
+      "destructiveHint": false,
+      "readOnlyHint": true
+    },
+    "name": "VSDTotalCancerTrialsByPhase",
+    "parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "study_phase": {
+          "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+          "maxLength": 500,
+          "type": "string"
+        }
+      },
+      "required": [
+        "study_phase"
+      ],
+      "type": "object"
+    },
+    "return_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "provenance": {
+          "type": "object"
+        },
+        "result": {
+          "type": "array"
+        }
+      },
+      "required": [
+        "result",
+        "provenance"
+      ],
+      "type": "object"
+    },
+    "type": "VSDDynamicRESTTool",
+    "vsd_operation": {
+      "auth": {
+        "type": "none"
+      },
+      "endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+      "fixed_query": {
+        "$limit": 25,
+        "$select": "date_opened,protocol,primary_site,study_phase,title,date_closed,principal_investigator"
+      },
+      "method": "GET",
+      "path_arguments": {},
+      "query_arguments": {
+        "study_phase": "study_phase"
+      },
+      "response_schema": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "date_closed": {
+              "description": "The date the clinical research study closed to accrual. If the study is still open, this field will be blank.",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "date_opened": {
+              "description": "The official start date (activation) of a trial",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "primary_site": {
+              "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "principal_investigator": {
+              "description": "The name of the Principal Investigator from Center who is responsible for the Clinical Research Study",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "protocol": {
+              "description": "The unique identifier for this study. For both national and externally",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "study_phase": {
+              "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "title": {
+              "description": "Name of the protocol provided by the study's principal investigator",
+              "maxLength": 500,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "maxItems": 25,
+        "type": "array"
+      },
+      "timeout_seconds": 20,
+      "version": 1
+    },
+    "vsd_promotion": {
+      "candidate_id": "31dcb2ce74f62d7c",
+      "catalog_domain": "data.ny.gov",
+      "dataset_id": "2ig8-yxf8",
+      "dataset_updated_at": "2026-04-14T21:08:58.000Z",
+      "filter_fields": [
+        "study_phase"
+      ],
+      "generator_version": 1,
+      "max_records": 25,
+      "return_fields": [
+        "date_opened",
+        "protocol",
+        "primary_site",
+        "study_phase",
+        "title",
+        "date_closed",
+        "principal_investigator"
+      ]
+    }
+  },
+  "decision_note": "Technical approval after field-contract review and three live provider cases; not scientific or clinical endorsement.",
+  "draft_id": "vsdtotalcancertrialsbyphase_df24873e96db",
+  "draft_sha256": "1118f91aaa25b923cebbb0e4de34954570409faf0d45bdb3410ce26d30aae86f",
+  "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+  "publication_sha256": "0a78f46737d17fd414645d13287e46a9241a311af177cb091091a32556b494aa",
+  "published_at": "2026-08-01T04:31:35.679733+00:00",
+  "reviewed_by": "SufianTA",
+  "tool_name": "VSDTotalCancerTrialsByPhase",
+  "verification_sha256": "2ce8b64fbf79cc1ad747ecbf28dd222dd8a6399a4d2b51f85374f1b04475d790",
+  "version": 1
+}

--- a/examples/vsd/artifacts/complete_pipeline_workspace/promotion/approved/VSDTotalCancerTrialsBySite.json
+++ b/examples/vsd/artifacts/complete_pipeline_workspace/promotion/approved/VSDTotalCancerTrialsBySite.json
@@ -1,0 +1,136 @@
+{
+  "approval_sha256": "f54da18517d7960ed1308531bd5cea0b93e708dcaffbefead9e1e46c021f44c0",
+  "config": {
+    "cacheable": false,
+    "category": "special_tools",
+    "description": "Query the reviewed Roswell Park active cancer-trial dataset by an exact primary cancer site.",
+    "mcp_annotations": {
+      "destructiveHint": false,
+      "readOnlyHint": true
+    },
+    "name": "VSDTotalCancerTrialsBySite",
+    "parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "primary_site": {
+          "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+          "maxLength": 500,
+          "type": "string"
+        }
+      },
+      "required": [
+        "primary_site"
+      ],
+      "type": "object"
+    },
+    "return_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "provenance": {
+          "type": "object"
+        },
+        "result": {
+          "type": "array"
+        }
+      },
+      "required": [
+        "result",
+        "provenance"
+      ],
+      "type": "object"
+    },
+    "type": "VSDDynamicRESTTool",
+    "vsd_operation": {
+      "auth": {
+        "type": "none"
+      },
+      "endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+      "fixed_query": {
+        "$limit": 25,
+        "$select": "date_opened,protocol,primary_site,study_phase,title,date_closed,principal_investigator"
+      },
+      "method": "GET",
+      "path_arguments": {},
+      "query_arguments": {
+        "primary_site": "primary_site"
+      },
+      "response_schema": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "date_closed": {
+              "description": "The date the clinical research study closed to accrual. If the study is still open, this field will be blank.",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "date_opened": {
+              "description": "The official start date (activation) of a trial",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "primary_site": {
+              "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "principal_investigator": {
+              "description": "The name of the Principal Investigator from Center who is responsible for the Clinical Research Study",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "protocol": {
+              "description": "The unique identifier for this study. For both national and externally",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "study_phase": {
+              "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "title": {
+              "description": "Name of the protocol provided by the study's principal investigator",
+              "maxLength": 500,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "maxItems": 25,
+        "type": "array"
+      },
+      "timeout_seconds": 20,
+      "version": 1
+    },
+    "vsd_promotion": {
+      "candidate_id": "31dcb2ce74f62d7c",
+      "catalog_domain": "data.ny.gov",
+      "dataset_id": "2ig8-yxf8",
+      "dataset_updated_at": "2026-04-14T21:08:58.000Z",
+      "filter_fields": [
+        "primary_site"
+      ],
+      "generator_version": 1,
+      "max_records": 25,
+      "return_fields": [
+        "date_opened",
+        "protocol",
+        "primary_site",
+        "study_phase",
+        "title",
+        "date_closed",
+        "principal_investigator"
+      ]
+    }
+  },
+  "decision_note": "Technical approval after field-contract review and three live provider cases; not scientific or clinical endorsement.",
+  "draft_id": "vsdtotalcancertrialsbysite_86a7b6f8e4f5",
+  "draft_sha256": "28bfd3429e704ebaeb16038f199491536822fe1098ac6b1619013c81934cd770",
+  "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+  "publication_sha256": "74ca9fe294424567af57f5da4e6cb3c6e325bd4b8caa0c01440140735e4e03bc",
+  "published_at": "2026-08-01T04:31:34.353408+00:00",
+  "reviewed_by": "SufianTA",
+  "tool_name": "VSDTotalCancerTrialsBySite",
+  "verification_sha256": "318d81ea17d38bcf3094d92855d87785533ebfeb8fec74d639e841a3a8221d05",
+  "version": 1
+}

--- a/examples/vsd/artifacts/complete_pipeline_workspace/promotion/drafts/vsdtotalcancertrialsbyphase_df24873e96db.json
+++ b/examples/vsd/artifacts/complete_pipeline_workspace/promotion/drafts/vsdtotalcancertrialsbyphase_df24873e96db.json
@@ -1,0 +1,131 @@
+{
+  "config": {
+    "cacheable": false,
+    "category": "special_tools",
+    "description": "Query the reviewed Roswell Park active cancer-trial dataset by an exact study phase.",
+    "mcp_annotations": {
+      "destructiveHint": false,
+      "readOnlyHint": true
+    },
+    "name": "VSDTotalCancerTrialsByPhase",
+    "parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "study_phase": {
+          "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+          "maxLength": 500,
+          "type": "string"
+        }
+      },
+      "required": [
+        "study_phase"
+      ],
+      "type": "object"
+    },
+    "return_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "provenance": {
+          "type": "object"
+        },
+        "result": {
+          "type": "array"
+        }
+      },
+      "required": [
+        "result",
+        "provenance"
+      ],
+      "type": "object"
+    },
+    "type": "VSDDynamicRESTTool",
+    "vsd_operation": {
+      "auth": {
+        "type": "none"
+      },
+      "endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+      "fixed_query": {
+        "$limit": 25,
+        "$select": "date_opened,protocol,primary_site,study_phase,title,date_closed,principal_investigator"
+      },
+      "method": "GET",
+      "path_arguments": {},
+      "query_arguments": {
+        "study_phase": "study_phase"
+      },
+      "response_schema": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "date_closed": {
+              "description": "The date the clinical research study closed to accrual. If the study is still open, this field will be blank.",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "date_opened": {
+              "description": "The official start date (activation) of a trial",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "primary_site": {
+              "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "principal_investigator": {
+              "description": "The name of the Principal Investigator from Center who is responsible for the Clinical Research Study",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "protocol": {
+              "description": "The unique identifier for this study. For both national and externally",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "study_phase": {
+              "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "title": {
+              "description": "Name of the protocol provided by the study's principal investigator",
+              "maxLength": 500,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "maxItems": 25,
+        "type": "array"
+      },
+      "timeout_seconds": 20,
+      "version": 1
+    },
+    "vsd_promotion": {
+      "candidate_id": "31dcb2ce74f62d7c",
+      "catalog_domain": "data.ny.gov",
+      "dataset_id": "2ig8-yxf8",
+      "dataset_updated_at": "2026-04-14T21:08:58.000Z",
+      "filter_fields": [
+        "study_phase"
+      ],
+      "generator_version": 1,
+      "max_records": 25,
+      "return_fields": [
+        "date_opened",
+        "protocol",
+        "primary_site",
+        "study_phase",
+        "title",
+        "date_closed",
+        "principal_investigator"
+      ]
+    }
+  },
+  "created_at": "2026-08-01T04:15:11.070572+00:00",
+  "draft_id": "vsdtotalcancertrialsbyphase_df24873e96db",
+  "draft_sha256": "1118f91aaa25b923cebbb0e4de34954570409faf0d45bdb3410ce26d30aae86f",
+  "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+  "state": "draft",
+  "version": 1
+}

--- a/examples/vsd/artifacts/complete_pipeline_workspace/promotion/drafts/vsdtotalcancertrialsbysite_86a7b6f8e4f5.json
+++ b/examples/vsd/artifacts/complete_pipeline_workspace/promotion/drafts/vsdtotalcancertrialsbysite_86a7b6f8e4f5.json
@@ -1,0 +1,131 @@
+{
+  "config": {
+    "cacheable": false,
+    "category": "special_tools",
+    "description": "Query the reviewed Roswell Park active cancer-trial dataset by an exact primary cancer site.",
+    "mcp_annotations": {
+      "destructiveHint": false,
+      "readOnlyHint": true
+    },
+    "name": "VSDTotalCancerTrialsBySite",
+    "parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "primary_site": {
+          "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+          "maxLength": 500,
+          "type": "string"
+        }
+      },
+      "required": [
+        "primary_site"
+      ],
+      "type": "object"
+    },
+    "return_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "provenance": {
+          "type": "object"
+        },
+        "result": {
+          "type": "array"
+        }
+      },
+      "required": [
+        "result",
+        "provenance"
+      ],
+      "type": "object"
+    },
+    "type": "VSDDynamicRESTTool",
+    "vsd_operation": {
+      "auth": {
+        "type": "none"
+      },
+      "endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+      "fixed_query": {
+        "$limit": 25,
+        "$select": "date_opened,protocol,primary_site,study_phase,title,date_closed,principal_investigator"
+      },
+      "method": "GET",
+      "path_arguments": {},
+      "query_arguments": {
+        "primary_site": "primary_site"
+      },
+      "response_schema": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "date_closed": {
+              "description": "The date the clinical research study closed to accrual. If the study is still open, this field will be blank.",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "date_opened": {
+              "description": "The official start date (activation) of a trial",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "primary_site": {
+              "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "principal_investigator": {
+              "description": "The name of the Principal Investigator from Center who is responsible for the Clinical Research Study",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "protocol": {
+              "description": "The unique identifier for this study. For both national and externally",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "study_phase": {
+              "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "title": {
+              "description": "Name of the protocol provided by the study's principal investigator",
+              "maxLength": 500,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "maxItems": 25,
+        "type": "array"
+      },
+      "timeout_seconds": 20,
+      "version": 1
+    },
+    "vsd_promotion": {
+      "candidate_id": "31dcb2ce74f62d7c",
+      "catalog_domain": "data.ny.gov",
+      "dataset_id": "2ig8-yxf8",
+      "dataset_updated_at": "2026-04-14T21:08:58.000Z",
+      "filter_fields": [
+        "primary_site"
+      ],
+      "generator_version": 1,
+      "max_records": 25,
+      "return_fields": [
+        "date_opened",
+        "protocol",
+        "primary_site",
+        "study_phase",
+        "title",
+        "date_closed",
+        "principal_investigator"
+      ]
+    }
+  },
+  "created_at": "2026-08-01T04:15:09.531514+00:00",
+  "draft_id": "vsdtotalcancertrialsbysite_86a7b6f8e4f5",
+  "draft_sha256": "28bfd3429e704ebaeb16038f199491536822fe1098ac6b1619013c81934cd770",
+  "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+  "state": "draft",
+  "version": 1
+}

--- a/examples/vsd/artifacts/complete_pipeline_workspace/promotion/evidence/vsdtotalcancertrialsbyphase_df24873e96db.json
+++ b/examples/vsd/artifacts/complete_pipeline_workspace/promotion/evidence/vsdtotalcancertrialsbyphase_df24873e96db.json
@@ -1,0 +1,112 @@
+{
+  "all_cases_passed": true,
+  "case_count": 3,
+  "cases": [
+    {
+      "arguments": {
+        "study_phase": "I"
+      },
+      "case_index": 0,
+      "expect": {
+        "equals": {
+          "study_phase": "I"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "study_phase"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+      "payload_sha256": "7de1c8fb37ce5a26b9a25de4e6d12fc6b639735d8a221bdf3ecdc2912501893a",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T04:31:34.786244+00:00",
+      "row_count": 25
+    },
+    {
+      "arguments": {
+        "study_phase": "II"
+      },
+      "case_index": 1,
+      "expect": {
+        "equals": {
+          "study_phase": "II"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "study_phase"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+      "payload_sha256": "7898177fe582799b118a98de9de2bd4603d9d60589e46d488af43a342812026a",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T04:31:35.235030+00:00",
+      "row_count": 25
+    },
+    {
+      "arguments": {
+        "study_phase": "III"
+      },
+      "case_index": 2,
+      "expect": {
+        "equals": {
+          "study_phase": "III"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "study_phase"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+      "payload_sha256": "322b0476c5a33b91b7eae1117283468bac557db1ac748bbf8645b4d2d8a7795d",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T04:31:35.639377+00:00",
+      "row_count": 25
+    }
+  ],
+  "draft_id": "vsdtotalcancertrialsbyphase_df24873e96db",
+  "draft_sha256": "1118f91aaa25b923cebbb0e4de34954570409faf0d45bdb3410ce26d30aae86f",
+  "operation_sha256": "df24873e96db4ffe65f8805bff4aa7bf3570d779ec5c1d5813aea805ca9dc5b8",
+  "tool_name": "VSDTotalCancerTrialsByPhase",
+  "verification_sha256": "2ce8b64fbf79cc1ad747ecbf28dd222dd8a6399a4d2b51f85374f1b04475d790",
+  "verified_at": "2026-08-01T04:31:35.641290+00:00",
+  "version": 1
+}

--- a/examples/vsd/artifacts/complete_pipeline_workspace/promotion/evidence/vsdtotalcancertrialsbysite_86a7b6f8e4f5.json
+++ b/examples/vsd/artifacts/complete_pipeline_workspace/promotion/evidence/vsdtotalcancertrialsbysite_86a7b6f8e4f5.json
@@ -1,0 +1,112 @@
+{
+  "all_cases_passed": true,
+  "case_count": 3,
+  "cases": [
+    {
+      "arguments": {
+        "primary_site": "Brain and Nervous System"
+      },
+      "case_index": 0,
+      "expect": {
+        "equals": {
+          "primary_site": "Brain and Nervous System"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "primary_site"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+      "payload_sha256": "177c396cab0849392b328bfb23a9cd648df0f4435c3d22920260f2c98a7454be",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T04:31:33.467679+00:00",
+      "row_count": 19
+    },
+    {
+      "arguments": {
+        "primary_site": "Breast"
+      },
+      "case_index": 1,
+      "expect": {
+        "equals": {
+          "primary_site": "Breast"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "primary_site"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+      "payload_sha256": "5562338d7fdf189fa5ec3eecbfedadcb579778970ac266b82400116b84adb90f",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T04:31:33.887712+00:00",
+      "row_count": 23
+    },
+    {
+      "arguments": {
+        "primary_site": "Prostate"
+      },
+      "case_index": 2,
+      "expect": {
+        "equals": {
+          "primary_site": "Prostate"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "primary_site"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+      "payload_sha256": "1dec38172ecdc0658609492f56125b67f2d0010c74509268a3019da6663af842",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T04:31:34.315035+00:00",
+      "row_count": 20
+    }
+  ],
+  "draft_id": "vsdtotalcancertrialsbysite_86a7b6f8e4f5",
+  "draft_sha256": "28bfd3429e704ebaeb16038f199491536822fe1098ac6b1619013c81934cd770",
+  "operation_sha256": "86a7b6f8e4f59427e81c4cd526aa1c91e9edea60c1058e0e80b416fb6777a089",
+  "tool_name": "VSDTotalCancerTrialsBySite",
+  "verification_sha256": "318d81ea17d38bcf3094d92855d87785533ebfeb8fec74d639e841a3a8221d05",
+  "verified_at": "2026-08-01T04:31:34.317301+00:00",
+  "version": 1
+}

--- a/examples/vsd/artifacts/promotion_workspace/.gitignore
+++ b/examples/vsd/artifacts/promotion_workspace/.gitignore
@@ -1,0 +1,2 @@
+.promotion.lock
+.runtime/

--- a/examples/vsd/artifacts/promotion_workspace/approvals/vsdgeneratedcancertrialsbyphase_5e49d68e48d1.json
+++ b/examples/vsd/artifacts/promotion_workspace/approvals/vsdgeneratedcancertrialsbyphase_5e49d68e48d1.json
@@ -1,0 +1,13 @@
+{
+  "approval_sha256": "a941ad94c5738ee6fd4ffbc3c08b4a796222c423569dd878266a58db0b12255c",
+  "approved_at": "2026-08-01T01:36:35.199192+00:00",
+  "decision": "approved",
+  "decision_note": "Technical approval after contract review and three live provider cases; this is not a scientific or clinical endorsement.",
+  "draft_id": "vsdgeneratedcancertrialsbyphase_5e49d68e48d1",
+  "draft_sha256": "48d8fd4e8be4ed8db3c719c72d3e8ce4f748ef96fb6f28e19ec39251fb1b8453",
+  "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+  "reviewed_by": "SufianTA",
+  "tool_name": "VSDGeneratedCancerTrialsByPhase",
+  "verification_sha256": "a523235b2149cffa21ac0ab93925cd7d721d3fb0bdf2d5cdbc305dee89b86f2d",
+  "version": 1
+}

--- a/examples/vsd/artifacts/promotion_workspace/approvals/vsdgeneratedcancertrialsbysite_1b11bb8efdd7.json
+++ b/examples/vsd/artifacts/promotion_workspace/approvals/vsdgeneratedcancertrialsbysite_1b11bb8efdd7.json
@@ -1,0 +1,13 @@
+{
+  "approval_sha256": "f78987b36e730fbe88b12f46b37f84c365a18196fe1a006d6c6614263ae92a46",
+  "approved_at": "2026-08-01T01:36:33.866962+00:00",
+  "decision": "approved",
+  "decision_note": "Technical approval after contract review and three live provider cases; this is not a scientific or clinical endorsement.",
+  "draft_id": "vsdgeneratedcancertrialsbysite_1b11bb8efdd7",
+  "draft_sha256": "50d1df7d7ac94e23c2bae37aff9a03e972261c985fed3b15690ec76a89817c6d",
+  "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+  "reviewed_by": "SufianTA",
+  "tool_name": "VSDGeneratedCancerTrialsBySite",
+  "verification_sha256": "7f63aeb2b7e77c1ddd1d1e74aabf89cd1b475cfd947bf53c6bc63cd6bba327b3",
+  "version": 1
+}

--- a/examples/vsd/artifacts/promotion_workspace/approved/VSDGeneratedCancerTrialsByPhase.json
+++ b/examples/vsd/artifacts/promotion_workspace/approved/VSDGeneratedCancerTrialsByPhase.json
@@ -1,0 +1,136 @@
+{
+  "approval_sha256": "a941ad94c5738ee6fd4ffbc3c08b4a796222c423569dd878266a58db0b12255c",
+  "config": {
+    "cacheable": false,
+    "category": "special_tools",
+    "description": "Query the reviewed Roswell Park active cancer-trial dataset by exact study phase.",
+    "mcp_annotations": {
+      "destructiveHint": false,
+      "readOnlyHint": true
+    },
+    "name": "VSDGeneratedCancerTrialsByPhase",
+    "parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "study_phase": {
+          "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+          "maxLength": 500,
+          "type": "string"
+        }
+      },
+      "required": [
+        "study_phase"
+      ],
+      "type": "object"
+    },
+    "return_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "provenance": {
+          "type": "object"
+        },
+        "result": {
+          "type": "array"
+        }
+      },
+      "required": [
+        "result",
+        "provenance"
+      ],
+      "type": "object"
+    },
+    "type": "VSDDynamicRESTTool",
+    "vsd_operation": {
+      "auth": {
+        "type": "none"
+      },
+      "endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+      "fixed_query": {
+        "$limit": 25,
+        "$select": "date_opened,protocol,primary_site,study_phase,title,date_closed,principal_investigator"
+      },
+      "method": "GET",
+      "path_arguments": {},
+      "query_arguments": {
+        "study_phase": "study_phase"
+      },
+      "response_schema": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "date_closed": {
+              "description": "The date the clinical research study closed to accrual. If the study is still open, this field will be blank.",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "date_opened": {
+              "description": "The official start date (activation) of a trial",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "primary_site": {
+              "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "principal_investigator": {
+              "description": "The name of the Principal Investigator from Center who is responsible for the Clinical Research Study",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "protocol": {
+              "description": "The unique identifier for this study. For both national and externally",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "study_phase": {
+              "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "title": {
+              "description": "Name of the protocol provided by the study's principal investigator",
+              "maxLength": 500,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "maxItems": 25,
+        "type": "array"
+      },
+      "timeout_seconds": 20,
+      "version": 1
+    },
+    "vsd_promotion": {
+      "candidate_id": "31dcb2ce74f62d7c",
+      "catalog_domain": "data.ny.gov",
+      "dataset_id": "2ig8-yxf8",
+      "dataset_updated_at": "2026-04-14T21:08:58.000Z",
+      "filter_fields": [
+        "study_phase"
+      ],
+      "generator_version": 1,
+      "max_records": 25,
+      "return_fields": [
+        "date_opened",
+        "protocol",
+        "primary_site",
+        "study_phase",
+        "title",
+        "date_closed",
+        "principal_investigator"
+      ]
+    }
+  },
+  "decision_note": "Technical approval after contract review and three live provider cases; this is not a scientific or clinical endorsement.",
+  "draft_id": "vsdgeneratedcancertrialsbyphase_5e49d68e48d1",
+  "draft_sha256": "48d8fd4e8be4ed8db3c719c72d3e8ce4f748ef96fb6f28e19ec39251fb1b8453",
+  "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+  "publication_sha256": "e4dcf6b3ef5259c1d1d8690c76eed7ebf9a51dd9439463b8ff4360183ee21587",
+  "published_at": "2026-08-01T01:36:35.217057+00:00",
+  "reviewed_by": "SufianTA",
+  "tool_name": "VSDGeneratedCancerTrialsByPhase",
+  "verification_sha256": "a523235b2149cffa21ac0ab93925cd7d721d3fb0bdf2d5cdbc305dee89b86f2d",
+  "version": 1
+}

--- a/examples/vsd/artifacts/promotion_workspace/approved/VSDGeneratedCancerTrialsBySite.json
+++ b/examples/vsd/artifacts/promotion_workspace/approved/VSDGeneratedCancerTrialsBySite.json
@@ -1,0 +1,136 @@
+{
+  "approval_sha256": "f78987b36e730fbe88b12f46b37f84c365a18196fe1a006d6c6614263ae92a46",
+  "config": {
+    "cacheable": false,
+    "category": "special_tools",
+    "description": "Query the reviewed Roswell Park active cancer-trial dataset by exact primary cancer site.",
+    "mcp_annotations": {
+      "destructiveHint": false,
+      "readOnlyHint": true
+    },
+    "name": "VSDGeneratedCancerTrialsBySite",
+    "parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "primary_site": {
+          "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+          "maxLength": 500,
+          "type": "string"
+        }
+      },
+      "required": [
+        "primary_site"
+      ],
+      "type": "object"
+    },
+    "return_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "provenance": {
+          "type": "object"
+        },
+        "result": {
+          "type": "array"
+        }
+      },
+      "required": [
+        "result",
+        "provenance"
+      ],
+      "type": "object"
+    },
+    "type": "VSDDynamicRESTTool",
+    "vsd_operation": {
+      "auth": {
+        "type": "none"
+      },
+      "endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+      "fixed_query": {
+        "$limit": 25,
+        "$select": "date_opened,protocol,primary_site,study_phase,title,date_closed,principal_investigator"
+      },
+      "method": "GET",
+      "path_arguments": {},
+      "query_arguments": {
+        "primary_site": "primary_site"
+      },
+      "response_schema": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "date_closed": {
+              "description": "The date the clinical research study closed to accrual. If the study is still open, this field will be blank.",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "date_opened": {
+              "description": "The official start date (activation) of a trial",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "primary_site": {
+              "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "principal_investigator": {
+              "description": "The name of the Principal Investigator from Center who is responsible for the Clinical Research Study",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "protocol": {
+              "description": "The unique identifier for this study. For both national and externally",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "study_phase": {
+              "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "title": {
+              "description": "Name of the protocol provided by the study's principal investigator",
+              "maxLength": 500,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "maxItems": 25,
+        "type": "array"
+      },
+      "timeout_seconds": 20,
+      "version": 1
+    },
+    "vsd_promotion": {
+      "candidate_id": "31dcb2ce74f62d7c",
+      "catalog_domain": "data.ny.gov",
+      "dataset_id": "2ig8-yxf8",
+      "dataset_updated_at": "2026-04-14T21:08:58.000Z",
+      "filter_fields": [
+        "primary_site"
+      ],
+      "generator_version": 1,
+      "max_records": 25,
+      "return_fields": [
+        "date_opened",
+        "protocol",
+        "primary_site",
+        "study_phase",
+        "title",
+        "date_closed",
+        "principal_investigator"
+      ]
+    }
+  },
+  "decision_note": "Technical approval after contract review and three live provider cases; this is not a scientific or clinical endorsement.",
+  "draft_id": "vsdgeneratedcancertrialsbysite_1b11bb8efdd7",
+  "draft_sha256": "50d1df7d7ac94e23c2bae37aff9a03e972261c985fed3b15690ec76a89817c6d",
+  "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+  "publication_sha256": "fd7eb7288659acc38cb78dbef5dc9a6e54fece807c9913539059daf4ed6a8d7b",
+  "published_at": "2026-08-01T01:36:33.890179+00:00",
+  "reviewed_by": "SufianTA",
+  "tool_name": "VSDGeneratedCancerTrialsBySite",
+  "verification_sha256": "7f63aeb2b7e77c1ddd1d1e74aabf89cd1b475cfd947bf53c6bc63cd6bba327b3",
+  "version": 1
+}

--- a/examples/vsd/artifacts/promotion_workspace/drafts/vsdgeneratedcancertrialsbyphase_5e49d68e48d1.json
+++ b/examples/vsd/artifacts/promotion_workspace/drafts/vsdgeneratedcancertrialsbyphase_5e49d68e48d1.json
@@ -1,0 +1,131 @@
+{
+  "config": {
+    "cacheable": false,
+    "category": "special_tools",
+    "description": "Query the reviewed Roswell Park active cancer-trial dataset by exact study phase.",
+    "mcp_annotations": {
+      "destructiveHint": false,
+      "readOnlyHint": true
+    },
+    "name": "VSDGeneratedCancerTrialsByPhase",
+    "parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "study_phase": {
+          "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+          "maxLength": 500,
+          "type": "string"
+        }
+      },
+      "required": [
+        "study_phase"
+      ],
+      "type": "object"
+    },
+    "return_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "provenance": {
+          "type": "object"
+        },
+        "result": {
+          "type": "array"
+        }
+      },
+      "required": [
+        "result",
+        "provenance"
+      ],
+      "type": "object"
+    },
+    "type": "VSDDynamicRESTTool",
+    "vsd_operation": {
+      "auth": {
+        "type": "none"
+      },
+      "endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+      "fixed_query": {
+        "$limit": 25,
+        "$select": "date_opened,protocol,primary_site,study_phase,title,date_closed,principal_investigator"
+      },
+      "method": "GET",
+      "path_arguments": {},
+      "query_arguments": {
+        "study_phase": "study_phase"
+      },
+      "response_schema": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "date_closed": {
+              "description": "The date the clinical research study closed to accrual. If the study is still open, this field will be blank.",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "date_opened": {
+              "description": "The official start date (activation) of a trial",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "primary_site": {
+              "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "principal_investigator": {
+              "description": "The name of the Principal Investigator from Center who is responsible for the Clinical Research Study",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "protocol": {
+              "description": "The unique identifier for this study. For both national and externally",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "study_phase": {
+              "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "title": {
+              "description": "Name of the protocol provided by the study's principal investigator",
+              "maxLength": 500,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "maxItems": 25,
+        "type": "array"
+      },
+      "timeout_seconds": 20,
+      "version": 1
+    },
+    "vsd_promotion": {
+      "candidate_id": "31dcb2ce74f62d7c",
+      "catalog_domain": "data.ny.gov",
+      "dataset_id": "2ig8-yxf8",
+      "dataset_updated_at": "2026-04-14T21:08:58.000Z",
+      "filter_fields": [
+        "study_phase"
+      ],
+      "generator_version": 1,
+      "max_records": 25,
+      "return_fields": [
+        "date_opened",
+        "protocol",
+        "primary_site",
+        "study_phase",
+        "title",
+        "date_closed",
+        "principal_investigator"
+      ]
+    }
+  },
+  "created_at": "2026-08-01T01:36:33.901231+00:00",
+  "draft_id": "vsdgeneratedcancertrialsbyphase_5e49d68e48d1",
+  "draft_sha256": "48d8fd4e8be4ed8db3c719c72d3e8ce4f748ef96fb6f28e19ec39251fb1b8453",
+  "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+  "state": "draft",
+  "version": 1
+}

--- a/examples/vsd/artifacts/promotion_workspace/drafts/vsdgeneratedcancertrialsbysite_1b11bb8efdd7.json
+++ b/examples/vsd/artifacts/promotion_workspace/drafts/vsdgeneratedcancertrialsbysite_1b11bb8efdd7.json
@@ -1,0 +1,131 @@
+{
+  "config": {
+    "cacheable": false,
+    "category": "special_tools",
+    "description": "Query the reviewed Roswell Park active cancer-trial dataset by exact primary cancer site.",
+    "mcp_annotations": {
+      "destructiveHint": false,
+      "readOnlyHint": true
+    },
+    "name": "VSDGeneratedCancerTrialsBySite",
+    "parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "primary_site": {
+          "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+          "maxLength": 500,
+          "type": "string"
+        }
+      },
+      "required": [
+        "primary_site"
+      ],
+      "type": "object"
+    },
+    "return_schema": {
+      "additionalProperties": false,
+      "properties": {
+        "provenance": {
+          "type": "object"
+        },
+        "result": {
+          "type": "array"
+        }
+      },
+      "required": [
+        "result",
+        "provenance"
+      ],
+      "type": "object"
+    },
+    "type": "VSDDynamicRESTTool",
+    "vsd_operation": {
+      "auth": {
+        "type": "none"
+      },
+      "endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+      "fixed_query": {
+        "$limit": 25,
+        "$select": "date_opened,protocol,primary_site,study_phase,title,date_closed,principal_investigator"
+      },
+      "method": "GET",
+      "path_arguments": {},
+      "query_arguments": {
+        "primary_site": "primary_site"
+      },
+      "response_schema": {
+        "items": {
+          "additionalProperties": false,
+          "properties": {
+            "date_closed": {
+              "description": "The date the clinical research study closed to accrual. If the study is still open, this field will be blank.",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "date_opened": {
+              "description": "The official start date (activation) of a trial",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "primary_site": {
+              "description": "The primary anatomic cancer site(s) (i.e., breast, ovary) the clinical research study focuses on. Not applicable is used when the research",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "principal_investigator": {
+              "description": "The name of the Principal Investigator from Center who is responsible for the Clinical Research Study",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "protocol": {
+              "description": "The unique identifier for this study. For both national and externally",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "study_phase": {
+              "description": "Current phase of the study as of last dataset refresh. Phases include: Pilot, Phase I, Phase I/II, Phase II, Phase II/III and Phase III. See the attached Overview document for explanations. Not Applicable is used for epidemiologic, cancer control/behavioral, observational, ancillary, correlative or",
+              "maxLength": 500,
+              "type": "string"
+            },
+            "title": {
+              "description": "Name of the protocol provided by the study's principal investigator",
+              "maxLength": 500,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "maxItems": 25,
+        "type": "array"
+      },
+      "timeout_seconds": 20,
+      "version": 1
+    },
+    "vsd_promotion": {
+      "candidate_id": "31dcb2ce74f62d7c",
+      "catalog_domain": "data.ny.gov",
+      "dataset_id": "2ig8-yxf8",
+      "dataset_updated_at": "2026-04-14T21:08:58.000Z",
+      "filter_fields": [
+        "primary_site"
+      ],
+      "generator_version": 1,
+      "max_records": 25,
+      "return_fields": [
+        "date_opened",
+        "protocol",
+        "primary_site",
+        "study_phase",
+        "title",
+        "date_closed",
+        "principal_investigator"
+      ]
+    }
+  },
+  "created_at": "2026-08-01T01:36:32.360625+00:00",
+  "draft_id": "vsdgeneratedcancertrialsbysite_1b11bb8efdd7",
+  "draft_sha256": "50d1df7d7ac94e23c2bae37aff9a03e972261c985fed3b15690ec76a89817c6d",
+  "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+  "state": "draft",
+  "version": 1
+}

--- a/examples/vsd/artifacts/promotion_workspace/evidence/vsdgeneratedcancertrialsbyphase_5e49d68e48d1.json
+++ b/examples/vsd/artifacts/promotion_workspace/evidence/vsdgeneratedcancertrialsbyphase_5e49d68e48d1.json
@@ -1,0 +1,112 @@
+{
+  "all_cases_passed": true,
+  "case_count": 3,
+  "cases": [
+    {
+      "arguments": {
+        "study_phase": "I"
+      },
+      "case_index": 0,
+      "expect": {
+        "equals": {
+          "study_phase": "I"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "study_phase"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+      "payload_sha256": "7de1c8fb37ce5a26b9a25de4e6d12fc6b639735d8a221bdf3ecdc2912501893a",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T01:36:34.335218+00:00",
+      "row_count": 25
+    },
+    {
+      "arguments": {
+        "study_phase": "II"
+      },
+      "case_index": 1,
+      "expect": {
+        "equals": {
+          "study_phase": "II"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "study_phase"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+      "payload_sha256": "7898177fe582799b118a98de9de2bd4603d9d60589e46d488af43a342812026a",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T01:36:34.765749+00:00",
+      "row_count": 25
+    },
+    {
+      "arguments": {
+        "study_phase": "III"
+      },
+      "case_index": 2,
+      "expect": {
+        "equals": {
+          "study_phase": "III"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "study_phase"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+      "payload_sha256": "322b0476c5a33b91b7eae1117283468bac557db1ac748bbf8645b4d2d8a7795d",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T01:36:35.171574+00:00",
+      "row_count": 25
+    }
+  ],
+  "draft_id": "vsdgeneratedcancertrialsbyphase_5e49d68e48d1",
+  "draft_sha256": "48d8fd4e8be4ed8db3c719c72d3e8ce4f748ef96fb6f28e19ec39251fb1b8453",
+  "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+  "tool_name": "VSDGeneratedCancerTrialsByPhase",
+  "verification_sha256": "a523235b2149cffa21ac0ab93925cd7d721d3fb0bdf2d5cdbc305dee89b86f2d",
+  "verified_at": "2026-08-01T01:36:35.173078+00:00",
+  "version": 1
+}

--- a/examples/vsd/artifacts/promotion_workspace/evidence/vsdgeneratedcancertrialsbysite_1b11bb8efdd7.json
+++ b/examples/vsd/artifacts/promotion_workspace/evidence/vsdgeneratedcancertrialsbysite_1b11bb8efdd7.json
@@ -1,0 +1,112 @@
+{
+  "all_cases_passed": true,
+  "case_count": 3,
+  "cases": [
+    {
+      "arguments": {
+        "primary_site": "Brain and Nervous System"
+      },
+      "case_index": 0,
+      "expect": {
+        "equals": {
+          "primary_site": "Brain and Nervous System"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "primary_site"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+      "payload_sha256": "177c396cab0849392b328bfb23a9cd648df0f4435c3d22920260f2c98a7454be",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T01:36:33.034833+00:00",
+      "row_count": 19
+    },
+    {
+      "arguments": {
+        "primary_site": "Breast"
+      },
+      "case_index": 1,
+      "expect": {
+        "equals": {
+          "primary_site": "Breast"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "primary_site"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+      "payload_sha256": "5562338d7fdf189fa5ec3eecbfedadcb579778970ac266b82400116b84adb90f",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T01:36:33.440018+00:00",
+      "row_count": 23
+    },
+    {
+      "arguments": {
+        "primary_site": "Prostate"
+      },
+      "case_index": 2,
+      "expect": {
+        "equals": {
+          "primary_site": "Prostate"
+        },
+        "max_items": 25,
+        "min_items": 1,
+        "required_fields": [
+          "protocol",
+          "title",
+          "primary_site"
+        ]
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "date_closed",
+        "date_opened",
+        "primary_site",
+        "principal_investigator",
+        "protocol",
+        "study_phase",
+        "title"
+      ],
+      "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+      "payload_sha256": "1dec38172ecdc0658609492f56125b67f2d0010c74509268a3019da6663af842",
+      "redirects": 0,
+      "retrieved_at": "2026-08-01T01:36:33.835258+00:00",
+      "row_count": 20
+    }
+  ],
+  "draft_id": "vsdgeneratedcancertrialsbysite_1b11bb8efdd7",
+  "draft_sha256": "50d1df7d7ac94e23c2bae37aff9a03e972261c985fed3b15690ec76a89817c6d",
+  "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+  "tool_name": "VSDGeneratedCancerTrialsBySite",
+  "verification_sha256": "7f63aeb2b7e77c1ddd1d1e74aabf89cd1b475cfd947bf53c6bc63cd6bba327b3",
+  "verified_at": "2026-08-01T01:36:33.835258+00:00",
+  "version": 1
+}

--- a/examples/vsd/artifacts/tool_promotion_snapshot.json
+++ b/examples/vsd/artifacts/tool_promotion_snapshot.json
@@ -1,0 +1,335 @@
+{
+  "case": "one_discovered_source_to_two_reviewed_cancer_trial_tools",
+  "generated_at": "2026-08-01T01:36:36.257934+00:00",
+  "interpretation_boundary": "This validates software contracts and live retrieval, not trial quality, clinical relevance, or scientific conclusions.",
+  "loaded_tools": [
+    "VSDGeneratedCancerTrialsByPhase",
+    "VSDGeneratedCancerTrialsBySite"
+  ],
+  "promotion_state": {
+    "approvals": [
+      "vsdgeneratedcancertrialsbyphase_5e49d68e48d1",
+      "vsdgeneratedcancertrialsbysite_1b11bb8efdd7"
+    ],
+    "approved": [
+      "VSDGeneratedCancerTrialsByPhase",
+      "VSDGeneratedCancerTrialsBySite"
+    ],
+    "drafts": [
+      "vsdgeneratedcancertrialsbyphase_5e49d68e48d1",
+      "vsdgeneratedcancertrialsbysite_1b11bb8efdd7"
+    ],
+    "evidence": [
+      "vsdgeneratedcancertrialsbyphase_5e49d68e48d1",
+      "vsdgeneratedcancertrialsbysite_1b11bb8efdd7"
+    ]
+  },
+  "promotions": [
+    {
+      "approval_sha256": "f78987b36e730fbe88b12f46b37f84c365a18196fe1a006d6c6614263ae92a46",
+      "case_count": 3,
+      "cases": [
+        {
+          "arguments": {
+            "primary_site": "Brain and Nervous System"
+          },
+          "case_index": 0,
+          "expect": {
+            "equals": {
+              "primary_site": "Brain and Nervous System"
+            },
+            "max_items": 25,
+            "min_items": 1,
+            "required_fields": [
+              "protocol",
+              "title",
+              "primary_site"
+            ]
+          },
+          "http_status": 200,
+          "observed_fields": [
+            "date_closed",
+            "date_opened",
+            "primary_site",
+            "principal_investigator",
+            "protocol",
+            "study_phase",
+            "title"
+          ],
+          "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+          "payload_sha256": "177c396cab0849392b328bfb23a9cd648df0f4435c3d22920260f2c98a7454be",
+          "redirects": 0,
+          "retrieved_at": "2026-08-01T01:36:33.034833+00:00",
+          "row_count": 19
+        },
+        {
+          "arguments": {
+            "primary_site": "Breast"
+          },
+          "case_index": 1,
+          "expect": {
+            "equals": {
+              "primary_site": "Breast"
+            },
+            "max_items": 25,
+            "min_items": 1,
+            "required_fields": [
+              "protocol",
+              "title",
+              "primary_site"
+            ]
+          },
+          "http_status": 200,
+          "observed_fields": [
+            "date_closed",
+            "date_opened",
+            "primary_site",
+            "principal_investigator",
+            "protocol",
+            "study_phase",
+            "title"
+          ],
+          "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+          "payload_sha256": "5562338d7fdf189fa5ec3eecbfedadcb579778970ac266b82400116b84adb90f",
+          "redirects": 0,
+          "retrieved_at": "2026-08-01T01:36:33.440018+00:00",
+          "row_count": 23
+        },
+        {
+          "arguments": {
+            "primary_site": "Prostate"
+          },
+          "case_index": 2,
+          "expect": {
+            "equals": {
+              "primary_site": "Prostate"
+            },
+            "max_items": 25,
+            "min_items": 1,
+            "required_fields": [
+              "protocol",
+              "title",
+              "primary_site"
+            ]
+          },
+          "http_status": 200,
+          "observed_fields": [
+            "date_closed",
+            "date_opened",
+            "primary_site",
+            "principal_investigator",
+            "protocol",
+            "study_phase",
+            "title"
+          ],
+          "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+          "payload_sha256": "1dec38172ecdc0658609492f56125b67f2d0010c74509268a3019da6663af842",
+          "redirects": 0,
+          "retrieved_at": "2026-08-01T01:36:33.835258+00:00",
+          "row_count": 20
+        }
+      ],
+      "draft_id": "vsdgeneratedcancertrialsbysite_1b11bb8efdd7",
+      "draft_sha256": "50d1df7d7ac94e23c2bae37aff9a03e972261c985fed3b15690ec76a89817c6d",
+      "filter_field": "primary_site",
+      "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+      "publication_sha256": "fd7eb7288659acc38cb78dbef5dc9a6e54fece807c9913539059daf4ed6a8d7b",
+      "tool_name": "VSDGeneratedCancerTrialsBySite",
+      "verification_sha256": "7f63aeb2b7e77c1ddd1d1e74aabf89cd1b475cfd947bf53c6bc63cd6bba327b3"
+    },
+    {
+      "approval_sha256": "a941ad94c5738ee6fd4ffbc3c08b4a796222c423569dd878266a58db0b12255c",
+      "case_count": 3,
+      "cases": [
+        {
+          "arguments": {
+            "study_phase": "I"
+          },
+          "case_index": 0,
+          "expect": {
+            "equals": {
+              "study_phase": "I"
+            },
+            "max_items": 25,
+            "min_items": 1,
+            "required_fields": [
+              "protocol",
+              "title",
+              "study_phase"
+            ]
+          },
+          "http_status": 200,
+          "observed_fields": [
+            "date_closed",
+            "date_opened",
+            "primary_site",
+            "principal_investigator",
+            "protocol",
+            "study_phase",
+            "title"
+          ],
+          "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+          "payload_sha256": "7de1c8fb37ce5a26b9a25de4e6d12fc6b639735d8a221bdf3ecdc2912501893a",
+          "redirects": 0,
+          "retrieved_at": "2026-08-01T01:36:34.335218+00:00",
+          "row_count": 25
+        },
+        {
+          "arguments": {
+            "study_phase": "II"
+          },
+          "case_index": 1,
+          "expect": {
+            "equals": {
+              "study_phase": "II"
+            },
+            "max_items": 25,
+            "min_items": 1,
+            "required_fields": [
+              "protocol",
+              "title",
+              "study_phase"
+            ]
+          },
+          "http_status": 200,
+          "observed_fields": [
+            "date_closed",
+            "date_opened",
+            "primary_site",
+            "principal_investigator",
+            "protocol",
+            "study_phase",
+            "title"
+          ],
+          "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+          "payload_sha256": "7898177fe582799b118a98de9de2bd4603d9d60589e46d488af43a342812026a",
+          "redirects": 0,
+          "retrieved_at": "2026-08-01T01:36:34.765749+00:00",
+          "row_count": 25
+        },
+        {
+          "arguments": {
+            "study_phase": "III"
+          },
+          "case_index": 2,
+          "expect": {
+            "equals": {
+              "study_phase": "III"
+            },
+            "max_items": 25,
+            "min_items": 1,
+            "required_fields": [
+              "protocol",
+              "title",
+              "study_phase"
+            ]
+          },
+          "http_status": 200,
+          "observed_fields": [
+            "date_closed",
+            "date_opened",
+            "primary_site",
+            "principal_investigator",
+            "protocol",
+            "study_phase",
+            "title"
+          ],
+          "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+          "payload_sha256": "322b0476c5a33b91b7eae1117283468bac557db1ac748bbf8645b4d2d8a7795d",
+          "redirects": 0,
+          "retrieved_at": "2026-08-01T01:36:35.171574+00:00",
+          "row_count": 25
+        }
+      ],
+      "draft_id": "vsdgeneratedcancertrialsbyphase_5e49d68e48d1",
+      "draft_sha256": "48d8fd4e8be4ed8db3c719c72d3e8ce4f748ef96fb6f28e19ec39251fb1b8453",
+      "filter_field": "study_phase",
+      "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+      "publication_sha256": "e4dcf6b3ef5259c1d1d8690c76eed7ebf9a51dd9439463b8ff4360183ee21587",
+      "tool_name": "VSDGeneratedCancerTrialsByPhase",
+      "verification_sha256": "a523235b2149cffa21ac0ab93925cd7d721d3fb0bdf2d5cdbc305dee89b86f2d"
+    }
+  ],
+  "runtime_checks": [
+    {
+      "arguments": {
+        "primary_site": "Breast"
+      },
+      "operation_sha256": "1b11bb8efdd7de752ae3e00eade850728d236bbbd83e35543d1b68b61e660b12",
+      "payload_sha256": "5562338d7fdf189fa5ec3eecbfedadcb579778970ac266b82400116b84adb90f",
+      "retrieved_at": "2026-08-01T01:36:35.766153+00:00",
+      "row_count": 23,
+      "sample_rows": [
+        {
+          "date_opened": "2020-08-05T00:00:00.000",
+          "primary_site": "Breast",
+          "principal_investigator": "Ambrosone, C",
+          "protocol": "I-724220",
+          "study_phase": "N/A",
+          "title": "The North-South Breast Cancer Study (NSBCS)"
+        },
+        {
+          "date_opened": "2018-10-18T00:00:00.000",
+          "primary_site": "Breast",
+          "principal_investigator": "Bonaccio, E",
+          "protocol": "I-60217",
+          "study_phase": "N/A",
+          "title": "Photoacoustic Imaging of Human Breast"
+        },
+        {
+          "date_closed": "2025-03-20T00:00:00.000",
+          "date_opened": "2021-09-16T00:00:00.000",
+          "primary_site": "Breast",
+          "principal_investigator": "Fung-Kee-Fung, S",
+          "protocol": "N-1764921",
+          "study_phase": "III",
+          "title": "NRG-BR007: A PHASE III CLINICAL TRIAL EVALUATING DE-ESCALATION OF BREAST RADIATION FOR CONSERVATIVE TREATMENT OF STAGE I, HORMONE SENSITIVE, HER2-NEGATIVE, ONCOTYPE RECURRENCE SCORE &#8804; 18 BREAST CANCER"
+        }
+      ],
+      "tool_name": "VSDGeneratedCancerTrialsBySite"
+    },
+    {
+      "arguments": {
+        "study_phase": "III"
+      },
+      "operation_sha256": "5e49d68e48d1abf030940abe4a1ae1640546255018618ed6fb83fa5923ee8e13",
+      "payload_sha256": "322b0476c5a33b91b7eae1117283468bac557db1ac748bbf8645b4d2d8a7795d",
+      "retrieved_at": "2026-08-01T01:36:36.256929+00:00",
+      "row_count": 25,
+      "sample_rows": [
+        {
+          "date_opened": "2021-07-19T00:00:00.000",
+          "primary_site": "Brain and Nervous System",
+          "principal_investigator": "Barth, M",
+          "protocol": "N-1385821",
+          "study_phase": "III",
+          "title": "(ACNS1931) A Phase 3 Study of Selumetinib (NSC# 748727, IND# 77782) or Selumetinib in Combination with Vinblastine for non-NF1, non-TSC Patients with Recurrent or Progressive Low-Grade Gliomas (LGGs) Lacking BRAFV600E or IDH1 Mutations"
+        },
+        {
+          "date_opened": "2020-01-06T00:00:00.000",
+          "primary_site": "Brain and Nervous System",
+          "principal_investigator": "Barth, M",
+          "protocol": "N-564119",
+          "study_phase": "III",
+          "title": "(ACNS1831) A Phase 3 Randomized Study of Selumetinib (IND # 77782) Versus Carboplatin/Vincristine in Newly Diagnosed or Previously Untreated Neurofibromatosis Type 1 (NF1) Associated Low-Grade Glioma (LGG)"
+        },
+        {
+          "date_opened": "2020-02-26T00:00:00.000",
+          "primary_site": "Brain and Nervous System",
+          "principal_investigator": "Barth, M",
+          "protocol": "N-632820",
+          "study_phase": "III",
+          "title": "(ACNS1833) A Phase 3 Randomized Non-Inferiority Study of Carboplatin and Vincristine versus Selumetinib (NSC# 748727, IND# 77782) in Newly Diagnosed or Previously Untreated Low-Grade Glioma (LGG) not associated with BRAFV600E Mutations or Systemic Neurofibromatosis Type 1 (NF1)"
+        }
+      ],
+      "tool_name": "VSDGeneratedCancerTrialsByPhase"
+    }
+  ],
+  "source": {
+    "api_endpoint": "https://data.ny.gov/resource/2ig8-yxf8.json",
+    "candidate_id": "31dcb2ce74f62d7c",
+    "catalog_domain": "data.ny.gov",
+    "dataset_id": "2ig8-yxf8",
+    "dataset_updated_at": "2026-04-14T21:08:58.000Z"
+  }
+}

--- a/examples/vsd/artifacts/tool_promotion_snapshot.md
+++ b/examples/vsd/artifacts/tool_promotion_snapshot.md
@@ -1,0 +1,36 @@
+# Reviewed Tool Promotion: Cancer-Trial Case Study
+
+## Result
+
+One discovery candidate produced two distinct, narrow ToolUniverse tools. Each tool passed three live provider cases, was approved against the exact verification hash, was published atomically, loaded into a fresh ToolUniverse instance, and executed again.
+
+- Provider: `https://data.ny.gov/resource/2ig8-yxf8.json`
+- Dataset: `2ig8-yxf8`
+- Loaded tools: `VSDGeneratedCancerTrialsByPhase`, `VSDGeneratedCancerTrialsBySite`
+- Boundary: This validates software contracts and live retrieval, not trial quality, clinical relevance, or scientific conclusions.
+
+## Promotion Evidence
+
+| Tool | Required filter | Verification cases | Rows observed | Operation hash |
+| --- | --- | ---: | --- | --- |
+| `VSDGeneratedCancerTrialsBySite` | `primary_site` | 3 | 19, 23, 20 | `1b11bb8efdd7de75...` |
+| `VSDGeneratedCancerTrialsByPhase` | `study_phase` | 3 | 25, 25, 25 | `5e49d68e48d1abf0...` |
+
+## Fresh Runtime Check
+
+| Tool | Query | Rows | Payload hash |
+| --- | --- | ---: | --- |
+| `VSDGeneratedCancerTrialsBySite` | `primary_site=Breast` | 23 | `5562338d7fdf189f...` |
+| `VSDGeneratedCancerTrialsByPhase` | `study_phase=III` | 25 | `322b0476c5a33b91...` |
+
+## What This Proves
+
+1. Discovery metadata alone never executes and never enters the approved directory.
+2. Generation converts reviewed fields into bounded GET contracts with mandatory filters.
+3. Verification uses ToolUniverse itself and records counts, fields, timestamps, and hashes without storing entire provider responses.
+4. Approval and publication fail if the draft, evidence, or approval chain changes.
+5. Published tools are loaded only by an explicit call and cannot replace an existing tool.
+
+## Interpretation
+
+This validates software contracts and live retrieval, not trial quality, clinical relevance, or scientific conclusions.

--- a/examples/vsd/complete_pipeline_case_study.py
+++ b/examples/vsd/complete_pipeline_case_study.py
@@ -1,0 +1,1044 @@
+"""Exercise the complete VSD governance path in one oncology case study."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import re
+from collections import Counter
+from collections.abc import Iterator
+from contextlib import contextmanager, redirect_stdout
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from tooluniverse import ToolUniverse
+from tooluniverse.vsd_admin_cli import main as vsd_admin_main
+from tooluniverse.vsd_dynamic_rest import (
+    operation_digest,
+    register_reviewed_rest_tool,
+)
+from tooluniverse.vsd_promotion import (
+    approve_draft,
+    create_draft,
+    list_promotion_state,
+    load_published_tools,
+    publish_draft,
+    verify_draft,
+)
+
+HERE = Path(__file__).resolve().parent
+ARTIFACTS = HERE / "artifacts"
+DEFAULT_WORKSPACE = ARTIFACTS / "complete_pipeline_workspace"
+DEFAULT_JSON = ARTIFACTS / "complete_pipeline_snapshot.json"
+DEFAULT_MARKDOWN = ARTIFACTS / "complete_pipeline_snapshot.md"
+
+ADMIN_SOURCE_ID = "openfda_tamoxifen_review"
+OPENFDA_ENDPOINT = "https://api.fda.gov/drug/label.json"
+OPENFDA_DEFAULT_PARAMS = {
+    "search": 'openfda.generic_name:"tamoxifen"',
+    "limit": 1,
+}
+DISCOVERY_QUERY = "active cancer clinical trials primary site phase protocol"
+EXPECTED_DATASET_ID = "2ig8-yxf8"
+EXPECTED_CATALOG_DOMAIN = "data.ny.gov"
+REQUIRED_DISCOVERY_FIELDS = {
+    "date_opened",
+    "principal_investigator",
+    "primary_site",
+    "protocol",
+    "study_phase",
+    "title",
+}
+RETURN_FIELDS = [
+    "date_opened",
+    "protocol",
+    "primary_site",
+    "study_phase",
+    "title",
+    "date_closed",
+    "principal_investigator",
+]
+ADMIN_TOOL_NAMES = {
+    "VSDRegisterSource",
+    "VSDListSources",
+    "VSDQuerySource",
+    "VSDRemoveSource",
+}
+EXPECTED_ASSERTIONS = {
+    "administrative_catalog_restored",
+    "administrative_tools_not_agent_facing",
+    "discovery_candidate_has_required_fields",
+    "discovery_candidate_remained_non_executable",
+    "dynamic_search_detail_identifier_match",
+    "fixed_adapter_matches_admin_record",
+    "promoted_tools_absent_before_explicit_load",
+    "promotion_hash_chain_complete",
+    "published_runtime_filters_exact",
+    "published_tools_loaded_explicitly",
+    "reviewed_source_discovered_offline",
+    "six_live_promotion_cases_passed",
+}
+ACTIVE_STATUSES = (
+    "RECRUITING|NOT_YET_RECRUITING|ACTIVE_NOT_RECRUITING|ENROLLING_BY_INVITATION"
+)
+DISCLAIMER = (
+    "This is a software-governance and public-record retrieval demonstration. "
+    "It does not match patients to trials, establish eligibility, compare "
+    "treatments, or provide medical advice. The state and national registries "
+    "are independent and are not joined at record level."
+)
+
+SEARCH_TOOL = {
+    "name": "VSDTotalClinicalTrialsSearch",
+    "type": "VSDDynamicRESTTool",
+    "description": (
+        "Search the reviewed ClinicalTrials.gov contract for active or upcoming "
+        "studies by condition and location expression."
+    ),
+    "category": "special_tools",
+    "cacheable": False,
+    "mcp_annotations": {"readOnlyHint": True, "destructiveHint": False},
+    "parameter": {
+        "type": "object",
+        "properties": {
+            "condition": {"type": "string", "minLength": 2, "maxLength": 200},
+            "location_query": {
+                "type": "string",
+                "minLength": 2,
+                "maxLength": 500,
+            },
+            "page_size": {"type": "integer", "minimum": 1, "maximum": 20},
+        },
+        "required": ["condition", "location_query", "page_size"],
+        "additionalProperties": False,
+    },
+    "vsd_operation": {
+        "version": 1,
+        "method": "GET",
+        "endpoint": "https://clinicaltrials.gov/api/v2/studies",
+        "path_arguments": {},
+        "query_arguments": {
+            "condition": "query.cond",
+            "location_query": "query.locn",
+            "page_size": "pageSize",
+        },
+        "fixed_query": {
+            "format": "json",
+            "countTotal": "true",
+            "filter.overallStatus": ACTIVE_STATUSES,
+            "fields": (
+                "NCTId,BriefTitle,OverallStatus,Phase,Condition,LocationFacility,"
+                "LocationCity,LocationState,LocationCountry,LocationStatus"
+            ),
+        },
+        "timeout_seconds": 30,
+        "auth": {"type": "none"},
+        "response_schema": {
+            "type": "object",
+            "properties": {
+                "studies": {"type": "array", "maxItems": 20},
+                "totalCount": {"type": "integer", "minimum": 0},
+                "nextPageToken": {"type": "string"},
+            },
+            "required": ["studies"],
+            "additionalProperties": True,
+        },
+    },
+}
+
+DETAIL_TOOL = {
+    "name": "VSDTotalClinicalTrialDetails",
+    "type": "VSDDynamicRESTTool",
+    "description": (
+        "Retrieve one record through the reviewed ClinicalTrials.gov contract "
+        "using a validated NCT identifier."
+    ),
+    "category": "special_tools",
+    "cacheable": False,
+    "mcp_annotations": {"readOnlyHint": True, "destructiveHint": False},
+    "parameter": {
+        "type": "object",
+        "properties": {"nct_id": {"type": "string", "pattern": "^NCT[0-9]{8}$"}},
+        "required": ["nct_id"],
+        "additionalProperties": False,
+    },
+    "vsd_operation": {
+        "version": 1,
+        "method": "GET",
+        "endpoint": "https://clinicaltrials.gov/api/v2/studies/{nctId}",
+        "path_arguments": {"nct_id": "nctId"},
+        "query_arguments": {},
+        "fixed_query": {"format": "json"},
+        "timeout_seconds": 30,
+        "auth": {"type": "none"},
+        "response_schema": {
+            "type": "object",
+            "properties": {"protocolSection": {"type": "object"}},
+            "required": ["protocolSection"],
+            "additionalProperties": True,
+        },
+    },
+}
+
+PROMOTION_SPECS = (
+    {
+        "tool_name": "VSDTotalCancerTrialsBySite",
+        "description": (
+            "Query the reviewed Roswell Park active cancer-trial dataset by an "
+            "exact primary cancer site."
+        ),
+        "filter_field": "primary_site",
+        "verification_values": (
+            "Brain and Nervous System",
+            "Breast",
+            "Prostate",
+        ),
+        "runtime_value": "Breast",
+    },
+    {
+        "tool_name": "VSDTotalCancerTrialsByPhase",
+        "description": (
+            "Query the reviewed Roswell Park active cancer-trial dataset by an "
+            "exact study phase."
+        ),
+        "filter_field": "study_phase",
+        "verification_values": ("I", "II", "III"),
+        "runtime_value": "III",
+    },
+)
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _successful_data(result: Any, tool_name: str) -> dict[str, Any]:
+    if not isinstance(result, dict) or result.get("status") != "success":
+        raise RuntimeError(f"{tool_name} did not succeed: {result!r}")
+    data = result.get("data")
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{tool_name} returned an invalid data envelope")
+    return data
+
+
+@contextmanager
+def _catalog_environment(catalog_dir: Path) -> Iterator[None]:
+    key = "TOOLUNIVERSE_VSD_DIR"
+    previous = os.environ.get(key)
+    os.environ[key] = str(catalog_dir)
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = previous
+
+
+def _run_admin(arguments: list[str], catalog_dir: Path) -> dict[str, Any]:
+    output = io.StringIO()
+    with _catalog_environment(catalog_dir):
+        with redirect_stdout(output):
+            return_code = vsd_admin_main(arguments)
+    if return_code != 0:
+        raise RuntimeError(f"VSD administration command failed: {arguments!r}")
+    try:
+        result = json.loads(output.getvalue())
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("VSD administration command returned invalid JSON") from exc
+    return _successful_data(result, f"tooluniverse-vsd-admin {arguments[0]}")
+
+
+def _admin_source_lifecycle(workspace: Path) -> tuple[dict[str, Any], str]:
+    catalog_dir = workspace / "catalog"
+    initial = _run_admin(["list"], catalog_dir)["sources"]
+    initial_ids = sorted(source["source_id"] for source in initial)
+    precleaned = False
+    if ADMIN_SOURCE_ID in initial_ids:
+        precleaned = _run_admin(["remove", ADMIN_SOURCE_ID], catalog_dir)["removed"]
+    baseline_ids = [item for item in initial_ids if item != ADMIN_SOURCE_ID]
+
+    registered = False
+    registration: dict[str, Any] | None = None
+    listed: dict[str, Any] | None = None
+    query: dict[str, Any] | None = None
+    removal: dict[str, Any] | None = None
+    try:
+        registration = _run_admin(
+            [
+                "register",
+                ADMIN_SOURCE_ID,
+                OPENFDA_ENDPOINT,
+                "--name",
+                "openFDA tamoxifen label review",
+                "--description",
+                (
+                    "Temporary administrative inspection of one public tamoxifen "
+                    "label before using the fixed reviewed adapter."
+                ),
+                "--default-params",
+                json.dumps(OPENFDA_DEFAULT_PARAMS, sort_keys=True),
+            ],
+            catalog_dir,
+        )
+        registered = True
+        listed = _run_admin(["list"], catalog_dir)
+        query = _run_admin(["query", ADMIN_SOURCE_ID], catalog_dir)
+    finally:
+        if registered:
+            removal = _run_admin(["remove", ADMIN_SOURCE_ID], catalog_dir)
+
+    if registration is None or listed is None or query is None or removal is None:
+        raise RuntimeError("Administrative source lifecycle was incomplete")
+    final_sources = _run_admin(["list"], catalog_dir)["sources"]
+    final_ids = sorted(source["source_id"] for source in final_sources)
+    payload = query["result"]
+    rows = payload.get("results") if isinstance(payload, dict) else None
+    if not isinstance(rows, list) or len(rows) != 1 or not isinstance(rows[0], dict):
+        raise RuntimeError("Administrative openFDA query did not return one label")
+    row = rows[0]
+    set_id = str(row.get("set_id") or "").lower()
+    generic_names = (row.get("openfda") or {}).get("generic_name") or []
+    if not re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        set_id,
+    ) or not any("tamoxifen" in str(name).casefold() for name in generic_names):
+        raise RuntimeError("Administrative openFDA result was not a tamoxifen label")
+
+    request = query["request"]
+    return (
+        {
+            "source_id": ADMIN_SOURCE_ID,
+            "endpoint": OPENFDA_ENDPOINT,
+            "preexisting_source_removed": precleaned,
+            "initial_source_ids": initial_ids,
+            "listed_source_ids": sorted(
+                source["source_id"] for source in listed["sources"]
+            ),
+            "registered": registration["registered"],
+            "registration_probe": registration["source"]["last_probe"],
+            "query": {
+                "default_params": OPENFDA_DEFAULT_PARAMS,
+                "returned_records": len(rows),
+                "provider_total_records": (payload.get("meta") or {})
+                .get("results", {})
+                .get("total"),
+                "selected_set_id": set_id,
+                "normalized_payload_sha256": _digest(payload),
+                "http_status": request["status_code"],
+                "content_type": request["content_type"],
+                "response_bytes": request["response_bytes"],
+                "redirects": request["redirects"],
+            },
+            "removed": removal["removed"],
+            "final_source_ids": final_ids,
+            "catalog_restored": final_ids == baseline_ids,
+            "boundary": (
+                "Registration and generic querying occurred only through the "
+                "administrator CLI. They did not publish an agent-facing tool."
+            ),
+        },
+        set_id,
+    )
+
+
+def _tool_call(
+    tooluniverse: ToolUniverse, name: str, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    return _successful_data(
+        tooluniverse.run_one_function(
+            {"name": name, "arguments": arguments}, use_cache=False
+        ),
+        name,
+    )
+
+
+def _module(study: dict[str, Any], name: str) -> dict[str, Any]:
+    protocol = study.get("protocolSection") or {}
+    value = protocol.get(name) or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _study_summary(study: dict[str, Any]) -> dict[str, Any]:
+    identification = _module(study, "identificationModule")
+    status = _module(study, "statusModule")
+    design = _module(study, "designModule")
+    contacts = _module(study, "contactsLocationsModule")
+    conditions = _module(study, "conditionsModule")
+    locations = contacts.get("locations") or []
+    return {
+        "nct_id": identification.get("nctId"),
+        "title": re.sub(r"\s+", " ", str(identification.get("briefTitle") or "")),
+        "overall_status": status.get("overallStatus"),
+        "phases": design.get("phases") or [],
+        "conditions": conditions.get("conditions") or [],
+        "new_york_locations": [
+            {
+                "facility": location.get("facility"),
+                "city": location.get("city"),
+                "status": location.get("status"),
+            }
+            for location in locations
+            if isinstance(location, dict) and location.get("state") == "New York"
+        ],
+    }
+
+
+def _review_discovery(
+    discovery: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    candidates = discovery.get("candidates")
+    if not isinstance(candidates, list):
+        raise RuntimeError("API discovery returned no candidate list")
+    reviewed = []
+    selectable = []
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            raise RuntimeError("API discovery returned a malformed candidate")
+        field_names = {
+            str(field.get("field"))
+            for field in candidate.get("fields") or []
+            if isinstance(field, dict)
+        }
+        score = candidate.get("score") or {}
+        missing = sorted(REQUIRED_DISCOVERY_FIELDS - field_names)
+        ready = (
+            candidate.get("execution_allowed") is False
+            and candidate.get("approval_state") == "unreviewed_candidate"
+            and score.get("api_ready") == 1.0
+            and score.get("official_catalog_label") == 1.0
+            and score.get("government_domain") == 1.0
+            and not missing
+        )
+        summary = {
+            "candidate_id": candidate.get("candidate_id"),
+            "name": candidate.get("name"),
+            "catalog_domain": candidate.get("catalog_domain"),
+            "dataset_id": candidate.get("dataset_id"),
+            "score": score.get("total"),
+            "field_count": len(field_names),
+            "matched_required_fields": sorted(REQUIRED_DISCOVERY_FIELDS & field_names),
+            "missing_required_fields": missing,
+            "execution_allowed": candidate.get("execution_allowed"),
+            "approval_state": candidate.get("approval_state"),
+            "selected_for_contract_review": ready,
+        }
+        reviewed.append(summary)
+        if ready:
+            selectable.append(candidate)
+    if not selectable:
+        raise RuntimeError("No discovered API passed the explicit review screen")
+    selected = sorted(
+        selectable,
+        key=lambda candidate: (
+            -float((candidate.get("score") or {}).get("total", 0)),
+            str(candidate.get("candidate_id")),
+        ),
+    )[0]
+    if (
+        selected.get("catalog_domain") != EXPECTED_CATALOG_DOMAIN
+        or selected.get("dataset_id") != EXPECTED_DATASET_ID
+    ):
+        raise RuntimeError(
+            "The highest-ranked candidate changed; human contract review is required"
+        )
+    return selected, reviewed
+
+
+def _run_agent_review(
+    set_id: str,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    tooluniverse = ToolUniverse()
+    requested_tools = [
+        "VSDDiscoverSources",
+        "VSDOpenFDALabelBySetId",
+        "VSDDiscoverAPICandidates",
+        *sorted(ADMIN_TOOL_NAMES),
+    ]
+    tooluniverse.load_tools(include_tools=requested_tools, quiet=True)
+    try:
+        loaded_before_dynamic = sorted(tool["name"] for tool in tooluniverse.all_tools)
+        source_discovery = _tool_call(
+            tooluniverse, "VSDDiscoverSources", {"query": "drug label"}
+        )
+        sources = source_discovery.get("sources")
+        if not isinstance(sources, list):
+            raise RuntimeError("Reviewed source discovery returned invalid data")
+        openfda_sources = [
+            source for source in sources if source.get("source_id") == "openfda_labels"
+        ]
+        if len(openfda_sources) != 1:
+            raise RuntimeError("Reviewed openFDA source was not uniquely discoverable")
+
+        label_data = _tool_call(
+            tooluniverse, "VSDOpenFDALabelBySetId", {"set_id": set_id}
+        )
+        label = label_data.get("label")
+        if not isinstance(label, dict) or label.get("set_id") != set_id:
+            raise RuntimeError("Reviewed label adapter returned a different record")
+        if "tamoxifen" not in str(label.get("generic_name") or "").casefold():
+            raise RuntimeError("Reviewed label adapter did not return tamoxifen")
+
+        for config in (SEARCH_TOOL, DETAIL_TOOL):
+            register_reviewed_rest_tool(tooluniverse, config)
+        search_data = _tool_call(
+            tooluniverse,
+            SEARCH_TOOL["name"],
+            {
+                "condition": "Breast Cancer",
+                "location_query": "AREA[LocationState]New York",
+                "page_size": 20,
+            },
+        )
+        search_result = search_data.get("result")
+        studies = (
+            search_result.get("studies") if isinstance(search_result, dict) else None
+        )
+        if not isinstance(studies, list) or not studies:
+            raise RuntimeError("Reviewed national trial search returned no studies")
+        summaries = [_study_summary(study) for study in studies]
+        summaries = [summary for summary in summaries if summary["nct_id"]]
+        if not summaries:
+            raise RuntimeError("Reviewed national trial search returned no NCT IDs")
+        selected_nct_id = sorted(summary["nct_id"] for summary in summaries)[0]
+        detail_data = _tool_call(
+            tooluniverse, DETAIL_TOOL["name"], {"nct_id": selected_nct_id}
+        )
+        detail = _study_summary(detail_data["result"])
+        if detail["nct_id"] != selected_nct_id:
+            raise RuntimeError("Reviewed search and detail operations disagreed")
+
+        discovery_data = _tool_call(
+            tooluniverse,
+            "VSDDiscoverAPICandidates",
+            {"query": DISCOVERY_QUERY, "limit": 10},
+        )
+        candidate, candidate_summaries = _review_discovery(discovery_data)
+        loaded_after_dynamic = sorted(tool["name"] for tool in tooluniverse.all_tools)
+    finally:
+        tooluniverse.close()
+
+    reviewed_source = {
+        "offline_query": "drug label",
+        "matched_source": openfda_sources[0],
+        "loaded_agent_tools_before_dynamic_registration": loaded_before_dynamic,
+        "administrative_tools_loaded": sorted(
+            ADMIN_TOOL_NAMES & set(loaded_before_dynamic)
+        ),
+        "label": {
+            "set_id": label["set_id"],
+            "effective_time": label["effective_time"],
+            "brand_name": label["brand_name"],
+            "generic_name": label["generic_name"],
+            "route": label["route"],
+            "warning_section_count": len(label["warnings"]),
+            "warning_sections_sha256": _digest(label["warnings"]),
+        },
+        "provenance": label_data["provenance"],
+    }
+    statuses = Counter(summary["overall_status"] or "UNKNOWN" for summary in summaries)
+    phases = Counter(
+        phase
+        for summary in summaries
+        for phase in (summary["phases"] or ["NOT_APPLICABLE"])
+    )
+    dynamic_rest = {
+        "tool_contracts": [
+            {
+                "name": config["name"],
+                "endpoint": config["vsd_operation"]["endpoint"],
+                "operation_sha256": operation_digest(config),
+            }
+            for config in (SEARCH_TOOL, DETAIL_TOOL)
+        ],
+        "search": {
+            "arguments": {
+                "condition": "Breast Cancer",
+                "location_query": "AREA[LocationState]New York",
+                "page_size": 20,
+            },
+            "provider_total_count": search_result.get("totalCount"),
+            "returned_records": len(summaries),
+            "returned_nct_ids": [summary["nct_id"] for summary in summaries],
+            "status_counts": dict(sorted(statuses.items())),
+            "phase_counts": dict(sorted(phases.items())),
+            "sample_studies": summaries[:5],
+            "provenance": search_data["provenance"],
+        },
+        "detail_follow_up": {
+            "selection_rule": "Lexicographically smallest valid returned NCT ID",
+            "selected_nct_id": selected_nct_id,
+            "identifier_matches_search": any(
+                summary["nct_id"] == detail["nct_id"] for summary in summaries
+            ),
+            "study": detail,
+            "provenance": detail_data["provenance"],
+        },
+    }
+    discovery = {
+        "query": DISCOVERY_QUERY,
+        "catalog_result_count": discovery_data.get("catalog_result_count"),
+        "returned_candidate_count": len(candidate_summaries),
+        "candidates": candidate_summaries,
+        "selected_candidate": {
+            **candidate,
+            "fields": candidate.get("fields") or [],
+        },
+        "selection_rule": (
+            "Require non-executable unreviewed state, an official government "
+            "API-ready catalog record, and all six demanded fields; then choose "
+            "the highest score with candidate ID as the stable tie-breaker."
+        ),
+        "loaded_agent_tools_after_dynamic_registration": loaded_after_dynamic,
+        "boundary": discovery_data.get("boundary"),
+        "provenance": discovery_data.get("provenance"),
+    }
+    return reviewed_source, dynamic_rest, discovery
+
+
+def _verification_cases(field: str, values: tuple[str, ...]) -> list[dict[str, Any]]:
+    return [
+        {
+            "arguments": {field: value},
+            "expect": {
+                "min_items": 1,
+                "max_items": 25,
+                "required_fields": ["protocol", "title", field],
+                "equals": {field: value},
+            },
+        }
+        for value in values
+    ]
+
+
+def _promote_and_execute(candidate: dict[str, Any], workspace: Path) -> dict[str, Any]:
+    promotion_workspace = workspace / "promotion"
+    promotions = []
+    for spec in PROMOTION_SPECS:
+        draft = create_draft(
+            candidate,
+            tool_name=spec["tool_name"],
+            description=spec["description"],
+            filter_fields=[spec["filter_field"]],
+            return_fields=RETURN_FIELDS,
+            max_records=25,
+            workspace=promotion_workspace,
+        )
+        evidence = verify_draft(
+            draft["draft_id"],
+            _verification_cases(spec["filter_field"], spec["verification_values"]),
+            workspace=promotion_workspace,
+        )
+        approval = approve_draft(
+            draft["draft_id"],
+            reviewed_by="SufianTA",
+            decision_note=(
+                "Technical approval after field-contract review and three live "
+                "provider cases; not scientific or clinical endorsement."
+            ),
+            workspace=promotion_workspace,
+        )
+        publication = publish_draft(
+            draft["draft_id"], workspace=promotion_workspace, replace=True
+        )
+        promotions.append(
+            {
+                "tool_name": spec["tool_name"],
+                "filter_field": spec["filter_field"],
+                "draft_id": draft["draft_id"],
+                "draft_sha256": draft["draft_sha256"],
+                "operation_sha256": draft["operation_sha256"],
+                "verification_sha256": evidence["verification_sha256"],
+                "approval_sha256": approval["approval_sha256"],
+                "publication_sha256": publication["publication_sha256"],
+                "case_count": evidence["case_count"],
+                "all_cases_passed": evidence["all_cases_passed"],
+                "cases": evidence["cases"],
+            }
+        )
+
+    runtime = ToolUniverse(
+        tool_files={},
+        keep_default_tools=False,
+        workspace=str(workspace / ".runtime"),
+    )
+    try:
+        loaded_before = sorted(tool["name"] for tool in runtime.all_tools)
+        loaded = load_published_tools(runtime, workspace=promotion_workspace)
+        checks = []
+        for spec in PROMOTION_SPECS:
+            arguments = {spec["filter_field"]: spec["runtime_value"]}
+            data = _tool_call(runtime, spec["tool_name"], arguments)
+            rows = data["result"]
+            if not rows or any(
+                row.get(spec["filter_field"]) != spec["runtime_value"] for row in rows
+            ):
+                raise RuntimeError("Published tool violated its reviewed exact filter")
+            checks.append(
+                {
+                    "tool_name": spec["tool_name"],
+                    "arguments": arguments,
+                    "row_count": len(rows),
+                    "sample_rows": rows[:3],
+                    "provenance": data["provenance"],
+                }
+            )
+    finally:
+        runtime.close()
+    return {
+        "promotions": promotions,
+        "verification_case_count": sum(item["case_count"] for item in promotions),
+        "promoted_tools_present_before_explicit_load": sorted(
+            set(loaded_before) & {spec["tool_name"] for spec in PROMOTION_SPECS}
+        ),
+        "loaded_tools": loaded,
+        "runtime_checks": checks,
+        "promotion_state": list_promotion_state(workspace=promotion_workspace),
+    }
+
+
+def _audit_inputs(snapshot: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "admin_query_payload": snapshot["administrative_source_lifecycle"]["query"][
+            "normalized_payload_sha256"
+        ],
+        "reviewed_label_payload": snapshot["reviewed_source_adapter"]["provenance"][
+            "payload_sha256"
+        ],
+        "dynamic_contracts": [
+            contract["operation_sha256"]
+            for contract in snapshot["reviewed_dynamic_rest"]["tool_contracts"]
+        ],
+        "dynamic_payloads": [
+            snapshot["reviewed_dynamic_rest"]["search"]["provenance"]["payload_sha256"],
+            snapshot["reviewed_dynamic_rest"]["detail_follow_up"]["provenance"][
+                "payload_sha256"
+            ],
+        ],
+        "discovery_payload": snapshot["demand_discovery"]["provenance"][
+            "payload_sha256"
+        ],
+        "selected_candidate": snapshot["demand_discovery"]["selected_candidate"][
+            "candidate_id"
+        ],
+        "promotion_chains": [
+            {
+                key: promotion[key]
+                for key in (
+                    "draft_sha256",
+                    "operation_sha256",
+                    "verification_sha256",
+                    "approval_sha256",
+                    "publication_sha256",
+                )
+            }
+            for promotion in snapshot["reviewed_promotion"]["promotions"]
+        ],
+        "runtime_payloads": [
+            check["provenance"]["payload_sha256"]
+            for check in snapshot["reviewed_promotion"]["runtime_checks"]
+        ],
+    }
+
+
+def validate_snapshot(snapshot: dict[str, Any]) -> None:
+    """Fail closed if any stage or audit-chain assertion is incomplete."""
+    if snapshot.get("case") != "complete_vsd_oncology_source_governance":
+        raise ValueError("Unexpected complete-case identifier")
+    assertions = snapshot.get("end_to_end_assertions")
+    if (
+        not isinstance(assertions, dict)
+        or set(assertions) != EXPECTED_ASSERTIONS
+        or not all(value is True for value in assertions.values())
+    ):
+        raise ValueError("One or more end-to-end assertions did not pass")
+    audit = snapshot.get("audit_chain")
+    if not isinstance(audit, dict) or audit.get("inputs") != _audit_inputs(snapshot):
+        raise ValueError("Audit-chain inputs do not match the stage evidence")
+    if audit.get("sha256") != _digest(audit["inputs"]):
+        raise ValueError("Audit-chain digest does not match its inputs")
+
+
+def run_case(*, workspace: Path) -> dict[str, Any]:
+    administrative, set_id = _admin_source_lifecycle(workspace)
+    reviewed_source, dynamic_rest, discovery = _run_agent_review(set_id)
+    promotion = _promote_and_execute(discovery["selected_candidate"], workspace)
+
+    expected_loaded = sorted(spec["tool_name"] for spec in PROMOTION_SPECS)
+    hash_fields = (
+        "draft_sha256",
+        "operation_sha256",
+        "verification_sha256",
+        "approval_sha256",
+        "publication_sha256",
+    )
+    assertions = {
+        "administrative_catalog_restored": administrative["catalog_restored"],
+        "administrative_tools_not_agent_facing": not reviewed_source[
+            "administrative_tools_loaded"
+        ],
+        "reviewed_source_discovered_offline": reviewed_source["matched_source"].get(
+            "source_id"
+        )
+        == "openfda_labels",
+        "fixed_adapter_matches_admin_record": reviewed_source["label"]["set_id"]
+        == administrative["query"]["selected_set_id"],
+        "dynamic_search_detail_identifier_match": dynamic_rest["detail_follow_up"][
+            "identifier_matches_search"
+        ],
+        "discovery_candidate_remained_non_executable": discovery["selected_candidate"][
+            "execution_allowed"
+        ]
+        is False,
+        "discovery_candidate_has_required_fields": not next(
+            candidate["missing_required_fields"]
+            for candidate in discovery["candidates"]
+            if candidate["candidate_id"]
+            == discovery["selected_candidate"]["candidate_id"]
+        ),
+        "six_live_promotion_cases_passed": promotion["verification_case_count"] == 6
+        and all(item["all_cases_passed"] for item in promotion["promotions"]),
+        "promotion_hash_chain_complete": all(
+            re.fullmatch(r"[0-9a-f]{64}", str(item.get(field, "")))
+            for item in promotion["promotions"]
+            for field in hash_fields
+        ),
+        "promoted_tools_absent_before_explicit_load": not promotion[
+            "promoted_tools_present_before_explicit_load"
+        ],
+        "published_tools_loaded_explicitly": promotion["loaded_tools"]
+        == expected_loaded,
+        "published_runtime_filters_exact": all(
+            check["row_count"] >= 1
+            and all(
+                row.get(next(iter(check["arguments"])))
+                == next(iter(check["arguments"].values()))
+                for row in check["sample_rows"]
+            )
+            for check in promotion["runtime_checks"]
+        ),
+    }
+    snapshot = {
+        "case": "complete_vsd_oncology_source_governance",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "decision_question": (
+            "Can ToolUniverse start from an oncology evidence need, keep generic "
+            "source administration outside the agent boundary, execute reviewed "
+            "contracts, discover an unknown API without executing it, and promote "
+            "only verified narrow tools with a complete audit chain?"
+        ),
+        "administrative_source_lifecycle": administrative,
+        "reviewed_source_adapter": reviewed_source,
+        "reviewed_dynamic_rest": dynamic_rest,
+        "demand_discovery": discovery,
+        "reviewed_promotion": promotion,
+        "end_to_end_assertions": assertions,
+        "interpretation_boundary": DISCLAIMER,
+    }
+    inputs = _audit_inputs(snapshot)
+    snapshot["audit_chain"] = {"inputs": inputs, "sha256": _digest(inputs)}
+    validate_snapshot(snapshot)
+    return snapshot
+
+
+def render_markdown(snapshot: dict[str, Any]) -> str:
+    admin = snapshot["administrative_source_lifecycle"]
+    source = snapshot["reviewed_source_adapter"]
+    dynamic = snapshot["reviewed_dynamic_rest"]
+    discovery = snapshot["demand_discovery"]
+    promotion = snapshot["reviewed_promotion"]
+    selected = discovery["selected_candidate"]
+    lines = [
+        "# Complete VSD Oncology Source-Governance Case Study",
+        "",
+        "## Decision Question",
+        "",
+        snapshot["decision_question"],
+        "",
+        "## End-to-End Result",
+        "",
+        "| Stage | Boundary exercised | Live proof |",
+        "| ---: | --- | --- |",
+        (
+            "| 1 | Administrator-only source catalog | Registered, probed, listed, "
+            "queried, removed, and restored the temporary catalog |"
+        ),
+        (
+            "| 2 | Packaged reviewed adapter | Discovered openFDA offline and "
+            "retrieved the same tamoxifen label through a fixed typed tool |"
+        ),
+        (
+            "| 3 | Reviewed dynamic REST | Searched active/upcoming New York breast-"
+            "cancer studies and retrieved one deterministic NCT record |"
+        ),
+        (
+            "| 4 | Demand-driven discovery | Searched the fixed Socrata catalog and "
+            "kept the selected API non-executable pending review |"
+        ),
+        (
+            "| 5 | Reviewed promotion | Ran six live verification cases, approved "
+            "hash-bound drafts, and published two bounded tools |"
+        ),
+        (
+            "| 6 | Explicit runtime loading | Loaded both publications into a fresh "
+            "ToolUniverse instance and executed exact-filter queries |"
+        ),
+        "",
+        "## 1. Administrative Source Lifecycle",
+        "",
+        f"- Source: `{admin['source_id']}` at `{admin['endpoint']}`",
+        f"- Probe HTTP status: **{admin['registration_probe']['status_code']}**",
+        f"- Query records: **{admin['query']['returned_records']}** of "
+        f"**{admin['query']['provider_total_records']}** provider matches",
+        f"- Selected label set ID: `{admin['query']['selected_set_id']}`",
+        f"- Removed after inspection: **{str(admin['removed']).lower()}**",
+        f"- Catalog restored: **{str(admin['catalog_restored']).lower()}**",
+        f"- Boundary: {admin['boundary']}",
+        "",
+        "## 2. Reviewed Source Adapter",
+        "",
+        f"- Offline source: **{source['matched_source']['name']}**",
+        f"- Agent-facing tool: `{source['matched_source']['tool_name']}`",
+        f"- Label: **{source['label']['brand_name']}** "
+        f"(`{source['label']['generic_name']}`)",
+        f"- Effective time: `{source['label']['effective_time']}`",
+        f"- Route: `{source['label']['route']}`",
+        f"- Administrative operations present in the agent runtime: "
+        f"**{len(source['administrative_tools_loaded'])}**",
+        f"- Provider payload: `{source['provenance']['payload_sha256']}`",
+        "",
+        "The generic administrative query established a record identifier only. "
+        "The agent-facing call used the fixed openFDA endpoint, UUID input contract, "
+        "source-specific response validation, and typed provenance.",
+        "",
+        "## 3. Reviewed Dynamic REST",
+        "",
+        f"- National registry matches: **{dynamic['search']['provider_total_count']}**",
+        f"- Bounded records returned: **{dynamic['search']['returned_records']}**",
+        f"- Status counts: `{json.dumps(dynamic['search']['status_counts'], sort_keys=True)}`",
+        f"- Phase counts: `{json.dumps(dynamic['search']['phase_counts'], sort_keys=True)}`",
+        f"- Deterministic detail record: `{dynamic['detail_follow_up']['selected_nct_id']}`",
+        f"- Search/detail ID match: "
+        f"**{str(dynamic['detail_follow_up']['identifier_matches_search']).lower()}**",
+        "",
+        "Both operations are reviewed HTTPS GET contracts with exact argument "
+        "mappings, bounded schemas, no credentials, zero redirects, pinned public "
+        "destinations, response limits, and operation/payload hashes.",
+        "",
+        "## 4. Demand-Driven API Discovery",
+        "",
+        f"- Demand query: `{discovery['query']}`",
+        f"- Catalog matches: **{discovery['catalog_result_count']}**",
+        f"- Candidates reviewed: **{discovery['returned_candidate_count']}**",
+        f"- Selected dataset: **{selected['name']}** (`{selected['dataset_id']}`)",
+        f"- Proposed endpoint: `{selected['api_endpoint']}`",
+        f"- Required fields present: **{len(REQUIRED_DISCOVERY_FIELDS)}/"
+        f"{len(REQUIRED_DISCOVERY_FIELDS)}**",
+        f"- Execution allowed before review: **{str(selected['execution_allowed']).lower()}**",
+        f"- Selection rule: {discovery['selection_rule']}",
+        "",
+        "## 5. Promotion And Fresh Runtime",
+        "",
+        "| Tool | Required filter | Verification rows | Runtime query | Runtime rows |",
+        "| --- | --- | --- | --- | ---: |",
+    ]
+    for item, runtime in zip(
+        promotion["promotions"], promotion["runtime_checks"], strict=True
+    ):
+        verification_rows = ", ".join(str(case["row_count"]) for case in item["cases"])
+        argument = next(iter(runtime["arguments"].items()))
+        lines.append(
+            f"| `{item['tool_name']}` | `{item['filter_field']}` | "
+            f"{verification_rows} | `{argument[0]}={argument[1]}` | "
+            f"{runtime['row_count']} |"
+        )
+    lines.extend(
+        [
+            "",
+            f"- Live verification cases: **{promotion['verification_case_count']}**",
+            f"- Promoted tools present before explicit load: "
+            f"**{len(promotion['promoted_tools_present_before_explicit_load'])}**",
+            "- Explicitly loaded publications: "
+            + ", ".join(f"`{name}`" for name in promotion["loaded_tools"]),
+            "",
+            "Every draft, verification result, approval, and publication is bound "
+            "to the preceding SHA-256 records. Loading is a separate explicit call; "
+            "discovery alone never executes or publishes a candidate.",
+            "",
+            "## End-to-End Assertions",
+            "",
+            "| Assertion | Result |",
+            "| --- | --- |",
+        ]
+    )
+    for name, passed in sorted(snapshot["end_to_end_assertions"].items()):
+        lines.append(f"| `{name}` | {'PASS' if passed else 'FAIL'} |")
+    lines.extend(
+        [
+            "",
+            "## Reproducibility And Audit Chain",
+            "",
+            f"- End-to-end evidence-chain SHA-256: `{snapshot['audit_chain']['sha256']}`",
+            f"- Generated at: `{snapshot['generated_at']}`",
+            "- The JSON artifact contains provider payload hashes, reviewed operation "
+            "hashes, promotion hashes, exact arguments, bounded samples, and every "
+            "assertion used to accept the run.",
+            "",
+            "## Interpretation Boundary",
+            "",
+            snapshot["interpretation_boundary"],
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_artifacts(
+    snapshot: dict[str, Any], output_json: Path, output_markdown: Path
+) -> tuple[Path, Path]:
+    validate_snapshot(snapshot)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_markdown.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    output_markdown.write_text(render_markdown(snapshot), encoding="utf-8")
+    return output_json, output_markdown
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace", type=Path, default=DEFAULT_WORKSPACE)
+    parser.add_argument("--output-json", type=Path, default=DEFAULT_JSON)
+    parser.add_argument("--output-markdown", type=Path, default=DEFAULT_MARKDOWN)
+    arguments = parser.parse_args(argv)
+    snapshot = run_case(workspace=arguments.workspace)
+    write_artifacts(snapshot, arguments.output_json, arguments.output_markdown)
+    print(
+        json.dumps(
+            {
+                "assertions_passed": sum(snapshot["end_to_end_assertions"].values()),
+                "audit_chain_sha256": snapshot["audit_chain"]["sha256"],
+                "loaded_tools": snapshot["reviewed_promotion"]["loaded_tools"],
+                "output_json": str(arguments.output_json),
+                "output_markdown": str(arguments.output_markdown),
+                "verification_cases": snapshot["reviewed_promotion"][
+                    "verification_case_count"
+                ],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/vsd/tool_promotion_cancer_case_study.py
+++ b/examples/vsd/tool_promotion_cancer_case_study.py
@@ -1,0 +1,290 @@
+"""Promote two narrow tools from one discovered cancer-trial data source."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from tooluniverse import ToolUniverse
+from tooluniverse.vsd_promotion import (
+    approve_draft,
+    create_draft,
+    list_promotion_state,
+    load_published_tools,
+    publish_draft,
+    verify_draft,
+)
+
+HERE = Path(__file__).resolve().parent
+ARTIFACTS = HERE / "artifacts"
+DISCOVERY_SNAPSHOT = ARTIFACTS / "api_discovery_snapshot.json"
+DEFAULT_WORKSPACE = ARTIFACTS / "promotion_workspace"
+DEFAULT_JSON = ARTIFACTS / "tool_promotion_snapshot.json"
+DEFAULT_MARKDOWN = ARTIFACTS / "tool_promotion_snapshot.md"
+RETURN_FIELDS = [
+    "date_opened",
+    "protocol",
+    "primary_site",
+    "study_phase",
+    "title",
+    "date_closed",
+    "principal_investigator",
+]
+DISCLAIMER = (
+    "This validates software contracts and live retrieval, not trial quality, "
+    "clinical relevance, or scientific conclusions."
+)
+
+
+def _verification_cases(field: str, values: list[str]) -> list[dict[str, Any]]:
+    return [
+        {
+            "arguments": {field: value},
+            "expect": {
+                "min_items": 1,
+                "max_items": 25,
+                "required_fields": ["protocol", "title", field],
+                "equals": {field: value},
+            },
+        }
+        for value in values
+    ]
+
+
+def _execute(tooluniverse: ToolUniverse, name: str, arguments: dict) -> dict:
+    result = tooluniverse.run_one_function(
+        {"name": name, "arguments": arguments}, use_cache=False
+    )
+    if not isinstance(result, dict) or result.get("status") != "success":
+        raise RuntimeError(f"Published tool execution failed: {result!r}")
+    return result["data"]
+
+
+def _markdown(snapshot: dict[str, Any]) -> str:
+    lines = [
+        "# Reviewed Tool Promotion: Cancer-Trial Case Study",
+        "",
+        "## Result",
+        "",
+        (
+            "One discovery candidate produced two distinct, narrow ToolUniverse "
+            "tools. Each tool passed three live provider cases, was approved against "
+            "the exact verification hash, was published atomically, loaded into a "
+            "fresh ToolUniverse instance, and executed again."
+        ),
+        "",
+        f"- Provider: `{snapshot['source']['api_endpoint']}`",
+        f"- Dataset: `{snapshot['source']['dataset_id']}`",
+        f"- Loaded tools: {', '.join(f'`{name}`' for name in snapshot['loaded_tools'])}",
+        f"- Boundary: {snapshot['interpretation_boundary']}",
+        "",
+        "## Promotion Evidence",
+        "",
+        "| Tool | Required filter | Verification cases | Rows observed | Operation hash |",
+        "| --- | --- | ---: | --- | --- |",
+    ]
+    for promotion in snapshot["promotions"]:
+        counts = ", ".join(str(case["row_count"]) for case in promotion["cases"])
+        lines.append(
+            f"| `{promotion['tool_name']}` | `{promotion['filter_field']}` | "
+            f"{promotion['case_count']} | {counts} | "
+            f"`{promotion['operation_sha256'][:16]}...` |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Fresh Runtime Check",
+            "",
+            "| Tool | Query | Rows | Payload hash |",
+            "| --- | --- | ---: | --- |",
+        ]
+    )
+    for check in snapshot["runtime_checks"]:
+        argument = next(iter(check["arguments"].items()))
+        lines.append(
+            f"| `{check['tool_name']}` | `{argument[0]}={argument[1]}` | "
+            f"{check['row_count']} | `{check['payload_sha256'][:16]}...` |"
+        )
+    lines.extend(
+        [
+            "",
+            "## What This Proves",
+            "",
+            "1. Discovery metadata alone never executes and never enters the approved directory.",
+            "2. Generation converts reviewed fields into bounded GET contracts with mandatory filters.",
+            "3. Verification uses ToolUniverse itself and records counts, fields, timestamps, and hashes without storing entire provider responses.",
+            "4. Approval and publication fail if the draft, evidence, or approval chain changes.",
+            "5. Published tools are loaded only by an explicit call and cannot replace an existing tool.",
+            "",
+            "## Interpretation",
+            "",
+            DISCLAIMER,
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def run_case(
+    *, workspace: Path, output_json: Path, output_markdown: Path
+) -> dict[str, Any]:
+    discovery = json.loads(DISCOVERY_SNAPSHOT.read_text(encoding="utf-8"))
+    candidate = discovery["analysis"]["selected_candidate"]
+    specs = [
+        {
+            "tool_name": "VSDGeneratedCancerTrialsBySite",
+            "description": (
+                "Query the reviewed Roswell Park active cancer-trial dataset by "
+                "exact primary cancer site."
+            ),
+            "filter_field": "primary_site",
+            "verification_values": [
+                "Brain and Nervous System",
+                "Breast",
+                "Prostate",
+            ],
+            "runtime_value": "Breast",
+        },
+        {
+            "tool_name": "VSDGeneratedCancerTrialsByPhase",
+            "description": (
+                "Query the reviewed Roswell Park active cancer-trial dataset by "
+                "exact study phase."
+            ),
+            "filter_field": "study_phase",
+            "verification_values": ["I", "II", "III"],
+            "runtime_value": "III",
+        },
+    ]
+    promotions = []
+    for spec in specs:
+        draft = create_draft(
+            candidate,
+            tool_name=spec["tool_name"],
+            description=spec["description"],
+            filter_fields=[spec["filter_field"]],
+            return_fields=RETURN_FIELDS,
+            max_records=25,
+            workspace=workspace,
+        )
+        evidence = verify_draft(
+            draft["draft_id"],
+            _verification_cases(spec["filter_field"], spec["verification_values"]),
+            workspace=workspace,
+        )
+        approval = approve_draft(
+            draft["draft_id"],
+            reviewed_by="SufianTA",
+            decision_note=(
+                "Technical approval after contract review and three live provider "
+                "cases; this is not a scientific or clinical endorsement."
+            ),
+            workspace=workspace,
+        )
+        publication = publish_draft(
+            draft["draft_id"], workspace=workspace, replace=True
+        )
+        promotions.append(
+            {
+                "tool_name": spec["tool_name"],
+                "filter_field": spec["filter_field"],
+                "draft_id": draft["draft_id"],
+                "draft_sha256": draft["draft_sha256"],
+                "operation_sha256": draft["operation_sha256"],
+                "verification_sha256": evidence["verification_sha256"],
+                "approval_sha256": approval["approval_sha256"],
+                "publication_sha256": publication["publication_sha256"],
+                "case_count": evidence["case_count"],
+                "cases": evidence["cases"],
+            }
+        )
+
+    runtime_workspace = workspace / ".runtime"
+    tooluniverse = ToolUniverse(
+        tool_files={}, keep_default_tools=False, workspace=str(runtime_workspace)
+    )
+    try:
+        loaded = load_published_tools(tooluniverse, workspace=workspace)
+        runtime_checks = []
+        for spec in specs:
+            arguments = {spec["filter_field"]: spec["runtime_value"]}
+            data = _execute(tooluniverse, spec["tool_name"], arguments)
+            rows = data["result"]
+            if any(
+                row.get(spec["filter_field"]) != spec["runtime_value"] for row in rows
+            ):
+                raise RuntimeError("Fresh runtime result violated its exact filter")
+            runtime_checks.append(
+                {
+                    "tool_name": spec["tool_name"],
+                    "arguments": arguments,
+                    "row_count": len(rows),
+                    "payload_sha256": data["provenance"]["payload_sha256"],
+                    "operation_sha256": data["provenance"]["operation_sha256"],
+                    "retrieved_at": data["provenance"]["retrieved_at"],
+                    "sample_rows": rows[:3],
+                }
+            )
+    finally:
+        tooluniverse.close()
+
+    snapshot = {
+        "case": "one_discovered_source_to_two_reviewed_cancer_trial_tools",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source": {
+            "candidate_id": candidate["candidate_id"],
+            "catalog_domain": candidate["catalog_domain"],
+            "dataset_id": candidate["dataset_id"],
+            "api_endpoint": candidate["api_endpoint"],
+            "dataset_updated_at": candidate.get("updated_at"),
+        },
+        "promotions": promotions,
+        "loaded_tools": loaded,
+        "runtime_checks": runtime_checks,
+        "promotion_state": list_promotion_state(workspace=workspace),
+        "interpretation_boundary": DISCLAIMER,
+    }
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    output_markdown.write_text(_markdown(snapshot), encoding="utf-8")
+    return snapshot
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace", type=Path, default=DEFAULT_WORKSPACE)
+    parser.add_argument("--output-json", type=Path, default=DEFAULT_JSON)
+    parser.add_argument("--output-markdown", type=Path, default=DEFAULT_MARKDOWN)
+    args = parser.parse_args()
+    snapshot = run_case(
+        workspace=args.workspace,
+        output_json=args.output_json,
+        output_markdown=args.output_markdown,
+    )
+    print(
+        json.dumps(
+            {
+                "loaded_tools": snapshot["loaded_tools"],
+                "verification_cases": sum(
+                    item["case_count"] for item in snapshot["promotions"]
+                ),
+                "runtime_rows": [
+                    item["row_count"] for item in snapshot["runtime_checks"]
+                ],
+                "output_json": str(args.output_json),
+                "output_markdown": str(args.output_markdown),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ tu-datastore = "tooluniverse.database_setup.cli:main"
 # Health Check Tool
 tooluniverse-doctor = "tooluniverse.doctor:main"
 tooluniverse-vsd-admin = "tooluniverse.vsd_admin_cli:main"
+tooluniverse-vsd-promote = "tooluniverse.vsd_promotion_cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/tooluniverse/vsd_promotion.py
+++ b/src/tooluniverse/vsd_promotion.py
@@ -1,0 +1,752 @@
+"""Administrator-reviewed draft, verification, approval, and publication flow."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+from urllib.parse import urlsplit
+
+from .execute_function import ToolUniverse
+from .vsd_dynamic_rest import (
+    VSDDynamicRESTError,
+    operation_digest,
+    register_reviewed_rest_tool,
+)
+from .vsd_tool import _acquire_process_lock, _release_process_lock
+
+_PROMOTION_VERSION = 1
+_GENERATOR_VERSION = 1
+_MAX_FILE_BYTES = 1_000_000
+_MAX_PUBLISHED_TOOLS = 100
+_TOOL_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,44}$")
+_DRAFT_ID_RE = re.compile(r"^[a-z][a-z0-9_]{2,127}_[0-9a-f]{12}$")
+_FIELD_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+_DATASET_ID_RE = re.compile(r"^[a-z0-9]{4}-[a-z0-9]{4}$")
+_PROMOTION_LOCK = threading.RLock()
+
+
+class VSDPromotionError(ValueError):
+    """Raised when an artifact cannot cross a promotion boundary."""
+
+
+def _root(workspace: str | Path | None = None) -> Path:
+    if workspace is not None:
+        root = Path(workspace).expanduser()
+    else:
+        configured = os.environ.get("TOOLUNIVERSE_VSD_DIR")
+        root = (
+            Path(configured).expanduser()
+            if configured
+            else Path.home() / ".tooluniverse" / "vsd"
+        )
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+@contextmanager
+def _promotion_transaction(root: Path) -> Iterator[None]:
+    with _PROMOTION_LOCK:
+        lock_path = root / ".promotion.lock"
+        with lock_path.open("a+b") as handle:
+            if handle.seek(0, os.SEEK_END) == 0:
+                handle.write(b"\0")
+                handle.flush()
+            _acquire_process_lock(handle)
+            try:
+                yield
+            finally:
+                _release_process_lock(handle)
+
+
+def _atomic_write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+    if len(encoded.encode("utf-8")) > _MAX_FILE_BYTES:
+        raise VSDPromotionError("Promotion artifact exceeds the 1 MB limit")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.stem}_", suffix=".json", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary_path, 0o600)
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        if path.stat().st_size > _MAX_FILE_BYTES:
+            raise VSDPromotionError(f"Artifact {path.name!r} exceeds the size limit")
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise VSDPromotionError(
+            f"Required artifact {path.name!r} does not exist"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise VSDPromotionError(f"Artifact {path.name!r} is not valid JSON") from exc
+
+
+def _canonical_digest(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _draft_id(value: str) -> str:
+    if not isinstance(value, str) or not _DRAFT_ID_RE.fullmatch(value):
+        raise VSDPromotionError("draft_id is not valid")
+    return value
+
+
+def _tool_name(value: Any) -> str:
+    if not isinstance(value, str) or not _TOOL_NAME_RE.fullmatch(value):
+        raise VSDPromotionError("tool_name must be a stable identifier")
+    return value
+
+
+def _review_text(value: Any, *, field: str, minimum: int, maximum: int) -> str:
+    text = str(value or "").strip()
+    if not minimum <= len(text) <= maximum:
+        raise VSDPromotionError(f"{field} must contain {minimum}-{maximum} characters")
+    if any(ord(character) < 32 for character in text):
+        raise VSDPromotionError(f"{field} contains control characters")
+    return text
+
+
+def _candidate_fields(candidate: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    fields = candidate.get("fields")
+    if not isinstance(fields, list) or not 1 <= len(fields) <= 50:
+        raise VSDPromotionError("Candidate must contain 1-50 field definitions")
+    indexed: dict[str, dict[str, Any]] = {}
+    for field in fields:
+        if not isinstance(field, dict):
+            raise VSDPromotionError("Candidate field definitions must be objects")
+        name = field.get("field")
+        if (
+            not isinstance(name, str)
+            or not _FIELD_RE.fullmatch(name)
+            or name in indexed
+        ):
+            raise VSDPromotionError("Candidate field names must be unique identifiers")
+        json_type = field.get("json_type")
+        if json_type not in {"boolean", "number", "object", "string"}:
+            raise VSDPromotionError(f"Candidate field {name!r} has an unsupported type")
+        indexed[name] = field
+    return indexed
+
+
+def _validated_candidate(
+    candidate: Any,
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    if not isinstance(candidate, dict):
+        raise VSDPromotionError("candidate must be an object")
+    if (
+        candidate.get("approval_state") != "unreviewed_candidate"
+        or candidate.get("execution_allowed") is not False
+        or candidate.get("metadata_trust") != "untrusted_catalog_metadata"
+    ):
+        raise VSDPromotionError("candidate did not come from the discovery boundary")
+    endpoint = candidate.get("api_endpoint")
+    if not isinstance(endpoint, str):
+        raise VSDPromotionError("candidate API endpoint is missing")
+    parsed = urlsplit(endpoint)
+    dataset_id = candidate.get("dataset_id")
+    catalog_domain = candidate.get("catalog_domain")
+    if (
+        parsed.scheme != "https"
+        or parsed.query
+        or parsed.fragment
+        or parsed.username
+        or parsed.password
+        or parsed.hostname != catalog_domain
+        or not isinstance(dataset_id, str)
+        or not _DATASET_ID_RE.fullmatch(dataset_id)
+        or parsed.path != f"/resource/{dataset_id}.json"
+    ):
+        raise VSDPromotionError(
+            "candidate endpoint does not match its catalog identity"
+        )
+    candidate_id = candidate.get("candidate_id")
+    expected_id = hashlib.sha256(endpoint.encode("utf-8")).hexdigest()[:16]
+    if candidate_id != expected_id:
+        raise VSDPromotionError("candidate ID does not match its endpoint")
+    return candidate, _candidate_fields(candidate)
+
+
+def _field_schema(field: dict[str, Any]) -> dict[str, Any]:
+    provider_type = field.get("provider_type")
+    if provider_type in {"Money", "Number"}:
+        schema: dict[str, Any] = {
+            "type": "string",
+            "pattern": r"^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$",
+            "maxLength": 256,
+        }
+    else:
+        schema = {"type": field["json_type"]}
+    description = str(field.get("description") or field.get("label") or "").strip()
+    if description:
+        schema["description"] = description[:300]
+    if schema["type"] == "string":
+        schema.setdefault("maxLength", 500)
+    return schema
+
+
+def build_socrata_tool_config(
+    candidate: dict[str, Any],
+    *,
+    tool_name: str,
+    description: str,
+    filter_fields: list[str],
+    return_fields: list[str],
+    max_records: int = 25,
+) -> dict[str, Any]:
+    """Generate one narrow, read-only draft from a discovered Socrata dataset."""
+    candidate, fields = _validated_candidate(candidate)
+    name = _tool_name(tool_name)
+    reviewed_description = _review_text(
+        description, field="description", minimum=20, maximum=1000
+    )
+    if (
+        not isinstance(filter_fields, list)
+        or not 1 <= len(filter_fields) <= 8
+        or len(filter_fields) != len(set(filter_fields))
+    ):
+        raise VSDPromotionError("filter_fields must contain 1-8 unique fields")
+    if (
+        not isinstance(return_fields, list)
+        or not 1 <= len(return_fields) <= 20
+        or len(return_fields) != len(set(return_fields))
+    ):
+        raise VSDPromotionError("return_fields must contain 1-20 unique fields")
+    unknown = (set(filter_fields) | set(return_fields)) - set(fields)
+    if unknown:
+        raise VSDPromotionError(f"Unknown candidate fields: {sorted(unknown)!r}")
+    non_scalar_filters = [
+        field for field in filter_fields if fields[field]["json_type"] == "object"
+    ]
+    if non_scalar_filters:
+        raise VSDPromotionError(
+            f"Object-valued fields cannot be direct filters: {non_scalar_filters!r}"
+        )
+    if (
+        isinstance(max_records, bool)
+        or not isinstance(max_records, int)
+        or not 1 <= max_records <= 100
+    ):
+        raise VSDPromotionError("max_records must be an integer between 1 and 100")
+
+    properties = {field: _field_schema(fields[field]) for field in filter_fields}
+    response_properties = {
+        field: _field_schema(fields[field]) for field in return_fields
+    }
+    return {
+        "name": name,
+        "type": "VSDDynamicRESTTool",
+        "description": reviewed_description,
+        "category": "special_tools",
+        "cacheable": False,
+        "mcp_annotations": {"readOnlyHint": True, "destructiveHint": False},
+        "parameter": {
+            "type": "object",
+            "properties": properties,
+            "required": list(filter_fields),
+            "additionalProperties": False,
+        },
+        "return_schema": {
+            "type": "object",
+            "properties": {
+                "result": {"type": "array"},
+                "provenance": {"type": "object"},
+            },
+            "required": ["result", "provenance"],
+            "additionalProperties": False,
+        },
+        "vsd_operation": {
+            "version": 1,
+            "method": "GET",
+            "endpoint": candidate["api_endpoint"],
+            "path_arguments": {},
+            "query_arguments": {field: field for field in filter_fields},
+            "fixed_query": {
+                "$limit": max_records,
+                "$select": ",".join(return_fields),
+            },
+            "timeout_seconds": 20,
+            "auth": {"type": "none"},
+            "response_schema": {
+                "type": "array",
+                "maxItems": max_records,
+                "items": {
+                    "type": "object",
+                    "properties": response_properties,
+                    "additionalProperties": False,
+                },
+            },
+        },
+        "vsd_promotion": {
+            "generator_version": _GENERATOR_VERSION,
+            "candidate_id": candidate["candidate_id"],
+            "catalog_domain": candidate["catalog_domain"],
+            "dataset_id": candidate["dataset_id"],
+            "dataset_updated_at": candidate.get("updated_at"),
+            "filter_fields": list(filter_fields),
+            "return_fields": list(return_fields),
+            "max_records": max_records,
+        },
+    }
+
+
+def create_draft(
+    candidate: dict[str, Any],
+    *,
+    tool_name: str,
+    description: str,
+    filter_fields: list[str],
+    return_fields: list[str],
+    max_records: int = 25,
+    workspace: str | Path | None = None,
+) -> dict[str, Any]:
+    """Create a content-addressed draft without making it executable."""
+    config = build_socrata_tool_config(
+        candidate,
+        tool_name=tool_name,
+        description=description,
+        filter_fields=filter_fields,
+        return_fields=return_fields,
+        max_records=max_records,
+    )
+    digest = operation_digest(config)
+    slug = re.sub(r"[^a-z0-9]+", "_", config["name"].casefold()).strip("_")
+    draft_id = f"{slug}_{digest[:12]}"
+    record_body = {
+        "version": _PROMOTION_VERSION,
+        "draft_id": draft_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "operation_sha256": digest,
+        "state": "draft",
+        "config": config,
+    }
+    record = {**record_body, "draft_sha256": _canonical_digest(record_body)}
+    root = _root(workspace)
+    path = root / "drafts" / f"{draft_id}.json"
+    with _promotion_transaction(root):
+        if path.exists():
+            existing = _read_json(path)
+            if (
+                existing.get("operation_sha256") != digest
+                or existing.get("config") != config
+            ):
+                raise VSDPromotionError(
+                    "Existing draft does not match generated content"
+                )
+            return existing
+        _atomic_write_json(path, record)
+    return record
+
+
+def _load_draft(root: Path, draft_id: str) -> dict[str, Any]:
+    record = _read_json(root / "drafts" / f"{_draft_id(draft_id)}.json")
+    if (
+        not isinstance(record, dict)
+        or record.get("version") != _PROMOTION_VERSION
+        or record.get("draft_id") != draft_id
+        or not isinstance(record.get("config"), dict)
+    ):
+        raise VSDPromotionError("Draft artifact has an unsupported structure")
+    try:
+        digest = operation_digest(record["config"])
+    except VSDDynamicRESTError as exc:
+        raise VSDPromotionError("Draft operation contract is invalid") from exc
+    if record.get("operation_sha256") != digest:
+        raise VSDPromotionError("Draft operation digest does not match its content")
+    body = {key: value for key, value in record.items() if key != "draft_sha256"}
+    if record.get("draft_sha256") != _canonical_digest(body):
+        raise VSDPromotionError("Draft artifact digest does not match its content")
+    return record
+
+
+def _validated_cases(cases: Any) -> list[dict[str, Any]]:
+    if not isinstance(cases, list) or not 3 <= len(cases) <= 20:
+        raise VSDPromotionError("Verification requires 3-20 cases")
+    validated = []
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict) or not isinstance(case.get("arguments"), dict):
+            raise VSDPromotionError(f"Verification case {index} requires arguments")
+        expect = case.get("expect")
+        if not isinstance(expect, dict):
+            raise VSDPromotionError(f"Verification case {index} requires expectations")
+        minimum = expect.get("min_items")
+        maximum = expect.get("max_items")
+        fields = expect.get("required_fields")
+        equals = expect.get("equals", {})
+        if (
+            isinstance(minimum, bool)
+            or not isinstance(minimum, int)
+            or minimum < 0
+            or isinstance(maximum, bool)
+            or not isinstance(maximum, int)
+            or maximum < minimum
+            or maximum > 100
+            or not isinstance(fields, list)
+            or not fields
+            or any(
+                not isinstance(field, str) or not _FIELD_RE.fullmatch(field)
+                for field in fields
+            )
+            or not isinstance(equals, dict)
+            or any(
+                not isinstance(field, str) or not _FIELD_RE.fullmatch(field)
+                for field in equals
+            )
+        ):
+            raise VSDPromotionError(
+                f"Verification case {index} has invalid expectations"
+            )
+        validated.append(
+            {
+                "arguments": dict(case["arguments"]),
+                "expect": {
+                    "min_items": minimum,
+                    "max_items": maximum,
+                    "required_fields": list(fields),
+                    "equals": dict(equals),
+                },
+            }
+        )
+    return validated
+
+
+def verify_draft(
+    draft_id: str,
+    cases: list[dict[str, Any]],
+    *,
+    workspace: str | Path | None = None,
+) -> dict[str, Any]:
+    """Execute a draft in an isolated verifier and persist bounded evidence."""
+    root = _root(workspace)
+    with _promotion_transaction(root):
+        draft = _load_draft(root, draft_id)
+    verified_cases = _validated_cases(cases)
+    tooluniverse = ToolUniverse()
+    try:
+        name = register_reviewed_rest_tool(tooluniverse, draft["config"])
+        results = []
+        for index, case in enumerate(verified_cases):
+            response = tooluniverse.run_one_function(
+                {"name": name, "arguments": case["arguments"]}, use_cache=False
+            )
+            if not isinstance(response, dict) or response.get("status") != "success":
+                raise VSDPromotionError(
+                    f"Verification case {index} did not execute successfully: {response!r}"
+                )
+            envelope = response.get("data")
+            rows = envelope.get("result") if isinstance(envelope, dict) else None
+            provenance = (
+                envelope.get("provenance") if isinstance(envelope, dict) else None
+            )
+            if not isinstance(rows, list) or not isinstance(provenance, dict):
+                raise VSDPromotionError(
+                    f"Verification case {index} returned an invalid evidence envelope"
+                )
+            expectation = case["expect"]
+            if (
+                provenance.get("operation_sha256") != draft["operation_sha256"]
+                or provenance.get("http_status") != 200
+                or provenance.get("redirects") != 0
+                or not re.fullmatch(
+                    r"[0-9a-f]{64}", str(provenance.get("payload_sha256", ""))
+                )
+            ):
+                raise VSDPromotionError(
+                    f"Verification case {index} returned invalid provenance"
+                )
+            if not expectation["min_items"] <= len(rows) <= expectation["max_items"]:
+                raise VSDPromotionError(
+                    f"Verification case {index} returned {len(rows)} rows outside "
+                    f"{expectation['min_items']}..{expectation['max_items']}"
+                )
+            for row_index, row in enumerate(rows):
+                if not isinstance(row, dict):
+                    raise VSDPromotionError(
+                        f"Verification case {index} row {row_index} is not an object"
+                    )
+                missing = [
+                    field
+                    for field in expectation["required_fields"]
+                    if not row.get(field)
+                ]
+                if missing:
+                    raise VSDPromotionError(
+                        f"Verification case {index} row {row_index} lacks values for {missing!r}"
+                    )
+                mismatched = {
+                    field: row.get(field)
+                    for field, expected in expectation["equals"].items()
+                    if row.get(field) != expected
+                }
+                if mismatched:
+                    raise VSDPromotionError(
+                        f"Verification case {index} row {row_index} failed equality assertions"
+                    )
+            results.append(
+                {
+                    "case_index": index,
+                    "arguments": case["arguments"],
+                    "expect": expectation,
+                    "row_count": len(rows),
+                    "observed_fields": sorted(
+                        {
+                            field
+                            for row in rows
+                            if isinstance(row, dict)
+                            for field in row
+                        }
+                    ),
+                    "payload_sha256": provenance.get("payload_sha256"),
+                    "operation_sha256": provenance.get("operation_sha256"),
+                    "retrieved_at": provenance.get("retrieved_at"),
+                    "http_status": provenance.get("http_status"),
+                    "redirects": provenance.get("redirects"),
+                }
+            )
+    finally:
+        tooluniverse.close()
+
+    evidence_body = {
+        "version": _PROMOTION_VERSION,
+        "draft_id": draft_id,
+        "tool_name": draft["config"]["name"],
+        "draft_sha256": draft["draft_sha256"],
+        "operation_sha256": draft["operation_sha256"],
+        "verified_at": datetime.now(timezone.utc).isoformat(),
+        "case_count": len(results),
+        "all_cases_passed": True,
+        "cases": results,
+    }
+    evidence = {
+        **evidence_body,
+        "verification_sha256": _canonical_digest(evidence_body),
+    }
+    with _promotion_transaction(root):
+        current = _load_draft(root, draft_id)
+        if current["operation_sha256"] != evidence["operation_sha256"]:
+            raise VSDPromotionError("Draft changed during verification")
+        _atomic_write_json(root / "evidence" / f"{draft_id}.json", evidence)
+    return evidence
+
+
+def _load_evidence(root: Path, draft: dict[str, Any]) -> dict[str, Any]:
+    evidence = _read_json(root / "evidence" / f"{draft['draft_id']}.json")
+    if (
+        not isinstance(evidence, dict)
+        or evidence.get("operation_sha256") != draft["operation_sha256"]
+        or evidence.get("draft_sha256") != draft["draft_sha256"]
+        or evidence.get("all_cases_passed") is not True
+        or not isinstance(evidence.get("cases"), list)
+        or evidence.get("case_count") != len(evidence["cases"])
+        or evidence["case_count"] < 3
+    ):
+        raise VSDPromotionError("Verification evidence does not match the draft")
+    body = {
+        key: value for key, value in evidence.items() if key != "verification_sha256"
+    }
+    if evidence.get("verification_sha256") != _canonical_digest(body):
+        raise VSDPromotionError(
+            "Verification evidence digest does not match its content"
+        )
+    return evidence
+
+
+def approve_draft(
+    draft_id: str,
+    *,
+    reviewed_by: str,
+    decision_note: str,
+    workspace: str | Path | None = None,
+) -> dict[str, Any]:
+    """Record explicit administrative approval of exact draft and evidence hashes."""
+    reviewer = _review_text(reviewed_by, field="reviewed_by", minimum=2, maximum=100)
+    note = _review_text(decision_note, field="decision_note", minimum=20, maximum=1000)
+    root = _root(workspace)
+    with _promotion_transaction(root):
+        draft = _load_draft(root, draft_id)
+        evidence = _load_evidence(root, draft)
+        approval_body = {
+            "version": _PROMOTION_VERSION,
+            "draft_id": draft_id,
+            "tool_name": draft["config"]["name"],
+            "decision": "approved",
+            "reviewed_by": reviewer,
+            "decision_note": note,
+            "approved_at": datetime.now(timezone.utc).isoformat(),
+            "draft_sha256": draft["draft_sha256"],
+            "operation_sha256": draft["operation_sha256"],
+            "verification_sha256": evidence["verification_sha256"],
+        }
+        approval = {
+            **approval_body,
+            "approval_sha256": _canonical_digest(approval_body),
+        }
+        _atomic_write_json(root / "approvals" / f"{draft_id}.json", approval)
+    return approval
+
+
+def _load_approval(
+    root: Path, draft: dict[str, Any], evidence: dict[str, Any]
+) -> dict[str, Any]:
+    approval = _read_json(root / "approvals" / f"{draft['draft_id']}.json")
+    if (
+        not isinstance(approval, dict)
+        or approval.get("decision") != "approved"
+        or approval.get("operation_sha256") != draft["operation_sha256"]
+        or approval.get("draft_sha256") != draft["draft_sha256"]
+        or approval.get("verification_sha256") != evidence["verification_sha256"]
+    ):
+        raise VSDPromotionError("Approval does not match the draft and verification")
+    body = {key: value for key, value in approval.items() if key != "approval_sha256"}
+    if approval.get("approval_sha256") != _canonical_digest(body):
+        raise VSDPromotionError("Approval digest does not match its content")
+    return approval
+
+
+def publish_draft(
+    draft_id: str,
+    *,
+    workspace: str | Path | None = None,
+    replace: bool = False,
+) -> dict[str, Any]:
+    """Atomically publish an approved record without loading or executing it."""
+    if type(replace) is not bool:
+        raise VSDPromotionError("replace must be a boolean")
+    root = _root(workspace)
+    with _promotion_transaction(root):
+        draft = _load_draft(root, draft_id)
+        evidence = _load_evidence(root, draft)
+        approval = _load_approval(root, draft, evidence)
+        tool_name = _tool_name(draft["config"]["name"])
+        published_body = {
+            "version": _PROMOTION_VERSION,
+            "tool_name": tool_name,
+            "draft_id": draft_id,
+            "published_at": datetime.now(timezone.utc).isoformat(),
+            "draft_sha256": draft["draft_sha256"],
+            "operation_sha256": draft["operation_sha256"],
+            "verification_sha256": evidence["verification_sha256"],
+            "approval_sha256": approval["approval_sha256"],
+            "reviewed_by": approval["reviewed_by"],
+            "decision_note": approval["decision_note"],
+            "config": draft["config"],
+        }
+        published = {
+            **published_body,
+            "publication_sha256": _canonical_digest(published_body),
+        }
+        path = root / "approved" / f"{tool_name}.json"
+        if path.exists() and not replace:
+            raise VSDPromotionError(
+                f"Published tool {tool_name!r} already exists; set replace=true explicitly"
+            )
+        if path.exists():
+            existing = _read_json(path)
+            if existing.get("tool_name") != tool_name:
+                raise VSDPromotionError("Published filename collides with another tool")
+        _atomic_write_json(path, published)
+    return published
+
+
+def _validated_publication(record: Any) -> dict[str, Any]:
+    if not isinstance(record, dict) or record.get("version") != _PROMOTION_VERSION:
+        raise VSDPromotionError("Published record has an unsupported structure")
+    tool_name = _tool_name(record.get("tool_name"))
+    _draft_id(record.get("draft_id"))
+    for field in (
+        "operation_sha256",
+        "draft_sha256",
+        "verification_sha256",
+        "approval_sha256",
+        "publication_sha256",
+    ):
+        if not re.fullmatch(r"[0-9a-f]{64}", str(record.get(field, ""))):
+            raise VSDPromotionError(f"Published {field} is invalid")
+    config = record.get("config")
+    if not isinstance(config, dict) or config.get("name") != tool_name:
+        raise VSDPromotionError("Published tool name does not match its configuration")
+    try:
+        digest = operation_digest(config)
+    except VSDDynamicRESTError as exc:
+        raise VSDPromotionError("Published operation contract is invalid") from exc
+    if digest != record.get("operation_sha256"):
+        raise VSDPromotionError("Published operation digest does not match")
+    body = {key: value for key, value in record.items() if key != "publication_sha256"}
+    if record.get("publication_sha256") != _canonical_digest(body):
+        raise VSDPromotionError("Publication digest does not match its content")
+    return record
+
+
+def load_published_tools(
+    tooluniverse,
+    *,
+    workspace: str | Path | None = None,
+) -> list[str]:
+    """Explicitly load valid published records into one ToolUniverse instance."""
+    root = _root(workspace)
+    approved = root / "approved"
+    paths = sorted(approved.glob("*.json")) if approved.exists() else []
+    if len(paths) > _MAX_PUBLISHED_TOOLS:
+        raise VSDPromotionError("Approved tool count exceeds the configured limit")
+    records = [_validated_publication(_read_json(path)) for path in paths]
+    names = [record["tool_name"] for record in records]
+    if len({name.casefold() for name in names}) != len(names):
+        raise VSDPromotionError(
+            "Published tool names contain a case-insensitive collision"
+        )
+    for name in names:
+        if name in tooluniverse.all_tool_dict:
+            raise VSDPromotionError(
+                f"Published tool {name!r} would replace a loaded tool"
+            )
+    loaded: list[str] = []
+    for record in records:
+        name = record["tool_name"]
+        register_reviewed_rest_tool(tooluniverse, record["config"])
+        loaded.append(name)
+    return loaded
+
+
+def list_promotion_state(
+    *, workspace: str | Path | None = None
+) -> dict[str, list[str]]:
+    """List artifact identifiers without returning host filesystem paths."""
+    root = _root(workspace)
+    return {
+        directory: sorted(path.stem for path in (root / directory).glob("*.json"))
+        if (root / directory).exists()
+        else []
+        for directory in ("drafts", "evidence", "approvals", "approved")
+    }
+
+
+__all__ = [
+    "VSDPromotionError",
+    "approve_draft",
+    "build_socrata_tool_config",
+    "create_draft",
+    "list_promotion_state",
+    "load_published_tools",
+    "publish_draft",
+    "verify_draft",
+]

--- a/src/tooluniverse/vsd_promotion_cli.py
+++ b/src/tooluniverse/vsd_promotion_cli.py
@@ -1,0 +1,121 @@
+"""Explicit administration CLI for the VSD tool-promotion pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+from .vsd_promotion import (
+    approve_draft,
+    create_draft,
+    list_promotion_state,
+    publish_draft,
+    verify_draft,
+)
+
+
+def _json_file(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise argparse.ArgumentTypeError(f"Could not read JSON from {path}") from exc
+
+
+def _csv(value: str) -> list[str]:
+    fields = [item.strip() for item in value.split(",") if item.strip()]
+    if not fields:
+        raise argparse.ArgumentTypeError("Provide at least one comma-separated field")
+    return fields
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tooluniverse-vsd-promote",
+        description=(
+            "Generate, verify, approve, and publish read-only VSD tools. "
+            "These administrator operations are not agent-facing."
+        ),
+    )
+    parser.add_argument("--workspace", type=Path)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    draft = commands.add_parser("draft-socrata")
+    draft.add_argument("candidate_file", type=Path)
+    draft.add_argument("--tool-name", required=True)
+    draft.add_argument("--description", required=True)
+    draft.add_argument("--filter-fields", required=True, type=_csv)
+    draft.add_argument("--return-fields", required=True, type=_csv)
+    draft.add_argument("--max-records", type=int, default=25)
+
+    verify = commands.add_parser("verify")
+    verify.add_argument("draft_id")
+    verify.add_argument("cases_file", type=Path)
+
+    approve = commands.add_parser("approve")
+    approve.add_argument("draft_id")
+    approve.add_argument("--reviewed-by", required=True)
+    approve.add_argument("--decision-note", required=True)
+
+    publish = commands.add_parser("publish")
+    publish.add_argument("draft_id")
+    publish.add_argument("--replace", action="store_true")
+
+    commands.add_parser("list")
+    return parser
+
+
+def _execute(namespace: argparse.Namespace) -> Any:
+    workspace = namespace.workspace
+    if namespace.command == "draft-socrata":
+        candidate = _json_file(namespace.candidate_file)
+        if isinstance(candidate, dict) and "selected_candidate" in candidate:
+            candidate = candidate["selected_candidate"]
+        elif (
+            isinstance(candidate, dict)
+            and isinstance(candidate.get("analysis"), dict)
+            and "selected_candidate" in candidate["analysis"]
+        ):
+            candidate = candidate["analysis"]["selected_candidate"]
+        return create_draft(
+            candidate,
+            tool_name=namespace.tool_name,
+            description=namespace.description,
+            filter_fields=namespace.filter_fields,
+            return_fields=namespace.return_fields,
+            max_records=namespace.max_records,
+            workspace=workspace,
+        )
+    if namespace.command == "verify":
+        return verify_draft(
+            namespace.draft_id,
+            _json_file(namespace.cases_file),
+            workspace=workspace,
+        )
+    if namespace.command == "approve":
+        return approve_draft(
+            namespace.draft_id,
+            reviewed_by=namespace.reviewed_by,
+            decision_note=namespace.decision_note,
+            workspace=workspace,
+        )
+    if namespace.command == "publish":
+        return publish_draft(
+            namespace.draft_id,
+            replace=namespace.replace,
+            workspace=workspace,
+        )
+    if namespace.command == "list":
+        return list_promotion_state(workspace=workspace)
+    raise AssertionError(f"Unsupported command: {namespace.command}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    result = _execute(build_parser().parse_args(argv))
+    print(json.dumps(result, indent=2, sort_keys=True, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tooluniverse/vsd_tool.py
+++ b/src/tooluniverse/vsd_tool.py
@@ -64,6 +64,7 @@ _BUILTIN_ALLOWED_HOSTS = frozenset(
         "api.us.socrata.com",
         "chronicdata.cdc.gov",
         "clinicaltrials.gov",
+        "data.ny.gov",
         "data.cdc.gov",
         "eutils.ncbi.nlm.nih.gov",
         "ghoapi.azureedge.net",

--- a/tests/unit/test_vsd_api_discovery_case_study.py
+++ b/tests/unit/test_vsd_api_discovery_case_study.py
@@ -15,7 +15,9 @@ pytestmark = pytest.mark.unit
 MODULE_PATH = (
     Path(__file__).parents[2] / "examples" / "vsd" / "api_discovery_case_study.py"
 )
-SPEC = importlib.util.spec_from_file_location("vsd_api_discovery_case_study", MODULE_PATH)
+SPEC = importlib.util.spec_from_file_location(
+    "vsd_api_discovery_case_study", MODULE_PATH
+)
 assert SPEC and SPEC.loader
 study = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = study

--- a/tests/unit/test_vsd_complete_pipeline_case_study.py
+++ b/tests/unit/test_vsd_complete_pipeline_case_study.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tooluniverse import vsd_discovery, vsd_dynamic_rest, vsd_tool
+
+pytestmark = pytest.mark.unit
+
+
+MODULE_PATH = (
+    Path(__file__).parents[2] / "examples" / "vsd" / "complete_pipeline_case_study.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "vsd_complete_pipeline_case_study", MODULE_PATH
+)
+assert SPEC and SPEC.loader
+study = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = study
+SPEC.loader.exec_module(study)
+
+
+def _request(url: str, payload: object) -> dict:
+    return {
+        "url": url,
+        "status_code": 200,
+        "content_type": "application/json",
+        "response_bytes": len(json.dumps(payload)),
+        "peer_ip": "8.8.8.8",
+        "redirects": 0,
+    }
+
+
+def _label_payload() -> dict:
+    return {
+        "meta": {"results": {"total": 14}},
+        "results": [
+            {
+                "set_id": "1e6ff055-590c-41e6-9530-1fdf04cdbd02",
+                "effective_time": "20211129",
+                "warnings": ["Reviewed warning section"],
+                "openfda": {
+                    "brand_name": ["SOLTAMOX"],
+                    "generic_name": ["TAMOXIFEN CITRATE"],
+                    "route": ["ORAL"],
+                },
+            }
+        ],
+    }
+
+
+def _catalog_payload() -> dict:
+    fields = [
+        "date_opened",
+        "protocol",
+        "primary_site",
+        "study_phase",
+        "title",
+        "date_closed",
+        "principal_investigator",
+    ]
+    return {
+        "results": [
+            {
+                "resource": {
+                    "name": "Current Active Clinical Trials",
+                    "id": "2ig8-yxf8",
+                    "description": "Active cancer studies by site, phase, and protocol.",
+                    "type": "dataset",
+                    "updatedAt": "2026-04-14T21:08:58Z",
+                    "provenance": "official",
+                    "columns_name": [
+                        field.replace("_", " ").title() for field in fields
+                    ],
+                    "columns_field_name": fields,
+                    "columns_datatype": ["Text"] * len(fields),
+                    "columns_description": [""] * len(fields),
+                },
+                "metadata": {"domain": "data.ny.gov"},
+                "classification": {"domain_tags": ["cancer", "clinical trials"]},
+                "permalink": "https://data.ny.gov/d/2ig8-yxf8",
+            }
+        ],
+        "resultSetSize": 13,
+    }
+
+
+def _trial(nct_id: str, *, status: str, phase: str) -> dict:
+    return {
+        "protocolSection": {
+            "identificationModule": {
+                "nctId": nct_id,
+                "briefTitle": f"Breast cancer study {nct_id}",
+            },
+            "statusModule": {"overallStatus": status},
+            "designModule": {"phases": [phase]},
+            "conditionsModule": {"conditions": ["Breast Cancer"]},
+            "contactsLocationsModule": {
+                "locations": [
+                    {
+                        "facility": "Cancer Center",
+                        "city": "Buffalo",
+                        "state": "New York",
+                        "country": "United States",
+                        "status": "RECRUITING",
+                    }
+                ]
+            },
+        }
+    }
+
+
+def test_complete_case_exercises_every_boundary_and_writes_auditable_artifacts(
+    monkeypatch, tmp_path: Path
+):
+    label_payload = _label_payload()
+    fda_calls = []
+
+    def fake_vsd_get(url, params=None, **_kwargs):
+        assert url == study.OPENFDA_ENDPOINT
+        fda_calls.append(dict(params or {}))
+        return label_payload, _request(url, label_payload)
+
+    monkeypatch.setattr(
+        vsd_tool, "_resolve_public_addresses", lambda _host, _port: ("8.8.8.8",)
+    )
+    monkeypatch.setattr(vsd_tool, "_safe_get_json", fake_vsd_get)
+
+    catalog_payload = _catalog_payload()
+
+    def fake_discovery_get(url, params, *, timeout):
+        assert url == "https://api.us.socrata.com/api/catalog/v1"
+        assert params["q"] == study.DISCOVERY_QUERY
+        assert timeout == 20
+        return catalog_payload, _request(url, catalog_payload)
+
+    monkeypatch.setattr(vsd_discovery, "_safe_get_json", fake_discovery_get)
+
+    trials = [
+        _trial("NCT00000002", status="RECRUITING", phase="PHASE2"),
+        _trial("NCT00000001", status="NOT_YET_RECRUITING", phase="PHASE3"),
+    ]
+    dynamic_calls = []
+
+    def fake_dynamic_get(url, params, *, timeout):
+        dynamic_calls.append((url, dict(params), timeout))
+        if url == "https://clinicaltrials.gov/api/v2/studies":
+            assert "NCTId" in params["fields"]
+            assert "LocationState" in params["fields"]
+            payload = {"studies": trials, "totalCount": 546, "nextPageToken": "next"}
+            return payload, _request(url, payload)
+        if url.endswith("/studies/NCT00000001"):
+            return trials[1], _request(url, trials[1])
+        assert url == "https://data.ny.gov/resource/2ig8-yxf8.json"
+        filter_field = next(key for key in params if not key.startswith("$"))
+        value = params[filter_field]
+        rows = [
+            {
+                "date_opened": "2024-01-01T00:00:00.000",
+                "protocol": f"RPCI-{index}",
+                "primary_site": (value if filter_field == "primary_site" else "Breast"),
+                "study_phase": value if filter_field == "study_phase" else "II",
+                "title": f"Verified trial {index}",
+                "principal_investigator": "Example Investigator",
+            }
+            for index in range(1, 3)
+        ]
+        return rows, _request(url, rows)
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", fake_dynamic_get)
+
+    workspace = tmp_path / "complete"
+    snapshot = study.run_case(workspace=workspace)
+    output_json = tmp_path / "snapshot.json"
+    output_markdown = tmp_path / "snapshot.md"
+    study.write_artifacts(snapshot, output_json, output_markdown)
+
+    assert len(fda_calls) == 3
+    assert len(dynamic_calls) == 10
+    assert snapshot["administrative_source_lifecycle"]["catalog_restored"] is True
+    assert snapshot["reviewed_source_adapter"]["administrative_tools_loaded"] == []
+    assert snapshot["reviewed_source_adapter"]["label"]["generic_name"] == (
+        "TAMOXIFEN CITRATE"
+    )
+    assert (
+        snapshot["reviewed_dynamic_rest"]["detail_follow_up"]["selected_nct_id"]
+        == "NCT00000001"
+    )
+    assert snapshot["demand_discovery"]["selected_candidate"]["dataset_id"] == (
+        "2ig8-yxf8"
+    )
+    assert (
+        snapshot["demand_discovery"]["selected_candidate"]["execution_allowed"] is False
+    )
+    assert snapshot["reviewed_promotion"]["verification_case_count"] == 6
+    assert snapshot["reviewed_promotion"]["loaded_tools"] == [
+        "VSDTotalCancerTrialsByPhase",
+        "VSDTotalCancerTrialsBySite",
+    ]
+    assert all(snapshot["end_to_end_assertions"].values())
+    assert len(snapshot["audit_chain"]["sha256"]) == 64
+    assert (
+        json.loads(output_json.read_text(encoding="utf-8"))["audit_chain"]
+        == (snapshot["audit_chain"])
+    )
+    report = output_markdown.read_text(encoding="utf-8")
+    assert "Complete VSD Oncology Source-Governance Case Study" in report
+    assert "Administrator-only source catalog" in report
+    assert "Demand-Driven API Discovery" in report
+    assert "End-to-End Assertions" in report
+
+    tampered = copy.deepcopy(snapshot)
+    tampered["reviewed_promotion"]["runtime_checks"][0]["provenance"][
+        "payload_sha256"
+    ] = "0" * 64
+    with pytest.raises(ValueError, match="Audit-chain inputs"):
+        study.validate_snapshot(tampered)
+
+    incomplete = copy.deepcopy(snapshot)
+    incomplete["end_to_end_assertions"].pop("administrative_catalog_restored")
+    with pytest.raises(ValueError, match="end-to-end assertions"):
+        study.validate_snapshot(incomplete)
+
+
+def test_discovery_review_refuses_an_executable_or_incomplete_candidate():
+    candidates = vsd_discovery.discover_api_candidates(
+        study.DISCOVERY_QUERY,
+        limit=1,
+        catalog_payload=_catalog_payload(),
+    )
+    candidates[0]["execution_allowed"] = True
+    with pytest.raises(RuntimeError, match="No discovered API"):
+        study._review_discovery({"candidates": candidates})
+
+    candidates = vsd_discovery.discover_api_candidates(
+        study.DISCOVERY_QUERY,
+        limit=1,
+        catalog_payload=_catalog_payload(),
+    )
+    candidates[0]["fields"] = [
+        field
+        for field in candidates[0]["fields"]
+        if field["field"] != "principal_investigator"
+    ]
+    with pytest.raises(RuntimeError, match="No discovered API"):
+        study._review_discovery({"candidates": candidates})
+
+
+def test_checked_complete_pipeline_artifacts_are_synchronized_and_valid():
+    artifacts = MODULE_PATH.parent / "artifacts"
+    snapshot = json.loads(
+        (artifacts / "complete_pipeline_snapshot.json").read_text(encoding="utf-8")
+    )
+    study.validate_snapshot(snapshot)
+    assert (artifacts / "complete_pipeline_snapshot.md").read_text(
+        encoding="utf-8"
+    ) == study.render_markdown(snapshot)
+    assert all(snapshot["end_to_end_assertions"].values())
+
+    workspace = artifacts / "complete_pipeline_workspace"
+    assert json.loads(
+        (workspace / "catalog" / "sources.json").read_text(encoding="utf-8")
+    ) == {"version": 1, "sources": {}}
+    for promotion in snapshot["reviewed_promotion"]["promotions"]:
+        draft_id = promotion["draft_id"]
+        tool_name = promotion["tool_name"]
+        records = {
+            "draft_sha256": workspace / "promotion" / "drafts" / f"{draft_id}.json",
+            "verification_sha256": workspace
+            / "promotion"
+            / "evidence"
+            / f"{draft_id}.json",
+            "approval_sha256": workspace
+            / "promotion"
+            / "approvals"
+            / f"{draft_id}.json",
+            "publication_sha256": workspace
+            / "promotion"
+            / "approved"
+            / f"{tool_name}.json",
+        }
+        for hash_field, path in records.items():
+            record = json.loads(path.read_text(encoding="utf-8"))
+            assert record[hash_field] == promotion[hash_field]

--- a/tests/unit/test_vsd_dynamic_rest_case_study.py
+++ b/tests/unit/test_vsd_dynamic_rest_case_study.py
@@ -15,7 +15,9 @@ pytestmark = pytest.mark.unit
 MODULE_PATH = (
     Path(__file__).parents[2] / "examples" / "vsd" / "dynamic_rest_als_case_study.py"
 )
-SPEC = importlib.util.spec_from_file_location("vsd_dynamic_rest_case_study", MODULE_PATH)
+SPEC = importlib.util.spec_from_file_location(
+    "vsd_dynamic_rest_case_study", MODULE_PATH
+)
 assert SPEC and SPEC.loader
 study = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = study

--- a/tests/unit/test_vsd_promotion.py
+++ b/tests/unit/test_vsd_promotion.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+
+import pytest
+
+from tooluniverse import ToolUniverse
+from tooluniverse import vsd_dynamic_rest, vsd_promotion
+
+pytestmark = pytest.mark.unit
+
+
+RETURN_FIELDS = [
+    "date_opened",
+    "protocol",
+    "primary_site",
+    "study_phase",
+    "title",
+    "date_closed",
+    "principal_investigator",
+]
+
+
+def _candidate() -> dict:
+    endpoint = "https://data.ny.gov/resource/2ig8-yxf8.json"
+    return {
+        "api_endpoint": endpoint,
+        "approval_state": "unreviewed_candidate",
+        "candidate_id": hashlib.sha256(endpoint.encode()).hexdigest()[:16],
+        "catalog_domain": "data.ny.gov",
+        "dataset_id": "2ig8-yxf8",
+        "execution_allowed": False,
+        "metadata_trust": "untrusted_catalog_metadata",
+        "updated_at": "2026-04-14T21:08:58.000Z",
+        "fields": [
+            {
+                "field": name,
+                "json_type": "string",
+                "label": name.replace("_", " ").title(),
+                "description": f"Reviewed provider field {name}.",
+            }
+            for name in RETURN_FIELDS
+        ],
+    }
+
+
+def _cases(field: str, values: tuple[str, str, str]) -> list[dict]:
+    return [
+        {
+            "arguments": {field: value},
+            "expect": {
+                "min_items": 1,
+                "max_items": 25,
+                "required_fields": ["protocol", "title", field],
+                "equals": {field: value},
+            },
+        }
+        for value in values
+    ]
+
+
+def _fake_socrata_get(url, params, *, timeout):
+    assert url == "https://data.ny.gov/resource/2ig8-yxf8.json"
+    assert params["$limit"] == 25
+    assert params["$select"] == ",".join(RETURN_FIELDS)
+    assert timeout == 20.0
+    filter_field = next(key for key in params if not key.startswith("$"))
+    value = params[filter_field]
+    rows = [
+        {
+            "date_opened": "2024-01-01T00:00:00.000",
+            "protocol": f"RPCI-{value[:3].upper()}-{index}",
+            "primary_site": value if filter_field == "primary_site" else "Breast",
+            "study_phase": value if filter_field == "study_phase" else "II",
+            "title": f"Reviewed trial {index} for {value}",
+            "principal_investigator": "Example Investigator",
+        }
+        for index in range(1, 3)
+    ]
+    encoded = json.dumps(rows).encode()
+    return rows, {
+        "status_code": 200,
+        "content_type": "application/json; charset=utf-8",
+        "response_bytes": len(encoded),
+        "redirects": 0,
+    }
+
+
+def _draft(workspace, *, tool_name="GeneratedCancerTrialsBySite"):
+    return vsd_promotion.create_draft(
+        _candidate(),
+        tool_name=tool_name,
+        description=(
+            "Query a reviewed New York State cancer-trial dataset by primary site."
+        ),
+        filter_fields=["primary_site"],
+        return_fields=RETURN_FIELDS,
+        workspace=workspace,
+    )
+
+
+def test_generator_builds_narrow_required_filter_contract():
+    config = vsd_promotion.build_socrata_tool_config(
+        _candidate(),
+        tool_name="GeneratedCancerTrialsBySite",
+        description="Query reviewed active cancer trials by their primary cancer site.",
+        filter_fields=["primary_site"],
+        return_fields=RETURN_FIELDS,
+    )
+
+    assert config["parameter"]["required"] == ["primary_site"]
+    assert config["parameter"]["additionalProperties"] is False
+    assert config["vsd_operation"]["method"] == "GET"
+    assert config["vsd_operation"]["auth"] == {"type": "none"}
+    assert config["vsd_operation"]["fixed_query"]["$limit"] == 25
+    assert config["vsd_operation"]["query_arguments"] == {
+        "primary_site": "primary_site"
+    }
+
+
+@pytest.mark.parametrize(
+    "mutation, message",
+    [
+        (lambda c: c.update(execution_allowed=True), "discovery boundary"),
+        (
+            lambda c: c.update(
+                api_endpoint="http://data.ny.gov/resource/2ig8-yxf8.json"
+            ),
+            "catalog identity",
+        ),
+        (lambda c: c.update(candidate_id="0" * 16), "candidate ID"),
+    ],
+)
+def test_generator_rejects_tampered_discovery_candidates(mutation, message):
+    candidate = _candidate()
+    mutation(candidate)
+    with pytest.raises(vsd_promotion.VSDPromotionError, match=message):
+        vsd_promotion.build_socrata_tool_config(
+            candidate,
+            tool_name="GeneratedCancerTrialsBySite",
+            description="Query reviewed active cancer trials by their primary cancer site.",
+            filter_fields=["primary_site"],
+            return_fields=RETURN_FIELDS,
+        )
+
+
+def test_generator_rejects_unknown_provider_fields():
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="Unknown"):
+        vsd_promotion.build_socrata_tool_config(
+            _candidate(),
+            tool_name="GeneratedCancerTrialsBySite",
+            description="Query reviewed active cancer trials by their primary cancer site.",
+            filter_fields=["invented_field"],
+            return_fields=RETURN_FIELDS,
+        )
+
+
+def test_generator_uses_socrata_number_wire_format_and_rejects_object_filters():
+    candidate = _candidate()
+    candidate["fields"].extend(
+        [
+            {
+                "field": "enrollment",
+                "json_type": "number",
+                "provider_type": "Number",
+            },
+            {"field": "location", "json_type": "object", "provider_type": "Point"},
+        ]
+    )
+    config = vsd_promotion.build_socrata_tool_config(
+        candidate,
+        tool_name="GeneratedTrialsByEnrollment",
+        description="Query reviewed cancer trials by exact enrollment value.",
+        filter_fields=["enrollment"],
+        return_fields=["protocol", "enrollment", "location"],
+    )
+    enrollment = config["parameter"]["properties"]["enrollment"]
+    assert enrollment["type"] == "string"
+    assert enrollment["pattern"].startswith("^-")
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="Object-valued"):
+        vsd_promotion.build_socrata_tool_config(
+            candidate,
+            tool_name="GeneratedTrialsByLocation",
+            description="Query reviewed cancer trials by exact provider location.",
+            filter_fields=["location"],
+            return_fields=["protocol", "location"],
+        )
+
+
+def test_verification_requires_three_cases_and_writes_no_failed_evidence(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", _fake_socrata_get)
+    draft = _draft(tmp_path)
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="3-20"):
+        vsd_promotion.verify_draft(
+            draft["draft_id"],
+            _cases("primary_site", ("Breast", "Prostate", "Lung"))[:2],
+            workspace=tmp_path,
+        )
+    assert not (tmp_path / "evidence" / f"{draft['draft_id']}.json").exists()
+
+    failing = _cases("primary_site", ("Breast", "Prostate", "Lung"))
+    failing[1]["expect"]["equals"]["primary_site"] = "Ovary"
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="equality"):
+        vsd_promotion.verify_draft(draft["draft_id"], failing, workspace=tmp_path)
+    assert not (tmp_path / "evidence" / f"{draft['draft_id']}.json").exists()
+
+
+def test_cannot_publish_without_matching_verification_and_approval(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", _fake_socrata_get)
+    draft = _draft(tmp_path)
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="does not exist"):
+        vsd_promotion.publish_draft(draft["draft_id"], workspace=tmp_path)
+
+    vsd_promotion.verify_draft(
+        draft["draft_id"],
+        _cases("primary_site", ("Breast", "Prostate", "Lung")),
+        workspace=tmp_path,
+    )
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="does not exist"):
+        vsd_promotion.publish_draft(draft["draft_id"], workspace=tmp_path)
+
+
+@pytest.mark.parametrize("artifact", ["draft", "evidence", "approval", "publication"])
+def test_hash_chain_detects_artifact_tampering(tmp_path, monkeypatch, artifact):
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", _fake_socrata_get)
+    draft = _draft(tmp_path)
+    evidence = vsd_promotion.verify_draft(
+        draft["draft_id"],
+        _cases("primary_site", ("Breast", "Prostate", "Lung")),
+        workspace=tmp_path,
+    )
+    approval = vsd_promotion.approve_draft(
+        draft["draft_id"],
+        reviewed_by="Test Reviewer",
+        decision_note="Approved after all three bounded integration cases passed.",
+        workspace=tmp_path,
+    )
+    publication = vsd_promotion.publish_draft(draft["draft_id"], workspace=tmp_path)
+    paths = {
+        "draft": tmp_path / "drafts" / f"{draft['draft_id']}.json",
+        "evidence": tmp_path / "evidence" / f"{draft['draft_id']}.json",
+        "approval": tmp_path / "approvals" / f"{draft['draft_id']}.json",
+        "publication": tmp_path / "approved" / f"{publication['tool_name']}.json",
+    }
+    record = json.loads(paths[artifact].read_text())
+    record["review_tampered"] = True
+    paths[artifact].write_text(json.dumps(record), encoding="utf-8")
+
+    if artifact == "draft":
+
+        def action():
+            return vsd_promotion.verify_draft(
+                draft["draft_id"],
+                _cases("primary_site", ("Breast", "Prostate", "Lung")),
+                workspace=tmp_path,
+            )
+
+    elif artifact == "evidence":
+
+        def action():
+            return vsd_promotion.approve_draft(
+                draft["draft_id"],
+                reviewed_by="Test Reviewer",
+                decision_note=(
+                    "Approved after all three bounded integration cases passed."
+                ),
+                workspace=tmp_path,
+            )
+
+    elif artifact == "approval":
+
+        def action():
+            return vsd_promotion.publish_draft(
+                draft["draft_id"], workspace=tmp_path, replace=True
+            )
+
+    else:
+        tooluniverse = ToolUniverse()
+
+        def action():
+            try:
+                return vsd_promotion.load_published_tools(
+                    tooluniverse, workspace=tmp_path
+                )
+            finally:
+                tooluniverse.close()
+
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="digest"):
+        action()
+    assert evidence["all_cases_passed"] is True
+    assert approval["decision"] == "approved"
+
+
+def test_two_generated_tools_complete_full_promotion_and_execution(
+    tmp_path, monkeypatch
+):
+    requests = []
+
+    def fake_get(url, params, *, timeout):
+        requests.append(deepcopy(params))
+        return _fake_socrata_get(url, params, timeout=timeout)
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", fake_get)
+    specs = (
+        (
+            "GeneratedCancerTrialsBySite",
+            "primary_site",
+            ("Brain and Nervous System", "Breast", "Prostate"),
+        ),
+        (
+            "GeneratedCancerTrialsByPhase",
+            "study_phase",
+            ("II", "III", "IV"),
+        ),
+    )
+    published = []
+    for name, field, values in specs:
+        draft = vsd_promotion.create_draft(
+            _candidate(),
+            tool_name=name,
+            description=f"Query the reviewed cancer-trial dataset by {field}.",
+            filter_fields=[field],
+            return_fields=RETURN_FIELDS,
+            workspace=tmp_path,
+        )
+        evidence = vsd_promotion.verify_draft(
+            draft["draft_id"], _cases(field, values), workspace=tmp_path
+        )
+        approval = vsd_promotion.approve_draft(
+            draft["draft_id"],
+            reviewed_by="Test Reviewer",
+            decision_note="Approved after contract review and three live-equivalent cases.",
+            workspace=tmp_path,
+        )
+        record = vsd_promotion.publish_draft(draft["draft_id"], workspace=tmp_path)
+        assert evidence["case_count"] == 3
+        assert approval["operation_sha256"] == draft["operation_sha256"]
+        published.append(record)
+
+    tooluniverse = ToolUniverse()
+    try:
+        assert vsd_promotion.load_published_tools(
+            tooluniverse, workspace=tmp_path
+        ) == sorted(record["tool_name"] for record in published)
+        by_site = tooluniverse.run_one_function(
+            {
+                "name": "GeneratedCancerTrialsBySite",
+                "arguments": {"primary_site": "Breast"},
+            },
+            use_cache=False,
+        )
+        by_phase = tooluniverse.run_one_function(
+            {
+                "name": "GeneratedCancerTrialsByPhase",
+                "arguments": {"study_phase": "III"},
+            },
+            use_cache=False,
+        )
+    finally:
+        tooluniverse.close()
+
+    assert by_site["data"]["result"][0]["primary_site"] == "Breast"
+    assert by_phase["data"]["result"][0]["study_phase"] == "III"
+    assert len(requests) == 8
+    assert vsd_promotion.list_promotion_state(workspace=tmp_path) == {
+        "drafts": sorted(record["draft_id"] for record in published),
+        "evidence": sorted(record["draft_id"] for record in published),
+        "approvals": sorted(record["draft_id"] for record in published),
+        "approved": sorted(record["tool_name"] for record in published),
+    }
+
+
+def test_loader_refuses_to_replace_an_existing_tool(tmp_path, monkeypatch):
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", _fake_socrata_get)
+    draft = _draft(tmp_path)
+    vsd_promotion.verify_draft(
+        draft["draft_id"],
+        _cases("primary_site", ("Breast", "Prostate", "Lung")),
+        workspace=tmp_path,
+    )
+    vsd_promotion.approve_draft(
+        draft["draft_id"],
+        reviewed_by="Test Reviewer",
+        decision_note="Approved after all three bounded integration cases passed.",
+        workspace=tmp_path,
+    )
+    vsd_promotion.publish_draft(draft["draft_id"], workspace=tmp_path)
+
+    tooluniverse = ToolUniverse()
+    try:
+        vsd_promotion.register_reviewed_rest_tool(tooluniverse, draft["config"])
+        with pytest.raises(vsd_promotion.VSDPromotionError, match="replace"):
+            vsd_promotion.load_published_tools(tooluniverse, workspace=tmp_path)
+    finally:
+        tooluniverse.close()
+
+
+def test_loader_validates_entire_set_before_registering_any_tool(tmp_path, monkeypatch):
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", _fake_socrata_get)
+    for name in ("GeneratedCancerTrialsAlpha", "GeneratedCancerTrialsZulu"):
+        draft = _draft(tmp_path, tool_name=name)
+        vsd_promotion.verify_draft(
+            draft["draft_id"],
+            _cases("primary_site", ("Breast", "Prostate", "Lung")),
+            workspace=tmp_path,
+        )
+        vsd_promotion.approve_draft(
+            draft["draft_id"],
+            reviewed_by="Test Reviewer",
+            decision_note="Approved after all three bounded integration cases passed.",
+            workspace=tmp_path,
+        )
+        vsd_promotion.publish_draft(draft["draft_id"], workspace=tmp_path)
+
+    bad_path = tmp_path / "approved" / "GeneratedCancerTrialsZulu.json"
+    bad_record = json.loads(bad_path.read_text(encoding="utf-8"))
+    bad_record["publication_sha256"] = "0" * 64
+    bad_path.write_text(json.dumps(bad_record), encoding="utf-8")
+
+    tooluniverse = ToolUniverse()
+    try:
+        with pytest.raises(vsd_promotion.VSDPromotionError, match="digest"):
+            vsd_promotion.load_published_tools(tooluniverse, workspace=tmp_path)
+        assert "GeneratedCancerTrialsAlpha" not in tooluniverse.all_tool_dict
+        assert "GeneratedCancerTrialsZulu" not in tooluniverse.all_tool_dict
+    finally:
+        tooluniverse.close()

--- a/tests/unit/test_vsd_promotion_cli.py
+++ b/tests/unit/test_vsd_promotion_cli.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from tooluniverse import vsd_dynamic_rest, vsd_promotion_cli
+
+pytestmark = pytest.mark.unit
+
+
+def _snapshot() -> dict:
+    endpoint = "https://data.ny.gov/resource/2ig8-yxf8.json"
+    return {
+        "analysis": {
+            "selected_candidate": {
+                "api_endpoint": endpoint,
+                "approval_state": "unreviewed_candidate",
+                "candidate_id": hashlib.sha256(endpoint.encode()).hexdigest()[:16],
+                "catalog_domain": "data.ny.gov",
+                "dataset_id": "2ig8-yxf8",
+                "execution_allowed": False,
+                "metadata_trust": "untrusted_catalog_metadata",
+                "fields": [
+                    {"field": "primary_site", "json_type": "string"},
+                    {"field": "protocol", "json_type": "string"},
+                    {"field": "title", "json_type": "string"},
+                ],
+            }
+        }
+    }
+
+
+def test_cli_accepts_discovery_snapshot_and_runs_every_gate(
+    tmp_path, monkeypatch, capsys
+):
+    candidate_file = tmp_path / "discovery.json"
+    candidate_file.write_text(json.dumps(_snapshot()), encoding="utf-8")
+    cases_file = tmp_path / "cases.json"
+    cases_file.write_text(
+        json.dumps(
+            [
+                {
+                    "arguments": {"primary_site": value},
+                    "expect": {
+                        "min_items": 1,
+                        "max_items": 10,
+                        "required_fields": ["primary_site", "protocol", "title"],
+                        "equals": {"primary_site": value},
+                    },
+                }
+                for value in ("Breast", "Prostate", "Lung")
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_get(url, params, *, timeout):
+        value = params["primary_site"]
+        rows = [{"primary_site": value, "protocol": "P-1", "title": "Trial"}]
+        return rows, {
+            "status_code": 200,
+            "content_type": "application/json",
+            "response_bytes": len(json.dumps(rows)),
+            "redirects": 0,
+        }
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", fake_get)
+    base = ["--workspace", str(tmp_path / "workspace")]
+    assert (
+        vsd_promotion_cli.main(
+            base
+            + [
+                "draft-socrata",
+                str(candidate_file),
+                "--tool-name",
+                "GeneratedCancerTrialsBySite",
+                "--description",
+                "Query reviewed cancer trials by their primary cancer site.",
+                "--filter-fields",
+                "primary_site",
+                "--return-fields",
+                "primary_site,protocol,title",
+                "--max-records",
+                "10",
+            ]
+        )
+        == 0
+    )
+    draft_id = json.loads(capsys.readouterr().out)["draft_id"]
+    assert vsd_promotion_cli.main(base + ["verify", draft_id, str(cases_file)]) == 0
+    capsys.readouterr()
+    assert (
+        vsd_promotion_cli.main(
+            base
+            + [
+                "approve",
+                draft_id,
+                "--reviewed-by",
+                "Test Reviewer",
+                "--decision-note",
+                "Approved after three representative provider cases passed.",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert vsd_promotion_cli.main(base + ["publish", draft_id]) == 0
+    capsys.readouterr()
+    assert vsd_promotion_cli.main(base + ["list"]) == 0
+    state = json.loads(capsys.readouterr().out)
+    assert state["approved"] == ["GeneratedCancerTrialsBySite"]

--- a/tests/unit/test_vsd_tool_promotion_case_study.py
+++ b/tests/unit/test_vsd_tool_promotion_case_study.py
@@ -1,14 +1,30 @@
 from __future__ import annotations
 
+import importlib.util
 import json
+import sys
 from pathlib import Path
 
 import pytest
 
-from examples.vsd import tool_promotion_cancer_case_study as study
 from tooluniverse import vsd_dynamic_rest
 
 pytestmark = pytest.mark.unit
+
+
+MODULE_PATH = (
+    Path(__file__).parents[2]
+    / "examples"
+    / "vsd"
+    / "tool_promotion_cancer_case_study.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "vsd_tool_promotion_case_study", MODULE_PATH
+)
+assert SPEC and SPEC.loader
+study = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = study
+SPEC.loader.exec_module(study)
 
 
 def test_complex_case_promotes_loads_and_executes_two_tools(

--- a/tests/unit/test_vsd_tool_promotion_case_study.py
+++ b/tests/unit/test_vsd_tool_promotion_case_study.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from examples.vsd import tool_promotion_cancer_case_study as study
+from tooluniverse import vsd_dynamic_rest
+
+pytestmark = pytest.mark.unit
+
+
+def test_complex_case_promotes_loads_and_executes_two_tools(
+    monkeypatch, tmp_path: Path
+):
+    calls = []
+
+    def fake_get(url, params, *, timeout):
+        assert url == "https://data.ny.gov/resource/2ig8-yxf8.json"
+        assert params["$limit"] == 25
+        assert timeout == 20.0
+        filter_field = next(key for key in params if not key.startswith("$"))
+        value = params[filter_field]
+        calls.append((filter_field, value))
+        rows = [
+            {
+                "date_opened": "2024-01-01T00:00:00.000",
+                "protocol": f"RPCI-{index}",
+                "primary_site": value if filter_field == "primary_site" else "Breast",
+                "study_phase": value if filter_field == "study_phase" else "II",
+                "title": f"Verified trial {index}",
+                "principal_investigator": "Example Investigator",
+            }
+            for index in range(1, 3)
+        ]
+        return rows, {
+            "status_code": 200,
+            "content_type": "application/json",
+            "response_bytes": len(json.dumps(rows)),
+            "redirects": 0,
+        }
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", fake_get)
+    workspace = tmp_path / "promotion"
+    output_json = tmp_path / "result.json"
+    output_markdown = tmp_path / "result.md"
+    result = study.run_case(
+        workspace=workspace,
+        output_json=output_json,
+        output_markdown=output_markdown,
+    )
+
+    assert len(calls) == 8
+    assert result["loaded_tools"] == [
+        "VSDGeneratedCancerTrialsByPhase",
+        "VSDGeneratedCancerTrialsBySite",
+    ]
+    assert [item["case_count"] for item in result["promotions"]] == [3, 3]
+    assert [item["row_count"] for item in result["runtime_checks"]] == [2, 2]
+    assert all(len(item["publication_sha256"]) == 64 for item in result["promotions"])
+    assert result["promotion_state"] == {
+        "drafts": sorted(item["draft_id"] for item in result["promotions"]),
+        "evidence": sorted(item["draft_id"] for item in result["promotions"]),
+        "approvals": sorted(item["draft_id"] for item in result["promotions"]),
+        "approved": result["loaded_tools"],
+    }
+    assert json.loads(output_json.read_text(encoding="utf-8"))["case"] == (
+        "one_discovered_source_to_two_reviewed_cancer_trial_tools"
+    )
+    report = output_markdown.read_text(encoding="utf-8")
+    assert "One discovery candidate produced two distinct" in report
+    assert "Fresh Runtime Check" in report
+    assert "not trial quality" in report


### PR DESCRIPTION
## Summary

- add an administrator-only draft, verification, approval, publication, and explicit loading pipeline for discovered Socrata datasets
- bind every transition to SHA-256 records and fail closed on tampered, incomplete, colliding, or partially invalid publication sets
- generate narrow read-only tools with mandatory filters, fixed projections and limits, no credentials, and the reviewed dynamic REST transport
- add an administration CLI, focused tests, live case studies, and checked machine-readable audit artifacts

## Scope rationale

This is the reviewed promotion phase extracted from #32. It depends on the non-executable discovery candidate from #418 and the secure dynamic REST runtime from #417. Discovery still does not probe, execute, approve, publish, or auto-load candidate APIs.

Stack order: #416 -> #417 -> #418 -> this PR.

## Focused promotion case

The focused case starts with New York State dataset `2ig8-yxf8` and creates two tools from that reviewed source:

- `VSDGeneratedCancerTrialsBySite`, verified with Brain and Nervous System, Breast, and Prostate
- `VSDGeneratedCancerTrialsByPhase`, verified with phases I, II, and III

The six live verification calls returned 19, 23, 20, 25, 25, and 25 rows. A fresh ToolUniverse instance explicitly loaded both publications and repeated independent queries.

## End-to-end validation

The new oncology source-governance study exercises all four VSD phases in one continuous live run:

1. The admin CLI registers, probes, lists, queries, removes, and restores an isolated openFDA source.
2. ToolUniverse is explicitly asked for three reviewed tools and four admin-only names; only the three reviewed tools load.
3. The fixed openFDA adapter retrieves the same tamoxifen label identified during admin inspection.
4. Two reviewed ClinicalTrials.gov operations search active/upcoming New York breast-cancer studies and retrieve a deterministic detail record.
5. Demand discovery searches the fixed Socrata catalog, checks six required fields, and keeps the candidate non-executable.
6. Two narrow tools cross draft, three live verification cases each, hash-bound approval, publication, explicit fresh-runtime loading, and post-publication execution.

The checked live run found 546 national-registry matches, returned a bounded 20 records, selected `NCT01766297`, reviewed 10 of 13 catalog matches, selected dataset `2ig8-yxf8`, passed all six promotion cases, loaded both published tools, and passed all 12 cross-stage assertions.

- [Detailed human-readable report](https://github.com/mims-harvard/ToolUniverse/blob/vsd-reviewed-tool-promotion/examples/vsd/artifacts/complete_pipeline_snapshot.md)
- [Machine-readable evidence ledger](https://github.com/mims-harvard/ToolUniverse/blob/vsd-reviewed-tool-promotion/examples/vsd/artifacts/complete_pipeline_snapshot.json)
- [Reproducible case implementation](https://github.com/mims-harvard/ToolUniverse/blob/vsd-reviewed-tool-promotion/examples/vsd/complete_pipeline_case_study.py)
- [Artifact-integrity and boundary tests](https://github.com/mims-harvard/ToolUniverse/blob/vsd-reviewed-tool-promotion/tests/unit/test_vsd_complete_pipeline_case_study.py)

### Issue identified during validation

The first live search correctly failed because twenty full ClinicalTrials.gov protocols exceeded the 1 MB VSD transport ceiling. The reviewed contract now requests only the ten fields used by the study, retaining 20 records in a 371,748-byte response without weakening the safety limit.

## Safety properties

- administration and publication are explicit control-plane actions
- discovered candidates remain untrusted and non-executable
- generated operations are HTTPS GET only, unauthenticated, bounded, redirect-free, DNS-pinned, response-size limited, and schema validated
- at least three passing provider cases are required before approval
- draft, operation, verification, approval, and publication hashes form an exact audit chain
- all publications are validated before registration, and existing tools cannot be replaced
- hashes provide tamper evidence, not signatures; workspace write access remains an administrative trust boundary
- technical verification is not scientific or clinical endorsement

## Verification

- final live run: 12/12 assertions, 6 promotion cases, 2 post-publication calls, audit chain `0530702a8466da09286370a3303fbf68361074ea6543f8d86ef57d2aa7a6ebc6`
- `110 passed` across all 15 VSD unit modules using the console `pytest` entry point
- `124 passed` in a detached current-main integration tree containing the full VSD stack plus #420
- Ruff checks passed for all changed VSD and Docker Python modules
- #417 and #418 case-study import regressions pass independently under console `pytest`
- clean merges with current `main` at `91e80405` and the independent Docker PR #420
