### PR TITLE
Add private VSD demand ranking and proposal export

### DIFF
--- a/examples/vsd/README.md
+++ b/examples/vsd/README.md
@@ -1,5 +1,66 @@
 # ToolUniverse VSD Validation Case Studies
 
+## Private Capability-Demand Ledger
+
+`demand_ledger_case_study.py` demonstrates how a library user can learn which
+capabilities recur without silently sending searches to the ToolUniverse team.
+The administrator-only `tooluniverse-vsd-demand` CLI resolves current registry
+coverage, records an explicit local observation, ranks repeated missing and
+partial coverage, and writes only explicitly selected proposals to a sanitized
+file. It is not registered as an agent-facing tool.
+
+The private ledger never stores the raw capability description or caller event
+ID. Each observation requires a separate 10-240 character public summary; URLs,
+email addresses, and credential-like assignments are rejected. The ledger is
+bounded, requests restrictive filesystem modes, uses atomic replacement, locks
+across threads and processes, and carries a content digest. Replayed event IDs
+are represented only by hashes and do not increase counts.
+
+Workflow plans can be recorded as one transaction with
+`record_plan_demands()`. The function verifies the complete plan SHA-256 and its
+non-execution boundary before it validates every selected step and public
+summary. A missing summary or altered plan aborts the entire batch without
+writing a partial ledger.
+
+The checked ALS study records three hash-bound seven-step workflow preflights, then
+replays one run to prove deduplication. It adds two observations for a distinct
+adaptive-optics retinal calibration gap and one exact FDA-label observation.
+The resulting unmet ranking contains six entries: the repeated ALS calibration
+gap scores 15, retinal calibration scores 10, and four partially covered ALS
+retrieval capabilities score 6 each. The satisfied FDA capability remains
+local but does not enter the ranking or export.
+
+Run the offline study from the repository root:
+
+```console
+PYTHONPATH=src python examples/vsd/demand_ledger_case_study.py
+```
+
+The study writes `artifacts/demand_ledger_snapshot.md`, the corresponding JSON
+audit snapshot, and `artifacts/demand_proposals.json`. The proposal file contains
+only the two reviewer-selected unmet capabilities and explicitly records that
+no transmission occurred. Its reduced public capability schema includes the
+provider identity, method, operation ID, and field names, but omits endpoint
+paths so tenant or record identifiers cannot cross the export boundary.
+
+A direct CLI lifecycle is:
+
+```console
+tooluniverse-vsd-demand --workspace ./private-vsd-demand record \
+  --description "calibrate adaptive optics retinal imaging phantoms" \
+  --public-summary "Adaptive-optics retinal calibration for research workflows" \
+  --source scheduled_scan --event-id scan-2026-08-01
+tooluniverse-vsd-demand --workspace ./private-vsd-demand rank
+tooluniverse-vsd-demand --workspace ./private-vsd-demand export proposals.json \
+  --demand-id 0123456789abcdef --reviewed-by "Local Maintainer" \
+  --decision-note "Selected after reviewing repeated unmet local demand."
+```
+
+The user must deliberately share the resulting proposal file through a normal
+issue or pull-request process if the core team should see it. There is no
+telemetry, upload endpoint, background reporting, candidate execution, tool
+registration, or approval bypass.
+
 ## Registry-First ALS Workflow Planning
 
 `workflow_planning_case_study.py` tests whether an agent can preflight a

--- a/examples/vsd/artifacts/demand_ledger_snapshot.json
+++ b/examples/vsd/artifacts/demand_ledger_snapshot.json
@@ -1,0 +1,359 @@
+{
+  "answer": "Yes. Three hash-bound ALS plans and two retinal-calibration observations produced a deterministic unmet-demand ranking; one exact FDA capability was retained locally but excluded, and only two reviewed proposals were written to a non-transmitting export.",
+  "audit_sha256": "ca1cdf0f5ff2f6c1018f39251323edd8e6789bdf0bff066cafdea012aa5aa346",
+  "end_to_end_assertions": {
+    "agent_synthesis_is_not_recorded": true,
+    "already_satisfied_demand_is_not_ranked": true,
+    "batch_plan_identity_is_verified": true,
+    "duplicate_run_is_deduplicated": true,
+    "event_ids_are_not_persisted": true,
+    "export_contains_only_selected_demands": true,
+    "export_is_hash_bound": true,
+    "export_is_local_only": true,
+    "ledger_has_expected_population": true,
+    "ledger_is_hash_bound": true,
+    "local_paths_are_not_exposed": true,
+    "raw_descriptions_are_not_persisted": true,
+    "repeated_missing_demand_ranks_first": true
+  },
+  "observation_summary": {
+    "duplicate_step_observations_rejected": 5,
+    "plan_runs_recorded": 3,
+    "plan_step_observations_recorded": 15,
+    "retinal_observations_recorded": 2,
+    "satisfied_observations_recorded": 1
+  },
+  "plan": {
+    "plan_id": "f41c063db82dc5db",
+    "plan_sha256": "f41c063db82dc5db288d4e8cc0989c8624bc49a445748acff65d39b2bdddabf7",
+    "registry_sha256": "ddc1d4e903cc80b554813a8aebf12c1481b736a7b7dfbf25420dfcab683c3752",
+    "steps": [
+      {
+        "classification": "existing_partial",
+        "fulfillment": "tool",
+        "step_id": "genes"
+      },
+      {
+        "classification": "existing_partial",
+        "fulfillment": "tool",
+        "step_id": "phenotypes"
+      },
+      {
+        "classification": "existing_partial",
+        "fulfillment": "tool",
+        "step_id": "literature"
+      },
+      {
+        "classification": "existing_partial",
+        "fulfillment": "tool",
+        "step_id": "trials"
+      },
+      {
+        "classification": "existing_exact",
+        "fulfillment": "tool",
+        "step_id": "drug_label"
+      },
+      {
+        "classification": "missing",
+        "fulfillment": "tool",
+        "step_id": "microscopy_calibration"
+      },
+      {
+        "classification": "agent_native",
+        "fulfillment": "agent",
+        "step_id": "synthesis"
+      }
+    ]
+  },
+  "privacy_boundary": "The ledger is private and local; raw descriptions and event IDs are not stored. Export is an explicit reviewed file write and performs no network transmission, candidate creation, tool registration, or execution.",
+  "proposal_export": {
+    "created_at": "2026-08-07T12:00:00+00:00",
+    "export_sha256": "fcec4c64b6522d01a6919133c98f8a347eb6b3eb23d4781ee1a3e593502aaec8",
+    "proposals": [
+      {
+        "capability": {
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [
+            "calibration_report"
+          ],
+          "provider": "",
+          "required_inputs": [
+            "instrument_id"
+          ]
+        },
+        "observation_counts": {
+          "exact": 0,
+          "missing": 3,
+          "partial": 0
+        },
+        "priority_score": 15,
+        "proposal_id": "332f9444843c672c",
+        "public_summary": "Quantitative microscopy calibration for ALS research workflows",
+        "recommended_next_step": "review_external_api_candidates",
+        "total_observations": 3,
+        "unmet_rate": 1.0
+      },
+      {
+        "capability": {
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [
+            "calibration_report"
+          ],
+          "provider": "",
+          "required_inputs": [
+            "instrument_id"
+          ]
+        },
+        "observation_counts": {
+          "exact": 0,
+          "missing": 2,
+          "partial": 0
+        },
+        "priority_score": 10,
+        "proposal_id": "2540259f913360b4",
+        "public_summary": "Traceable adaptive-optics retinal imaging calibration for research workflows",
+        "recommended_next_step": "review_external_api_candidates",
+        "total_observations": 2,
+        "unmet_rate": 1.0
+      }
+    ],
+    "review": {
+      "decision_note": "Selected the two highest repeated unmet capabilities after local review.",
+      "reviewed_by": "VSD Case Study Maintainer"
+    },
+    "transmission": "none; this file was written locally for explicit human review",
+    "version": 1
+  },
+  "question": "Can repeated workflow gaps be counted and prioritized locally without silently reporting queries or exporting satisfied capabilities?",
+  "ranking": {
+    "ledger_sha256": "240d1ceb612d5408b6a1ebb4c0232f5eaeadb6be4a88c2fd6a4797de266b33d6",
+    "matching_demand_count": 6,
+    "privacy": "The demand ledger is local and explicit. Raw query descriptions and event IDs are not stored, and nothing is transmitted automatically.",
+    "ranked_demands": [
+      {
+        "capability": {
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [
+            "calibration_report"
+          ],
+          "provider": "",
+          "required_inputs": [
+            "instrument_id"
+          ]
+        },
+        "demand_id": "eec597e027a35585",
+        "first_observed_at": "2026-08-01T12:00:00+00:00",
+        "last_matches": [],
+        "last_observed_at": "2026-08-03T12:00:00+00:00",
+        "observation_counts": {
+          "exact": 0,
+          "missing": 3,
+          "partial": 0
+        },
+        "priority_score": 15,
+        "public_summary": "Quantitative microscopy calibration for ALS research workflows",
+        "registry_snapshots": [
+          "ddc1d4e903cc80b554813a8aebf12c1481b736a7b7dfbf25420dfcab683c3752"
+        ],
+        "source_counts": {
+          "scheduled_scan": 3
+        },
+        "total_observations": 3,
+        "unmet_rate": 1.0
+      },
+      {
+        "capability": {
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [
+            "calibration_report"
+          ],
+          "provider": "",
+          "required_inputs": [
+            "instrument_id"
+          ]
+        },
+        "demand_id": "96cde8a6de35e15e",
+        "first_observed_at": "2026-08-04T12:00:00+00:00",
+        "last_matches": [],
+        "last_observed_at": "2026-08-05T12:00:00+00:00",
+        "observation_counts": {
+          "exact": 0,
+          "missing": 2,
+          "partial": 0
+        },
+        "priority_score": 10,
+        "public_summary": "Traceable adaptive-optics retinal imaging calibration for research workflows",
+        "registry_snapshots": [
+          "ddc1d4e903cc80b554813a8aebf12c1481b736a7b7dfbf25420dfcab683c3752"
+        ],
+        "source_counts": {
+          "scheduled_scan": 2
+        },
+        "total_observations": 2,
+        "unmet_rate": 1.0
+      },
+      {
+        "capability": {
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "",
+          "required_inputs": [
+            "query"
+          ]
+        },
+        "demand_id": "7ac48399f2fb1293",
+        "first_observed_at": "2026-08-01T12:00:00+00:00",
+        "last_matches": [
+          "PubTator3_GetEntityRelations",
+          "PubMed_search_articles",
+          "PubTator3_get_annotations",
+          "BioPortal_search_ontology_terms",
+          "biostudies_search"
+        ],
+        "last_observed_at": "2026-08-03T12:00:00+00:00",
+        "observation_counts": {
+          "exact": 0,
+          "missing": 0,
+          "partial": 3
+        },
+        "priority_score": 6,
+        "public_summary": "ALS biomedical literature retrieval for evidence workflows",
+        "registry_snapshots": [
+          "ddc1d4e903cc80b554813a8aebf12c1481b736a7b7dfbf25420dfcab683c3752"
+        ],
+        "source_counts": {
+          "scheduled_scan": 3
+        },
+        "total_observations": 3,
+        "unmet_rate": 1.0
+      },
+      {
+        "capability": {
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "",
+          "required_inputs": [
+            "condition"
+          ]
+        },
+        "demand_id": "bba147addff7536b",
+        "first_observed_at": "2026-08-01T12:00:00+00:00",
+        "last_matches": [
+          "ClinicalTrials_get_field_values",
+          "ClinicalTrials_search_by_intervention",
+          "ClinicalTrials_search_by_sponsor",
+          "ClinicalTrials_search_studies",
+          "ImmPort_search_studies"
+        ],
+        "last_observed_at": "2026-08-03T12:00:00+00:00",
+        "observation_counts": {
+          "exact": 0,
+          "missing": 0,
+          "partial": 3
+        },
+        "priority_score": 6,
+        "public_summary": "ALS clinical-trial retrieval for evidence workflows",
+        "registry_snapshots": [
+          "ddc1d4e903cc80b554813a8aebf12c1481b736a7b7dfbf25420dfcab683c3752"
+        ],
+        "source_counts": {
+          "scheduled_scan": 3
+        },
+        "total_observations": 3,
+        "unmet_rate": 1.0
+      },
+      {
+        "capability": {
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "",
+          "required_inputs": [
+            "disease"
+          ]
+        },
+        "demand_id": "6410ec941a19937e",
+        "first_observed_at": "2026-08-01T12:00:00+00:00",
+        "last_matches": [
+          "Orphanet_get_genes",
+          "Alliance_get_disease_genes",
+          "CELLxGENE_get_expression_data",
+          "DisGeNET_get_disease_genes",
+          "DisGeNET_search_disease"
+        ],
+        "last_observed_at": "2026-08-03T12:00:00+00:00",
+        "observation_counts": {
+          "exact": 0,
+          "missing": 0,
+          "partial": 3
+        },
+        "priority_score": 6,
+        "public_summary": "ALS rare-disease gene retrieval for evidence workflows",
+        "registry_snapshots": [
+          "ddc1d4e903cc80b554813a8aebf12c1481b736a7b7dfbf25420dfcab683c3752"
+        ],
+        "source_counts": {
+          "scheduled_scan": 3
+        },
+        "total_observations": 3,
+        "unmet_rate": 1.0
+      },
+      {
+        "capability": {
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "",
+          "required_inputs": [
+            "disease"
+          ]
+        },
+        "demand_id": "fd9d57398a2074de",
+        "first_observed_at": "2026-08-01T12:00:00+00:00",
+        "last_matches": [
+          "Orphanet_get_phenotypes",
+          "Alliance_get_disease_genes",
+          "BioPortal_search_ontology_terms",
+          "ensembl_vep_region",
+          "FinnGen_list_phenotypes"
+        ],
+        "last_observed_at": "2026-08-03T12:00:00+00:00",
+        "observation_counts": {
+          "exact": 0,
+          "missing": 0,
+          "partial": 3
+        },
+        "priority_score": 6,
+        "public_summary": "ALS rare-disease phenotype retrieval for evidence workflows",
+        "registry_snapshots": [
+          "ddc1d4e903cc80b554813a8aebf12c1481b736a7b7dfbf25420dfcab683c3752"
+        ],
+        "source_counts": {
+          "scheduled_scan": 3
+        },
+        "total_observations": 3,
+        "unmet_rate": 1.0
+      }
+    ],
+    "total_demand_count": 7
+  },
+  "title": "Private ALS Capability-Demand Ledger Case Study"
+}

