### PR TITLE
Add reviewed OpenAPI ingestion for VSD

### DIFF
--- a/examples/vsd/README.md
+++ b/examples/vsd/README.md
@@ -1,5 +1,61 @@
 # ToolUniverse VSD Validation Case Studies
 
+## OpenAPI-to-Tool ALS Registry Pipeline
+
+`openapi_als_case_study.py` demonstrates how an administrator can turn one
+operation from a provider's official OpenAPI document into a narrow, reviewed
+ToolUniverse tool. The inspector reads only a local JSON or YAML file; it does
+not fetch the contract, execute candidates, register tools, or make candidates
+available to an agent.
+
+The live study uses the current ClinicalTrials.gov OpenAPI 3.0 contract. It
+inspects all nine operations, selects `fetchStudy`, exposes only the required
+`nctId` path argument, fixes the provider format to JSON, and preserves the
+provider's complete response schema. The candidate remains inert until the
+existing promotion pipeline verifies three distinct ALS records, records an
+explicit approval, publishes the exact hash chain, and loads it into a fresh
+ToolUniverse instance.
+
+Download the official contract and run the study from the repository root:
+
+```console
+curl -fsS https://clinicaltrials.gov/api/oas/v2 -o ctg-oas-v2.yaml
+PYTHONPATH=src python examples/vsd/openapi_als_case_study.py --spec ctg-oas-v2.yaml
+```
+
+The checked run retrieved `NCT03019419`, `NCT04428775`, and `NCT04745299`.
+Each verification required nested title, status, condition, and identifier
+fields and asserted that the returned NCT identifier exactly matched the
+request. It also proved that malformed identifiers are rejected by the reviewed
+input schema before transport and that every live response used HTTPS, returned
+HTTP 200, and followed zero redirects.
+
+Review `artifacts/openapi_als_snapshot.md` for the readable report,
+`artifacts/openapi_als_snapshot.json` for the machine-readable audit ledger, and
+`artifacts/openapi_ingestion_workspace/` for the draft, verification, approval,
+and publication records. The checked audit links the official document hash to
+the candidate, generated operation, verification evidence, approval, and
+publication.
+
+For administrator scripting, the same two entry points are available through
+the promotion CLI:
+
+```console
+tooluniverse-vsd-promote inspect-openapi ctg-oas-v2.yaml > inspection.json
+tooluniverse-vsd-promote --workspace ./vsd-review draft-openapi inspection.json \
+  --candidate-id 47a4c7402dfb7b86 \
+  --tool-name VSDClinicalTrialsStudyByNCT \
+  --description "Fetch one reviewed ClinicalTrials.gov record by NCT identifier." \
+  --fixed-query-file fixed-query.json
+```
+
+`candidate-id` values are content-addressed and change when the provider
+contract changes. Administrators must select the value produced by their own
+inspection rather than reuse the example value above. Authentication, write
+methods, external schema references, non-JSON responses, unsupported parameter
+styles, and oversized schemas are emitted with explicit blockers and cannot be
+drafted.
+
 ## Complete Oncology Source-Governance Pipeline
 
 `complete_pipeline_case_study.py` exercises the entire VSD stack in one

