### PR TITLE
Add registry-first VSD capability coverage

### DIFF
--- a/docs/dev_docs/VSD_CAPABILITY_COVERAGE.md
+++ b/docs/dev_docs/VSD_CAPABILITY_COVERAGE.md
@@ -1,0 +1,36 @@
+# VSD capability coverage resolution
+
+VSD must inspect ToolUniverse before discovering or generating another tool. The
+coverage resolver reads built-in specifications and runtime registrations without
+instantiating all tools, changing the active tool selection, writing a search log,
+or sending the request anywhere.
+
+## Classification contract
+
+- `existing_exact`: a stable operation identifier or reviewed endpoint contract
+  matches, or a provider-specific tool satisfies the requested semantics and fields.
+- `existing_partial`: a provider, tool, or composed workflow plausibly overlaps but
+  does not prove complete operation coverage.
+- `missing`: no provider, tool, or workflow crosses the conservative match boundary.
+
+Exact matches return `use_existing`. Partial matches return
+`review_existing_or_extend_provider`, which prevents creation of a duplicate source
+while allowing a new operation in an existing provider family. Only missing requests
+return `discover_external_candidate`.
+
+The result includes scoring components, exact tool and workflow counts, a normalized
+capability digest, and a digest of the registry snapshot used for the decision.
+These hashes make a decision reproducible; they do not identify a user or transmit
+anything to the ToolUniverse maintainers.
+
+## Case study
+
+`examples/vsd/capability_coverage_case_study.py` evaluates four demands against the
+real packaged registry. It demonstrates that rare-disease registry demand resolves
+to Orphanet, FDA label demand resolves to the existing FDA family, a multi-stage
+drug-discovery request identifies a composed workflow, and an intentionally alien
+capability remains missing and may proceed to external discovery.
+
+Checked evidence is available in both
+`examples/vsd/artifacts/capability_coverage_snapshot.md` and the corresponding JSON
+ledger.

