### PR TITLE
Add administrator-only Docker LLM provisioning

### DIFF
--- a/.github/workflows/docker-llm-smoke.yml
+++ b/.github/workflows/docker-llm-smoke.yml
@@ -1,0 +1,63 @@
+name: Docker LLM Administrator Smoke
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/docker-llm-smoke.yml"
+      - "src/tooluniverse/remote/docker_llm/**"
+      - "tests/fixtures/docker_llm_smoke/**"
+      - "tests/unit/test_docker_llm_*.py"
+      - "examples/docker_llm/**"
+      - "pyproject.toml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-smoke:
+    name: Real container lifecycle and ToolUniverse call
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install focused dependencies
+        run: >-
+          python -m pip install
+          pytest pytest-cov requests pyyaml jsonschema huggingface_hub python-dotenv
+
+      - name: Run Docker policy tests
+        env:
+          PYTHONPATH: src
+          TOOLUNIVERSE_LIGHT_IMPORT: "true"
+        run: >-
+          python -m pytest
+          tests/unit/test_docker_llm_provision.py
+          tests/unit/test_docker_llm_cli.py
+          tests/unit/test_docker_llm_case_study.py
+          -q --no-cov
+
+      - name: Run real Docker smoke case
+        env:
+          PYTHONPATH: src
+          TOOLUNIVERSE_LIGHT_IMPORT: "true"
+        run: python examples/docker_llm/run_smoke_case.py
+
+      - name: Upload Docker validation evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-llm-smoke-evidence
+          path: |
+            examples/docker_llm/artifacts/docker_smoke_snapshot.json
+            examples/docker_llm/artifacts/docker_smoke_snapshot.md
+            examples/docker_llm/artifacts/docker_provision_record.json
+          if-no-files-found: error

--- a/.github/workflows/docker-llm-smoke.yml
+++ b/.github/workflows/docker-llm-smoke.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install focused dependencies
         run: >-
           python -m pip install
-          pytest pytest-cov requests pyyaml jsonschema huggingface_hub python-dotenv
+          pytest pytest-asyncio pytest-cov requests pyyaml jsonschema huggingface_hub python-dotenv
 
       - name: Run Docker policy tests
         env:

--- a/.github/workflows/docker-llm-smoke.yml
+++ b/.github/workflows/docker-llm-smoke.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Install focused dependencies
         run: >-
           python -m pip install
-          pytest pytest-asyncio pytest-cov requests pyyaml jsonschema huggingface_hub python-dotenv
+          pytest pytest-asyncio pytest-cov pytest-timeout
+          requests pyyaml jsonschema huggingface_hub python-dotenv
 
       - name: Run Docker policy tests
         env:

--- a/docs/dev_docs/DOCKER_LLM_ADMIN_VALIDATION.md
+++ b/docs/dev_docs/DOCKER_LLM_ADMIN_VALIDATION.md
@@ -1,0 +1,117 @@
+# Docker LLM Administrator Provisioning
+
+This integration gives an administrator a bounded way to start a reviewed local
+container and publish one fixed ToolUniverse inference client. Container lifecycle
+operations are deliberately absent from the agent tool registry.
+
+## What Changed From PR #32
+
+The earlier implementation exposed image selection, the Docker executable, volumes,
+environment variables, extra Docker arguments, host binding, container ports, and
+container replacement through an agent-callable compose tool. This implementation
+does none of those things.
+
+An administrator supplies a strict JSON profile. The CLI accepts only the profile,
+a loopback host port, a constrained container name, and a lifecycle command. Unknown
+profile fields fail validation, so volumes, arbitrary Docker flags, host networking,
+privileged mode, alternate executables, and arbitrary server URLs have no input path.
+
+## Required Policy
+
+`TOOLUNIVERSE_DOCKER_ALLOWED_IMAGES` must contain the profile's exact image reference.
+The provisioner uses `--pull never`, resolves the local image to its content ID before
+start, and checks the running container against that ID afterward. It clears Docker
+environment overrides and rejects saved contexts whose daemon endpoint is not a local
+Unix socket or Windows named pipe.
+
+Every new container has these enforced settings:
+
+- host port published only on `127.0.0.1`
+- read-only root filesystem plus a bounded `/tmp` tmpfs
+- all Linux capabilities dropped
+- `no-new-privileges` enabled
+- privileged, host-network, host-PID, host-IPC, and bind-mount configurations rejected
+- reviewed CPU, memory, process, health, prompt, response, and request-time limits
+
+After Docker reports the expected labels, image ID, port binding, and isolation flags,
+the provisioner performs a redirect-free, proxy-free JSON health request. The health
+payload must return the exact reviewed service identity. Only then is a hash-bound
+ToolUniverse client record written atomically with owner-only file permissions.
+
+## Administration CLI
+
+The fixture profile demonstrates the complete schema:
+`tests/fixtures/docker_llm_smoke/profile.json`.
+
+```console
+export TOOLUNIVERSE_DOCKER_ALLOWED_IMAGES='registry.example/reviewed-llm@sha256:...'
+
+tooluniverse-docker-llm-admin --profile reviewed-profile.json plan
+tooluniverse-docker-llm-admin --profile reviewed-profile.json --host-port 9000 start
+tooluniverse-docker-llm-admin --profile reviewed-profile.json --host-port 9000 status
+tooluniverse-docker-llm-admin --profile reviewed-profile.json --host-port 9000 stop
+tooluniverse-docker-llm-admin --profile reviewed-profile.json --host-port 9000 remove --yes
+```
+
+`plan` does not contact Docker. `start`, `status`, `stop`, and `remove` validate the
+same profile and exact container identity. Removal requires `--yes` and refuses to
+touch a container without the matching management labels, profile hash, image ID,
+port binding, and security settings.
+
+Loading the resulting inference tool is also explicit:
+
+```python
+from tooluniverse import ToolUniverse
+from tooluniverse.remote.docker_llm import load_provisioned_tool
+
+tu = ToolUniverse()
+load_provisioned_tool(tu, "ReviewedDockerEvidenceTool")
+result = tu.run_one_function(
+    {
+        "name": "ReviewedDockerEvidenceTool",
+        "arguments": {"prompt": "Synthesize these reviewed evidence records..."},
+    },
+    use_cache=False,
+)
+```
+
+The client can call only the generated `http://127.0.0.1:<port>/<reviewed-path>`
+endpoint. It disables proxy inheritance and redirects, caps the response at 1 MB,
+requires JSON and exactly one response choice, and reports image, profile, and payload
+hashes as provenance.
+
+## Real Container Case
+
+`examples/docker_llm/run_smoke_case.py` builds a non-root, dependency-free fixture
+image and exercises this sequence:
+
+1. plan the exact command;
+2. start and inspect the constrained container;
+3. verify service identity through `/health`;
+4. publish and explicitly load the client into a fresh ToolUniverse instance;
+5. send a long, six-section pharmacovigilance evidence prompt;
+6. verify the service received the exact prompt SHA-256;
+7. stop, re-inspect, remove, and confirm absence.
+
+The fixture implements the same OpenAI-compatible transport contract but is
+deterministic infrastructure, not a real language model. Therefore the case proves
+lifecycle, isolation, registration, payload integrity, response bounds, and cleanup;
+it does not claim model-quality or scientific validation.
+
+The local development machine used for this change does not have Docker installed.
+The dedicated GitHub Actions job runs the real container case on Linux and uploads
+the JSON report, Markdown report, and provision record as build artifacts.
+
+## Local Verification
+
+```console
+PYTHONPATH=src python -m pytest \
+  tests/unit/test_docker_llm_provision.py \
+  tests/unit/test_docker_llm_cli.py -q
+
+PYTHONPATH=src python examples/docker_llm/run_smoke_case.py
+```
+
+Provision records use SHA-256 for tamper evidence, not digital signatures. Local
+administrators who can change the workspace or allowlist remain inside the trust
+boundary, as do the reviewed image contents and the local Docker daemon.

--- a/docs/dev_docs/DOCKER_LLM_ADMIN_VALIDATION.md
+++ b/docs/dev_docs/DOCKER_LLM_ADMIN_VALIDATION.md
@@ -99,8 +99,9 @@ lifecycle, isolation, registration, payload integrity, response bounds, and clea
 it does not claim model-quality or scientific validation.
 
 The local development machine used for this change does not have Docker installed.
-The dedicated GitHub Actions job runs the real container case on Linux and uploads
-the JSON report, Markdown report, and provision record as build artifacts.
+The dedicated GitHub Actions job completed the real container case on Docker 28.0.4.
+Its validated outputs are checked in at `examples/docker_llm/artifacts/` and are also
+uploaded by every run as `docker-llm-smoke-evidence`.
 
 ## Local Verification
 

--- a/examples/docker_llm/.gitignore
+++ b/examples/docker_llm/.gitignore
@@ -1,0 +1,2 @@
+artifacts/workspace/
+artifacts/.runtime/

--- a/examples/docker_llm/artifacts/docker_provision_record.json
+++ b/examples/docker_llm/artifacts/docker_provision_record.json
@@ -1,0 +1,104 @@
+{
+  "container_name": "tooluniverse-docker-llm-smoke-case",
+  "created_at": "2026-08-01T02:16:21.210741+00:00",
+  "docker_context": "default",
+  "docker_server_version": "28.0.4",
+  "health": {
+    "model": "fixture-evidence-synthesizer",
+    "service_id": "tooluniverse-docker-llm-smoke",
+    "status": "ok"
+  },
+  "host_port": 19090,
+  "image": "tooluniverse/docker-llm-smoke:test",
+  "image_id": "sha256:6f9459d804c3546c24e184e5099fad16a9aea73c0e957bba4425c08824ded58a",
+  "profile_name": "docker-llm-smoke",
+  "profile_sha256": "5de381c0fe30a88ddd896b1e830a10ea40f794a09090cd9726e0de7c96fb81d8",
+  "record_sha256": "e422bb0cf2470c22f8dc9d6ea0663172ef9defc71ff73f895a6e2fda3c3d5951",
+  "security": {
+    "bind_mounts": 0,
+    "cap_drop": [
+      "ALL"
+    ],
+    "cpus": 1.0,
+    "host_binding": "127.0.0.1:19090",
+    "memory_mb": 256,
+    "no_new_privileges": true,
+    "pids_limit": 64,
+    "privileged": false,
+    "read_only_rootfs": true,
+    "running": true
+  },
+  "tool_config": {
+    "cacheable": false,
+    "category": "special_tools",
+    "description": "Send a bounded evidence-synthesis prompt to the reviewed loopback Docker service.",
+    "docker_llm": {
+      "endpoint": "http://127.0.0.1:19090/v1/chat/completions",
+      "image_id": "sha256:6f9459d804c3546c24e184e5099fad16a9aea73c0e957bba4425c08824ded58a",
+      "max_prompt_chars": 20000,
+      "max_tokens_cap": 1024,
+      "model": "fixture-evidence-synthesizer",
+      "profile_sha256": "5de381c0fe30a88ddd896b1e830a10ea40f794a09090cd9726e0de7c96fb81d8",
+      "request_timeout_seconds": 15,
+      "service_id": "tooluniverse-docker-llm-smoke"
+    },
+    "mcp_annotations": {
+      "destructiveHint": false,
+      "readOnlyHint": true
+    },
+    "name": "DockerEvidenceSynthesizer",
+    "parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "max_tokens": {
+          "default": 512,
+          "maximum": 1024,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "prompt": {
+          "maxLength": 20000,
+          "minLength": 1,
+          "type": "string"
+        },
+        "temperature": {
+          "default": 0.0,
+          "maximum": 2,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "prompt"
+      ],
+      "type": "object"
+    },
+    "return_schema": {
+      "properties": {
+        "model": {
+          "type": "string"
+        },
+        "provenance": {
+          "type": "object"
+        },
+        "response": {
+          "type": "string"
+        },
+        "usage": {
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "response",
+        "model",
+        "provenance"
+      ],
+      "type": "object"
+    },
+    "type": "DockerLLMClientTool"
+  },
+  "version": 1
+}