--- a/examples/vsd/artifacts/demand_ledger_snapshot.md
+++ b/examples/vsd/artifacts/demand_ledger_snapshot.md
@@ -1,0 +1,71 @@
+# Private ALS Capability-Demand Ledger Case Study
+
+## Decision Question
+
+Can repeated workflow gaps be counted and prioritized locally without silently reporting queries or exporting satisfied capabilities?
+
+**Result:** Yes. Three hash-bound ALS plans and two retinal-calibration observations produced a deterministic unmet-demand ranking; one exact FDA capability was retained locally but excluded, and only two reviewed proposals were written to a non-transmitting export.
+
+## Hash-Bound Workflow Input
+
+Plan `f41c063db82dc5db` was verified against its complete SHA-256 before any observations were committed. Three distinct scheduled runs recorded five unmet tool steps each; replaying the last run recorded nothing because its event hashes were already present.
+
+| Step | Fulfillment | Coverage |
+| --- | --- | --- |
+| `genes` | tool | existing_partial |
+| `phenotypes` | tool | existing_partial |
+| `literature` | tool | existing_partial |
+| `trials` | tool | existing_partial |
+| `drug_label` | tool | existing_exact |
+| `microscopy_calibration` | tool | missing |
+| `synthesis` | agent | agent_native |
+
+## Local Priority Ranking
+
+Missing observations receive five points and partial observations receive two. Exact coverage remains available in the private ledger but does not enter the unmet-demand ranking.
+
+| Rank | Reviewed public summary | Exact | Partial | Missing | Score |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 1 | Quantitative microscopy calibration for ALS research workflows | 0 | 0 | 3 | 15 |
+| 2 | Traceable adaptive-optics retinal imaging calibration for research workflows | 0 | 0 | 2 | 10 |
+| 3 | ALS biomedical literature retrieval for evidence workflows | 0 | 3 | 0 | 6 |
+| 4 | ALS clinical-trial retrieval for evidence workflows | 0 | 3 | 0 | 6 |
+| 5 | ALS rare-disease gene retrieval for evidence workflows | 0 | 3 | 0 | 6 |
+| 6 | ALS rare-disease phenotype retrieval for evidence workflows | 0 | 3 | 0 | 6 |
+
+## Explicit Proposal Export
+
+Only the two highest reviewed demand IDs were selected. The export contains stable proposal IDs, safe structured capability fields, aggregate counts, and a review decision. It contains no local demand IDs, raw query descriptions, event IDs, or filesystem paths.
+
+| Proposal | Public summary | Next step |
+| --- | --- | --- |
+| `332f9444843c672c` | Quantitative microscopy calibration for ALS research workflows | `review_external_api_candidates` |
+| `2540259f913360b4` | Traceable adaptive-optics retinal imaging calibration for research workflows | `review_external_api_candidates` |
+
+## End-to-End Assertions
+
+| Assertion | Result |
+| --- | --- |
+| `agent_synthesis_is_not_recorded` | PASS |
+| `already_satisfied_demand_is_not_ranked` | PASS |
+| `batch_plan_identity_is_verified` | PASS |
+| `duplicate_run_is_deduplicated` | PASS |
+| `event_ids_are_not_persisted` | PASS |
+| `export_contains_only_selected_demands` | PASS |
+| `export_is_hash_bound` | PASS |
+| `export_is_local_only` | PASS |
+| `ledger_has_expected_population` | PASS |
+| `ledger_is_hash_bound` | PASS |
+| `local_paths_are_not_exposed` | PASS |
+| `raw_descriptions_are_not_persisted` | PASS |
+| `repeated_missing_demand_ranks_first` | PASS |
+
+## Privacy And Execution Boundary
+
+The ledger is private and local; raw descriptions and event IDs are not stored. Export is an explicit reviewed file write and performs no network transmission, candidate creation, tool registration, or execution.
+
+**Ledger SHA-256:** `240d1ceb612d5408b6a1ebb4c0232f5eaeadb6be4a88c2fd6a4797de266b33d6`
+
+**Export SHA-256:** `fcec4c64b6522d01a6919133c98f8a347eb6b3eb23d4781ee1a3e593502aaec8`
+
+**Case audit SHA-256:** `ca1cdf0f5ff2f6c1018f39251323edd8e6789bdf0bff066cafdea012aa5aa346`

--- a/examples/vsd/artifacts/demand_proposals.json
+++ b/examples/vsd/artifacts/demand_proposals.json
@@ -1,0 +1,60 @@
+{
+  "created_at": "2026-08-07T12:00:00+00:00",
+  "export_sha256": "fcec4c64b6522d01a6919133c98f8a347eb6b3eb23d4781ee1a3e593502aaec8",
+  "proposals": [
+    {
+      "capability": {
+        "method": "GET",
+        "operation_id": "",
+        "output_fields": [
+          "calibration_report"
+        ],
+        "provider": "",
+        "required_inputs": [
+          "instrument_id"
+        ]
+      },
+      "observation_counts": {
+        "exact": 0,
+        "missing": 3,
+        "partial": 0
+      },
+      "priority_score": 15,
+      "proposal_id": "332f9444843c672c",
+      "public_summary": "Quantitative microscopy calibration for ALS research workflows",
+      "recommended_next_step": "review_external_api_candidates",
+      "total_observations": 3,
+      "unmet_rate": 1.0
+    },
+    {
+      "capability": {
+        "method": "GET",
+        "operation_id": "",
+        "output_fields": [
+          "calibration_report"
+        ],
+        "provider": "",
+        "required_inputs": [
+          "instrument_id"
+        ]
+      },
+      "observation_counts": {
+        "exact": 0,
+        "missing": 2,
+        "partial": 0
+      },
+      "priority_score": 10,
+      "proposal_id": "2540259f913360b4",
+      "public_summary": "Traceable adaptive-optics retinal imaging calibration for research workflows",
+      "recommended_next_step": "review_external_api_candidates",
+      "total_observations": 2,
+      "unmet_rate": 1.0
+    }
+  ],
+  "review": {
+    "decision_note": "Selected the two highest repeated unmet capabilities after local review.",
+    "reviewed_by": "VSD Case Study Maintainer"
+  },
+  "transmission": "none; this file was written locally for explicit human review",
+  "version": 1
+}

--- a/examples/vsd/artifacts/workflow_planning_snapshot.json
+++ b/examples/vsd/artifacts/workflow_planning_snapshot.json
@@ -4,8 +4,8 @@
     "goal": "Build an ALS evidence workflow from rare disease genes, phenotypes, literature, clinical trials, drug labels, and quantitative microscopy",
     "optional_gap_count": 0,
     "overall_action": "discover_missing_capabilities",
-    "plan_id": "fd56f4bffc949afc",
-    "plan_sha256": "fd56f4bffc949afcfc38f85feb9979b2bd21f22ab6d80a2e9b65f24a8e77baff",
+    "plan_id": "66bb1aa37bc9e144",
+    "plan_sha256": "66bb1aa37bc9e144ac155a12e31a073f07bc4a9e15e146b5e01db673b3738917",
     "privacy": "Workflow planning is local, read-only, and not persisted or reported.",
     "ready_agent_step_count": 0,
     "ready_step_count": 1,
@@ -106,6 +106,18 @@
         "optional": false,
         "position": 1,
         "recommended_action": "review_existing_or_extend_provider",