--- a/examples/vsd/artifacts/capability_coverage_snapshot.json
+++ b/examples/vsd/artifacts/capability_coverage_snapshot.json
@@ -1,0 +1,405 @@
+{
+  "all_assertions_passed": true,
+  "assertions": {
+    "als_uses_existing_registry": true,
+    "fda_uses_existing_tool_family": true,
+    "real_gap_can_continue_to_discovery": true,
+    "workflow_is_detected": true
+  },
+  "case": "registry-first capability resolution",
+  "demands": {
+    "als_registry": {
+      "description": "rare disease registry genes and phenotypes",
+      "required_inputs": [
+        "disease"
+      ]
+    },
+    "drug_discovery_workflow": {
+      "description": "complete disease target compound ADMET literature workflow"
+    },
+    "fda_label": {
+      "description": "retrieve FDA drug label by set identifier",
+      "provider": "FDA",
+      "required_inputs": [
+        "set_id"
+      ]
+    },
+    "intentional_gap": {
+      "description": "quantum microscope calibration waveform optimizer"
+    }
+  },
+  "results": {
+    "als_registry": {
+      "capability_id": "64b118dddfd04d71",
+      "classification": "existing_partial",
+      "exact_match_count": 0,
+      "match_count": 23,
+      "matches": [
+        {
+          "category": "alliance_genome",
+          "coverage": "partial",
+          "description": "Get genes associated with a disease across all model organisms from the Alliance of Genome Resources. Uses Disease Ontology (DO) IDs to find genes linked to a disease from human, mouse, rat, zebrafish, fly, worm, and other organisms. Includes both direct annotations and inferred associations from model organism phenotypes. Example: 'DOID:162' (cancer) returns TP53, BRCA1, and thousands more.",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "Alliance_get_disease_genes",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": false,
+          "score": 0.55,
+          "semantic_recall": 0.6
+        },
+        {
+          "category": "ensembl",
+          "coverage": "partial",
+          "description": "Variant Effect Predictor (VEP) for genomic variants. Predicts functional consequences of variants including impact on genes, transcripts, and proteins. Returns SIFT/PolyPhen scores, consequence types, and affected transcripts. Essential for variant interpretation.",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "ensembl_vep_region",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": false,
+          "score": 0.55,
+          "semantic_recall": 0.6
+        },
+        {
+          "category": "hpo",
+          "coverage": "partial",
+          "description": "Get the full curated HPO annotation profile for a disease, keyed by a disease ID (OMIM / ORPHA / DECIPHER), from the JAX HPO network annotations. Returns three things: (1) medical_actions \u2014 MAxO curated treatments / management actions, each with TREATS / PREVENTS relations and the specific phenotypes they target; (2) categories \u2014 the disease's phenotypes grouped by body system (e.g., Cardiovascular, Nervous System, Eye), each with frequency / onset; (3) genes \u2014 the causative genes (NCBI gene IDs",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "HPO_get_disease_annotations",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": false,
+          "score": 0.55,
+          "semantic_recall": 0.6
+        },
+        {
+          "category": "medgen",
+          "coverage": "partial",
+          "description": "Get detailed information about a specific genetic condition from NCBI MedGen by UID or UMLS CUI. Returns full definition, associated genes, OMIM IDs, synonyms, modes of inheritance, and clinical features (HPO phenotypes). Example: uid='41393' returns cystic fibrosis with CFTR/TGFB1/FCGR2A genes, autosomal recessive inheritance, 30+ clinical features.",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "MedGen_get_condition",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": false,
+          "score": 0.55,
+          "semantic_recall": 0.6
+        },
+        {
+          "category": "monarch_new",
+          "coverage": "partial",
+          "description": "Get detailed information about any biomedical entity in the Monarch Initiative knowledge graph by its CURIE identifier. Supports genes (HGNC), diseases (MONDO, OMIM), phenotypes (HP), variants, and more. Returns the entity name, category, description, synonyms, cross-references, and species. Example: HGNC:11998 returns TP53 gene; MONDO:0007739 returns Huntington disease with cross-refs to OMIM, DOID, ICD10.",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "Monarch_get_entity",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": false,
+          "score": 0.55,
+          "semantic_recall": 0.6
+        },
+        {
+          "category": "monarch_new",
+          "coverage": "partial",
+          "description": "Search the Monarch Initiative knowledge graph for biomedical entities by name or keyword. Returns genes, diseases, phenotypes, and other entities matching the query, with CURIE identifiers and categories. Filter by category (biolink:Gene, biolink:Disease, biolink:PhenotypicFeature) to narrow results. Use returned CURIEs with Monarch_get_entity and Monarch_get_associations for detailed lookups.",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "Monarch_search",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": false,
+          "score": 0.55,
+          "semantic_recall": 0.6
+        },
+        {
+          "category": "monarch_v3",
+          "coverage": "partial",
+          "description": "Search the Monarch Initiative knowledge graph for biomedical entities by name or keyword. Returns genes, diseases, phenotypes, and other entities matching the query, with their CURIE identifiers and categories. Useful for finding entity IDs to use with MonarchV3_get_entity and MonarchV3_get_associations. Example: searching 'BRCA1' returns HGNC:1100 (gene), 'Alzheimer' returns MONDO disease entries.",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "MonarchV3_search",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": false,
+          "score": 0.55,
+          "semantic_recall": 0.6
+        },
+        {
+          "category": "mondo",
+          "coverage": "partial",
+          "description": "Get detailed information about a disease from the Mondo Disease Ontology by its MONDO ID. Returns the disease name, description, synonyms, cross-references (OMIM, Orphanet, DOID, MeSH, ICD-10, NCIT, UMLS, SNOMED-CT), hierarchy (parent diseases), subtypes count, causal genes, inheritance pattern, and association counts (phenotypes, correlated genes, etc.). Essential for understanding disease classification and finding equivalent IDs across ontologies.",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "Mondo_get_disease",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": false,
+          "score": 0.55,
+          "semantic_recall": 0.6
+        },
+        {
+          "category": "mousemine",
+          "coverage": "partial",
+          "description": "Search MouseMine, the InterMine data warehouse for mouse (Mus musculus) genomics data from MGI (Mouse Genome Informatics). Searches across genes, alleles, proteins, publications, gene ontology terms, protein domains, and more. Returns matching records with category facets and relevance scores. MouseMine integrates data from MGI including gene annotations, phenotypes, alleles, expression data, pathways, and disease models. Use facet_Category parameter to filter by specific entity type (e.g., 'Pro",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "MouseMine_search",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": false,
+          "score": 0.55,
+          "semantic_recall": 0.6
+        },
+        {
+          "category": "orphanet",
+          "coverage": "partial",
+          "description": "Get genes associated with a rare disease from Orphanet. Returns gene symbols, names, and association types (causative, modifier, susceptibility). Essential for rare disease genetic diagnosis.",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "Orphanet_get_genes",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": false,
+          "score": 0.55,
+          "semantic_recall": 0.6
+        }
+      ],
+      "privacy": "Coverage resolution is local, read-only, and not persisted or reported.",
+      "recommended_action": "review_existing_or_extend_provider",
+      "registry_sha256": "4c93a7a90997627fc06edc5c7d73977a0f4759195d9d3ccfe0d1ca0b55a78cb6",
+      "registry_tool_count": 2743,
+      "request": {
+        "description": "rare disease registry genes and phenotypes",
+        "endpoint_host": "",
+        "endpoint_path": "",
+        "method": "GET",
+        "operation_id": "",
+        "output_fields": [],
+        "provider": "",
+        "required_inputs": [
+          "disease"
+        ]
+      },
+      "tool_matches": 23,
+      "workflow_matches": 0
+    },
+    "drug_discovery_workflow": {
+      "capability_id": "1e1d26e0dfe20c68",
+      "classification": "existing_exact",
+      "exact_match_count": 1,
+      "match_count": 1,
+      "matches": [
+        {
+          "category": "compose",
+          "coverage": "exact",
+          "description": "Complete end-to-end drug discovery workflow from disease to optimized candidates. Identifies targets, discovers lead compounds, screens for ADMET properties, assesses safety, and validates with literature.",
+          "input_recall": 1.0,
+          "kind": "workflow",
+          "name": "ComprehensiveDrugDiscoveryPipeline",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": false,
+          "score": 0.75,
+          "semantic_recall": 1.0
+        }
+      ],
+      "privacy": "Coverage resolution is local, read-only, and not persisted or reported.",
+      "recommended_action": "use_existing",
+      "registry_sha256": "4c93a7a90997627fc06edc5c7d73977a0f4759195d9d3ccfe0d1ca0b55a78cb6",
+      "registry_tool_count": 2743,
+      "request": {
+        "description": "complete disease target compound ADMET literature workflow",
+        "endpoint_host": "",
+        "endpoint_path": "",
+        "method": "GET",
+        "operation_id": "",
+        "output_fields": [],
+        "provider": "",
+        "required_inputs": []
+      },
+      "tool_matches": 0,
+      "workflow_matches": 1
+    },
+    "fda_label": {
+      "capability_id": "5a4c0251f79f0f58",
+      "classification": "existing_exact",
+      "exact_match_count": 2,
+      "match_count": 207,
+      "matches": [
+        {
+          "category": "fda_drug_label",
+          "coverage": "exact",
+          "description": "Retrieve the drug name based on the Set ID of the labeling.",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "FDA_get_drug_name_by_set_id",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": true,
+          "score": 0.95,
+          "semantic_recall": 1.0
+        },
+        {
+          "category": "fda_drug_label",
+          "coverage": "exact",
+          "description": "Retrieve FDA drug label information by searching a specific FDA drug label field for a given value (field:value). This is a generic field-based lookup. Use `return_fields` to choose which sections/fields to return, or pass \"ALL\" to return full label records. Note: for `openfda.generic_name`, values are typically uppercase (e.g., \"ASPIRIN\").\n\nAllowed fields (use these for both `field` and `return_fields`): abuse, accessories, active_ingredient, adverse_reactions, alarms, animal_pharmacology_and_o",
+          "input_recall": 1.0,
+          "kind": "tool",
+          "name": "FDA_get_drug_label_info_by_field_value",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": true,
+          "score": 0.8667,
+          "semantic_recall": 0.8333
+        },
+        {
+          "category": "fda_drug_label",
+          "coverage": "partial",
+          "description": "Retrieve the drug name based on the FDA application number, NUI unique identifier, document ID of a specific version of the drug's Structured Product Label (SPL), or set ID of the drug's Structured Product Label that works across label versions.",
+          "input_recall": 0.0,
+          "kind": "tool",
+          "name": "FDA_get_drug_name_by_SPL_ID",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": true,
+          "score": 0.8,
+          "semantic_recall": 1.0
+        },
+        {
+          "category": "fda_drug_adverse_event_detail",
+          "coverage": "partial",
+          "description": "Search and retrieve detailed reports of serious adverse events for a specific drug. Returns individual case reports with patient information, adverse event details, drug information, and report metadata. Only medicinalproduct is required; all other parameters (limit, skip, seriousnessdeath, seriousnesshospitalization, seriousnesslifethreatening, seriousnessdisabling, patientsex, patientagegroup) are optional. Data source: FDA Adverse Event Reporting System (FAERS).",
+          "input_recall": 0.0,
+          "kind": "tool",
+          "name": "FAERS_search_serious_reports_by_drug",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": true,
+          "score": 0.7167,
+          "semantic_recall": 0.8333
+        },
+        {
+          "category": "fda_drug_label",
+          "coverage": "partial",
+          "description": "Retrieve the drug name based on the document ID.",
+          "input_recall": 0.0,
+          "kind": "tool",
+          "name": "FDA_get_drug_name_by_document_id",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": true,
+          "score": 0.7167,
+          "semantic_recall": 0.8333
+        },
+        {
+          "category": "fda_drug_adverse_event_detail",
+          "coverage": "partial",
+          "description": "Search and retrieve detailed adverse event reports from FAERS. Returns individual case reports with patient information, adverse event details, drug information, and report metadata. Only medicinalproduct is required; all other parameters (limit, skip, patientsex, patientagegroup, occurcountry, serious, seriousnessdeath) are optional. Use filters sparingly to avoid overly restrictive searches. Data source: FDA Adverse Event Reporting System (FAERS).",
+          "input_recall": 0.0,
+          "kind": "tool",
+          "name": "FAERS_search_adverse_event_reports",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": true,
+          "score": 0.6333,
+          "semantic_recall": 0.6667
+        },
+        {
+          "category": "fda_drug_adverse_event_detail",
+          "coverage": "partial",
+          "description": "Search and retrieve detailed adverse event reports for a specific drug and indication. Returns individual case reports with patient information, adverse event details, drug information, and report metadata. Only medicinalproduct is required; all other parameters (drugindication, limit, skip, patientsex, patientagegroup, serious) are optional. Data source: FDA Adverse Event Reporting System (FAERS).",
+          "input_recall": 0.0,
+          "kind": "tool",
+          "name": "FAERS_search_reports_by_drug_and_indication",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": true,
+          "score": 0.6333,
+          "semantic_recall": 0.6667
+        },
+        {
+          "category": "fda_drug_adverse_event_detail",
+          "coverage": "partial",
+          "description": "Search and retrieve detailed adverse event reports for a specific drug filtered by reaction outcome. Returns individual case reports with patient information, adverse event details, drug information, and report metadata. Only medicinalproduct is required; all other parameters (reactionoutcome, limit, skip, patientsex, patientagegroup, serious) are optional. Data source: FDA Adverse Event Reporting System (FAERS).",
+          "input_recall": 0.0,
+          "kind": "tool",
+          "name": "FAERS_search_reports_by_drug_and_outcome",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": true,
+          "score": 0.6333,
+          "semantic_recall": 0.6667
+        },
+        {
+          "category": "fda_drug_adverse_event_detail",
+          "coverage": "partial",
+          "description": "Search and retrieve detailed adverse event reports for a specific drug and reaction type. Returns individual case reports with patient information, adverse event details, drug information, and report metadata. Only medicinalproduct and reactionmeddrapt are required; all other parameters (limit, skip, patientsex, patientagegroup, serious) are optional. Data source: FDA Adverse Event Reporting System (FAERS).",
+          "input_recall": 0.0,
+          "kind": "tool",
+          "name": "FAERS_search_reports_by_drug_and_reaction",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": true,
+          "score": 0.6333,
+          "semantic_recall": 0.6667
+        },
+        {
+          "category": "fda_drug_adverse_event_detail",
+          "coverage": "partial",
+          "description": "Search and retrieve detailed adverse event reports involving multiple drugs (drug interactions). Returns individual case reports where all specified drugs are present. Only medicinalproducts (list of at least 2 drug names) is required; all other parameters (limit, skip, patientsex, patientagegroup, serious) are optional. Data source: FDA Adverse Event Reporting System (FAERS).",
+          "input_recall": 0.0,
+          "kind": "tool",
+          "name": "FAERS_search_reports_by_drug_combination",
+          "operation_match": false,
+          "output_recall": 1.0,
+          "provider_match": true,
+          "score": 0.6333,
+          "semantic_recall": 0.6667
+        }
+      ],
+      "privacy": "Coverage resolution is local, read-only, and not persisted or reported.",
+      "recommended_action": "use_existing",
+      "registry_sha256": "4c93a7a90997627fc06edc5c7d73977a0f4759195d9d3ccfe0d1ca0b55a78cb6",
+      "registry_tool_count": 2743,
+      "request": {
+        "description": "retrieve FDA drug label by set identifier",
+        "endpoint_host": "",
+        "endpoint_path": "",
+        "method": "GET",
+        "operation_id": "",
+        "output_fields": [],
+        "provider": "fda",
+        "required_inputs": [
+          "set_id"
+        ]
+      },
+      "tool_matches": 207,
+      "workflow_matches": 0
+    },
+    "intentional_gap": {
+      "capability_id": "e0d6ddae29dc09c9",
+      "classification": "missing",
+      "exact_match_count": 0,
+      "match_count": 0,
+      "matches": [],
+      "privacy": "Coverage resolution is local, read-only, and not persisted or reported.",
+      "recommended_action": "discover_external_candidate",
+      "registry_sha256": "4c93a7a90997627fc06edc5c7d73977a0f4759195d9d3ccfe0d1ca0b55a78cb6",
+      "registry_tool_count": 2743,
+      "request": {
+        "description": "quantum microscope calibration waveform optimizer",
+        "endpoint_host": "",
+        "endpoint_path": "",
+        "method": "GET",
+        "operation_id": "",
+        "output_fields": [],
+        "provider": "",
+        "required_inputs": []
+      },
+      "tool_matches": 0,
+      "workflow_matches": 0
+    }
+  }
+}