--- a/examples/docker_llm/artifacts/docker_smoke_snapshot.json
+++ b/examples/docker_llm/artifacts/docker_smoke_snapshot.json
@@ -1,0 +1,178 @@
+{
+  "case": "reviewed_docker_llm_lifecycle_and_complex_prompt",
+  "docker_server_version": "28.0.4",
+  "generated_at": "2026-08-01T02:16:31.676797+00:00",
+  "interpretation_boundary": "Infrastructure validation only; the deterministic fixture is not a real model and does not validate scientific synthesis quality.",
+  "lifecycle": {
+    "absent_after_remove": true,
+    "remove": {
+      "client_record_removed": true,
+      "container_name": "tooluniverse-docker-llm-smoke-case",
+      "removed": true
+    },
+    "running_status_verified": true,
+    "stop": {
+      "container_name": "tooluniverse-docker-llm-smoke-case",
+      "stopped": true,
+      "was_running": true
+    },
+    "stopped_status_verified": true
+  },
+  "plan": {
+    "container_name": "tooluniverse-docker-llm-smoke-case",
+    "docker_argv": [
+      "docker",
+      "run",
+      "--detach",
+      "--name",
+      "tooluniverse-docker-llm-smoke-case",
+      "--pull",
+      "never",
+      "--label",
+      "org.tooluniverse.managed=true",
+      "--label",
+      "org.tooluniverse.profile-sha256=5de381c0fe30a88ddd896b1e830a10ea40f794a09090cd9726e0de7c96fb81d8",
+      "--label",
+      "org.tooluniverse.service-id=tooluniverse-docker-llm-smoke",
+      "--publish",
+      "127.0.0.1:19090:8000",
+      "--read-only",
+      "--cap-drop",
+      "ALL",
+      "--security-opt",
+      "no-new-privileges:true",
+      "--pids-limit",
+      "64",
+      "--memory",
+      "256m",
+      "--cpus",
+      "1.0",
+      "--tmpfs",
+      "/tmp:rw,noexec,nosuid,size=64m",
+      "tooluniverse/docker-llm-smoke:test"
+    ],
+    "host_binding": "127.0.0.1:19090:8000",
+    "image": "tooluniverse/docker-llm-smoke:test",
+    "profile_name": "docker-llm-smoke",
+    "profile_sha256": "5de381c0fe30a88ddd896b1e830a10ea40f794a09090cd9726e0de7c96fb81d8"
+  },
+  "provisioning": {
+    "container_name": "tooluniverse-docker-llm-smoke-case",
+    "created_at": "2026-08-01T02:16:21.210741+00:00",
+    "docker_context": "default",
+    "docker_server_version": "28.0.4",
+    "health": {
+      "model": "fixture-evidence-synthesizer",
+      "service_id": "tooluniverse-docker-llm-smoke",
+      "status": "ok"
+    },
+    "host_port": 19090,
+    "image": "tooluniverse/docker-llm-smoke:test",
+    "image_id": "sha256:6f9459d804c3546c24e184e5099fad16a9aea73c0e957bba4425c08824ded58a",
+    "profile_name": "docker-llm-smoke",
+    "profile_sha256": "5de381c0fe30a88ddd896b1e830a10ea40f794a09090cd9726e0de7c96fb81d8",
+    "record_sha256": "e422bb0cf2470c22f8dc9d6ea0663172ef9defc71ff73f895a6e2fda3c3d5951",
+    "security": {
+      "bind_mounts": 0,
+      "cap_drop": [
+        "ALL"
+      ],
+      "cpus": 1.0,
+      "host_binding": "127.0.0.1:19090",
+      "memory_mb": 256,
+      "no_new_privileges": true,
+      "pids_limit": 64,
+      "privileged": false,
+      "read_only_rootfs": true,
+      "running": true
+    },
+    "tool_config": {
+      "cacheable": false,
+      "category": "special_tools",
+      "description": "Send a bounded evidence-synthesis prompt to the reviewed loopback Docker service.",
+      "docker_llm": {
+        "endpoint": "http://127.0.0.1:19090/v1/chat/completions",
+        "image_id": "sha256:6f9459d804c3546c24e184e5099fad16a9aea73c0e957bba4425c08824ded58a",
+        "max_prompt_chars": 20000,
+        "max_tokens_cap": 1024,
+        "model": "fixture-evidence-synthesizer",
+        "profile_sha256": "5de381c0fe30a88ddd896b1e830a10ea40f794a09090cd9726e0de7c96fb81d8",
+        "request_timeout_seconds": 15,
+        "service_id": "tooluniverse-docker-llm-smoke"
+      },
+      "mcp_annotations": {
+        "destructiveHint": false,
+        "readOnlyHint": true
+      },
+      "name": "DockerEvidenceSynthesizer",
+      "parameter": {
+        "additionalProperties": false,
+        "properties": {
+          "max_tokens": {
+            "default": 512,
+            "maximum": 1024,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "prompt": {
+            "maxLength": 20000,
+            "minLength": 1,
+            "type": "string"
+          },
+          "temperature": {
+            "default": 0.0,
+            "maximum": 2,
+            "minimum": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "type": "object"
+      },
+      "return_schema": {
+        "properties": {
+          "model": {
+            "type": "string"
+          },
+          "provenance": {
+            "type": "object"
+          },
+          "response": {
+            "type": "string"
+          },
+          "usage": {
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "response",
+          "model",
+          "provenance"
+        ],
+        "type": "object"
+      },
+      "type": "DockerLLMClientTool"
+    },
+    "version": 1
+  },
+  "tooluniverse_inference": {
+    "evidence_sections": 6,
+    "model": "fixture-evidence-synthesizer",
+    "payload_sha256": "b2cce5603b057dedf95450141f3f60b98bb3dd1205a8dac3b656f3224a6a6dac",
+    "prompt_hash_verified": true,
+    "prompt_sha256": "1d9f7583b5f03ec83efb79e858fdc8dd7ce22d6a3d713a5c294d76ad37508673",
+    "prompt_words": 199,
+    "response": "service_id=tooluniverse-docker-llm-smoke; prompt_sha256=1d9f7583b5f03ec83efb79e858fdc8dd7ce22d6a3d713a5c294d76ad37508673; word_count=199; evidence_sections=6; contract=openai-chat-completions",
+    "tool_name": "DockerEvidenceSynthesizer",
+    "usage": {
+      "completion_tokens": 5,
+      "prompt_tokens": 199,
+      "total_tokens": 204
+    }
+  }
+}

--- a/examples/docker_llm/artifacts/docker_smoke_snapshot.md
+++ b/examples/docker_llm/artifacts/docker_smoke_snapshot.md
@@ -1,0 +1,34 @@
+# Docker LLM Administrator Smoke Validation
+
+## Result
+
+A locally built service image was allowlisted, started through the administrator-only provisioner, inspected for the reviewed security settings, called through a freshly registered ToolUniverse tool, stopped, and removed.
+
+- Docker server: `28.0.4`
+- Image ID: `sha256:6f9459d804c3546c24e184e5099fad16a9aea73c0e957bba4425c08824ded58a`
+- Profile SHA-256: `5de381c0fe30a88ddd896b1e830a10ea40f794a09090cd9726e0de7c96fb81d8`
+- Tool: `DockerEvidenceSynthesizer`
+- Prompt SHA-256 verified by service: **true**
+- Response payload SHA-256: `b2cce5603b057dedf95450141f3f60b98bb3dd1205a8dac3b656f3224a6a6dac`
+
+## Inspected Container Policy
+
+| Property | Observed |
+| --- | --- |
+| Host binding | `127.0.0.1:19090` |
+| Read-only root filesystem | `True` |
+| Linux capabilities dropped | `ALL` |
+| No new privileges | `True` |
+| Privileged | `False` |
+| Bind mounts | `0` |
+| CPU limit | `1.0` |
+| Memory limit | `256 MB` |
+| PID limit | `64` |
+
+## Complicated Payload
+
+The request contained `199` words across `6` labeled sections covering spontaneous reports, trials, observational evidence, mechanistic evidence, and explicit output constraints. The service returned the exact prompt hash through the OpenAI-compatible endpoint, proving that the complete payload crossed Docker and ToolUniverse without truncation or substitution.
+
+## Boundary
+
+The fixture validates Docker lifecycle, isolation flags, health identity, client publication, request transport, response limits, and cleanup. It is deterministic infrastructure, not a real language model, so it does not validate synthesis quality or scientific conclusions.

--- a/examples/docker_llm/run_smoke_case.py
+++ b/examples/docker_llm/run_smoke_case.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -203,7 +204,7 @@ def run_case(
                 "tool_name": "DockerEvidenceSynthesizer",
                 "prompt_sha256": prompt_hash,
                 "prompt_hash_verified": prompt_hash_verified,
-                "prompt_words": len(PROMPT.split()),
+                "prompt_words": len(re.findall(r"\b[\w'-]+\b", PROMPT)),
                 "evidence_sections": PROMPT.count("## "),
                 "response": data["response"],
                 "model": data["model"],

--- a/examples/docker_llm/run_smoke_case.py
+++ b/examples/docker_llm/run_smoke_case.py
@@ -1,0 +1,282 @@
+"""Run a real Docker lifecycle and ToolUniverse inference-contract smoke case."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from tooluniverse import ToolUniverse
+from tooluniverse.remote.docker_llm.provision import (
+    load_provisioned_tool,
+    plan_container,
+    provision_container,
+    remove_container,
+    status_container,
+    stop_container,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "tests" / "fixtures" / "docker_llm_smoke"
+PROFILE = FIXTURE / "profile.json"
+IMAGE = "tooluniverse/docker-llm-smoke:test"
+ARTIFACTS = Path(__file__).resolve().parent / "artifacts"
+DEFAULT_JSON = ARTIFACTS / "docker_smoke_snapshot.json"
+DEFAULT_MARKDOWN = ARTIFACTS / "docker_smoke_snapshot.md"
+DEFAULT_RECORD = ARTIFACTS / "docker_provision_record.json"
+PROMPT = """## Question
+Assess whether the following mixed pharmacovigilance evidence warrants escalation for a possible drug-induced liver injury signal. Separate observed facts, conflicts, missing denominators, and next analyses.
+
+## Spontaneous reports
+Twenty-eight reports mention hepatocellular injury after exposure; nine include a positive dechallenge, two include a positive rechallenge, and seven have substantial concomitant-drug confounding. Reporting volume rose after a label change.
+
+## Trial evidence
+Across three randomized trials, ALT greater than three times the upper limit of normal occurred in 17 of 1,204 exposed participants and 6 of 1,198 controls. Trial follow-up ranged from 12 to 36 weeks, and severe baseline liver disease was excluded.
+
+## Observational evidence
+A claims analysis reports an adjusted hazard ratio of 1.42 with a 95% confidence interval of 0.96 to 2.10. Exposure was inferred from dispensing, outcome validation was available for 63 percent of cases, and residual alcohol-use confounding is plausible.
+
+## Mechanistic evidence
+An in-vitro assay found concentration-dependent mitochondrial stress above clinically observed free-drug concentrations. No validated human susceptibility biomarker is available.
+
+## Required output
+Return a concise evidence table, identify contradictions and bias risks, state whether the signal is detected versus confirmed, and list three falsifiable follow-up analyses. Do not give patient-specific advice."""
+
+
+def _run(command: list[str]) -> str:
+    result = subprocess.run(
+        command,
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=300,
+    )
+    if result.returncode != 0:
+        raise RuntimeError((result.stderr or result.stdout)[-2000:])
+    return result.stdout.strip()
+
+
+def _markdown(snapshot: dict[str, Any]) -> str:
+    security = snapshot["provisioning"]["security"]
+    inference = snapshot["tooluniverse_inference"]
+    return "\n".join(
+        [
+            "# Docker LLM Administrator Smoke Validation",
+            "",
+            "## Result",
+            "",
+            "A locally built service image was allowlisted, started through the administrator-only provisioner, inspected for the reviewed security settings, called through a freshly registered ToolUniverse tool, stopped, and removed.",
+            "",
+            f"- Docker server: `{snapshot['docker_server_version']}`",
+            f"- Image ID: `{snapshot['provisioning']['image_id']}`",
+            f"- Profile SHA-256: `{snapshot['provisioning']['profile_sha256']}`",
+            f"- Tool: `{inference['tool_name']}`",
+            f"- Prompt SHA-256 verified by service: **{str(inference['prompt_hash_verified']).lower()}**",
+            f"- Response payload SHA-256: `{inference['payload_sha256']}`",
+            "",
+            "## Inspected Container Policy",
+            "",
+            "| Property | Observed |",
+            "| --- | --- |",
+            f"| Host binding | `{security['host_binding']}` |",
+            f"| Read-only root filesystem | `{security['read_only_rootfs']}` |",
+            f"| Linux capabilities dropped | `{', '.join(security['cap_drop'])}` |",
+            f"| No new privileges | `{security['no_new_privileges']}` |",
+            f"| Privileged | `{security['privileged']}` |",
+            f"| Bind mounts | `{security['bind_mounts']}` |",
+            f"| CPU limit | `{security['cpus']}` |",
+            f"| Memory limit | `{security['memory_mb']} MB` |",
+            f"| PID limit | `{security['pids_limit']}` |",
+            "",
+            "## Complicated Payload",
+            "",
+            f"The request contained `{inference['prompt_words']}` words across `{inference['evidence_sections']}` labeled sections covering spontaneous reports, trials, observational evidence, mechanistic evidence, and explicit output constraints. The service returned the exact prompt hash through the OpenAI-compatible endpoint, proving that the complete payload crossed Docker and ToolUniverse without truncation or substitution.",
+            "",
+            "## Boundary",
+            "",
+            "The fixture validates Docker lifecycle, isolation flags, health identity, client publication, request transport, response limits, and cleanup. It is deterministic infrastructure, not a real language model, so it does not validate synthesis quality or scientific conclusions.",
+            "",
+        ]
+    )
+
+
+def run_case(
+    *,
+    host_port: int,
+    workspace: Path,
+    output_json: Path,
+    output_markdown: Path,
+    output_record: Path,
+) -> dict[str, Any]:
+    _run(["docker", "build", "--pull", "--tag", IMAGE, str(FIXTURE)])
+    previous_allowlist = os.environ.get("TOOLUNIVERSE_DOCKER_ALLOWED_IMAGES")
+    os.environ["TOOLUNIVERSE_DOCKER_ALLOWED_IMAGES"] = IMAGE
+    container_name = "tooluniverse-docker-llm-smoke-case"
+    provisioned = None
+    removed = None
+    try:
+        plan = plan_container(
+            PROFILE, host_port=host_port, container_name=container_name
+        )
+        provisioned = provision_container(
+            PROFILE,
+            host_port=host_port,
+            container_name=container_name,
+            workspace=workspace,
+        )
+        running = status_container(
+            PROFILE, host_port=host_port, container_name=container_name
+        )
+        record = {
+            key: value for key, value in provisioned.items() if key != "record_path"
+        }
+        output_record.parent.mkdir(parents=True, exist_ok=True)
+        output_record.write_text(
+            json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+        runtime = ARTIFACTS / ".runtime"
+        tooluniverse = ToolUniverse(
+            tool_files={}, keep_default_tools=False, workspace=str(runtime)
+        )
+        try:
+            name = load_provisioned_tool(
+                tooluniverse, "DockerEvidenceSynthesizer", workspace=workspace
+            )
+            result = tooluniverse.run_one_function(
+                {
+                    "name": name,
+                    "arguments": {
+                        "prompt": PROMPT,
+                        "temperature": 0.0,
+                        "max_tokens": 700,
+                    },
+                },
+                use_cache=False,
+            )
+        finally:
+            tooluniverse.close()
+        if not isinstance(result, dict) or result.get("status") != "success":
+            raise RuntimeError(f"ToolUniverse inference failed: {result!r}")
+        data = result["data"]
+        prompt_hash = hashlib.sha256(PROMPT.encode("utf-8")).hexdigest()
+        prompt_hash_verified = f"prompt_sha256={prompt_hash}" in data["response"]
+        if not prompt_hash_verified:
+            raise RuntimeError(
+                "Container response did not confirm the exact prompt hash"
+            )
+        stopped = stop_container(
+            PROFILE, host_port=host_port, container_name=container_name
+        )
+        stopped_status = status_container(
+            PROFILE, host_port=host_port, container_name=container_name
+        )
+        if stopped_status["security"]["running"]:
+            raise RuntimeError("Container remained running after stop")
+        removed = remove_container(
+            PROFILE,
+            host_port=host_port,
+            container_name=container_name,
+            workspace=workspace,
+            confirm=True,
+        )
+        final_status = status_container(
+            PROFILE, host_port=host_port, container_name=container_name
+        )
+        if final_status["exists"]:
+            raise RuntimeError("Container remained present after removal")
+        snapshot = {
+            "case": "reviewed_docker_llm_lifecycle_and_complex_prompt",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "docker_server_version": provisioned["docker_server_version"],
+            "plan": plan,
+            "provisioning": record,
+            "tooluniverse_inference": {
+                "tool_name": "DockerEvidenceSynthesizer",
+                "prompt_sha256": prompt_hash,
+                "prompt_hash_verified": prompt_hash_verified,
+                "prompt_words": len(PROMPT.split()),
+                "evidence_sections": PROMPT.count("## "),
+                "response": data["response"],
+                "model": data["model"],
+                "usage": data["usage"],
+                "payload_sha256": data["provenance"]["payload_sha256"],
+            },
+            "lifecycle": {
+                "running_status_verified": running["security"]["running"],
+                "stop": stopped,
+                "stopped_status_verified": not stopped_status["security"]["running"],
+                "remove": removed,
+                "absent_after_remove": not final_status["exists"],
+            },
+            "interpretation_boundary": (
+                "Infrastructure validation only; the deterministic fixture is not a "
+                "real model and does not validate scientific synthesis quality."
+            ),
+        }
+        output_json.parent.mkdir(parents=True, exist_ok=True)
+        output_json.write_text(
+            json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        output_markdown.write_text(_markdown(snapshot), encoding="utf-8")
+        return snapshot
+    finally:
+        if provisioned is not None and removed is None:
+            try:
+                remove_container(
+                    PROFILE,
+                    host_port=host_port,
+                    container_name=container_name,
+                    workspace=workspace,
+                    confirm=True,
+                )
+            except Exception:
+                pass
+        if previous_allowlist is None:
+            os.environ.pop("TOOLUNIVERSE_DOCKER_ALLOWED_IMAGES", None)
+        else:
+            os.environ["TOOLUNIVERSE_DOCKER_ALLOWED_IMAGES"] = previous_allowlist
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host-port", type=int, default=19090)
+    parser.add_argument("--workspace", type=Path, default=ARTIFACTS / "workspace")
+    parser.add_argument("--output-json", type=Path, default=DEFAULT_JSON)
+    parser.add_argument("--output-markdown", type=Path, default=DEFAULT_MARKDOWN)
+    parser.add_argument("--output-record", type=Path, default=DEFAULT_RECORD)
+    args = parser.parse_args()
+    snapshot = run_case(
+        host_port=args.host_port,
+        workspace=args.workspace,
+        output_json=args.output_json,
+        output_markdown=args.output_markdown,
+        output_record=args.output_record,
+    )
+    print(
+        json.dumps(
+            {
+                "image_id": snapshot["provisioning"]["image_id"],
+                "prompt_hash_verified": snapshot["tooluniverse_inference"][
+                    "prompt_hash_verified"
+                ],
+                "security": snapshot["provisioning"]["security"],
+                "lifecycle": snapshot["lifecycle"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ tooluniverse-smcp-stdio = "tooluniverse.smcp_server:run_stdio_server"
 # HTTP API Server for ToolUniverse class methods
 tooluniverse-http-api = "tooluniverse.http_api_server_cli:run_http_api_server"
 generate-mcp-tools = "tooluniverse.generate_mcp_tools:run_generate"
+tooluniverse-docker-llm-admin = "tooluniverse.remote.docker_llm.cli:main"
 # Human Expert Feedback System
 tooluniverse-expert-feedback = "tooluniverse.remote.expert_feedback.human_expert_mcp_tools:main"
 tooluniverse-expert-feedback-web = "tooluniverse.remote.expert_feedback.start_web_interface:main"
@@ -168,7 +169,6 @@ tu-datastore = "tooluniverse.database_setup.cli:main"
 # tooluniverse-wide-research = "tooluniverse.web_tools.literature_search_ui.simple_app:main"
 # Health Check Tool
 tooluniverse-doctor = "tooluniverse.doctor:main"
-tooluniverse-docker-llm-admin = "tooluniverse.remote.docker_llm.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ tu-datastore = "tooluniverse.database_setup.cli:main"
 # tooluniverse-wide-research = "tooluniverse.web_tools.literature_search_ui.simple_app:main"
 # Health Check Tool
 tooluniverse-doctor = "tooluniverse.doctor:main"
+tooluniverse-docker-llm-admin = "tooluniverse.remote.docker_llm.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/tooluniverse/remote/docker_llm/__init__.py
+++ b/src/tooluniverse/remote/docker_llm/__init__.py
@@ -1,0 +1,23 @@
+"""Administrator-managed Docker LLM integration."""
+
+from .client import DockerLLMClientTool
+from .provision import (
+    DockerProvisionError,
+    load_provisioned_tool,
+    plan_container,
+    provision_container,
+    remove_container,
+    status_container,
+    stop_container,
+)
+
+__all__ = [
+    "DockerLLMClientTool",
+    "DockerProvisionError",
+    "load_provisioned_tool",
+    "plan_container",
+    "provision_container",
+    "remove_container",
+    "status_container",
+    "stop_container",
+]

--- a/src/tooluniverse/remote/docker_llm/cli.py
+++ b/src/tooluniverse/remote/docker_llm/cli.py
@@ -1,0 +1,79 @@
+"""Administrator CLI for reviewed Docker LLM lifecycle operations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .provision import (
+    DockerProvisionError,
+    plan_container,
+    provision_container,
+    remove_container,
+    status_container,
+    stop_container,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tooluniverse-docker-llm-admin",
+        description=(
+            "Manage one reviewed, allowlisted Docker LLM profile. "
+            "This lifecycle interface is not a ToolUniverse agent tool."
+        ),
+    )
+    parser.add_argument("--profile", type=Path, required=True)
+    parser.add_argument("--workspace", type=Path)
+    parser.add_argument("--host-port", type=int, default=9000)
+    parser.add_argument("--container-name")
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("plan")
+    commands.add_parser("start")
+    commands.add_parser("status")
+    commands.add_parser("stop")
+    remove = commands.add_parser("remove")
+    remove.add_argument("--yes", action="store_true")
+    return parser
+
+
+def _execute(namespace: argparse.Namespace):
+    common = {
+        "host_port": namespace.host_port,
+        "container_name": namespace.container_name,
+    }
+    if namespace.command == "plan":
+        return plan_container(namespace.profile, **common)
+    if namespace.command == "start":
+        return provision_container(
+            namespace.profile, workspace=namespace.workspace, **common
+        )
+    if namespace.command == "status":
+        return status_container(namespace.profile, **common)
+    if namespace.command == "stop":
+        return stop_container(namespace.profile, **common)
+    if namespace.command == "remove":
+        return remove_container(
+            namespace.profile,
+            workspace=namespace.workspace,
+            confirm=namespace.yes,
+            **common,
+        )
+    raise AssertionError(f"Unsupported command: {namespace.command}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        result = _execute(build_parser().parse_args(argv))
+    except DockerProvisionError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
+        return 2
+    print(json.dumps({"ok": True, "result": result}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tooluniverse/remote/docker_llm/client.py
+++ b/src/tooluniverse/remote/docker_llm/client.py
@@ -1,0 +1,267 @@
+"""Bounded loopback client for an administrator-provisioned LLM container."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+from urllib.parse import urlsplit
+
+import requests
+
+from ...base_tool import BaseTool
+from ...tool_registry import register_tool
+
+_MAX_RESPONSE_BYTES = 1_000_000
+_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,44}$")
+_SHA256_RE = re.compile(r"^(?:sha256:)?[0-9a-f]{64}$")
+
+
+class DockerLLMClientError(RuntimeError):
+    """Raised when a provisioned client contract or response fails closed."""
+
+
+def _validated_client_config(config: Any) -> dict[str, Any]:
+    if not isinstance(config, dict):
+        raise DockerLLMClientError("Client configuration must be an object")
+    allowed = {
+        "name",
+        "type",
+        "description",
+        "category",
+        "cacheable",
+        "mcp_annotations",
+        "parameter",
+        "return_schema",
+        "docker_llm",
+    }
+    if set(config) - allowed:
+        raise DockerLLMClientError("Client configuration contains unknown fields")
+    name = config.get("name")
+    if not isinstance(name, str) or not _NAME_RE.fullmatch(name):
+        raise DockerLLMClientError("Client tool name is not valid")
+    description = config.get("description")
+    if not isinstance(description, str) or not 20 <= len(description.strip()) <= 1000:
+        raise DockerLLMClientError("Client description must contain 20-1000 characters")
+    if config.get("type") != "DockerLLMClientTool":
+        raise DockerLLMClientError("Client type must be DockerLLMClientTool")
+    runtime = config.get("docker_llm")
+    if not isinstance(runtime, dict):
+        raise DockerLLMClientError("docker_llm runtime configuration is required")
+    if set(runtime) != {
+        "endpoint",
+        "service_id",
+        "model",
+        "request_timeout_seconds",
+        "max_prompt_chars",
+        "max_tokens_cap",
+        "image_id",
+        "profile_sha256",
+    }:
+        raise DockerLLMClientError(
+            "docker_llm runtime fields do not match the contract"
+        )
+    endpoint = runtime["endpoint"]
+    parsed = urlsplit(endpoint) if isinstance(endpoint, str) else None
+    if (
+        parsed is None
+        or parsed.scheme != "http"
+        or parsed.hostname != "127.0.0.1"
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.port is None
+        or not 1024 <= parsed.port <= 65535
+        or not parsed.path.startswith("/")
+        or ".." in parsed.path
+    ):
+        raise DockerLLMClientError(
+            "Inference endpoint must be a fixed loopback HTTP URL"
+        )
+    for field, maximum in (("service_id", 80), ("model", 200)):
+        value = runtime[field]
+        if (
+            not isinstance(value, str)
+            or not value
+            or len(value) > maximum
+            or any(ord(character) < 32 for character in value)
+        ):
+            raise DockerLLMClientError(f"docker_llm.{field} is invalid")
+    timeout = runtime["request_timeout_seconds"]
+    prompt_limit = runtime["max_prompt_chars"]
+    token_limit = runtime["max_tokens_cap"]
+    if (
+        isinstance(timeout, bool)
+        or not isinstance(timeout, int)
+        or not 1 <= timeout <= 120
+    ):
+        raise DockerLLMClientError("Request timeout must be 1-120 seconds")
+    if (
+        isinstance(prompt_limit, bool)
+        or not isinstance(prompt_limit, int)
+        or not 100 <= prompt_limit <= 100_000
+    ):
+        raise DockerLLMClientError("Prompt limit must be 100-100000 characters")
+    if (
+        isinstance(token_limit, bool)
+        or not isinstance(token_limit, int)
+        or not 1 <= token_limit <= 8192
+    ):
+        raise DockerLLMClientError("Token limit must be 1-8192")
+    if not _SHA256_RE.fullmatch(str(runtime["image_id"])):
+        raise DockerLLMClientError("Container image ID is invalid")
+    if not re.fullmatch(r"[0-9a-f]{64}", str(runtime["profile_sha256"])):
+        raise DockerLLMClientError("Profile digest is invalid")
+    parameter = config.get("parameter")
+    if (
+        not isinstance(parameter, dict)
+        or parameter.get("additionalProperties") is not False
+    ):
+        raise DockerLLMClientError(
+            "Client parameters must reject additional properties"
+        )
+    return config
+
+
+def _read_bounded_response(response: requests.Response) -> tuple[bytes, dict[str, Any]]:
+    if response.is_redirect or response.is_permanent_redirect:
+        raise DockerLLMClientError("Inference redirects are prohibited")
+    if response.status_code != 200:
+        raise DockerLLMClientError(
+            f"Inference endpoint returned HTTP {response.status_code}"
+        )
+    content_type = response.headers.get("Content-Type", "").split(";", 1)[0].lower()
+    if content_type != "application/json":
+        raise DockerLLMClientError("Inference endpoint did not return application/json")
+    length = response.headers.get("Content-Length")
+    if length:
+        try:
+            if int(length) > _MAX_RESPONSE_BYTES:
+                raise DockerLLMClientError("Inference response exceeds the 1 MB limit")
+        except ValueError as exc:
+            raise DockerLLMClientError("Inference Content-Length is invalid") from exc
+    body = bytearray()
+    for chunk in response.iter_content(chunk_size=65_536):
+        body.extend(chunk)
+        if len(body) > _MAX_RESPONSE_BYTES:
+            raise DockerLLMClientError("Inference response exceeds the 1 MB limit")
+    try:
+        payload = json.loads(bytes(body))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DockerLLMClientError("Inference response is not valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise DockerLLMClientError("Inference response must be a JSON object")
+    return bytes(body), payload
+
+
+@register_tool("DockerLLMClientTool")
+class DockerLLMClientTool(BaseTool):
+    """Call one fixed, loopback-only OpenAI-compatible inference endpoint."""
+
+    def __init__(self, tool_config):
+        super().__init__(_validated_client_config(tool_config))
+
+    def run(self, arguments=None, **_: Any):
+        values = {} if arguments is None else arguments
+        if not isinstance(values, dict):
+            raise DockerLLMClientError("Tool arguments must be an object")
+        runtime = self.tool_config["docker_llm"]
+        prompt = values.get("prompt")
+        if (
+            not isinstance(prompt, str)
+            or not prompt.strip()
+            or len(prompt) > runtime["max_prompt_chars"]
+            or any(
+                ord(character) < 32 and character not in "\n\r\t"
+                for character in prompt
+            )
+        ):
+            raise DockerLLMClientError(
+                "prompt is empty, too long, or contains control characters"
+            )
+        temperature = values.get("temperature", 0.0)
+        max_tokens = values.get("max_tokens", min(512, runtime["max_tokens_cap"]))
+        if (
+            isinstance(temperature, bool)
+            or not isinstance(temperature, (int, float))
+            or not 0 <= temperature <= 2
+        ):
+            raise DockerLLMClientError("temperature must be between 0 and 2")
+        if (
+            isinstance(max_tokens, bool)
+            or not isinstance(max_tokens, int)
+            or not 1 <= max_tokens <= runtime["max_tokens_cap"]
+        ):
+            raise DockerLLMClientError("max_tokens exceeds the reviewed limit")
+        request_body = {
+            "model": runtime["model"],
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        session = requests.Session()
+        session.trust_env = False
+        response = None
+        try:
+            response = session.post(
+                runtime["endpoint"],
+                json=request_body,
+                timeout=runtime["request_timeout_seconds"],
+                allow_redirects=False,
+                stream=True,
+                headers={"Accept": "application/json"},
+            )
+            raw, payload = _read_bounded_response(response)
+        except requests.RequestException as exc:
+            raise DockerLLMClientError("Loopback inference request failed") from exc
+        finally:
+            if response is not None:
+                response.close()
+            session.close()
+        choices = payload.get("choices")
+        if not isinstance(choices, list) or len(choices) != 1:
+            raise DockerLLMClientError(
+                "Inference response must contain exactly one choice"
+            )
+        choice = choices[0]
+        message = choice.get("message") if isinstance(choice, dict) else None
+        content = message.get("content") if isinstance(message, dict) else None
+        if (
+            not isinstance(content, str)
+            or not content
+            or len(content) > _MAX_RESPONSE_BYTES
+        ):
+            raise DockerLLMClientError("Inference choice content is invalid")
+        usage = payload.get("usage")
+        if usage is not None and not isinstance(usage, dict):
+            raise DockerLLMClientError("Inference usage must be an object")
+        response_model = payload.get("model", runtime["model"])
+        if (
+            not isinstance(response_model, str)
+            or not response_model
+            or len(response_model) > 200
+            or any(ord(character) < 32 for character in response_model)
+        ):
+            raise DockerLLMClientError("Inference model identifier is invalid")
+        return {
+            "status": "success",
+            "data": {
+                "response": content,
+                "model": response_model,
+                "usage": usage,
+                "provenance": {
+                    "endpoint": runtime["endpoint"],
+                    "service_id": runtime["service_id"],
+                    "image_id": runtime["image_id"],
+                    "profile_sha256": runtime["profile_sha256"],
+                    "payload_sha256": hashlib.sha256(raw).hexdigest(),
+                    "http_status": 200,
+                    "redirects": 0,
+                },
+            },
+        }
+
+
+__all__ = ["DockerLLMClientError", "DockerLLMClientTool"]

--- a/src/tooluniverse/remote/docker_llm/provision.py
+++ b/src/tooluniverse/remote/docker_llm/provision.py
@@ -1,0 +1,899 @@
+"""Administrator-only provisioning for a reviewed Docker LLM profile."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import socket
+import subprocess
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+from urllib.parse import urlsplit
+
+import requests
+
+from .client import DockerLLMClientTool, _validated_client_config
+
+_VERSION = 1
+_MAX_ARTIFACT_BYTES = 1_000_000
+_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{2,62}$")
+_TOOL_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,44}$")
+_IMAGE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,254}$")
+_PATH_RE = re.compile(r"^/[A-Za-z0-9._~!$&'()*+,;=:@%/-]{1,127}$")
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_MANAGED_LABEL = "org.tooluniverse.managed"
+_PROFILE_LABEL = "org.tooluniverse.profile-sha256"
+_SERVICE_LABEL = "org.tooluniverse.service-id"
+
+
+class DockerProvisionError(RuntimeError):
+    """Raised when a Docker lifecycle or profile check fails closed."""
+
+
+def _canonical_digest(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _workspace_root(workspace: str | Path | None) -> Path:
+    if workspace is not None:
+        root = Path(workspace).expanduser()
+    else:
+        configured = os.environ.get("TOOLUNIVERSE_DOCKER_DIR")
+        root = (
+            Path(configured).expanduser()
+            if configured
+            else Path.home() / ".tooluniverse" / "docker_llm"
+        )
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        if path.stat().st_size > _MAX_ARTIFACT_BYTES:
+            raise DockerProvisionError(f"Artifact {path.name!r} exceeds 1 MB")
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise DockerProvisionError(f"Artifact {path.name!r} does not exist") from exc
+    except json.JSONDecodeError as exc:
+        raise DockerProvisionError(f"Artifact {path.name!r} is not valid JSON") from exc
+
+
+def _atomic_write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+    if len(encoded.encode("utf-8")) > _MAX_ARTIFACT_BYTES:
+        raise DockerProvisionError("Provisioning artifact exceeds 1 MB")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.stem}_", suffix=".json", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _bounded_text(value: Any, *, field: str, minimum: int, maximum: int) -> str:
+    text = str(value or "").strip()
+    if not minimum <= len(text) <= maximum or any(
+        ord(character) < 32 for character in text
+    ):
+        raise DockerProvisionError(
+            f"{field} must contain {minimum}-{maximum} printable characters"
+        )
+    return text
+
+
+def _allowed_images() -> set[str]:
+    raw = os.environ.get("TOOLUNIVERSE_DOCKER_ALLOWED_IMAGES", "")
+    images = {item.strip() for item in raw.split(",") if item.strip()}
+    if not images:
+        raise DockerProvisionError(
+            "TOOLUNIVERSE_DOCKER_ALLOWED_IMAGES must list exact approved image references"
+        )
+    return images
+
+
+def load_profile(profile_path: str | Path) -> tuple[dict[str, Any], str]:
+    """Load and strictly validate one administrator-reviewed JSON profile."""
+    profile = _read_json(Path(profile_path))
+    if not isinstance(profile, dict) or set(profile) != {
+        "version",
+        "profile_name",
+        "service_id",
+        "image",
+        "container_port",
+        "health_path",
+        "inference_path",
+        "model",
+        "tool",
+        "resources",
+        "timeouts",
+    }:
+        raise DockerProvisionError("Profile fields do not match the reviewed schema")
+    if profile["version"] != _VERSION:
+        raise DockerProvisionError("Profile version must be 1")
+    for field in ("profile_name", "service_id"):
+        value = profile[field]
+        if not isinstance(value, str) or not _NAME_RE.fullmatch(value):
+            raise DockerProvisionError(f"{field} must be a lowercase stable identifier")
+    image = profile["image"]
+    if (
+        not isinstance(image, str)
+        or not _IMAGE_RE.fullmatch(image)
+        or image.startswith("-")
+        or image not in _allowed_images()
+    ):
+        raise DockerProvisionError("Profile image is not in the exact image allowlist")
+    port = profile["container_port"]
+    if isinstance(port, bool) or not isinstance(port, int) or not 1024 <= port <= 65535:
+        raise DockerProvisionError("container_port must be between 1024 and 65535")
+    for field in ("health_path", "inference_path"):
+        path = profile[field]
+        if (
+            not isinstance(path, str)
+            or not _PATH_RE.fullmatch(path)
+            or ".." in path
+            or "//" in path
+        ):
+            raise DockerProvisionError(f"{field} must be a fixed absolute URL path")
+    if profile["health_path"] == profile["inference_path"]:
+        raise DockerProvisionError("Health and inference paths must differ")
+    _bounded_text(profile["model"], field="model", minimum=1, maximum=200)
+
+    tool = profile["tool"]
+    if not isinstance(tool, dict) or set(tool) != {
+        "name",
+        "description",
+        "max_prompt_chars",
+        "max_tokens_cap",
+        "default_temperature",
+    }:
+        raise DockerProvisionError("tool fields do not match the reviewed schema")
+    if not isinstance(tool["name"], str) or not _TOOL_NAME_RE.fullmatch(tool["name"]):
+        raise DockerProvisionError("tool.name is not MCP-compatible")
+    _bounded_text(
+        tool["description"], field="tool.description", minimum=20, maximum=1000
+    )
+    prompt_limit = tool["max_prompt_chars"]
+    token_limit = tool["max_tokens_cap"]
+    temperature = tool["default_temperature"]
+    if (
+        isinstance(prompt_limit, bool)
+        or not isinstance(prompt_limit, int)
+        or not 100 <= prompt_limit <= 100_000
+    ):
+        raise DockerProvisionError("tool.max_prompt_chars must be 100-100000")
+    if (
+        isinstance(token_limit, bool)
+        or not isinstance(token_limit, int)
+        or not 1 <= token_limit <= 8192
+    ):
+        raise DockerProvisionError("tool.max_tokens_cap must be 1-8192")
+    if (
+        isinstance(temperature, bool)
+        or not isinstance(temperature, (int, float))
+        or not 0 <= temperature <= 2
+    ):
+        raise DockerProvisionError("tool.default_temperature must be between 0 and 2")
+
+    resources = profile["resources"]
+    if not isinstance(resources, dict) or set(resources) != {
+        "cpus",
+        "memory_mb",
+        "pids_limit",
+        "tmpfs_mb",
+    }:
+        raise DockerProvisionError("resources fields do not match the reviewed schema")
+    cpus = resources["cpus"]
+    if (
+        isinstance(cpus, bool)
+        or not isinstance(cpus, (int, float))
+        or not 0.25 <= cpus <= 32
+    ):
+        raise DockerProvisionError("resources.cpus must be between 0.25 and 32")
+    for field, minimum, maximum in (
+        ("memory_mb", 128, 131_072),
+        ("pids_limit", 32, 4096),
+        ("tmpfs_mb", 16, 4096),
+    ):
+        value = resources[field]
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or not minimum <= value <= maximum
+        ):
+            raise DockerProvisionError(
+                f"resources.{field} must be an integer between {minimum} and {maximum}"
+            )
+
+    timeouts = profile["timeouts"]
+    if not isinstance(timeouts, dict) or set(timeouts) != {
+        "health_seconds",
+        "inference_seconds",
+    }:
+        raise DockerProvisionError("timeouts fields do not match the reviewed schema")
+    for field, maximum in (("health_seconds", 300), ("inference_seconds", 120)):
+        value = timeouts[field]
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or not 1 <= value <= maximum
+        ):
+            raise DockerProvisionError(
+                f"timeouts.{field} must be between 1 and {maximum}"
+            )
+    return profile, _canonical_digest(profile)
+
+
+def _docker_environment() -> dict[str, str]:
+    allowed = ("PATH", "SystemRoot", "HOME", "USERPROFILE", "TEMP", "TMP")
+    return {name: os.environ[name] for name in allowed if name in os.environ}
+
+
+def _run_docker(
+    arguments: Sequence[str], *, check: bool = True, timeout: int = 60
+) -> subprocess.CompletedProcess:
+    if not isinstance(arguments, (list, tuple)) or any(
+        not isinstance(item, str) for item in arguments
+    ):
+        raise DockerProvisionError("Docker arguments must be a sequence of strings")
+    try:
+        result = subprocess.run(
+            ["docker", *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            env=_docker_environment(),
+        )
+    except FileNotFoundError as exc:
+        raise DockerProvisionError("Docker CLI is not installed") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise DockerProvisionError("Docker command exceeded its timeout") from exc
+    if check and result.returncode != 0:
+        detail = (result.stderr or result.stdout or "unknown Docker error").strip()[
+            :1000
+        ]
+        raise DockerProvisionError(f"Docker command failed: {detail}")
+    return result
+
+
+def _check_docker() -> tuple[str, str]:
+    context_result = _run_docker(["context", "show"])
+    context = context_result.stdout.strip()
+    if not context or len(context) > 100:
+        raise DockerProvisionError("Docker returned an invalid context name")
+    inspect_result = _run_docker(["context", "inspect", context])
+    try:
+        contexts = json.loads(inspect_result.stdout)
+        daemon_host = contexts[0]["Endpoints"]["docker"]["Host"]
+    except (json.JSONDecodeError, IndexError, KeyError, TypeError) as exc:
+        raise DockerProvisionError(
+            "Docker context inspection returned invalid data"
+        ) from exc
+    local_unix = isinstance(daemon_host, str) and daemon_host.startswith("unix:///")
+    local_pipe = isinstance(daemon_host, str) and daemon_host.startswith(
+        "npipe:////./pipe/"
+    )
+    if not local_unix and not local_pipe:
+        raise DockerProvisionError(
+            "Docker context must use a local socket or named pipe"
+        )
+    result = _run_docker(["version", "--format", "{{.Server.Version}}"])
+    version = result.stdout.strip()
+    if not version or len(version) > 100:
+        raise DockerProvisionError("Docker server returned an invalid version")
+    return version, context
+
+
+def _image_id(image: str) -> str:
+    result = _run_docker(["image", "inspect", "--format", "{{.Id}}", image])
+    image_id = result.stdout.strip()
+    if not _SHA256_RE.fullmatch(image_id):
+        raise DockerProvisionError("Docker image did not resolve to a content ID")
+    return image_id
+
+
+def _inspect_container(container_name: str) -> dict[str, Any] | None:
+    result = _run_docker(["container", "inspect", container_name], check=False)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).casefold()
+        if "no such" in detail:
+            return None
+        raise DockerProvisionError("Docker could not inspect the requested container")
+    try:
+        records = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise DockerProvisionError("Docker inspect returned invalid JSON") from exc
+    if (
+        not isinstance(records, list)
+        or len(records) != 1
+        or not isinstance(records[0], dict)
+    ):
+        raise DockerProvisionError("Docker inspect returned an unexpected record set")
+    return records[0]
+
+
+def _container_name(value: str | None, profile: dict[str, Any]) -> str:
+    name = value or f"tooluniverse-{profile['profile_name']}"
+    if not isinstance(name, str) or not _NAME_RE.fullmatch(name):
+        raise DockerProvisionError(
+            "Container name must be a lowercase stable identifier"
+        )
+    return name
+
+
+def _host_port(value: int) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 1024 <= value <= 65535
+    ):
+        raise DockerProvisionError("Host port must be between 1024 and 65535")
+    return value
+
+
+def _expected_labels(profile: dict[str, Any], profile_sha256: str) -> dict[str, str]:
+    return {
+        _MANAGED_LABEL: "true",
+        _PROFILE_LABEL: profile_sha256,
+        _SERVICE_LABEL: profile["service_id"],
+    }
+
+
+def _run_arguments(
+    profile: dict[str, Any], profile_sha256: str, name: str, host_port: int
+) -> list[str]:
+    resources = profile["resources"]
+    arguments = [
+        "run",
+        "--detach",
+        "--name",
+        name,
+        "--pull",
+        "never",
+    ]
+    for key, value in _expected_labels(profile, profile_sha256).items():
+        arguments.extend(["--label", f"{key}={value}"])
+    arguments.extend(
+        [
+            "--publish",
+            f"127.0.0.1:{host_port}:{profile['container_port']}",
+            "--read-only",
+            "--cap-drop",
+            "ALL",
+            "--security-opt",
+            "no-new-privileges:true",
+            "--pids-limit",
+            str(resources["pids_limit"]),
+            "--memory",
+            f"{resources['memory_mb']}m",
+            "--cpus",
+            str(resources["cpus"]),
+            "--tmpfs",
+            f"/tmp:rw,noexec,nosuid,size={resources['tmpfs_mb']}m",
+            profile["image"],
+        ]
+    )
+    return arguments
+
+
+def _security_summary(
+    record: dict[str, Any],
+    profile: dict[str, Any],
+    profile_sha256: str,
+    image_id: str,
+    name: str,
+    host_port: int,
+) -> dict[str, Any]:
+    config = record.get("Config") or {}
+    host = record.get("HostConfig") or {}
+    state = record.get("State") or {}
+    labels = config.get("Labels") or {}
+    expected_labels = _expected_labels(profile, profile_sha256)
+    if record.get("Name", "").lstrip("/") != name:
+        raise DockerProvisionError("Container inspect name does not match")
+    if any(labels.get(key) != value for key, value in expected_labels.items()):
+        raise DockerProvisionError(
+            "Existing container is not managed by this exact profile"
+        )
+    if record.get("Image") != image_id or config.get("Image") != profile["image"]:
+        raise DockerProvisionError("Container image does not match the reviewed image")
+    port_key = f"{profile['container_port']}/tcp"
+    bindings = (host.get("PortBindings") or {}).get(port_key)
+    if bindings != [{"HostIp": "127.0.0.1", "HostPort": str(host_port)}]:
+        raise DockerProvisionError("Container port is not bound exactly to loopback")
+    security_opt = host.get("SecurityOpt") or []
+    cap_drop = host.get("CapDrop") or []
+    resources = profile["resources"]
+    expected_nano_cpus = int(float(resources["cpus"]) * 1_000_000_000)
+    if (
+        host.get("ReadonlyRootfs") is not True
+        or "ALL" not in cap_drop
+        or not any(item.startswith("no-new-privileges") for item in security_opt)
+        or host.get("Privileged") is True
+        or host.get("NetworkMode") == "host"
+        or host.get("PidMode") == "host"
+        or host.get("IpcMode") == "host"
+        or (host.get("Binds") or [])
+        or host.get("PidsLimit") != resources["pids_limit"]
+        or host.get("Memory") != resources["memory_mb"] * 1024 * 1024
+        or host.get("NanoCpus") != expected_nano_cpus
+    ):
+        raise DockerProvisionError(
+            "Container security settings do not match the profile"
+        )
+    return {
+        "running": state.get("Running") is True,
+        "read_only_rootfs": True,
+        "cap_drop": sorted(cap_drop),
+        "no_new_privileges": True,
+        "privileged": False,
+        "bind_mounts": 0,
+        "host_binding": f"127.0.0.1:{host_port}",
+        "pids_limit": host["PidsLimit"],
+        "memory_mb": host["Memory"] // (1024 * 1024),
+        "cpus": host["NanoCpus"] / 1_000_000_000,
+    }
+
+
+def _port_is_available(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        try:
+            listener.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+    return True
+
+
+def _health_url(profile: dict[str, Any], host_port: int) -> str:
+    return f"http://127.0.0.1:{host_port}{profile['health_path']}"
+
+
+def _wait_for_health(profile: dict[str, Any], host_port: int) -> dict[str, Any]:
+    deadline = time.monotonic() + profile["timeouts"]["health_seconds"]
+    session = requests.Session()
+    session.trust_env = False
+    last_error = "service did not answer"
+    try:
+        while time.monotonic() < deadline:
+            response = None
+            try:
+                response = session.get(
+                    _health_url(profile, host_port),
+                    timeout=min(5, profile["timeouts"]["health_seconds"]),
+                    allow_redirects=False,
+                    stream=True,
+                    headers={"Accept": "application/json"},
+                )
+                if response.is_redirect or response.status_code != 200:
+                    last_error = f"HTTP {response.status_code}"
+                else:
+                    content_type = (
+                        response.headers.get("Content-Type", "")
+                        .split(";", 1)[0]
+                        .lower()
+                    )
+                    content_length = response.headers.get("Content-Length")
+                    declared_too_large = False
+                    if content_length:
+                        try:
+                            declared_too_large = int(content_length) > 65_536
+                        except ValueError:
+                            declared_too_large = True
+                    if content_type != "application/json":
+                        last_error = "health response was not application/json"
+                    elif declared_too_large:
+                        last_error = "health response exceeded 64 KiB"
+                    else:
+                        body = response.raw.read(65_537, decode_content=True)
+                        if len(body) > 65_536:
+                            last_error = "health response exceeded 64 KiB"
+                        else:
+                            payload = json.loads(body)
+                            if (
+                                isinstance(payload, dict)
+                                and payload.get("status") == "ok"
+                                and payload.get("service_id") == profile["service_id"]
+                            ):
+                                return payload
+                            last_error = "health identity did not match the profile"
+            except (
+                requests.RequestException,
+                json.JSONDecodeError,
+                UnicodeDecodeError,
+            ) as exc:
+                last_error = type(exc).__name__
+            finally:
+                if response is not None:
+                    response.close()
+            time.sleep(0.25)
+    finally:
+        session.close()
+    raise DockerProvisionError(f"Container health check failed: {last_error}")
+
+
+def _client_config(
+    profile: dict[str, Any], profile_sha256: str, image_id: str, host_port: int
+) -> dict[str, Any]:
+    tool = profile["tool"]
+    config = {
+        "name": tool["name"],
+        "type": "DockerLLMClientTool",
+        "description": tool["description"],
+        "category": "special_tools",
+        "cacheable": False,
+        "mcp_annotations": {"readOnlyHint": True, "destructiveHint": False},
+        "parameter": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": tool["max_prompt_chars"],
+                },
+                "temperature": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 2,
+                    "default": tool["default_temperature"],
+                },
+                "max_tokens": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": tool["max_tokens_cap"],
+                    "default": min(512, tool["max_tokens_cap"]),
+                },
+            },
+            "required": ["prompt"],
+            "additionalProperties": False,
+        },
+        "return_schema": {
+            "type": "object",
+            "properties": {
+                "response": {"type": "string"},
+                "model": {"type": "string"},
+                "usage": {"type": ["object", "null"]},
+                "provenance": {"type": "object"},
+            },
+            "required": ["response", "model", "provenance"],
+        },
+        "docker_llm": {
+            "endpoint": f"http://127.0.0.1:{host_port}{profile['inference_path']}",
+            "service_id": profile["service_id"],
+            "model": profile["model"],
+            "request_timeout_seconds": profile["timeouts"]["inference_seconds"],
+            "max_prompt_chars": tool["max_prompt_chars"],
+            "max_tokens_cap": tool["max_tokens_cap"],
+            "image_id": image_id,
+            "profile_sha256": profile_sha256,
+        },
+    }
+    return _validated_client_config(config)
+
+
+def _write_record(
+    workspace: str | Path | None,
+    profile: dict[str, Any],
+    profile_sha256: str,
+    image_id: str,
+    docker_version: str,
+    docker_context: str,
+    container_name: str,
+    host_port: int,
+    security: dict[str, Any],
+    health: dict[str, Any],
+) -> dict[str, Any]:
+    config = _client_config(profile, profile_sha256, image_id, host_port)
+    body = {
+        "version": _VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "profile_name": profile["profile_name"],
+        "profile_sha256": profile_sha256,
+        "image": profile["image"],
+        "image_id": image_id,
+        "docker_server_version": docker_version,
+        "docker_context": docker_context,
+        "container_name": container_name,
+        "host_port": host_port,
+        "security": security,
+        "health": {
+            "status": health["status"],
+            "service_id": health["service_id"],
+            "model": health.get("model"),
+        },
+        "tool_config": config,
+    }
+    record = {**body, "record_sha256": _canonical_digest(body)}
+    path = _workspace_root(workspace) / "approved" / f"{config['name']}.json"
+    _atomic_write_json(path, record)
+    return {**record, "record_path": str(path)}
+
+
+def plan_container(
+    profile_path: str | Path,
+    *,
+    host_port: int = 9000,
+    container_name: str | None = None,
+) -> dict[str, Any]:
+    """Return the exact bounded Docker command without contacting Docker."""
+    profile, digest = load_profile(profile_path)
+    port = _host_port(host_port)
+    name = _container_name(container_name, profile)
+    return {
+        "profile_name": profile["profile_name"],
+        "profile_sha256": digest,
+        "container_name": name,
+        "image": profile["image"],
+        "host_binding": f"127.0.0.1:{port}:{profile['container_port']}",
+        "docker_argv": ["docker", *_run_arguments(profile, digest, name, port)],
+    }
+
+
+def provision_container(
+    profile_path: str | Path,
+    *,
+    host_port: int = 9000,
+    container_name: str | None = None,
+    workspace: str | Path | None = None,
+) -> dict[str, Any]:
+    """Start or reuse an exact managed container, verify it, then publish its client."""
+    profile, digest = load_profile(profile_path)
+    port = _host_port(host_port)
+    name = _container_name(container_name, profile)
+    docker_version, docker_context = _check_docker()
+    image_id = _image_id(profile["image"])
+    existing = _inspect_container(name)
+    created = False
+    started_existing = False
+    try:
+        if existing is None:
+            if not _port_is_available(port):
+                raise DockerProvisionError("Requested loopback port is already in use")
+            _run_docker(_run_arguments(profile, digest, name, port), timeout=180)
+            created = True
+        else:
+            existing_security = _security_summary(
+                existing, profile, digest, image_id, name, port
+            )
+            if not existing_security["running"]:
+                _run_docker(["container", "start", name])
+                started_existing = True
+        inspected = _inspect_container(name)
+        if inspected is None:
+            raise DockerProvisionError("Container disappeared after start")
+        security = _security_summary(inspected, profile, digest, image_id, name, port)
+        if not security["running"]:
+            raise DockerProvisionError("Container is not running after start")
+        health = _wait_for_health(profile, port)
+        return _write_record(
+            workspace,
+            profile,
+            digest,
+            image_id,
+            docker_version,
+            docker_context,
+            name,
+            port,
+            security,
+            health,
+        )
+    except Exception:
+        current = _inspect_container(name)
+        if current is not None:
+            try:
+                _security_summary(current, profile, digest, image_id, name, port)
+            except DockerProvisionError:
+                pass
+            else:
+                if created:
+                    _run_docker(["container", "rm", "--force", name], check=False)
+                elif started_existing:
+                    _run_docker(
+                        ["container", "stop", "--time", "10", name], check=False
+                    )
+        raise
+
+
+def status_container(
+    profile_path: str | Path,
+    *,
+    host_port: int = 9000,
+    container_name: str | None = None,
+) -> dict[str, Any]:
+    profile, digest = load_profile(profile_path)
+    port = _host_port(host_port)
+    name = _container_name(container_name, profile)
+    docker_version, docker_context = _check_docker()
+    record = _inspect_container(name)
+    if record is None:
+        return {
+            "exists": False,
+            "container_name": name,
+            "docker_server_version": docker_version,
+            "docker_context": docker_context,
+        }
+    image_id = _image_id(profile["image"])
+    security = _security_summary(record, profile, digest, image_id, name, port)
+    return {
+        "exists": True,
+        "container_name": name,
+        "image_id": image_id,
+        "docker_server_version": docker_version,
+        "docker_context": docker_context,
+        "security": security,
+    }
+
+
+def stop_container(
+    profile_path: str | Path,
+    *,
+    host_port: int = 9000,
+    container_name: str | None = None,
+) -> dict[str, Any]:
+    profile, digest = load_profile(profile_path)
+    port = _host_port(host_port)
+    name = _container_name(container_name, profile)
+    _check_docker()
+    image_id = _image_id(profile["image"])
+    record = _inspect_container(name)
+    if record is None:
+        raise DockerProvisionError("Managed container does not exist")
+    security = _security_summary(record, profile, digest, image_id, name, port)
+    if security["running"]:
+        _run_docker(["container", "stop", "--time", "10", name], timeout=30)
+    return {"container_name": name, "stopped": True, "was_running": security["running"]}
+
+
+def remove_container(
+    profile_path: str | Path,
+    *,
+    host_port: int = 9000,
+    container_name: str | None = None,
+    workspace: str | Path | None = None,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    if confirm is not True:
+        raise DockerProvisionError("Container removal requires explicit confirmation")
+    profile, digest = load_profile(profile_path)
+    port = _host_port(host_port)
+    name = _container_name(container_name, profile)
+    _check_docker()
+    image_id = _image_id(profile["image"])
+    record = _inspect_container(name)
+    if record is None:
+        raise DockerProvisionError("Managed container does not exist")
+    _security_summary(record, profile, digest, image_id, name, port)
+    config_path = (
+        _workspace_root(workspace) / "approved" / f"{profile['tool']['name']}.json"
+    )
+    client_record_removed = config_path.exists()
+    if config_path.exists():
+        provisioned = _validated_record(_read_json(config_path))
+        if not (
+            provisioned["profile_sha256"] == digest
+            and provisioned["image_id"] == image_id
+            and provisioned["container_name"] == name
+            and provisioned["host_port"] == port
+        ):
+            raise DockerProvisionError(
+                "Client record does not match the managed container"
+            )
+    _run_docker(["container", "rm", "--force", name], timeout=30)
+    if client_record_removed:
+        config_path.unlink()
+    return {
+        "container_name": name,
+        "removed": True,
+        "client_record_removed": client_record_removed,
+    }
+
+
+def _validated_record(record: Any) -> dict[str, Any]:
+    if not isinstance(record, dict) or record.get("version") != _VERSION:
+        raise DockerProvisionError("Provisioning record has an unsupported structure")
+    if set(record) != {
+        "version",
+        "created_at",
+        "profile_name",
+        "profile_sha256",
+        "image",
+        "image_id",
+        "docker_server_version",
+        "docker_context",
+        "container_name",
+        "host_port",
+        "security",
+        "health",
+        "tool_config",
+        "record_sha256",
+    }:
+        raise DockerProvisionError(
+            "Provisioning record fields do not match the contract"
+        )
+    body = {key: value for key, value in record.items() if key != "record_sha256"}
+    if record.get("record_sha256") != _canonical_digest(body):
+        raise DockerProvisionError(
+            "Provisioning record digest does not match its content"
+        )
+    if not re.fullmatch(r"[0-9a-f]{64}", str(record.get("profile_sha256", ""))):
+        raise DockerProvisionError("Provisioning profile digest is invalid")
+    if not _SHA256_RE.fullmatch(str(record.get("image_id", ""))):
+        raise DockerProvisionError("Provisioning image ID is invalid")
+    if (
+        not isinstance(record.get("profile_name"), str)
+        or not _NAME_RE.fullmatch(record["profile_name"])
+        or not isinstance(record.get("container_name"), str)
+        or not _NAME_RE.fullmatch(record["container_name"])
+        or not isinstance(record.get("host_port"), int)
+        or not 1024 <= record["host_port"] <= 65535
+        or not isinstance(record.get("security"), dict)
+        or record["security"].get("read_only_rootfs") is not True
+        or not isinstance(record.get("health"), dict)
+        or record["health"].get("status") != "ok"
+    ):
+        raise DockerProvisionError("Provisioning record identity or policy is invalid")
+    config = _validated_client_config(record.get("tool_config"))
+    if (
+        config["docker_llm"]["profile_sha256"] != record["profile_sha256"]
+        or config["docker_llm"]["image_id"] != record["image_id"]
+        or urlsplit(config["docker_llm"]["endpoint"]).port != record["host_port"]
+        or config["docker_llm"]["service_id"] != record["health"].get("service_id")
+    ):
+        raise DockerProvisionError(
+            "Client config does not match provisioning provenance"
+        )
+    return record
+
+
+def load_provisioned_tool(
+    tooluniverse,
+    tool_name: str,
+    *,
+    workspace: str | Path | None = None,
+) -> str:
+    """Explicitly load one validated provisioned client into one ToolUniverse instance."""
+    if not isinstance(tool_name, str) or not _TOOL_NAME_RE.fullmatch(tool_name):
+        raise DockerProvisionError("Tool name is not valid")
+    path = _workspace_root(workspace) / "approved" / f"{tool_name}.json"
+    record = _validated_record(_read_json(path))
+    config = record["tool_config"]
+    if config["name"] != tool_name:
+        raise DockerProvisionError("Provisioned tool name does not match its filename")
+    if tool_name in tooluniverse.all_tool_dict:
+        raise DockerProvisionError("Provisioned tool would replace an existing tool")
+    return tooluniverse.register_custom_tool(
+        tool_class=DockerLLMClientTool,
+        tool_name=tool_name,
+        tool_config=config,
+        tool_instance=DockerLLMClientTool(config),
+    )
+
+
+__all__ = [
+    "DockerProvisionError",
+    "load_profile",
+    "load_provisioned_tool",
+    "plan_container",
+    "provision_container",
+    "remove_container",
+    "status_container",
+    "stop_container",
+]

--- a/tests/fixtures/docker_llm_smoke/Dockerfile
+++ b/tests/fixtures/docker_llm_smoke/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-alpine
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN addgroup -S app && adduser -S -G app -u 10001 app
+WORKDIR /app
+COPY server.py /app/server.py
+USER app
+EXPOSE 8000
+
+CMD ["python", "/app/server.py"]

--- a/tests/fixtures/docker_llm_smoke/profile.json
+++ b/tests/fixtures/docker_llm_smoke/profile.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "profile_name": "docker-llm-smoke",
+  "service_id": "tooluniverse-docker-llm-smoke",
+  "image": "tooluniverse/docker-llm-smoke:test",
+  "container_port": 8000,
+  "health_path": "/health",
+  "inference_path": "/v1/chat/completions",
+  "model": "fixture-evidence-synthesizer",
+  "tool": {
+    "name": "DockerEvidenceSynthesizer",
+    "description": "Send a bounded evidence-synthesis prompt to the reviewed loopback Docker service.",
+    "max_prompt_chars": 20000,
+    "max_tokens_cap": 1024,
+    "default_temperature": 0.0
+  },
+  "resources": {
+    "cpus": 1.0,
+    "memory_mb": 256,
+    "pids_limit": 64,
+    "tmpfs_mb": 64
+  },
+  "timeouts": {
+    "health_seconds": 30,
+    "inference_seconds": 15
+  }
+}