+        "request": {
+          "description": "rare disease registry genes",
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "",
+          "required_inputs": [
+            "disease"
+          ]
+        },
         "selected_match": {
           "category": "orphanet",
           "coverage": "partial",
@@ -212,6 +224,18 @@
         "optional": false,
         "position": 2,
         "recommended_action": "review_existing_or_extend_provider",
+        "request": {
+          "description": "rare disease registry phenotypes",
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "",
+          "required_inputs": [
+            "disease"
+          ]
+        },
         "selected_match": {
           "category": "orphanet",
           "coverage": "partial",
@@ -318,6 +342,18 @@
         "optional": false,
         "position": 3,
         "recommended_action": "review_existing_or_extend_provider",
+        "request": {
+          "description": "search biomedical literature articles by disease",
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "",
+          "required_inputs": [
+            "query"
+          ]
+        },
         "selected_match": {
           "category": "pubtator3_ext",
           "coverage": "partial",
@@ -430,6 +466,18 @@
         "optional": false,
         "position": 4,
         "recommended_action": "review_existing_or_extend_provider",
+        "request": {
+          "description": "search clinical trials by disease condition",
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "",
+          "required_inputs": [
+            "condition"
+          ]
+        },
         "selected_match": {
           "category": "clinical_trials",
           "coverage": "partial",
@@ -536,6 +584,18 @@
         "optional": false,
         "position": 5,
         "recommended_action": "use_existing",
+        "request": {
+          "description": "retrieve FDA drug label by set identifier",
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "fda",
+          "required_inputs": [
+            "set_id"
+          ]
+        },
         "selected_match": {
           "category": "fda_drug_label",
           "coverage": "exact",
@@ -574,6 +634,16 @@
         "optional": false,
         "position": 6,
         "recommended_action": "discover_external_candidate",
+        "request": {
+          "description": "quantum microscope calibration waveform optimizer",
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "",
+          "required_inputs": []
+        },
         "selected_match": null,
         "state": "missing",
         "step_id": "microscopy_calibration"
@@ -607,6 +677,16 @@
         "optional": false,
         "position": 7,
         "recommended_action": "perform_after_dependencies",
+        "request": {
+          "description": "combine ALS genes phenotypes literature clinical trials drug labels and quantitative microscopy evidence",
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "",
+          "required_inputs": []
+        },
         "selected_match": null,
         "state": "blocked_by_dependencies",
         "step_id": "synthesis"
@@ -617,7 +697,7 @@
     "workflow_shortcut": null
   },
   "answer": "Yes. The planner retained exact and partial registry coverage for review, sent only the microscopy-calibration gap to non-executable discovery, and recognized an existing drug-discovery workflow with all dependencies present.",
-  "audit_sha256": "f687bfaacee2e21ec95ec90ec186e807fea0cbce785a6456464086415eeb0b83",
+  "audit_sha256": "8f2863ca0fdfd5f5577f36a33f72fb0efe1043e6156b3743b7e7ab54b88e2d0a",
   "end_to_end_assertions": {
     "dependency_order_is_valid": true,
     "drug_label_reuses_exact_tools": true,
@@ -638,8 +718,8 @@
     "goal": "complete disease target compound ADMET literature workflow",
     "optional_gap_count": 0,
     "overall_action": "use_existing_workflow",
-    "plan_id": "d48b35428955eec4",
-    "plan_sha256": "d48b35428955eec49a4df05a766f381af9f008ffba4039b3737212f235b68dc1",
+    "plan_id": "d07579f2fcc7ef9d",
+    "plan_sha256": "d07579f2fcc7ef9d5bc14cf5c45b262634b06af7c9a04819cc769a628894282c",
     "privacy": "Workflow planning is local, read-only, and not persisted or reported.",
     "ready_agent_step_count": 0,
     "ready_step_count": 1,
@@ -684,6 +764,16 @@
         "optional": false,
         "position": 1,
         "recommended_action": "use_existing",
+        "request": {
+          "description": "complete disease target compound ADMET literature workflow",
+          "endpoint_host": "",
+          "endpoint_path": "",
+          "method": "GET",
+          "operation_id": "",
+          "output_fields": [],
+          "provider": "",
+          "required_inputs": []
+        },
         "selected_match": {
           "category": "compose",
           "coverage": "exact",
@@ -1031,7 +1121,7 @@
     ],
     "total_matches": 739
   },
-  "generated_at": "2026-08-01T19:30:19.485163+00:00",
+  "generated_at": "2026-08-01T19:45:04.241132+00:00",
   "initially_loaded_tools": [
     "Tool_Finder_Keyword",
     "VSDPlanWorkflow"

--- a/examples/vsd/artifacts/workflow_planning_snapshot.md
+++ b/examples/vsd/artifacts/workflow_planning_snapshot.md
@@ -1,6 +1,6 @@
 # Registry-First ALS Workflow Planning Case Study
 
-**Generated:** 2026-08-01T19:30:19.485163+00:00
+**Generated:** 2026-08-01T19:45:04.241132+00:00
 
 ## Decision Question
 
@@ -64,4 +64,4 @@ The existing keyword finder was called with capability coverage enabled. It retu
 
 This study plans and inspects only. It does not execute scientific tools, download data, persist demand, or create API candidates.
 
-**Audit SHA-256:** `f687bfaacee2e21ec95ec90ec186e807fea0cbce785a6456464086415eeb0b83`
+**Audit SHA-256:** `8f2863ca0fdfd5f5577f36a33f72fb0efe1043e6156b3743b7e7ab54b88e2d0a`

--- a/examples/vsd/demand_ledger_case_study.py
+++ b/examples/vsd/demand_ledger_case_study.py
@@ -1,0 +1,486 @@
+"""Exercise private VSD demand aggregation and explicit proposal export."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from tooluniverse import ToolUniverse
+from tooluniverse.vsd_demand import (
+    export_proposals,
+    observe_capability_demand,
+    rank_demands,
+    record_plan_demands,
+    validate_proposal_export,
+)
+from tooluniverse.vsd_planning import plan_workflow
+
+HERE = Path(__file__).resolve().parent
+ARTIFACTS = HERE / "artifacts"
+DEFAULT_JSON = ARTIFACTS / "demand_ledger_snapshot.json"
+DEFAULT_MARKDOWN = ARTIFACTS / "demand_ledger_snapshot.md"
+DEFAULT_PROPOSALS = ARTIFACTS / "demand_proposals.json"
+
+ALS_GOAL = (
+    "Build an ALS evidence workflow from rare disease genes, phenotypes, "
+    "literature, clinical trials, drug labels, and quantitative microscopy"
+)
+ALS_CAPABILITIES = [
+    {
+        "step_id": "genes",
+        "description": "rare disease registry genes",
+        "required_inputs": ["disease"],
+    },
+    {
+        "step_id": "phenotypes",
+        "description": "rare disease registry phenotypes",
+        "required_inputs": ["disease"],
+    },
+    {
+        "step_id": "literature",
+        "description": "search biomedical literature articles by disease",
+        "required_inputs": ["query"],
+    },
+    {
+        "step_id": "trials",
+        "description": "search clinical trials by disease condition",
+        "required_inputs": ["condition"],
+        "depends_on": ["genes", "phenotypes"],
+    },
+    {
+        "step_id": "drug_label",
+        "description": "retrieve FDA drug label by set identifier",
+        "provider": "FDA",
+        "required_inputs": ["set_id"],
+    },
+    {
+        "step_id": "microscopy_calibration",
+        "description": "quantum microscope calibration waveform optimizer",
+        "required_inputs": ["instrument_id"],
+        "output_fields": ["calibration_report"],
+        "depends_on": ["genes"],
+    },
+    {
+        "step_id": "synthesis",
+        "description": "synthesize ALS evidence into a reviewed research brief",
+        "fulfillment": "agent",
+        "depends_on": [
+            "genes",
+            "phenotypes",
+            "literature",
+            "trials",
+            "drug_label",
+            "microscopy_calibration",
+        ],
+    },
+]
+PUBLIC_SUMMARIES = {
+    "genes": "ALS rare-disease gene retrieval for evidence workflows",
+    "phenotypes": "ALS rare-disease phenotype retrieval for evidence workflows",
+    "literature": "ALS biomedical literature retrieval for evidence workflows",
+    "trials": "ALS clinical-trial retrieval for evidence workflows",
+    "microscopy_calibration": (
+        "Quantitative microscopy calibration for ALS research workflows"
+    ),
+}
+RETINAL_REQUEST = {
+    "description": (
+        "calibrate adaptive optics retinal imaging phantoms with traceable "
+        "wavefront uncertainty"
+    ),
+    "required_inputs": ["instrument_id"],
+    "output_fields": ["calibration_report"],
+}
+RETINAL_SUMMARY = (
+    "Traceable adaptive-optics retinal imaging calibration for research workflows"
+)
+FDA_REQUEST = {
+    "description": "retrieve FDA drug label by set identifier",
+    "provider": "FDA",
+    "required_inputs": ["set_id"],
+}
+FDA_SUMMARY = "FDA drug-label retrieval by reviewed set identifier"
+RAW_DESCRIPTIONS = {
+    *(step["description"] for step in ALS_CAPABILITIES),
+    RETINAL_REQUEST["description"],
+    FDA_REQUEST["description"],
+}
+RUN_IDS = ("als-run-001", "als-run-002", "als-run-003")
+EXPECTED_ASSERTIONS = {
+    "agent_synthesis_is_not_recorded",
+    "already_satisfied_demand_is_not_ranked",
+    "batch_plan_identity_is_verified",
+    "duplicate_run_is_deduplicated",
+    "event_ids_are_not_persisted",
+    "export_contains_only_selected_demands",
+    "export_is_hash_bound",
+    "export_is_local_only",
+    "ledger_has_expected_population",
+    "ledger_is_hash_bound",
+    "local_paths_are_not_exposed",
+    "raw_descriptions_are_not_persisted",
+    "repeated_missing_demand_ranks_first",
+}
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def run_case(workspace: Path) -> dict[str, Any]:
+    workspace = Path(workspace)
+    proposal_path = workspace / "selected_proposals.json"
+    tooluniverse = ToolUniverse()
+    try:
+        plan = plan_workflow(
+            tooluniverse,
+            goal=ALS_GOAL,
+            capabilities=ALS_CAPABILITIES,
+            limit=5,
+        )
+        batches = [
+            record_plan_demands(
+                plan,
+                PUBLIC_SUMMARIES,
+                workspace=workspace,
+                source="scheduled_scan",
+                run_id=run_id,
+                observed_at=f"2026-08-0{index}T12:00:00+00:00",
+            )
+            for index, run_id in enumerate(RUN_IDS, start=1)
+        ]
+        duplicate = record_plan_demands(
+            plan,
+            PUBLIC_SUMMARIES,
+            workspace=workspace,
+            source="scheduled_scan",
+            run_id=RUN_IDS[-1],
+            observed_at="2026-08-03T12:00:00+00:00",
+        )
+        retinal = [
+            observe_capability_demand(
+                tooluniverse,
+                RETINAL_REQUEST,
+                public_summary=RETINAL_SUMMARY,
+                source="scheduled_scan",
+                event_id=f"retinal-run-{index:03d}",
+                observed_at=f"2026-08-0{index + 3}T12:00:00+00:00",
+                workspace=workspace,
+            )
+            for index in range(1, 3)
+        ]
+        satisfied = observe_capability_demand(
+            tooluniverse,
+            FDA_REQUEST,
+            public_summary=FDA_SUMMARY,
+            source="manual_review",
+            event_id="fda-review-001",
+            observed_at="2026-08-06T12:00:00+00:00",
+            workspace=workspace,
+        )
+    finally:
+        tooluniverse.close()
+
+    ranking = rank_demands(workspace=workspace)["data"]
+    ranked = ranking["ranked_demands"]
+    selected_ids = [item["demand_id"] for item in ranked[:2]]
+    proposals = export_proposals(
+        selected_ids,
+        proposal_path,
+        reviewed_by="VSD Case Study Maintainer",
+        decision_note=(
+            "Selected the two highest repeated unmet capabilities after local review."
+        ),
+        workspace=workspace,
+        created_at="2026-08-07T12:00:00+00:00",
+    )
+    validate_proposal_export(proposals)
+
+    ledger_path = workspace / "demand_ledger.json"
+    ledger_text = ledger_path.read_text(encoding="utf-8")
+    proposal_text = proposal_path.read_text(encoding="utf-8")
+    ranked_summaries = [item["public_summary"] for item in ranked]
+    plan_steps = [
+        {
+            "step_id": step["step_id"],
+            "classification": step["classification"],
+            "fulfillment": step["fulfillment"],
+        }
+        for step in plan["data"]["steps"]
+    ]
+    assertions = {
+        "batch_plan_identity_is_verified": (
+            all(
+                batch["data"]["plan_id"] == plan["data"]["plan_id"] for batch in batches
+            )
+            and all(batch["data"]["recorded_count"] == 5 for batch in batches)
+        ),
+        "duplicate_run_is_deduplicated": (
+            duplicate["data"]["recorded_count"] == 0
+            and duplicate["data"]["deduplicated_count"] == 5
+        ),
+        "ledger_has_expected_population": (
+            ranking["total_demand_count"] == 7 and ranking["matching_demand_count"] == 6
+        ),
+        "repeated_missing_demand_ranks_first": (
+            [item["priority_score"] for item in ranked[:3]] == [15, 10, 6]
+            and ranked[0]["public_summary"]
+            == PUBLIC_SUMMARIES["microscopy_calibration"]
+            and ranked[1]["public_summary"] == RETINAL_SUMMARY
+        ),
+        "already_satisfied_demand_is_not_ranked": (
+            satisfied["data"]["demand"]["observation_counts"]["exact"] == 1
+            and FDA_SUMMARY not in ranked_summaries
+        ),
+        "agent_synthesis_is_not_recorded": (
+            next(step for step in plan_steps if step["step_id"] == "synthesis")[
+                "fulfillment"
+            ]
+            == "agent"
+            and "synthesis" not in PUBLIC_SUMMARIES
+            and "synthesize" not in ledger_text.casefold()
+        ),
+        "export_contains_only_selected_demands": (
+            len(proposals["proposals"]) == 2
+            and [item["public_summary"] for item in proposals["proposals"]]
+            == ranked_summaries[:2]
+            and all(demand_id not in proposal_text for demand_id in selected_ids)
+        ),
+        "raw_descriptions_are_not_persisted": all(
+            description not in ledger_text and description not in proposal_text
+            for description in RAW_DESCRIPTIONS
+        ),
+        "event_ids_are_not_persisted": all(
+            run_id not in ledger_text and run_id not in proposal_text
+            for run_id in (
+                *RUN_IDS,
+                "retinal-run-001",
+                "retinal-run-002",
+                "fda-review-001",
+            )
+        ),
+        "local_paths_are_not_exposed": (
+            str(workspace) not in ledger_text
+            and str(workspace) not in proposal_text
+            and str(workspace) not in json.dumps(ranking)
+        ),
+        "ledger_is_hash_bound": (
+            len(ranking["ledger_sha256"]) == 64
+            and all(batch["data"]["ledger_sha256"] for batch in [*batches, duplicate])
+        ),
+        "export_is_hash_bound": (
+            len(proposals["export_sha256"]) == 64
+            and json.loads(proposal_text)["export_sha256"] == proposals["export_sha256"]
+        ),
+        "export_is_local_only": proposals["transmission"].startswith("none;"),
+    }
+    snapshot = {
+        "title": "Private ALS Capability-Demand Ledger Case Study",
+        "question": (
+            "Can repeated workflow gaps be counted and prioritized locally without "
+            "silently reporting queries or exporting satisfied capabilities?"
+        ),
+        "answer": (
+            "Yes. Three hash-bound ALS plans and two retinal-calibration observations "
+            "produced a deterministic unmet-demand ranking; one exact FDA capability "
+            "was retained locally but excluded, and only two reviewed proposals were "
+            "written to a non-transmitting export."
+        ),
+        "plan": {
+            "plan_id": plan["data"]["plan_id"],
+            "plan_sha256": plan["data"]["plan_sha256"],
+            "registry_sha256": plan["data"]["registry_sha256"],
+            "steps": plan_steps,
+        },
+        "observation_summary": {
+            "plan_runs_recorded": len(batches),
+            "plan_step_observations_recorded": sum(
+                batch["data"]["recorded_count"] for batch in batches
+            ),
+            "duplicate_step_observations_rejected": duplicate["data"][
+                "deduplicated_count"
+            ],
+            "retinal_observations_recorded": sum(
+                item["data"]["recorded"] for item in retinal
+            ),
+            "satisfied_observations_recorded": int(satisfied["data"]["recorded"]),
+        },
+        "ranking": ranking,
+        "proposal_export": proposals,
+        "privacy_boundary": (
+            "The ledger is private and local; raw descriptions and event IDs are not "
+            "stored. Export is an explicit reviewed file write and performs no network "
+            "transmission, candidate creation, tool registration, or execution."
+        ),
+        "end_to_end_assertions": assertions,
+    }
+    snapshot["audit_sha256"] = _digest(
+        {
+            "plan": snapshot["plan"],
+            "observation_summary": snapshot["observation_summary"],
+            "ranking": snapshot["ranking"],
+            "proposal_export": snapshot["proposal_export"],
+            "privacy_boundary": snapshot["privacy_boundary"],
+            "end_to_end_assertions": assertions,
+        }
+    )
+    validate_snapshot(snapshot)
+    return snapshot
+
+
+def validate_snapshot(snapshot: dict[str, Any]) -> None:
+    assertions = snapshot.get("end_to_end_assertions")
+    if not isinstance(assertions, dict) or set(assertions) != EXPECTED_ASSERTIONS:
+        raise ValueError("Snapshot does not contain the complete assertion set")
+    if not all(assertions.values()):
+        failed = sorted(name for name, passed in assertions.items() if not passed)
+        raise ValueError(f"End-to-end assertions failed: {failed!r}")
+    validate_proposal_export(snapshot.get("proposal_export"))
+    expected = _digest(
+        {
+            "plan": snapshot["plan"],
+            "observation_summary": snapshot["observation_summary"],
+            "ranking": snapshot["ranking"],
+            "proposal_export": snapshot["proposal_export"],
+            "privacy_boundary": snapshot["privacy_boundary"],
+            "end_to_end_assertions": assertions,
+        }
+    )
+    if snapshot.get("audit_sha256") != expected:
+        raise ValueError("Snapshot audit digest does not match its content")
+
+
+def _markdown(snapshot: dict[str, Any]) -> str:
+    ranking = snapshot["ranking"]
+    proposals = snapshot["proposal_export"]["proposals"]
+    lines = [
+        "# Private ALS Capability-Demand Ledger Case Study",
+        "",
+        "## Decision Question",
+        "",
+        snapshot["question"],
+        "",
+        f"**Result:** {snapshot['answer']}",
+        "",
+        "## Hash-Bound Workflow Input",
+        "",
+        f"Plan `{snapshot['plan']['plan_id']}` was verified against its complete "
+        "SHA-256 before any observations were committed. Three distinct scheduled "
+        "runs recorded five unmet tool steps each; replaying the last run recorded "
+        "nothing because its event hashes were already present.",
+        "",
+        "| Step | Fulfillment | Coverage |",
+        "| --- | --- | --- |",
+    ]
+    lines.extend(
+        f"| `{step['step_id']}` | {step['fulfillment']} | {step['classification']} |"
+        for step in snapshot["plan"]["steps"]
+    )
+    lines.extend(
+        [
+            "",
+            "## Local Priority Ranking",
+            "",
+            "Missing observations receive five points and partial observations receive "
+            "two. Exact coverage remains available in the private ledger but does not "
+            "enter the unmet-demand ranking.",
+            "",
+            "| Rank | Reviewed public summary | Exact | Partial | Missing | Score |",
+            "| ---: | --- | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for index, item in enumerate(ranking["ranked_demands"], start=1):
+        counts = item["observation_counts"]
+        lines.append(
+            f"| {index} | {item['public_summary']} | {counts['exact']} | "
+            f"{counts['partial']} | {counts['missing']} | {item['priority_score']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Explicit Proposal Export",
+            "",
+            "Only the two highest reviewed demand IDs were selected. The export "
+            "contains stable proposal IDs, safe structured capability fields, aggregate "
+            "counts, and a review decision. It contains no local demand IDs, raw query "
+            "descriptions, event IDs, or filesystem paths.",
+            "",
+            "| Proposal | Public summary | Next step |",
+            "| --- | --- | --- |",
+        ]
+    )
+    lines.extend(
+        f"| `{item['proposal_id']}` | {item['public_summary']} | "
+        f"`{item['recommended_next_step']}` |"
+        for item in proposals
+    )
+    lines.extend(
+        [
+            "",
+            "## End-to-End Assertions",
+            "",
+            "| Assertion | Result |",
+            "| --- | --- |",
+        ]
+    )
+    lines.extend(
+        f"| `{name}` | {'PASS' if passed else 'FAIL'} |"
+        for name, passed in sorted(snapshot["end_to_end_assertions"].items())
+    )
+    lines.extend(
+        [
+            "",
+            "## Privacy And Execution Boundary",
+            "",
+            snapshot["privacy_boundary"],
+            "",
+            f"**Ledger SHA-256:** `{ranking['ledger_sha256']}`",
+            "",
+            f"**Export SHA-256:** `{snapshot['proposal_export']['export_sha256']}`",
+            "",
+            f"**Case audit SHA-256:** `{snapshot['audit_sha256']}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_artifacts(
+    snapshot: dict[str, Any],
+    json_path: Path = DEFAULT_JSON,
+    markdown_path: Path = DEFAULT_MARKDOWN,
+    proposals_path: Path = DEFAULT_PROPOSALS,
+) -> None:
+    validate_snapshot(snapshot)
+    for path in (json_path, markdown_path, proposals_path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(_markdown(snapshot), encoding="utf-8")
+    proposals_path.write_text(
+        json.dumps(
+            snapshot["proposal_export"], indent=2, sort_keys=True, ensure_ascii=True
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="tooluniverse-vsd-demand-") as directory:
+        snapshot = run_case(Path(directory))
+    write_artifacts(snapshot)
+    print(json.dumps({"status": "passed", "audit_sha256": snapshot["audit_sha256"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ tu-datastore = "tooluniverse.database_setup.cli:main"
 tooluniverse-doctor = "tooluniverse.doctor:main"
 tooluniverse-vsd-admin = "tooluniverse.vsd_admin_cli:main"
 tooluniverse-vsd-promote = "tooluniverse.vsd_promotion_cli:main"
+tooluniverse-vsd-demand = "tooluniverse.vsd_demand_cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/tooluniverse/vsd_demand.py
+++ b/src/tooluniverse/vsd_demand.py
@@ -1,0 +1,1003 @@
+"""Private, explicit demand aggregation for VSD capability planning.
+
+The ledger is local-only and administrator controlled. It never transmits data,
+never stores the raw capability description, and never makes candidates
+executable. Export requires an explicit allowlist of demand IDs and writes a
+sanitized proposal file for human review.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import ipaddress
+import json
+import os
+import re
+import tempfile
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+from .vsd_coverage import normalize_capability_request, resolve_capability
+from .vsd_tool import _acquire_process_lock, _release_process_lock
+
+_LEDGER_VERSION = 1
+_EXPORT_VERSION = 1
+_MAX_FILE_BYTES = 2_000_000
+_MAX_DEMANDS = 1000
+_MAX_EVENT_HASHES = 100
+_MAX_REGISTRY_SNAPSHOTS = 20
+_MAX_MATCHES = 5
+_DEMAND_ID_RE = re.compile(r"^[0-9a-f]{16}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_SOURCE_RE = re.compile(r"^[a-z][a-z0-9_]{2,31}$")
+_PUBLIC_PROVIDER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 .:_-]{2,199}$")
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I)
+_URL_RE = re.compile(r"https?://", re.I)
+_SECRET_RE = re.compile(
+    r"(?:api[_-]?key|access[_-]?token|password|secret)\s*[:=]|\bbearer\s+\S+",
+    re.I,
+)
+_LEDGER_LOCK = threading.RLock()
+_CAPABILITY_KEYS = {
+    "provider",
+    "method",
+    "endpoint_host",
+    "endpoint_path",
+    "operation_id",
+    "required_inputs",
+    "output_fields",
+}
+_PUBLIC_CAPABILITY_KEYS = {
+    "provider",
+    "method",
+    "operation_id",
+    "required_inputs",
+    "output_fields",
+}
+_OBSERVATION_KEYS = {"exact", "partial", "missing"}
+_CLASSIFICATIONS = {
+    "existing_exact": "exact",
+    "existing_partial": "partial",
+    "missing": "missing",
+}
+
+
+class VSDDemandError(ValueError):
+    """Raised when local demand data cannot be recorded or exported safely."""
+
+
+def _root(workspace: str | Path | None = None) -> Path:
+    if workspace is not None:
+        root = Path(workspace).expanduser()
+    else:
+        configured = os.environ.get("TOOLUNIVERSE_VSD_DIR")
+        base = (
+            Path(configured).expanduser()
+            if configured
+            else Path.home() / ".tooluniverse" / "vsd"
+        )
+        root = base / "demand"
+    root.mkdir(parents=True, exist_ok=True)
+    os.chmod(root, 0o700)
+    return root
+
+
+def _canonical_digest(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _with_integrity(ledger: dict[str, Any]) -> dict[str, Any]:
+    body = {"version": ledger["version"], "records": ledger["records"]}
+    return {**body, "integrity_sha256": _canonical_digest(body)}
+
+
+def _empty_ledger() -> dict[str, Any]:
+    return _with_integrity({"version": _LEDGER_VERSION, "records": {}})
+
+
+@contextmanager
+def _ledger_transaction(root: Path) -> Iterator[None]:
+    with _LEDGER_LOCK:
+        lock_path = root / ".demand.lock"
+        with lock_path.open("a+b") as handle:
+            if handle.seek(0, os.SEEK_END) == 0:
+                handle.write(b"\0")
+                handle.flush()
+            _acquire_process_lock(handle)
+            try:
+                yield
+            finally:
+                _release_process_lock(handle)
+
+
+def _atomic_write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+    if len(encoded.encode("utf-8")) > _MAX_FILE_BYTES:
+        raise VSDDemandError("Demand artifact exceeds the 2 MB limit")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.stem}_", suffix=".json", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary_path, 0o600)
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _safe_public_text(value: Any, *, field: str, minimum: int, maximum: int) -> str:
+    text = str(value or "").strip()
+    if not minimum <= len(text) <= maximum:
+        raise VSDDemandError(f"{field} must contain {minimum}-{maximum} characters")
+    if any(ord(character) < 32 for character in text):
+        raise VSDDemandError(f"{field} contains control characters")
+    if _URL_RE.search(text) or _EMAIL_RE.search(text) or _SECRET_RE.search(text):
+        raise VSDDemandError(
+            f"{field} must not contain URLs, email addresses, or credential-like data"
+        )
+    return text
+
+
+def _public_provider(value: Any) -> str:
+    provider = str(value or "").strip()
+    if not provider:
+        return ""
+    if not _PUBLIC_PROVIDER_RE.fullmatch(provider):
+        raise VSDDemandError("provider is not safe for public export")
+    if (
+        _URL_RE.search(provider)
+        or _EMAIL_RE.search(provider)
+        or _SECRET_RE.search(provider)
+    ):
+        raise VSDDemandError("provider is not safe for public export")
+    host = provider.casefold().rstrip(".")
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        address = None
+    if (
+        (address is not None and not address.is_global)
+        or host == "localhost"
+        or host.endswith((".local", ".internal", ".localhost"))
+    ):
+        raise VSDDemandError("provider is not safe for public export")
+    return provider
+
+
+def _source(value: Any) -> str:
+    source = str(value or "").strip()
+    if not _SOURCE_RE.fullmatch(source):
+        raise VSDDemandError("source must be a stable lowercase identifier")
+    return source
+
+
+def _timestamp(value: str | None = None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).isoformat()
+    if not isinstance(value, str) or len(value) > 64:
+        raise VSDDemandError("observed_at must be a bounded ISO-8601 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise VSDDemandError("observed_at must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise VSDDemandError("observed_at must include a timezone")
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _event_hash(source: str, event_id: str | None) -> str | None:
+    if event_id is None:
+        return None
+    if not isinstance(event_id, str) or not 1 <= len(event_id) <= 200:
+        raise VSDDemandError("event_id must contain 1-200 characters")
+    if any(ord(character) < 32 for character in event_id):
+        raise VSDDemandError("event_id contains control characters")
+    return _canonical_digest({"source": source, "event_id": event_id})
+
+
+def _stored_capability(normalized: dict[str, Any]) -> dict[str, Any]:
+    return {key: copy.deepcopy(normalized[key]) for key in sorted(_CAPABILITY_KEYS)}
+
+
+def _normalized_request(request: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(request, dict) and set(request) == _CAPABILITY_KEYS | {"description"}:
+        capability = _stored_capability(request)
+        _validate_capability(capability)
+        reconstructed = {
+            "description": request["description"],
+            "provider": capability["provider"],
+            "method": capability["method"],
+            "operation_id": capability["operation_id"],
+            "required_inputs": capability["required_inputs"],
+            "output_fields": capability["output_fields"],
+        }
+        if capability["endpoint_host"]:
+            reconstructed["endpoint"] = (
+                f"https://{capability['endpoint_host']}{capability['endpoint_path']}"
+            )
+        normalized = normalize_capability_request(reconstructed)
+        if normalized != request:
+            raise VSDDemandError("Normalized capability request is not canonical")
+        return normalized
+    return normalize_capability_request(request)
+
+
+def _validate_capability(capability: Any) -> None:
+    if not isinstance(capability, dict) or set(capability) != _CAPABILITY_KEYS:
+        raise VSDDemandError("Demand ledger has an invalid capability record")
+    reconstructed = {
+        "description": "validated public capability placeholder",
+        "provider": capability["provider"],
+        "method": capability["method"],
+        "operation_id": capability["operation_id"],
+        "required_inputs": capability["required_inputs"],
+        "output_fields": capability["output_fields"],
+    }
+    if capability["endpoint_host"]:
+        reconstructed["endpoint"] = (
+            f"https://{capability['endpoint_host']}{capability['endpoint_path']}"
+        )
+    try:
+        expected = _stored_capability(normalize_capability_request(reconstructed))
+    except ValueError as exc:
+        raise VSDDemandError("Demand ledger has an invalid capability record") from exc
+    if capability != expected:
+        raise VSDDemandError("Demand ledger capability is not canonical")
+
+
+def _export_capability(capability: dict[str, Any]) -> dict[str, Any]:
+    _validate_capability(capability)
+    return {
+        "provider": _public_provider(capability["provider"]),
+        "method": capability["method"],
+        "operation_id": capability["operation_id"],
+        "required_inputs": copy.deepcopy(capability["required_inputs"]),
+        "output_fields": copy.deepcopy(capability["output_fields"]),
+    }
+
+
+def _validate_export_capability(capability: Any) -> None:
+    if not isinstance(capability, dict) or set(capability) != _PUBLIC_CAPABILITY_KEYS:
+        raise VSDDemandError("Proposal export has an invalid public capability")
+    reconstructed = {
+        "description": "validated public capability placeholder",
+        "provider": _public_provider(capability["provider"]),
+        "method": capability["method"],
+        "operation_id": capability["operation_id"],
+        "required_inputs": capability["required_inputs"],
+        "output_fields": capability["output_fields"],
+    }
+    try:
+        normalized = normalize_capability_request(reconstructed)
+    except ValueError as exc:
+        raise VSDDemandError(
+            "Proposal export has an invalid public capability"
+        ) from exc
+    expected = {key: normalized[key] for key in sorted(_PUBLIC_CAPABILITY_KEYS)}
+    if capability != expected:
+        raise VSDDemandError("Proposal export capability is not canonical")
+
+
+def _validate_record(demand_id: str, record: Any) -> None:
+    if not _DEMAND_ID_RE.fullmatch(demand_id) or not isinstance(record, dict):
+        raise VSDDemandError("Demand ledger has an invalid record")
+    required = {
+        "demand_id",
+        "public_summary",
+        "capability",
+        "observation_counts",
+        "total_observations",
+        "source_counts",
+        "first_observed_at",
+        "last_observed_at",
+        "registry_snapshots",
+        "last_matches",
+        "event_hashes",
+    }
+    if set(record) != required or record.get("demand_id") != demand_id:
+        raise VSDDemandError("Demand ledger has an unsupported record")
+    summary = _safe_public_text(
+        record.get("public_summary"),
+        field="public_summary",
+        minimum=10,
+        maximum=240,
+    )
+    _validate_capability(record.get("capability"))
+    expected_id = _canonical_digest(
+        {"public_summary": summary.casefold(), "capability": record["capability"]}
+    )[:16]
+    if expected_id != demand_id:
+        raise VSDDemandError("Demand ID does not match its sanitized content")
+    counts = record.get("observation_counts")
+    if (
+        not isinstance(counts, dict)
+        or set(counts) != _OBSERVATION_KEYS
+        or any(type(value) is not int or value < 0 for value in counts.values())
+        or record.get("total_observations") != sum(counts.values())
+    ):
+        raise VSDDemandError("Demand ledger has invalid observation counts")
+    source_counts = record.get("source_counts")
+    if (
+        not isinstance(source_counts, dict)
+        or len(source_counts) > 20
+        or any(
+            not _SOURCE_RE.fullmatch(name) or type(count) is not int or count < 1
+            for name, count in source_counts.items()
+        )
+        or sum(source_counts.values()) != record["total_observations"]
+    ):
+        raise VSDDemandError("Demand ledger has invalid source counts")
+    first = _timestamp(record.get("first_observed_at"))
+    last = _timestamp(record.get("last_observed_at"))
+    if (
+        first != record["first_observed_at"]
+        or last != record["last_observed_at"]
+        or datetime.fromisoformat(first) > datetime.fromisoformat(last)
+    ):
+        raise VSDDemandError("Demand ledger timestamps are not canonical")
+    snapshots = record.get("registry_snapshots")
+    if (
+        not isinstance(snapshots, list)
+        or len(snapshots) > _MAX_REGISTRY_SNAPSHOTS
+        or len(snapshots) != len(set(snapshots))
+        or any(
+            not isinstance(value, str) or not _SHA256_RE.fullmatch(value)
+            for value in snapshots
+        )
+    ):
+        raise VSDDemandError("Demand ledger has invalid registry snapshots")
+    matches = record.get("last_matches")
+    if (
+        not isinstance(matches, list)
+        or len(matches) > _MAX_MATCHES
+        or len(matches) != len(set(matches))
+        or any(
+            not isinstance(value, str) or not 1 <= len(value) <= 128
+            for value in matches
+        )
+    ):
+        raise VSDDemandError("Demand ledger has invalid tool matches")
+    events = record.get("event_hashes")
+    if (
+        not isinstance(events, list)
+        or len(events) > _MAX_EVENT_HASHES
+        or len(events) != len(set(events))
+        or any(
+            not isinstance(value, str) or not _SHA256_RE.fullmatch(value)
+            for value in events
+        )
+    ):
+        raise VSDDemandError("Demand ledger has invalid event hashes")
+
+
+def _load_ledger(root: Path) -> dict[str, Any]:
+    path = root / "demand_ledger.json"
+    if not path.exists():
+        return _empty_ledger()
+    try:
+        if path.stat().st_size > _MAX_FILE_BYTES:
+            raise VSDDemandError("Demand ledger exceeds the 2 MB limit")
+        ledger = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise VSDDemandError("Demand ledger is unreadable") from exc
+    if (
+        not isinstance(ledger, dict)
+        or set(ledger) != {"version", "records", "integrity_sha256"}
+        or ledger.get("version") != _LEDGER_VERSION
+        or not isinstance(ledger.get("records"), dict)
+        or len(ledger["records"]) > _MAX_DEMANDS
+    ):
+        raise VSDDemandError("Demand ledger has an unsupported structure")
+    expected = _with_integrity(ledger)
+    if ledger.get("integrity_sha256") != expected["integrity_sha256"]:
+        raise VSDDemandError("Demand ledger integrity digest does not match")
+    for demand_id, record in ledger["records"].items():
+        _validate_record(demand_id, record)
+    return ledger
+
+
+def _observation_from_coverage(
+    request: dict[str, Any], coverage: dict[str, Any]
+) -> tuple[dict[str, Any], str, str, list[str]]:
+    normalized = _normalized_request(request)
+    data = coverage.get("data") if isinstance(coverage, dict) else None
+    if not isinstance(data, dict) or data.get("request") != normalized:
+        raise VSDDemandError("Coverage result does not match the capability request")
+    observation = _CLASSIFICATIONS.get(data.get("classification"))
+    registry_sha256 = data.get("registry_sha256")
+    matches = data.get("matches")
+    if (
+        observation is None
+        or not isinstance(registry_sha256, str)
+        or not _SHA256_RE.fullmatch(registry_sha256)
+        or not isinstance(matches, list)
+    ):
+        raise VSDDemandError("Coverage result has an unsupported structure")
+    names = []
+    for match in matches[:_MAX_MATCHES]:
+        name = match.get("name") if isinstance(match, dict) else None
+        if not isinstance(name, str) or not 1 <= len(name) <= 128:
+            raise VSDDemandError("Coverage result has an invalid match name")
+        if name not in names:
+            names.append(name)
+    return normalized, observation, registry_sha256, names
+
+
+def _prepare_observation(
+    request: dict[str, Any],
+    coverage: dict[str, Any],
+    *,
+    public_summary: str,
+    source: str,
+    event_id: str | None,
+    observed_at: str | None,
+) -> dict[str, Any]:
+    summary = _safe_public_text(
+        public_summary, field="public_summary", minimum=10, maximum=240
+    )
+    source_id = _source(source)
+    timestamp = _timestamp(observed_at)
+    normalized, observation, registry_sha256, matches = _observation_from_coverage(
+        request, coverage
+    )
+    capability = _stored_capability(normalized)
+    demand_id = _canonical_digest(
+        {"public_summary": summary.casefold(), "capability": capability}
+    )[:16]
+    return {
+        "demand_id": demand_id,
+        "public_summary": summary,
+        "capability": capability,
+        "observation": observation,
+        "source": source_id,
+        "timestamp": timestamp,
+        "registry_sha256": registry_sha256,
+        "matches": matches,
+        "event_hash": _event_hash(source_id, event_id),
+    }
+
+
+def _apply_observation(
+    ledger: dict[str, Any], prepared: dict[str, Any]
+) -> tuple[bool, dict[str, Any]]:
+    demand_id = prepared["demand_id"]
+    record = ledger["records"].get(demand_id)
+    if record is None:
+        if len(ledger["records"]) >= _MAX_DEMANDS:
+            raise VSDDemandError("Demand ledger reached its 1000-record limit")
+        record = {
+            "demand_id": demand_id,
+            "public_summary": prepared["public_summary"],
+            "capability": prepared["capability"],
+            "observation_counts": {key: 0 for key in sorted(_OBSERVATION_KEYS)},
+            "total_observations": 0,
+            "source_counts": {},
+            "first_observed_at": prepared["timestamp"],
+            "last_observed_at": prepared["timestamp"],
+            "registry_snapshots": [],
+            "last_matches": [],
+            "event_hashes": [],
+        }
+        ledger["records"][demand_id] = record
+    event_hash = prepared["event_hash"]
+    if event_hash is not None and event_hash in record["event_hashes"]:
+        return False, record
+    observation = prepared["observation"]
+    source = prepared["source"]
+    if source not in record["source_counts"] and len(record["source_counts"]) >= 20:
+        raise VSDDemandError("Demand record reached its 20-source limit")
+    record["observation_counts"][observation] += 1
+    record["total_observations"] += 1
+    record["source_counts"][source] = record["source_counts"].get(source, 0) + 1
+    observed = datetime.fromisoformat(prepared["timestamp"])
+    first = datetime.fromisoformat(record["first_observed_at"])
+    last = datetime.fromisoformat(record["last_observed_at"])
+    record["first_observed_at"] = min(first, observed).isoformat()
+    record["last_observed_at"] = max(last, observed).isoformat()
+    registry_sha256 = prepared["registry_sha256"]
+    if registry_sha256 not in record["registry_snapshots"]:
+        record["registry_snapshots"].append(registry_sha256)
+        record["registry_snapshots"] = record["registry_snapshots"][
+            -_MAX_REGISTRY_SNAPSHOTS:
+        ]
+    record["last_matches"] = prepared["matches"]
+    if event_hash is not None:
+        record["event_hashes"].append(event_hash)
+        record["event_hashes"] = record["event_hashes"][-_MAX_EVENT_HASHES:]
+    return True, record
+
+
+def record_coverage_observation(
+    request: dict[str, Any],
+    coverage: dict[str, Any],
+    *,
+    public_summary: str,
+    source: str = "manual",
+    event_id: str | None = None,
+    observed_at: str | None = None,
+    workspace: str | Path | None = None,
+) -> dict[str, Any]:
+    """Record one explicit local observation without persisting the raw query."""
+    prepared = _prepare_observation(
+        request,
+        coverage,
+        public_summary=public_summary,
+        source=source,
+        event_id=event_id,
+        observed_at=observed_at,
+    )
+    root = _root(workspace)
+    with _ledger_transaction(root):
+        ledger = _load_ledger(root)
+        recorded, record = _apply_observation(ledger, prepared)
+        if not recorded:
+            return {
+                "status": "success",
+                "data": {
+                    "recorded": False,
+                    "deduplicated": True,
+                    "demand": _public_record(record),
+                    "privacy": _privacy_statement(),
+                },
+            }
+        updated = _with_integrity(ledger)
+        _atomic_write_json(root / "demand_ledger.json", updated)
+        return {
+            "status": "success",
+            "data": {
+                "recorded": True,
+                "deduplicated": False,
+                "demand": _public_record(record),
+                "ledger_sha256": updated["integrity_sha256"],
+                "privacy": _privacy_statement(),
+            },
+        }
+
+
+def observe_capability_demand(
+    tooluniverse: Any,
+    request: dict[str, Any],
+    *,
+    public_summary: str,
+    source: str = "manual",
+    event_id: str | None = None,
+    observed_at: str | None = None,
+    workspace: str | Path | None = None,
+    limit: int = 5,
+) -> dict[str, Any]:
+    """Resolve current local coverage and explicitly record the observation."""
+    coverage = resolve_capability(tooluniverse, request, limit=limit)
+    return record_coverage_observation(
+        request,
+        coverage,
+        public_summary=public_summary,
+        source=source,
+        event_id=event_id,
+        observed_at=observed_at,
+        workspace=workspace,
+    )
+
+
+def record_plan_demands(
+    plan: dict[str, Any],
+    public_summaries: dict[str, str],
+    *,
+    workspace: str | Path | None = None,
+    source: str = "workflow_plan",
+    run_id: str | None = None,
+    observed_at: str | None = None,
+    include_classifications: tuple[str, ...] = ("missing", "existing_partial"),
+) -> dict[str, Any]:
+    """Atomically record summarized tool steps from a hash-bound VSD plan."""
+    data = plan.get("data") if isinstance(plan, dict) and "data" in plan else plan
+    if not isinstance(data, dict):
+        raise VSDDemandError("plan must be a VSD workflow plan object")
+    plan_sha256 = data.get("plan_sha256")
+    plan_id = data.get("plan_id")
+    body = {
+        key: value
+        for key, value in data.items()
+        if key not in {"plan_id", "plan_sha256"}
+    }
+    expected = _canonical_digest(body)
+    if (
+        not isinstance(plan_sha256, str)
+        or plan_sha256 != expected
+        or plan_id != expected[:16]
+        or data.get("execution_allowed") is not False
+        or not isinstance(data.get("registry_sha256"), str)
+        or not _SHA256_RE.fullmatch(data["registry_sha256"])
+    ):
+        raise VSDDemandError("Plan identity or non-execution boundary is invalid")
+    allowed = {"missing", "existing_partial", "existing_exact"}
+    if (
+        not isinstance(include_classifications, tuple)
+        or not include_classifications
+        or len(include_classifications) != len(set(include_classifications))
+        or not set(include_classifications) <= allowed
+    ):
+        raise VSDDemandError("include_classifications contains unsupported values")
+    if not isinstance(public_summaries, dict) or any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in public_summaries.items()
+    ):
+        raise VSDDemandError("public_summaries must map step IDs to reviewed text")
+    source_id = _source(source)
+    timestamp = _timestamp(observed_at)
+    if run_id is not None and (
+        not isinstance(run_id, str)
+        or not 1 <= len(run_id) <= 100
+        or any(ord(character) < 32 for character in run_id)
+    ):
+        raise VSDDemandError("run_id must contain 1-100 printable characters")
+    steps = data.get("steps")
+    if not isinstance(steps, list) or not 1 <= len(steps) <= 20:
+        raise VSDDemandError("Plan must contain 1-20 workflow steps")
+    known_step_ids = {step.get("step_id") for step in steps if isinstance(step, dict)}
+    if None in known_step_ids or set(public_summaries) - known_step_ids:
+        raise VSDDemandError("public_summaries contains unknown workflow steps")
+    selected = [
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and step.get("fulfillment") == "tool"
+        and step.get("classification") in include_classifications
+    ]
+    missing_summaries = sorted(
+        step["step_id"] for step in selected if step["step_id"] not in public_summaries
+    )
+    if missing_summaries:
+        raise VSDDemandError(
+            f"Reviewed public summaries are required for steps: {missing_summaries!r}"
+        )
+    prepared = []
+    for step in selected:
+        classification = step["classification"]
+        request = step.get("request")
+        coverage = {
+            "data": {
+                "request": request,
+                "classification": classification,
+                "registry_sha256": data["registry_sha256"],
+                "matches": step.get("matches"),
+            }
+        }
+        event_id = f"{run_id or plan_id}:{step['step_id']}"
+        prepared.append(
+            _prepare_observation(
+                request,
+                coverage,
+                public_summary=public_summaries[step["step_id"]],
+                source=source_id,
+                event_id=event_id,
+                observed_at=timestamp,
+            )
+        )
+    root = _root(workspace)
+    with _ledger_transaction(root):
+        ledger = _load_ledger(root)
+        outcomes = [_apply_observation(ledger, item) for item in prepared]
+        recorded_count = sum(recorded for recorded, _ in outcomes)
+        if recorded_count:
+            updated = _with_integrity(ledger)
+            _atomic_write_json(root / "demand_ledger.json", updated)
+        else:
+            updated = ledger
+    return {
+        "status": "success",
+        "data": {
+            "plan_id": plan_id,
+            "selected_step_count": len(selected),
+            "recorded_count": recorded_count,
+            "deduplicated_count": len(selected) - recorded_count,
+            "demands": [_public_record(record) for _, record in outcomes],
+            "ledger_sha256": updated["integrity_sha256"],
+            "privacy": _privacy_statement(),
+        },
+    }
+
+
+def _priority(record: dict[str, Any]) -> tuple[int, float]:
+    counts = record["observation_counts"]
+    score = counts["missing"] * 5 + counts["partial"] * 2
+    unmet = counts["missing"] + counts["partial"]
+    return score, round(unmet / record["total_observations"], 4)
+
+
+def _public_record(record: dict[str, Any]) -> dict[str, Any]:
+    score, unmet_rate = _priority(record)
+    return {
+        key: copy.deepcopy(value)
+        for key, value in record.items()
+        if key != "event_hashes"
+    } | {"priority_score": score, "unmet_rate": unmet_rate}
+
+
+def _privacy_statement() -> str:
+    return (
+        "The demand ledger is local and explicit. Raw query descriptions and event "
+        "IDs are not stored, and nothing is transmitted automatically."
+    )
+
+
+def rank_demands(
+    *,
+    workspace: str | Path | None = None,
+    minimum_observations: int = 1,
+    limit: int = 100,
+    include_satisfied: bool = False,
+) -> dict[str, Any]:
+    """Return deterministic local priority ordering without changing the ledger."""
+    if (
+        type(minimum_observations) is not int
+        or not 1 <= minimum_observations <= 1_000_000
+    ):
+        raise VSDDemandError("minimum_observations must be a positive integer")
+    if type(limit) is not int or not 1 <= limit <= 1000:
+        raise VSDDemandError("limit must be an integer between 1 and 1000")
+    if type(include_satisfied) is not bool:
+        raise VSDDemandError("include_satisfied must be boolean")
+    root = _root(workspace)
+    with _ledger_transaction(root):
+        ledger = _load_ledger(root)
+    ranked = [
+        _public_record(record)
+        for record in ledger["records"].values()
+        if record["total_observations"] >= minimum_observations
+        and (
+            include_satisfied
+            or record["observation_counts"]["missing"] > 0
+            or record["observation_counts"]["partial"] > 0
+        )
+    ]
+    ranked.sort(
+        key=lambda record: (
+            -record["priority_score"],
+            -record["total_observations"],
+            record["public_summary"].casefold(),
+            record["demand_id"],
+        )
+    )
+    return {
+        "status": "success",
+        "data": {
+            "ranked_demands": ranked[:limit],
+            "matching_demand_count": len(ranked),
+            "total_demand_count": len(ledger["records"]),
+            "ledger_sha256": ledger["integrity_sha256"],
+            "privacy": _privacy_statement(),
+        },
+    }
+
+
+def export_proposals(
+    demand_ids: list[str],
+    output_path: str | Path,
+    *,
+    reviewed_by: str,
+    decision_note: str,
+    workspace: str | Path | None = None,
+    created_at: str | None = None,
+    replace: bool = False,
+) -> dict[str, Any]:
+    """Write an explicitly selected, sanitized proposal bundle without sending it."""
+    if (
+        not isinstance(demand_ids, list)
+        or not 1 <= len(demand_ids) <= 100
+        or len(demand_ids) != len(set(demand_ids))
+        or any(
+            not isinstance(value, str) or not _DEMAND_ID_RE.fullmatch(value)
+            for value in demand_ids
+        )
+    ):
+        raise VSDDemandError("demand_ids must contain 1-100 unique demand IDs")
+    reviewer = _safe_public_text(
+        reviewed_by, field="reviewed_by", minimum=3, maximum=100
+    )
+    note = _safe_public_text(
+        decision_note, field="decision_note", minimum=20, maximum=500
+    )
+    if type(replace) is not bool:
+        raise VSDDemandError("replace must be boolean")
+    timestamp = _timestamp(created_at)
+    root = _root(workspace)
+    with _ledger_transaction(root):
+        ledger = _load_ledger(root)
+    unknown = sorted(set(demand_ids) - set(ledger["records"]))
+    if unknown:
+        raise VSDDemandError(f"Unknown demand IDs: {unknown!r}")
+    proposals = []
+    for demand_id in demand_ids:
+        record = ledger["records"][demand_id]
+        counts = record["observation_counts"]
+        if counts["missing"] == 0 and counts["partial"] == 0:
+            raise VSDDemandError(
+                f"Demand {demand_id!r} has no unmet observations to export"
+            )
+        score, unmet_rate = _priority(record)
+        proposal_body = {
+            "public_summary": record["public_summary"],
+            "capability": _export_capability(record["capability"]),
+            "observation_counts": copy.deepcopy(counts),
+            "total_observations": record["total_observations"],
+            "priority_score": score,
+            "unmet_rate": unmet_rate,
+            "recommended_next_step": (
+                "review_external_api_candidates"
+                if counts["missing"] > 0
+                else "inspect_or_extend_existing_tools"
+            ),
+        }
+        proposals.append(
+            {"proposal_id": _canonical_digest(proposal_body)[:16], **proposal_body}
+        )
+    export = {
+        "version": _EXPORT_VERSION,
+        "created_at": timestamp,
+        "review": {"reviewed_by": reviewer, "decision_note": note},
+        "proposals": proposals,
+        "transmission": "none; this file was written locally for explicit human review",
+    }
+    export["export_sha256"] = _canonical_digest(export)
+    validate_proposal_export(export)
+    destination = Path(output_path).expanduser()
+    protected = {
+        (root / "demand_ledger.json").resolve(),
+        (root / ".demand.lock").resolve(),
+    }
+    if destination.resolve() in protected:
+        raise VSDDemandError("Proposal output must not replace private ledger files")
+    if destination.suffix.casefold() != ".json":
+        raise VSDDemandError("Proposal output must use a .json filename")
+    if destination.exists() and not replace:
+        raise VSDDemandError("Proposal output already exists; set replace explicitly")
+    _atomic_write_json(destination, export)
+    return export
+
+
+def validate_proposal_export(value: Any) -> None:
+    """Validate the complete sanitized export and its content digest."""
+    required = {
+        "version",
+        "created_at",
+        "review",
+        "proposals",
+        "transmission",
+        "export_sha256",
+    }
+    if not isinstance(value, dict) or set(value) != required:
+        raise VSDDemandError("Proposal export has an unsupported structure")
+    if value.get("version") != _EXPORT_VERSION:
+        raise VSDDemandError("Proposal export version is not supported")
+    if _timestamp(value.get("created_at")) != value["created_at"]:
+        raise VSDDemandError("Proposal export timestamp is not canonical")
+    review = value.get("review")
+    if not isinstance(review, dict) or set(review) != {"reviewed_by", "decision_note"}:
+        raise VSDDemandError("Proposal export review is invalid")
+    _safe_public_text(
+        review["reviewed_by"], field="reviewed_by", minimum=3, maximum=100
+    )
+    _safe_public_text(
+        review["decision_note"], field="decision_note", minimum=20, maximum=500
+    )
+    proposals = value.get("proposals")
+    if not isinstance(proposals, list) or not 1 <= len(proposals) <= 100:
+        raise VSDDemandError("Proposal export must contain 1-100 proposals")
+    proposal_ids: set[str] = set()
+    proposal_keys = {
+        "proposal_id",
+        "public_summary",
+        "capability",
+        "observation_counts",
+        "total_observations",
+        "priority_score",
+        "unmet_rate",
+        "recommended_next_step",
+    }
+    for proposal in proposals:
+        if not isinstance(proposal, dict) or set(proposal) != proposal_keys:
+            raise VSDDemandError("Proposal export contains an invalid proposal")
+        proposal_id = proposal.get("proposal_id")
+        if (
+            not isinstance(proposal_id, str)
+            or not _DEMAND_ID_RE.fullmatch(proposal_id)
+            or proposal_id in proposal_ids
+        ):
+            raise VSDDemandError("Proposal export contains invalid proposal IDs")
+        proposal_ids.add(proposal_id)
+        _safe_public_text(
+            proposal["public_summary"],
+            field="public_summary",
+            minimum=10,
+            maximum=240,
+        )
+        _validate_export_capability(proposal["capability"])
+        counts = proposal.get("observation_counts")
+        if (
+            not isinstance(counts, dict)
+            or set(counts) != _OBSERVATION_KEYS
+            or any(type(count) is not int or count < 0 for count in counts.values())
+            or proposal.get("total_observations") != sum(counts.values())
+            or counts["missing"] + counts["partial"] == 0
+        ):
+            raise VSDDemandError("Proposal export contains invalid observation counts")
+        score = counts["missing"] * 5 + counts["partial"] * 2
+        unmet_rate = round(
+            (counts["missing"] + counts["partial"]) / proposal["total_observations"],
+            4,
+        )
+        expected_next = (
+            "review_external_api_candidates"
+            if counts["missing"] > 0
+            else "inspect_or_extend_existing_tools"
+        )
+        body = {key: proposal[key] for key in proposal_keys - {"proposal_id"}}
+        if (
+            proposal["priority_score"] != score
+            or proposal["unmet_rate"] != unmet_rate
+            or proposal["recommended_next_step"] != expected_next
+            or proposal_id != _canonical_digest(body)[:16]
+        ):
+            raise VSDDemandError("Proposal export contains inconsistent derived fields")
+    if value.get("transmission") != (
+        "none; this file was written locally for explicit human review"
+    ):
+        raise VSDDemandError("Proposal export transmission boundary is invalid")
+    expected_digest = _canonical_digest(
+        {key: item for key, item in value.items() if key != "export_sha256"}
+    )
+    if value.get("export_sha256") != expected_digest:
+        raise VSDDemandError("Proposal export integrity digest does not match")
+
+
+def remove_demand(
+    demand_id: str,
+    *,
+    workspace: str | Path | None = None,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    """Remove one local aggregate through an explicit privacy control."""
+    if not isinstance(demand_id, str) or not _DEMAND_ID_RE.fullmatch(demand_id):
+        raise VSDDemandError("demand_id is not valid")
+    if confirm is not True:
+        raise VSDDemandError("confirm=True is required to remove a demand")
+    root = _root(workspace)
+    with _ledger_transaction(root):
+        ledger = _load_ledger(root)
+        if demand_id not in ledger["records"]:
+            raise VSDDemandError("Demand does not exist")
+        del ledger["records"][demand_id]
+        updated = _with_integrity(ledger)
+        _atomic_write_json(root / "demand_ledger.json", updated)
+    return {
+        "status": "success",
+        "data": {
+            "removed": True,
+            "demand_id": demand_id,
+            "ledger_sha256": updated["integrity_sha256"],
+        },
+    }
+
+
+__all__ = [
+    "VSDDemandError",
+    "export_proposals",
+    "observe_capability_demand",
+    "rank_demands",
+    "record_coverage_observation",
+    "record_plan_demands",
+    "remove_demand",
+    "validate_proposal_export",
+]

--- a/src/tooluniverse/vsd_demand_cli.py
+++ b/src/tooluniverse/vsd_demand_cli.py
@@ -1,0 +1,170 @@
+"""Explicit local administration CLI for VSD demand aggregation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+from .execute_function import ToolUniverse
+from .vsd_demand import (
+    export_proposals,
+    observe_capability_demand,
+    rank_demands,
+    record_plan_demands,
+    remove_demand,
+)
+
+
+def _csv(value: str) -> list[str]:
+    fields = [item.strip() for item in value.split(",") if item.strip()]
+    if not fields:
+        raise argparse.ArgumentTypeError("Provide at least one comma-separated field")
+    return fields
+
+
+def _json_file(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise argparse.ArgumentTypeError(
+            "Could not read the requested JSON file"
+        ) from exc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tooluniverse-vsd-demand",
+        description=(
+            "Record and rank private local VSD demand, then explicitly export "
+            "selected sanitized proposals. Nothing is transmitted automatically."
+        ),
+    )
+    parser.add_argument("--workspace", type=Path)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    record = commands.add_parser("record")
+    record.add_argument("--description", required=True)
+    record.add_argument("--public-summary", required=True)
+    record.add_argument("--provider")
+    record.add_argument("--method", default="GET")
+    record.add_argument("--endpoint")
+    record.add_argument("--operation-id")
+    record.add_argument("--required-inputs", type=_csv)
+    record.add_argument("--output-fields", type=_csv)
+    record.add_argument("--source", default="manual")
+    record.add_argument("--event-id")
+    record.add_argument("--limit", type=int, default=5)
+
+    record_plan = commands.add_parser("record-plan")
+    record_plan.add_argument("plan_file", type=Path)
+    record_plan.add_argument("summaries_file", type=Path)
+    record_plan.add_argument("--source", default="workflow_plan")
+    record_plan.add_argument("--run-id")
+    record_plan.add_argument(
+        "--include",
+        type=_csv,
+        default=["missing", "existing_partial"],
+        help="Comma-separated missing, existing_partial, or existing_exact values.",
+    )
+
+    rank = commands.add_parser("rank")
+    rank.add_argument("--minimum-observations", type=int, default=1)
+    rank.add_argument("--limit", type=int, default=100)
+    rank.add_argument("--include-satisfied", action="store_true")
+
+    export = commands.add_parser("export")
+    export.add_argument("output_file", type=Path)
+    export.add_argument("--demand-id", action="append", required=True)
+    export.add_argument("--reviewed-by", required=True)
+    export.add_argument("--decision-note", required=True)
+    export.add_argument("--replace", action="store_true")
+
+    remove = commands.add_parser("remove")
+    remove.add_argument("demand_id")
+    remove.add_argument("--confirm", action="store_true")
+    return parser
+
+
+def _request(namespace: argparse.Namespace) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in {
+            "description": namespace.description,
+            "provider": namespace.provider,
+            "method": namespace.method,
+            "endpoint": namespace.endpoint,
+            "operation_id": namespace.operation_id,
+            "required_inputs": namespace.required_inputs,
+            "output_fields": namespace.output_fields,
+        }.items()
+        if value is not None
+    }
+
+
+def _execute(namespace: argparse.Namespace) -> dict[str, Any]:
+    workspace = namespace.workspace
+    if namespace.command == "record":
+        tooluniverse = ToolUniverse()
+        try:
+            return observe_capability_demand(
+                tooluniverse,
+                _request(namespace),
+                public_summary=namespace.public_summary,
+                source=namespace.source,
+                event_id=namespace.event_id,
+                workspace=workspace,
+                limit=namespace.limit,
+            )
+        finally:
+            tooluniverse.close()
+    if namespace.command == "rank":
+        return rank_demands(
+            workspace=workspace,
+            minimum_observations=namespace.minimum_observations,
+            limit=namespace.limit,
+            include_satisfied=namespace.include_satisfied,
+        )
+    if namespace.command == "record-plan":
+        plan = _json_file(namespace.plan_file)
+        summaries = _json_file(namespace.summaries_file)
+        if not isinstance(summaries, dict):
+            raise argparse.ArgumentTypeError("summaries file must contain an object")
+        return record_plan_demands(
+            plan,
+            summaries,
+            workspace=workspace,
+            source=namespace.source,
+            run_id=namespace.run_id,
+            include_classifications=tuple(namespace.include),
+        )
+    if namespace.command == "export":
+        return {
+            "status": "success",
+            "data": export_proposals(
+                namespace.demand_id,
+                namespace.output_file,
+                reviewed_by=namespace.reviewed_by,
+                decision_note=namespace.decision_note,
+                workspace=workspace,
+                replace=namespace.replace,
+            ),
+        }
+    if namespace.command == "remove":
+        return remove_demand(
+            namespace.demand_id,
+            workspace=workspace,
+            confirm=namespace.confirm,
+        )
+    raise AssertionError(f"Unsupported command: {namespace.command}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    result = _execute(build_parser().parse_args(argv))
+    print(json.dumps(result, indent=2, sort_keys=True, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tooluniverse/vsd_planning.py
+++ b/src/tooluniverse/vsd_planning.py
@@ -304,6 +304,7 @@ def plan_workflow(
                 "depends_on": step["depends_on"],
                 "optional": step["optional"],
                 "fulfillment": step["fulfillment"],
+                "request": deepcopy(step["capability"]),
                 "state": state,
                 "dependency_blockers": dependency_blockers,
                 "classification": classification,

--- a/tests/unit/test_vsd_demand.py
+++ b/tests/unit/test_vsd_demand.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import copy
+import json
+import multiprocessing
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.vsd_coverage import resolve_capability
+from tooluniverse.vsd_demand import (
+    VSDDemandError,
+    export_proposals,
+    observe_capability_demand,
+    rank_demands,
+    record_coverage_observation,
+    record_plan_demands,
+    remove_demand,
+    validate_proposal_export,
+)
+from tooluniverse.vsd_planning import plan_workflow
+from tooluniverse.tool_registry import get_config_registry, get_tool_registry
+
+pytestmark = pytest.mark.unit
+
+MISSING_REQUEST = {
+    "description": "quantum microscope calibration waveform optimizer",
+    "required_inputs": ["sample_id"],
+    "output_fields": ["calibration_score"],
+}
+MISSING_SUMMARY = "Quantitative microscopy calibration for research workflows"
+
+
+class _Registry:
+    tool_files = {}
+
+    def __init__(self, tools=()):
+        self.all_tools = list(tools)
+        self.all_tool_dict = {tool["name"]: tool for tool in self.all_tools}
+
+
+def _existing_tool() -> dict:
+    return {
+        "name": "ExistingRegistryRecords",
+        "type": "VSDDynamicRESTTool",
+        "category": "special_tools",
+        "description": "Retrieve reviewed disease registry records by disease.",
+        "parameter": {
+            "type": "object",
+            "properties": {"disease": {"type": "string"}},
+            "required": ["disease"],
+        },
+        "return_schema": {
+            "type": "object",
+            "properties": {"registry_id": {"type": "string"}},
+        },
+        "vsd_operation": {
+            "method": "GET",
+            "endpoint": "https://registry.example.org/v1/diseases",
+        },
+        "vsd_capability": {"operation_id": "registry.search_diseases"},
+    }
+
+
+def _exact_request() -> dict:
+    return {
+        "description": "retrieve disease registry records",
+        "operation_id": "registry.search_diseases",
+        "required_inputs": ["disease"],
+        "output_fields": ["registry_id"],
+    }
+
+
+def _missing_coverage() -> dict:
+    return resolve_capability(_Registry(), MISSING_REQUEST)
+
+
+def _record_missing(
+    workspace: Path,
+    *,
+    event_id: str | None = None,
+    observed_at: str = "2026-08-01T12:00:00+00:00",
+) -> dict:
+    return record_coverage_observation(
+        MISSING_REQUEST,
+        _missing_coverage(),
+        public_summary=MISSING_SUMMARY,
+        source="scheduled_scan",
+        event_id=event_id,
+        observed_at=observed_at,
+        workspace=workspace,
+    )
+
+
+def _concurrent_record_worker(workspace: str, event_id: str, results) -> None:
+    try:
+        result = _record_missing(Path(workspace), event_id=event_id)
+        results.put((result["data"]["recorded"], None))
+    except Exception as exc:  # pragma: no cover - asserted in parent process
+        results.put((False, repr(exc)))
+        raise
+
+
+def test_demand_mutation_and_export_are_not_agent_facing_tools():
+    prohibited = {"VSDRecordDemand", "VSDRankDemands", "VSDExportProposals"}
+    assert prohibited.isdisjoint(get_tool_registry())
+    assert prohibited.isdisjoint(get_config_registry())
+
+
+def test_private_ledger_omits_raw_query_and_event_ids_and_deduplicates(tmp_path):
+    first = _record_missing(tmp_path, event_id="cron-run-001")
+    duplicate = _record_missing(tmp_path, event_id="cron-run-001")
+    ledger_text = (tmp_path / "demand_ledger.json").read_text(encoding="utf-8")
+
+    assert first["data"]["recorded"] is True
+    assert duplicate["data"]["recorded"] is False
+    assert duplicate["data"]["deduplicated"] is True
+    assert first["data"]["demand"]["total_observations"] == 1
+    assert "quantum microscope calibration waveform optimizer" not in ledger_text
+    assert "cron-run-001" not in ledger_text
+    assert MISSING_SUMMARY in ledger_text
+    assert str(tmp_path) not in json.dumps(first)
+
+
+def test_ranking_prioritizes_repeated_missing_then_partial_and_hides_satisfied(
+    tmp_path,
+):
+    for index in range(2):
+        _record_missing(tmp_path, event_id=f"missing-{index}")
+
+    partial_request = {
+        "description": "retrieve registry investigator contacts",
+        "provider": "registry.example.org",
+        "required_inputs": ["investigator_id"],
+    }
+    partial_coverage = resolve_capability(
+        _Registry([_existing_tool()]), partial_request
+    )
+    assert partial_coverage["data"]["classification"] == "existing_partial"
+    record_coverage_observation(
+        partial_request,
+        partial_coverage,
+        public_summary="Registry investigator contact lookup for evidence review",
+        workspace=tmp_path,
+    )
+
+    exact_request = _exact_request()
+    exact_coverage = resolve_capability(_Registry([_existing_tool()]), exact_request)
+    record_coverage_observation(
+        exact_request,
+        exact_coverage,
+        public_summary="Reviewed disease registry lookup by disease identifier",
+        workspace=tmp_path,
+    )
+
+    ranked = rank_demands(workspace=tmp_path)["data"]
+    assert [item["priority_score"] for item in ranked["ranked_demands"]] == [10, 2]
+    assert ranked["ranked_demands"][0]["public_summary"] == MISSING_SUMMARY
+    assert ranked["total_demand_count"] == 3
+    assert ranked["matching_demand_count"] == 2
+    assert (
+        len(
+            rank_demands(workspace=tmp_path, include_satisfied=True)["data"][
+                "ranked_demands"
+            ]
+        )
+        == 3
+    )
+
+
+def test_export_is_explicit_sanitized_hash_bound_and_tamper_detecting(tmp_path):
+    result = _record_missing(tmp_path, event_id="private-event-value")
+    demand_id = result["data"]["demand"]["demand_id"]
+    output = tmp_path / "review" / "proposals.json"
+    exported = export_proposals(
+        [demand_id],
+        output,
+        reviewed_by="VSD Maintainer",
+        decision_note="Selected after reviewing the local unmet-demand aggregate.",
+        workspace=tmp_path,
+        created_at="2026-08-01T13:00:00+00:00",
+    )
+
+    validate_proposal_export(exported)
+    serialized = json.dumps(exported, sort_keys=True)
+    assert demand_id not in serialized
+    assert "private-event-value" not in serialized
+    assert "quantum microscope calibration waveform optimizer" not in serialized
+    assert str(tmp_path) not in serialized
+    assert exported["transmission"].startswith("none;")
+    assert json.loads(output.read_text(encoding="utf-8")) == exported
+
+    with pytest.raises(VSDDemandError, match="already exists"):
+        export_proposals(
+            [demand_id],
+            output,
+            reviewed_by="VSD Maintainer",
+            decision_note="Selected after reviewing the local unmet-demand aggregate.",
+            workspace=tmp_path,
+        )
+
+    tampered = copy.deepcopy(exported)
+    tampered["proposals"][0]["priority_score"] = 999
+    with pytest.raises(VSDDemandError, match="derived fields"):
+        validate_proposal_export(tampered)
+
+
+def test_export_omits_endpoint_paths_and_rejects_private_providers(tmp_path):
+    request = {
+        "description": "retrieve specialist assay calibration records",
+        "endpoint": "https://api.example.org/private-tenant/record-12345",
+    }
+    result = record_coverage_observation(
+        request,
+        resolve_capability(_Registry(), request),
+        public_summary="Specialist assay calibration records for research workflows",
+        workspace=tmp_path,
+    )
+    exported = export_proposals(
+        [result["data"]["demand"]["demand_id"]],
+        tmp_path / "safe-proposal.json",
+        reviewed_by="VSD Maintainer",
+        decision_note="Selected after verifying the reduced public capability fields.",
+        workspace=tmp_path,
+    )
+    serialized = json.dumps(exported, sort_keys=True)
+    assert "private-tenant" not in serialized
+    assert "record-12345" not in serialized
+    assert "endpoint_host" not in serialized
+    assert "endpoint_path" not in serialized
+    assert exported["proposals"][0]["capability"]["provider"] == "api.example.org"
+
+    private_request = {
+        "description": "retrieve an internal calibration registry",
+        "provider": "registry.internal",
+    }
+    private = record_coverage_observation(
+        private_request,
+        resolve_capability(_Registry(), private_request),
+        public_summary="Internal calibration registry for research workflows",
+        workspace=tmp_path,
+    )
+    with pytest.raises(VSDDemandError, match="not safe for public export"):
+        export_proposals(
+            [private["data"]["demand"]["demand_id"]],
+            tmp_path / "unsafe-proposal.json",
+            reviewed_by="VSD Maintainer",
+            decision_note="Testing rejection of an internal provider identifier.",
+            workspace=tmp_path,
+        )
+
+
+@pytest.mark.parametrize(
+    "summary",
+    [
+        "Contact maintainer@example.org about this missing research API",
+        "Review https://private.example.org/source for this capability",
+        "Research source with api_key=do-not-store-this credential",
+        "Research source with Authorization Bearer private-token-value",
+    ],
+)
+def test_sensitive_public_summaries_are_rejected(tmp_path, summary):
+    with pytest.raises(VSDDemandError, match="must not contain"):
+        record_coverage_observation(
+            MISSING_REQUEST,
+            _missing_coverage(),
+            public_summary=summary,
+            workspace=tmp_path,
+        )
+    assert not (tmp_path / "demand_ledger.json").exists()
+
+
+def test_mismatched_coverage_and_tampered_ledger_fail_closed(tmp_path):
+    other_request = {"description": "a different missing capability"}
+    with pytest.raises(VSDDemandError, match="does not match"):
+        record_coverage_observation(
+            other_request,
+            _missing_coverage(),
+            public_summary="Different missing capability for a research workflow",
+            workspace=tmp_path,
+        )
+
+    _record_missing(tmp_path)
+    path = tmp_path / "demand_ledger.json"
+    ledger = json.loads(path.read_text(encoding="utf-8"))
+    record = next(iter(ledger["records"].values()))
+    record["observation_counts"]["missing"] = 500
+    path.write_text(json.dumps(ledger), encoding="utf-8")
+    with pytest.raises(VSDDemandError, match="integrity digest"):
+        rank_demands(workspace=tmp_path)
+
+
+def test_exact_only_demand_cannot_be_exported(tmp_path):
+    request = _exact_request()
+    result = observe_capability_demand(
+        _Registry([_existing_tool()]),
+        request,
+        public_summary="Reviewed disease registry lookup by disease identifier",
+        workspace=tmp_path,
+    )
+    with pytest.raises(VSDDemandError, match="no unmet observations"):
+        export_proposals(
+            [result["data"]["demand"]["demand_id"]],
+            tmp_path / "proposal.json",
+            reviewed_by="VSD Maintainer",
+            decision_note="Reviewed the satisfied capability before export attempt.",
+            workspace=tmp_path,
+        )
+
+
+def test_export_cannot_replace_private_ledger_files(tmp_path):
+    demand_id = _record_missing(tmp_path)["data"]["demand"]["demand_id"]
+    with pytest.raises(VSDDemandError, match="must not replace"):
+        export_proposals(
+            [demand_id],
+            tmp_path / "demand_ledger.json",
+            reviewed_by="VSD Maintainer",
+            decision_note="Reviewed this proposal before testing protected output.",
+            workspace=tmp_path,
+            replace=True,
+        )
+    assert rank_demands(workspace=tmp_path)["data"]["total_demand_count"] == 1
+
+
+def test_source_cardinality_is_bounded_without_corrupting_ledger(tmp_path):
+    for index in range(20):
+        record_coverage_observation(
+            MISSING_REQUEST,
+            _missing_coverage(),
+            public_summary=MISSING_SUMMARY,
+            source=f"source_{index:02d}",
+            event_id=f"event-{index}",
+            workspace=tmp_path,
+        )
+    with pytest.raises(VSDDemandError, match="20-source limit"):
+        record_coverage_observation(
+            MISSING_REQUEST,
+            _missing_coverage(),
+            public_summary=MISSING_SUMMARY,
+            source="source_20",
+            event_id="event-20",
+            workspace=tmp_path,
+        )
+    demand = rank_demands(workspace=tmp_path)["data"]["ranked_demands"][0]
+    assert demand["total_observations"] == 20
+    assert len(demand["source_counts"]) == 20
+
+
+def test_out_of_order_observations_preserve_timestamp_bounds(tmp_path):
+    _record_missing(
+        tmp_path,
+        event_id="later",
+        observed_at="2026-08-05T12:00:00+00:00",
+    )
+    _record_missing(
+        tmp_path,
+        event_id="earlier",
+        observed_at="2026-08-01T12:00:00+00:00",
+    )
+    demand = rank_demands(workspace=tmp_path)["data"]["ranked_demands"][0]
+    assert demand["first_observed_at"] == "2026-08-01T12:00:00+00:00"
+    assert demand["last_observed_at"] == "2026-08-05T12:00:00+00:00"
+
+
+def test_remove_requires_confirmation_and_preserves_integrity(tmp_path):
+    demand_id = _record_missing(tmp_path)["data"]["demand"]["demand_id"]
+    with pytest.raises(VSDDemandError, match="confirm=True"):
+        remove_demand(demand_id, workspace=tmp_path)
+    removed = remove_demand(demand_id, workspace=tmp_path, confirm=True)
+    assert removed["data"]["removed"] is True
+    assert rank_demands(workspace=tmp_path)["data"]["total_demand_count"] == 0
+
+
+def test_hash_bound_workflow_plan_is_recorded_atomically_and_deduplicated(tmp_path):
+    plan = plan_workflow(
+        _Registry([_existing_tool()]),
+        goal="Build a registry and quantitative microscopy evidence workflow",
+        capabilities=[
+            {
+                "step_id": "registry",
+                "description": "retrieve disease registry records",
+                "operation_id": "registry.search_diseases",
+            },
+            {
+                "step_id": "calibration",
+                **MISSING_REQUEST,
+                "depends_on": ["registry"],
+            },
+            {
+                "step_id": "synthesis",
+                "description": "synthesize the reviewed evidence package",
+                "fulfillment": "agent",
+                "depends_on": ["registry", "calibration"],
+            },
+        ],
+    )
+    summaries = {"calibration": MISSING_SUMMARY}
+
+    first = record_plan_demands(plan, summaries, workspace=tmp_path)
+    duplicate = record_plan_demands(plan, summaries, workspace=tmp_path)
+    second_run = record_plan_demands(
+        plan, summaries, workspace=tmp_path, run_id="scheduled-run-002"
+    )
+
+    assert first["data"]["selected_step_count"] == 1
+    assert first["data"]["recorded_count"] == 1
+    assert duplicate["data"]["deduplicated_count"] == 1
+    assert second_run["data"]["recorded_count"] == 1
+    ranked = rank_demands(workspace=tmp_path)["data"]["ranked_demands"]
+    assert ranked[0]["observation_counts"]["missing"] == 2
+    ledger_text = (tmp_path / "demand_ledger.json").read_text(encoding="utf-8")
+    assert MISSING_REQUEST["description"] not in ledger_text
+    assert "scheduled-run-002" not in ledger_text
+
+
+def test_plan_batch_fails_before_writing_when_summary_is_missing_or_hash_is_tampered(
+    tmp_path,
+):
+    plan = plan_workflow(
+        _Registry([_existing_tool()]),
+        goal="Build a registry investigator and calibration workflow",
+        capabilities=[
+            {
+                "step_id": "contacts",
+                "description": "retrieve registry investigator contacts",
+                "provider": "registry.example.org",
+                "required_inputs": ["investigator_id"],
+            },
+            {"step_id": "calibration", **MISSING_REQUEST},
+        ],
+    )
+    with pytest.raises(VSDDemandError, match="required for steps"):
+        record_plan_demands(
+            plan,
+            {"calibration": MISSING_SUMMARY},
+            workspace=tmp_path,
+        )
+    assert not (tmp_path / "demand_ledger.json").exists()
+
+    tampered = copy.deepcopy(plan)
+    tampered["data"]["steps"][0]["classification"] = "missing"
+    with pytest.raises(VSDDemandError, match="Plan identity"):
+        record_plan_demands(
+            tampered,
+            {
+                "contacts": "Registry investigator contacts for evidence review",
+                "calibration": MISSING_SUMMARY,
+            },
+            workspace=tmp_path,
+        )
+    assert not (tmp_path / "demand_ledger.json").exists()
+
+
+def test_concurrent_process_observations_do_not_lose_counts(tmp_path):
+    context = multiprocessing.get_context("spawn")
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_concurrent_record_worker,
+            args=(str(tmp_path), f"worker-{index}", results),
+        )
+        for index in range(2)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=20)
+
+    outcomes = [results.get(timeout=2) for _ in processes]
+    assert outcomes == [(True, None), (True, None)]
+    assert [process.exitcode for process in processes] == [0, 0]
+    demand = rank_demands(workspace=tmp_path)["data"]["ranked_demands"][0]
+    assert demand["total_observations"] == 2
+    assert demand["observation_counts"]["missing"] == 2

--- a/tests/unit/test_vsd_demand_cli.py
+++ b/tests/unit/test_vsd_demand_cli.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tooluniverse import vsd_demand_cli
+from tooluniverse.vsd_planning import plan_workflow
+
+pytestmark = pytest.mark.unit
+
+
+class _EmptyToolUniverse:
+    tool_files = {}
+
+    def __init__(self):
+        self.all_tools = []
+        self.all_tool_dict = {}
+
+    def close(self):
+        pass
+
+
+def test_cli_completes_private_record_rank_export_remove_lifecycle(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(vsd_demand_cli, "ToolUniverse", _EmptyToolUniverse)
+    workspace = tmp_path / "demand"
+    base = ["--workspace", str(workspace)]
+    assert (
+        vsd_demand_cli.main(
+            base
+            + [
+                "record",
+                "--description",
+                "quantum microscope calibration waveform optimizer",
+                "--public-summary",
+                "Quantitative microscopy calibration for research workflows",
+                "--required-inputs",
+                "sample_id",
+                "--output-fields",
+                "calibration_score",
+                "--source",
+                "scheduled_scan",
+                "--event-id",
+                "scan-001",
+            ]
+        )
+        == 0
+    )
+    recorded = json.loads(capsys.readouterr().out)
+    demand_id = recorded["data"]["demand"]["demand_id"]
+
+    assert vsd_demand_cli.main(base + ["rank"]) == 0
+    ranked = json.loads(capsys.readouterr().out)
+    assert ranked["data"]["ranked_demands"][0]["demand_id"] == demand_id
+
+    output = tmp_path / "selected-proposals.json"
+    assert (
+        vsd_demand_cli.main(
+            base
+            + [
+                "export",
+                str(output),
+                "--demand-id",
+                demand_id,
+                "--reviewed-by",
+                "VSD Maintainer",
+                "--decision-note",
+                "Selected after reviewing the local unmet-demand aggregate.",
+            ]
+        )
+        == 0
+    )
+    exported = json.loads(capsys.readouterr().out)
+    assert exported["data"]["transmission"].startswith("none;")
+    assert output.exists()
+
+    assert vsd_demand_cli.main(base + ["remove", demand_id, "--confirm"]) == 0
+    removed = json.loads(capsys.readouterr().out)
+    assert removed["data"]["removed"] is True
+    assert vsd_demand_cli.main(base + ["rank"]) == 0
+    assert json.loads(capsys.readouterr().out)["data"]["total_demand_count"] == 0
+
+
+def test_cli_records_complete_hash_bound_plan_batch(tmp_path, capsys):
+    plan = plan_workflow(
+        _EmptyToolUniverse(),
+        goal="Build a quantitative microscopy calibration workflow",
+        capabilities=[
+            {
+                "step_id": "calibration",
+                "description": "quantum microscope calibration waveform optimizer",
+            }
+        ],
+    )
+    plan_file = tmp_path / "plan.json"
+    summaries_file = tmp_path / "summaries.json"
+    plan_file.write_text(json.dumps(plan), encoding="utf-8")
+    summaries_file.write_text(
+        json.dumps(
+            {
+                "calibration": (
+                    "Quantitative microscopy calibration for research workflows"
+                )
+            }
+        ),
+        encoding="utf-8",
+    )
+    base = ["--workspace", str(tmp_path / "demand")]
+
+    assert (
+        vsd_demand_cli.main(
+            base
+            + [
+                "record-plan",
+                str(plan_file),
+                str(summaries_file),
+                "--source",
+                "scheduled_scan",
+                "--run-id",
+                "batch-001",
+            ]
+        )
+        == 0
+    )
+    result = json.loads(capsys.readouterr().out)
+    assert result["data"]["selected_step_count"] == 1
+    assert result["data"]["recorded_count"] == 1

--- a/tests/unit/test_vsd_demand_ledger_case_study.py
+++ b/tests/unit/test_vsd_demand_ledger_case_study.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.vsd_demand import VSDDemandError, validate_proposal_export
+
+pytestmark = pytest.mark.unit
+
+MODULE_PATH = (
+    Path(__file__).parents[2] / "examples" / "vsd" / "demand_ledger_case_study.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "vsd_demand_ledger_case_study", MODULE_PATH
+)
+assert SPEC and SPEC.loader
+study = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = study
+SPEC.loader.exec_module(study)
+
+
+def test_demand_case_runs_hash_bound_plan_ranking_and_explicit_export(tmp_path):
+    snapshot = study.run_case(tmp_path / "private-ledger")
+    output_json = tmp_path / "snapshot.json"
+    output_markdown = tmp_path / "snapshot.md"
+    output_proposals = tmp_path / "proposals.json"
+    study.write_artifacts(
+        snapshot,
+        json_path=output_json,
+        markdown_path=output_markdown,
+        proposals_path=output_proposals,
+    )
+
+    assert all(snapshot["end_to_end_assertions"].values())
+    assert snapshot["observation_summary"] == {
+        "plan_runs_recorded": 3,
+        "plan_step_observations_recorded": 15,
+        "duplicate_step_observations_rejected": 5,
+        "retinal_observations_recorded": 2,
+        "satisfied_observations_recorded": 1,
+    }
+    assert [
+        item["priority_score"] for item in snapshot["ranking"]["ranked_demands"]
+    ] == [15, 10, 6, 6, 6, 6]
+    assert len(snapshot["proposal_export"]["proposals"]) == 2
+    assert len(snapshot["audit_sha256"]) == 64
+    assert json.loads(output_json.read_text(encoding="utf-8")) == snapshot
+    assert (
+        json.loads(output_proposals.read_text(encoding="utf-8"))
+        == snapshot["proposal_export"]
+    )
+    report = output_markdown.read_text(encoding="utf-8")
+    assert "Private ALS Capability-Demand Ledger Case Study" in report
+    assert "Hash-Bound Workflow Input" in report
+    assert "Local Priority Ranking" in report
+    assert "Explicit Proposal Export" in report
+    assert "Privacy And Execution Boundary" in report
+
+    tampered = copy.deepcopy(snapshot)
+    tampered["ranking"]["ranked_demands"][0]["priority_score"] = 500
+    with pytest.raises(ValueError, match="audit digest"):
+        study.validate_snapshot(tampered)
+
+
+def test_checked_proposal_artifact_is_synchronized_and_tamper_detecting():
+    snapshot = json.loads(study.DEFAULT_JSON.read_text(encoding="utf-8"))
+    proposals = json.loads(study.DEFAULT_PROPOSALS.read_text(encoding="utf-8"))
+    study.validate_snapshot(snapshot)
+    validate_proposal_export(proposals)
+    assert snapshot["proposal_export"] == proposals
+
+    tampered = copy.deepcopy(proposals)
+    tampered["proposals"][0]["public_summary"] = "A changed public proposal summary"
+    with pytest.raises(VSDDemandError, match="derived fields"):
+        validate_proposal_export(tampered)


### PR DESCRIPTION
## Summary

- add an administrator-only private demand ledger with no agent-facing tool registration
- resolve and aggregate exact, partial, and missing capability observations without storing raw query descriptions or event IDs
- atomically ingest hash-bound `VSDPlanWorkflow` results after validating every selected step and reviewer-approved public summary
- rank repeated unmet demand deterministically and keep already-satisfied capabilities out of the default ranking
- export only explicitly selected, sanitized proposal records to a local file without transmitting them

## Privacy and integrity boundaries

- raw capability descriptions are never persisted or exported
- caller event IDs are stored only as bounded hashes for deduplication
- public summaries reject URLs, email addresses, and credential-like assignments
- proposal capability records omit endpoint paths and reject internal/private provider identities
- local writes are bounded, process-locked, atomic, and request restrictive filesystem modes
- ledger, proposal, and case artifacts carry complete content digests
- proposal export cannot overwrite the ledger or lock file and requires explicit replacement for any existing output
- removal requires an explicit confirmation flag

There is no telemetry, upload endpoint, candidate execution, tool registration, or approval bypass. A user must intentionally share the generated proposal file through the normal issue or pull-request process for maintainers to see it.

## Case study

The checked ALS study records three hash-bound seven-step workflow preflights, rejects a replayed run, adds two observations for a separate adaptive-optics retinal calibration gap, and records one exact FDA-label capability. The unmet ranking contains six demands: repeated ALS calibration scores 15, retinal calibration scores 10, and four partially covered retrieval capabilities score 6 each; the satisfied FDA demand stays local but is excluded.

Only the two highest reviewed demand IDs are exported. The proposal bundle contains no local demand IDs, raw descriptions, event IDs, endpoint paths, or filesystem paths and explicitly states that no transmission occurred.

Artifacts:

- `examples/vsd/artifacts/demand_ledger_snapshot.md`
- `examples/vsd/artifacts/demand_ledger_snapshot.json`
- `examples/vsd/artifacts/demand_proposals.json`

The case passes all 13 end-to-end assertions with audit SHA-256 `ca1cdf0f5ff2f6c1018f39251323edd8e6789bdf0bff066cafdea012aa5aa346`.

## Verification

- 175 cumulative VSD unit and case-study tests passed
- 22 focused demand-ledger, CLI, concurrency, and artifact tests passed
- a real two-process write race preserved both observations
- Ruff formatting and lint passed
- CLI entry-point metadata parsed successfully
- artifact validation, Python compilation, and `git diff --check` passed

## Stack

This draft is stacked on #424 and should be reviewed after that phase.