--- a/examples/vsd/artifacts/capability_coverage_snapshot.md
+++ b/examples/vsd/artifacts/capability_coverage_snapshot.md
@@ -1,0 +1,34 @@
+# VSD registry-first coverage study
+
+## Question
+
+Can VSD prevent duplicate API/tool generation by checking the real ToolUniverse
+registry and its composed workflows before external discovery?
+
+## Method
+
+The offline study read 2,743 packaged and runtime-visible tool specifications. It
+did not instantiate those tools, write a demand log, contact an API, or send the
+capability descriptions anywhere. Four materially different demands exercised the
+exact, partial, workflow, and missing branches.
+
+## Results
+
+| Demand | Classification | Decisive evidence | Action |
+| --- | --- | --- | --- |
+| Rare-disease genes and phenotypes | Existing partial | Existing Orphanet gene/phenotype tools and other disease resources | Review and reuse or extend existing providers |
+| FDA label by set identifier | Existing exact | `FDA_get_drug_name_by_set_id` and the generic FDA label-field tool | Use existing tools |
+| Disease-to-target-to-compound-to-ADMET literature workflow | Existing exact | `ComprehensiveDrugDiscoveryPipeline` | Use existing workflow |
+| Quantum microscope waveform optimizer | Missing | No tool or workflow crossed the conservative match threshold | Continue to external discovery |
+
+All four assertions passed. The complete normalized requests, bounded match
+evidence, scoring components, registry digest, and capability digests are in
+`capability_coverage_snapshot.json`.
+
+## Interpretation
+
+Provider overlap alone does not prove an exact operation. The resolver therefore
+distinguishes a reusable exact operation from partial provider coverage, allowing
+ToolUniverse to add a genuinely new operation without registering the same source
+again. A missing result is only permission to begin candidate discovery; it is not
+approval to execute or publish anything.