--- a/tests/fixtures/docker_llm_smoke/server.py
+++ b/tests/fixtures/docker_llm_smoke/server.py
@@ -1,0 +1,87 @@
+"""Dependency-free OpenAI-compatible server used only by the Docker smoke test."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+SERVICE_ID = "tooluniverse-docker-llm-smoke"
+MODEL = "fixture-evidence-synthesizer"
+MAX_REQUEST_BYTES = 65_536
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        if self.path != "/health":
+            self._json(404, {"error": "not found"})
+            return
+        self._json(200, {"status": "ok", "service_id": SERVICE_ID, "model": MODEL})
+
+    def do_POST(self) -> None:
+        if self.path != "/v1/chat/completions":
+            self._json(404, {"error": "not found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self._json(400, {"error": "invalid content length"})
+            return
+        if not 1 <= length <= MAX_REQUEST_BYTES:
+            self._json(413, {"error": "request too large"})
+            return
+        try:
+            payload = json.loads(self.rfile.read(length))
+            messages = payload["messages"]
+            prompt = messages[0]["content"]
+            if payload["model"] != MODEL or not isinstance(prompt, str):
+                raise ValueError
+        except (json.JSONDecodeError, KeyError, IndexError, TypeError, ValueError):
+            self._json(400, {"error": "invalid inference request"})
+            return
+        prompt_hash = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+        words = len(re.findall(r"\b[\w'-]+\b", prompt))
+        sections = len(re.findall(r"(?m)^## ", prompt))
+        content = (
+            f"service_id={SERVICE_ID}; prompt_sha256={prompt_hash}; "
+            f"word_count={words}; evidence_sections={sections}; "
+            "contract=openai-chat-completions"
+        )
+        self._json(
+            200,
+            {
+                "id": f"smoke-{prompt_hash[:12]}",
+                "object": "chat.completion",
+                "model": MODEL,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": content},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": words,
+                    "completion_tokens": len(content.split()),
+                    "total_tokens": words + len(content.split()),
+                },
+            },
+        )
+
+    def log_message(self, format: str, *args) -> None:
+        return
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("0.0.0.0", 8000), Handler).serve_forever()

--- a/tests/unit/test_docker_llm_case_study.py
+++ b/tests/unit/test_docker_llm_case_study.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from examples.docker_llm import run_smoke_case as study
+
+pytestmark = pytest.mark.unit
+
+
+def test_case_orchestrates_full_lifecycle_and_writes_reports(monkeypatch, tmp_path):
+    prompt_hash = hashlib.sha256(study.PROMPT.encode()).hexdigest()
+    security = {
+        "running": True,
+        "read_only_rootfs": True,
+        "cap_drop": ["ALL"],
+        "no_new_privileges": True,
+        "privileged": False,
+        "bind_mounts": 0,
+        "host_binding": "127.0.0.1:19090",
+        "pids_limit": 64,
+        "memory_mb": 256,
+        "cpus": 1.0,
+    }
+    provisioned = {
+        "version": 1,
+        "record_path": str(tmp_path / "workspace" / "approved" / "tool.json"),
+        "record_sha256": "a" * 64,
+        "profile_sha256": "b" * 64,
+        "image_id": "sha256:" + "c" * 64,
+        "docker_server_version": "27.5.1",
+        "security": security,
+    }
+    statuses = iter(
+        [
+            {"exists": True, "security": {**security, "running": True}},
+            {"exists": True, "security": {**security, "running": False}},
+            {"exists": False},
+        ]
+    )
+    monkeypatch.setattr(study, "_run", lambda command: "built")
+    monkeypatch.setattr(
+        study,
+        "plan_container",
+        lambda *args, **kwargs: {
+            "docker_argv": ["docker", "run"],
+            "profile_sha256": "b" * 64,
+        },
+    )
+    monkeypatch.setattr(
+        study, "provision_container", lambda *args, **kwargs: provisioned
+    )
+    monkeypatch.setattr(
+        study, "status_container", lambda *args, **kwargs: next(statuses)
+    )
+    monkeypatch.setattr(
+        study,
+        "stop_container",
+        lambda *args, **kwargs: {"stopped": True, "was_running": True},
+    )
+    monkeypatch.setattr(
+        study,
+        "remove_container",
+        lambda *args, **kwargs: {
+            "removed": True,
+            "client_record_removed": True,
+        },
+    )
+    monkeypatch.setattr(
+        study,
+        "load_provisioned_tool",
+        lambda *args, **kwargs: "DockerEvidenceSynthesizer",
+    )
+
+    class FakeToolUniverse:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def run_one_function(self, call, use_cache=False):
+            assert call["arguments"]["prompt"] == study.PROMPT
+            assert use_cache is False
+            return {
+                "status": "success",
+                "data": {
+                    "response": f"prompt_sha256={prompt_hash}; evidence_sections=6",
+                    "model": "fixture-evidence-synthesizer",
+                    "usage": {"prompt_tokens": 200},
+                    "provenance": {"payload_sha256": "d" * 64},
+                },
+            }
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(study, "ToolUniverse", FakeToolUniverse)
+    output_json = tmp_path / "snapshot.json"
+    output_markdown = tmp_path / "snapshot.md"
+    output_record = tmp_path / "record.json"
+    result = study.run_case(
+        host_port=19090,
+        workspace=tmp_path / "workspace",
+        output_json=output_json,
+        output_markdown=output_markdown,
+        output_record=output_record,
+    )
+
+    assert result["tooluniverse_inference"]["prompt_hash_verified"] is True
+    assert result["lifecycle"]["absent_after_remove"] is True
+    assert json.loads(output_json.read_text())["case"] == (
+        "reviewed_docker_llm_lifecycle_and_complex_prompt"
+    )
+    assert json.loads(output_record.read_text())["image_id"].startswith("sha256:")
+    report = output_markdown.read_text()
+    assert "Inspected Container Policy" in report
+    assert "deterministic infrastructure" in report

--- a/tests/unit/test_docker_llm_case_study.py
+++ b/tests/unit/test_docker_llm_case_study.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import json
+import sys
+from pathlib import Path
 
 import pytest
 
-from examples.docker_llm import run_smoke_case as study
-
 pytestmark = pytest.mark.unit
+
+
+MODULE_PATH = Path(__file__).parents[2] / "examples" / "docker_llm" / "run_smoke_case.py"
+SPEC = importlib.util.spec_from_file_location("docker_llm_smoke_case", MODULE_PATH)
+assert SPEC and SPEC.loader
+study = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = study
+SPEC.loader.exec_module(study)
 
 
 def test_case_orchestrates_full_lifecycle_and_writes_reports(monkeypatch, tmp_path):

--- a/tests/unit/test_docker_llm_cli.py
+++ b/tests/unit/test_docker_llm_cli.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tooluniverse.remote.docker_llm import cli
+
+pytestmark = pytest.mark.unit
+
+
+def test_cli_plan_passes_only_reviewed_lifecycle_inputs(monkeypatch, capsys, tmp_path):
+    observed = {}
+
+    def fake_plan(profile, **kwargs):
+        observed.update(profile=profile, **kwargs)
+        return {"docker_argv": ["docker", "run", "reviewed-image"]}
+
+    monkeypatch.setattr(cli, "plan_container", fake_plan)
+    assert (
+        cli.main(
+            [
+                "--profile",
+                str(tmp_path / "profile.json"),
+                "--host-port",
+                "19090",
+                "--container-name",
+                "reviewed-container",
+                "plan",
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert observed["host_port"] == 19090
+    assert observed["container_name"] == "reviewed-container"
+
+
+def test_cli_remove_requires_explicit_yes(monkeypatch, capsys, tmp_path):
+    observed = {}
+
+    def fake_remove(profile, **kwargs):
+        observed.update(profile=profile, **kwargs)
+        return {"removed": kwargs["confirm"]}
+
+    monkeypatch.setattr(cli, "remove_container", fake_remove)
+    assert (
+        cli.main(
+            [
+                "--profile",
+                str(tmp_path / "profile.json"),
+                "--workspace",
+                str(tmp_path / "workspace"),
+                "remove",
+                "--yes",
+            ]
+        )
+        == 0
+    )
+    assert observed["confirm"] is True
+    assert observed["workspace"] == tmp_path / "workspace"
+    assert json.loads(capsys.readouterr().out)["result"]["removed"] is True

--- a/tests/unit/test_docker_llm_provision.py
+++ b/tests/unit/test_docker_llm_provision.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from tooluniverse import ToolUniverse
+from tooluniverse.remote.docker_llm import client, provision
+
+pytestmark = pytest.mark.unit
+
+IMAGE = "registry.example/reviewed-llm@sha256:" + "a" * 64
+IMAGE_ID = "sha256:" + "b" * 64
+
+
+def _profile() -> dict:
+    return {
+        "version": 1,
+        "profile_name": "reviewed-llm",
+        "service_id": "reviewed-llm-service",
+        "image": IMAGE,
+        "container_port": 8000,
+        "health_path": "/health",
+        "inference_path": "/v1/chat/completions",
+        "model": "reviewed-model",
+        "tool": {
+            "name": "ReviewedDockerEvidenceTool",
+            "description": "Run bounded evidence prompts in the reviewed local container.",
+            "max_prompt_chars": 5000,
+            "max_tokens_cap": 1000,
+            "default_temperature": 0.0,
+        },
+        "resources": {
+            "cpus": 1.5,
+            "memory_mb": 512,
+            "pids_limit": 96,
+            "tmpfs_mb": 64,
+        },
+        "timeouts": {"health_seconds": 10, "inference_seconds": 15},
+    }
+
+
+def _write_profile(tmp_path: Path, profile_data: dict | None = None) -> Path:
+    path = tmp_path / "profile.json"
+    path.write_text(json.dumps(profile_data or _profile()), encoding="utf-8")
+    return path
+
+
+def _container_record(
+    profile_data: dict,
+    digest: str,
+    *,
+    name: str = "tooluniverse-reviewed-llm",
+    port: int = 19090,
+    running: bool = True,
+    labels: dict | None = None,
+) -> dict:
+    resources = profile_data["resources"]
+    return {
+        "Name": f"/{name}",
+        "Image": IMAGE_ID,
+        "Config": {
+            "Image": profile_data["image"],
+            "Labels": labels
+            or {
+                provision._MANAGED_LABEL: "true",
+                provision._PROFILE_LABEL: digest,
+                provision._SERVICE_LABEL: profile_data["service_id"],
+            },
+        },
+        "State": {"Running": running},
+        "HostConfig": {
+            "PortBindings": {
+                f"{profile_data['container_port']}/tcp": [
+                    {"HostIp": "127.0.0.1", "HostPort": str(port)}
+                ]
+            },
+            "ReadonlyRootfs": True,
+            "CapDrop": ["ALL"],
+            "SecurityOpt": ["no-new-privileges:true"],
+            "Privileged": False,
+            "NetworkMode": "default",
+            "PidMode": "",
+            "IpcMode": "private",
+            "Binds": None,
+            "PidsLimit": resources["pids_limit"],
+            "Memory": resources["memory_mb"] * 1024 * 1024,
+            "NanoCpus": int(resources["cpus"] * 1_000_000_000),
+        },
+    }
+
+
+class FakeDocker:
+    def __init__(self, profile_data: dict, digest: str, *, existing=None):
+        self.profile = profile_data
+        self.digest = digest
+        self.record = existing
+        self.commands: list[list[str]] = []
+
+    def __call__(self, arguments, *, check=True, timeout=60):
+        args = list(arguments)
+        self.commands.append(args)
+        stdout = ""
+        stderr = ""
+        returncode = 0
+        if args == ["context", "show"]:
+            stdout = "default\n"
+        elif args == ["context", "inspect", "default"]:
+            stdout = json.dumps(
+                [{"Endpoints": {"docker": {"Host": "unix:///var/run/docker.sock"}}}]
+            )
+        elif args[:2] == ["version", "--format"]:
+            stdout = "27.5.1\n"
+        elif args[:3] == ["image", "inspect", "--format"]:
+            stdout = IMAGE_ID + "\n"
+        elif args[:2] == ["container", "inspect"]:
+            if self.record is None:
+                returncode, stderr = 1, "Error: No such object"
+            else:
+                stdout = json.dumps([self.record])
+        elif args[0] == "run":
+            self.record = _container_record(self.profile, self.digest)
+            stdout = "container-id\n"
+        elif args[:2] == ["container", "start"]:
+            self.record["State"]["Running"] = True
+        elif args[:2] == ["container", "stop"]:
+            self.record["State"]["Running"] = False
+        elif args[:3] == ["container", "rm", "--force"]:
+            self.record = None
+        else:
+            raise AssertionError(f"Unexpected Docker command: {args}")
+        result = subprocess.CompletedProcess(
+            ["docker", *args], returncode, stdout, stderr
+        )
+        if check and returncode:
+            raise provision.DockerProvisionError("fake Docker failure")
+        return result
+
+
+@pytest.fixture
+def approved_image(monkeypatch):
+    monkeypatch.setenv("TOOLUNIVERSE_DOCKER_ALLOWED_IMAGES", IMAGE)
+
+
+def test_profile_rejects_unallowlisted_images_and_unknown_docker_controls(
+    tmp_path, monkeypatch
+):
+    path = _write_profile(tmp_path)
+    monkeypatch.delenv("TOOLUNIVERSE_DOCKER_ALLOWED_IMAGES", raising=False)
+    with pytest.raises(provision.DockerProvisionError, match="must list"):
+        provision.load_profile(path)
+
+    monkeypatch.setenv("TOOLUNIVERSE_DOCKER_ALLOWED_IMAGES", IMAGE)
+    unsafe = _profile()
+    unsafe["volumes"] = ["/:/host"]
+    path = _write_profile(tmp_path, unsafe)
+    with pytest.raises(provision.DockerProvisionError, match="fields"):
+        provision.load_profile(path)
+
+
+def test_plan_has_fixed_loopback_and_no_arbitrary_docker_escape(
+    tmp_path, approved_image
+):
+    plan = provision.plan_container(_write_profile(tmp_path), host_port=19090)
+    command = plan["docker_argv"]
+    assert command[:3] == ["docker", "run", "--detach"]
+    assert "127.0.0.1:19090:8000" in command
+    assert [
+        command[index + 1]
+        for index, item in enumerate(command[:-1])
+        if item == "--cap-drop"
+    ] == ["ALL"]
+    assert "--read-only" in command
+    assert "no-new-privileges:true" in command
+    assert "--pull" in command and "never" in command
+    assert "--volume" not in command and "-v" not in command
+    assert "--privileged" not in command
+    assert "--network" not in command
+    assert command[-1] == IMAGE
+
+
+def test_provision_inspects_security_before_publishing_client(
+    tmp_path, monkeypatch, approved_image
+):
+    profile_path = _write_profile(tmp_path)
+    profile_data, digest = provision.load_profile(profile_path)
+    fake = FakeDocker(profile_data, digest)
+    monkeypatch.setattr(provision, "_run_docker", fake)
+    monkeypatch.setattr(provision, "_port_is_available", lambda port: True)
+    monkeypatch.setattr(
+        provision,
+        "_wait_for_health",
+        lambda profile_data, port: {
+            "status": "ok",
+            "service_id": profile_data["service_id"],
+            "model": profile_data["model"],
+        },
+    )
+
+    result = provision.provision_container(
+        profile_path, host_port=19090, workspace=tmp_path / "workspace"
+    )
+
+    assert result["security"]["read_only_rootfs"] is True
+    assert result["security"]["bind_mounts"] == 0
+    assert result["security"]["host_binding"] == "127.0.0.1:19090"
+    assert result["image"] == IMAGE
+    assert result["image_id"] == IMAGE_ID
+    assert len(result["record_sha256"]) == 64
+    assert Path(result["record_path"]).exists()
+
+
+def test_health_failure_removes_only_new_managed_container(
+    tmp_path, monkeypatch, approved_image
+):
+    profile_path = _write_profile(tmp_path)
+    profile_data, digest = provision.load_profile(profile_path)
+    fake = FakeDocker(profile_data, digest)
+    monkeypatch.setattr(provision, "_run_docker", fake)
+    monkeypatch.setattr(provision, "_port_is_available", lambda port: True)
+
+    def fail_health(*args):
+        raise provision.DockerProvisionError("health identity failed")
+
+    monkeypatch.setattr(provision, "_wait_for_health", fail_health)
+    with pytest.raises(provision.DockerProvisionError, match="health"):
+        provision.provision_container(profile_path, host_port=19090)
+    assert ["container", "rm", "--force", "tooluniverse-reviewed-llm"] in fake.commands
+    assert fake.record is None
+
+
+def test_mismatched_existing_container_is_never_started_or_removed(
+    tmp_path, monkeypatch, approved_image
+):
+    profile_path = _write_profile(tmp_path)
+    profile_data, digest = provision.load_profile(profile_path)
+    existing = _container_record(
+        profile_data,
+        digest,
+        running=False,
+        labels={provision._MANAGED_LABEL: "false"},
+    )
+    fake = FakeDocker(profile_data, digest, existing=existing)
+    monkeypatch.setattr(provision, "_run_docker", fake)
+    with pytest.raises(provision.DockerProvisionError, match="not managed"):
+        provision.provision_container(profile_path, host_port=19090)
+    assert not any(
+        command[:2] in (["container", "start"], ["container", "rm"])
+        for command in fake.commands
+    )
+    assert fake.record is existing
+
+
+def test_stop_and_remove_require_exact_profile_and_confirmation(
+    tmp_path, monkeypatch, approved_image
+):
+    profile_path = _write_profile(tmp_path)
+    profile_data, digest = provision.load_profile(profile_path)
+    fake = FakeDocker(
+        profile_data, digest, existing=_container_record(profile_data, digest)
+    )
+    monkeypatch.setattr(provision, "_run_docker", fake)
+    stopped = provision.stop_container(profile_path, host_port=19090)
+    assert stopped == {
+        "container_name": "tooluniverse-reviewed-llm",
+        "stopped": True,
+        "was_running": True,
+    }
+    with pytest.raises(provision.DockerProvisionError, match="confirmation"):
+        provision.remove_container(profile_path, host_port=19090)
+    removed = provision.remove_container(
+        profile_path, host_port=19090, workspace=tmp_path, confirm=True
+    )
+    assert removed["removed"] is True
+    assert fake.record is None
+
+
+def test_docker_subprocess_environment_drops_remote_daemon_controls(monkeypatch):
+    monkeypatch.setenv("DOCKER_HOST", "tcp://untrusted.example:2375")
+    monkeypatch.setenv("DOCKER_CONTEXT", "remote")
+    monkeypatch.setenv("DOCKER_TLS_VERIFY", "1")
+    environment = provision._docker_environment()
+    assert "PATH" in environment
+    assert not {"DOCKER_HOST", "DOCKER_CONTEXT", "DOCKER_TLS_VERIFY"} & set(environment)
+
+
+def test_docker_check_rejects_remote_saved_context(monkeypatch):
+    def fake_docker(arguments, *, check=True, timeout=60):
+        if list(arguments) == ["context", "show"]:
+            output = "remote-production\n"
+        elif list(arguments) == ["context", "inspect", "remote-production"]:
+            output = json.dumps(
+                [{"Endpoints": {"docker": {"Host": "ssh://admin@example.com"}}}]
+            )
+        else:
+            raise AssertionError("Version must not run for a remote context")
+        return subprocess.CompletedProcess(["docker", *arguments], 0, output, "")
+
+    monkeypatch.setattr(provision, "_run_docker", fake_docker)
+    with pytest.raises(provision.DockerProvisionError, match="local socket"):
+        provision._check_docker()
+
+
+class FakeResponse:
+    def __init__(self, payload: dict, *, status=200, redirect=False, size_header=None):
+        self.body = json.dumps(payload).encode()
+        self.status_code = status
+        self.is_redirect = redirect
+        self.is_permanent_redirect = False
+        self.headers = {
+            "Content-Type": "application/json",
+            "Content-Length": str(
+                size_header if size_header is not None else len(self.body)
+            ),
+        }
+        self.closed = False
+
+    def iter_content(self, chunk_size):
+        yield self.body
+
+    def close(self):
+        self.closed = True
+
+
+class FakeSession:
+    def __init__(self, response):
+        self.response = response
+        self.trust_env = True
+        self.request = None
+        self.closed = False
+
+    def post(self, url, **kwargs):
+        self.request = (url, kwargs, self.trust_env)
+        return self.response
+
+    def close(self):
+        self.closed = True
+
+
+def test_published_client_executes_through_real_tooluniverse(
+    tmp_path, monkeypatch, approved_image
+):
+    profile_path = _write_profile(tmp_path)
+    profile_data, digest = provision.load_profile(profile_path)
+    fake_docker = FakeDocker(profile_data, digest)
+    monkeypatch.setattr(provision, "_run_docker", fake_docker)
+    monkeypatch.setattr(provision, "_port_is_available", lambda port: True)
+    monkeypatch.setattr(
+        provision,
+        "_wait_for_health",
+        lambda profile_data, port: {
+            "status": "ok",
+            "service_id": profile_data["service_id"],
+            "model": profile_data["model"],
+        },
+    )
+    workspace = tmp_path / "workspace"
+    provision.provision_container(profile_path, host_port=19090, workspace=workspace)
+    response = FakeResponse(
+        {
+            "model": "reviewed-model",
+            "choices": [
+                {"message": {"role": "assistant", "content": "bounded synthesis"}}
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2},
+        }
+    )
+    session = FakeSession(response)
+    monkeypatch.setattr(client.requests, "Session", lambda: session)
+    tooluniverse = ToolUniverse(
+        tool_files={}, keep_default_tools=False, workspace=str(tmp_path / "runtime")
+    )
+    try:
+        assert (
+            provision.load_provisioned_tool(
+                tooluniverse, "ReviewedDockerEvidenceTool", workspace=workspace
+            )
+            == "ReviewedDockerEvidenceTool"
+        )
+        result = tooluniverse.run_one_function(
+            {
+                "name": "ReviewedDockerEvidenceTool",
+                "arguments": {"prompt": "Synthesize records A, B, and C."},
+            },
+            use_cache=False,
+        )
+    finally:
+        tooluniverse.close()
+    assert result["status"] == "success"
+    assert result["data"]["response"] == "bounded synthesis"
+    assert result["data"]["provenance"]["image_id"] == IMAGE_ID
+    assert session.request[0] == "http://127.0.0.1:19090/v1/chat/completions"
+    assert session.request[1]["allow_redirects"] is False
+    assert session.request[2] is False
+    assert response.closed and session.closed
+
+
+def test_client_rejects_redirects_oversize_and_non_loopback(monkeypatch):
+    profile_data = _profile()
+    config = provision._client_config(profile_data, "c" * 64, IMAGE_ID, 19090)
+    external = deepcopy(config)
+    external["docker_llm"]["endpoint"] = "http://example.com/v1/chat/completions"
+    with pytest.raises(client.DockerLLMClientError, match="loopback"):
+        client.DockerLLMClientTool(external)
+
+    for response, message in (
+        (
+            FakeResponse({"choices": [{"message": {"content": "x"}}]}, redirect=True),
+            "redirect",
+        ),
+        (
+            FakeResponse(
+                {"choices": [{"message": {"content": "x"}}]}, size_header=1_000_001
+            ),
+            "1 MB",
+        ),
+    ):
+        monkeypatch.setattr(client.requests, "Session", lambda: FakeSession(response))
+        with pytest.raises(client.DockerLLMClientError, match=message):
+            client.DockerLLMClientTool(config).run({"prompt": "test prompt"})
+
+
+def test_tampered_client_record_is_not_loaded(tmp_path, approved_image):
+    profile_data = _profile()
+    config = provision._client_config(profile_data, "d" * 64, IMAGE_ID, 19090)
+    record_body = {
+        "version": 1,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "profile_name": "reviewed-llm",
+        "profile_sha256": "d" * 64,
+        "image": IMAGE,
+        "image_id": IMAGE_ID,
+        "docker_server_version": "27.5.1",
+        "docker_context": "default",
+        "container_name": "tooluniverse-reviewed-llm",
+        "host_port": 19090,
+        "security": {"read_only_rootfs": True},
+        "health": {"status": "ok", "service_id": "reviewed-llm-service"},
+        "tool_config": config,
+    }
+    record = {**record_body, "record_sha256": provision._canonical_digest(record_body)}
+    path = tmp_path / "approved" / "ReviewedDockerEvidenceTool.json"
+    path.parent.mkdir()
+    path.write_text(json.dumps(record), encoding="utf-8")
+    record["unexpected_change"] = True
+    path.write_text(json.dumps(record), encoding="utf-8")
+    tooluniverse = ToolUniverse()
+    try:
+        with pytest.raises(provision.DockerProvisionError, match="contract|digest"):
+            provision.load_provisioned_tool(
+                tooluniverse, "ReviewedDockerEvidenceTool", workspace=tmp_path
+            )
+        assert "ReviewedDockerEvidenceTool" not in tooluniverse.all_tool_dict
+    finally:
+        tooluniverse.close()


### PR DESCRIPTION
## Summary

- replace the agent-callable Docker design from #32 with a separate administrator-only lifecycle CLI
- require a strict reviewed profile, exact image allowlist, local Docker context, loopback-only publishing, immutable post-start image verification, and constrained resources
- publish one hash-bound, loopback-only ToolUniverse inference client only after container inspection and exact health-identity validation
- add unit and orchestration coverage plus a dedicated GitHub Actions job that builds and exercises a real non-root container

This PR is intentionally independent of #416-#419 and is based directly on `main`.

## Removed attack surface

There is no agent tool for Docker lifecycle operations. The profile and CLI provide no fields for an alternate executable, volumes, environment variables, arbitrary Docker arguments, privileged mode, host networking, arbitrary host binding, arbitrary server URLs, or automatic tool discovery.

The run command is constructed internally with:

- `--pull never` and an exact allowlisted image reference
- `127.0.0.1` port publishing
- read-only root filesystem and bounded `/tmp` tmpfs
- all Linux capabilities dropped and no-new-privileges
- fixed CPU, memory, and PID limits from the validated profile
- management, profile-hash, and service-identity labels

The provisioner also strips Docker daemon environment overrides and refuses a saved Docker context unless it resolves to a local Unix socket or Windows named pipe.

## Lifecycle guarantees

- a foreign or mismatched existing container is never started, stopped, reused, or removed
- a newly created container is removed if health or post-start inspection fails
- a previously stopped matching container is returned to stopped state if health fails
- health is proxy-free, redirect-free, JSON-only, 64 KiB bounded, and identity checked
- the client record is written atomically only after every check passes
- removal requires `--yes` and validates the exact container and client record first
- the published inference client accepts only a fixed loopback endpoint, has prompt/token/time limits, disables proxies and redirects, caps responses at 1 MB, and records image/profile/payload hashes

## End-to-end validation

The real-container job builds a non-root OpenAI-compatible fixture image, provisions it, inspects every security property, and explicitly loads `DockerEvidenceSynthesizer` into a fresh ToolUniverse instance. It sends a six-section pharmacovigilance evidence prompt containing spontaneous-report, trial, observational, and mechanistic evidence plus output constraints; the service returns the exact prompt SHA-256 so the test proves complete payload integrity across ToolUniverse and Docker.

The case then stops the container, re-inspects it as stopped, removes it with explicit confirmation, and confirms it is absent. The fixture is deterministic infrastructure rather than a real model, so this validates lifecycle, isolation, transport, bounds, and cleanup rather than synthesis quality. The successful Docker 28.0.4 reports and hash-bound provision record are checked in under `examples/docker_llm/artifacts/`.

## Verification

- `14 passed` in the focused Docker policy, CLI, and case-orchestration suite
- `30 passed` with ToolUniverse dependency-isolation regression coverage included
- hosted Python 3.12 repository suite passed: `3901 passed, 36 skipped`; lint, SDK generation, and the doctor CLI also passed
- Ruff 0.14.5 and the CI version 0.15.22 passed
- wheel build passed; all four package modules and `tooluniverse-docker-llm-admin` were present in the built wheel
- dedicated real-container check passed on Docker 28.0.4: exact prompt hash verified, loopback/read-only/capability/resource checks passed, stop state verified, removal verified, and the evidence artifact uploaded
- local Docker execution was unavailable because this workstation has no Docker runtime; the checked evidence was produced and independently validated from the successful Linux CI run