--- a/examples/vsd/artifacts/openapi_als_snapshot.json
+++ b/examples/vsd/artifacts/openapi_als_snapshot.json
@@ -1,0 +1,337 @@
+{
+  "answer": "Yes. The local specification produced an inert candidate; the selected GET operation passed three exact record checks, was hash-approved, then loaded explicitly into a fresh ToolUniverse instance.",
+  "audit_sha256": "cec78d5359fdf83a262576323925d7ed1b750bafbfd2490dbb18d677fab18170",
+  "disclaimer": "This case demonstrates software-governance and public-registry retrieval. It does not assess eligibility, efficacy, safety, or treatment suitability.",
+  "end_to_end_assertions": {
+    "candidate_inert_before_review": true,
+    "candidate_integrity_hash_propagated": true,
+    "exact_nested_identifiers_verified": true,
+    "fresh_runtime_loaded_explicitly": true,
+    "generated_contract_is_read_only": true,
+    "hash_chain_complete": true,
+    "invalid_identifier_rejected_before_transport": true,
+    "official_contract_parsed": true,
+    "provider_responses_schema_validated": true,
+    "published_tool_absent_before_load": true,
+    "three_distinct_cases_verified": true,
+    "zero_redirect_https_provenance": true
+  },
+  "generated_at": "2026-08-01T18:52:50.208765+00:00",
+  "hash_chain": {
+    "approval_sha256": "a8a7689c9dceb80d7682dcbf663d7f14bd4db281c597c4d5db8dc52d37958a46",
+    "candidate_sha256": "47a4c7402dfb7b8699690b6ba5146eb2755472d21b0cc330e5fc620b097da99f",
+    "draft_sha256": "2d97d81a7723e51789beedc77210be958ea438368c472b3533ca738729f4d3cd",
+    "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+    "publication_sha256": "38541a6ba926f5fe3937ff0a60fffce88293afb3e711bdad9267b62c5914080a",
+    "source_document_sha256": "ba31adaea67e6bb09ff77af5c0c11daf36d5aff7f5d6cbed89f0aab04b297aea",
+    "verification_sha256": "55d799070ea17713f2b0355eff968acf031d69bd04973d5d0bc62c0f8b7a67f0"
+  },
+  "inspection": {
+    "blocked_count": 0,
+    "candidate_count": 9,
+    "operation_ids": [
+      "listFieldSizesStats",
+      "fieldValuesStats",
+      "sizeStats",
+      "listStudies",
+      "enums",
+      "studiesMetadata",
+      "searchAreas",
+      "fetchStudy",
+      "version"
+    ],
+    "promotable_count": 9
+  },
+  "promotion": {
+    "decision_note": "Approved after schema review and three distinct ALS registry records passed exact nested-identifier verification.",
+    "draft_id": "vsdclinicaltrialsstudybynct_27f9c4e92c3f",
+    "loaded_tools": [
+      "VSDClinicalTrialsStudyByNCT"
+    ],
+    "reviewed_by": "ToolUniverse VSD case-study reviewer",
+    "state": {
+      "approvals": [
+        "vsdclinicaltrialsstudybynct_27f9c4e92c3f"
+      ],
+      "approved": [
+        "VSDClinicalTrialsStudyByNCT"
+      ],
+      "drafts": [
+        "vsdclinicaltrialsstudybynct_27f9c4e92c3f"
+      ],
+      "evidence": [
+        "vsdclinicaltrialsstudybynct_27f9c4e92c3f"
+      ]
+    },
+    "verification_case_count": 3,
+    "verification_cases": [
+      {
+        "arguments": {
+          "nctId": "NCT03019419"
+        },
+        "case_index": 0,
+        "expect": {
+          "equals": {},
+          "equals_paths": {
+            "/protocolSection/identificationModule/nctId": "NCT03019419"
+          },
+          "max_items": null,
+          "min_items": null,
+          "required_fields": [
+            "protocolSection"
+          ],
+          "required_paths": [
+            "/protocolSection/identificationModule/nctId",
+            "/protocolSection/identificationModule/briefTitle",
+            "/protocolSection/statusModule/overallStatus",
+            "/protocolSection/conditionsModule/conditions"
+          ],
+          "result_type": "object"
+        },
+        "http_status": 200,
+        "observed_fields": [
+          "derivedSection",
+          "hasResults",
+          "protocolSection"
+        ],
+        "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+        "payload_sha256": "4fce0ba178580566ab3d97bb5aa0d7f77cca287b4d193539dfa9cbaacfeb60da",
+        "redirects": 0,
+        "result_type": "object",
+        "retrieved_at": "2026-08-01T18:52:47.404925+00:00",
+        "row_count": null
+      },
+      {
+        "arguments": {
+          "nctId": "NCT04428775"
+        },
+        "case_index": 1,
+        "expect": {
+          "equals": {},
+          "equals_paths": {
+            "/protocolSection/identificationModule/nctId": "NCT04428775"
+          },
+          "max_items": null,
+          "min_items": null,
+          "required_fields": [
+            "protocolSection"
+          ],
+          "required_paths": [
+            "/protocolSection/identificationModule/nctId",
+            "/protocolSection/identificationModule/briefTitle",
+            "/protocolSection/statusModule/overallStatus",
+            "/protocolSection/conditionsModule/conditions"
+          ],
+          "result_type": "object"
+        },
+        "http_status": 200,
+        "observed_fields": [
+          "derivedSection",
+          "hasResults",
+          "protocolSection"
+        ],
+        "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+        "payload_sha256": "17df843a24f19baad6655410238244ba464c171d2cdc048f08c0c158432f68ca",
+        "redirects": 0,
+        "result_type": "object",
+        "retrieved_at": "2026-08-01T18:52:47.595065+00:00",
+        "row_count": null
+      },
+      {
+        "arguments": {
+          "nctId": "NCT04745299"
+        },
+        "case_index": 2,
+        "expect": {
+          "equals": {},
+          "equals_paths": {
+            "/protocolSection/identificationModule/nctId": "NCT04745299"
+          },
+          "max_items": null,
+          "min_items": null,
+          "required_fields": [
+            "protocolSection"
+          ],
+          "required_paths": [
+            "/protocolSection/identificationModule/nctId",
+            "/protocolSection/identificationModule/briefTitle",
+            "/protocolSection/statusModule/overallStatus",
+            "/protocolSection/conditionsModule/conditions"
+          ],
+          "result_type": "object"
+        },
+        "http_status": 200,
+        "observed_fields": [
+          "derivedSection",
+          "hasResults",
+          "protocolSection"
+        ],
+        "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+        "payload_sha256": "95a907ff858124aa0d29c0367a1de9f8e32ee7686a96bf9285a47f94370ab34d",
+        "redirects": 0,
+        "result_type": "object",
+        "retrieved_at": "2026-08-01T18:52:47.835388+00:00",
+        "row_count": null
+      }
+    ]
+  },
+  "question": "Can an administrator turn the provider's current OpenAPI operation into a narrow ToolUniverse tool that retrieves exact ALS trial records without granting an agent arbitrary API access?",
+  "retrieved_als_records": [
+    {
+      "brief_title": "Perampanel for Sporadic Amyotrophic Lateral Sclerosis (ALS)",
+      "conditions": [
+        "ALS"
+      ],
+      "nct_id": "NCT03019419",
+      "overall_status": "COMPLETED",
+      "phases": [
+        "PHASE2"
+      ],
+      "provenance": {
+        "content_type": "application/json",
+        "endpoint": "https://clinicaltrials.gov/api/v2/studies/NCT03019419",
+        "http_status": 200,
+        "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+        "payload_sha256": "4fce0ba178580566ab3d97bb5aa0d7f77cca287b4d193539dfa9cbaacfeb60da",
+        "provider": "clinicaltrials.gov",
+        "redirects": 0,
+        "response_bytes": 7724,
+        "retrieved_at": "2026-08-01T18:52:49.328804+00:00"
+      }
+    },
+    {
+      "brief_title": "A Safety and Biomarker Study of ALZT-OP1a in Subjects With Mild-Moderate ALS Disease",
+      "conditions": [
+        "Amyotrophic Lateral Sclerosis"
+      ],
+      "nct_id": "NCT04428775",
+      "overall_status": "TERMINATED",
+      "phases": [
+        "PHASE2"
+      ],
+      "provenance": {
+        "content_type": "application/json",
+        "endpoint": "https://clinicaltrials.gov/api/v2/studies/NCT04428775",
+        "http_status": 200,
+        "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+        "payload_sha256": "17df843a24f19baad6655410238244ba464c171d2cdc048f08c0c158432f68ca",
+        "provider": "clinicaltrials.gov",
+        "redirects": 0,
+        "response_bytes": 14170,
+        "retrieved_at": "2026-08-01T18:52:49.540687+00:00"
+      }
+    },
+    {
+      "brief_title": "Evaluation the Efficacy and Safety of Mutiple Lenzumestrocel (Neuronata-R\u00ae Inj.) Treatment in Patients With ALS",
+      "conditions": [
+        "Amyotrophic Lateral Sclerosis"
+      ],
+      "nct_id": "NCT04745299",
+      "overall_status": "COMPLETED",
+      "phases": [
+        "PHASE3"
+      ],
+      "provenance": {
+        "content_type": "application/json",
+        "endpoint": "https://clinicaltrials.gov/api/v2/studies/NCT04745299",
+        "http_status": 200,
+        "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+        "payload_sha256": "95a907ff858124aa0d29c0367a1de9f8e32ee7686a96bf9285a47f94370ab34d",
+        "provider": "clinicaltrials.gov",
+        "redirects": 0,
+        "response_bytes": 17119,
+        "retrieved_at": "2026-08-01T18:52:49.763791+00:00"
+      }
+    }
+  ],
+  "selected_operation": {
+    "blockers": [],
+    "candidate_id": "47a4c7402dfb7b86",
+    "candidate_sha256": "47a4c7402dfb7b8699690b6ba5146eb2755472d21b0cc330e5fc620b097da99f",
+    "method": "GET",
+    "operation_id": "fetchStudy",
+    "parameters": [
+      {
+        "argument_name": "nctId",
+        "description": "NCT Number of a study. If found in [NCTIdAlias](data-api/about-api/study-data-structure#NCTIdAlias) field, 301 HTTP redirect to the actual study will be returned.",
+        "explode": false,
+        "location": "path",
+        "provider_name": "nctId",
+        "required": true,
+        "schema": {
+          "pattern": "^[Nn][Cc][Tt]0*[1-9]\\d{0,7}$",
+          "type": "string"
+        },
+        "style": "simple"
+      },
+      {
+        "argument_name": "format",
+        "description": "Must be one of the following: * `csv`- return CSV table; available fields are listed on [CSV Download](/data-api/about-api/csv-download) * `json`- return JSON object; format of `markup` fields depends on `markupFormat` parameter * `json.zip`- put JSON object into a .json file and download it as zip archive; field values of type `markup` are in [markdown](https://spec.commonmark.org/0.28/) format * `fhir.json` - return FHIR JSON; fields are not customizable; see [Access Data in FHIR](/data-api/fhir) * `ris`- return RIS record; available tags are listed on [RIS Download](/data-api/about-api/ris-download)",
+        "explode": true,
+        "location": "query",
+        "provider_name": "format",
+        "required": false,
+        "schema": {
+          "default": "json",
+          "enum": [
+            "csv",
+            "json",
+            "json.zip",
+            "fhir.json",
+            "ris"
+          ],
+          "type": "string"
+        },
+        "style": "form"
+      },
+      {
+        "argument_name": "markupFormat",
+        "description": "Format of `markup` type fields: * `markdown`- [markdown](https://spec.commonmark.org/0.28/) format * `legacy`- compatible with classic PRS Applicable only to `json` format.",
+        "explode": true,
+        "location": "query",
+        "provider_name": "markupFormat",
+        "required": false,
+        "schema": {
+          "default": "markdown",
+          "enum": [
+            "markdown",
+            "legacy"
+          ],
+          "type": "string"
+        },
+        "style": "form"
+      },
+      {
+        "argument_name": "fields",
+        "description": "If specified, must be non-empty comma- or pipe-separated list of fields to return. If unspecified, all fields will be returned. Order of the fields does not matter. For `csv` format, specify list of columns. The column names are available on [CSV Download](/data-api/about-api/csv-download). For `json` and `json.zip` formats, every list item is either area name, piece name, or field name. If a piece or a field is a branch node, all descendant fields will be included. All area names are available on [Search Areas](/data-api/about-api/search-areas), the piece and field names - on [Data Structure](/data-api/about-api/study-data-structure) and also can be retrieved at `/studies/metadata` endpoint. For `fhir.json` format, all available fields are returned and this parameter must be unspecified. For `ris` format, specify list of tags. The tag names are available on [RIS Download](/data-api/about-api/ris-download).",
+        "explode": false,
+        "location": "query",
+        "provider_name": "fields",
+        "required": false,
+        "schema": {
+          "items": {
+            "pattern": "^[a-zA-Z][a-zA-Z0-9\\-. ]*$",
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "style": "pipeDelimited"
+      }
+    ],
+    "path": "/studies/{nctId}",
+    "response_media_type": "application/json",
+    "server_url": "https://clinicaltrials.gov/api/v2",
+    "warnings": []
+  },
+  "source_contract": {
+    "api_title": "ClinicalTrials.gov REST API",
+    "api_version": "2.0.5",
+    "document_sha256": "ba31adaea67e6bb09ff77af5c0c11daf36d5aff7f5d6cbed89f0aab04b297aea",
+    "local_file": ".tmp_ctg_oas.yaml",
+    "official_docs_url": "https://clinicaltrials.gov/data-api/api",
+    "official_spec_url": "https://clinicaltrials.gov/api/oas/v2",
+    "openapi_version": "3.0.3"
+  },
+  "title": "OpenAPI-to-Tool ALS Registry Case Study"
+}

--- a/examples/vsd/artifacts/openapi_als_snapshot.md
+++ b/examples/vsd/artifacts/openapi_als_snapshot.md
@@ -1,0 +1,68 @@
+# OpenAPI-to-Tool ALS Registry Case Study
+
+**Generated:** 2026-08-01T18:52:50.208765+00:00
+
+## Decision Question
+
+Can an administrator turn the provider's current OpenAPI operation into a narrow ToolUniverse tool that retrieves exact ALS trial records without granting an agent arbitrary API access?
+
+**Result:** Yes. The local specification produced an inert candidate; the selected GET operation passed three exact record checks, was hash-approved, then loaded explicitly into a fresh ToolUniverse instance.
+
+## Official Contract Inspection
+
+- Provider documentation: https://clinicaltrials.gov/data-api/api
+- Current specification: https://clinicaltrials.gov/api/oas/v2
+- Contract: ClinicalTrials.gov REST API 2.0.5 (OpenAPI 3.0.3)
+- Source SHA-256: `ba31adaea67e6bb09ff77af5c0c11daf36d5aff7f5d6cbed89f0aab04b297aea`
+- Operations inspected: 9 (9 promotable, 0 blocked)
+
+The inspector read a local, bounded copy of the provider contract. It did not fetch, register, or execute any operation. Every candidate began with `execution_allowed: false`.
+
+## Selected Operation
+
+| Property | Reviewed value |
+| --- | --- |
+| Operation | `fetchStudy` |
+| Request | `GET https://clinicaltrials.gov/api/v2/studies/{nctId}` |
+| Response | `application/json` validated against the provider schema |
+| Candidate | `47a4c7402dfb7b86` |
+| Blockers | `[]` |
+
+Only the required `nctId` path argument was exposed. The response format was fixed to JSON; CSV, ZIP, RIS, and FHIR choices in the broader provider operation were not exposed by this generated tool.
+
+## Verification And Approval
+
+The draft `vsdclinicaltrialsstudybynct_27f9c4e92c3f` ran 3 distinct ALS record cases. Each case required the nested title, status, condition, and NCT identifier paths and asserted that the returned identifier exactly matched the requested one.
+
+| NCT ID | Status | Phase | Brief title | Response bytes |
+| --- | --- | --- | --- | ---: |
+| `NCT03019419` | COMPLETED | PHASE2 | Perampanel for Sporadic Amyotrophic Lateral Sclerosis (ALS) | 7724 |
+| `NCT04428775` | TERMINATED | PHASE2 | A Safety and Biomarker Study of ALZT-OP1a in Subjects With Mild-Moderate ALS Disease | 14170 |
+| `NCT04745299` | COMPLETED | PHASE3 | Evaluation the Efficacy and Safety of Mutiple Lenzumestrocel (Neuronata-R® Inj.) Treatment in Patients With ALS | 17119 |
+
+Approval bound the exact source, candidate, operation, draft, verification, and publication hashes. A fresh ToolUniverse instance did not contain the tool until the approved publication was loaded explicitly.
+
+## End-to-End Assertions
+
+| Assertion | Result |
+| --- | --- |
+| `candidate_inert_before_review` | PASS |
+| `candidate_integrity_hash_propagated` | PASS |
+| `exact_nested_identifiers_verified` | PASS |
+| `fresh_runtime_loaded_explicitly` | PASS |
+| `generated_contract_is_read_only` | PASS |
+| `hash_chain_complete` | PASS |
+| `invalid_identifier_rejected_before_transport` | PASS |
+| `official_contract_parsed` | PASS |
+| `provider_responses_schema_validated` | PASS |
+| `published_tool_absent_before_load` | PASS |
+| `three_distinct_cases_verified` | PASS |
+| `zero_redirect_https_provenance` | PASS |
+
+## Interpretation
+
+The practical value is contract conversion with evidence: an administrator can review one operation in a provider's official specification, narrow its inputs, prove it against real records, and distribute a hash-bound tool. The agent receives only that approved operation, not a generic HTTP client or the ability to promote other operations.
+
+**Boundary:** This case demonstrates software-governance and public-registry retrieval. It does not assess eligibility, efficacy, safety, or treatment suitability.
+
+**Audit SHA-256:** `cec78d5359fdf83a262576323925d7ed1b750bafbfd2490dbb18d677fab18170`

--- a/examples/vsd/artifacts/openapi_ingestion_workspace/.gitignore
+++ b/examples/vsd/artifacts/openapi_ingestion_workspace/.gitignore
@@ -1,0 +1,1 @@
+.promotion.lock

--- a/examples/vsd/artifacts/openapi_ingestion_workspace/approvals/vsdclinicaltrialsstudybynct_27f9c4e92c3f.json
+++ b/examples/vsd/artifacts/openapi_ingestion_workspace/approvals/vsdclinicaltrialsstudybynct_27f9c4e92c3f.json
@@ -1,0 +1,13 @@
+{
+  "approval_sha256": "a8a7689c9dceb80d7682dcbf663d7f14bd4db281c597c4d5db8dc52d37958a46",
+  "approved_at": "2026-08-01T18:52:48.166914+00:00",
+  "decision": "approved",
+  "decision_note": "Approved after schema review and three distinct ALS registry records passed exact nested-identifier verification.",
+  "draft_id": "vsdclinicaltrialsstudybynct_27f9c4e92c3f",
+  "draft_sha256": "2d97d81a7723e51789beedc77210be958ea438368c472b3533ca738729f4d3cd",
+  "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+  "reviewed_by": "ToolUniverse VSD case-study reviewer",
+  "tool_name": "VSDClinicalTrialsStudyByNCT",
+  "verification_sha256": "55d799070ea17713f2b0355eff968acf031d69bd04973d5d0bc62c0f8b7a67f0",
+  "version": 1
+}

--- a/examples/vsd/artifacts/openapi_ingestion_workspace/approved/VSDClinicalTrialsStudyByNCT.json
+++ b/examples/vsd/artifacts/openapi_ingestion_workspace/approved/VSDClinicalTrialsStudyByNCT.json
@@ -1,0 +1,4432 @@
+{
+  "approval_sha256": "a8a7689c9dceb80d7682dcbf663d7f14bd4db281c597c4d5db8dc52d37958a46",
+  "config": {
+    "cacheable": false,
+    "category": "special_tools",
+    "description": "Fetch one reviewed ClinicalTrials.gov study record by its validated NCT identifier using the provider's official OpenAPI contract.",
+    "mcp_annotations": {
+      "destructiveHint": false,
+      "readOnlyHint": true
+    },
+    "name": "VSDClinicalTrialsStudyByNCT",
+    "parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "nctId": {
+          "description": "NCT Number of a study. If found in [NCTIdAlias](data-api/about-api/study-data-structure#NCTIdAlias) field, 301 HTTP redirect to the actual study will be returned.",
+          "pattern": "^[Nn][Cc][Tt]0*[1-9]\\d{0,7}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "nctId"
+      ],
+      "type": "object"
+    },
+    "return_schema": {
+      "$defs": {
+        "AdverseEvent": {
+          "properties": {
+            "assessmentType": {
+              "$ref": "#/$defs/EventAssessment"
+            },
+            "notes": {
+              "type": "string"
+            },
+            "organSystem": {
+              "type": "string"
+            },
+            "sourceVocabulary": {
+              "type": "string"
+            },
+            "stats": {
+              "items": {
+                "$ref": "#/$defs/EventStats"
+              },
+              "type": "array"
+            },
+            "term": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "AdverseEventsModule": {
+          "properties": {
+            "allCauseMortalityComment": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "eventGroups": {
+              "items": {
+                "$ref": "#/$defs/EventGroup"
+              },
+              "type": "array"
+            },
+            "frequencyThreshold": {
+              "type": "string"
+            },
+            "otherEvents": {
+              "items": {
+                "$ref": "#/$defs/AdverseEvent"
+              },
+              "type": "array"
+            },
+            "seriousEvents": {
+              "items": {
+                "$ref": "#/$defs/AdverseEvent"
+              },
+              "type": "array"
+            },
+            "timeFrame": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "AgencyClass": {
+          "enum": [
+            "NIH",
+            "FED",
+            "OTHER_GOV",
+            "INDIV",
+            "INDUSTRY",
+            "NETWORK",
+            "AMBIG",
+            "OTHER",
+            "UNKNOWN"
+          ],
+          "type": "string"
+        },
+        "AgreementRestrictionType": {
+          "enum": [
+            "LTE60",
+            "GT60",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "AnalysisDispersionType": {
+          "enum": [
+            "STANDARD_DEVIATION",
+            "STANDARD_ERROR_OF_MEAN"
+          ],
+          "type": "string"
+        },
+        "AnnotationModule": {
+          "properties": {
+            "unpostedAnnotation": {
+              "$ref": "#/$defs/UnpostedAnnotation"
+            },
+            "violationAnnotation": {
+              "$ref": "#/$defs/ViolationAnnotation"
+            }
+          },
+          "type": "object"
+        },
+        "AnnotationSection": {
+          "properties": {
+            "annotationModule": {
+              "$ref": "#/$defs/AnnotationModule"
+            }
+          },
+          "type": "object"
+        },
+        "ArmGroup": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "interventionNames": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "label": {
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/ArmGroupType"
+            }
+          },
+          "type": "object"
+        },
+        "ArmGroupType": {
+          "enum": [
+            "EXPERIMENTAL",
+            "ACTIVE_COMPARATOR",
+            "PLACEBO_COMPARATOR",
+            "SHAM_COMPARATOR",
+            "NO_INTERVENTION",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "ArmsInterventionsModule": {
+          "properties": {
+            "armGroups": {
+              "items": {
+                "$ref": "#/$defs/ArmGroup"
+              },
+              "type": "array"
+            },
+            "interventions": {
+              "items": {
+                "$ref": "#/$defs/Intervention"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "AvailIpd": {
+          "properties": {
+            "comment": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "BaselineCharacteristicsModule": {
+          "properties": {
+            "denoms": {
+              "items": {
+                "$ref": "#/$defs/Denom"
+              },
+              "type": "array"
+            },
+            "groups": {
+              "items": {
+                "$ref": "#/$defs/MeasureGroup"
+              },
+              "type": "array"
+            },
+            "measures": {
+              "items": {
+                "$ref": "#/$defs/BaselineMeasure"
+              },
+              "type": "array"
+            },
+            "populationDescription": {
+              "type": "string"
+            },
+            "typeUnitsAnalyzed": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "BaselineMeasure": {
+          "properties": {
+            "calculatePct": {
+              "type": "boolean"
+            },
+            "classes": {
+              "items": {
+                "$ref": "#/$defs/MeasureClass"
+              },
+              "type": "array"
+            },
+            "denomUnitsSelected": {
+              "type": "string"
+            },
+            "denoms": {
+              "items": {
+                "$ref": "#/$defs/Denom"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": "string"
+            },
+            "dispersionType": {
+              "$ref": "#/$defs/MeasureDispersionType"
+            },
+            "paramType": {
+              "$ref": "#/$defs/MeasureParam"
+            },
+            "populationDescription": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unitOfMeasure": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "BioSpec": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "retention": {
+              "$ref": "#/$defs/BioSpecRetention"
+            }
+          },
+          "type": "object"
+        },
+        "BioSpecRetention": {
+          "enum": [
+            "NONE_RETAINED",
+            "SAMPLES_WITH_DNA",
+            "SAMPLES_WITHOUT_DNA"
+          ],
+          "type": "string"
+        },
+        "BrowseBranch": {
+          "properties": {
+            "abbrev": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "BrowseLeaf": {
+          "properties": {
+            "asFound": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "relevance": {
+              "$ref": "#/$defs/BrowseLeafRelevance"
+            }
+          },
+          "type": "object"
+        },
+        "BrowseLeafRelevance": {
+          "enum": [
+            "LOW",
+            "HIGH"
+          ],
+          "type": "string"
+        },
+        "BrowseModule": {
+          "properties": {
+            "ancestors": {
+              "items": {
+                "$ref": "#/$defs/Mesh"
+              },
+              "type": "array"
+            },
+            "browseBranches": {
+              "items": {
+                "$ref": "#/$defs/BrowseBranch"
+              },
+              "type": "array"
+            },
+            "browseLeaves": {
+              "items": {
+                "$ref": "#/$defs/BrowseLeaf"
+              },
+              "type": "array"
+            },
+            "meshes": {
+              "items": {
+                "$ref": "#/$defs/Mesh"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "CertainAgreement": {
+          "properties": {
+            "otherDetails": {
+              "type": "string"
+            },
+            "piSponsorEmployee": {
+              "type": "boolean"
+            },
+            "restrictionType": {
+              "$ref": "#/$defs/AgreementRestrictionType"
+            },
+            "restrictiveAgreement": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "ConditionsModule": {
+          "properties": {
+            "conditions": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "keywords": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "ConfidenceIntervalNumSides": {
+          "enum": [
+            "ONE_SIDED",
+            "TWO_SIDED"
+          ],
+          "type": "string"
+        },
+        "Contact": {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "phone": {
+              "type": "string"
+            },
+            "phoneExt": {
+              "type": "string"
+            },
+            "role": {
+              "$ref": "#/$defs/ContactRole"
+            }
+          },
+          "type": "object"
+        },
+        "ContactRole": {
+          "enum": [
+            "STUDY_CHAIR",
+            "STUDY_DIRECTOR",
+            "PRINCIPAL_INVESTIGATOR",
+            "SUB_INVESTIGATOR",
+            "CONTACT"
+          ],
+          "type": "string"
+        },
+        "ContactsLocationsModule": {
+          "properties": {
+            "centralContacts": {
+              "items": {
+                "$ref": "#/$defs/Contact"
+              },
+              "type": "array"
+            },
+            "locations": {
+              "items": {
+                "$ref": "#/$defs/Location"
+              },
+              "type": "array"
+            },
+            "overallOfficials": {
+              "items": {
+                "$ref": "#/$defs/Official"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "DateStruct": {
+          "properties": {
+            "date": {
+              "format": "date",
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/DateType"
+            }
+          },
+          "type": "object"
+        },
+        "DateTimeMinutes": {
+          "description": "Date and time in `yyyy-MM-dd'T'HH:mm` format",
+          "type": "string"
+        },
+        "DateType": {
+          "enum": [
+            "ACTUAL",
+            "ESTIMATED"
+          ],
+          "type": "string"
+        },
+        "Denom": {
+          "properties": {
+            "counts": {
+              "items": {
+                "$ref": "#/$defs/DenomCount"
+              },
+              "type": "array"
+            },
+            "units": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "DenomCount": {
+          "properties": {
+            "groupId": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "DerivedSection": {
+          "properties": {
+            "conditionBrowseModule": {
+              "$ref": "#/$defs/BrowseModule"
+            },
+            "interventionBrowseModule": {
+              "$ref": "#/$defs/BrowseModule"
+            },
+            "miscInfoModule": {
+              "$ref": "#/$defs/MiscInfoModule"
+            }
+          },
+          "type": "object"
+        },
+        "DescriptionModule": {
+          "properties": {
+            "briefSummary": {
+              "type": "string"
+            },
+            "detailedDescription": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "DesignAllocation": {
+          "enum": [
+            "RANDOMIZED",
+            "NON_RANDOMIZED",
+            "NA"
+          ],
+          "type": "string"
+        },
+        "DesignInfo": {
+          "properties": {
+            "allocation": {
+              "$ref": "#/$defs/DesignAllocation"
+            },
+            "interventionModel": {
+              "$ref": "#/$defs/InterventionalAssignment"
+            },
+            "interventionModelDescription": {
+              "type": "string"
+            },
+            "maskingInfo": {
+              "$ref": "#/$defs/MaskingBlock"
+            },
+            "observationalModel": {
+              "$ref": "#/$defs/ObservationalModel"
+            },
+            "primaryPurpose": {
+              "$ref": "#/$defs/PrimaryPurpose"
+            },
+            "timePerspective": {
+              "$ref": "#/$defs/DesignTimePerspective"
+            }
+          },
+          "type": "object"
+        },
+        "DesignMasking": {
+          "enum": [
+            "NONE",
+            "SINGLE",
+            "DOUBLE",
+            "TRIPLE",
+            "QUADRUPLE"
+          ],
+          "type": "string"
+        },
+        "DesignModule": {
+          "properties": {
+            "bioSpec": {
+              "$ref": "#/$defs/BioSpec"
+            },
+            "designInfo": {
+              "$ref": "#/$defs/DesignInfo"
+            },
+            "enrollmentInfo": {
+              "$ref": "#/$defs/EnrollmentInfo"
+            },
+            "expandedAccessTypes": {
+              "$ref": "#/$defs/ExpandedAccessTypes"
+            },
+            "nPtrsToThisExpAccNctId": {
+              "type": "integer"
+            },
+            "patientRegistry": {
+              "type": "boolean"
+            },
+            "phases": {
+              "items": {
+                "$ref": "#/$defs/Phase"
+              },
+              "type": "array"
+            },
+            "studyType": {
+              "$ref": "#/$defs/StudyType"
+            },
+            "targetDuration": {
+              "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "DesignTimePerspective": {
+          "enum": [
+            "RETROSPECTIVE",
+            "PROSPECTIVE",
+            "CROSS_SECTIONAL",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "DocumentSection": {
+          "properties": {
+            "largeDocumentModule": {
+              "$ref": "#/$defs/LargeDocumentModule"
+            }
+          },
+          "type": "object"
+        },
+        "DropWithdraw": {
+          "properties": {
+            "comment": {
+              "type": "string"
+            },
+            "reasons": {
+              "items": {
+                "$ref": "#/$defs/FlowStats"
+              },
+              "type": "array"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "EligibilityModule": {
+          "properties": {
+            "eligibilityCriteria": {
+              "type": "string"
+            },
+            "genderBased": {
+              "type": "boolean"
+            },
+            "genderDescription": {
+              "type": "string"
+            },
+            "healthyVolunteers": {
+              "type": "boolean"
+            },
+            "maximumAge": {
+              "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+              "type": "string"
+            },
+            "minimumAge": {
+              "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+              "type": "string"
+            },
+            "samplingMethod": {
+              "$ref": "#/$defs/SamplingMethod"
+            },
+            "sex": {
+              "$ref": "#/$defs/Sex"
+            },
+            "stdAges": {
+              "items": {
+                "$ref": "#/$defs/StandardAge"
+              },
+              "type": "array"
+            },
+            "studyPopulation": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "EnrollmentInfo": {
+          "properties": {
+            "count": {
+              "type": "integer"
+            },
+            "type": {
+              "$ref": "#/$defs/EnrollmentType"
+            }
+          },
+          "type": "object"
+        },
+        "EnrollmentType": {
+          "enum": [
+            "ACTUAL",
+            "ESTIMATED"
+          ],
+          "type": "string"
+        },
+        "EventAssessment": {
+          "enum": [
+            "NON_SYSTEMATIC_ASSESSMENT",
+            "SYSTEMATIC_ASSESSMENT"
+          ],
+          "type": "string"
+        },
+        "EventGroup": {
+          "properties": {
+            "deathsNumAffected": {
+              "type": "integer"
+            },
+            "deathsNumAtRisk": {
+              "type": "integer"
+            },
+            "description": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "otherNumAffected": {
+              "type": "integer"
+            },
+            "otherNumAtRisk": {
+              "type": "integer"
+            },
+            "seriousNumAffected": {
+              "type": "integer"
+            },
+            "seriousNumAtRisk": {
+              "type": "integer"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "EventStats": {
+          "properties": {
+            "groupId": {
+              "type": "string"
+            },
+            "numAffected": {
+              "type": "integer"
+            },
+            "numAtRisk": {
+              "type": "integer"
+            },
+            "numEvents": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "ExpandedAccessInfo": {
+          "properties": {
+            "hasExpandedAccess": {
+              "type": "boolean"
+            },
+            "nctId": {
+              "$ref": "#/$defs/nct"
+            },
+            "statusForNctId": {
+              "$ref": "#/$defs/ExpandedAccessStatus"
+            }
+          },
+          "type": "object"
+        },
+        "ExpandedAccessStatus": {
+          "enum": [
+            "AVAILABLE",
+            "NO_LONGER_AVAILABLE",
+            "TEMPORARILY_NOT_AVAILABLE",
+            "APPROVED_FOR_MARKETING"
+          ],
+          "type": "string"
+        },
+        "ExpandedAccessTypes": {
+          "properties": {
+            "individual": {
+              "type": "boolean"
+            },
+            "intermediate": {
+              "type": "boolean"
+            },
+            "treatment": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "FirstMcpInfo": {
+          "properties": {
+            "postDateStruct": {
+              "$ref": "#/$defs/DateStruct"
+            }
+          },
+          "type": "object"
+        },
+        "FlowGroup": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "FlowMilestone": {
+          "properties": {
+            "achievements": {
+              "items": {
+                "$ref": "#/$defs/FlowStats"
+              },
+              "type": "array"
+            },
+            "comment": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "FlowPeriod": {
+          "properties": {
+            "dropWithdraws": {
+              "items": {
+                "$ref": "#/$defs/DropWithdraw"
+              },
+              "type": "array"
+            },
+            "milestones": {
+              "items": {
+                "$ref": "#/$defs/FlowMilestone"
+              },
+              "type": "array"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "FlowStats": {
+          "properties": {
+            "comment": {
+              "type": "string"
+            },
+            "groupId": {
+              "type": "string"
+            },
+            "numSubjects": {
+              "type": "string"
+            },
+            "numUnits": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "GeoName": {
+          "description": "State/province or city name",
+          "type": "string"
+        },
+        "GeoPoint": {
+          "properties": {
+            "lat": {
+              "type": "number"
+            },
+            "lon": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "lat",
+            "lon"
+          ],
+          "type": "object"
+        },
+        "IdentificationModule": {
+          "properties": {
+            "acronym": {
+              "type": "string"
+            },
+            "briefTitle": {
+              "type": "string"
+            },
+            "nctId": {
+              "$ref": "#/$defs/nct"
+            },
+            "nctIdAliases": {
+              "items": {
+                "$ref": "#/$defs/nct"
+              },
+              "type": "array"
+            },
+            "officialTitle": {
+              "type": "string"
+            },
+            "orgStudyIdInfo": {
+              "$ref": "#/$defs/OrgStudyIdInfo"
+            },
+            "organization": {
+              "$ref": "#/$defs/Organization"
+            },
+            "secondaryIdInfos": {
+              "items": {
+                "$ref": "#/$defs/SecondaryIdInfo"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "Intervention": {
+          "properties": {
+            "armGroupLabels": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "otherNames": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "$ref": "#/$defs/InterventionType"
+            }
+          },
+          "type": "object"
+        },
+        "InterventionType": {
+          "enum": [
+            "BEHAVIORAL",
+            "BIOLOGICAL",
+            "COMBINATION_PRODUCT",
+            "DEVICE",
+            "DIAGNOSTIC_TEST",
+            "DIETARY_SUPPLEMENT",
+            "DRUG",
+            "GENETIC",
+            "PROCEDURE",
+            "RADIATION",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "InterventionalAssignment": {
+          "enum": [
+            "SINGLE_GROUP",
+            "PARALLEL",
+            "CROSSOVER",
+            "FACTORIAL",
+            "SEQUENTIAL"
+          ],
+          "type": "string"
+        },
+        "IpdSharing": {
+          "enum": [
+            "YES",
+            "NO",
+            "UNDECIDED"
+          ],
+          "type": "string"
+        },
+        "IpdSharingInfoType": {
+          "enum": [
+            "STUDY_PROTOCOL",
+            "SAP",
+            "ICF",
+            "CSR",
+            "ANALYTIC_CODE"
+          ],
+          "type": "string"
+        },
+        "IpdSharingStatementModule": {
+          "properties": {
+            "accessCriteria": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "infoTypes": {
+              "items": {
+                "$ref": "#/$defs/IpdSharingInfoType"
+              },
+              "type": "array"
+            },
+            "ipdSharing": {
+              "$ref": "#/$defs/IpdSharing"
+            },
+            "timeFrame": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "LargeDoc": {
+          "properties": {
+            "date": {
+              "format": "date",
+              "type": "string"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hasIcf": {
+              "type": "boolean"
+            },
+            "hasProtocol": {
+              "type": "boolean"
+            },
+            "hasSap": {
+              "type": "boolean"
+            },
+            "label": {
+              "type": "string"
+            },
+            "size": {
+              "type": "integer"
+            },
+            "typeAbbrev": {
+              "type": "string"
+            },
+            "uploadDate": {
+              "$ref": "#/$defs/DateTimeMinutes"
+            }
+          },
+          "type": "object"
+        },
+        "LargeDocumentModule": {
+          "properties": {
+            "largeDocs": {
+              "items": {
+                "$ref": "#/$defs/LargeDoc"
+              },
+              "type": "array"
+            },
+            "noSap": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "LimitationsAndCaveats": {
+          "properties": {
+            "description": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Location": {
+          "properties": {
+            "city": {
+              "$ref": "#/$defs/GeoName"
+            },
+            "contacts": {
+              "items": {
+                "$ref": "#/$defs/Contact"
+              },
+              "type": "array"
+            },
+            "country": {
+              "type": "string"
+            },
+            "facility": {
+              "type": "string"
+            },
+            "geoPoint": {
+              "$ref": "#/$defs/GeoPoint"
+            },
+            "state": {
+              "$ref": "#/$defs/GeoName"
+            },
+            "status": {
+              "$ref": "#/$defs/RecruitmentStatus"
+            },
+            "zip": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MaskingBlock": {
+          "properties": {
+            "masking": {
+              "$ref": "#/$defs/DesignMasking"
+            },
+            "maskingDescription": {
+              "type": "string"
+            },
+            "whoMasked": {
+              "items": {
+                "$ref": "#/$defs/WhoMasked"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "MeasureAnalysis": {
+          "properties": {
+            "ciLowerLimit": {
+              "type": "string"
+            },
+            "ciLowerLimitComment": {
+              "type": "string"
+            },
+            "ciNumSides": {
+              "$ref": "#/$defs/ConfidenceIntervalNumSides"
+            },
+            "ciPctValue": {
+              "type": "string"
+            },
+            "ciUpperLimit": {
+              "type": "string"
+            },
+            "ciUpperLimitComment": {
+              "type": "string"
+            },
+            "dispersionType": {
+              "$ref": "#/$defs/AnalysisDispersionType"
+            },
+            "dispersionValue": {
+              "type": "string"
+            },
+            "estimateComment": {
+              "type": "string"
+            },
+            "groupDescription": {
+              "type": "string"
+            },
+            "groupIds": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "nonInferiorityComment": {
+              "type": "string"
+            },
+            "nonInferiorityType": {
+              "$ref": "#/$defs/NonInferiorityType"
+            },
+            "otherAnalysisDescription": {
+              "type": "string"
+            },
+            "pValue": {
+              "type": "string"
+            },
+            "pValueComment": {
+              "type": "string"
+            },
+            "paramType": {
+              "type": "string"
+            },
+            "paramValue": {
+              "type": "string"
+            },
+            "statisticalComment": {
+              "type": "string"
+            },
+            "statisticalMethod": {
+              "type": "string"
+            },
+            "testedNonInferiority": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "MeasureCategory": {
+          "properties": {
+            "measurements": {
+              "items": {
+                "$ref": "#/$defs/Measurement"
+              },
+              "type": "array"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MeasureClass": {
+          "properties": {
+            "categories": {
+              "items": {
+                "$ref": "#/$defs/MeasureCategory"
+              },
+              "type": "array"
+            },
+            "denoms": {
+              "items": {
+                "$ref": "#/$defs/Denom"
+              },
+              "type": "array"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MeasureDispersionType": {
+          "enum": [
+            "NA",
+            "STANDARD_DEVIATION",
+            "STANDARD_ERROR",
+            "INTER_QUARTILE_RANGE",
+            "FULL_RANGE",
+            "CONFIDENCE_80",
+            "CONFIDENCE_90",
+            "CONFIDENCE_95",
+            "CONFIDENCE_975",
+            "CONFIDENCE_99",
+            "CONFIDENCE_OTHER",
+            "GEOMETRIC_COEFFICIENT"
+          ],
+          "type": "string"
+        },
+        "MeasureGroup": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MeasureParam": {
+          "enum": [
+            "GEOMETRIC_MEAN",
+            "GEOMETRIC_LEAST_SQUARES_MEAN",
+            "LEAST_SQUARES_MEAN",
+            "LOG_MEAN",
+            "MEAN",
+            "MEDIAN",
+            "NUMBER",
+            "COUNT_OF_PARTICIPANTS",
+            "COUNT_OF_UNITS"
+          ],
+          "type": "string"
+        },
+        "Measurement": {
+          "properties": {
+            "comment": {
+              "type": "string"
+            },
+            "groupId": {
+              "type": "string"
+            },
+            "lowerLimit": {
+              "type": "string"
+            },
+            "spread": {
+              "type": "string"
+            },
+            "upperLimit": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Mesh": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "term": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MiscInfoModule": {
+          "properties": {
+            "removedCountries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "submissionTracking": {
+              "$ref": "#/$defs/SubmissionTracking"
+            },
+            "versionHolder": {
+              "format": "date",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MoreInfoModule": {
+          "properties": {
+            "certainAgreement": {
+              "$ref": "#/$defs/CertainAgreement"
+            },
+            "limitationsAndCaveats": {
+              "$ref": "#/$defs/LimitationsAndCaveats"
+            },
+            "pointOfContact": {
+              "$ref": "#/$defs/PointOfContact"
+            }
+          },
+          "type": "object"
+        },
+        "NonInferiorityType": {
+          "enum": [
+            "SUPERIORITY",
+            "NON_INFERIORITY",
+            "EQUIVALENCE",
+            "OTHER",
+            "NON_INFERIORITY_OR_EQUIVALENCE",
+            "SUPERIORITY_OR_OTHER",
+            "NON_INFERIORITY_OR_EQUIVALENCE_LEGACY",
+            "SUPERIORITY_OR_OTHER_LEGACY"
+          ],
+          "type": "string"
+        },
+        "ObservationalModel": {
+          "enum": [
+            "COHORT",
+            "CASE_CONTROL",
+            "CASE_ONLY",
+            "CASE_CROSSOVER",
+            "ECOLOGIC_OR_COMMUNITY",
+            "FAMILY_BASED",
+            "DEFINED_POPULATION",
+            "NATURAL_HISTORY",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "Official": {
+          "properties": {
+            "affiliation": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "role": {
+              "$ref": "#/$defs/OfficialRole"
+            }
+          },
+          "type": "object"
+        },
+        "OfficialRole": {
+          "enum": [
+            "STUDY_CHAIR",
+            "STUDY_DIRECTOR",
+            "PRINCIPAL_INVESTIGATOR",
+            "SUB_INVESTIGATOR"
+          ],
+          "type": "string"
+        },
+        "OrgStudyIdInfo": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "link": {
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/OrgStudyIdType"
+            }
+          },
+          "type": "object"
+        },
+        "OrgStudyIdType": {
+          "enum": [
+            "NIH",
+            "FDA",
+            "VA",
+            "CDC",
+            "AHRQ",
+            "SAMHSA"
+          ],
+          "type": "string"
+        },
+        "Organization": {
+          "properties": {
+            "class": {
+              "$ref": "#/$defs/AgencyClass"
+            },
+            "fullName": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Outcome": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "measure": {
+              "type": "string"
+            },
+            "timeFrame": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "OutcomeMeasure": {
+          "properties": {
+            "analyses": {
+              "items": {
+                "$ref": "#/$defs/MeasureAnalysis"
+              },
+              "type": "array"
+            },
+            "anticipatedPostingDate": {
+              "$ref": "#/$defs/PartialDate"
+            },
+            "calculatePct": {
+              "type": "boolean"
+            },
+            "classes": {
+              "items": {
+                "$ref": "#/$defs/MeasureClass"
+              },
+              "type": "array"
+            },
+            "denomUnitsSelected": {
+              "type": "string"
+            },
+            "denoms": {
+              "items": {
+                "$ref": "#/$defs/Denom"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": "string"
+            },
+            "dispersionType": {
+              "type": "string"
+            },
+            "groups": {
+              "items": {
+                "$ref": "#/$defs/MeasureGroup"
+              },
+              "type": "array"
+            },
+            "paramType": {
+              "$ref": "#/$defs/MeasureParam"
+            },
+            "populationDescription": {
+              "type": "string"
+            },
+            "reportingStatus": {
+              "$ref": "#/$defs/ReportingStatus"
+            },
+            "timeFrame": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/OutcomeMeasureType"
+            },
+            "typeUnitsAnalyzed": {
+              "type": "string"
+            },
+            "unitOfMeasure": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "OutcomeMeasureType": {
+          "enum": [
+            "PRIMARY",
+            "SECONDARY",
+            "OTHER_PRE_SPECIFIED",
+            "POST_HOC"
+          ],
+          "type": "string"
+        },
+        "OutcomeMeasuresModule": {
+          "properties": {
+            "outcomeMeasures": {
+              "items": {
+                "$ref": "#/$defs/OutcomeMeasure"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "OutcomesModule": {
+          "properties": {
+            "otherOutcomes": {
+              "items": {
+                "$ref": "#/$defs/Outcome"
+              },
+              "type": "array"
+            },
+            "primaryOutcomes": {
+              "items": {
+                "$ref": "#/$defs/Outcome"
+              },
+              "type": "array"
+            },
+            "secondaryOutcomes": {
+              "items": {
+                "$ref": "#/$defs/Outcome"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "OversightModule": {
+          "properties": {
+            "fdaaa801Violation": {
+              "type": "boolean"
+            },
+            "isFdaRegulatedDevice": {
+              "type": "boolean"
+            },
+            "isFdaRegulatedDrug": {
+              "type": "boolean"
+            },
+            "isPpsd": {
+              "type": "boolean"
+            },
+            "isUnapprovedDevice": {
+              "type": "boolean"
+            },
+            "isUsExport": {
+              "type": "boolean"
+            },
+            "oversightHasDmc": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "PartialDate": {
+          "description": "Date in `yyyy`, `yyyy-MM`, or `yyyy-MM-dd` format",
+          "type": "string"
+        },
+        "PartialDateStruct": {
+          "properties": {
+            "date": {
+              "$ref": "#/$defs/PartialDate"
+            },
+            "type": {
+              "$ref": "#/$defs/DateType"
+            }
+          },
+          "type": "object"
+        },
+        "ParticipantFlowModule": {
+          "properties": {
+            "groups": {
+              "items": {
+                "$ref": "#/$defs/FlowGroup"
+              },
+              "type": "array"
+            },
+            "periods": {
+              "items": {
+                "$ref": "#/$defs/FlowPeriod"
+              },
+              "type": "array"
+            },
+            "preAssignmentDetails": {
+              "type": "string"
+            },
+            "recruitmentDetails": {
+              "type": "string"
+            },
+            "typeUnitsAnalyzed": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Phase": {
+          "enum": [
+            "NA",
+            "EARLY_PHASE1",
+            "PHASE1",
+            "PHASE2",
+            "PHASE3",
+            "PHASE4"
+          ],
+          "type": "string"
+        },
+        "PointOfContact": {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "organization": {
+              "type": "string"
+            },
+            "phone": {
+              "type": "string"
+            },
+            "phoneExt": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "PrimaryPurpose": {
+          "enum": [
+            "TREATMENT",
+            "PREVENTION",
+            "DIAGNOSTIC",
+            "ECT",
+            "SUPPORTIVE_CARE",
+            "SCREENING",
+            "HEALTH_SERVICES_RESEARCH",
+            "BASIC_SCIENCE",
+            "DEVICE_FEASIBILITY",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "ProtocolSection": {
+          "properties": {
+            "armsInterventionsModule": {
+              "$ref": "#/$defs/ArmsInterventionsModule"
+            },
+            "conditionsModule": {
+              "$ref": "#/$defs/ConditionsModule"
+            },
+            "contactsLocationsModule": {
+              "$ref": "#/$defs/ContactsLocationsModule"
+            },
+            "descriptionModule": {
+              "$ref": "#/$defs/DescriptionModule"
+            },
+            "designModule": {
+              "$ref": "#/$defs/DesignModule"
+            },
+            "eligibilityModule": {
+              "$ref": "#/$defs/EligibilityModule"
+            },
+            "identificationModule": {
+              "$ref": "#/$defs/IdentificationModule"
+            },
+            "ipdSharingStatementModule": {
+              "$ref": "#/$defs/IpdSharingStatementModule"
+            },
+            "outcomesModule": {
+              "$ref": "#/$defs/OutcomesModule"
+            },
+            "oversightModule": {
+              "$ref": "#/$defs/OversightModule"
+            },
+            "referencesModule": {
+              "$ref": "#/$defs/ReferencesModule"
+            },
+            "sponsorCollaboratorsModule": {
+              "$ref": "#/$defs/SponsorCollaboratorsModule"
+            },
+            "statusModule": {
+              "$ref": "#/$defs/StatusModule"
+            }
+          },
+          "type": "object"
+        },
+        "RecruitmentStatus": {
+          "enum": [
+            "ACTIVE_NOT_RECRUITING",
+            "COMPLETED",
+            "ENROLLING_BY_INVITATION",
+            "NOT_YET_RECRUITING",
+            "RECRUITING",
+            "SUSPENDED",
+            "TERMINATED",
+            "WITHDRAWN",
+            "AVAILABLE"
+          ],
+          "type": "string"
+        },
+        "Reference": {
+          "properties": {
+            "citation": {
+              "type": "string"
+            },
+            "pmid": {
+              "type": "string"
+            },
+            "retractions": {
+              "items": {
+                "$ref": "#/$defs/Retraction"
+              },
+              "type": "array"
+            },
+            "type": {
+              "$ref": "#/$defs/ReferenceType"
+            }
+          },
+          "type": "object"
+        },
+        "ReferenceType": {
+          "enum": [
+            "BACKGROUND",
+            "RESULT",
+            "DERIVED"
+          ],
+          "type": "string"
+        },
+        "ReferencesModule": {
+          "properties": {
+            "availIpds": {
+              "items": {
+                "$ref": "#/$defs/AvailIpd"
+              },
+              "type": "array"
+            },
+            "references": {
+              "items": {
+                "$ref": "#/$defs/Reference"
+              },
+              "type": "array"
+            },
+            "seeAlsoLinks": {
+              "items": {
+                "$ref": "#/$defs/SeeAlsoLink"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "ReportingStatus": {
+          "enum": [
+            "NOT_POSTED",
+            "POSTED"
+          ],
+          "type": "string"
+        },
+        "ResponsibleParty": {
+          "properties": {
+            "investigatorAffiliation": {
+              "type": "string"
+            },
+            "investigatorFullName": {
+              "type": "string"
+            },
+            "investigatorTitle": {
+              "type": "string"
+            },
+            "oldNameTitle": {
+              "type": "string"
+            },
+            "oldOrganization": {
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/ResponsiblePartyType"
+            }
+          },
+          "type": "object"
+        },
+        "ResponsiblePartyType": {
+          "enum": [
+            "SPONSOR",
+            "PRINCIPAL_INVESTIGATOR",
+            "SPONSOR_INVESTIGATOR"
+          ],
+          "type": "string"
+        },
+        "ResultsSection": {
+          "properties": {
+            "adverseEventsModule": {
+              "$ref": "#/$defs/AdverseEventsModule"
+            },
+            "baselineCharacteristicsModule": {
+              "$ref": "#/$defs/BaselineCharacteristicsModule"
+            },
+            "moreInfoModule": {
+              "$ref": "#/$defs/MoreInfoModule"
+            },
+            "outcomeMeasuresModule": {
+              "$ref": "#/$defs/OutcomeMeasuresModule"
+            },
+            "participantFlowModule": {
+              "$ref": "#/$defs/ParticipantFlowModule"
+            }
+          },
+          "type": "object"
+        },
+        "Retraction": {
+          "properties": {
+            "pmid": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "SamplingMethod": {
+          "enum": [
+            "PROBABILITY_SAMPLE",
+            "NON_PROBABILITY_SAMPLE"
+          ],
+          "type": "string"
+        },
+        "SecondaryIdInfo": {
+          "properties": {
+            "domain": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "link": {
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/SecondaryIdType"
+            }
+          },
+          "type": "object"
+        },
+        "SecondaryIdType": {
+          "enum": [
+            "NIH",
+            "FDA",
+            "VA",
+            "CDC",
+            "AHRQ",
+            "SAMHSA",
+            "OTHER_GRANT",
+            "EUDRACT_NUMBER",
+            "CTIS",
+            "REGISTRY",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "SeeAlsoLink": {
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Sex": {
+          "enum": [
+            "FEMALE",
+            "MALE",
+            "ALL"
+          ],
+          "type": "string"
+        },
+        "Sponsor": {
+          "properties": {
+            "class": {
+              "$ref": "#/$defs/AgencyClass"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "SponsorCollaboratorsModule": {
+          "properties": {
+            "collaborators": {
+              "items": {
+                "$ref": "#/$defs/Sponsor"
+              },
+              "type": "array"
+            },
+            "leadSponsor": {
+              "$ref": "#/$defs/Sponsor"
+            },
+            "responsibleParty": {
+              "$ref": "#/$defs/ResponsibleParty"
+            }
+          },
+          "type": "object"
+        },
+        "StandardAge": {
+          "enum": [
+            "CHILD",
+            "ADULT",
+            "OLDER_ADULT"
+          ],
+          "type": "string"
+        },
+        "Status": {
+          "enum": [
+            "ACTIVE_NOT_RECRUITING",
+            "COMPLETED",
+            "ENROLLING_BY_INVITATION",
+            "NOT_YET_RECRUITING",
+            "RECRUITING",
+            "SUSPENDED",
+            "TERMINATED",
+            "WITHDRAWN",
+            "AVAILABLE",
+            "NO_LONGER_AVAILABLE",
+            "TEMPORARILY_NOT_AVAILABLE",
+            "APPROVED_FOR_MARKETING",
+            "WITHHELD",
+            "UNKNOWN"
+          ],
+          "type": "string"
+        },
+        "StatusModule": {
+          "properties": {
+            "completionDateStruct": {
+              "$ref": "#/$defs/PartialDateStruct"
+            },
+            "delayedPosting": {
+              "type": "boolean"
+            },
+            "dispFirstPostDateStruct": {
+              "$ref": "#/$defs/DateStruct"
+            },
+            "dispFirstSubmitDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "dispFirstSubmitQcDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "expandedAccessInfo": {
+              "$ref": "#/$defs/ExpandedAccessInfo"
+            },
+            "lastKnownStatus": {
+              "$ref": "#/$defs/Status"
+            },
+            "lastUpdatePostDateStruct": {
+              "$ref": "#/$defs/DateStruct"
+            },
+            "lastUpdateSubmitDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "overallStatus": {
+              "$ref": "#/$defs/Status"
+            },
+            "primaryCompletionDateStruct": {
+              "$ref": "#/$defs/PartialDateStruct"
+            },
+            "resultsFirstPostDateStruct": {
+              "$ref": "#/$defs/DateStruct"
+            },
+            "resultsFirstSubmitDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "resultsFirstSubmitQcDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "resultsWaived": {
+              "type": "boolean"
+            },
+            "startDateStruct": {
+              "$ref": "#/$defs/PartialDateStruct"
+            },
+            "statusVerifiedDate": {
+              "$ref": "#/$defs/PartialDate"
+            },
+            "studyFirstPostDateStruct": {
+              "$ref": "#/$defs/DateStruct"
+            },
+            "studyFirstSubmitDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "studyFirstSubmitQcDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "whyStopped": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Study": {
+          "properties": {
+            "annotationSection": {
+              "$ref": "#/$defs/AnnotationSection"
+            },
+            "derivedSection": {
+              "$ref": "#/$defs/DerivedSection"
+            },
+            "documentSection": {
+              "$ref": "#/$defs/DocumentSection"
+            },
+            "hasResults": {
+              "type": "boolean"
+            },
+            "protocolSection": {
+              "$ref": "#/$defs/ProtocolSection"
+            },
+            "resultsSection": {
+              "$ref": "#/$defs/ResultsSection"
+            }
+          },
+          "type": "object"
+        },
+        "StudyType": {
+          "enum": [
+            "EXPANDED_ACCESS",
+            "INTERVENTIONAL",
+            "OBSERVATIONAL"
+          ],
+          "type": "string"
+        },
+        "SubmissionInfo": {
+          "properties": {
+            "mcpReleaseN": {
+              "type": "integer"
+            },
+            "releaseDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "resetDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "unreleaseDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "unreleaseDateUnknown": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "SubmissionTracking": {
+          "properties": {
+            "estimatedResultsFirstSubmitDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "firstMcpInfo": {
+              "$ref": "#/$defs/FirstMcpInfo"
+            },
+            "submissionInfos": {
+              "items": {
+                "$ref": "#/$defs/SubmissionInfo"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "UnpostedAnnotation": {
+          "properties": {
+            "unpostedEvents": {
+              "items": {
+                "$ref": "#/$defs/UnpostedEvent"
+              },
+              "type": "array"
+            },
+            "unpostedResponsibleParty": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "UnpostedEvent": {
+          "properties": {
+            "date": {
+              "format": "date",
+              "type": "string"
+            },
+            "dateUnknown": {
+              "type": "boolean"
+            },
+            "type": {
+              "$ref": "#/$defs/UnpostedEventType"
+            }
+          },
+          "type": "object"
+        },
+        "UnpostedEventType": {
+          "enum": [
+            "RESET",
+            "RELEASE",
+            "UNRELEASE"
+          ],
+          "type": "string"
+        },
+        "ViolationAnnotation": {
+          "properties": {
+            "violationEvents": {
+              "items": {
+                "$ref": "#/$defs/ViolationEvent"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "ViolationEvent": {
+          "properties": {
+            "creationDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "issuedDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "postedDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "releaseDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/ViolationEventType"
+            }
+          },
+          "type": "object"
+        },
+        "ViolationEventType": {
+          "enum": [
+            "VIOLATION_IDENTIFIED",
+            "CORRECTION_CONFIRMED",
+            "PENALTY_IMPOSED",
+            "ISSUES_IN_LETTER_ADDRESSED_CONFIRMED"
+          ],
+          "type": "string"
+        },
+        "WhoMasked": {
+          "enum": [
+            "PARTICIPANT",
+            "CARE_PROVIDER",
+            "INVESTIGATOR",
+            "OUTCOMES_ASSESSOR"
+          ],
+          "type": "string"
+        },
+        "nct": {
+          "description": "NCT number",
+          "maxLength": 11,
+          "minLength": 11,
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "provenance": {
+          "type": "object"
+        },
+        "result": {
+          "$ref": "#/$defs/Study"
+        }
+      },
+      "required": [
+        "result",
+        "provenance"
+      ],
+      "type": "object"
+    },
+    "type": "VSDDynamicRESTTool",
+    "vsd_operation": {
+      "auth": {
+        "type": "none"
+      },
+      "endpoint": "https://clinicaltrials.gov/api/v2/studies/{nctId}",
+      "fixed_query": {
+        "format": "json"
+      },
+      "method": "GET",
+      "path_arguments": {
+        "nctId": "nctId"
+      },
+      "query_arguments": {},
+      "query_serialization": {},
+      "response_schema": {
+        "$defs": {
+          "AdverseEvent": {
+            "properties": {
+              "assessmentType": {
+                "$ref": "#/$defs/EventAssessment"
+              },
+              "notes": {
+                "type": "string"
+              },
+              "organSystem": {
+                "type": "string"
+              },
+              "sourceVocabulary": {
+                "type": "string"
+              },
+              "stats": {
+                "items": {
+                  "$ref": "#/$defs/EventStats"
+                },
+                "type": "array"
+              },
+              "term": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "AdverseEventsModule": {
+            "properties": {
+              "allCauseMortalityComment": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "eventGroups": {
+                "items": {
+                  "$ref": "#/$defs/EventGroup"
+                },
+                "type": "array"
+              },
+              "frequencyThreshold": {
+                "type": "string"
+              },
+              "otherEvents": {
+                "items": {
+                  "$ref": "#/$defs/AdverseEvent"
+                },
+                "type": "array"
+              },
+              "seriousEvents": {
+                "items": {
+                  "$ref": "#/$defs/AdverseEvent"
+                },
+                "type": "array"
+              },
+              "timeFrame": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "AgencyClass": {
+            "enum": [
+              "NIH",
+              "FED",
+              "OTHER_GOV",
+              "INDIV",
+              "INDUSTRY",
+              "NETWORK",
+              "AMBIG",
+              "OTHER",
+              "UNKNOWN"
+            ],
+            "type": "string"
+          },
+          "AgreementRestrictionType": {
+            "enum": [
+              "LTE60",
+              "GT60",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "AnalysisDispersionType": {
+            "enum": [
+              "STANDARD_DEVIATION",
+              "STANDARD_ERROR_OF_MEAN"
+            ],
+            "type": "string"
+          },
+          "AnnotationModule": {
+            "properties": {
+              "unpostedAnnotation": {
+                "$ref": "#/$defs/UnpostedAnnotation"
+              },
+              "violationAnnotation": {
+                "$ref": "#/$defs/ViolationAnnotation"
+              }
+            },
+            "type": "object"
+          },
+          "AnnotationSection": {
+            "properties": {
+              "annotationModule": {
+                "$ref": "#/$defs/AnnotationModule"
+              }
+            },
+            "type": "object"
+          },
+          "ArmGroup": {
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "interventionNames": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "label": {
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/ArmGroupType"
+              }
+            },
+            "type": "object"
+          },
+          "ArmGroupType": {
+            "enum": [
+              "EXPERIMENTAL",
+              "ACTIVE_COMPARATOR",
+              "PLACEBO_COMPARATOR",
+              "SHAM_COMPARATOR",
+              "NO_INTERVENTION",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "ArmsInterventionsModule": {
+            "properties": {
+              "armGroups": {
+                "items": {
+                  "$ref": "#/$defs/ArmGroup"
+                },
+                "type": "array"
+              },
+              "interventions": {
+                "items": {
+                  "$ref": "#/$defs/Intervention"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "AvailIpd": {
+            "properties": {
+              "comment": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "BaselineCharacteristicsModule": {
+            "properties": {
+              "denoms": {
+                "items": {
+                  "$ref": "#/$defs/Denom"
+                },
+                "type": "array"
+              },
+              "groups": {
+                "items": {
+                  "$ref": "#/$defs/MeasureGroup"
+                },
+                "type": "array"
+              },
+              "measures": {
+                "items": {
+                  "$ref": "#/$defs/BaselineMeasure"
+                },
+                "type": "array"
+              },
+              "populationDescription": {
+                "type": "string"
+              },
+              "typeUnitsAnalyzed": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "BaselineMeasure": {
+            "properties": {
+              "calculatePct": {
+                "type": "boolean"
+              },
+              "classes": {
+                "items": {
+                  "$ref": "#/$defs/MeasureClass"
+                },
+                "type": "array"
+              },
+              "denomUnitsSelected": {
+                "type": "string"
+              },
+              "denoms": {
+                "items": {
+                  "$ref": "#/$defs/Denom"
+                },
+                "type": "array"
+              },
+              "description": {
+                "type": "string"
+              },
+              "dispersionType": {
+                "$ref": "#/$defs/MeasureDispersionType"
+              },
+              "paramType": {
+                "$ref": "#/$defs/MeasureParam"
+              },
+              "populationDescription": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "unitOfMeasure": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "BioSpec": {
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "retention": {
+                "$ref": "#/$defs/BioSpecRetention"
+              }
+            },
+            "type": "object"
+          },
+          "BioSpecRetention": {
+            "enum": [
+              "NONE_RETAINED",
+              "SAMPLES_WITH_DNA",
+              "SAMPLES_WITHOUT_DNA"
+            ],
+            "type": "string"
+          },
+          "BrowseBranch": {
+            "properties": {
+              "abbrev": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "BrowseLeaf": {
+            "properties": {
+              "asFound": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "relevance": {
+                "$ref": "#/$defs/BrowseLeafRelevance"
+              }
+            },
+            "type": "object"
+          },
+          "BrowseLeafRelevance": {
+            "enum": [
+              "LOW",
+              "HIGH"
+            ],
+            "type": "string"
+          },
+          "BrowseModule": {
+            "properties": {
+              "ancestors": {
+                "items": {
+                  "$ref": "#/$defs/Mesh"
+                },
+                "type": "array"
+              },
+              "browseBranches": {
+                "items": {
+                  "$ref": "#/$defs/BrowseBranch"
+                },
+                "type": "array"
+              },
+              "browseLeaves": {
+                "items": {
+                  "$ref": "#/$defs/BrowseLeaf"
+                },
+                "type": "array"
+              },
+              "meshes": {
+                "items": {
+                  "$ref": "#/$defs/Mesh"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "CertainAgreement": {
+            "properties": {
+              "otherDetails": {
+                "type": "string"
+              },
+              "piSponsorEmployee": {
+                "type": "boolean"
+              },
+              "restrictionType": {
+                "$ref": "#/$defs/AgreementRestrictionType"
+              },
+              "restrictiveAgreement": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "ConditionsModule": {
+            "properties": {
+              "conditions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "keywords": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "ConfidenceIntervalNumSides": {
+            "enum": [
+              "ONE_SIDED",
+              "TWO_SIDED"
+            ],
+            "type": "string"
+          },
+          "Contact": {
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "phoneExt": {
+                "type": "string"
+              },
+              "role": {
+                "$ref": "#/$defs/ContactRole"
+              }
+            },
+            "type": "object"
+          },
+          "ContactRole": {
+            "enum": [
+              "STUDY_CHAIR",
+              "STUDY_DIRECTOR",
+              "PRINCIPAL_INVESTIGATOR",
+              "SUB_INVESTIGATOR",
+              "CONTACT"
+            ],
+            "type": "string"
+          },
+          "ContactsLocationsModule": {
+            "properties": {
+              "centralContacts": {
+                "items": {
+                  "$ref": "#/$defs/Contact"
+                },
+                "type": "array"
+              },
+              "locations": {
+                "items": {
+                  "$ref": "#/$defs/Location"
+                },
+                "type": "array"
+              },
+              "overallOfficials": {
+                "items": {
+                  "$ref": "#/$defs/Official"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "DateStruct": {
+            "properties": {
+              "date": {
+                "format": "date",
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/DateType"
+              }
+            },
+            "type": "object"
+          },
+          "DateTimeMinutes": {
+            "description": "Date and time in `yyyy-MM-dd'T'HH:mm` format",
+            "type": "string"
+          },
+          "DateType": {
+            "enum": [
+              "ACTUAL",
+              "ESTIMATED"
+            ],
+            "type": "string"
+          },
+          "Denom": {
+            "properties": {
+              "counts": {
+                "items": {
+                  "$ref": "#/$defs/DenomCount"
+                },
+                "type": "array"
+              },
+              "units": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "DenomCount": {
+            "properties": {
+              "groupId": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "DerivedSection": {
+            "properties": {
+              "conditionBrowseModule": {
+                "$ref": "#/$defs/BrowseModule"
+              },
+              "interventionBrowseModule": {
+                "$ref": "#/$defs/BrowseModule"
+              },
+              "miscInfoModule": {
+                "$ref": "#/$defs/MiscInfoModule"
+              }
+            },
+            "type": "object"
+          },
+          "DescriptionModule": {
+            "properties": {
+              "briefSummary": {
+                "type": "string"
+              },
+              "detailedDescription": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "DesignAllocation": {
+            "enum": [
+              "RANDOMIZED",
+              "NON_RANDOMIZED",
+              "NA"
+            ],
+            "type": "string"
+          },
+          "DesignInfo": {
+            "properties": {
+              "allocation": {
+                "$ref": "#/$defs/DesignAllocation"
+              },
+              "interventionModel": {
+                "$ref": "#/$defs/InterventionalAssignment"
+              },
+              "interventionModelDescription": {
+                "type": "string"
+              },
+              "maskingInfo": {
+                "$ref": "#/$defs/MaskingBlock"
+              },
+              "observationalModel": {
+                "$ref": "#/$defs/ObservationalModel"
+              },
+              "primaryPurpose": {
+                "$ref": "#/$defs/PrimaryPurpose"
+              },
+              "timePerspective": {
+                "$ref": "#/$defs/DesignTimePerspective"
+              }
+            },
+            "type": "object"
+          },
+          "DesignMasking": {
+            "enum": [
+              "NONE",
+              "SINGLE",
+              "DOUBLE",
+              "TRIPLE",
+              "QUADRUPLE"
+            ],
+            "type": "string"
+          },
+          "DesignModule": {
+            "properties": {
+              "bioSpec": {
+                "$ref": "#/$defs/BioSpec"
+              },
+              "designInfo": {
+                "$ref": "#/$defs/DesignInfo"
+              },
+              "enrollmentInfo": {
+                "$ref": "#/$defs/EnrollmentInfo"
+              },
+              "expandedAccessTypes": {
+                "$ref": "#/$defs/ExpandedAccessTypes"
+              },
+              "nPtrsToThisExpAccNctId": {
+                "type": "integer"
+              },
+              "patientRegistry": {
+                "type": "boolean"
+              },
+              "phases": {
+                "items": {
+                  "$ref": "#/$defs/Phase"
+                },
+                "type": "array"
+              },
+              "studyType": {
+                "$ref": "#/$defs/StudyType"
+              },
+              "targetDuration": {
+                "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "DesignTimePerspective": {
+            "enum": [
+              "RETROSPECTIVE",
+              "PROSPECTIVE",
+              "CROSS_SECTIONAL",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "DocumentSection": {
+            "properties": {
+              "largeDocumentModule": {
+                "$ref": "#/$defs/LargeDocumentModule"
+              }
+            },
+            "type": "object"
+          },
+          "DropWithdraw": {
+            "properties": {
+              "comment": {
+                "type": "string"
+              },
+              "reasons": {
+                "items": {
+                  "$ref": "#/$defs/FlowStats"
+                },
+                "type": "array"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "EligibilityModule": {
+            "properties": {
+              "eligibilityCriteria": {
+                "type": "string"
+              },
+              "genderBased": {
+                "type": "boolean"
+              },
+              "genderDescription": {
+                "type": "string"
+              },
+              "healthyVolunteers": {
+                "type": "boolean"
+              },
+              "maximumAge": {
+                "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+                "type": "string"
+              },
+              "minimumAge": {
+                "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+                "type": "string"
+              },
+              "samplingMethod": {
+                "$ref": "#/$defs/SamplingMethod"
+              },
+              "sex": {
+                "$ref": "#/$defs/Sex"
+              },
+              "stdAges": {
+                "items": {
+                  "$ref": "#/$defs/StandardAge"
+                },
+                "type": "array"
+              },
+              "studyPopulation": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "EnrollmentInfo": {
+            "properties": {
+              "count": {
+                "type": "integer"
+              },
+              "type": {
+                "$ref": "#/$defs/EnrollmentType"
+              }
+            },
+            "type": "object"
+          },
+          "EnrollmentType": {
+            "enum": [
+              "ACTUAL",
+              "ESTIMATED"
+            ],
+            "type": "string"
+          },
+          "EventAssessment": {
+            "enum": [
+              "NON_SYSTEMATIC_ASSESSMENT",
+              "SYSTEMATIC_ASSESSMENT"
+            ],
+            "type": "string"
+          },
+          "EventGroup": {
+            "properties": {
+              "deathsNumAffected": {
+                "type": "integer"
+              },
+              "deathsNumAtRisk": {
+                "type": "integer"
+              },
+              "description": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "otherNumAffected": {
+                "type": "integer"
+              },
+              "otherNumAtRisk": {
+                "type": "integer"
+              },
+              "seriousNumAffected": {
+                "type": "integer"
+              },
+              "seriousNumAtRisk": {
+                "type": "integer"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "EventStats": {
+            "properties": {
+              "groupId": {
+                "type": "string"
+              },
+              "numAffected": {
+                "type": "integer"
+              },
+              "numAtRisk": {
+                "type": "integer"
+              },
+              "numEvents": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "ExpandedAccessInfo": {
+            "properties": {
+              "hasExpandedAccess": {
+                "type": "boolean"
+              },
+              "nctId": {
+                "$ref": "#/$defs/nct"
+              },
+              "statusForNctId": {
+                "$ref": "#/$defs/ExpandedAccessStatus"
+              }
+            },
+            "type": "object"
+          },
+          "ExpandedAccessStatus": {
+            "enum": [
+              "AVAILABLE",
+              "NO_LONGER_AVAILABLE",
+              "TEMPORARILY_NOT_AVAILABLE",
+              "APPROVED_FOR_MARKETING"
+            ],
+            "type": "string"
+          },
+          "ExpandedAccessTypes": {
+            "properties": {
+              "individual": {
+                "type": "boolean"
+              },
+              "intermediate": {
+                "type": "boolean"
+              },
+              "treatment": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "FirstMcpInfo": {
+            "properties": {
+              "postDateStruct": {
+                "$ref": "#/$defs/DateStruct"
+              }
+            },
+            "type": "object"
+          },
+          "FlowGroup": {
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "FlowMilestone": {
+            "properties": {
+              "achievements": {
+                "items": {
+                  "$ref": "#/$defs/FlowStats"
+                },
+                "type": "array"
+              },
+              "comment": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "FlowPeriod": {
+            "properties": {
+              "dropWithdraws": {
+                "items": {
+                  "$ref": "#/$defs/DropWithdraw"
+                },
+                "type": "array"
+              },
+              "milestones": {
+                "items": {
+                  "$ref": "#/$defs/FlowMilestone"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "FlowStats": {
+            "properties": {
+              "comment": {
+                "type": "string"
+              },
+              "groupId": {
+                "type": "string"
+              },
+              "numSubjects": {
+                "type": "string"
+              },
+              "numUnits": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "GeoName": {
+            "description": "State/province or city name",
+            "type": "string"
+          },
+          "GeoPoint": {
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "lon": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "lat",
+              "lon"
+            ],
+            "type": "object"
+          },
+          "IdentificationModule": {
+            "properties": {
+              "acronym": {
+                "type": "string"
+              },
+              "briefTitle": {
+                "type": "string"
+              },
+              "nctId": {
+                "$ref": "#/$defs/nct"
+              },
+              "nctIdAliases": {
+                "items": {
+                  "$ref": "#/$defs/nct"
+                },
+                "type": "array"
+              },
+              "officialTitle": {
+                "type": "string"
+              },
+              "orgStudyIdInfo": {
+                "$ref": "#/$defs/OrgStudyIdInfo"
+              },
+              "organization": {
+                "$ref": "#/$defs/Organization"
+              },
+              "secondaryIdInfos": {
+                "items": {
+                  "$ref": "#/$defs/SecondaryIdInfo"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "Intervention": {
+            "properties": {
+              "armGroupLabels": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "otherNames": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": {
+                "$ref": "#/$defs/InterventionType"
+              }
+            },
+            "type": "object"
+          },
+          "InterventionType": {
+            "enum": [
+              "BEHAVIORAL",
+              "BIOLOGICAL",
+              "COMBINATION_PRODUCT",
+              "DEVICE",
+              "DIAGNOSTIC_TEST",
+              "DIETARY_SUPPLEMENT",
+              "DRUG",
+              "GENETIC",
+              "PROCEDURE",
+              "RADIATION",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "InterventionalAssignment": {
+            "enum": [
+              "SINGLE_GROUP",
+              "PARALLEL",
+              "CROSSOVER",
+              "FACTORIAL",
+              "SEQUENTIAL"
+            ],
+            "type": "string"
+          },
+          "IpdSharing": {
+            "enum": [
+              "YES",
+              "NO",
+              "UNDECIDED"
+            ],
+            "type": "string"
+          },
+          "IpdSharingInfoType": {
+            "enum": [
+              "STUDY_PROTOCOL",
+              "SAP",
+              "ICF",
+              "CSR",
+              "ANALYTIC_CODE"
+            ],
+            "type": "string"
+          },
+          "IpdSharingStatementModule": {
+            "properties": {
+              "accessCriteria": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "infoTypes": {
+                "items": {
+                  "$ref": "#/$defs/IpdSharingInfoType"
+                },
+                "type": "array"
+              },
+              "ipdSharing": {
+                "$ref": "#/$defs/IpdSharing"
+              },
+              "timeFrame": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "LargeDoc": {
+            "properties": {
+              "date": {
+                "format": "date",
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              },
+              "hasIcf": {
+                "type": "boolean"
+              },
+              "hasProtocol": {
+                "type": "boolean"
+              },
+              "hasSap": {
+                "type": "boolean"
+              },
+              "label": {
+                "type": "string"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "typeAbbrev": {
+                "type": "string"
+              },
+              "uploadDate": {
+                "$ref": "#/$defs/DateTimeMinutes"
+              }
+            },
+            "type": "object"
+          },
+          "LargeDocumentModule": {
+            "properties": {
+              "largeDocs": {
+                "items": {
+                  "$ref": "#/$defs/LargeDoc"
+                },
+                "type": "array"
+              },
+              "noSap": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "LimitationsAndCaveats": {
+            "properties": {
+              "description": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Location": {
+            "properties": {
+              "city": {
+                "$ref": "#/$defs/GeoName"
+              },
+              "contacts": {
+                "items": {
+                  "$ref": "#/$defs/Contact"
+                },
+                "type": "array"
+              },
+              "country": {
+                "type": "string"
+              },
+              "facility": {
+                "type": "string"
+              },
+              "geoPoint": {
+                "$ref": "#/$defs/GeoPoint"
+              },
+              "state": {
+                "$ref": "#/$defs/GeoName"
+              },
+              "status": {
+                "$ref": "#/$defs/RecruitmentStatus"
+              },
+              "zip": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MaskingBlock": {
+            "properties": {
+              "masking": {
+                "$ref": "#/$defs/DesignMasking"
+              },
+              "maskingDescription": {
+                "type": "string"
+              },
+              "whoMasked": {
+                "items": {
+                  "$ref": "#/$defs/WhoMasked"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "MeasureAnalysis": {
+            "properties": {
+              "ciLowerLimit": {
+                "type": "string"
+              },
+              "ciLowerLimitComment": {
+                "type": "string"
+              },
+              "ciNumSides": {
+                "$ref": "#/$defs/ConfidenceIntervalNumSides"
+              },
+              "ciPctValue": {
+                "type": "string"
+              },
+              "ciUpperLimit": {
+                "type": "string"
+              },
+              "ciUpperLimitComment": {
+                "type": "string"
+              },
+              "dispersionType": {
+                "$ref": "#/$defs/AnalysisDispersionType"
+              },
+              "dispersionValue": {
+                "type": "string"
+              },
+              "estimateComment": {
+                "type": "string"
+              },
+              "groupDescription": {
+                "type": "string"
+              },
+              "groupIds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "nonInferiorityComment": {
+                "type": "string"
+              },
+              "nonInferiorityType": {
+                "$ref": "#/$defs/NonInferiorityType"
+              },
+              "otherAnalysisDescription": {
+                "type": "string"
+              },
+              "pValue": {
+                "type": "string"
+              },
+              "pValueComment": {
+                "type": "string"
+              },
+              "paramType": {
+                "type": "string"
+              },
+              "paramValue": {
+                "type": "string"
+              },
+              "statisticalComment": {
+                "type": "string"
+              },
+              "statisticalMethod": {
+                "type": "string"
+              },
+              "testedNonInferiority": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "MeasureCategory": {
+            "properties": {
+              "measurements": {
+                "items": {
+                  "$ref": "#/$defs/Measurement"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MeasureClass": {
+            "properties": {
+              "categories": {
+                "items": {
+                  "$ref": "#/$defs/MeasureCategory"
+                },
+                "type": "array"
+              },
+              "denoms": {
+                "items": {
+                  "$ref": "#/$defs/Denom"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MeasureDispersionType": {
+            "enum": [
+              "NA",
+              "STANDARD_DEVIATION",
+              "STANDARD_ERROR",
+              "INTER_QUARTILE_RANGE",
+              "FULL_RANGE",
+              "CONFIDENCE_80",
+              "CONFIDENCE_90",
+              "CONFIDENCE_95",
+              "CONFIDENCE_975",
+              "CONFIDENCE_99",
+              "CONFIDENCE_OTHER",
+              "GEOMETRIC_COEFFICIENT"
+            ],
+            "type": "string"
+          },
+          "MeasureGroup": {
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MeasureParam": {
+            "enum": [
+              "GEOMETRIC_MEAN",
+              "GEOMETRIC_LEAST_SQUARES_MEAN",
+              "LEAST_SQUARES_MEAN",
+              "LOG_MEAN",
+              "MEAN",
+              "MEDIAN",
+              "NUMBER",
+              "COUNT_OF_PARTICIPANTS",
+              "COUNT_OF_UNITS"
+            ],
+            "type": "string"
+          },
+          "Measurement": {
+            "properties": {
+              "comment": {
+                "type": "string"
+              },
+              "groupId": {
+                "type": "string"
+              },
+              "lowerLimit": {
+                "type": "string"
+              },
+              "spread": {
+                "type": "string"
+              },
+              "upperLimit": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Mesh": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "term": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MiscInfoModule": {
+            "properties": {
+              "removedCountries": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "submissionTracking": {
+                "$ref": "#/$defs/SubmissionTracking"
+              },
+              "versionHolder": {
+                "format": "date",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MoreInfoModule": {
+            "properties": {
+              "certainAgreement": {
+                "$ref": "#/$defs/CertainAgreement"
+              },
+              "limitationsAndCaveats": {
+                "$ref": "#/$defs/LimitationsAndCaveats"
+              },
+              "pointOfContact": {
+                "$ref": "#/$defs/PointOfContact"
+              }
+            },
+            "type": "object"
+          },
+          "NonInferiorityType": {
+            "enum": [
+              "SUPERIORITY",
+              "NON_INFERIORITY",
+              "EQUIVALENCE",
+              "OTHER",
+              "NON_INFERIORITY_OR_EQUIVALENCE",
+              "SUPERIORITY_OR_OTHER",
+              "NON_INFERIORITY_OR_EQUIVALENCE_LEGACY",
+              "SUPERIORITY_OR_OTHER_LEGACY"
+            ],
+            "type": "string"
+          },
+          "ObservationalModel": {
+            "enum": [
+              "COHORT",
+              "CASE_CONTROL",
+              "CASE_ONLY",
+              "CASE_CROSSOVER",
+              "ECOLOGIC_OR_COMMUNITY",
+              "FAMILY_BASED",
+              "DEFINED_POPULATION",
+              "NATURAL_HISTORY",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "Official": {
+            "properties": {
+              "affiliation": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "role": {
+                "$ref": "#/$defs/OfficialRole"
+              }
+            },
+            "type": "object"
+          },
+          "OfficialRole": {
+            "enum": [
+              "STUDY_CHAIR",
+              "STUDY_DIRECTOR",
+              "PRINCIPAL_INVESTIGATOR",
+              "SUB_INVESTIGATOR"
+            ],
+            "type": "string"
+          },
+          "OrgStudyIdInfo": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "link": {
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/OrgStudyIdType"
+              }
+            },
+            "type": "object"
+          },
+          "OrgStudyIdType": {
+            "enum": [
+              "NIH",
+              "FDA",
+              "VA",
+              "CDC",
+              "AHRQ",
+              "SAMHSA"
+            ],
+            "type": "string"
+          },
+          "Organization": {
+            "properties": {
+              "class": {
+                "$ref": "#/$defs/AgencyClass"
+              },
+              "fullName": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Outcome": {
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "measure": {
+                "type": "string"
+              },
+              "timeFrame": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "OutcomeMeasure": {
+            "properties": {
+              "analyses": {
+                "items": {
+                  "$ref": "#/$defs/MeasureAnalysis"
+                },
+                "type": "array"
+              },
+              "anticipatedPostingDate": {
+                "$ref": "#/$defs/PartialDate"
+              },
+              "calculatePct": {
+                "type": "boolean"
+              },
+              "classes": {
+                "items": {
+                  "$ref": "#/$defs/MeasureClass"
+                },
+                "type": "array"
+              },
+              "denomUnitsSelected": {
+                "type": "string"
+              },
+              "denoms": {
+                "items": {
+                  "$ref": "#/$defs/Denom"
+                },
+                "type": "array"
+              },
+              "description": {
+                "type": "string"
+              },
+              "dispersionType": {
+                "type": "string"
+              },
+              "groups": {
+                "items": {
+                  "$ref": "#/$defs/MeasureGroup"
+                },
+                "type": "array"
+              },
+              "paramType": {
+                "$ref": "#/$defs/MeasureParam"
+              },
+              "populationDescription": {
+                "type": "string"
+              },
+              "reportingStatus": {
+                "$ref": "#/$defs/ReportingStatus"
+              },
+              "timeFrame": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/OutcomeMeasureType"
+              },
+              "typeUnitsAnalyzed": {
+                "type": "string"
+              },
+              "unitOfMeasure": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "OutcomeMeasureType": {
+            "enum": [
+              "PRIMARY",
+              "SECONDARY",
+              "OTHER_PRE_SPECIFIED",
+              "POST_HOC"
+            ],
+            "type": "string"
+          },
+          "OutcomeMeasuresModule": {
+            "properties": {
+              "outcomeMeasures": {
+                "items": {
+                  "$ref": "#/$defs/OutcomeMeasure"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "OutcomesModule": {
+            "properties": {
+              "otherOutcomes": {
+                "items": {
+                  "$ref": "#/$defs/Outcome"
+                },
+                "type": "array"
+              },
+              "primaryOutcomes": {
+                "items": {
+                  "$ref": "#/$defs/Outcome"
+                },
+                "type": "array"
+              },
+              "secondaryOutcomes": {
+                "items": {
+                  "$ref": "#/$defs/Outcome"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "OversightModule": {
+            "properties": {
+              "fdaaa801Violation": {
+                "type": "boolean"
+              },
+              "isFdaRegulatedDevice": {
+                "type": "boolean"
+              },
+              "isFdaRegulatedDrug": {
+                "type": "boolean"
+              },
+              "isPpsd": {
+                "type": "boolean"
+              },
+              "isUnapprovedDevice": {
+                "type": "boolean"
+              },
+              "isUsExport": {
+                "type": "boolean"
+              },
+              "oversightHasDmc": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "PartialDate": {
+            "description": "Date in `yyyy`, `yyyy-MM`, or `yyyy-MM-dd` format",
+            "type": "string"
+          },
+          "PartialDateStruct": {
+            "properties": {
+              "date": {
+                "$ref": "#/$defs/PartialDate"
+              },
+              "type": {
+                "$ref": "#/$defs/DateType"
+              }
+            },
+            "type": "object"
+          },
+          "ParticipantFlowModule": {
+            "properties": {
+              "groups": {
+                "items": {
+                  "$ref": "#/$defs/FlowGroup"
+                },
+                "type": "array"
+              },
+              "periods": {
+                "items": {
+                  "$ref": "#/$defs/FlowPeriod"
+                },
+                "type": "array"
+              },
+              "preAssignmentDetails": {
+                "type": "string"
+              },
+              "recruitmentDetails": {
+                "type": "string"
+              },
+              "typeUnitsAnalyzed": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Phase": {
+            "enum": [
+              "NA",
+              "EARLY_PHASE1",
+              "PHASE1",
+              "PHASE2",
+              "PHASE3",
+              "PHASE4"
+            ],
+            "type": "string"
+          },
+          "PointOfContact": {
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "organization": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "phoneExt": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "PrimaryPurpose": {
+            "enum": [
+              "TREATMENT",
+              "PREVENTION",
+              "DIAGNOSTIC",
+              "ECT",
+              "SUPPORTIVE_CARE",
+              "SCREENING",
+              "HEALTH_SERVICES_RESEARCH",
+              "BASIC_SCIENCE",
+              "DEVICE_FEASIBILITY",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "ProtocolSection": {
+            "properties": {
+              "armsInterventionsModule": {
+                "$ref": "#/$defs/ArmsInterventionsModule"
+              },
+              "conditionsModule": {
+                "$ref": "#/$defs/ConditionsModule"
+              },
+              "contactsLocationsModule": {
+                "$ref": "#/$defs/ContactsLocationsModule"
+              },
+              "descriptionModule": {
+                "$ref": "#/$defs/DescriptionModule"
+              },
+              "designModule": {
+                "$ref": "#/$defs/DesignModule"
+              },
+              "eligibilityModule": {
+                "$ref": "#/$defs/EligibilityModule"
+              },
+              "identificationModule": {
+                "$ref": "#/$defs/IdentificationModule"
+              },
+              "ipdSharingStatementModule": {
+                "$ref": "#/$defs/IpdSharingStatementModule"
+              },
+              "outcomesModule": {
+                "$ref": "#/$defs/OutcomesModule"
+              },
+              "oversightModule": {
+                "$ref": "#/$defs/OversightModule"
+              },
+              "referencesModule": {
+                "$ref": "#/$defs/ReferencesModule"
+              },
+              "sponsorCollaboratorsModule": {
+                "$ref": "#/$defs/SponsorCollaboratorsModule"
+              },
+              "statusModule": {
+                "$ref": "#/$defs/StatusModule"
+              }
+            },
+            "type": "object"
+          },
+          "RecruitmentStatus": {
+            "enum": [
+              "ACTIVE_NOT_RECRUITING",
+              "COMPLETED",
+              "ENROLLING_BY_INVITATION",
+              "NOT_YET_RECRUITING",
+              "RECRUITING",
+              "SUSPENDED",
+              "TERMINATED",
+              "WITHDRAWN",
+              "AVAILABLE"
+            ],
+            "type": "string"
+          },
+          "Reference": {
+            "properties": {
+              "citation": {
+                "type": "string"
+              },
+              "pmid": {
+                "type": "string"
+              },
+              "retractions": {
+                "items": {
+                  "$ref": "#/$defs/Retraction"
+                },
+                "type": "array"
+              },
+              "type": {
+                "$ref": "#/$defs/ReferenceType"
+              }
+            },
+            "type": "object"
+          },
+          "ReferenceType": {
+            "enum": [
+              "BACKGROUND",
+              "RESULT",
+              "DERIVED"
+            ],
+            "type": "string"
+          },
+          "ReferencesModule": {
+            "properties": {
+              "availIpds": {
+                "items": {
+                  "$ref": "#/$defs/AvailIpd"
+                },
+                "type": "array"
+              },
+              "references": {
+                "items": {
+                  "$ref": "#/$defs/Reference"
+                },
+                "type": "array"
+              },
+              "seeAlsoLinks": {
+                "items": {
+                  "$ref": "#/$defs/SeeAlsoLink"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "ReportingStatus": {
+            "enum": [
+              "NOT_POSTED",
+              "POSTED"
+            ],
+            "type": "string"
+          },
+          "ResponsibleParty": {
+            "properties": {
+              "investigatorAffiliation": {
+                "type": "string"
+              },
+              "investigatorFullName": {
+                "type": "string"
+              },
+              "investigatorTitle": {
+                "type": "string"
+              },
+              "oldNameTitle": {
+                "type": "string"
+              },
+              "oldOrganization": {
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/ResponsiblePartyType"
+              }
+            },
+            "type": "object"
+          },
+          "ResponsiblePartyType": {
+            "enum": [
+              "SPONSOR",
+              "PRINCIPAL_INVESTIGATOR",
+              "SPONSOR_INVESTIGATOR"
+            ],
+            "type": "string"
+          },
+          "ResultsSection": {
+            "properties": {
+              "adverseEventsModule": {
+                "$ref": "#/$defs/AdverseEventsModule"
+              },
+              "baselineCharacteristicsModule": {
+                "$ref": "#/$defs/BaselineCharacteristicsModule"
+              },
+              "moreInfoModule": {
+                "$ref": "#/$defs/MoreInfoModule"
+              },
+              "outcomeMeasuresModule": {
+                "$ref": "#/$defs/OutcomeMeasuresModule"
+              },
+              "participantFlowModule": {
+                "$ref": "#/$defs/ParticipantFlowModule"
+              }
+            },
+            "type": "object"
+          },
+          "Retraction": {
+            "properties": {
+              "pmid": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "SamplingMethod": {
+            "enum": [
+              "PROBABILITY_SAMPLE",
+              "NON_PROBABILITY_SAMPLE"
+            ],
+            "type": "string"
+          },
+          "SecondaryIdInfo": {
+            "properties": {
+              "domain": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "link": {
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/SecondaryIdType"
+              }
+            },
+            "type": "object"
+          },
+          "SecondaryIdType": {
+            "enum": [
+              "NIH",
+              "FDA",
+              "VA",
+              "CDC",
+              "AHRQ",
+              "SAMHSA",
+              "OTHER_GRANT",
+              "EUDRACT_NUMBER",
+              "CTIS",
+              "REGISTRY",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "SeeAlsoLink": {
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Sex": {
+            "enum": [
+              "FEMALE",
+              "MALE",
+              "ALL"
+            ],
+            "type": "string"
+          },
+          "Sponsor": {
+            "properties": {
+              "class": {
+                "$ref": "#/$defs/AgencyClass"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "SponsorCollaboratorsModule": {
+            "properties": {
+              "collaborators": {
+                "items": {
+                  "$ref": "#/$defs/Sponsor"
+                },
+                "type": "array"
+              },
+              "leadSponsor": {
+                "$ref": "#/$defs/Sponsor"
+              },
+              "responsibleParty": {
+                "$ref": "#/$defs/ResponsibleParty"
+              }
+            },
+            "type": "object"
+          },
+          "StandardAge": {
+            "enum": [
+              "CHILD",
+              "ADULT",
+              "OLDER_ADULT"
+            ],
+            "type": "string"
+          },
+          "Status": {
+            "enum": [
+              "ACTIVE_NOT_RECRUITING",
+              "COMPLETED",
+              "ENROLLING_BY_INVITATION",
+              "NOT_YET_RECRUITING",
+              "RECRUITING",
+              "SUSPENDED",
+              "TERMINATED",
+              "WITHDRAWN",
+              "AVAILABLE",
+              "NO_LONGER_AVAILABLE",
+              "TEMPORARILY_NOT_AVAILABLE",
+              "APPROVED_FOR_MARKETING",
+              "WITHHELD",
+              "UNKNOWN"
+            ],
+            "type": "string"
+          },
+          "StatusModule": {
+            "properties": {
+              "completionDateStruct": {
+                "$ref": "#/$defs/PartialDateStruct"
+              },
+              "delayedPosting": {
+                "type": "boolean"
+              },
+              "dispFirstPostDateStruct": {
+                "$ref": "#/$defs/DateStruct"
+              },
+              "dispFirstSubmitDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "dispFirstSubmitQcDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "expandedAccessInfo": {
+                "$ref": "#/$defs/ExpandedAccessInfo"
+              },
+              "lastKnownStatus": {
+                "$ref": "#/$defs/Status"
+              },
+              "lastUpdatePostDateStruct": {
+                "$ref": "#/$defs/DateStruct"
+              },
+              "lastUpdateSubmitDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "overallStatus": {
+                "$ref": "#/$defs/Status"
+              },
+              "primaryCompletionDateStruct": {
+                "$ref": "#/$defs/PartialDateStruct"
+              },
+              "resultsFirstPostDateStruct": {
+                "$ref": "#/$defs/DateStruct"
+              },
+              "resultsFirstSubmitDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "resultsFirstSubmitQcDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "resultsWaived": {
+                "type": "boolean"
+              },
+              "startDateStruct": {
+                "$ref": "#/$defs/PartialDateStruct"
+              },
+              "statusVerifiedDate": {
+                "$ref": "#/$defs/PartialDate"
+              },
+              "studyFirstPostDateStruct": {
+                "$ref": "#/$defs/DateStruct"
+              },
+              "studyFirstSubmitDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "studyFirstSubmitQcDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "whyStopped": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Study": {
+            "properties": {
+              "annotationSection": {
+                "$ref": "#/$defs/AnnotationSection"
+              },
+              "derivedSection": {
+                "$ref": "#/$defs/DerivedSection"
+              },
+              "documentSection": {
+                "$ref": "#/$defs/DocumentSection"
+              },
+              "hasResults": {
+                "type": "boolean"
+              },
+              "protocolSection": {
+                "$ref": "#/$defs/ProtocolSection"
+              },
+              "resultsSection": {
+                "$ref": "#/$defs/ResultsSection"
+              }
+            },
+            "type": "object"
+          },
+          "StudyType": {
+            "enum": [
+              "EXPANDED_ACCESS",
+              "INTERVENTIONAL",
+              "OBSERVATIONAL"
+            ],
+            "type": "string"
+          },
+          "SubmissionInfo": {
+            "properties": {
+              "mcpReleaseN": {
+                "type": "integer"
+              },
+              "releaseDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "resetDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "unreleaseDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "unreleaseDateUnknown": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "SubmissionTracking": {
+            "properties": {
+              "estimatedResultsFirstSubmitDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "firstMcpInfo": {
+                "$ref": "#/$defs/FirstMcpInfo"
+              },
+              "submissionInfos": {
+                "items": {
+                  "$ref": "#/$defs/SubmissionInfo"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "UnpostedAnnotation": {
+            "properties": {
+              "unpostedEvents": {
+                "items": {
+                  "$ref": "#/$defs/UnpostedEvent"
+                },
+                "type": "array"
+              },
+              "unpostedResponsibleParty": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "UnpostedEvent": {
+            "properties": {
+              "date": {
+                "format": "date",
+                "type": "string"
+              },
+              "dateUnknown": {
+                "type": "boolean"
+              },
+              "type": {
+                "$ref": "#/$defs/UnpostedEventType"
+              }
+            },
+            "type": "object"
+          },
+          "UnpostedEventType": {
+            "enum": [
+              "RESET",
+              "RELEASE",
+              "UNRELEASE"
+            ],
+            "type": "string"
+          },
+          "ViolationAnnotation": {
+            "properties": {
+              "violationEvents": {
+                "items": {
+                  "$ref": "#/$defs/ViolationEvent"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "ViolationEvent": {
+            "properties": {
+              "creationDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "issuedDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "postedDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "releaseDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/ViolationEventType"
+              }
+            },
+            "type": "object"
+          },
+          "ViolationEventType": {
+            "enum": [
+              "VIOLATION_IDENTIFIED",
+              "CORRECTION_CONFIRMED",
+              "PENALTY_IMPOSED",
+              "ISSUES_IN_LETTER_ADDRESSED_CONFIRMED"
+            ],
+            "type": "string"
+          },
+          "WhoMasked": {
+            "enum": [
+              "PARTICIPANT",
+              "CARE_PROVIDER",
+              "INVESTIGATOR",
+              "OUTCOMES_ASSESSOR"
+            ],
+            "type": "string"
+          },
+          "nct": {
+            "description": "NCT number",
+            "maxLength": 11,
+            "minLength": 11,
+            "type": "string"
+          }
+        },
+        "$ref": "#/$defs/Study"
+      },
+      "timeout_seconds": 30,
+      "version": 1
+    },
+    "vsd_promotion": {
+      "api_title": "ClinicalTrials.gov REST API",
+      "api_version": "2.0.5",
+      "candidate_id": "47a4c7402dfb7b86",
+      "candidate_sha256": "47a4c7402dfb7b8699690b6ba5146eb2755472d21b0cc330e5fc620b097da99f",
+      "fixed_query": {
+        "format": "json"
+      },
+      "generator_version": 1,
+      "included_parameters": [
+        "nctId"
+      ],
+      "method": "GET",
+      "openapi_version": "3.0.3",
+      "operation_id": "fetchStudy",
+      "path": "/studies/{nctId}",
+      "response_media_type": "application/json",
+      "source_document_sha256": "ba31adaea67e6bb09ff77af5c0c11daf36d5aff7f5d6cbed89f0aab04b297aea",
+      "source_type": "openapi"
+    }
+  },
+  "decision_note": "Approved after schema review and three distinct ALS registry records passed exact nested-identifier verification.",
+  "draft_id": "vsdclinicaltrialsstudybynct_27f9c4e92c3f",
+  "draft_sha256": "2d97d81a7723e51789beedc77210be958ea438368c472b3533ca738729f4d3cd",
+  "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+  "publication_sha256": "38541a6ba926f5fe3937ff0a60fffce88293afb3e711bdad9267b62c5914080a",
+  "published_at": "2026-08-01T18:52:48.353591+00:00",
+  "reviewed_by": "ToolUniverse VSD case-study reviewer",
+  "tool_name": "VSDClinicalTrialsStudyByNCT",
+  "verification_sha256": "55d799070ea17713f2b0355eff968acf031d69bd04973d5d0bc62c0f8b7a67f0",
+  "version": 1
+}

--- a/examples/vsd/artifacts/openapi_ingestion_workspace/drafts/vsdclinicaltrialsstudybynct_27f9c4e92c3f.json
+++ b/examples/vsd/artifacts/openapi_ingestion_workspace/drafts/vsdclinicaltrialsstudybynct_27f9c4e92c3f.json
@@ -1,0 +1,4427 @@
+{
+  "config": {
+    "cacheable": false,
+    "category": "special_tools",
+    "description": "Fetch one reviewed ClinicalTrials.gov study record by its validated NCT identifier using the provider's official OpenAPI contract.",
+    "mcp_annotations": {
+      "destructiveHint": false,
+      "readOnlyHint": true
+    },
+    "name": "VSDClinicalTrialsStudyByNCT",
+    "parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "nctId": {
+          "description": "NCT Number of a study. If found in [NCTIdAlias](data-api/about-api/study-data-structure#NCTIdAlias) field, 301 HTTP redirect to the actual study will be returned.",
+          "pattern": "^[Nn][Cc][Tt]0*[1-9]\\d{0,7}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "nctId"
+      ],
+      "type": "object"
+    },
+    "return_schema": {
+      "$defs": {
+        "AdverseEvent": {
+          "properties": {
+            "assessmentType": {
+              "$ref": "#/$defs/EventAssessment"
+            },
+            "notes": {
+              "type": "string"
+            },
+            "organSystem": {
+              "type": "string"
+            },
+            "sourceVocabulary": {
+              "type": "string"
+            },
+            "stats": {
+              "items": {
+                "$ref": "#/$defs/EventStats"
+              },
+              "type": "array"
+            },
+            "term": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "AdverseEventsModule": {
+          "properties": {
+            "allCauseMortalityComment": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "eventGroups": {
+              "items": {
+                "$ref": "#/$defs/EventGroup"
+              },
+              "type": "array"
+            },
+            "frequencyThreshold": {
+              "type": "string"
+            },
+            "otherEvents": {
+              "items": {
+                "$ref": "#/$defs/AdverseEvent"
+              },
+              "type": "array"
+            },
+            "seriousEvents": {
+              "items": {
+                "$ref": "#/$defs/AdverseEvent"
+              },
+              "type": "array"
+            },
+            "timeFrame": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "AgencyClass": {
+          "enum": [
+            "NIH",
+            "FED",
+            "OTHER_GOV",
+            "INDIV",
+            "INDUSTRY",
+            "NETWORK",
+            "AMBIG",
+            "OTHER",
+            "UNKNOWN"
+          ],
+          "type": "string"
+        },
+        "AgreementRestrictionType": {
+          "enum": [
+            "LTE60",
+            "GT60",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "AnalysisDispersionType": {
+          "enum": [
+            "STANDARD_DEVIATION",
+            "STANDARD_ERROR_OF_MEAN"
+          ],
+          "type": "string"
+        },
+        "AnnotationModule": {
+          "properties": {
+            "unpostedAnnotation": {
+              "$ref": "#/$defs/UnpostedAnnotation"
+            },
+            "violationAnnotation": {
+              "$ref": "#/$defs/ViolationAnnotation"
+            }
+          },
+          "type": "object"
+        },
+        "AnnotationSection": {
+          "properties": {
+            "annotationModule": {
+              "$ref": "#/$defs/AnnotationModule"
+            }
+          },
+          "type": "object"
+        },
+        "ArmGroup": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "interventionNames": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "label": {
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/ArmGroupType"
+            }
+          },
+          "type": "object"
+        },
+        "ArmGroupType": {
+          "enum": [
+            "EXPERIMENTAL",
+            "ACTIVE_COMPARATOR",
+            "PLACEBO_COMPARATOR",
+            "SHAM_COMPARATOR",
+            "NO_INTERVENTION",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "ArmsInterventionsModule": {
+          "properties": {
+            "armGroups": {
+              "items": {
+                "$ref": "#/$defs/ArmGroup"
+              },
+              "type": "array"
+            },
+            "interventions": {
+              "items": {
+                "$ref": "#/$defs/Intervention"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "AvailIpd": {
+          "properties": {
+            "comment": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "BaselineCharacteristicsModule": {
+          "properties": {
+            "denoms": {
+              "items": {
+                "$ref": "#/$defs/Denom"
+              },
+              "type": "array"
+            },
+            "groups": {
+              "items": {
+                "$ref": "#/$defs/MeasureGroup"
+              },
+              "type": "array"
+            },
+            "measures": {
+              "items": {
+                "$ref": "#/$defs/BaselineMeasure"
+              },
+              "type": "array"
+            },
+            "populationDescription": {
+              "type": "string"
+            },
+            "typeUnitsAnalyzed": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "BaselineMeasure": {
+          "properties": {
+            "calculatePct": {
+              "type": "boolean"
+            },
+            "classes": {
+              "items": {
+                "$ref": "#/$defs/MeasureClass"
+              },
+              "type": "array"
+            },
+            "denomUnitsSelected": {
+              "type": "string"
+            },
+            "denoms": {
+              "items": {
+                "$ref": "#/$defs/Denom"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": "string"
+            },
+            "dispersionType": {
+              "$ref": "#/$defs/MeasureDispersionType"
+            },
+            "paramType": {
+              "$ref": "#/$defs/MeasureParam"
+            },
+            "populationDescription": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "unitOfMeasure": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "BioSpec": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "retention": {
+              "$ref": "#/$defs/BioSpecRetention"
+            }
+          },
+          "type": "object"
+        },
+        "BioSpecRetention": {
+          "enum": [
+            "NONE_RETAINED",
+            "SAMPLES_WITH_DNA",
+            "SAMPLES_WITHOUT_DNA"
+          ],
+          "type": "string"
+        },
+        "BrowseBranch": {
+          "properties": {
+            "abbrev": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "BrowseLeaf": {
+          "properties": {
+            "asFound": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "relevance": {
+              "$ref": "#/$defs/BrowseLeafRelevance"
+            }
+          },
+          "type": "object"
+        },
+        "BrowseLeafRelevance": {
+          "enum": [
+            "LOW",
+            "HIGH"
+          ],
+          "type": "string"
+        },
+        "BrowseModule": {
+          "properties": {
+            "ancestors": {
+              "items": {
+                "$ref": "#/$defs/Mesh"
+              },
+              "type": "array"
+            },
+            "browseBranches": {
+              "items": {
+                "$ref": "#/$defs/BrowseBranch"
+              },
+              "type": "array"
+            },
+            "browseLeaves": {
+              "items": {
+                "$ref": "#/$defs/BrowseLeaf"
+              },
+              "type": "array"
+            },
+            "meshes": {
+              "items": {
+                "$ref": "#/$defs/Mesh"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "CertainAgreement": {
+          "properties": {
+            "otherDetails": {
+              "type": "string"
+            },
+            "piSponsorEmployee": {
+              "type": "boolean"
+            },
+            "restrictionType": {
+              "$ref": "#/$defs/AgreementRestrictionType"
+            },
+            "restrictiveAgreement": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "ConditionsModule": {
+          "properties": {
+            "conditions": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "keywords": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "ConfidenceIntervalNumSides": {
+          "enum": [
+            "ONE_SIDED",
+            "TWO_SIDED"
+          ],
+          "type": "string"
+        },
+        "Contact": {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "phone": {
+              "type": "string"
+            },
+            "phoneExt": {
+              "type": "string"
+            },
+            "role": {
+              "$ref": "#/$defs/ContactRole"
+            }
+          },
+          "type": "object"
+        },
+        "ContactRole": {
+          "enum": [
+            "STUDY_CHAIR",
+            "STUDY_DIRECTOR",
+            "PRINCIPAL_INVESTIGATOR",
+            "SUB_INVESTIGATOR",
+            "CONTACT"
+          ],
+          "type": "string"
+        },
+        "ContactsLocationsModule": {
+          "properties": {
+            "centralContacts": {
+              "items": {
+                "$ref": "#/$defs/Contact"
+              },
+              "type": "array"
+            },
+            "locations": {
+              "items": {
+                "$ref": "#/$defs/Location"
+              },
+              "type": "array"
+            },
+            "overallOfficials": {
+              "items": {
+                "$ref": "#/$defs/Official"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "DateStruct": {
+          "properties": {
+            "date": {
+              "format": "date",
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/DateType"
+            }
+          },
+          "type": "object"
+        },
+        "DateTimeMinutes": {
+          "description": "Date and time in `yyyy-MM-dd'T'HH:mm` format",
+          "type": "string"
+        },
+        "DateType": {
+          "enum": [
+            "ACTUAL",
+            "ESTIMATED"
+          ],
+          "type": "string"
+        },
+        "Denom": {
+          "properties": {
+            "counts": {
+              "items": {
+                "$ref": "#/$defs/DenomCount"
+              },
+              "type": "array"
+            },
+            "units": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "DenomCount": {
+          "properties": {
+            "groupId": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "DerivedSection": {
+          "properties": {
+            "conditionBrowseModule": {
+              "$ref": "#/$defs/BrowseModule"
+            },
+            "interventionBrowseModule": {
+              "$ref": "#/$defs/BrowseModule"
+            },
+            "miscInfoModule": {
+              "$ref": "#/$defs/MiscInfoModule"
+            }
+          },
+          "type": "object"
+        },
+        "DescriptionModule": {
+          "properties": {
+            "briefSummary": {
+              "type": "string"
+            },
+            "detailedDescription": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "DesignAllocation": {
+          "enum": [
+            "RANDOMIZED",
+            "NON_RANDOMIZED",
+            "NA"
+          ],
+          "type": "string"
+        },
+        "DesignInfo": {
+          "properties": {
+            "allocation": {
+              "$ref": "#/$defs/DesignAllocation"
+            },
+            "interventionModel": {
+              "$ref": "#/$defs/InterventionalAssignment"
+            },
+            "interventionModelDescription": {
+              "type": "string"
+            },
+            "maskingInfo": {
+              "$ref": "#/$defs/MaskingBlock"
+            },
+            "observationalModel": {
+              "$ref": "#/$defs/ObservationalModel"
+            },
+            "primaryPurpose": {
+              "$ref": "#/$defs/PrimaryPurpose"
+            },
+            "timePerspective": {
+              "$ref": "#/$defs/DesignTimePerspective"
+            }
+          },
+          "type": "object"
+        },
+        "DesignMasking": {
+          "enum": [
+            "NONE",
+            "SINGLE",
+            "DOUBLE",
+            "TRIPLE",
+            "QUADRUPLE"
+          ],
+          "type": "string"
+        },
+        "DesignModule": {
+          "properties": {
+            "bioSpec": {
+              "$ref": "#/$defs/BioSpec"
+            },
+            "designInfo": {
+              "$ref": "#/$defs/DesignInfo"
+            },
+            "enrollmentInfo": {
+              "$ref": "#/$defs/EnrollmentInfo"
+            },
+            "expandedAccessTypes": {
+              "$ref": "#/$defs/ExpandedAccessTypes"
+            },
+            "nPtrsToThisExpAccNctId": {
+              "type": "integer"
+            },
+            "patientRegistry": {
+              "type": "boolean"
+            },
+            "phases": {
+              "items": {
+                "$ref": "#/$defs/Phase"
+              },
+              "type": "array"
+            },
+            "studyType": {
+              "$ref": "#/$defs/StudyType"
+            },
+            "targetDuration": {
+              "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "DesignTimePerspective": {
+          "enum": [
+            "RETROSPECTIVE",
+            "PROSPECTIVE",
+            "CROSS_SECTIONAL",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "DocumentSection": {
+          "properties": {
+            "largeDocumentModule": {
+              "$ref": "#/$defs/LargeDocumentModule"
+            }
+          },
+          "type": "object"
+        },
+        "DropWithdraw": {
+          "properties": {
+            "comment": {
+              "type": "string"
+            },
+            "reasons": {
+              "items": {
+                "$ref": "#/$defs/FlowStats"
+              },
+              "type": "array"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "EligibilityModule": {
+          "properties": {
+            "eligibilityCriteria": {
+              "type": "string"
+            },
+            "genderBased": {
+              "type": "boolean"
+            },
+            "genderDescription": {
+              "type": "string"
+            },
+            "healthyVolunteers": {
+              "type": "boolean"
+            },
+            "maximumAge": {
+              "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+              "type": "string"
+            },
+            "minimumAge": {
+              "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+              "type": "string"
+            },
+            "samplingMethod": {
+              "$ref": "#/$defs/SamplingMethod"
+            },
+            "sex": {
+              "$ref": "#/$defs/Sex"
+            },
+            "stdAges": {
+              "items": {
+                "$ref": "#/$defs/StandardAge"
+              },
+              "type": "array"
+            },
+            "studyPopulation": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "EnrollmentInfo": {
+          "properties": {
+            "count": {
+              "type": "integer"
+            },
+            "type": {
+              "$ref": "#/$defs/EnrollmentType"
+            }
+          },
+          "type": "object"
+        },
+        "EnrollmentType": {
+          "enum": [
+            "ACTUAL",
+            "ESTIMATED"
+          ],
+          "type": "string"
+        },
+        "EventAssessment": {
+          "enum": [
+            "NON_SYSTEMATIC_ASSESSMENT",
+            "SYSTEMATIC_ASSESSMENT"
+          ],
+          "type": "string"
+        },
+        "EventGroup": {
+          "properties": {
+            "deathsNumAffected": {
+              "type": "integer"
+            },
+            "deathsNumAtRisk": {
+              "type": "integer"
+            },
+            "description": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "otherNumAffected": {
+              "type": "integer"
+            },
+            "otherNumAtRisk": {
+              "type": "integer"
+            },
+            "seriousNumAffected": {
+              "type": "integer"
+            },
+            "seriousNumAtRisk": {
+              "type": "integer"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "EventStats": {
+          "properties": {
+            "groupId": {
+              "type": "string"
+            },
+            "numAffected": {
+              "type": "integer"
+            },
+            "numAtRisk": {
+              "type": "integer"
+            },
+            "numEvents": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "ExpandedAccessInfo": {
+          "properties": {
+            "hasExpandedAccess": {
+              "type": "boolean"
+            },
+            "nctId": {
+              "$ref": "#/$defs/nct"
+            },
+            "statusForNctId": {
+              "$ref": "#/$defs/ExpandedAccessStatus"
+            }
+          },
+          "type": "object"
+        },
+        "ExpandedAccessStatus": {
+          "enum": [
+            "AVAILABLE",
+            "NO_LONGER_AVAILABLE",
+            "TEMPORARILY_NOT_AVAILABLE",
+            "APPROVED_FOR_MARKETING"
+          ],
+          "type": "string"
+        },
+        "ExpandedAccessTypes": {
+          "properties": {
+            "individual": {
+              "type": "boolean"
+            },
+            "intermediate": {
+              "type": "boolean"
+            },
+            "treatment": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "FirstMcpInfo": {
+          "properties": {
+            "postDateStruct": {
+              "$ref": "#/$defs/DateStruct"
+            }
+          },
+          "type": "object"
+        },
+        "FlowGroup": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "FlowMilestone": {
+          "properties": {
+            "achievements": {
+              "items": {
+                "$ref": "#/$defs/FlowStats"
+              },
+              "type": "array"
+            },
+            "comment": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "FlowPeriod": {
+          "properties": {
+            "dropWithdraws": {
+              "items": {
+                "$ref": "#/$defs/DropWithdraw"
+              },
+              "type": "array"
+            },
+            "milestones": {
+              "items": {
+                "$ref": "#/$defs/FlowMilestone"
+              },
+              "type": "array"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "FlowStats": {
+          "properties": {
+            "comment": {
+              "type": "string"
+            },
+            "groupId": {
+              "type": "string"
+            },
+            "numSubjects": {
+              "type": "string"
+            },
+            "numUnits": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "GeoName": {
+          "description": "State/province or city name",
+          "type": "string"
+        },
+        "GeoPoint": {
+          "properties": {
+            "lat": {
+              "type": "number"
+            },
+            "lon": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "lat",
+            "lon"
+          ],
+          "type": "object"
+        },
+        "IdentificationModule": {
+          "properties": {
+            "acronym": {
+              "type": "string"
+            },
+            "briefTitle": {
+              "type": "string"
+            },
+            "nctId": {
+              "$ref": "#/$defs/nct"
+            },
+            "nctIdAliases": {
+              "items": {
+                "$ref": "#/$defs/nct"
+              },
+              "type": "array"
+            },
+            "officialTitle": {
+              "type": "string"
+            },
+            "orgStudyIdInfo": {
+              "$ref": "#/$defs/OrgStudyIdInfo"
+            },
+            "organization": {
+              "$ref": "#/$defs/Organization"
+            },
+            "secondaryIdInfos": {
+              "items": {
+                "$ref": "#/$defs/SecondaryIdInfo"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "Intervention": {
+          "properties": {
+            "armGroupLabels": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "otherNames": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "$ref": "#/$defs/InterventionType"
+            }
+          },
+          "type": "object"
+        },
+        "InterventionType": {
+          "enum": [
+            "BEHAVIORAL",
+            "BIOLOGICAL",
+            "COMBINATION_PRODUCT",
+            "DEVICE",
+            "DIAGNOSTIC_TEST",
+            "DIETARY_SUPPLEMENT",
+            "DRUG",
+            "GENETIC",
+            "PROCEDURE",
+            "RADIATION",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "InterventionalAssignment": {
+          "enum": [
+            "SINGLE_GROUP",
+            "PARALLEL",
+            "CROSSOVER",
+            "FACTORIAL",
+            "SEQUENTIAL"
+          ],
+          "type": "string"
+        },
+        "IpdSharing": {
+          "enum": [
+            "YES",
+            "NO",
+            "UNDECIDED"
+          ],
+          "type": "string"
+        },
+        "IpdSharingInfoType": {
+          "enum": [
+            "STUDY_PROTOCOL",
+            "SAP",
+            "ICF",
+            "CSR",
+            "ANALYTIC_CODE"
+          ],
+          "type": "string"
+        },
+        "IpdSharingStatementModule": {
+          "properties": {
+            "accessCriteria": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "infoTypes": {
+              "items": {
+                "$ref": "#/$defs/IpdSharingInfoType"
+              },
+              "type": "array"
+            },
+            "ipdSharing": {
+              "$ref": "#/$defs/IpdSharing"
+            },
+            "timeFrame": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "LargeDoc": {
+          "properties": {
+            "date": {
+              "format": "date",
+              "type": "string"
+            },
+            "filename": {
+              "type": "string"
+            },
+            "hasIcf": {
+              "type": "boolean"
+            },
+            "hasProtocol": {
+              "type": "boolean"
+            },
+            "hasSap": {
+              "type": "boolean"
+            },
+            "label": {
+              "type": "string"
+            },
+            "size": {
+              "type": "integer"
+            },
+            "typeAbbrev": {
+              "type": "string"
+            },
+            "uploadDate": {
+              "$ref": "#/$defs/DateTimeMinutes"
+            }
+          },
+          "type": "object"
+        },
+        "LargeDocumentModule": {
+          "properties": {
+            "largeDocs": {
+              "items": {
+                "$ref": "#/$defs/LargeDoc"
+              },
+              "type": "array"
+            },
+            "noSap": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "LimitationsAndCaveats": {
+          "properties": {
+            "description": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Location": {
+          "properties": {
+            "city": {
+              "$ref": "#/$defs/GeoName"
+            },
+            "contacts": {
+              "items": {
+                "$ref": "#/$defs/Contact"
+              },
+              "type": "array"
+            },
+            "country": {
+              "type": "string"
+            },
+            "facility": {
+              "type": "string"
+            },
+            "geoPoint": {
+              "$ref": "#/$defs/GeoPoint"
+            },
+            "state": {
+              "$ref": "#/$defs/GeoName"
+            },
+            "status": {
+              "$ref": "#/$defs/RecruitmentStatus"
+            },
+            "zip": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MaskingBlock": {
+          "properties": {
+            "masking": {
+              "$ref": "#/$defs/DesignMasking"
+            },
+            "maskingDescription": {
+              "type": "string"
+            },
+            "whoMasked": {
+              "items": {
+                "$ref": "#/$defs/WhoMasked"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "MeasureAnalysis": {
+          "properties": {
+            "ciLowerLimit": {
+              "type": "string"
+            },
+            "ciLowerLimitComment": {
+              "type": "string"
+            },
+            "ciNumSides": {
+              "$ref": "#/$defs/ConfidenceIntervalNumSides"
+            },
+            "ciPctValue": {
+              "type": "string"
+            },
+            "ciUpperLimit": {
+              "type": "string"
+            },
+            "ciUpperLimitComment": {
+              "type": "string"
+            },
+            "dispersionType": {
+              "$ref": "#/$defs/AnalysisDispersionType"
+            },
+            "dispersionValue": {
+              "type": "string"
+            },
+            "estimateComment": {
+              "type": "string"
+            },
+            "groupDescription": {
+              "type": "string"
+            },
+            "groupIds": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "nonInferiorityComment": {
+              "type": "string"
+            },
+            "nonInferiorityType": {
+              "$ref": "#/$defs/NonInferiorityType"
+            },
+            "otherAnalysisDescription": {
+              "type": "string"
+            },
+            "pValue": {
+              "type": "string"
+            },
+            "pValueComment": {
+              "type": "string"
+            },
+            "paramType": {
+              "type": "string"
+            },
+            "paramValue": {
+              "type": "string"
+            },
+            "statisticalComment": {
+              "type": "string"
+            },
+            "statisticalMethod": {
+              "type": "string"
+            },
+            "testedNonInferiority": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "MeasureCategory": {
+          "properties": {
+            "measurements": {
+              "items": {
+                "$ref": "#/$defs/Measurement"
+              },
+              "type": "array"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MeasureClass": {
+          "properties": {
+            "categories": {
+              "items": {
+                "$ref": "#/$defs/MeasureCategory"
+              },
+              "type": "array"
+            },
+            "denoms": {
+              "items": {
+                "$ref": "#/$defs/Denom"
+              },
+              "type": "array"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MeasureDispersionType": {
+          "enum": [
+            "NA",
+            "STANDARD_DEVIATION",
+            "STANDARD_ERROR",
+            "INTER_QUARTILE_RANGE",
+            "FULL_RANGE",
+            "CONFIDENCE_80",
+            "CONFIDENCE_90",
+            "CONFIDENCE_95",
+            "CONFIDENCE_975",
+            "CONFIDENCE_99",
+            "CONFIDENCE_OTHER",
+            "GEOMETRIC_COEFFICIENT"
+          ],
+          "type": "string"
+        },
+        "MeasureGroup": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MeasureParam": {
+          "enum": [
+            "GEOMETRIC_MEAN",
+            "GEOMETRIC_LEAST_SQUARES_MEAN",
+            "LEAST_SQUARES_MEAN",
+            "LOG_MEAN",
+            "MEAN",
+            "MEDIAN",
+            "NUMBER",
+            "COUNT_OF_PARTICIPANTS",
+            "COUNT_OF_UNITS"
+          ],
+          "type": "string"
+        },
+        "Measurement": {
+          "properties": {
+            "comment": {
+              "type": "string"
+            },
+            "groupId": {
+              "type": "string"
+            },
+            "lowerLimit": {
+              "type": "string"
+            },
+            "spread": {
+              "type": "string"
+            },
+            "upperLimit": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Mesh": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "term": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MiscInfoModule": {
+          "properties": {
+            "removedCountries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "submissionTracking": {
+              "$ref": "#/$defs/SubmissionTracking"
+            },
+            "versionHolder": {
+              "format": "date",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "MoreInfoModule": {
+          "properties": {
+            "certainAgreement": {
+              "$ref": "#/$defs/CertainAgreement"
+            },
+            "limitationsAndCaveats": {
+              "$ref": "#/$defs/LimitationsAndCaveats"
+            },
+            "pointOfContact": {
+              "$ref": "#/$defs/PointOfContact"
+            }
+          },
+          "type": "object"
+        },
+        "NonInferiorityType": {
+          "enum": [
+            "SUPERIORITY",
+            "NON_INFERIORITY",
+            "EQUIVALENCE",
+            "OTHER",
+            "NON_INFERIORITY_OR_EQUIVALENCE",
+            "SUPERIORITY_OR_OTHER",
+            "NON_INFERIORITY_OR_EQUIVALENCE_LEGACY",
+            "SUPERIORITY_OR_OTHER_LEGACY"
+          ],
+          "type": "string"
+        },
+        "ObservationalModel": {
+          "enum": [
+            "COHORT",
+            "CASE_CONTROL",
+            "CASE_ONLY",
+            "CASE_CROSSOVER",
+            "ECOLOGIC_OR_COMMUNITY",
+            "FAMILY_BASED",
+            "DEFINED_POPULATION",
+            "NATURAL_HISTORY",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "Official": {
+          "properties": {
+            "affiliation": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "role": {
+              "$ref": "#/$defs/OfficialRole"
+            }
+          },
+          "type": "object"
+        },
+        "OfficialRole": {
+          "enum": [
+            "STUDY_CHAIR",
+            "STUDY_DIRECTOR",
+            "PRINCIPAL_INVESTIGATOR",
+            "SUB_INVESTIGATOR"
+          ],
+          "type": "string"
+        },
+        "OrgStudyIdInfo": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "link": {
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/OrgStudyIdType"
+            }
+          },
+          "type": "object"
+        },
+        "OrgStudyIdType": {
+          "enum": [
+            "NIH",
+            "FDA",
+            "VA",
+            "CDC",
+            "AHRQ",
+            "SAMHSA"
+          ],
+          "type": "string"
+        },
+        "Organization": {
+          "properties": {
+            "class": {
+              "$ref": "#/$defs/AgencyClass"
+            },
+            "fullName": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Outcome": {
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "measure": {
+              "type": "string"
+            },
+            "timeFrame": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "OutcomeMeasure": {
+          "properties": {
+            "analyses": {
+              "items": {
+                "$ref": "#/$defs/MeasureAnalysis"
+              },
+              "type": "array"
+            },
+            "anticipatedPostingDate": {
+              "$ref": "#/$defs/PartialDate"
+            },
+            "calculatePct": {
+              "type": "boolean"
+            },
+            "classes": {
+              "items": {
+                "$ref": "#/$defs/MeasureClass"
+              },
+              "type": "array"
+            },
+            "denomUnitsSelected": {
+              "type": "string"
+            },
+            "denoms": {
+              "items": {
+                "$ref": "#/$defs/Denom"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": "string"
+            },
+            "dispersionType": {
+              "type": "string"
+            },
+            "groups": {
+              "items": {
+                "$ref": "#/$defs/MeasureGroup"
+              },
+              "type": "array"
+            },
+            "paramType": {
+              "$ref": "#/$defs/MeasureParam"
+            },
+            "populationDescription": {
+              "type": "string"
+            },
+            "reportingStatus": {
+              "$ref": "#/$defs/ReportingStatus"
+            },
+            "timeFrame": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/OutcomeMeasureType"
+            },
+            "typeUnitsAnalyzed": {
+              "type": "string"
+            },
+            "unitOfMeasure": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "OutcomeMeasureType": {
+          "enum": [
+            "PRIMARY",
+            "SECONDARY",
+            "OTHER_PRE_SPECIFIED",
+            "POST_HOC"
+          ],
+          "type": "string"
+        },
+        "OutcomeMeasuresModule": {
+          "properties": {
+            "outcomeMeasures": {
+              "items": {
+                "$ref": "#/$defs/OutcomeMeasure"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "OutcomesModule": {
+          "properties": {
+            "otherOutcomes": {
+              "items": {
+                "$ref": "#/$defs/Outcome"
+              },
+              "type": "array"
+            },
+            "primaryOutcomes": {
+              "items": {
+                "$ref": "#/$defs/Outcome"
+              },
+              "type": "array"
+            },
+            "secondaryOutcomes": {
+              "items": {
+                "$ref": "#/$defs/Outcome"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "OversightModule": {
+          "properties": {
+            "fdaaa801Violation": {
+              "type": "boolean"
+            },
+            "isFdaRegulatedDevice": {
+              "type": "boolean"
+            },
+            "isFdaRegulatedDrug": {
+              "type": "boolean"
+            },
+            "isPpsd": {
+              "type": "boolean"
+            },
+            "isUnapprovedDevice": {
+              "type": "boolean"
+            },
+            "isUsExport": {
+              "type": "boolean"
+            },
+            "oversightHasDmc": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "PartialDate": {
+          "description": "Date in `yyyy`, `yyyy-MM`, or `yyyy-MM-dd` format",
+          "type": "string"
+        },
+        "PartialDateStruct": {
+          "properties": {
+            "date": {
+              "$ref": "#/$defs/PartialDate"
+            },
+            "type": {
+              "$ref": "#/$defs/DateType"
+            }
+          },
+          "type": "object"
+        },
+        "ParticipantFlowModule": {
+          "properties": {
+            "groups": {
+              "items": {
+                "$ref": "#/$defs/FlowGroup"
+              },
+              "type": "array"
+            },
+            "periods": {
+              "items": {
+                "$ref": "#/$defs/FlowPeriod"
+              },
+              "type": "array"
+            },
+            "preAssignmentDetails": {
+              "type": "string"
+            },
+            "recruitmentDetails": {
+              "type": "string"
+            },
+            "typeUnitsAnalyzed": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Phase": {
+          "enum": [
+            "NA",
+            "EARLY_PHASE1",
+            "PHASE1",
+            "PHASE2",
+            "PHASE3",
+            "PHASE4"
+          ],
+          "type": "string"
+        },
+        "PointOfContact": {
+          "properties": {
+            "email": {
+              "type": "string"
+            },
+            "organization": {
+              "type": "string"
+            },
+            "phone": {
+              "type": "string"
+            },
+            "phoneExt": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "PrimaryPurpose": {
+          "enum": [
+            "TREATMENT",
+            "PREVENTION",
+            "DIAGNOSTIC",
+            "ECT",
+            "SUPPORTIVE_CARE",
+            "SCREENING",
+            "HEALTH_SERVICES_RESEARCH",
+            "BASIC_SCIENCE",
+            "DEVICE_FEASIBILITY",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "ProtocolSection": {
+          "properties": {
+            "armsInterventionsModule": {
+              "$ref": "#/$defs/ArmsInterventionsModule"
+            },
+            "conditionsModule": {
+              "$ref": "#/$defs/ConditionsModule"
+            },
+            "contactsLocationsModule": {
+              "$ref": "#/$defs/ContactsLocationsModule"
+            },
+            "descriptionModule": {
+              "$ref": "#/$defs/DescriptionModule"
+            },
+            "designModule": {
+              "$ref": "#/$defs/DesignModule"
+            },
+            "eligibilityModule": {
+              "$ref": "#/$defs/EligibilityModule"
+            },
+            "identificationModule": {
+              "$ref": "#/$defs/IdentificationModule"
+            },
+            "ipdSharingStatementModule": {
+              "$ref": "#/$defs/IpdSharingStatementModule"
+            },
+            "outcomesModule": {
+              "$ref": "#/$defs/OutcomesModule"
+            },
+            "oversightModule": {
+              "$ref": "#/$defs/OversightModule"
+            },
+            "referencesModule": {
+              "$ref": "#/$defs/ReferencesModule"
+            },
+            "sponsorCollaboratorsModule": {
+              "$ref": "#/$defs/SponsorCollaboratorsModule"
+            },
+            "statusModule": {
+              "$ref": "#/$defs/StatusModule"
+            }
+          },
+          "type": "object"
+        },
+        "RecruitmentStatus": {
+          "enum": [
+            "ACTIVE_NOT_RECRUITING",
+            "COMPLETED",
+            "ENROLLING_BY_INVITATION",
+            "NOT_YET_RECRUITING",
+            "RECRUITING",
+            "SUSPENDED",
+            "TERMINATED",
+            "WITHDRAWN",
+            "AVAILABLE"
+          ],
+          "type": "string"
+        },
+        "Reference": {
+          "properties": {
+            "citation": {
+              "type": "string"
+            },
+            "pmid": {
+              "type": "string"
+            },
+            "retractions": {
+              "items": {
+                "$ref": "#/$defs/Retraction"
+              },
+              "type": "array"
+            },
+            "type": {
+              "$ref": "#/$defs/ReferenceType"
+            }
+          },
+          "type": "object"
+        },
+        "ReferenceType": {
+          "enum": [
+            "BACKGROUND",
+            "RESULT",
+            "DERIVED"
+          ],
+          "type": "string"
+        },
+        "ReferencesModule": {
+          "properties": {
+            "availIpds": {
+              "items": {
+                "$ref": "#/$defs/AvailIpd"
+              },
+              "type": "array"
+            },
+            "references": {
+              "items": {
+                "$ref": "#/$defs/Reference"
+              },
+              "type": "array"
+            },
+            "seeAlsoLinks": {
+              "items": {
+                "$ref": "#/$defs/SeeAlsoLink"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "ReportingStatus": {
+          "enum": [
+            "NOT_POSTED",
+            "POSTED"
+          ],
+          "type": "string"
+        },
+        "ResponsibleParty": {
+          "properties": {
+            "investigatorAffiliation": {
+              "type": "string"
+            },
+            "investigatorFullName": {
+              "type": "string"
+            },
+            "investigatorTitle": {
+              "type": "string"
+            },
+            "oldNameTitle": {
+              "type": "string"
+            },
+            "oldOrganization": {
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/ResponsiblePartyType"
+            }
+          },
+          "type": "object"
+        },
+        "ResponsiblePartyType": {
+          "enum": [
+            "SPONSOR",
+            "PRINCIPAL_INVESTIGATOR",
+            "SPONSOR_INVESTIGATOR"
+          ],
+          "type": "string"
+        },
+        "ResultsSection": {
+          "properties": {
+            "adverseEventsModule": {
+              "$ref": "#/$defs/AdverseEventsModule"
+            },
+            "baselineCharacteristicsModule": {
+              "$ref": "#/$defs/BaselineCharacteristicsModule"
+            },
+            "moreInfoModule": {
+              "$ref": "#/$defs/MoreInfoModule"
+            },
+            "outcomeMeasuresModule": {
+              "$ref": "#/$defs/OutcomeMeasuresModule"
+            },
+            "participantFlowModule": {
+              "$ref": "#/$defs/ParticipantFlowModule"
+            }
+          },
+          "type": "object"
+        },
+        "Retraction": {
+          "properties": {
+            "pmid": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "SamplingMethod": {
+          "enum": [
+            "PROBABILITY_SAMPLE",
+            "NON_PROBABILITY_SAMPLE"
+          ],
+          "type": "string"
+        },
+        "SecondaryIdInfo": {
+          "properties": {
+            "domain": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "link": {
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/SecondaryIdType"
+            }
+          },
+          "type": "object"
+        },
+        "SecondaryIdType": {
+          "enum": [
+            "NIH",
+            "FDA",
+            "VA",
+            "CDC",
+            "AHRQ",
+            "SAMHSA",
+            "OTHER_GRANT",
+            "EUDRACT_NUMBER",
+            "CTIS",
+            "REGISTRY",
+            "OTHER"
+          ],
+          "type": "string"
+        },
+        "SeeAlsoLink": {
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Sex": {
+          "enum": [
+            "FEMALE",
+            "MALE",
+            "ALL"
+          ],
+          "type": "string"
+        },
+        "Sponsor": {
+          "properties": {
+            "class": {
+              "$ref": "#/$defs/AgencyClass"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "SponsorCollaboratorsModule": {
+          "properties": {
+            "collaborators": {
+              "items": {
+                "$ref": "#/$defs/Sponsor"
+              },
+              "type": "array"
+            },
+            "leadSponsor": {
+              "$ref": "#/$defs/Sponsor"
+            },
+            "responsibleParty": {
+              "$ref": "#/$defs/ResponsibleParty"
+            }
+          },
+          "type": "object"
+        },
+        "StandardAge": {
+          "enum": [
+            "CHILD",
+            "ADULT",
+            "OLDER_ADULT"
+          ],
+          "type": "string"
+        },
+        "Status": {
+          "enum": [
+            "ACTIVE_NOT_RECRUITING",
+            "COMPLETED",
+            "ENROLLING_BY_INVITATION",
+            "NOT_YET_RECRUITING",
+            "RECRUITING",
+            "SUSPENDED",
+            "TERMINATED",
+            "WITHDRAWN",
+            "AVAILABLE",
+            "NO_LONGER_AVAILABLE",
+            "TEMPORARILY_NOT_AVAILABLE",
+            "APPROVED_FOR_MARKETING",
+            "WITHHELD",
+            "UNKNOWN"
+          ],
+          "type": "string"
+        },
+        "StatusModule": {
+          "properties": {
+            "completionDateStruct": {
+              "$ref": "#/$defs/PartialDateStruct"
+            },
+            "delayedPosting": {
+              "type": "boolean"
+            },
+            "dispFirstPostDateStruct": {
+              "$ref": "#/$defs/DateStruct"
+            },
+            "dispFirstSubmitDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "dispFirstSubmitQcDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "expandedAccessInfo": {
+              "$ref": "#/$defs/ExpandedAccessInfo"
+            },
+            "lastKnownStatus": {
+              "$ref": "#/$defs/Status"
+            },
+            "lastUpdatePostDateStruct": {
+              "$ref": "#/$defs/DateStruct"
+            },
+            "lastUpdateSubmitDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "overallStatus": {
+              "$ref": "#/$defs/Status"
+            },
+            "primaryCompletionDateStruct": {
+              "$ref": "#/$defs/PartialDateStruct"
+            },
+            "resultsFirstPostDateStruct": {
+              "$ref": "#/$defs/DateStruct"
+            },
+            "resultsFirstSubmitDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "resultsFirstSubmitQcDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "resultsWaived": {
+              "type": "boolean"
+            },
+            "startDateStruct": {
+              "$ref": "#/$defs/PartialDateStruct"
+            },
+            "statusVerifiedDate": {
+              "$ref": "#/$defs/PartialDate"
+            },
+            "studyFirstPostDateStruct": {
+              "$ref": "#/$defs/DateStruct"
+            },
+            "studyFirstSubmitDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "studyFirstSubmitQcDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "whyStopped": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "Study": {
+          "properties": {
+            "annotationSection": {
+              "$ref": "#/$defs/AnnotationSection"
+            },
+            "derivedSection": {
+              "$ref": "#/$defs/DerivedSection"
+            },
+            "documentSection": {
+              "$ref": "#/$defs/DocumentSection"
+            },
+            "hasResults": {
+              "type": "boolean"
+            },
+            "protocolSection": {
+              "$ref": "#/$defs/ProtocolSection"
+            },
+            "resultsSection": {
+              "$ref": "#/$defs/ResultsSection"
+            }
+          },
+          "type": "object"
+        },
+        "StudyType": {
+          "enum": [
+            "EXPANDED_ACCESS",
+            "INTERVENTIONAL",
+            "OBSERVATIONAL"
+          ],
+          "type": "string"
+        },
+        "SubmissionInfo": {
+          "properties": {
+            "mcpReleaseN": {
+              "type": "integer"
+            },
+            "releaseDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "resetDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "unreleaseDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "unreleaseDateUnknown": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "SubmissionTracking": {
+          "properties": {
+            "estimatedResultsFirstSubmitDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "firstMcpInfo": {
+              "$ref": "#/$defs/FirstMcpInfo"
+            },
+            "submissionInfos": {
+              "items": {
+                "$ref": "#/$defs/SubmissionInfo"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "UnpostedAnnotation": {
+          "properties": {
+            "unpostedEvents": {
+              "items": {
+                "$ref": "#/$defs/UnpostedEvent"
+              },
+              "type": "array"
+            },
+            "unpostedResponsibleParty": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "UnpostedEvent": {
+          "properties": {
+            "date": {
+              "format": "date",
+              "type": "string"
+            },
+            "dateUnknown": {
+              "type": "boolean"
+            },
+            "type": {
+              "$ref": "#/$defs/UnpostedEventType"
+            }
+          },
+          "type": "object"
+        },
+        "UnpostedEventType": {
+          "enum": [
+            "RESET",
+            "RELEASE",
+            "UNRELEASE"
+          ],
+          "type": "string"
+        },
+        "ViolationAnnotation": {
+          "properties": {
+            "violationEvents": {
+              "items": {
+                "$ref": "#/$defs/ViolationEvent"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "ViolationEvent": {
+          "properties": {
+            "creationDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "issuedDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "postedDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "releaseDate": {
+              "format": "date",
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/$defs/ViolationEventType"
+            }
+          },
+          "type": "object"
+        },
+        "ViolationEventType": {
+          "enum": [
+            "VIOLATION_IDENTIFIED",
+            "CORRECTION_CONFIRMED",
+            "PENALTY_IMPOSED",
+            "ISSUES_IN_LETTER_ADDRESSED_CONFIRMED"
+          ],
+          "type": "string"
+        },
+        "WhoMasked": {
+          "enum": [
+            "PARTICIPANT",
+            "CARE_PROVIDER",
+            "INVESTIGATOR",
+            "OUTCOMES_ASSESSOR"
+          ],
+          "type": "string"
+        },
+        "nct": {
+          "description": "NCT number",
+          "maxLength": 11,
+          "minLength": 11,
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "properties": {
+        "provenance": {
+          "type": "object"
+        },
+        "result": {
+          "$ref": "#/$defs/Study"
+        }
+      },
+      "required": [
+        "result",
+        "provenance"
+      ],
+      "type": "object"
+    },
+    "type": "VSDDynamicRESTTool",
+    "vsd_operation": {
+      "auth": {
+        "type": "none"
+      },
+      "endpoint": "https://clinicaltrials.gov/api/v2/studies/{nctId}",
+      "fixed_query": {
+        "format": "json"
+      },
+      "method": "GET",
+      "path_arguments": {
+        "nctId": "nctId"
+      },
+      "query_arguments": {},
+      "query_serialization": {},
+      "response_schema": {
+        "$defs": {
+          "AdverseEvent": {
+            "properties": {
+              "assessmentType": {
+                "$ref": "#/$defs/EventAssessment"
+              },
+              "notes": {
+                "type": "string"
+              },
+              "organSystem": {
+                "type": "string"
+              },
+              "sourceVocabulary": {
+                "type": "string"
+              },
+              "stats": {
+                "items": {
+                  "$ref": "#/$defs/EventStats"
+                },
+                "type": "array"
+              },
+              "term": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "AdverseEventsModule": {
+            "properties": {
+              "allCauseMortalityComment": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "eventGroups": {
+                "items": {
+                  "$ref": "#/$defs/EventGroup"
+                },
+                "type": "array"
+              },
+              "frequencyThreshold": {
+                "type": "string"
+              },
+              "otherEvents": {
+                "items": {
+                  "$ref": "#/$defs/AdverseEvent"
+                },
+                "type": "array"
+              },
+              "seriousEvents": {
+                "items": {
+                  "$ref": "#/$defs/AdverseEvent"
+                },
+                "type": "array"
+              },
+              "timeFrame": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "AgencyClass": {
+            "enum": [
+              "NIH",
+              "FED",
+              "OTHER_GOV",
+              "INDIV",
+              "INDUSTRY",
+              "NETWORK",
+              "AMBIG",
+              "OTHER",
+              "UNKNOWN"
+            ],
+            "type": "string"
+          },
+          "AgreementRestrictionType": {
+            "enum": [
+              "LTE60",
+              "GT60",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "AnalysisDispersionType": {
+            "enum": [
+              "STANDARD_DEVIATION",
+              "STANDARD_ERROR_OF_MEAN"
+            ],
+            "type": "string"
+          },
+          "AnnotationModule": {
+            "properties": {
+              "unpostedAnnotation": {
+                "$ref": "#/$defs/UnpostedAnnotation"
+              },
+              "violationAnnotation": {
+                "$ref": "#/$defs/ViolationAnnotation"
+              }
+            },
+            "type": "object"
+          },
+          "AnnotationSection": {
+            "properties": {
+              "annotationModule": {
+                "$ref": "#/$defs/AnnotationModule"
+              }
+            },
+            "type": "object"
+          },
+          "ArmGroup": {
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "interventionNames": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "label": {
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/ArmGroupType"
+              }
+            },
+            "type": "object"
+          },
+          "ArmGroupType": {
+            "enum": [
+              "EXPERIMENTAL",
+              "ACTIVE_COMPARATOR",
+              "PLACEBO_COMPARATOR",
+              "SHAM_COMPARATOR",
+              "NO_INTERVENTION",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "ArmsInterventionsModule": {
+            "properties": {
+              "armGroups": {
+                "items": {
+                  "$ref": "#/$defs/ArmGroup"
+                },
+                "type": "array"
+              },
+              "interventions": {
+                "items": {
+                  "$ref": "#/$defs/Intervention"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "AvailIpd": {
+            "properties": {
+              "comment": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "BaselineCharacteristicsModule": {
+            "properties": {
+              "denoms": {
+                "items": {
+                  "$ref": "#/$defs/Denom"
+                },
+                "type": "array"
+              },
+              "groups": {
+                "items": {
+                  "$ref": "#/$defs/MeasureGroup"
+                },
+                "type": "array"
+              },
+              "measures": {
+                "items": {
+                  "$ref": "#/$defs/BaselineMeasure"
+                },
+                "type": "array"
+              },
+              "populationDescription": {
+                "type": "string"
+              },
+              "typeUnitsAnalyzed": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "BaselineMeasure": {
+            "properties": {
+              "calculatePct": {
+                "type": "boolean"
+              },
+              "classes": {
+                "items": {
+                  "$ref": "#/$defs/MeasureClass"
+                },
+                "type": "array"
+              },
+              "denomUnitsSelected": {
+                "type": "string"
+              },
+              "denoms": {
+                "items": {
+                  "$ref": "#/$defs/Denom"
+                },
+                "type": "array"
+              },
+              "description": {
+                "type": "string"
+              },
+              "dispersionType": {
+                "$ref": "#/$defs/MeasureDispersionType"
+              },
+              "paramType": {
+                "$ref": "#/$defs/MeasureParam"
+              },
+              "populationDescription": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "unitOfMeasure": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "BioSpec": {
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "retention": {
+                "$ref": "#/$defs/BioSpecRetention"
+              }
+            },
+            "type": "object"
+          },
+          "BioSpecRetention": {
+            "enum": [
+              "NONE_RETAINED",
+              "SAMPLES_WITH_DNA",
+              "SAMPLES_WITHOUT_DNA"
+            ],
+            "type": "string"
+          },
+          "BrowseBranch": {
+            "properties": {
+              "abbrev": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "BrowseLeaf": {
+            "properties": {
+              "asFound": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "relevance": {
+                "$ref": "#/$defs/BrowseLeafRelevance"
+              }
+            },
+            "type": "object"
+          },
+          "BrowseLeafRelevance": {
+            "enum": [
+              "LOW",
+              "HIGH"
+            ],
+            "type": "string"
+          },
+          "BrowseModule": {
+            "properties": {
+              "ancestors": {
+                "items": {
+                  "$ref": "#/$defs/Mesh"
+                },
+                "type": "array"
+              },
+              "browseBranches": {
+                "items": {
+                  "$ref": "#/$defs/BrowseBranch"
+                },
+                "type": "array"
+              },
+              "browseLeaves": {
+                "items": {
+                  "$ref": "#/$defs/BrowseLeaf"
+                },
+                "type": "array"
+              },
+              "meshes": {
+                "items": {
+                  "$ref": "#/$defs/Mesh"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "CertainAgreement": {
+            "properties": {
+              "otherDetails": {
+                "type": "string"
+              },
+              "piSponsorEmployee": {
+                "type": "boolean"
+              },
+              "restrictionType": {
+                "$ref": "#/$defs/AgreementRestrictionType"
+              },
+              "restrictiveAgreement": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "ConditionsModule": {
+            "properties": {
+              "conditions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "keywords": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "ConfidenceIntervalNumSides": {
+            "enum": [
+              "ONE_SIDED",
+              "TWO_SIDED"
+            ],
+            "type": "string"
+          },
+          "Contact": {
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "phoneExt": {
+                "type": "string"
+              },
+              "role": {
+                "$ref": "#/$defs/ContactRole"
+              }
+            },
+            "type": "object"
+          },
+          "ContactRole": {
+            "enum": [
+              "STUDY_CHAIR",
+              "STUDY_DIRECTOR",
+              "PRINCIPAL_INVESTIGATOR",
+              "SUB_INVESTIGATOR",
+              "CONTACT"
+            ],
+            "type": "string"
+          },
+          "ContactsLocationsModule": {
+            "properties": {
+              "centralContacts": {
+                "items": {
+                  "$ref": "#/$defs/Contact"
+                },
+                "type": "array"
+              },
+              "locations": {
+                "items": {
+                  "$ref": "#/$defs/Location"
+                },
+                "type": "array"
+              },
+              "overallOfficials": {
+                "items": {
+                  "$ref": "#/$defs/Official"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "DateStruct": {
+            "properties": {
+              "date": {
+                "format": "date",
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/DateType"
+              }
+            },
+            "type": "object"
+          },
+          "DateTimeMinutes": {
+            "description": "Date and time in `yyyy-MM-dd'T'HH:mm` format",
+            "type": "string"
+          },
+          "DateType": {
+            "enum": [
+              "ACTUAL",
+              "ESTIMATED"
+            ],
+            "type": "string"
+          },
+          "Denom": {
+            "properties": {
+              "counts": {
+                "items": {
+                  "$ref": "#/$defs/DenomCount"
+                },
+                "type": "array"
+              },
+              "units": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "DenomCount": {
+            "properties": {
+              "groupId": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "DerivedSection": {
+            "properties": {
+              "conditionBrowseModule": {
+                "$ref": "#/$defs/BrowseModule"
+              },
+              "interventionBrowseModule": {
+                "$ref": "#/$defs/BrowseModule"
+              },
+              "miscInfoModule": {
+                "$ref": "#/$defs/MiscInfoModule"
+              }
+            },
+            "type": "object"
+          },
+          "DescriptionModule": {
+            "properties": {
+              "briefSummary": {
+                "type": "string"
+              },
+              "detailedDescription": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "DesignAllocation": {
+            "enum": [
+              "RANDOMIZED",
+              "NON_RANDOMIZED",
+              "NA"
+            ],
+            "type": "string"
+          },
+          "DesignInfo": {
+            "properties": {
+              "allocation": {
+                "$ref": "#/$defs/DesignAllocation"
+              },
+              "interventionModel": {
+                "$ref": "#/$defs/InterventionalAssignment"
+              },
+              "interventionModelDescription": {
+                "type": "string"
+              },
+              "maskingInfo": {
+                "$ref": "#/$defs/MaskingBlock"
+              },
+              "observationalModel": {
+                "$ref": "#/$defs/ObservationalModel"
+              },
+              "primaryPurpose": {
+                "$ref": "#/$defs/PrimaryPurpose"
+              },
+              "timePerspective": {
+                "$ref": "#/$defs/DesignTimePerspective"
+              }
+            },
+            "type": "object"
+          },
+          "DesignMasking": {
+            "enum": [
+              "NONE",
+              "SINGLE",
+              "DOUBLE",
+              "TRIPLE",
+              "QUADRUPLE"
+            ],
+            "type": "string"
+          },
+          "DesignModule": {
+            "properties": {
+              "bioSpec": {
+                "$ref": "#/$defs/BioSpec"
+              },
+              "designInfo": {
+                "$ref": "#/$defs/DesignInfo"
+              },
+              "enrollmentInfo": {
+                "$ref": "#/$defs/EnrollmentInfo"
+              },
+              "expandedAccessTypes": {
+                "$ref": "#/$defs/ExpandedAccessTypes"
+              },
+              "nPtrsToThisExpAccNctId": {
+                "type": "integer"
+              },
+              "patientRegistry": {
+                "type": "boolean"
+              },
+              "phases": {
+                "items": {
+                  "$ref": "#/$defs/Phase"
+                },
+                "type": "array"
+              },
+              "studyType": {
+                "$ref": "#/$defs/StudyType"
+              },
+              "targetDuration": {
+                "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "DesignTimePerspective": {
+            "enum": [
+              "RETROSPECTIVE",
+              "PROSPECTIVE",
+              "CROSS_SECTIONAL",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "DocumentSection": {
+            "properties": {
+              "largeDocumentModule": {
+                "$ref": "#/$defs/LargeDocumentModule"
+              }
+            },
+            "type": "object"
+          },
+          "DropWithdraw": {
+            "properties": {
+              "comment": {
+                "type": "string"
+              },
+              "reasons": {
+                "items": {
+                  "$ref": "#/$defs/FlowStats"
+                },
+                "type": "array"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "EligibilityModule": {
+            "properties": {
+              "eligibilityCriteria": {
+                "type": "string"
+              },
+              "genderBased": {
+                "type": "boolean"
+              },
+              "genderDescription": {
+                "type": "string"
+              },
+              "healthyVolunteers": {
+                "type": "boolean"
+              },
+              "maximumAge": {
+                "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+                "type": "string"
+              },
+              "minimumAge": {
+                "pattern": "^\\d+ (Year|Years|Month|Months|Week|Weeks|Day|Days|Hour|Hours|Minute|Minutes)$",
+                "type": "string"
+              },
+              "samplingMethod": {
+                "$ref": "#/$defs/SamplingMethod"
+              },
+              "sex": {
+                "$ref": "#/$defs/Sex"
+              },
+              "stdAges": {
+                "items": {
+                  "$ref": "#/$defs/StandardAge"
+                },
+                "type": "array"
+              },
+              "studyPopulation": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "EnrollmentInfo": {
+            "properties": {
+              "count": {
+                "type": "integer"
+              },
+              "type": {
+                "$ref": "#/$defs/EnrollmentType"
+              }
+            },
+            "type": "object"
+          },
+          "EnrollmentType": {
+            "enum": [
+              "ACTUAL",
+              "ESTIMATED"
+            ],
+            "type": "string"
+          },
+          "EventAssessment": {
+            "enum": [
+              "NON_SYSTEMATIC_ASSESSMENT",
+              "SYSTEMATIC_ASSESSMENT"
+            ],
+            "type": "string"
+          },
+          "EventGroup": {
+            "properties": {
+              "deathsNumAffected": {
+                "type": "integer"
+              },
+              "deathsNumAtRisk": {
+                "type": "integer"
+              },
+              "description": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "otherNumAffected": {
+                "type": "integer"
+              },
+              "otherNumAtRisk": {
+                "type": "integer"
+              },
+              "seriousNumAffected": {
+                "type": "integer"
+              },
+              "seriousNumAtRisk": {
+                "type": "integer"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "EventStats": {
+            "properties": {
+              "groupId": {
+                "type": "string"
+              },
+              "numAffected": {
+                "type": "integer"
+              },
+              "numAtRisk": {
+                "type": "integer"
+              },
+              "numEvents": {
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "ExpandedAccessInfo": {
+            "properties": {
+              "hasExpandedAccess": {
+                "type": "boolean"
+              },
+              "nctId": {
+                "$ref": "#/$defs/nct"
+              },
+              "statusForNctId": {
+                "$ref": "#/$defs/ExpandedAccessStatus"
+              }
+            },
+            "type": "object"
+          },
+          "ExpandedAccessStatus": {
+            "enum": [
+              "AVAILABLE",
+              "NO_LONGER_AVAILABLE",
+              "TEMPORARILY_NOT_AVAILABLE",
+              "APPROVED_FOR_MARKETING"
+            ],
+            "type": "string"
+          },
+          "ExpandedAccessTypes": {
+            "properties": {
+              "individual": {
+                "type": "boolean"
+              },
+              "intermediate": {
+                "type": "boolean"
+              },
+              "treatment": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "FirstMcpInfo": {
+            "properties": {
+              "postDateStruct": {
+                "$ref": "#/$defs/DateStruct"
+              }
+            },
+            "type": "object"
+          },
+          "FlowGroup": {
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "FlowMilestone": {
+            "properties": {
+              "achievements": {
+                "items": {
+                  "$ref": "#/$defs/FlowStats"
+                },
+                "type": "array"
+              },
+              "comment": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "FlowPeriod": {
+            "properties": {
+              "dropWithdraws": {
+                "items": {
+                  "$ref": "#/$defs/DropWithdraw"
+                },
+                "type": "array"
+              },
+              "milestones": {
+                "items": {
+                  "$ref": "#/$defs/FlowMilestone"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "FlowStats": {
+            "properties": {
+              "comment": {
+                "type": "string"
+              },
+              "groupId": {
+                "type": "string"
+              },
+              "numSubjects": {
+                "type": "string"
+              },
+              "numUnits": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "GeoName": {
+            "description": "State/province or city name",
+            "type": "string"
+          },
+          "GeoPoint": {
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "lon": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "lat",
+              "lon"
+            ],
+            "type": "object"
+          },
+          "IdentificationModule": {
+            "properties": {
+              "acronym": {
+                "type": "string"
+              },
+              "briefTitle": {
+                "type": "string"
+              },
+              "nctId": {
+                "$ref": "#/$defs/nct"
+              },
+              "nctIdAliases": {
+                "items": {
+                  "$ref": "#/$defs/nct"
+                },
+                "type": "array"
+              },
+              "officialTitle": {
+                "type": "string"
+              },
+              "orgStudyIdInfo": {
+                "$ref": "#/$defs/OrgStudyIdInfo"
+              },
+              "organization": {
+                "$ref": "#/$defs/Organization"
+              },
+              "secondaryIdInfos": {
+                "items": {
+                  "$ref": "#/$defs/SecondaryIdInfo"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "Intervention": {
+            "properties": {
+              "armGroupLabels": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "otherNames": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": {
+                "$ref": "#/$defs/InterventionType"
+              }
+            },
+            "type": "object"
+          },
+          "InterventionType": {
+            "enum": [
+              "BEHAVIORAL",
+              "BIOLOGICAL",
+              "COMBINATION_PRODUCT",
+              "DEVICE",
+              "DIAGNOSTIC_TEST",
+              "DIETARY_SUPPLEMENT",
+              "DRUG",
+              "GENETIC",
+              "PROCEDURE",
+              "RADIATION",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "InterventionalAssignment": {
+            "enum": [
+              "SINGLE_GROUP",
+              "PARALLEL",
+              "CROSSOVER",
+              "FACTORIAL",
+              "SEQUENTIAL"
+            ],
+            "type": "string"
+          },
+          "IpdSharing": {
+            "enum": [
+              "YES",
+              "NO",
+              "UNDECIDED"
+            ],
+            "type": "string"
+          },
+          "IpdSharingInfoType": {
+            "enum": [
+              "STUDY_PROTOCOL",
+              "SAP",
+              "ICF",
+              "CSR",
+              "ANALYTIC_CODE"
+            ],
+            "type": "string"
+          },
+          "IpdSharingStatementModule": {
+            "properties": {
+              "accessCriteria": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "infoTypes": {
+                "items": {
+                  "$ref": "#/$defs/IpdSharingInfoType"
+                },
+                "type": "array"
+              },
+              "ipdSharing": {
+                "$ref": "#/$defs/IpdSharing"
+              },
+              "timeFrame": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "LargeDoc": {
+            "properties": {
+              "date": {
+                "format": "date",
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              },
+              "hasIcf": {
+                "type": "boolean"
+              },
+              "hasProtocol": {
+                "type": "boolean"
+              },
+              "hasSap": {
+                "type": "boolean"
+              },
+              "label": {
+                "type": "string"
+              },
+              "size": {
+                "type": "integer"
+              },
+              "typeAbbrev": {
+                "type": "string"
+              },
+              "uploadDate": {
+                "$ref": "#/$defs/DateTimeMinutes"
+              }
+            },
+            "type": "object"
+          },
+          "LargeDocumentModule": {
+            "properties": {
+              "largeDocs": {
+                "items": {
+                  "$ref": "#/$defs/LargeDoc"
+                },
+                "type": "array"
+              },
+              "noSap": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "LimitationsAndCaveats": {
+            "properties": {
+              "description": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Location": {
+            "properties": {
+              "city": {
+                "$ref": "#/$defs/GeoName"
+              },
+              "contacts": {
+                "items": {
+                  "$ref": "#/$defs/Contact"
+                },
+                "type": "array"
+              },
+              "country": {
+                "type": "string"
+              },
+              "facility": {
+                "type": "string"
+              },
+              "geoPoint": {
+                "$ref": "#/$defs/GeoPoint"
+              },
+              "state": {
+                "$ref": "#/$defs/GeoName"
+              },
+              "status": {
+                "$ref": "#/$defs/RecruitmentStatus"
+              },
+              "zip": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MaskingBlock": {
+            "properties": {
+              "masking": {
+                "$ref": "#/$defs/DesignMasking"
+              },
+              "maskingDescription": {
+                "type": "string"
+              },
+              "whoMasked": {
+                "items": {
+                  "$ref": "#/$defs/WhoMasked"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "MeasureAnalysis": {
+            "properties": {
+              "ciLowerLimit": {
+                "type": "string"
+              },
+              "ciLowerLimitComment": {
+                "type": "string"
+              },
+              "ciNumSides": {
+                "$ref": "#/$defs/ConfidenceIntervalNumSides"
+              },
+              "ciPctValue": {
+                "type": "string"
+              },
+              "ciUpperLimit": {
+                "type": "string"
+              },
+              "ciUpperLimitComment": {
+                "type": "string"
+              },
+              "dispersionType": {
+                "$ref": "#/$defs/AnalysisDispersionType"
+              },
+              "dispersionValue": {
+                "type": "string"
+              },
+              "estimateComment": {
+                "type": "string"
+              },
+              "groupDescription": {
+                "type": "string"
+              },
+              "groupIds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "nonInferiorityComment": {
+                "type": "string"
+              },
+              "nonInferiorityType": {
+                "$ref": "#/$defs/NonInferiorityType"
+              },
+              "otherAnalysisDescription": {
+                "type": "string"
+              },
+              "pValue": {
+                "type": "string"
+              },
+              "pValueComment": {
+                "type": "string"
+              },
+              "paramType": {
+                "type": "string"
+              },
+              "paramValue": {
+                "type": "string"
+              },
+              "statisticalComment": {
+                "type": "string"
+              },
+              "statisticalMethod": {
+                "type": "string"
+              },
+              "testedNonInferiority": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "MeasureCategory": {
+            "properties": {
+              "measurements": {
+                "items": {
+                  "$ref": "#/$defs/Measurement"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MeasureClass": {
+            "properties": {
+              "categories": {
+                "items": {
+                  "$ref": "#/$defs/MeasureCategory"
+                },
+                "type": "array"
+              },
+              "denoms": {
+                "items": {
+                  "$ref": "#/$defs/Denom"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MeasureDispersionType": {
+            "enum": [
+              "NA",
+              "STANDARD_DEVIATION",
+              "STANDARD_ERROR",
+              "INTER_QUARTILE_RANGE",
+              "FULL_RANGE",
+              "CONFIDENCE_80",
+              "CONFIDENCE_90",
+              "CONFIDENCE_95",
+              "CONFIDENCE_975",
+              "CONFIDENCE_99",
+              "CONFIDENCE_OTHER",
+              "GEOMETRIC_COEFFICIENT"
+            ],
+            "type": "string"
+          },
+          "MeasureGroup": {
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MeasureParam": {
+            "enum": [
+              "GEOMETRIC_MEAN",
+              "GEOMETRIC_LEAST_SQUARES_MEAN",
+              "LEAST_SQUARES_MEAN",
+              "LOG_MEAN",
+              "MEAN",
+              "MEDIAN",
+              "NUMBER",
+              "COUNT_OF_PARTICIPANTS",
+              "COUNT_OF_UNITS"
+            ],
+            "type": "string"
+          },
+          "Measurement": {
+            "properties": {
+              "comment": {
+                "type": "string"
+              },
+              "groupId": {
+                "type": "string"
+              },
+              "lowerLimit": {
+                "type": "string"
+              },
+              "spread": {
+                "type": "string"
+              },
+              "upperLimit": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Mesh": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "term": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MiscInfoModule": {
+            "properties": {
+              "removedCountries": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "submissionTracking": {
+                "$ref": "#/$defs/SubmissionTracking"
+              },
+              "versionHolder": {
+                "format": "date",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "MoreInfoModule": {
+            "properties": {
+              "certainAgreement": {
+                "$ref": "#/$defs/CertainAgreement"
+              },
+              "limitationsAndCaveats": {
+                "$ref": "#/$defs/LimitationsAndCaveats"
+              },
+              "pointOfContact": {
+                "$ref": "#/$defs/PointOfContact"
+              }
+            },
+            "type": "object"
+          },
+          "NonInferiorityType": {
+            "enum": [
+              "SUPERIORITY",
+              "NON_INFERIORITY",
+              "EQUIVALENCE",
+              "OTHER",
+              "NON_INFERIORITY_OR_EQUIVALENCE",
+              "SUPERIORITY_OR_OTHER",
+              "NON_INFERIORITY_OR_EQUIVALENCE_LEGACY",
+              "SUPERIORITY_OR_OTHER_LEGACY"
+            ],
+            "type": "string"
+          },
+          "ObservationalModel": {
+            "enum": [
+              "COHORT",
+              "CASE_CONTROL",
+              "CASE_ONLY",
+              "CASE_CROSSOVER",
+              "ECOLOGIC_OR_COMMUNITY",
+              "FAMILY_BASED",
+              "DEFINED_POPULATION",
+              "NATURAL_HISTORY",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "Official": {
+            "properties": {
+              "affiliation": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "role": {
+                "$ref": "#/$defs/OfficialRole"
+              }
+            },
+            "type": "object"
+          },
+          "OfficialRole": {
+            "enum": [
+              "STUDY_CHAIR",
+              "STUDY_DIRECTOR",
+              "PRINCIPAL_INVESTIGATOR",
+              "SUB_INVESTIGATOR"
+            ],
+            "type": "string"
+          },
+          "OrgStudyIdInfo": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "link": {
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/OrgStudyIdType"
+              }
+            },
+            "type": "object"
+          },
+          "OrgStudyIdType": {
+            "enum": [
+              "NIH",
+              "FDA",
+              "VA",
+              "CDC",
+              "AHRQ",
+              "SAMHSA"
+            ],
+            "type": "string"
+          },
+          "Organization": {
+            "properties": {
+              "class": {
+                "$ref": "#/$defs/AgencyClass"
+              },
+              "fullName": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Outcome": {
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "measure": {
+                "type": "string"
+              },
+              "timeFrame": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "OutcomeMeasure": {
+            "properties": {
+              "analyses": {
+                "items": {
+                  "$ref": "#/$defs/MeasureAnalysis"
+                },
+                "type": "array"
+              },
+              "anticipatedPostingDate": {
+                "$ref": "#/$defs/PartialDate"
+              },
+              "calculatePct": {
+                "type": "boolean"
+              },
+              "classes": {
+                "items": {
+                  "$ref": "#/$defs/MeasureClass"
+                },
+                "type": "array"
+              },
+              "denomUnitsSelected": {
+                "type": "string"
+              },
+              "denoms": {
+                "items": {
+                  "$ref": "#/$defs/Denom"
+                },
+                "type": "array"
+              },
+              "description": {
+                "type": "string"
+              },
+              "dispersionType": {
+                "type": "string"
+              },
+              "groups": {
+                "items": {
+                  "$ref": "#/$defs/MeasureGroup"
+                },
+                "type": "array"
+              },
+              "paramType": {
+                "$ref": "#/$defs/MeasureParam"
+              },
+              "populationDescription": {
+                "type": "string"
+              },
+              "reportingStatus": {
+                "$ref": "#/$defs/ReportingStatus"
+              },
+              "timeFrame": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/OutcomeMeasureType"
+              },
+              "typeUnitsAnalyzed": {
+                "type": "string"
+              },
+              "unitOfMeasure": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "OutcomeMeasureType": {
+            "enum": [
+              "PRIMARY",
+              "SECONDARY",
+              "OTHER_PRE_SPECIFIED",
+              "POST_HOC"
+            ],
+            "type": "string"
+          },
+          "OutcomeMeasuresModule": {
+            "properties": {
+              "outcomeMeasures": {
+                "items": {
+                  "$ref": "#/$defs/OutcomeMeasure"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "OutcomesModule": {
+            "properties": {
+              "otherOutcomes": {
+                "items": {
+                  "$ref": "#/$defs/Outcome"
+                },
+                "type": "array"
+              },
+              "primaryOutcomes": {
+                "items": {
+                  "$ref": "#/$defs/Outcome"
+                },
+                "type": "array"
+              },
+              "secondaryOutcomes": {
+                "items": {
+                  "$ref": "#/$defs/Outcome"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "OversightModule": {
+            "properties": {
+              "fdaaa801Violation": {
+                "type": "boolean"
+              },
+              "isFdaRegulatedDevice": {
+                "type": "boolean"
+              },
+              "isFdaRegulatedDrug": {
+                "type": "boolean"
+              },
+              "isPpsd": {
+                "type": "boolean"
+              },
+              "isUnapprovedDevice": {
+                "type": "boolean"
+              },
+              "isUsExport": {
+                "type": "boolean"
+              },
+              "oversightHasDmc": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "PartialDate": {
+            "description": "Date in `yyyy`, `yyyy-MM`, or `yyyy-MM-dd` format",
+            "type": "string"
+          },
+          "PartialDateStruct": {
+            "properties": {
+              "date": {
+                "$ref": "#/$defs/PartialDate"
+              },
+              "type": {
+                "$ref": "#/$defs/DateType"
+              }
+            },
+            "type": "object"
+          },
+          "ParticipantFlowModule": {
+            "properties": {
+              "groups": {
+                "items": {
+                  "$ref": "#/$defs/FlowGroup"
+                },
+                "type": "array"
+              },
+              "periods": {
+                "items": {
+                  "$ref": "#/$defs/FlowPeriod"
+                },
+                "type": "array"
+              },
+              "preAssignmentDetails": {
+                "type": "string"
+              },
+              "recruitmentDetails": {
+                "type": "string"
+              },
+              "typeUnitsAnalyzed": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Phase": {
+            "enum": [
+              "NA",
+              "EARLY_PHASE1",
+              "PHASE1",
+              "PHASE2",
+              "PHASE3",
+              "PHASE4"
+            ],
+            "type": "string"
+          },
+          "PointOfContact": {
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "organization": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "phoneExt": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "PrimaryPurpose": {
+            "enum": [
+              "TREATMENT",
+              "PREVENTION",
+              "DIAGNOSTIC",
+              "ECT",
+              "SUPPORTIVE_CARE",
+              "SCREENING",
+              "HEALTH_SERVICES_RESEARCH",
+              "BASIC_SCIENCE",
+              "DEVICE_FEASIBILITY",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "ProtocolSection": {
+            "properties": {
+              "armsInterventionsModule": {
+                "$ref": "#/$defs/ArmsInterventionsModule"
+              },
+              "conditionsModule": {
+                "$ref": "#/$defs/ConditionsModule"
+              },
+              "contactsLocationsModule": {
+                "$ref": "#/$defs/ContactsLocationsModule"
+              },
+              "descriptionModule": {
+                "$ref": "#/$defs/DescriptionModule"
+              },
+              "designModule": {
+                "$ref": "#/$defs/DesignModule"
+              },
+              "eligibilityModule": {
+                "$ref": "#/$defs/EligibilityModule"
+              },
+              "identificationModule": {
+                "$ref": "#/$defs/IdentificationModule"
+              },
+              "ipdSharingStatementModule": {
+                "$ref": "#/$defs/IpdSharingStatementModule"
+              },
+              "outcomesModule": {
+                "$ref": "#/$defs/OutcomesModule"
+              },
+              "oversightModule": {
+                "$ref": "#/$defs/OversightModule"
+              },
+              "referencesModule": {
+                "$ref": "#/$defs/ReferencesModule"
+              },
+              "sponsorCollaboratorsModule": {
+                "$ref": "#/$defs/SponsorCollaboratorsModule"
+              },
+              "statusModule": {
+                "$ref": "#/$defs/StatusModule"
+              }
+            },
+            "type": "object"
+          },
+          "RecruitmentStatus": {
+            "enum": [
+              "ACTIVE_NOT_RECRUITING",
+              "COMPLETED",
+              "ENROLLING_BY_INVITATION",
+              "NOT_YET_RECRUITING",
+              "RECRUITING",
+              "SUSPENDED",
+              "TERMINATED",
+              "WITHDRAWN",
+              "AVAILABLE"
+            ],
+            "type": "string"
+          },
+          "Reference": {
+            "properties": {
+              "citation": {
+                "type": "string"
+              },
+              "pmid": {
+                "type": "string"
+              },
+              "retractions": {
+                "items": {
+                  "$ref": "#/$defs/Retraction"
+                },
+                "type": "array"
+              },
+              "type": {
+                "$ref": "#/$defs/ReferenceType"
+              }
+            },
+            "type": "object"
+          },
+          "ReferenceType": {
+            "enum": [
+              "BACKGROUND",
+              "RESULT",
+              "DERIVED"
+            ],
+            "type": "string"
+          },
+          "ReferencesModule": {
+            "properties": {
+              "availIpds": {
+                "items": {
+                  "$ref": "#/$defs/AvailIpd"
+                },
+                "type": "array"
+              },
+              "references": {
+                "items": {
+                  "$ref": "#/$defs/Reference"
+                },
+                "type": "array"
+              },
+              "seeAlsoLinks": {
+                "items": {
+                  "$ref": "#/$defs/SeeAlsoLink"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "ReportingStatus": {
+            "enum": [
+              "NOT_POSTED",
+              "POSTED"
+            ],
+            "type": "string"
+          },
+          "ResponsibleParty": {
+            "properties": {
+              "investigatorAffiliation": {
+                "type": "string"
+              },
+              "investigatorFullName": {
+                "type": "string"
+              },
+              "investigatorTitle": {
+                "type": "string"
+              },
+              "oldNameTitle": {
+                "type": "string"
+              },
+              "oldOrganization": {
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/ResponsiblePartyType"
+              }
+            },
+            "type": "object"
+          },
+          "ResponsiblePartyType": {
+            "enum": [
+              "SPONSOR",
+              "PRINCIPAL_INVESTIGATOR",
+              "SPONSOR_INVESTIGATOR"
+            ],
+            "type": "string"
+          },
+          "ResultsSection": {
+            "properties": {
+              "adverseEventsModule": {
+                "$ref": "#/$defs/AdverseEventsModule"
+              },
+              "baselineCharacteristicsModule": {
+                "$ref": "#/$defs/BaselineCharacteristicsModule"
+              },
+              "moreInfoModule": {
+                "$ref": "#/$defs/MoreInfoModule"
+              },
+              "outcomeMeasuresModule": {
+                "$ref": "#/$defs/OutcomeMeasuresModule"
+              },
+              "participantFlowModule": {
+                "$ref": "#/$defs/ParticipantFlowModule"
+              }
+            },
+            "type": "object"
+          },
+          "Retraction": {
+            "properties": {
+              "pmid": {
+                "type": "string"
+              },
+              "source": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "SamplingMethod": {
+            "enum": [
+              "PROBABILITY_SAMPLE",
+              "NON_PROBABILITY_SAMPLE"
+            ],
+            "type": "string"
+          },
+          "SecondaryIdInfo": {
+            "properties": {
+              "domain": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "link": {
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/SecondaryIdType"
+              }
+            },
+            "type": "object"
+          },
+          "SecondaryIdType": {
+            "enum": [
+              "NIH",
+              "FDA",
+              "VA",
+              "CDC",
+              "AHRQ",
+              "SAMHSA",
+              "OTHER_GRANT",
+              "EUDRACT_NUMBER",
+              "CTIS",
+              "REGISTRY",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "SeeAlsoLink": {
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Sex": {
+            "enum": [
+              "FEMALE",
+              "MALE",
+              "ALL"
+            ],
+            "type": "string"
+          },
+          "Sponsor": {
+            "properties": {
+              "class": {
+                "$ref": "#/$defs/AgencyClass"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "SponsorCollaboratorsModule": {
+            "properties": {
+              "collaborators": {
+                "items": {
+                  "$ref": "#/$defs/Sponsor"
+                },
+                "type": "array"
+              },
+              "leadSponsor": {
+                "$ref": "#/$defs/Sponsor"
+              },
+              "responsibleParty": {
+                "$ref": "#/$defs/ResponsibleParty"
+              }
+            },
+            "type": "object"
+          },
+          "StandardAge": {
+            "enum": [
+              "CHILD",
+              "ADULT",
+              "OLDER_ADULT"
+            ],
+            "type": "string"
+          },
+          "Status": {
+            "enum": [
+              "ACTIVE_NOT_RECRUITING",
+              "COMPLETED",
+              "ENROLLING_BY_INVITATION",
+              "NOT_YET_RECRUITING",
+              "RECRUITING",
+              "SUSPENDED",
+              "TERMINATED",
+              "WITHDRAWN",
+              "AVAILABLE",
+              "NO_LONGER_AVAILABLE",
+              "TEMPORARILY_NOT_AVAILABLE",
+              "APPROVED_FOR_MARKETING",
+              "WITHHELD",
+              "UNKNOWN"
+            ],
+            "type": "string"
+          },
+          "StatusModule": {
+            "properties": {
+              "completionDateStruct": {
+                "$ref": "#/$defs/PartialDateStruct"
+              },
+              "delayedPosting": {
+                "type": "boolean"
+              },
+              "dispFirstPostDateStruct": {
+                "$ref": "#/$defs/DateStruct"
+              },
+              "dispFirstSubmitDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "dispFirstSubmitQcDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "expandedAccessInfo": {
+                "$ref": "#/$defs/ExpandedAccessInfo"
+              },
+              "lastKnownStatus": {
+                "$ref": "#/$defs/Status"
+              },
+              "lastUpdatePostDateStruct": {
+                "$ref": "#/$defs/DateStruct"
+              },
+              "lastUpdateSubmitDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "overallStatus": {
+                "$ref": "#/$defs/Status"
+              },
+              "primaryCompletionDateStruct": {
+                "$ref": "#/$defs/PartialDateStruct"
+              },
+              "resultsFirstPostDateStruct": {
+                "$ref": "#/$defs/DateStruct"
+              },
+              "resultsFirstSubmitDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "resultsFirstSubmitQcDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "resultsWaived": {
+                "type": "boolean"
+              },
+              "startDateStruct": {
+                "$ref": "#/$defs/PartialDateStruct"
+              },
+              "statusVerifiedDate": {
+                "$ref": "#/$defs/PartialDate"
+              },
+              "studyFirstPostDateStruct": {
+                "$ref": "#/$defs/DateStruct"
+              },
+              "studyFirstSubmitDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "studyFirstSubmitQcDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "whyStopped": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "Study": {
+            "properties": {
+              "annotationSection": {
+                "$ref": "#/$defs/AnnotationSection"
+              },
+              "derivedSection": {
+                "$ref": "#/$defs/DerivedSection"
+              },
+              "documentSection": {
+                "$ref": "#/$defs/DocumentSection"
+              },
+              "hasResults": {
+                "type": "boolean"
+              },
+              "protocolSection": {
+                "$ref": "#/$defs/ProtocolSection"
+              },
+              "resultsSection": {
+                "$ref": "#/$defs/ResultsSection"
+              }
+            },
+            "type": "object"
+          },
+          "StudyType": {
+            "enum": [
+              "EXPANDED_ACCESS",
+              "INTERVENTIONAL",
+              "OBSERVATIONAL"
+            ],
+            "type": "string"
+          },
+          "SubmissionInfo": {
+            "properties": {
+              "mcpReleaseN": {
+                "type": "integer"
+              },
+              "releaseDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "resetDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "unreleaseDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "unreleaseDateUnknown": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "SubmissionTracking": {
+            "properties": {
+              "estimatedResultsFirstSubmitDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "firstMcpInfo": {
+                "$ref": "#/$defs/FirstMcpInfo"
+              },
+              "submissionInfos": {
+                "items": {
+                  "$ref": "#/$defs/SubmissionInfo"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "UnpostedAnnotation": {
+            "properties": {
+              "unpostedEvents": {
+                "items": {
+                  "$ref": "#/$defs/UnpostedEvent"
+                },
+                "type": "array"
+              },
+              "unpostedResponsibleParty": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "UnpostedEvent": {
+            "properties": {
+              "date": {
+                "format": "date",
+                "type": "string"
+              },
+              "dateUnknown": {
+                "type": "boolean"
+              },
+              "type": {
+                "$ref": "#/$defs/UnpostedEventType"
+              }
+            },
+            "type": "object"
+          },
+          "UnpostedEventType": {
+            "enum": [
+              "RESET",
+              "RELEASE",
+              "UNRELEASE"
+            ],
+            "type": "string"
+          },
+          "ViolationAnnotation": {
+            "properties": {
+              "violationEvents": {
+                "items": {
+                  "$ref": "#/$defs/ViolationEvent"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "ViolationEvent": {
+            "properties": {
+              "creationDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "issuedDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "postedDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "releaseDate": {
+                "format": "date",
+                "type": "string"
+              },
+              "type": {
+                "$ref": "#/$defs/ViolationEventType"
+              }
+            },
+            "type": "object"
+          },
+          "ViolationEventType": {
+            "enum": [
+              "VIOLATION_IDENTIFIED",
+              "CORRECTION_CONFIRMED",
+              "PENALTY_IMPOSED",
+              "ISSUES_IN_LETTER_ADDRESSED_CONFIRMED"
+            ],
+            "type": "string"
+          },
+          "WhoMasked": {
+            "enum": [
+              "PARTICIPANT",
+              "CARE_PROVIDER",
+              "INVESTIGATOR",
+              "OUTCOMES_ASSESSOR"
+            ],
+            "type": "string"
+          },
+          "nct": {
+            "description": "NCT number",
+            "maxLength": 11,
+            "minLength": 11,
+            "type": "string"
+          }
+        },
+        "$ref": "#/$defs/Study"
+      },
+      "timeout_seconds": 30,
+      "version": 1
+    },
+    "vsd_promotion": {
+      "api_title": "ClinicalTrials.gov REST API",
+      "api_version": "2.0.5",
+      "candidate_id": "47a4c7402dfb7b86",
+      "candidate_sha256": "47a4c7402dfb7b8699690b6ba5146eb2755472d21b0cc330e5fc620b097da99f",
+      "fixed_query": {
+        "format": "json"
+      },
+      "generator_version": 1,
+      "included_parameters": [
+        "nctId"
+      ],
+      "method": "GET",
+      "openapi_version": "3.0.3",
+      "operation_id": "fetchStudy",
+      "path": "/studies/{nctId}",
+      "response_media_type": "application/json",
+      "source_document_sha256": "ba31adaea67e6bb09ff77af5c0c11daf36d5aff7f5d6cbed89f0aab04b297aea",
+      "source_type": "openapi"
+    }
+  },
+  "created_at": "2026-08-01T18:51:14.281978+00:00",
+  "draft_id": "vsdclinicaltrialsstudybynct_27f9c4e92c3f",
+  "draft_sha256": "2d97d81a7723e51789beedc77210be958ea438368c472b3533ca738729f4d3cd",
+  "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+  "state": "draft",
+  "version": 1
+}

--- a/examples/vsd/artifacts/openapi_ingestion_workspace/evidence/vsdclinicaltrialsstudybynct_27f9c4e92c3f.json
+++ b/examples/vsd/artifacts/openapi_ingestion_workspace/evidence/vsdclinicaltrialsstudybynct_27f9c4e92c3f.json
@@ -1,0 +1,121 @@
+{
+  "all_cases_passed": true,
+  "case_count": 3,
+  "cases": [
+    {
+      "arguments": {
+        "nctId": "NCT03019419"
+      },
+      "case_index": 0,
+      "expect": {
+        "equals": {},
+        "equals_paths": {
+          "/protocolSection/identificationModule/nctId": "NCT03019419"
+        },
+        "max_items": null,
+        "min_items": null,
+        "required_fields": [
+          "protocolSection"
+        ],
+        "required_paths": [
+          "/protocolSection/identificationModule/nctId",
+          "/protocolSection/identificationModule/briefTitle",
+          "/protocolSection/statusModule/overallStatus",
+          "/protocolSection/conditionsModule/conditions"
+        ],
+        "result_type": "object"
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "derivedSection",
+        "hasResults",
+        "protocolSection"
+      ],
+      "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+      "payload_sha256": "4fce0ba178580566ab3d97bb5aa0d7f77cca287b4d193539dfa9cbaacfeb60da",
+      "redirects": 0,
+      "result_type": "object",
+      "retrieved_at": "2026-08-01T18:52:47.404925+00:00",
+      "row_count": null
+    },
+    {
+      "arguments": {
+        "nctId": "NCT04428775"
+      },
+      "case_index": 1,
+      "expect": {
+        "equals": {},
+        "equals_paths": {
+          "/protocolSection/identificationModule/nctId": "NCT04428775"
+        },
+        "max_items": null,
+        "min_items": null,
+        "required_fields": [
+          "protocolSection"
+        ],
+        "required_paths": [
+          "/protocolSection/identificationModule/nctId",
+          "/protocolSection/identificationModule/briefTitle",
+          "/protocolSection/statusModule/overallStatus",
+          "/protocolSection/conditionsModule/conditions"
+        ],
+        "result_type": "object"
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "derivedSection",
+        "hasResults",
+        "protocolSection"
+      ],
+      "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+      "payload_sha256": "17df843a24f19baad6655410238244ba464c171d2cdc048f08c0c158432f68ca",
+      "redirects": 0,
+      "result_type": "object",
+      "retrieved_at": "2026-08-01T18:52:47.595065+00:00",
+      "row_count": null
+    },
+    {
+      "arguments": {
+        "nctId": "NCT04745299"
+      },
+      "case_index": 2,
+      "expect": {
+        "equals": {},
+        "equals_paths": {
+          "/protocolSection/identificationModule/nctId": "NCT04745299"
+        },
+        "max_items": null,
+        "min_items": null,
+        "required_fields": [
+          "protocolSection"
+        ],
+        "required_paths": [
+          "/protocolSection/identificationModule/nctId",
+          "/protocolSection/identificationModule/briefTitle",
+          "/protocolSection/statusModule/overallStatus",
+          "/protocolSection/conditionsModule/conditions"
+        ],
+        "result_type": "object"
+      },
+      "http_status": 200,
+      "observed_fields": [
+        "derivedSection",
+        "hasResults",
+        "protocolSection"
+      ],
+      "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+      "payload_sha256": "95a907ff858124aa0d29c0367a1de9f8e32ee7686a96bf9285a47f94370ab34d",
+      "redirects": 0,
+      "result_type": "object",
+      "retrieved_at": "2026-08-01T18:52:47.835388+00:00",
+      "row_count": null
+    }
+  ],
+  "draft_id": "vsdclinicaltrialsstudybynct_27f9c4e92c3f",
+  "draft_sha256": "2d97d81a7723e51789beedc77210be958ea438368c472b3533ca738729f4d3cd",
+  "operation_sha256": "27f9c4e92c3ff99ea44fe05456c6f34a90fb6cf0ac29a21163a41398e7992be0",
+  "tool_name": "VSDClinicalTrialsStudyByNCT",
+  "verification_sha256": "55d799070ea17713f2b0355eff968acf031d69bd04973d5d0bc62c0f8b7a67f0",
+  "verified_at": "2026-08-01T18:52:47.836991+00:00",
+  "version": 1
+}

--- a/examples/vsd/openapi_als_case_study.py
+++ b/examples/vsd/openapi_als_case_study.py
@@ -1,0 +1,477 @@
+"""Prove OpenAPI ingestion and reviewed promotion with real ALS trial records."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from tooluniverse import ToolUniverse
+from tooluniverse.vsd_dynamic_rest import VSDDynamicRESTError, VSDDynamicRESTTool
+from tooluniverse.vsd_openapi import inspect_openapi_document
+from tooluniverse.vsd_promotion import (
+    approve_draft,
+    create_openapi_draft,
+    list_promotion_state,
+    load_published_tools,
+    publish_draft,
+    verify_draft,
+)
+
+HERE = Path(__file__).resolve().parent
+ARTIFACTS = HERE / "artifacts"
+DEFAULT_WORKSPACE = ARTIFACTS / "openapi_ingestion_workspace"
+DEFAULT_JSON = ARTIFACTS / "openapi_als_snapshot.json"
+DEFAULT_MARKDOWN = ARTIFACTS / "openapi_als_snapshot.md"
+OFFICIAL_SPEC_URL = "https://clinicaltrials.gov/api/oas/v2"
+OFFICIAL_DOCS_URL = "https://clinicaltrials.gov/data-api/api"
+TOOL_NAME = "VSDClinicalTrialsStudyByNCT"
+OPERATION_ID = "fetchStudy"
+ALS_STUDIES = (
+    "NCT03019419",
+    "NCT04428775",
+    "NCT04745299",
+)
+EXPECTED_ASSERTIONS = {
+    "candidate_inert_before_review",
+    "candidate_integrity_hash_propagated",
+    "exact_nested_identifiers_verified",
+    "fresh_runtime_loaded_explicitly",
+    "generated_contract_is_read_only",
+    "hash_chain_complete",
+    "invalid_identifier_rejected_before_transport",
+    "official_contract_parsed",
+    "published_tool_absent_before_load",
+    "provider_responses_schema_validated",
+    "three_distinct_cases_verified",
+    "zero_redirect_https_provenance",
+}
+DISCLAIMER = (
+    "This case demonstrates software-governance and public-registry retrieval. "
+    "It does not assess eligibility, efficacy, safety, or treatment suitability."
+)
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _successful_result(response: Any) -> tuple[Any, dict[str, Any]]:
+    if not isinstance(response, dict) or response.get("status") != "success":
+        raise RuntimeError(f"Generated tool execution failed: {response!r}")
+    data = response.get("data")
+    if not isinstance(data, dict) or not isinstance(data.get("provenance"), dict):
+        raise RuntimeError("Generated tool returned an invalid evidence envelope")
+    return data.get("result"), data["provenance"]
+
+
+def _study_summary(payload: Any, provenance: dict[str, Any]) -> dict[str, Any]:
+    try:
+        protocol = payload["protocolSection"]
+        identification = protocol["identificationModule"]
+        status = protocol["statusModule"]
+        conditions = protocol["conditionsModule"]["conditions"]
+    except (KeyError, TypeError) as exc:
+        raise RuntimeError("Trial record lacks the reviewed study fields") from exc
+    phases = protocol.get("designModule", {}).get("phases", [])
+    brief_title = identification["briefTitle"].replace("\u00c2\u00ae", "(R)")
+    return {
+        "nct_id": identification["nctId"],
+        "brief_title": brief_title,
+        "overall_status": status["overallStatus"],
+        "conditions": conditions,
+        "phases": phases,
+        "provenance": {
+            key: provenance[key]
+            for key in (
+                "provider",
+                "endpoint",
+                "http_status",
+                "content_type",
+                "response_bytes",
+                "redirects",
+                "payload_sha256",
+                "operation_sha256",
+                "retrieved_at",
+            )
+        },
+    }
+
+
+def _verification_cases() -> list[dict[str, Any]]:
+    return [
+        {
+            "arguments": {"nctId": nct_id},
+            "expect": {
+                "result_type": "object",
+                "required_fields": ["protocolSection"],
+                "required_paths": [
+                    "/protocolSection/identificationModule/nctId",
+                    "/protocolSection/identificationModule/briefTitle",
+                    "/protocolSection/statusModule/overallStatus",
+                    "/protocolSection/conditionsModule/conditions",
+                ],
+                "equals": {},
+                "equals_paths": {"/protocolSection/identificationModule/nctId": nct_id},
+            },
+        }
+        for nct_id in ALS_STUDIES
+    ]
+
+
+def run_case(*, spec_path: Path, workspace: Path) -> dict[str, Any]:
+    """Run inspection, promotion, verification, publication, and fresh execution."""
+    inspection = inspect_openapi_document(spec_path)
+    matches = [
+        candidate
+        for candidate in inspection["candidates"]
+        if candidate["operation_id"] == OPERATION_ID
+    ]
+    if len(matches) != 1:
+        raise RuntimeError(f"Expected exactly one {OPERATION_ID!r} operation")
+    candidate = matches[0]
+    if candidate["blockers"]:
+        raise RuntimeError(f"Selected operation is blocked: {candidate['blockers']!r}")
+    if candidate["execution_allowed"] is not False:
+        raise RuntimeError("Inspection candidate unexpectedly became executable")
+
+    draft = create_openapi_draft(
+        candidate,
+        tool_name=TOOL_NAME,
+        description=(
+            "Fetch one reviewed ClinicalTrials.gov study record by its validated "
+            "NCT identifier using the provider's official OpenAPI contract."
+        ),
+        fixed_query={"format": "json"},
+        timeout_seconds=30,
+        workspace=workspace,
+    )
+    evidence = verify_draft(
+        draft["draft_id"], _verification_cases(), workspace=workspace
+    )
+    approval = approve_draft(
+        draft["draft_id"],
+        reviewed_by="ToolUniverse VSD case-study reviewer",
+        decision_note=(
+            "Approved after schema review and three distinct ALS registry records "
+            "passed exact nested-identifier verification."
+        ),
+        workspace=workspace,
+    )
+    publication_path = workspace / "approved" / f"{TOOL_NAME}.json"
+    publication = publish_draft(
+        draft["draft_id"],
+        workspace=workspace,
+        replace=publication_path.exists(),
+    )
+
+    tooluniverse = ToolUniverse()
+    try:
+        absent_before_load = TOOL_NAME not in tooluniverse.all_tool_dict
+        loaded = load_published_tools(tooluniverse, workspace=workspace)
+        studies = []
+        for nct_id in ALS_STUDIES:
+            response = tooluniverse.run_one_function(
+                {"name": TOOL_NAME, "arguments": {"nctId": nct_id}},
+                use_cache=False,
+            )
+            payload, provenance = _successful_result(response)
+            studies.append(_study_summary(payload, provenance))
+    finally:
+        tooluniverse.close()
+
+    invalid_identifier_rejected = False
+    generated = VSDDynamicRESTTool(draft["config"])
+    try:
+        generated.run({"nctId": "ALS-UNKNOWN"})
+    except VSDDynamicRESTError as exc:
+        invalid_identifier_rejected = "failed the reviewed schema" in str(exc)
+
+    chain = {
+        "source_document_sha256": inspection["source_document_sha256"],
+        "candidate_sha256": candidate["candidate_sha256"],
+        "operation_sha256": draft["operation_sha256"],
+        "draft_sha256": draft["draft_sha256"],
+        "verification_sha256": evidence["verification_sha256"],
+        "approval_sha256": approval["approval_sha256"],
+        "publication_sha256": publication["publication_sha256"],
+    }
+    assertions = {
+        "official_contract_parsed": inspection["candidate_count"] > 0,
+        "candidate_inert_before_review": candidate["execution_allowed"] is False,
+        "candidate_integrity_hash_propagated": (
+            draft["config"]["vsd_promotion"]["candidate_sha256"]
+            == candidate["candidate_sha256"]
+            and draft["config"]["vsd_promotion"]["source_document_sha256"]
+            == inspection["source_document_sha256"]
+        ),
+        "generated_contract_is_read_only": (
+            draft["config"]["vsd_operation"]["method"] == "GET"
+            and draft["config"]["vsd_operation"]["auth"] == {"type": "none"}
+        ),
+        "three_distinct_cases_verified": (
+            evidence["case_count"] == 3
+            and len({case["arguments"]["nctId"] for case in evidence["cases"]}) == 3
+        ),
+        "exact_nested_identifiers_verified": all(
+            case["expect"]["equals_paths"][
+                "/protocolSection/identificationModule/nctId"
+            ]
+            == case["arguments"]["nctId"]
+            for case in evidence["cases"]
+        ),
+        "hash_chain_complete": (
+            approval["verification_sha256"] == evidence["verification_sha256"]
+            and publication["approval_sha256"] == approval["approval_sha256"]
+            and all(len(value) == 64 for value in chain.values())
+        ),
+        "published_tool_absent_before_load": absent_before_load,
+        "fresh_runtime_loaded_explicitly": loaded == [TOOL_NAME],
+        "provider_responses_schema_validated": [study["nct_id"] for study in studies]
+        == list(ALS_STUDIES),
+        "zero_redirect_https_provenance": all(
+            study["provenance"]["provider"] == "clinicaltrials.gov"
+            and study["provenance"]["http_status"] == 200
+            and study["provenance"]["redirects"] == 0
+            and study["provenance"]["endpoint"].startswith("https://")
+            for study in studies
+        ),
+        "invalid_identifier_rejected_before_transport": invalid_identifier_rejected,
+    }
+    snapshot = {
+        "title": "OpenAPI-to-Tool ALS Registry Case Study",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "question": (
+            "Can an administrator turn the provider's current OpenAPI operation "
+            "into a narrow ToolUniverse tool that retrieves exact ALS trial records "
+            "without granting an agent arbitrary API access?"
+        ),
+        "answer": (
+            "Yes. The local specification produced an inert candidate; the selected "
+            "GET operation passed three exact record checks, was hash-approved, then "
+            "loaded explicitly into a fresh ToolUniverse instance."
+        ),
+        "disclaimer": DISCLAIMER,
+        "source_contract": {
+            "official_docs_url": OFFICIAL_DOCS_URL,
+            "official_spec_url": OFFICIAL_SPEC_URL,
+            "local_file": spec_path.name,
+            "document_sha256": inspection["source_document_sha256"],
+            "api_title": inspection["api_title"],
+            "api_version": inspection["api_version"],
+            "openapi_version": inspection["openapi_version"],
+        },
+        "inspection": {
+            "candidate_count": inspection["candidate_count"],
+            "promotable_count": inspection["promotable_count"],
+            "blocked_count": inspection["blocked_count"],
+            "operation_ids": [
+                item["operation_id"] for item in inspection["candidates"]
+            ],
+        },
+        "selected_operation": {
+            key: candidate[key]
+            for key in (
+                "candidate_id",
+                "candidate_sha256",
+                "operation_id",
+                "method",
+                "server_url",
+                "path",
+                "response_media_type",
+                "parameters",
+                "blockers",
+                "warnings",
+            )
+        },
+        "promotion": {
+            "draft_id": draft["draft_id"],
+            "verification_case_count": evidence["case_count"],
+            "verification_cases": evidence["cases"],
+            "reviewed_by": approval["reviewed_by"],
+            "decision_note": approval["decision_note"],
+            "loaded_tools": loaded,
+            "state": list_promotion_state(workspace=workspace),
+        },
+        "retrieved_als_records": studies,
+        "hash_chain": chain,
+        "end_to_end_assertions": assertions,
+    }
+    snapshot["audit_sha256"] = _digest(
+        {
+            "source_contract": snapshot["source_contract"],
+            "selected_operation": snapshot["selected_operation"],
+            "promotion": snapshot["promotion"],
+            "retrieved_als_records": snapshot["retrieved_als_records"],
+            "hash_chain": snapshot["hash_chain"],
+            "end_to_end_assertions": snapshot["end_to_end_assertions"],
+        }
+    )
+    validate_snapshot(snapshot)
+    return snapshot
+
+
+def validate_snapshot(snapshot: dict[str, Any]) -> None:
+    assertions = snapshot.get("end_to_end_assertions")
+    if not isinstance(assertions, dict) or set(assertions) != EXPECTED_ASSERTIONS:
+        raise ValueError("Snapshot does not contain the complete assertion set")
+    if not all(assertions.values()):
+        failed = sorted(name for name, passed in assertions.items() if not passed)
+        raise ValueError(f"End-to-end assertions failed: {failed!r}")
+    chain = snapshot.get("hash_chain")
+    if not isinstance(chain, dict) or any(
+        not isinstance(value, str) or len(value) != 64 for value in chain.values()
+    ):
+        raise ValueError("Snapshot hash chain is invalid")
+    expected_audit = _digest(
+        {
+            "source_contract": snapshot["source_contract"],
+            "selected_operation": snapshot["selected_operation"],
+            "promotion": snapshot["promotion"],
+            "retrieved_als_records": snapshot["retrieved_als_records"],
+            "hash_chain": snapshot["hash_chain"],
+            "end_to_end_assertions": snapshot["end_to_end_assertions"],
+        }
+    )
+    if snapshot.get("audit_sha256") != expected_audit:
+        raise ValueError("Snapshot audit digest does not match its content")
+
+
+def _markdown(snapshot: dict[str, Any]) -> str:
+    source = snapshot["source_contract"]
+    selected = snapshot["selected_operation"]
+    promotion = snapshot["promotion"]
+    lines = [
+        "# OpenAPI-to-Tool ALS Registry Case Study",
+        "",
+        f"**Generated:** {snapshot['generated_at']}",
+        "",
+        "## Decision Question",
+        "",
+        snapshot["question"],
+        "",
+        f"**Result:** {snapshot['answer']}",
+        "",
+        "## Official Contract Inspection",
+        "",
+        f"- Provider documentation: {source['official_docs_url']}",
+        f"- Current specification: {source['official_spec_url']}",
+        f"- Contract: {source['api_title']} {source['api_version']} "
+        f"(OpenAPI {source['openapi_version']})",
+        f"- Source SHA-256: `{source['document_sha256']}`",
+        f"- Operations inspected: {snapshot['inspection']['candidate_count']} "
+        f"({snapshot['inspection']['promotable_count']} promotable, "
+        f"{snapshot['inspection']['blocked_count']} blocked)",
+        "",
+        "The inspector read a local, bounded copy of the provider contract. It did "
+        "not fetch, register, or execute any operation. Every candidate began with "
+        "`execution_allowed: false`.",
+        "",
+        "## Selected Operation",
+        "",
+        "| Property | Reviewed value |",
+        "| --- | --- |",
+        f"| Operation | `{selected['operation_id']}` |",
+        f"| Request | `{selected['method']} {selected['server_url']}{selected['path']}` |",
+        f"| Response | `{selected['response_media_type']}` validated against the "
+        "provider schema |",
+        f"| Candidate | `{selected['candidate_id']}` |",
+        f"| Blockers | `{json.dumps(selected['blockers'])}` |",
+        "",
+        "Only the required `nctId` path argument was exposed. The response format "
+        "was fixed to JSON; CSV, ZIP, RIS, and FHIR choices in the broader provider "
+        "operation were not exposed by this generated tool.",
+        "",
+        "## Verification And Approval",
+        "",
+        f"The draft `{promotion['draft_id']}` ran "
+        f"{promotion['verification_case_count']} distinct ALS record cases. Each case "
+        "required the nested title, status, condition, and NCT identifier paths and "
+        "asserted that the returned identifier exactly matched the requested one.",
+        "",
+        "| NCT ID | Status | Phase | Brief title | Response bytes |",
+        "| --- | --- | --- | --- | ---: |",
+    ]
+    for study in snapshot["retrieved_als_records"]:
+        title = study["brief_title"].replace("|", "\\|")
+        phase = ", ".join(study["phases"]) or "Not reported"
+        lines.append(
+            f"| `{study['nct_id']}` | {study['overall_status']} | {phase} | "
+            f"{title} | {study['provenance']['response_bytes']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "Approval bound the exact source, candidate, operation, draft, verification, "
+            "and publication hashes. A fresh ToolUniverse instance did not contain the "
+            "tool until the approved publication was loaded explicitly.",
+            "",
+            "## End-to-End Assertions",
+            "",
+            "| Assertion | Result |",
+            "| --- | --- |",
+        ]
+    )
+    lines.extend(
+        f"| `{name}` | {'PASS' if passed else 'FAIL'} |"
+        for name, passed in sorted(snapshot["end_to_end_assertions"].items())
+    )
+    lines.extend(
+        [
+            "",
+            "## Interpretation",
+            "",
+            "The practical value is contract conversion with evidence: an administrator "
+            "can review one operation in a provider's official specification, narrow its "
+            "inputs, prove it against real records, and distribute a hash-bound tool. The "
+            "agent receives only that approved operation, not a generic HTTP client or the "
+            "ability to promote other operations.",
+            "",
+            f"**Boundary:** {snapshot['disclaimer']}",
+            "",
+            f"**Audit SHA-256:** `{snapshot['audit_sha256']}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_artifacts(
+    snapshot: dict[str, Any], output_json: Path, output_md: Path
+) -> None:
+    validate_snapshot(snapshot)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_md.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    output_md.write_text(_markdown(snapshot), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--spec",
+        type=Path,
+        required=True,
+        help="Local copy of the reviewed OpenAPI JSON or YAML document.",
+    )
+    parser.add_argument("--workspace", type=Path, default=DEFAULT_WORKSPACE)
+    parser.add_argument("--output-json", type=Path, default=DEFAULT_JSON)
+    parser.add_argument("--output-markdown", type=Path, default=DEFAULT_MARKDOWN)
+    args = parser.parse_args()
+    snapshot = run_case(spec_path=args.spec, workspace=args.workspace)
+    write_artifacts(snapshot, args.output_json, args.output_markdown)
+    print(json.dumps({"status": "passed", "audit_sha256": snapshot["audit_sha256"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tooluniverse/vsd_dynamic_rest.py
+++ b/src/tooluniverse/vsd_dynamic_rest.py
@@ -111,8 +111,14 @@ def _validated_operation_config(config: Any) -> dict[str, Any]:
         raise VSDDynamicRESTError("parameter.properties must be an object")
     path_arguments = operation.get("path_arguments", {})
     query_arguments = operation.get("query_arguments", {})
+    has_query_serialization = "query_serialization" in operation
+    query_serialization = operation.get("query_serialization", {})
     fixed_query = operation.get("fixed_query", {})
-    if not isinstance(path_arguments, dict) or not isinstance(query_arguments, dict):
+    if (
+        not isinstance(path_arguments, dict)
+        or not isinstance(query_arguments, dict)
+        or not isinstance(query_serialization, dict)
+    ):
         raise VSDDynamicRESTError("Argument mappings must be objects")
     for argument, target in (*path_arguments.items(), *query_arguments.items()):
         if (
@@ -143,6 +149,39 @@ def _validated_operation_config(config: Any) -> dict[str, Any]:
         raise VSDDynamicRESTError(
             f"Every input must map to the request; unmapped inputs: {sorted(unmapped)!r}"
         )
+    unknown_serialization = set(query_serialization) - set(query_arguments)
+    if unknown_serialization:
+        raise VSDDynamicRESTError(
+            "Query serialization references unmapped arguments: "
+            f"{sorted(unknown_serialization)!r}"
+        )
+    normalized_serialization: dict[str, dict[str, Any]] = {}
+    for argument in query_arguments:
+        rule = query_serialization.get(argument, {"style": "form", "explode": True})
+        if not isinstance(rule, dict) or set(rule) - {"style", "explode"}:
+            raise VSDDynamicRESTError(
+                f"Query serialization for {argument!r} is invalid"
+            )
+        style = rule.get("style", "form")
+        explode = rule.get("explode", style == "form")
+        if style not in {"form", "pipeDelimited", "spaceDelimited"}:
+            raise VSDDynamicRESTError(
+                f"Query serialization style for {argument!r} is unsupported"
+            )
+        if type(explode) is not bool:
+            raise VSDDynamicRESTError(
+                f"Query serialization explode for {argument!r} must be boolean"
+            )
+        if style != "form" and explode:
+            raise VSDDynamicRESTError(
+                f"Query serialization style {style!r} cannot explode values"
+            )
+        normalized_serialization[argument] = {
+            "style": style,
+            "explode": explode,
+        }
+    if has_query_serialization:
+        operation["query_serialization"] = normalized_serialization
     if not isinstance(fixed_query, dict):
         raise VSDDynamicRESTError("fixed_query must be an object")
     try:
@@ -198,7 +237,19 @@ def _provider_request(
     query = dict(operation.get("fixed_query", {}))
     for argument, parameter_name in operation.get("query_arguments", {}).items():
         if argument in arguments and arguments[argument] is not None:
-            query[parameter_name] = arguments[argument]
+            value = arguments[argument]
+            serialization = operation.get("query_serialization", {}).get(
+                argument, {"style": "form", "explode": True}
+            )
+            if isinstance(value, list):
+                style = serialization["style"]
+                if style == "pipeDelimited":
+                    value = "|".join(str(item) for item in value)
+                elif style == "spaceDelimited":
+                    value = " ".join(str(item) for item in value)
+                elif not serialization["explode"]:
+                    value = ",".join(str(item) for item in value)
+            query[parameter_name] = value
     try:
         return endpoint, _validated_params(query)
     except VSDPolicyError as exc:

--- a/src/tooluniverse/vsd_openapi.py
+++ b/src/tooluniverse/vsd_openapi.py
@@ -1,0 +1,716 @@
+"""Bounded OpenAPI ingestion for administrator-reviewed VSD promotion.
+
+The functions in this module inspect a local OpenAPI document and emit inert
+operation candidates. They never fetch a specification, execute an operation,
+persist a tool, or bypass the existing verification and approval pipeline.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.events import AliasEvent
+
+from .vsd_dynamic_rest import VSDDynamicRESTError, _schema_validator
+
+_FORMAT_VERSION = 1
+_MAX_DOCUMENT_BYTES = 1_000_000
+_MAX_DOCUMENT_DEPTH = 100
+_MAX_DOCUMENT_NODES = 100_000
+_MAX_PATHS = 250
+_MAX_OPERATIONS = 500
+_MAX_SERVERS = 20
+_MAX_PARAMETERS = 100
+_MAX_TEXT = 2_000
+_MAX_RESPONSE_SCHEMA_BYTES = 65_536
+_HTTP_METHODS = frozenset(
+    {"delete", "get", "head", "options", "patch", "post", "put", "trace"}
+)
+_ARGUMENT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+_PROVIDER_PARAMETER_RE = re.compile(r"^[A-Za-z0-9_.\[\]-]{1,128}$")
+_PATH_TOKEN_RE = re.compile(r"\{([^{}]+)\}")
+_JSON_TYPES = frozenset(
+    {"array", "boolean", "integer", "null", "number", "object", "string"}
+)
+
+
+class VSDOpenAPIError(ValueError):
+    """Raised when an OpenAPI document crosses the safe ingestion boundary."""
+
+
+class _StrictSafeLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects aliases and duplicate mapping keys."""
+
+    def compose_node(self, parent, index):
+        if self.check_event(AliasEvent):
+            event = self.get_event()
+            raise ConstructorError(
+                None,
+                None,
+                f"YAML aliases are not supported: *{event.anchor}",
+                event.start_mark,
+            )
+        return super().compose_node(parent, index)
+
+    def construct_mapping(self, node, deep=False):
+        self.flatten_mapping(node)
+        mapping: dict[Any, Any] = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                duplicate = key in mapping
+            except TypeError as exc:
+                raise ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    "found an unhashable mapping key",
+                    key_node.start_mark,
+                ) from exc
+            if duplicate:
+                raise ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r}",
+                    key_node.start_mark,
+                )
+            mapping[key] = self.construct_object(value_node, deep=deep)
+        return mapping
+
+
+def _duplicate_json_key(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise VSDOpenAPIError(f"JSON document contains duplicate key {key!r}")
+        result[key] = value
+    return result
+
+
+def _bounded_document(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise VSDOpenAPIError("OpenAPI document root must be an object")
+    count = 0
+    pending: list[tuple[Any, int]] = [(value, 0)]
+    while pending:
+        node, depth = pending.pop()
+        count += 1
+        if count > _MAX_DOCUMENT_NODES:
+            raise VSDOpenAPIError("OpenAPI document exceeds the node limit")
+        if depth > _MAX_DOCUMENT_DEPTH:
+            raise VSDOpenAPIError("OpenAPI document exceeds the depth limit")
+        if isinstance(node, dict):
+            for key, child in node.items():
+                if not isinstance(key, str):
+                    raise VSDOpenAPIError("OpenAPI object keys must be strings")
+                pending.append((child, depth + 1))
+        elif isinstance(node, list):
+            pending.extend((child, depth + 1) for child in node)
+        elif isinstance(node, float) and not math.isfinite(node):
+            raise VSDOpenAPIError("OpenAPI document must contain finite JSON values")
+        elif node is not None and not isinstance(node, (str, int, float, bool)):
+            raise VSDOpenAPIError("OpenAPI document contains a non-JSON value")
+    return value
+
+
+def load_openapi_document(path: str | Path) -> tuple[dict[str, Any], str]:
+    """Load one bounded local JSON or YAML document and return it with its hash."""
+    source = Path(path)
+    try:
+        size = source.stat().st_size
+        if size > _MAX_DOCUMENT_BYTES:
+            raise VSDOpenAPIError("OpenAPI document exceeds the 1 MB limit")
+        raw = source.read_bytes()
+    except OSError as exc:
+        raise VSDOpenAPIError(f"Could not read OpenAPI document {source}") from exc
+    if len(raw) > _MAX_DOCUMENT_BYTES:
+        raise VSDOpenAPIError("OpenAPI document exceeds the 1 MB limit")
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise VSDOpenAPIError("OpenAPI document must be UTF-8") from exc
+
+    try:
+        if source.suffix.casefold() == ".json" or text.lstrip().startswith(("{", "[")):
+            value = json.loads(
+                text,
+                object_pairs_hook=_duplicate_json_key,
+                parse_constant=lambda value: (_ for _ in ()).throw(
+                    VSDOpenAPIError(f"Non-finite JSON value {value!r} is prohibited")
+                ),
+            )
+        else:
+            value = yaml.load(text, Loader=_StrictSafeLoader)
+    except VSDOpenAPIError:
+        raise
+    except json.JSONDecodeError as exc:
+        raise VSDOpenAPIError(
+            "OpenAPI document is not valid JSON or safe YAML"
+        ) from exc
+    except yaml.YAMLError as exc:
+        detail = str(getattr(exc, "problem", None) or exc).splitlines()[0]
+        raise VSDOpenAPIError(f"OpenAPI YAML rejected: {detail}") from exc
+    return _bounded_document(value), hashlib.sha256(raw).hexdigest()
+
+
+def _text(value: Any, *, fallback: str = "") -> str:
+    if not isinstance(value, str):
+        return fallback
+    normalized = " ".join(value.split())
+    return normalized[:_MAX_TEXT]
+
+
+def _pointer(document: dict[str, Any], reference: str) -> Any:
+    if not reference.startswith("#/"):
+        raise VSDOpenAPIError("external_reference")
+    current: Any = document
+    for raw_token in reference[2:].split("/"):
+        token = raw_token.replace("~1", "/").replace("~0", "~")
+        if not isinstance(current, dict) or token not in current:
+            raise VSDOpenAPIError("unresolved_local_reference")
+        current = current[token]
+    return current
+
+
+def _resolved_object(
+    value: Any, document: dict[str, Any], *, kind: str
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise VSDOpenAPIError(f"{kind}_not_object")
+    reference = value.get("$ref")
+    if reference is None:
+        return value
+    if not isinstance(reference, str):
+        raise VSDOpenAPIError("invalid_reference")
+    target = _pointer(document, reference)
+    if not isinstance(target, dict):
+        raise VSDOpenAPIError(f"referenced_{kind}_not_object")
+    merged = copy.deepcopy(target)
+    merged.update({key: child for key, child in value.items() if key != "$ref"})
+    return merged
+
+
+def _schema_closure(schema: Any, document: dict[str, Any]) -> dict[str, Any]:
+    """Convert an OpenAPI schema into a self-contained JSON Schema."""
+    if schema is True:
+        return {}
+    if schema is False:
+        return {"not": {}}
+    if not isinstance(schema, dict):
+        raise VSDOpenAPIError("response_schema_missing")
+    definitions: dict[str, Any] = {}
+    active: set[str] = set()
+
+    def convert(node: Any) -> Any:
+        if isinstance(node, list):
+            return [convert(child) for child in node]
+        if not isinstance(node, dict):
+            return copy.deepcopy(node)
+        reference = node.get("$ref")
+        converted: dict[str, Any] = {}
+        if reference is not None:
+            if not isinstance(reference, str) or not reference.startswith(
+                "#/components/schemas/"
+            ):
+                raise VSDOpenAPIError("external_or_unsupported_schema_reference")
+            name = reference.removeprefix("#/components/schemas/")
+            if not name or "/" in name:
+                raise VSDOpenAPIError("unsupported_schema_reference")
+            converted["$ref"] = f"#/$defs/{name}"
+            if name not in definitions and name not in active:
+                active.add(name)
+                target = _pointer(document, reference)
+                definitions[name] = convert(target)
+                active.remove(name)
+
+        for key, child in node.items():
+            if key in {"$ref", "discriminator", "example", "externalDocs", "xml"}:
+                continue
+            if key == "nullable":
+                continue
+            converted[key] = convert(child)
+
+        if node.get("nullable") is True:
+            schema_type = converted.get("type")
+            if isinstance(schema_type, str) and schema_type in _JSON_TYPES:
+                converted["type"] = [schema_type, "null"]
+            elif isinstance(schema_type, list) and "null" not in schema_type:
+                converted["type"] = [*schema_type, "null"]
+            else:
+                converted = {"anyOf": [converted, {"type": "null"}]}
+        if node.get("exclusiveMinimum") is True and isinstance(
+            node.get("minimum"), (int, float)
+        ):
+            converted["exclusiveMinimum"] = node["minimum"]
+            converted.pop("minimum", None)
+        if node.get("exclusiveMaximum") is True and isinstance(
+            node.get("maximum"), (int, float)
+        ):
+            converted["exclusiveMaximum"] = node["maximum"]
+            converted.pop("maximum", None)
+        return converted
+
+    root = convert(schema)
+    if definitions:
+        root["$defs"] = definitions
+    try:
+        _schema_validator(root, field="OpenAPI schema")
+    except VSDDynamicRESTError as exc:
+        raise VSDOpenAPIError(str(exc)) from exc
+    return root
+
+
+def _server_url(
+    operation: dict[str, Any],
+    path_item: dict[str, Any],
+    document: dict[str, Any],
+    *,
+    server_index: int,
+) -> str:
+    servers = operation.get(
+        "servers", path_item.get("servers", document.get("servers"))
+    )
+    if not isinstance(servers, list) or not servers:
+        raise VSDOpenAPIError("server_missing")
+    if len(servers) > _MAX_SERVERS:
+        raise VSDOpenAPIError("too_many_servers")
+    if not 0 <= server_index < len(servers):
+        raise VSDOpenAPIError("server_index_out_of_range")
+    server = servers[server_index]
+    if not isinstance(server, dict) or not isinstance(server.get("url"), str):
+        raise VSDOpenAPIError("server_invalid")
+    url = server["url"]
+    variables = server.get("variables", {})
+    if not isinstance(variables, dict):
+        raise VSDOpenAPIError("server_variables_invalid")
+    for name in _PATH_TOKEN_RE.findall(url):
+        definition = variables.get(name)
+        default = definition.get("default") if isinstance(definition, dict) else None
+        if not isinstance(default, (str, int, float, bool)):
+            raise VSDOpenAPIError("server_variable_default_missing")
+        url = url.replace("{" + name + "}", str(default))
+    parsed = urlsplit(url)
+    if (
+        parsed.scheme.casefold() != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise VSDOpenAPIError("server_must_be_plain_https")
+    return url.rstrip("/")
+
+
+def _argument_name(provider_name: str, location: str, used: set[str]) -> str:
+    base = re.sub(r"[^A-Za-z0-9_]+", "_", provider_name).strip("_")
+    if not base or not base[0].isalpha():
+        base = f"param_{base}"
+    base = base[:64]
+    if not _ARGUMENT_RE.fullmatch(base):
+        base = f"parameter_{hashlib.sha256(provider_name.encode()).hexdigest()[:8]}"
+    candidate = base
+    if candidate in used:
+        suffix = hashlib.sha256(f"{location}:{provider_name}".encode()).hexdigest()[:8]
+        candidate = f"{base[:55]}_{suffix}"
+    if candidate in used:
+        raise VSDOpenAPIError("parameter_name_collision")
+    used.add(candidate)
+    return candidate
+
+
+def _parameters(
+    operation: dict[str, Any], path_item: dict[str, Any], document: dict[str, Any]
+) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    raw_parameters = [
+        *(path_item.get("parameters", []) or []),
+        *(operation.get("parameters", []) or []),
+    ]
+    if not isinstance(raw_parameters, list) or len(raw_parameters) > _MAX_PARAMETERS:
+        raise VSDOpenAPIError("parameters_invalid_or_excessive")
+    by_identity: dict[tuple[str, str], dict[str, Any]] = {}
+    blockers: list[str] = []
+    warnings: list[str] = []
+    for raw in raw_parameters:
+        try:
+            parameter = _resolved_object(raw, document, kind="parameter")
+        except VSDOpenAPIError as exc:
+            blockers.append(str(exc))
+            continue
+        name, location = parameter.get("name"), parameter.get("in")
+        if (
+            not isinstance(name, str)
+            or not name
+            or location
+            not in {
+                "cookie",
+                "header",
+                "path",
+                "query",
+            }
+        ):
+            blockers.append("parameter_identity_invalid")
+            continue
+        if not _PROVIDER_PARAMETER_RE.fullmatch(name):
+            blockers.append(f"unsupported_parameter_name:{location}:{name}")
+            continue
+        if location == "path" and not _ARGUMENT_RE.fullmatch(name):
+            blockers.append(f"unsupported_path_parameter_name:{name}")
+            continue
+        by_identity[(location, name)] = parameter
+
+    used: set[str] = set()
+    normalized: list[dict[str, Any]] = []
+    for (location, name), parameter in by_identity.items():
+        required = parameter.get("required") is True or location == "path"
+        if location not in {"path", "query"}:
+            message = f"unsupported_{location}_parameter:{name}"
+            (blockers if required else warnings).append(message)
+            continue
+        raw_schema = parameter.get("schema")
+        try:
+            schema = _schema_closure(raw_schema, document)
+        except VSDOpenAPIError as exc:
+            blockers.append(f"parameter_schema:{name}:{exc}")
+            continue
+        schema_type = schema.get("type")
+        if schema_type == "object" or (schema_type == "array" and location == "path"):
+            blockers.append(f"unsupported_parameter_shape:{location}:{name}")
+            continue
+        style = parameter.get("style", "simple" if location == "path" else "form")
+        explode = parameter.get("explode", style == "form")
+        if location == "query" and style not in {
+            "form",
+            "pipeDelimited",
+            "spaceDelimited",
+        }:
+            blockers.append(f"unsupported_query_style:{name}:{style}")
+            continue
+        normalized.append(
+            {
+                "argument_name": _argument_name(name, location, used),
+                "provider_name": name,
+                "location": location,
+                "required": required,
+                "description": _text(parameter.get("description")),
+                "style": style,
+                "explode": bool(explode),
+                "schema": schema,
+            }
+        )
+    return normalized, sorted(set(blockers)), sorted(set(warnings))
+
+
+def _response_schema(
+    operation: dict[str, Any], document: dict[str, Any]
+) -> tuple[dict[str, Any] | None, str | None, list[str]]:
+    responses = operation.get("responses")
+    if not isinstance(responses, dict):
+        return None, None, ["responses_missing"]
+    success_keys = sorted(
+        str(key) for key in responses if re.fullmatch(r"2[0-9][0-9]", str(key))
+    )
+    if not success_keys:
+        return None, None, ["success_response_missing"]
+    try:
+        response = _resolved_object(
+            responses[success_keys[0]], document, kind="response"
+        )
+    except VSDOpenAPIError as exc:
+        return None, None, [str(exc)]
+    content = response.get("content")
+    if not isinstance(content, dict):
+        return None, None, ["json_response_missing"]
+    media_type = next(
+        (item for item in content if item.casefold() == "application/json"),
+        None,
+    )
+    if media_type is None:
+        media_type = next(
+            (
+                item
+                for item in content
+                if item.casefold().startswith("application/")
+                and item.casefold().endswith("+json")
+            ),
+            None,
+        )
+    if media_type is None or not isinstance(content.get(media_type), dict):
+        return None, None, ["json_response_missing"]
+    try:
+        schema = _schema_closure(content[media_type].get("schema"), document)
+    except VSDOpenAPIError as exc:
+        return None, media_type, [f"response_schema:{exc}"]
+    encoded = json.dumps(schema, separators=(",", ":"), ensure_ascii=True)
+    if len(encoded.encode("utf-8")) > _MAX_RESPONSE_SCHEMA_BYTES:
+        return None, media_type, ["response_schema_too_large"]
+    return schema, media_type, []
+
+
+def _candidate_digest(body: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        body, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def inspect_openapi_document(
+    path: str | Path, *, server_index: int = 0
+) -> dict[str, Any]:
+    """Inspect a local OpenAPI document and return inert operation candidates."""
+    document, document_sha256 = load_openapi_document(path)
+    version = document.get("openapi")
+    if not isinstance(version, str) or not re.fullmatch(
+        r"3\.(?:0|1)(?:\.[0-9]+)?", version
+    ):
+        raise VSDOpenAPIError("Only OpenAPI 3.0 and 3.1 documents are supported")
+    info = document.get("info")
+    if (
+        not isinstance(info, dict)
+        or not isinstance(info.get("title"), str)
+        or not info["title"].strip()
+        or not isinstance(info.get("version"), str)
+        or not info["version"].strip()
+    ):
+        raise VSDOpenAPIError("OpenAPI info.title and info.version are required")
+    paths = document.get("paths")
+    if not isinstance(paths, dict) or not paths or len(paths) > _MAX_PATHS:
+        raise VSDOpenAPIError("OpenAPI paths must contain 1-250 entries")
+
+    candidates: list[dict[str, Any]] = []
+    for path_name, raw_path_item in sorted(paths.items()):
+        if not isinstance(path_name, str) or not path_name.startswith("/"):
+            raise VSDOpenAPIError("OpenAPI path keys must start with '/'")
+        try:
+            path_item = _resolved_object(raw_path_item, document, kind="path_item")
+        except VSDOpenAPIError as exc:
+            raise VSDOpenAPIError(f"Path {path_name!r} is invalid: {exc}") from exc
+        for method in sorted(set(path_item) & _HTTP_METHODS):
+            if len(candidates) >= _MAX_OPERATIONS:
+                raise VSDOpenAPIError("OpenAPI document exceeds the operation limit")
+            raw_operation = path_item[method]
+            blockers: list[str] = []
+            warnings: list[str] = []
+            if not isinstance(raw_operation, dict):
+                blockers.append("operation_not_object")
+                operation: dict[str, Any] = {}
+            else:
+                operation = raw_operation
+            if method != "get":
+                blockers.append("method_not_read_only")
+            if operation.get("deprecated") is True:
+                blockers.append("operation_deprecated")
+            if "requestBody" in operation:
+                blockers.append("request_body_not_supported")
+            if "callbacks" in operation:
+                blockers.append("callbacks_not_supported")
+            security = operation.get("security", document.get("security", []))
+            if security not in (None, []):
+                blockers.append("authentication_required")
+            try:
+                server_url = _server_url(
+                    operation, path_item, document, server_index=server_index
+                )
+            except VSDOpenAPIError as exc:
+                server_url = ""
+                blockers.append(str(exc))
+            parameters, parameter_blockers, parameter_warnings = _parameters(
+                operation, path_item, document
+            )
+            blockers.extend(parameter_blockers)
+            warnings.extend(parameter_warnings)
+            tokens = _PATH_TOKEN_RE.findall(path_name)
+            mapped_tokens = {
+                item["provider_name"]
+                for item in parameters
+                if item["location"] == "path"
+            }
+            if len(tokens) != len(set(tokens)) or set(tokens) != mapped_tokens:
+                blockers.append("path_parameters_do_not_match_template")
+            response_schema, response_media_type, response_blockers = _response_schema(
+                operation, document
+            )
+            blockers.extend(response_blockers)
+            operation_id = operation.get("operationId")
+            if not isinstance(operation_id, str) or not operation_id.strip():
+                operation_id = f"{method}_{path_name}"
+                warnings.append("operation_id_missing")
+            candidate_body = {
+                "format": "vsd_openapi_operation_v1",
+                "version": _FORMAT_VERSION,
+                "approval_state": "unreviewed_candidate",
+                "execution_allowed": False,
+                "metadata_trust": "untrusted_openapi_metadata",
+                "source_document_sha256": document_sha256,
+                "openapi_version": version,
+                "api_title": _text(info["title"]),
+                "api_version": _text(info["version"]),
+                "server_url": server_url,
+                "path": path_name,
+                "method": method.upper(),
+                "operation_id": _text(operation_id),
+                "summary": _text(operation.get("summary"), fallback=operation_id),
+                "description": _text(operation.get("description")),
+                "tags": [
+                    _text(tag)
+                    for tag in operation.get("tags", [])
+                    if isinstance(tag, str)
+                ][:20],
+                "parameters": parameters,
+                "response_media_type": response_media_type,
+                "response_schema": response_schema,
+                "blockers": sorted(set(blockers)),
+                "warnings": sorted(set(warnings)),
+            }
+            digest = _candidate_digest(candidate_body)
+            candidates.append(
+                {
+                    **candidate_body,
+                    "candidate_id": digest[:16],
+                    "candidate_sha256": digest,
+                }
+            )
+    return {
+        "format": "vsd_openapi_inspection_v1",
+        "version": _FORMAT_VERSION,
+        "source_file": Path(path).name,
+        "source_document_sha256": document_sha256,
+        "openapi_version": version,
+        "api_title": _text(info["title"]),
+        "api_version": _text(info["version"]),
+        "candidate_count": len(candidates),
+        "promotable_count": sum(not item["blockers"] for item in candidates),
+        "blocked_count": sum(bool(item["blockers"]) for item in candidates),
+        "candidates": candidates,
+    }
+
+
+def validate_openapi_candidate(candidate: Any) -> dict[str, Any]:
+    """Validate the integrity and inert state of one inspection candidate."""
+    if not isinstance(candidate, dict):
+        raise VSDOpenAPIError("OpenAPI candidate must be an object")
+    if (
+        candidate.get("format") != "vsd_openapi_operation_v1"
+        or candidate.get("version") != _FORMAT_VERSION
+        or candidate.get("approval_state") != "unreviewed_candidate"
+        or candidate.get("execution_allowed") is not False
+        or candidate.get("metadata_trust") != "untrusted_openapi_metadata"
+    ):
+        raise VSDOpenAPIError("Candidate did not come from the OpenAPI boundary")
+    body = {
+        key: value
+        for key, value in candidate.items()
+        if key not in {"candidate_id", "candidate_sha256"}
+    }
+    digest = _candidate_digest(body)
+    if (
+        candidate.get("candidate_sha256") != digest
+        or candidate.get("candidate_id") != digest[:16]
+    ):
+        raise VSDOpenAPIError("OpenAPI candidate digest does not match its content")
+    if candidate.get("blockers"):
+        raise VSDOpenAPIError(
+            f"OpenAPI candidate is not promotable: {candidate['blockers']!r}"
+        )
+    parameters = candidate.get("parameters")
+    if not isinstance(parameters, list) or len(parameters) > _MAX_PARAMETERS:
+        raise VSDOpenAPIError("OpenAPI candidate parameters are invalid")
+    argument_names: set[str] = set()
+    path_names: set[str] = set()
+    for parameter in parameters:
+        if not isinstance(parameter, dict):
+            raise VSDOpenAPIError("OpenAPI candidate parameter is invalid")
+        argument = parameter.get("argument_name")
+        provider = parameter.get("provider_name")
+        location = parameter.get("location")
+        style = parameter.get("style")
+        explode = parameter.get("explode")
+        if (
+            not isinstance(argument, str)
+            or not _ARGUMENT_RE.fullmatch(argument)
+            or argument in argument_names
+            or not isinstance(provider, str)
+            or not _PROVIDER_PARAMETER_RE.fullmatch(provider)
+            or location not in {"path", "query"}
+            or type(parameter.get("required")) is not bool
+            or type(explode) is not bool
+            or (location == "path" and style != "simple")
+            or (
+                location == "query"
+                and style not in {"form", "pipeDelimited", "spaceDelimited"}
+            )
+            or (style != "form" and explode)
+        ):
+            raise VSDOpenAPIError("OpenAPI candidate parameter contract is invalid")
+        try:
+            _schema_validator(parameter.get("schema"), field=f"parameter {argument}")
+        except VSDDynamicRESTError as exc:
+            raise VSDOpenAPIError(
+                f"OpenAPI candidate parameter {argument!r} has an invalid schema"
+            ) from exc
+        argument_names.add(argument)
+        if location == "path":
+            path_names.add(provider)
+    try:
+        parsed = urlsplit(candidate["server_url"])
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+            or candidate.get("method") != "GET"
+            or not isinstance(candidate.get("path"), str)
+            or not candidate["path"].startswith("/")
+            or set(_PATH_TOKEN_RE.findall(candidate["path"])) != path_names
+            or candidate.get("response_media_type") is None
+            or not (
+                candidate["response_media_type"].casefold() == "application/json"
+                or candidate["response_media_type"].casefold().endswith("+json")
+            )
+            or not re.fullmatch(
+                r"[0-9a-f]{64}", str(candidate.get("source_document_sha256", ""))
+            )
+        ):
+            raise KeyError
+        _schema_validator(candidate.get("response_schema"), field="response_schema")
+    except (KeyError, TypeError, VSDDynamicRESTError) as exc:
+        raise VSDOpenAPIError("OpenAPI candidate operation is invalid") from exc
+    return copy.deepcopy(candidate)
+
+
+def select_openapi_candidate(report: Any, candidate_id: str | None) -> dict[str, Any]:
+    """Select exactly one operation from an inspection report or direct candidate."""
+    if isinstance(report, dict) and report.get("format") == "vsd_openapi_operation_v1":
+        if candidate_id is not None and report.get("candidate_id") != candidate_id:
+            raise VSDOpenAPIError("Requested candidate ID is not present")
+        return validate_openapi_candidate(report)
+    candidates = report.get("candidates") if isinstance(report, dict) else None
+    if not isinstance(candidates, list):
+        raise VSDOpenAPIError("OpenAPI inspection report is invalid")
+    matches = [
+        item
+        for item in candidates
+        if candidate_id is None or item.get("candidate_id") == candidate_id
+    ]
+    if len(matches) != 1:
+        raise VSDOpenAPIError("Select exactly one OpenAPI candidate by candidate ID")
+    return validate_openapi_candidate(matches[0])
+
+
+__all__ = [
+    "VSDOpenAPIError",
+    "inspect_openapi_document",
+    "load_openapi_document",
+    "select_openapi_candidate",
+    "validate_openapi_candidate",
+]

--- a/src/tooluniverse/vsd_promotion.py
+++ b/src/tooluniverse/vsd_promotion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import os
@@ -14,6 +15,8 @@ from pathlib import Path
 from typing import Any, Iterator
 from urllib.parse import urlsplit
 
+from jsonschema.exceptions import ValidationError
+
 from .execute_function import ToolUniverse
 from .vsd_dynamic_rest import (
     VSDDynamicRESTError,
@@ -21,6 +24,7 @@ from .vsd_dynamic_rest import (
     register_reviewed_rest_tool,
 )
 from .vsd_tool import _acquire_process_lock, _release_process_lock
+from .vsd_openapi import VSDOpenAPIError, validate_openapi_candidate
 
 _PROMOTION_VERSION = 1
 _GENERATOR_VERSION = 1
@@ -329,6 +333,13 @@ def create_draft(
         return_fields=return_fields,
         max_records=max_records,
     )
+    return _create_draft_from_config(config, workspace=workspace)
+
+
+def _create_draft_from_config(
+    config: dict[str, Any], *, workspace: str | Path | None = None
+) -> dict[str, Any]:
+    """Persist one already-validated generated configuration as an inert draft."""
     digest = operation_digest(config)
     slug = re.sub(r"[^a-z0-9]+", "_", config["name"].casefold()).strip("_")
     draft_id = f"{slug}_{digest[:12]}"
@@ -356,6 +367,228 @@ def create_draft(
             return existing
         _atomic_write_json(path, record)
     return record
+
+
+def _hoist_schema_definitions(
+    schema: dict[str, Any], definitions: dict[str, Any]
+) -> dict[str, Any]:
+    normalized = copy.deepcopy(schema)
+    nested = normalized.pop("$defs", {})
+    if not isinstance(nested, dict):
+        raise VSDPromotionError("OpenAPI schema definitions must be an object")
+    for name, definition in nested.items():
+        existing = definitions.get(name)
+        if existing is not None and existing != definition:
+            raise VSDPromotionError(
+                f"OpenAPI schema definition {name!r} is inconsistent"
+            )
+        definitions[name] = definition
+    return normalized
+
+
+def build_openapi_tool_config(
+    candidate: dict[str, Any],
+    *,
+    tool_name: str,
+    description: str,
+    include_parameters: list[str] | None = None,
+    fixed_query: dict[str, Any] | None = None,
+    timeout_seconds: int | float = 20,
+) -> dict[str, Any]:
+    """Generate one narrow read-only tool from an inspected OpenAPI operation."""
+    try:
+        reviewed = validate_openapi_candidate(candidate)
+    except VSDOpenAPIError as exc:
+        raise VSDPromotionError(str(exc)) from exc
+    name = _tool_name(tool_name)
+    reviewed_description = _review_text(
+        description, field="description", minimum=20, maximum=1000
+    )
+    parameters = reviewed.get("parameters")
+    if not isinstance(parameters, list):
+        raise VSDPromotionError("OpenAPI candidate parameters are invalid")
+    indexed = {
+        parameter.get("argument_name"): parameter
+        for parameter in parameters
+        if isinstance(parameter, dict)
+        and isinstance(parameter.get("argument_name"), str)
+    }
+    if len(indexed) != len(parameters):
+        raise VSDPromotionError("OpenAPI candidate argument names must be unique")
+    required_names = {
+        parameter["argument_name"]
+        for parameter in parameters
+        if parameter.get("required") is True
+    }
+    if include_parameters is None:
+        selected_names = set(required_names)
+    elif (
+        not isinstance(include_parameters, list)
+        or len(include_parameters) != len(set(include_parameters))
+        or any(not isinstance(item, str) for item in include_parameters)
+    ):
+        raise VSDPromotionError("include_parameters must contain unique names")
+    else:
+        selected_names = set(include_parameters)
+    unknown = selected_names - set(indexed)
+    if unknown:
+        raise VSDPromotionError(f"Unknown OpenAPI parameters: {sorted(unknown)!r}")
+
+    fixed = {} if fixed_query is None else copy.deepcopy(fixed_query)
+    if not isinstance(fixed, dict):
+        raise VSDPromotionError("fixed_query must be an object")
+    provider_index = {
+        parameter["provider_name"]: parameter
+        for parameter in parameters
+        if parameter.get("location") == "query"
+    }
+    unknown_fixed = set(fixed) - set(provider_index)
+    if unknown_fixed:
+        raise VSDPromotionError(
+            f"Unknown fixed OpenAPI query parameters: {sorted(unknown_fixed)!r}"
+        )
+    for provider_name, value in fixed.items():
+        parameter = provider_index[provider_name]
+        if parameter["argument_name"] in selected_names:
+            raise VSDPromotionError(
+                f"OpenAPI query parameter {provider_name!r} cannot be fixed and exposed"
+            )
+        try:
+            from .vsd_dynamic_rest import _schema_validator
+
+            _schema_validator(
+                parameter["schema"], field=f"fixed query {provider_name}"
+            ).validate(value)
+        except (VSDDynamicRESTError, ValidationError) as exc:
+            raise VSDPromotionError(
+                f"Fixed OpenAPI query parameter {provider_name!r} is invalid"
+            ) from exc
+    unsatisfied = {
+        parameter["argument_name"]
+        for parameter in parameters
+        if parameter.get("required") is True
+        and parameter["argument_name"] not in selected_names
+        and not (
+            parameter.get("location") == "query"
+            and parameter.get("provider_name") in fixed
+        )
+    }
+    if unsatisfied:
+        raise VSDPromotionError(
+            f"Required OpenAPI parameters are not supplied: {sorted(unsatisfied)!r}"
+        )
+    if (
+        isinstance(timeout_seconds, bool)
+        or not isinstance(timeout_seconds, (int, float))
+        or not 1 <= timeout_seconds <= 60
+    ):
+        raise VSDPromotionError("timeout_seconds must be between 1 and 60")
+
+    input_definitions: dict[str, Any] = {}
+    properties: dict[str, Any] = {}
+    path_arguments: dict[str, str] = {}
+    query_arguments: dict[str, str] = {}
+    query_serialization: dict[str, dict[str, Any]] = {}
+    for parameter in parameters:
+        argument = parameter["argument_name"]
+        if argument not in selected_names:
+            continue
+        schema = _hoist_schema_definitions(parameter["schema"], input_definitions)
+        if parameter.get("description") and "description" not in schema:
+            schema["description"] = parameter["description"]
+        properties[argument] = schema
+        if parameter["location"] == "path":
+            path_arguments[argument] = parameter["provider_name"]
+        else:
+            query_arguments[argument] = parameter["provider_name"]
+            query_serialization[argument] = {
+                "style": parameter["style"],
+                "explode": parameter["explode"],
+            }
+
+    input_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "required": sorted(required_names & selected_names),
+        "additionalProperties": False,
+    }
+    if input_definitions:
+        input_schema["$defs"] = input_definitions
+
+    response_schema = copy.deepcopy(reviewed["response_schema"])
+    return_definitions = response_schema.pop("$defs", {})
+    return_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "result": response_schema,
+            "provenance": {"type": "object"},
+        },
+        "required": ["result", "provenance"],
+        "additionalProperties": False,
+    }
+    if return_definitions:
+        return_schema["$defs"] = return_definitions
+    endpoint = reviewed["server_url"] + "/" + reviewed["path"].lstrip("/")
+    return {
+        "name": name,
+        "type": "VSDDynamicRESTTool",
+        "description": reviewed_description,
+        "category": "special_tools",
+        "cacheable": False,
+        "mcp_annotations": {"readOnlyHint": True, "destructiveHint": False},
+        "parameter": input_schema,
+        "return_schema": return_schema,
+        "vsd_operation": {
+            "version": 1,
+            "method": "GET",
+            "endpoint": endpoint,
+            "path_arguments": path_arguments,
+            "query_arguments": query_arguments,
+            "query_serialization": query_serialization,
+            "fixed_query": fixed,
+            "timeout_seconds": timeout_seconds,
+            "auth": {"type": "none"},
+            "response_schema": reviewed["response_schema"],
+        },
+        "vsd_promotion": {
+            "generator_version": _GENERATOR_VERSION,
+            "source_type": "openapi",
+            "candidate_id": reviewed["candidate_id"],
+            "candidate_sha256": reviewed["candidate_sha256"],
+            "source_document_sha256": reviewed["source_document_sha256"],
+            "openapi_version": reviewed["openapi_version"],
+            "api_title": reviewed["api_title"],
+            "api_version": reviewed["api_version"],
+            "operation_id": reviewed["operation_id"],
+            "method": reviewed["method"],
+            "path": reviewed["path"],
+            "response_media_type": reviewed["response_media_type"],
+            "included_parameters": sorted(selected_names),
+            "fixed_query": fixed,
+        },
+    }
+
+
+def create_openapi_draft(
+    candidate: dict[str, Any],
+    *,
+    tool_name: str,
+    description: str,
+    include_parameters: list[str] | None = None,
+    fixed_query: dict[str, Any] | None = None,
+    timeout_seconds: int | float = 20,
+    workspace: str | Path | None = None,
+) -> dict[str, Any]:
+    """Create an inert, content-addressed draft from one OpenAPI candidate."""
+    config = build_openapi_tool_config(
+        candidate,
+        tool_name=tool_name,
+        description=description,
+        include_parameters=include_parameters,
+        fixed_query=fixed_query,
+        timeout_seconds=timeout_seconds,
+    )
+    return _create_draft_from_config(config, workspace=workspace)
 
 
 def _load_draft(root: Path, draft_id: str) -> dict[str, Any]:
@@ -389,20 +622,33 @@ def _validated_cases(cases: Any) -> list[dict[str, Any]]:
         expect = case.get("expect")
         if not isinstance(expect, dict):
             raise VSDPromotionError(f"Verification case {index} requires expectations")
-        minimum = expect.get("min_items")
-        maximum = expect.get("max_items")
+        result_type = expect.get("result_type", "array")
+        minimum = expect.get("min_items") if result_type == "array" else None
+        maximum = expect.get("max_items") if result_type == "array" else None
         fields = expect.get("required_fields")
         equals = expect.get("equals", {})
+        required_paths = expect.get("required_paths", [])
+        equals_paths = expect.get("equals_paths", {})
         if (
-            isinstance(minimum, bool)
-            or not isinstance(minimum, int)
-            or minimum < 0
-            or isinstance(maximum, bool)
-            or not isinstance(maximum, int)
-            or maximum < minimum
-            or maximum > 100
+            result_type not in {"array", "object"}
+            or (
+                result_type == "array"
+                and (
+                    isinstance(minimum, bool)
+                    or not isinstance(minimum, int)
+                    or minimum < 0
+                    or isinstance(maximum, bool)
+                    or not isinstance(maximum, int)
+                    or maximum < minimum
+                    or maximum > 100
+                )
+            )
+            or (
+                result_type == "object"
+                and ("min_items" in expect or "max_items" in expect)
+            )
             or not isinstance(fields, list)
-            or not fields
+            or (not fields and not required_paths)
             or any(
                 not isinstance(field, str) or not _FIELD_RE.fullmatch(field)
                 for field in fields
@@ -412,22 +658,73 @@ def _validated_cases(cases: Any) -> list[dict[str, Any]]:
                 not isinstance(field, str) or not _FIELD_RE.fullmatch(field)
                 for field in equals
             )
+            or not isinstance(required_paths, list)
+            or any(not _valid_json_pointer(path) for path in required_paths)
+            or len(required_paths) != len(set(required_paths))
+            or not isinstance(equals_paths, dict)
+            or any(not _valid_json_pointer(path) for path in equals_paths)
         ):
             raise VSDPromotionError(
                 f"Verification case {index} has invalid expectations"
+            )
+        try:
+            encoded_expectations = json.dumps(
+                {"equals": equals, "equals_paths": equals_paths},
+                allow_nan=False,
+                ensure_ascii=True,
+            )
+        except (TypeError, ValueError) as exc:
+            raise VSDPromotionError(
+                f"Verification case {index} expectations must be finite JSON"
+            ) from exc
+        if len(encoded_expectations.encode("utf-8")) > 16_384:
+            raise VSDPromotionError(
+                f"Verification case {index} expectations exceed 16 KiB"
             )
         validated.append(
             {
                 "arguments": dict(case["arguments"]),
                 "expect": {
+                    "result_type": result_type,
                     "min_items": minimum,
                     "max_items": maximum,
                     "required_fields": list(fields),
                     "equals": dict(equals),
+                    "required_paths": list(required_paths),
+                    "equals_paths": dict(equals_paths),
                 },
             }
         )
     return validated
+
+
+_POINTER_MISSING = object()
+
+
+def _valid_json_pointer(value: Any) -> bool:
+    if not isinstance(value, str) or not value.startswith("/") or len(value) > 512:
+        return False
+    if any(ord(character) < 32 for character in value):
+        return False
+    return all(not re.search(r"~(?:[^01]|$)", token) for token in value.split("/")[1:])
+
+
+def _json_pointer_value(document: Any, pointer: str) -> Any:
+    current = document
+    for raw_token in pointer.split("/")[1:]:
+        token = raw_token.replace("~1", "/").replace("~0", "~")
+        if isinstance(current, dict):
+            if token not in current:
+                return _POINTER_MISSING
+            current = current[token]
+        elif isinstance(current, list) and token.isdigit():
+            index = int(token)
+            if index >= len(current):
+                return _POINTER_MISSING
+            current = current[index]
+        else:
+            return _POINTER_MISSING
+    return current
 
 
 def verify_draft(
@@ -454,15 +751,20 @@ def verify_draft(
                     f"Verification case {index} did not execute successfully: {response!r}"
                 )
             envelope = response.get("data")
-            rows = envelope.get("result") if isinstance(envelope, dict) else None
+            result = envelope.get("result") if isinstance(envelope, dict) else None
             provenance = (
                 envelope.get("provenance") if isinstance(envelope, dict) else None
             )
-            if not isinstance(rows, list) or not isinstance(provenance, dict):
+            expectation = case["expect"]
+            result_type = expectation["result_type"]
+            if (
+                (result_type == "array" and not isinstance(result, list))
+                or (result_type == "object" and not isinstance(result, dict))
+                or not isinstance(provenance, dict)
+            ):
                 raise VSDPromotionError(
                     f"Verification case {index} returned an invalid evidence envelope"
                 )
-            expectation = case["expect"]
             if (
                 provenance.get("operation_sha256") != draft["operation_sha256"]
                 or provenance.get("http_status") != 200
@@ -474,7 +776,10 @@ def verify_draft(
                 raise VSDPromotionError(
                     f"Verification case {index} returned invalid provenance"
                 )
-            if not expectation["min_items"] <= len(rows) <= expectation["max_items"]:
+            rows = result if result_type == "array" else [result]
+            if result_type == "array" and not (
+                expectation["min_items"] <= len(rows) <= expectation["max_items"]
+            ):
                 raise VSDPromotionError(
                     f"Verification case {index} returned {len(rows)} rows outside "
                     f"{expectation['min_items']}..{expectation['max_items']}"
@@ -487,7 +792,7 @@ def verify_draft(
                 missing = [
                     field
                     for field in expectation["required_fields"]
-                    if not row.get(field)
+                    if field not in row or row[field] is None
                 ]
                 if missing:
                     raise VSDPromotionError(
@@ -502,12 +807,34 @@ def verify_draft(
                     raise VSDPromotionError(
                         f"Verification case {index} row {row_index} failed equality assertions"
                     )
+                missing_paths = [
+                    pointer
+                    for pointer in expectation["required_paths"]
+                    if _json_pointer_value(row, pointer) is _POINTER_MISSING
+                    or _json_pointer_value(row, pointer) is None
+                ]
+                if missing_paths:
+                    raise VSDPromotionError(
+                        f"Verification case {index} row {row_index} lacks values "
+                        f"for JSON pointers {missing_paths!r}"
+                    )
+                mismatched_paths = {
+                    pointer: _json_pointer_value(row, pointer)
+                    for pointer, expected in expectation["equals_paths"].items()
+                    if _json_pointer_value(row, pointer) != expected
+                }
+                if mismatched_paths:
+                    raise VSDPromotionError(
+                        f"Verification case {index} row {row_index} failed JSON "
+                        "pointer equality assertions"
+                    )
             results.append(
                 {
                     "case_index": index,
                     "arguments": case["arguments"],
                     "expect": expectation,
-                    "row_count": len(rows),
+                    "result_type": result_type,
+                    "row_count": len(rows) if result_type == "array" else None,
                     "observed_fields": sorted(
                         {
                             field
@@ -743,8 +1070,10 @@ def list_promotion_state(
 __all__ = [
     "VSDPromotionError",
     "approve_draft",
+    "build_openapi_tool_config",
     "build_socrata_tool_config",
     "create_draft",
+    "create_openapi_draft",
     "list_promotion_state",
     "load_published_tools",
     "publish_draft",

--- a/src/tooluniverse/vsd_promotion_cli.py
+++ b/src/tooluniverse/vsd_promotion_cli.py
@@ -7,9 +7,11 @@ import json
 from pathlib import Path
 from typing import Any, Sequence
 
+from .vsd_openapi import inspect_openapi_document, select_openapi_candidate
 from .vsd_promotion import (
     approve_draft,
     create_draft,
+    create_openapi_draft,
     list_promotion_state,
     publish_draft,
     verify_draft,
@@ -49,6 +51,19 @@ def build_parser() -> argparse.ArgumentParser:
     draft.add_argument("--return-fields", required=True, type=_csv)
     draft.add_argument("--max-records", type=int, default=25)
 
+    inspect_openapi = commands.add_parser("inspect-openapi")
+    inspect_openapi.add_argument("spec_file", type=Path)
+    inspect_openapi.add_argument("--server-index", type=int, default=0)
+
+    draft_openapi = commands.add_parser("draft-openapi")
+    draft_openapi.add_argument("candidate_file", type=Path)
+    draft_openapi.add_argument("--candidate-id")
+    draft_openapi.add_argument("--tool-name", required=True)
+    draft_openapi.add_argument("--description", required=True)
+    draft_openapi.add_argument("--include-parameters", type=_csv)
+    draft_openapi.add_argument("--fixed-query-file", type=Path)
+    draft_openapi.add_argument("--timeout-seconds", type=float, default=20)
+
     verify = commands.add_parser("verify")
     verify.add_argument("draft_id")
     verify.add_argument("cases_file", type=Path)
@@ -85,6 +100,29 @@ def _execute(namespace: argparse.Namespace) -> Any:
             filter_fields=namespace.filter_fields,
             return_fields=namespace.return_fields,
             max_records=namespace.max_records,
+            workspace=workspace,
+        )
+    if namespace.command == "inspect-openapi":
+        return inspect_openapi_document(
+            namespace.spec_file, server_index=namespace.server_index
+        )
+    if namespace.command == "draft-openapi":
+        report = _json_file(namespace.candidate_file)
+        candidate = select_openapi_candidate(report, namespace.candidate_id)
+        fixed_query = (
+            _json_file(namespace.fixed_query_file)
+            if namespace.fixed_query_file is not None
+            else None
+        )
+        if fixed_query is not None and not isinstance(fixed_query, dict):
+            raise argparse.ArgumentTypeError("fixed query file must contain an object")
+        return create_openapi_draft(
+            candidate,
+            tool_name=namespace.tool_name,
+            description=namespace.description,
+            include_parameters=namespace.include_parameters,
+            fixed_query=fixed_query,
+            timeout_seconds=namespace.timeout_seconds,
             workspace=workspace,
         )
     if namespace.command == "verify":

--- a/tests/unit/test_vsd_openapi.py
+++ b/tests/unit/test_vsd_openapi.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+
+import pytest
+import yaml
+
+from tooluniverse import ToolUniverse
+from tooluniverse import vsd_dynamic_rest, vsd_promotion
+from tooluniverse.vsd_openapi import (
+    VSDOpenAPIError,
+    inspect_openapi_document,
+    select_openapi_candidate,
+    validate_openapi_candidate,
+)
+from tooluniverse.vsd_promotion_cli import _execute, build_parser
+
+pytestmark = pytest.mark.unit
+
+
+def _document() -> dict:
+    return {
+        "openapi": "3.0.3",
+        "info": {"title": "Reviewed Trial Registry", "version": "2.4.0"},
+        "servers": [{"url": "https://clinicaltrials.gov/api/v2"}],
+        "paths": {
+            "/studies/{nctId}": {
+                "get": {
+                    "operationId": "fetchStudy",
+                    "summary": "Single Study",
+                    "parameters": [
+                        {
+                            "name": "nctId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {
+                                "type": "string",
+                                "pattern": "^[Nn][Cc][Tt][0-9]{8}$",
+                            },
+                        },
+                        {
+                            "name": "fields",
+                            "in": "query",
+                            "style": "pipeDelimited",
+                            "explode": False,
+                            "schema": {
+                                "type": "array",
+                                "minItems": 1,
+                                "maxItems": 5,
+                                "items": {"type": "string"},
+                            },
+                        },
+                        {
+                            "name": "format",
+                            "in": "query",
+                            "schema": {
+                                "type": "string",
+                                "enum": ["csv", "json"],
+                                "default": "json",
+                            },
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "OK",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Study"}
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Study": {
+                    "type": "object",
+                    "properties": {
+                        "nctId": {"$ref": "#/components/schemas/NctId"},
+                        "status": {"type": "string"},
+                        "enrollment": {"type": "integer", "nullable": True},
+                    },
+                    "required": ["nctId", "status"],
+                    "additionalProperties": False,
+                },
+                "NctId": {"type": "string", "minLength": 11, "maxLength": 11},
+            }
+        },
+    }
+
+
+def _write_document(tmp_path, document=None, *, suffix=".json"):
+    value = _document() if document is None else document
+    path = tmp_path / f"registry{suffix}"
+    text = json.dumps(value) if suffix == ".json" else yaml.safe_dump(value)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _candidate(tmp_path):
+    report = inspect_openapi_document(_write_document(tmp_path))
+    assert report["candidate_count"] == 1
+    return report["candidates"][0]
+
+
+def _object_cases():
+    return [
+        {
+            "arguments": {"nctId": nct_id},
+            "expect": {
+                "result_type": "object",
+                "required_fields": ["nctId", "status"],
+                "equals": {"nctId": nct_id},
+                "required_paths": ["/nctId"],
+                "equals_paths": {"/nctId": nct_id},
+            },
+        }
+        for nct_id in ("NCT00522899", "NCT00791154", "NCT01766297")
+    ]
+
+
+def _fake_get(url, params, *, timeout):
+    nct_id = url.rsplit("/", 1)[-1]
+    assert params == {"format": "json"}
+    assert timeout == 20.0
+    payload = {"nctId": nct_id, "status": "COMPLETED", "enrollment": 120}
+    return payload, {
+        "status_code": 200,
+        "content_type": "application/json",
+        "response_bytes": len(json.dumps(payload).encode()),
+        "redirects": 0,
+    }
+
+
+def test_json_and_yaml_documents_produce_equivalent_operation_contracts(tmp_path):
+    json_candidate = inspect_openapi_document(
+        _write_document(tmp_path, suffix=".json")
+    )["candidates"][0]
+    yaml_candidate = inspect_openapi_document(
+        _write_document(tmp_path, suffix=".yaml")
+    )["candidates"][0]
+
+    ignored = {"source_document_sha256", "candidate_id", "candidate_sha256"}
+    assert {k: v for k, v in json_candidate.items() if k not in ignored} == {
+        k: v for k, v in yaml_candidate.items() if k not in ignored
+    }
+    assert json_candidate["blockers"] == []
+    assert json_candidate["parameters"][1]["style"] == "pipeDelimited"
+    assert json_candidate["response_schema"]["$defs"]["Study"]["properties"][
+        "enrollment"
+    ]["type"] == ["integer", "null"]
+
+
+def test_openapi_31_boolean_response_schema_is_supported(tmp_path):
+    document = _document()
+    document["openapi"] = "3.1.1"
+    document["paths"]["/studies/{nctId}"]["get"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"] = True
+    candidate = inspect_openapi_document(_write_document(tmp_path, document))[
+        "candidates"
+    ][0]
+    assert candidate["blockers"] == []
+    assert candidate["response_schema"] == {}
+
+
+@pytest.mark.parametrize(
+    "contents, suffix, message",
+    [
+        ('{"openapi":"3.0.3","openapi":"3.1.0"}', ".json", "duplicate"),
+        (
+            "openapi: 3.0.3\ninfo: &info\n  title: A\n  version: B\ncopy: *info\n",
+            ".yaml",
+            "aliases",
+        ),
+        (
+            "openapi: 3.0.3\ninfo:\n  title: A\n  title: B\n  version: C\n",
+            ".yaml",
+            "duplicate",
+        ),
+    ],
+)
+def test_loader_rejects_ambiguous_json_and_yaml(tmp_path, contents, suffix, message):
+    path = tmp_path / f"bad{suffix}"
+    path.write_text(contents, encoding="utf-8")
+    with pytest.raises(VSDOpenAPIError, match=message):
+        inspect_openapi_document(path)
+
+
+def test_loader_rejects_wrong_version_excessive_depth_and_file_size(tmp_path):
+    wrong = _document()
+    wrong["openapi"] = "2.0"
+    with pytest.raises(VSDOpenAPIError, match="3.0 and 3.1"):
+        inspect_openapi_document(_write_document(tmp_path, wrong))
+
+    deep: dict = {}
+    cursor = deep
+    for _ in range(105):
+        cursor["next"] = {}
+        cursor = cursor["next"]
+    path = tmp_path / "deep.json"
+    path.write_text(json.dumps(deep), encoding="utf-8")
+    with pytest.raises(VSDOpenAPIError, match="depth"):
+        inspect_openapi_document(path)
+
+    large = tmp_path / "large.json"
+    large.write_bytes(b" " * 1_000_001)
+    with pytest.raises(VSDOpenAPIError, match="1 MB"):
+        inspect_openapi_document(large)
+
+
+def test_inspection_exposes_explicit_non_promotable_reasons(tmp_path):
+    document = _document()
+    get = document["paths"]["/studies/{nctId}"]["get"]
+    get["security"] = [{"bearerAuth": []}]
+    get["parameters"].append(
+        {
+            "name": "X-Required",
+            "in": "header",
+            "required": True,
+            "schema": {"type": "string"},
+        }
+    )
+    document["paths"]["/studies/{nctId}"]["post"] = deepcopy(get)
+    report = inspect_openapi_document(_write_document(tmp_path, document))
+
+    by_method = {item["method"]: item for item in report["candidates"]}
+    assert "authentication_required" in by_method["GET"]["blockers"]
+    assert "unsupported_header_parameter:X-Required" in by_method["GET"]["blockers"]
+    assert "method_not_read_only" in by_method["POST"]["blockers"]
+    with pytest.raises(VSDOpenAPIError, match="not promotable"):
+        validate_openapi_candidate(by_method["GET"])
+
+
+def test_external_schema_reference_blocks_only_affected_operation(tmp_path):
+    document = _document()
+    schema = document["paths"]["/studies/{nctId}"]["get"]["responses"]["200"][
+        "content"
+    ]["application/json"]["schema"]
+    schema["$ref"] = "https://example.org/schema.json"
+    report = inspect_openapi_document(_write_document(tmp_path, document))
+    assert report["promotable_count"] == 0
+    assert any(
+        "external_or_unsupported_schema_reference" in blocker
+        for blocker in report["candidates"][0]["blockers"]
+    )
+
+
+def test_candidate_hash_detects_operation_metadata_tampering(tmp_path):
+    candidate = _candidate(tmp_path)
+    candidate["server_url"] = "https://example.org"
+    with pytest.raises(VSDOpenAPIError, match="digest"):
+        validate_openapi_candidate(candidate)
+
+
+def test_candidate_validation_rejects_malformed_rehashed_parameter_contract(tmp_path):
+    candidate = _candidate(tmp_path)
+    candidate["parameters"][1]["style"] = "deepObject"
+    body = {
+        key: value
+        for key, value in candidate.items()
+        if key not in {"candidate_id", "candidate_sha256"}
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            body, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode()
+    ).hexdigest()
+    candidate["candidate_id"] = digest[:16]
+    candidate["candidate_sha256"] = digest
+    with pytest.raises(VSDOpenAPIError, match="parameter contract"):
+        validate_openapi_candidate(candidate)
+
+
+def test_generator_builds_narrow_mappings_and_serialization(tmp_path):
+    config = vsd_promotion.build_openapi_tool_config(
+        _candidate(tmp_path),
+        tool_name="GeneratedTrialRecord",
+        description="Fetch one reviewed trial-registry record by its NCT identifier.",
+        include_parameters=["nctId", "fields"],
+        fixed_query={"format": "json"},
+    )
+    operation = config["vsd_operation"]
+    assert config["parameter"]["required"] == ["nctId"]
+    assert operation["path_arguments"] == {"nctId": "nctId"}
+    assert operation["query_arguments"] == {"fields": "fields"}
+    assert operation["query_serialization"] == {
+        "fields": {"style": "pipeDelimited", "explode": False}
+    }
+    assert operation["fixed_query"] == {"format": "json"}
+
+    endpoint, query = vsd_dynamic_rest._provider_request(
+        config,
+        {"nctId": "NCT00522899", "fields": ["NCTId", "BriefTitle"]},
+    )
+    assert endpoint.endswith("/studies/NCT00522899")
+    assert query == {"format": "json", "fields": "NCTId|BriefTitle"}
+
+
+def test_generator_rejects_unknown_conflicting_and_invalid_fixed_parameters(tmp_path):
+    candidate = _candidate(tmp_path)
+    kwargs = {
+        "candidate": candidate,
+        "tool_name": "GeneratedTrialRecord",
+        "description": "Fetch one reviewed trial-registry record by NCT identifier.",
+    }
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="Unknown OpenAPI"):
+        vsd_promotion.build_openapi_tool_config(
+            **kwargs, include_parameters=["missing"]
+        )
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="fixed and exposed"):
+        vsd_promotion.build_openapi_tool_config(
+            **kwargs,
+            include_parameters=["nctId", "format"],
+            fixed_query={"format": "json"},
+        )
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="is invalid"):
+        vsd_promotion.build_openapi_tool_config(**kwargs, fixed_query={"format": "xml"})
+
+
+def test_openapi_object_operation_completes_promotion_and_fresh_load(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", _fake_get)
+    draft = vsd_promotion.create_openapi_draft(
+        _candidate(tmp_path),
+        tool_name="GeneratedTrialRecord",
+        description="Fetch one reviewed trial-registry record by its NCT identifier.",
+        fixed_query={"format": "json"},
+        workspace=tmp_path / "promotion",
+    )
+    evidence = vsd_promotion.verify_draft(
+        draft["draft_id"], _object_cases(), workspace=tmp_path / "promotion"
+    )
+    approval = vsd_promotion.approve_draft(
+        draft["draft_id"],
+        reviewed_by="Test Reviewer",
+        decision_note="Approved after three distinct trial identifiers passed verification.",
+        workspace=tmp_path / "promotion",
+    )
+    publication = vsd_promotion.publish_draft(
+        draft["draft_id"], workspace=tmp_path / "promotion"
+    )
+
+    tooluniverse = ToolUniverse()
+    try:
+        loaded = vsd_promotion.load_published_tools(
+            tooluniverse, workspace=tmp_path / "promotion"
+        )
+        response = tooluniverse.run_one_function(
+            {
+                "name": "GeneratedTrialRecord",
+                "arguments": {"nctId": "NCT00522899"},
+            },
+            use_cache=False,
+        )
+    finally:
+        tooluniverse.close()
+
+    assert loaded == ["GeneratedTrialRecord"]
+    assert evidence["case_count"] == 3
+    assert all(case["result_type"] == "object" for case in evidence["cases"])
+    assert approval["operation_sha256"] == draft["operation_sha256"]
+    assert publication["config"]["vsd_promotion"]["source_type"] == "openapi"
+    assert response["data"]["result"]["nctId"] == "NCT00522899"
+
+
+def test_cli_inspects_selects_and_creates_openapi_draft(tmp_path):
+    spec_path = _write_document(tmp_path)
+    report = _execute(build_parser().parse_args(["inspect-openapi", str(spec_path)]))
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+    fixed_path = tmp_path / "fixed.json"
+    fixed_path.write_text('{"format":"json"}', encoding="utf-8")
+
+    draft = _execute(
+        build_parser().parse_args(
+            [
+                "--workspace",
+                str(tmp_path / "promotion"),
+                "draft-openapi",
+                str(report_path),
+                "--candidate-id",
+                report["candidates"][0]["candidate_id"],
+                "--tool-name",
+                "GeneratedTrialRecord",
+                "--description",
+                "Fetch one reviewed trial-registry record by its NCT identifier.",
+                "--fixed-query-file",
+                str(fixed_path),
+            ]
+        )
+    )
+    assert draft["config"]["vsd_promotion"]["operation_id"] == "fetchStudy"
+    assert select_openapi_candidate(
+        report, draft["config"]["vsd_promotion"]["candidate_id"]
+    )

--- a/tests/unit/test_vsd_openapi_als_case_study.py
+++ b/tests/unit/test_vsd_openapi_als_case_study.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tooluniverse import vsd_dynamic_rest
+
+pytestmark = pytest.mark.unit
+
+MODULE_PATH = (
+    Path(__file__).parents[2] / "examples" / "vsd" / "openapi_als_case_study.py"
+)
+SPEC = importlib.util.spec_from_file_location("vsd_openapi_als_case_study", MODULE_PATH)
+assert SPEC and SPEC.loader
+study = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = study
+SPEC.loader.exec_module(study)
+
+
+def _specification() -> dict:
+    return {
+        "openapi": "3.0.3",
+        "info": {"title": "ClinicalTrials.gov REST API", "version": "2.0.3"},
+        "servers": [{"url": "https://clinicaltrials.gov/api/v2"}],
+        "paths": {
+            "/studies/{nctId}": {
+                "get": {
+                    "operationId": "fetchStudy",
+                    "summary": "Single Study",
+                    "parameters": [
+                        {
+                            "name": "nctId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {
+                                "type": "string",
+                                "pattern": "^[Nn][Cc][Tt]0*[1-9]\\d{0,7}$",
+                            },
+                        },
+                        {
+                            "name": "format",
+                            "in": "query",
+                            "schema": {
+                                "type": "string",
+                                "enum": ["csv", "json"],
+                            },
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "OK",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Study"}
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Study": {
+                    "type": "object",
+                    "properties": {
+                        "protocolSection": {
+                            "$ref": "#/components/schemas/ProtocolSection"
+                        }
+                    },
+                    "required": ["protocolSection"],
+                },
+                "ProtocolSection": {
+                    "type": "object",
+                    "properties": {
+                        "identificationModule": {"type": "object"},
+                        "statusModule": {"type": "object"},
+                        "conditionsModule": {"type": "object"},
+                        "designModule": {"type": "object"},
+                    },
+                    "required": [
+                        "identificationModule",
+                        "statusModule",
+                        "conditionsModule",
+                    ],
+                },
+            }
+        },
+    }
+
+
+def _payload(nct_id: str) -> dict:
+    return {
+        "protocolSection": {
+            "identificationModule": {
+                "nctId": nct_id,
+                "briefTitle": f"ALS registry study {nct_id}",
+            },
+            "statusModule": {"overallStatus": "COMPLETED"},
+            "conditionsModule": {"conditions": ["Amyotrophic Lateral Sclerosis"]},
+            "designModule": {"phases": ["PHASE2"]},
+        }
+    }
+
+
+def test_openapi_als_case_runs_full_hash_bound_pipeline(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_get(url, params, *, timeout):
+        nct_id = url.rsplit("/", 1)[-1]
+        calls.append(nct_id)
+        assert params == {"format": "json"}
+        assert timeout == 30.0
+        payload = _payload(nct_id)
+        return payload, {
+            "status_code": 200,
+            "content_type": "application/json",
+            "response_bytes": len(json.dumps(payload).encode()),
+            "redirects": 0,
+        }
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", fake_get)
+    spec_path = tmp_path / "ctg-openapi.yaml"
+    spec_path.write_text(yaml.safe_dump(_specification()), encoding="utf-8")
+    snapshot = study.run_case(spec_path=spec_path, workspace=tmp_path / "promotion")
+    output_json = tmp_path / "snapshot.json"
+    output_md = tmp_path / "snapshot.md"
+    study.write_artifacts(snapshot, output_json, output_md)
+
+    assert calls == [*study.ALS_STUDIES, *study.ALS_STUDIES]
+    assert snapshot["inspection"]["candidate_count"] == 1
+    assert snapshot["promotion"]["verification_case_count"] == 3
+    assert [item["nct_id"] for item in snapshot["retrieved_als_records"]] == list(
+        study.ALS_STUDIES
+    )
+    assert all(snapshot["end_to_end_assertions"].values())
+    assert len(snapshot["audit_sha256"]) == 64
+    assert (
+        json.loads(output_json.read_text(encoding="utf-8"))["hash_chain"]
+        == (snapshot["hash_chain"])
+    )
+    report = output_md.read_text(encoding="utf-8")
+    assert "OpenAPI-to-Tool ALS Registry Case Study" in report
+    assert "Official Contract Inspection" in report
+    assert "Verification And Approval" in report
+    assert "End-to-End Assertions" in report
+
+    tampered = copy.deepcopy(snapshot)
+    tampered["retrieved_als_records"][0]["overall_status"] = "RECRUITING"
+    with pytest.raises(ValueError, match="audit digest"):
+        study.validate_snapshot(tampered)


### PR DESCRIPTION
## Summary

- inspect bounded local OpenAPI 3.0/3.1 JSON or YAML documents and emit content-addressed, non-executable operation candidates
- block authentication, write methods, external references, non-JSON responses, unsafe servers, unsupported parameters, oversized schemas, and malformed candidate contracts before drafting
- generate narrow HTTPS GET tools through the existing verification, approval, publication, and explicit-load boundaries
- support OpenAPI query serialization plus object-result verification with nested JSON Pointer assertions
- include a live ALS registry study using the current ClinicalTrials.gov contract and three exact NCT record checks

## Safety boundaries

The inspector never downloads a specification, executes a candidate, persists a tool, or registers anything into an agent-facing ToolUniverse instance. Promotion remains administrator-only, candidates begin with `execution_allowed: false`, generated calls remain allowlisted HTTPS GET requests without credentials or redirects, and publication still requires three passing cases plus explicit hash-bound approval.

## Verification

- `python -m pytest tests/unit -k vsd -q --no-cov` (136 passed)
- focused OpenAPI, dynamic REST, promotion, CLI, and case-study suite (40 passed)
- Ruff 0.14.5 format and lint checks passed
- live case parsed the current 80 KB ClinicalTrials.gov OpenAPI 3.0.3 contract, inspected 9 operations, generated `fetchStudy`, verified 3 distinct ALS NCT records, explicitly loaded the publication into a fresh ToolUniverse instance, and passed all 12 recorded assertions

## Evidence

- [Readable ALS case report](https://github.com/mims-harvard/ToolUniverse/blob/vsd-openapi-ingestion/examples/vsd/artifacts/openapi_als_snapshot.md)
- [Machine-readable audit ledger](https://github.com/mims-harvard/ToolUniverse/blob/vsd-openapi-ingestion/examples/vsd/artifacts/openapi_als_snapshot.json)
- [Promotion artifacts](https://github.com/mims-harvard/ToolUniverse/tree/vsd-openapi-ingestion/examples/vsd/artifacts/openapi_ingestion_workspace)

This is stacked on #421; review that capability-resolution phase first.