--- a/examples/vsd/capability_coverage_case_study.py
+++ b/examples/vsd/capability_coverage_case_study.py
@@ -1,0 +1,76 @@
+"""Offline case study proving VSD checks existing coverage before discovery."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tooluniverse import ToolUniverse
+from tooluniverse.vsd_coverage import resolve_capability
+
+
+DEMANDS = {
+    "als_registry": {
+        "description": "rare disease registry genes and phenotypes",
+        "required_inputs": ["disease"],
+    },
+    "fda_label": {
+        "description": "retrieve FDA drug label by set identifier",
+        "provider": "FDA",
+        "required_inputs": ["set_id"],
+    },
+    "drug_discovery_workflow": {
+        "description": "complete disease target compound ADMET literature workflow",
+    },
+    "intentional_gap": {
+        "description": "quantum microscope calibration waveform optimizer",
+    },
+}
+
+
+def run_case() -> dict:
+    tooluniverse = ToolUniverse()
+    try:
+        results = {
+            name: resolve_capability(tooluniverse, request, limit=10)["data"]
+            for name, request in DEMANDS.items()
+        }
+    finally:
+        tooluniverse.close()
+    assertions = {
+        "als_uses_existing_registry": any(
+            match["name"] in {"Orphanet_get_genes", "Orphanet_get_phenotypes"}
+            for match in results["als_registry"]["matches"]
+        ),
+        "fda_uses_existing_tool_family": any(
+            "FDA" in match["name"] for match in results["fda_label"]["matches"]
+        ),
+        "workflow_is_detected": results["drug_discovery_workflow"]["workflow_matches"]
+        > 0,
+        "real_gap_can_continue_to_discovery": results["intentional_gap"][
+            "classification"
+        ]
+        == "missing",
+    }
+    return {
+        "case": "registry-first capability resolution",
+        "demands": DEMANDS,
+        "results": results,
+        "assertions": assertions,
+        "all_assertions_passed": all(assertions.values()),
+    }
+
+
+def main() -> int:
+    report = run_case()
+    artifact = Path(__file__).parent / "artifacts" / "capability_coverage_snapshot.json"
+    artifact.write_text(
+        json.dumps(report, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=True))
+    return 0 if report["all_assertions_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tooluniverse/_lazy_registry_static.py
+++ b/src/tooluniverse/_lazy_registry_static.py
@@ -682,6 +682,7 @@ STATIC_LAZY_REGISTRY = {
     "VSDQuerySource": "vsd_tool",
     "VSDRegisterSource": "vsd_tool",
     "VSDRemoveSource": "vsd_tool",
+    "VSDResolveCapability": "vsd_coverage",
     "VisualizationTool": "visualization_tool",
     "WFGYPromptBundleTool": "wfgy_promptbundle_tool",
     "WHOGHOQueryTool": "who_gho_tool",

--- a/src/tooluniverse/data/vsd_tools.json
+++ b/src/tooluniverse/data/vsd_tools.json
@@ -1,5 +1,82 @@
 [
   {
+    "name": "VSDResolveCapability",
+    "type": "VSDResolveCapability",
+    "description": "Check a requested capability against registered ToolUniverse tools and composed workflows before searching for an external API. Returns exact, partial, or missing coverage with deterministic evidence and never persists or reports the request.",
+    "cacheable": false,
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 500,
+          "description": "Non-sensitive description of the required capability."
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 500,
+          "description": "Optional provider name or HTTPS provider URL."
+        },
+        "method": {
+          "type": "string",
+          "enum": ["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"],
+          "default": "GET"
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Optional exact HTTPS operation endpoint without query parameters."
+        },
+        "operation_id": {
+          "type": "string",
+          "description": "Optional stable provider operation identifier."
+        },
+        "required_inputs": {
+          "type": "array",
+          "maxItems": 20,
+          "uniqueItems": true,
+          "items": {"type": "string"},
+          "default": []
+        },
+        "output_fields": {
+          "type": "array",
+          "maxItems": 20,
+          "uniqueItems": true,
+          "items": {"type": "string"},
+          "default": []
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 20,
+          "default": 10
+        }
+      },
+      "required": ["description"],
+      "additionalProperties": false
+    },
+    "return_schema": {
+      "type": "object",
+      "properties": {
+        "status": {"type": "string"},
+        "data": {"type": "object"}
+      },
+      "required": ["status", "data"]
+    },
+    "mcp_annotations": {
+      "readOnlyHint": true,
+      "destructiveHint": false
+    },
+    "test_examples": [
+      {
+        "description": "Find a rare disease registry for ALS genes and phenotypes",
+        "required_inputs": ["disease"],
+        "limit": 5
+      }
+    ]
+  },
+  {
     "name": "VSDDiscoverAPICandidates",
     "type": "VSDDiscoverAPICandidates",
     "description": "Search the fixed Socrata public-data catalog for API-ready datasets related to a research demand. Returned metadata is untrusted and non-executable until separately reviewed, verified, and approved.",

--- a/src/tooluniverse/execute_function.py
+++ b/src/tooluniverse/execute_function.py
@@ -3621,6 +3621,7 @@ class ToolUniverse:
                     "GrepTools",
                     "GetToolInfo",
                     "ExecuteTool",
+                    "VSDResolveCapability",
                 ]:
                     # Tool discovery tools need tooluniverse parameter
                     new_tool = tool_class(tool_config=tool, tooluniverse=self)

--- a/src/tooluniverse/tools/.tool_metadata.json
+++ b/src/tooluniverse/tools/.tool_metadata.json
@@ -2108,6 +2108,7 @@
   "VSDDiscoverSources": "1517133606abd36891b08e9c46315767",
   "VSDEnsemblServiceStatus": "b584b8125d9b2219b87ae0f81dd1c24a",
   "VSDOpenFDALabelBySetId": "94f5f499c44a60e5d14e3fa22826c4db",
+  "VSDResolveCapability": "73d43c7342d9ee37614f2d28c687525f",
   "VSDWHOHypertensionIndicator": "69033b05f857e1b96ef43d5f6ecb5aa2",
   "VariantValidator_format_genomic_to_transcripts": "90fbaa1e507117dcef069b7132f32de4",
   "VariantValidator_gene2transcripts": "a4e6f3c6dfe99a3ea14e0dae25a15581",

--- a/src/tooluniverse/tools/VSDResolveCapability.py
+++ b/src/tooluniverse/tools/VSDResolveCapability.py
@@ -1,0 +1,88 @@
+"""
+VSDResolveCapability
+
+Check a requested capability against registered ToolUniverse tools and composed workflows before ...
+"""
+
+from typing import Any, Optional, Callable
+from ._shared_client import get_shared_client
+
+
+def VSDResolveCapability(
+    description: str,
+    provider: Optional[str] = None,
+    method: Optional[str] = "GET",
+    endpoint: Optional[str] = None,
+    operation_id: Optional[str] = None,
+    required_inputs: Optional[list[str]] = None,
+    output_fields: Optional[list[str]] = None,
+    limit: Optional[int] = 10,
+    *,
+    stream_callback: Optional[Callable[[str], None]] = None,
+    use_cache: bool = False,
+    validate: bool = True,
+) -> dict[str, Any]:
+    """
+    Check a requested capability against registered ToolUniverse tools and composed workflows before ...
+
+    Parameters
+    ----------
+    description : str
+        Non-sensitive description of the required capability.
+    provider : str
+        Optional provider name or HTTPS provider URL.
+    method : str
+
+    endpoint : str
+        Optional exact HTTPS operation endpoint without query parameters.
+    operation_id : str
+        Optional stable provider operation identifier.
+    required_inputs : list[str]
+
+    output_fields : list[str]
+
+    limit : int
+
+    stream_callback : Callable, optional
+        Callback for streaming output
+    use_cache : bool, default False
+        Enable caching
+    validate : bool, default True
+        Validate parameters
+
+    Returns
+    -------
+    dict[str, Any]
+    """
+    # Handle mutable defaults to avoid B006 linting error
+    if required_inputs is None:
+        required_inputs = []
+    if output_fields is None:
+        output_fields = []
+    # Strip None values so optional parameters don't trigger schema validation errors
+    _args = {
+        k: v
+        for k, v in {
+            "description": description,
+            "provider": provider,
+            "method": method,
+            "endpoint": endpoint,
+            "operation_id": operation_id,
+            "required_inputs": required_inputs,
+            "output_fields": output_fields,
+            "limit": limit,
+        }.items()
+        if v is not None
+    }
+    return get_shared_client().run_one_function(
+        {
+            "name": "VSDResolveCapability",
+            "arguments": _args,
+        },
+        stream_callback=stream_callback,
+        use_cache=use_cache,
+        validate=validate,
+    )
+
+
+__all__ = ["VSDResolveCapability"]

--- a/src/tooluniverse/tools/__init__.py
+++ b/src/tooluniverse/tools/__init__.py
@@ -2588,6 +2588,7 @@ from .VSDDiscoverAPICandidates import VSDDiscoverAPICandidates
 from .VSDDiscoverSources import VSDDiscoverSources
 from .VSDEnsemblServiceStatus import VSDEnsemblServiceStatus
 from .VSDOpenFDALabelBySetId import VSDOpenFDALabelBySetId
+from .VSDResolveCapability import VSDResolveCapability
 from .VSDWHOHypertensionIndicator import VSDWHOHypertensionIndicator
 from .VariantValidator_format_genomic_to_transcripts import (
     VariantValidator_format_genomic_to_transcripts,
@@ -5418,6 +5419,7 @@ __all__ = [
     "VSDDiscoverSources",
     "VSDEnsemblServiceStatus",
     "VSDOpenFDALabelBySetId",
+    "VSDResolveCapability",
     "VSDWHOHypertensionIndicator",
     "VariantValidator_format_genomic_to_transcripts",
     "VariantValidator_gene2transcripts",

--- a/src/tooluniverse/vsd_coverage.py
+++ b/src/tooluniverse/vsd_coverage.py
@@ -1,0 +1,521 @@
+"""Deterministic registry coverage analysis for VSD capability requests.
+
+Coverage resolution is deliberately local and read-only.  It examines registered
+ToolUniverse specifications before VSD searches an external catalog, and it does
+not persist the request or report it to a third party.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlsplit
+
+from .base_tool import BaseTool
+from .execute_function import read_json_list
+from .tool_registry import register_tool
+
+_TEXT_RE = re.compile(r"^[^\x00-\x1f\x7f]{3,500}$")
+_FIELD_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]{0,63}$")
+_OPERATION_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:/-]{2,127}$")
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_URL_RE = re.compile(r"https://[^\s\"'<>]+", re.IGNORECASE)
+_METHODS = {"GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"}
+_STOP_WORDS = {
+    "a",
+    "an",
+    "and",
+    "api",
+    "by",
+    "data",
+    "for",
+    "from",
+    "get",
+    "in",
+    "of",
+    "on",
+    "or",
+    "search",
+    "the",
+    "to",
+    "tool",
+    "tools",
+    "using",
+    "with",
+}
+
+
+class VSDCoverageError(ValueError):
+    """Raised when a capability request cannot be analyzed safely."""
+
+
+def _bounded_text(value: Any, *, field: str, required: bool = False) -> str:
+    text = str(value or "").strip()
+    if not text:
+        if required:
+            raise VSDCoverageError(f"{field} is required")
+        return ""
+    if not _TEXT_RE.fullmatch(text):
+        raise VSDCoverageError(f"{field} must contain 3-500 printable characters")
+    return text
+
+
+def _field_list(value: Any, *, field: str) -> list[str]:
+    if value is None:
+        return []
+    if (
+        not isinstance(value, list)
+        or len(value) > 20
+        or len(value) != len(set(value))
+        or any(
+            not isinstance(item, str) or not _FIELD_RE.fullmatch(item) for item in value
+        )
+    ):
+        raise VSDCoverageError(
+            f"{field} must contain at most 20 unique stable field names"
+        )
+    return list(value)
+
+
+def _normalize_endpoint(value: Any) -> tuple[str, str]:
+    if value in (None, ""):
+        return "", ""
+    if not isinstance(value, str) or len(value) > 1000:
+        raise VSDCoverageError("endpoint must be a bounded HTTPS URL")
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme.lower() != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise VSDCoverageError(
+            "endpoint must be an HTTPS URL without credentials, query, or fragment"
+        )
+    host = parsed.hostname.casefold().rstrip(".")
+    path = re.sub(r"/+", "/", parsed.path or "/").rstrip("/") or "/"
+    return host, path
+
+
+def _normalize_provider(value: Any) -> str:
+    provider = _bounded_text(value, field="provider")
+    if not provider:
+        return ""
+    if "://" in provider:
+        host, _ = _normalize_endpoint(provider)
+        return host
+    return provider.casefold().rstrip(".")
+
+
+def normalize_capability_request(request: Any) -> dict[str, Any]:
+    """Validate and canonicalize one non-sensitive capability description."""
+    if not isinstance(request, dict):
+        raise VSDCoverageError("Capability request must be an object")
+    description = _bounded_text(
+        request.get("description"), field="description", required=True
+    )
+    method = str(request.get("method") or "GET").upper()
+    if method not in _METHODS:
+        raise VSDCoverageError("method must be a recognized HTTP method")
+    operation_id = str(request.get("operation_id") or "").strip()
+    if operation_id and not _OPERATION_RE.fullmatch(operation_id):
+        raise VSDCoverageError("operation_id must be a stable identifier")
+    endpoint_host, endpoint_path = _normalize_endpoint(request.get("endpoint"))
+    provider = _normalize_provider(request.get("provider"))
+    if endpoint_host and provider and not _provider_matches(provider, endpoint_host):
+        raise VSDCoverageError("provider does not match endpoint host")
+    if endpoint_host:
+        provider = endpoint_host
+    return {
+        "description": description,
+        "provider": provider,
+        "method": method,
+        "endpoint_host": endpoint_host,
+        "endpoint_path": endpoint_path,
+        "operation_id": operation_id,
+        "required_inputs": _field_list(
+            request.get("required_inputs"), field="required_inputs"
+        ),
+        "output_fields": _field_list(
+            request.get("output_fields"), field="output_fields"
+        ),
+    }
+
+
+def _tokens(value: str) -> set[str]:
+    return {
+        token
+        for token in _TOKEN_RE.findall(value.casefold().replace("_", " "))
+        if token not in _STOP_WORDS and len(token) > 1
+    }
+
+
+def _flatten_strings(value: Any, *, limit: int = 1000) -> list[str]:
+    found: list[str] = []
+    pending = [value]
+    while pending and len(found) < limit:
+        item = pending.pop()
+        if isinstance(item, str):
+            found.append(item[:2000])
+        elif isinstance(item, dict):
+            pending.extend(reversed(list(item.keys())))
+            pending.extend(reversed(list(item.values())))
+        elif isinstance(item, list):
+            pending.extend(reversed(item[:200]))
+    return found
+
+
+def _tool_hosts(config: dict[str, Any]) -> set[str]:
+    hosts: set[str] = set()
+    operation = config.get("vsd_operation")
+    if isinstance(operation, dict):
+        endpoint = operation.get("endpoint")
+        if isinstance(endpoint, str):
+            parsed = urlsplit(endpoint)
+            if parsed.hostname:
+                hosts.add(parsed.hostname.casefold().rstrip("."))
+    for text in _flatten_strings(config, limit=300):
+        for url in _URL_RE.findall(text):
+            parsed = urlsplit(url.rstrip(".,);]"))
+            if parsed.hostname:
+                hosts.add(parsed.hostname.casefold().rstrip("."))
+    return hosts
+
+
+def _provider_terms(config: dict[str, Any]) -> set[str]:
+    identity = {
+        "name": config.get("name", ""),
+        "type": config.get("type", ""),
+        "category": config.get("category", ""),
+        "provider": config.get("provider", ""),
+        "source": config.get("source", ""),
+        "vsd_promotion": config.get("vsd_promotion", {}),
+    }
+    return _tokens(" ".join(_flatten_strings(identity, limit=100)))
+
+
+def _provider_matches(requested: str, actual: str) -> bool:
+    if not requested or not actual:
+        return False
+    requested = requested.casefold().rstrip(".")
+    actual = actual.casefold().rstrip(".")
+    if requested == actual:
+        return True
+    if "." in requested and "." in actual:
+        return requested.endswith("." + actual) or actual.endswith("." + requested)
+    return requested in _tokens(actual) or actual in _tokens(requested)
+
+
+def _schema_fields(schema: Any) -> set[str]:
+    if not isinstance(schema, dict):
+        return set()
+    fields: set[str] = set()
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        fields.update(str(name).casefold() for name in properties)
+        for child in properties.values():
+            fields.update(_schema_fields(child))
+    items = schema.get("items")
+    if isinstance(items, dict):
+        fields.update(_schema_fields(items))
+    return fields
+
+
+def _schema_terms(schema: Any) -> set[str]:
+    """Return field identifiers plus bounded descriptive terms for alias matching."""
+    fields = _schema_fields(schema)
+    terms = set(fields)
+    for field in fields:
+        terms.update(_tokens(field))
+        terms.add(re.sub(r"[^a-z0-9]", "", field))
+    for text in _flatten_strings(schema, limit=300):
+        terms.update(_tokens(text))
+    return terms
+
+
+def _field_recall(requested: Iterable[str], available: set[str]) -> float:
+    values = list(requested)
+    if not values:
+        return 1.0
+    matches = 0
+    for value in values:
+        normalized = value.casefold()
+        collapsed = re.sub(r"[^a-z0-9]", "", normalized)
+        value_tokens = _tokens(normalized)
+        if (
+            normalized in available
+            or collapsed in available
+            or (value_tokens and value_tokens <= available)
+        ):
+            matches += 1
+    return matches / len(values)
+
+
+def _registry_tools(tooluniverse: Any) -> list[dict[str, Any]]:
+    """Read built-in specifications plus runtime registrations without loading tools."""
+    indexed: dict[str, dict[str, Any]] = {}
+    tool_files = getattr(tooluniverse, "tool_files", {})
+    if isinstance(tool_files, dict):
+        for category, file_path in sorted(tool_files.items()):
+            try:
+                entries = read_json_list(Path(file_path))
+            except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                continue
+            if isinstance(entries, dict):
+                entries = [entries]
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if isinstance(entry, dict) and isinstance(entry.get("name"), str):
+                    record = dict(entry)
+                    record.setdefault("category", category)
+                    indexed[record["name"]] = record
+    for entry in getattr(tooluniverse, "all_tools", []):
+        if isinstance(entry, dict) and isinstance(entry.get("name"), str):
+            indexed[entry["name"]] = dict(entry)
+    return [indexed[name] for name in sorted(indexed, key=str.casefold)]
+
+
+def _ratio(requested: Iterable[str], available: set[str]) -> float:
+    requested_set = {str(value).casefold() for value in requested}
+    if not requested_set:
+        return 1.0
+    return len(requested_set & available) / len(requested_set)
+
+
+def _operation_identity(config: dict[str, Any]) -> tuple[str, str, str]:
+    operation = config.get("vsd_operation")
+    if not isinstance(operation, dict):
+        return "", "", ""
+    endpoint = operation.get("endpoint")
+    if not isinstance(endpoint, str):
+        return "", "", ""
+    parsed = urlsplit(endpoint)
+    if not parsed.hostname:
+        return "", "", ""
+    path = re.sub(r"/+", "/", parsed.path or "/").rstrip("/") or "/"
+    return (
+        str(operation.get("method") or "GET").upper(),
+        parsed.hostname.casefold().rstrip("."),
+        path,
+    )
+
+
+def _match_tool(
+    request: dict[str, Any], config: dict[str, Any]
+) -> dict[str, Any] | None:
+    name = str(config.get("name") or "")
+    if not name:
+        return None
+    searchable = " ".join(
+        _flatten_strings(
+            {
+                "name": name,
+                "description": config.get("description", ""),
+                "category": config.get("category", ""),
+                "parameter": config.get("parameter", {}),
+                "return_schema": config.get("return_schema", {}),
+                "required_tools": config.get("required_tools", []),
+                "vsd_capability": config.get("vsd_capability", {}),
+            }
+        )
+    )
+    available_tokens = _tokens(searchable)
+    requested_tokens = _tokens(request["description"])
+    semantic_recall = _ratio(requested_tokens, available_tokens)
+
+    hosts = _tool_hosts(config)
+    provider_match = any(_provider_matches(request["provider"], host) for host in hosts)
+    if request["provider"] and not provider_match:
+        provider_tokens = _tokens(request["provider"])
+        provider_match = bool(provider_tokens) and provider_tokens <= _provider_terms(
+            config
+        )
+
+    parameter_fields = _schema_terms(config.get("parameter"))
+    return_fields = _schema_terms(config.get("return_schema"))
+    operation = config.get("vsd_operation")
+    if isinstance(operation, dict):
+        response_schema = operation.get("response_schema")
+        return_fields.update(_schema_terms(response_schema))
+    input_recall = _field_recall(request["required_inputs"], parameter_fields)
+    output_recall = _field_recall(
+        request["output_fields"], return_fields | available_tokens
+    )
+
+    method, host, path = _operation_identity(config)
+    endpoint_match = bool(
+        request["endpoint_host"]
+        and request["endpoint_path"]
+        and request["method"] == method
+        and request["endpoint_host"] == host
+        and request["endpoint_path"] == path
+    )
+    capability = config.get("vsd_capability")
+    explicit_operation_match = bool(
+        request["operation_id"]
+        and isinstance(capability, dict)
+        and capability.get("operation_id") == request["operation_id"]
+    )
+
+    score = (
+        semantic_recall * 0.5
+        + (0.2 if provider_match else 0.0)
+        + input_recall * 0.15
+        + output_recall * 0.1
+        + (0.05 if endpoint_match or explicit_operation_match else 0.0)
+    )
+    kind = (
+        "workflow"
+        if config.get("type") == "ComposeTool"
+        or str(config.get("category") or "").casefold() == "compose_tools"
+        else "tool"
+    )
+    exact = bool(
+        explicit_operation_match
+        or (endpoint_match and input_recall == 1.0 and output_recall >= 0.5)
+        or (
+            provider_match
+            and semantic_recall >= 0.6
+            and input_recall == 1.0
+            and output_recall >= 0.5
+        )
+        or (
+            kind == "workflow"
+            and not request["provider"]
+            and semantic_recall >= 0.8
+            and input_recall == 1.0
+            and output_recall >= 0.5
+        )
+    )
+    plausible = (
+        exact or provider_match
+        if request["provider"]
+        else exact or semantic_recall >= 0.5 or score >= 0.55
+    )
+    if not plausible:
+        return None
+    return {
+        "name": name,
+        "kind": kind,
+        "coverage": "exact" if exact else "partial",
+        "score": round(score, 4),
+        "provider_match": provider_match,
+        "operation_match": endpoint_match or explicit_operation_match,
+        "semantic_recall": round(semantic_recall, 4),
+        "input_recall": round(input_recall, 4),
+        "output_recall": round(output_recall, 4),
+        "category": str(config.get("category") or ""),
+        "description": str(config.get("description") or "")[:500],
+    }
+
+
+def resolve_capability(
+    tooluniverse: Any, request: dict[str, Any], *, limit: int = 10
+) -> dict[str, Any]:
+    """Classify a capability against existing tools and composed workflows."""
+    if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= 20:
+        raise VSDCoverageError("limit must be an integer between 1 and 20")
+    normalized = normalize_capability_request(request)
+    registry = _registry_tools(tooluniverse)
+    matches = [
+        match
+        for config in registry
+        if (match := _match_tool(normalized, config)) is not None
+    ]
+    matches.sort(
+        key=lambda match: (
+            match["coverage"] != "exact",
+            -match["score"],
+            match["kind"] != "tool",
+            match["name"].casefold(),
+        )
+    )
+    selected = matches[:limit]
+    exact = [match for match in matches if match["coverage"] == "exact"]
+    if exact:
+        classification = "existing_exact"
+        action = "use_existing"
+    elif matches:
+        classification = "existing_partial"
+        action = "review_existing_or_extend_provider"
+    else:
+        classification = "missing"
+        action = "discover_external_candidate"
+
+    registry_summary = [
+        {
+            "name": config.get("name"),
+            "type": config.get("type"),
+            "category": config.get("category"),
+            "description": config.get("description"),
+            "parameter": config.get("parameter"),
+            "return_schema": config.get("return_schema"),
+            "vsd_operation": config.get("vsd_operation"),
+        }
+        for config in registry
+    ]
+    request_digest = hashlib.sha256(
+        json.dumps(
+            normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+    ).hexdigest()
+    registry_digest = hashlib.sha256(
+        json.dumps(
+            registry_summary,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    return {
+        "status": "success",
+        "data": {
+            "capability_id": request_digest[:16],
+            "classification": classification,
+            "recommended_action": action,
+            "request": normalized,
+            "matches": selected,
+            "match_count": len(matches),
+            "exact_match_count": len(exact),
+            "tool_matches": sum(match["kind"] == "tool" for match in matches),
+            "workflow_matches": sum(match["kind"] == "workflow" for match in matches),
+            "registry_tool_count": len(registry),
+            "registry_sha256": registry_digest,
+            "privacy": (
+                "Coverage resolution is local, read-only, and not persisted or reported."
+            ),
+        },
+    }
+
+
+@register_tool("VSDResolveCapability")
+class VSDResolveCapability(BaseTool):
+    """Resolve a requested capability against ToolUniverse before API discovery."""
+
+    def __init__(self, tool_config, tooluniverse=None):
+        super().__init__(tool_config)
+        self.tooluniverse = tooluniverse
+
+    def run(self, arguments=None, **_: Any):
+        if self.tooluniverse is None:
+            raise VSDCoverageError("ToolUniverse reference is required")
+        arguments = arguments or {}
+        if not isinstance(arguments, dict):
+            raise VSDCoverageError("Tool arguments must be an object")
+        limit = arguments.get("limit", 10)
+        request = {key: value for key, value in arguments.items() if key != "limit"}
+        return resolve_capability(self.tooluniverse, request, limit=limit)
+
+
+__all__ = [
+    "VSDCoverageError",
+    "VSDResolveCapability",
+    "normalize_capability_request",
+    "resolve_capability",
+]

--- a/tests/unit/test_vsd_coverage.py
+++ b/tests/unit/test_vsd_coverage.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tooluniverse import ToolUniverse
+from tooluniverse.vsd_coverage import (
+    VSDCoverageError,
+    normalize_capability_request,
+    resolve_capability,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _Registry:
+    tool_files = {}
+
+    def __init__(self, tools):
+        self.all_tools = tools
+
+
+def _dynamic_tool(name="ExistingRecords"):
+    return {
+        "name": name,
+        "type": "VSDDynamicRESTTool",
+        "description": "Retrieve reviewed disease registry records by disease.",
+        "category": "special_tools",
+        "parameter": {
+            "type": "object",
+            "properties": {"disease": {"type": "string"}},
+            "required": ["disease"],
+        },
+        "return_schema": {
+            "type": "object",
+            "properties": {"registry_id": {"type": "string"}},
+        },
+        "vsd_operation": {
+            "method": "GET",
+            "endpoint": "https://registry.example.org/v1/diseases",
+            "response_schema": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"registry_id": {"type": "string"}},
+                },
+            },
+        },
+        "vsd_capability": {"operation_id": "registry.search_diseases"},
+    }
+
+
+def test_exact_operation_identity_prevents_duplicate_generation():
+    result = resolve_capability(
+        _Registry([_dynamic_tool()]),
+        {
+            "description": "Retrieve disease registry records",
+            "provider": "registry.example.org",
+            "operation_id": "registry.search_diseases",
+            "required_inputs": ["disease"],
+            "output_fields": ["registry_id"],
+        },
+    )["data"]
+
+    assert result["classification"] == "existing_exact"
+    assert result["recommended_action"] == "use_existing"
+    assert result["matches"][0]["operation_match"] is True
+
+
+def test_same_provider_different_operation_is_partial_not_missing():
+    result = resolve_capability(
+        _Registry([_dynamic_tool()]),
+        {
+            "description": "Retrieve registry investigator contact information",
+            "provider": "https://registry.example.org",
+            "required_inputs": ["investigator_id"],
+            "output_fields": ["email"],
+        },
+    )["data"]
+
+    assert result["classification"] == "existing_partial"
+    assert result["recommended_action"] == "review_existing_or_extend_provider"
+    assert result["matches"][0]["provider_match"] is True
+
+
+def test_composed_workflows_are_included_in_coverage_results():
+    workflow = {
+        "name": "RareDiseaseEvidenceWorkflow",
+        "type": "ComposeTool",
+        "description": "Combine rare disease genes, phenotypes, and literature evidence.",
+        "required_tools": ["ExistingRecords", "PubMed_search_articles"],
+        "parameter": {
+            "type": "object",
+            "properties": {"disease": {"type": "string"}},
+        },
+    }
+    result = resolve_capability(
+        _Registry([_dynamic_tool(), workflow]),
+        {"description": "rare disease genes phenotypes literature evidence"},
+    )["data"]
+
+    assert result["workflow_matches"] == 1
+    assert any(match["kind"] == "workflow" for match in result["matches"])
+
+
+def test_genuinely_unmatched_capability_is_missing_and_not_persisted(tmp_path):
+    registry = _Registry([_dynamic_tool()])
+    result = resolve_capability(
+        registry,
+        {"description": "quantum microscope calibration waveform optimizer"},
+    )["data"]
+
+    assert result["classification"] == "missing"
+    assert result["matches"] == []
+    assert list(tmp_path.iterdir()) == []
+    assert "not persisted" in result["privacy"]
+
+
+@pytest.mark.parametrize(
+    "capability, message",
+    [
+        ({"description": "x"}, "3-500"),
+        ({"description": "valid request", "endpoint": "http://example.org"}, "HTTPS"),
+        (
+            {
+                "description": "valid request",
+                "provider": "one.example.org",
+                "endpoint": "https://two.example.org/path",
+            },
+            "does not match",
+        ),
+        (
+            {"description": "valid request", "required_inputs": ["bad field"]},
+            "stable field",
+        ),
+    ],
+)
+def test_request_validation_fails_closed(capability, message):
+    with pytest.raises(VSDCoverageError, match=message):
+        normalize_capability_request(capability)
+
+
+def test_capability_and_registry_digests_are_deterministic():
+    registry = _Registry([_dynamic_tool()])
+    request = {"description": "Retrieve disease registry records"}
+    first = resolve_capability(registry, request)["data"]
+    second = resolve_capability(registry, request)["data"]
+
+    assert first["capability_id"] == second["capability_id"]
+    assert first["registry_sha256"] == second["registry_sha256"]
+    json.dumps(first, allow_nan=False)
+
+
+def test_real_registry_resolves_als_to_orphanet_without_loading_every_tool():
+    tooluniverse = ToolUniverse()
+    try:
+        tooluniverse.load_tools(include_tools=["VSDResolveCapability"], quiet=True)
+        result = tooluniverse.run_one_function(
+            {
+                "name": "VSDResolveCapability",
+                "arguments": {
+                    "description": "rare disease registry genes and phenotypes",
+                    "required_inputs": ["disease"],
+                    "limit": 10,
+                },
+            },
+            use_cache=False,
+        )
+    finally:
+        tooluniverse.close()
+
+    assert result["status"] == "success"
+    assert result["data"]["classification"] != "missing"
+    names = {match["name"] for match in result["data"]["matches"]}
+    assert {"Orphanet_get_genes", "Orphanet_get_phenotypes"} & names
+    assert len(tooluniverse.all_tools) <= 1
+
+
+def test_real_registry_recognizes_existing_fda_label_capability():
+    tooluniverse = ToolUniverse()
+    try:
+        result = resolve_capability(
+            tooluniverse,
+            {
+                "description": "retrieve FDA drug label by set identifier",
+                "provider": "FDA",
+                "required_inputs": ["set_id"],
+                "limit": 10,
+            },
+        )["data"]
+    finally:
+        tooluniverse.close()
+
+    assert result["classification"] != "missing"
+    assert any("FDA" in match["name"] for match in result["matches"])

--- a/tests/unit/test_vsd_tool_contracts.py
+++ b/tests/unit/test_vsd_tool_contracts.py
@@ -13,6 +13,7 @@ pytestmark = pytest.mark.unit
 
 
 SOURCE_TOOL_NAMES = (
+    "VSDResolveCapability",
     "VSDDiscoverAPICandidates",
     "VSDDiscoverSources",
     "VSDWHOHypertensionIndicator",
@@ -46,7 +47,7 @@ def test_default_surface_contains_only_read_only_source_specific_tools():
 
         for name in SOURCE_TOOL_NAMES:
             config = tooluniverse.all_tool_dict[name]
-            assert config["cacheable"] is True
+            assert config["cacheable"] is (name != "VSDResolveCapability")
             assert config["mcp_annotations"] == {
                 "readOnlyHint": True,
                 "destructiveHint": False,


### PR DESCRIPTION
## Summary

This phase adds a deterministic, local coverage check before VSD performs external
API discovery or generates another tool.

- reads built-in specifications and runtime registrations without instantiating the full registry
- classifies demand as `existing_exact`, `existing_partial`, or `missing`
- distinguishes tools from composed workflows and recognizes stable operation identifiers and reviewed endpoint contracts
- returns bounded scoring evidence plus capability and registry digests
- performs no persistence, telemetry, or outbound reporting
- exposes the read-only `VSDResolveCapability` tool and generated Python wrapper

## Rationale

ToolUniverse already contains extensive source and workflow coverage. VSD should
reuse an exact operation, review or extend a partially covered provider, and search
externally only when no plausible existing capability is present.

## Case study

The checked offline study evaluates four demands against 2,743 packaged and
runtime-visible specifications:

- rare-disease gene and phenotype demand finds existing Orphanet and related disease tools
- FDA label lookup by set identifier resolves to exact existing FDA tools
- a disease-to-target-to-compound-to-ADMET literature request resolves exactly to `ComprehensiveDrugDiscoveryPipeline`
- an intentionally unrelated microscope waveform capability remains missing and is allowed to proceed to discovery

All four assertions pass. The branch includes a human-readable report and a
machine-readable evidence ledger.

## Verification

- 121 VSD-selected unit and integration tests passed
- 22 coverage, source-contract, generated-wrapper, and clean-import tests passed under the worktree UTF-8 environment
- focused coverage suite: 11 passed
- repository-pinned Ruff 0.14.5 lint and formatting checks passed
- JSON validation and `git diff --check` passed

## Stack

Base: #419

The next phase adds administrator-reviewed OpenAPI ingestion for API formats beyond
Socrata.
