### PR TITLE
Add environment-backed credentials for reviewed VSD tools

### DIFF
--- a/examples/vsd/README.md
+++ b/examples/vsd/README.md
@@ -1,5 +1,58 @@
 # ToolUniverse VSD Validation Case Studies
 
+## Environment-Backed Credentials For Reviewed APIs
+
+VSD can promote a reviewed OpenAPI operation that requires either one header
+API key or one HTTP bearer token. The inspector derives the authentication
+contract from the OpenAPI security scheme, while the administrator supplies a
+`TOOLUNIVERSE_VSD_*` environment-variable reference during drafting. Only the
+reference is persisted; the credential value is read separately for every
+execution and is excluded from the operation result and provenance.
+
+Query and cookie API keys, HTTP basic authentication, OAuth flows, scopes,
+multiple simultaneous schemes, and ambiguous security alternatives remain
+blocked. Header names and values are bounded and validated before transport.
+Missing or malformed credentials fail before a request, and a provider payload
+that contains the exact credential value is rejected before result
+construction. Because the environment value is not part of the reviewed
+operation digest, an operator can rotate it without republishing the tool.
+
+The checked rare-disease study inspects a protected OpenAPI 3.1 contract,
+creates an inert candidate, binds the reviewed `X-Rare-Disease-Key` header to an
+environment reference, verifies ALS, Duchenne muscular dystrophy, and spinal
+muscular atrophy records, approves and publishes the hash-bound operation, and
+loads it into a fresh ToolUniverse instance. It then proves credential rotation,
+pre-network failure, provider-reflection rejection, and absence of all test
+credential values from persisted JSON and ToolUniverse results.
+
+Run the deterministic offline study from the repository root:
+
+```console
+PYTHONPATH=src python examples/vsd/credential_reference_case_study.py
+```
+
+The study writes `artifacts/credential_reference_snapshot.md` and the
+corresponding JSON audit snapshot. A deterministic protected rare-disease
+provider replaces only network transport because the repository cannot bundle
+a live credential; OpenAPI inspection, promotion, verification, publication,
+fresh loading, and execution all use the production code paths.
+
+For a real reviewed contract, use the same administrator flow:
+
+```console
+tooluniverse-vsd-promote inspect-openapi protected-api.yaml > inspection.json
+tooluniverse-vsd-promote --workspace ./vsd-review draft-openapi inspection.json \
+  --candidate-id <candidate-id> \
+  --tool-name VSDProtectedEvidenceById \
+  --description "Retrieve one reviewed protected evidence record by identifier." \
+  --credential-env TOOLUNIVERSE_VSD_PROVIDER_KEY
+```
+
+Configure `TOOLUNIVERSE_VSD_PROVIDER_KEY` in the runtime's secret manager or
+process environment before verification and execution. Do not put a credential
+value in the inspection file, command line, tool configuration, or case
+artifact.
+
 ## Private Capability-Demand Ledger
 
 `demand_ledger_case_study.py` demonstrates how a library user can learn which
@@ -146,10 +199,10 @@ tooluniverse-vsd-promote --workspace ./vsd-review draft-openapi inspection.json 
 
 `candidate-id` values are content-addressed and change when the provider
 contract changes. Administrators must select the value produced by their own
-inspection rather than reuse the example value above. Authentication, write
-methods, external schema references, non-JSON responses, unsupported parameter
-styles, and oversized schemas are emitted with explicit blockers and cannot be
-drafted.
+inspection rather than reuse the example value above. Authentication schemes
+outside the supported header API-key and bearer-token subset, write methods,
+external schema references, non-JSON responses, unsupported parameter styles,
+and oversized schemas are emitted with explicit blockers and cannot be drafted.
 
 ## Complete Oncology Source-Governance Pipeline
 

--- a/examples/vsd/artifacts/credential_reference_snapshot.json
+++ b/examples/vsd/artifacts/credential_reference_snapshot.json
@@ -1,0 +1,124 @@
+{
+  "answer": "Yes. The protected header was derived from a reviewed OpenAPI scheme, read only at execution, rotated without changing the operation digest, and rejected when missing, malformed, or reflected by the provider.",
+  "audit_sha256": "0fd635055d4f7c06cf8568d9d83d09c5697b98021d7fe3ae8b6c5f535fc066d5",
+  "end_to_end_assertions": {
+    "approved_publication_is_hash_bound": true,
+    "candidate_remains_inert_before_promotion": true,
+    "credential_environment_is_restored": true,
+    "credential_reference_is_the_only_persisted_auth_material": true,
+    "fresh_tooluniverse_executes_published_tool": true,
+    "header_is_not_exposed_in_result_or_provenance": true,
+    "invalid_credential_fails_before_transport": true,
+    "missing_credential_fails_before_transport": true,
+    "openapi_header_auth_is_recognized": true,
+    "provider_reflection_is_rejected": true,
+    "secret_rotation_preserves_operation_identity": true,
+    "secret_values_are_absent_from_artifacts": true,
+    "three_authenticated_verification_cases_pass": true,
+    "transport_receives_only_reviewed_header": true
+  },
+  "inspection": {
+    "auth": {
+      "header": "X-Rare-Disease-Key",
+      "scheme_name": "registryKey",
+      "type": "api_key_header"
+    },
+    "blockers": [],
+    "candidate_id": "00e6491e07dff951",
+    "candidate_sha256": "00e6491e07dff951de78a1f99fed202365db16114c4333fb689faeeb445f35dc",
+    "source_document_sha256": "c3d06bbcb8690111c1046d57ac60eeda36ed1a58274e1e1c3970ffcb144bb5c0"
+  },
+  "promotion": {
+    "approval_sha256": "627048f102a22863fccc5dfe568fd1b0fd9ae1695bbf74199cd7d3fd9f89333b",
+    "artifact_file_sha256": {
+      "approval": "6e3dd73804e189d1ecea3997e2129308c507f5443ad5c50992a0ffb2c891e584",
+      "draft": "32e74447b1568da7ea3bcdec8b2086e1ee92714f855d41d4252987c27aded578",
+      "evidence": "4edae9b01e6271f1913fdc825bb9d5fb10716e7fe2cb9b310ffdb8599f6038d9",
+      "publication": "26f5bc248166f9a79e8f6d7f06c415722a69db76e4d51aa83553617a10bd7eb4"
+    },
+    "draft_id": "vsdprotectedrarediseaseevidence_d9f22e4ffdae",
+    "draft_sha256": "98cb65b06de746ef4bb13229701b62a89d1c9988e3ee37c9b6d8dd2499352939",
+    "operation_sha256": "d9f22e4ffdaead4202c5f2416509c73a472f57ff5ef018fc23e018709a371595",
+    "publication_sha256": "6e46c2dda4472b19a7010ec395dbd60cba9bfdb738a72ec44dfc1c70b2cdd2f4",
+    "verification_case_count": 3,
+    "verification_sha256": "af0f010bc059a009edc44275596bd8982e93d9e7bab04b98b2ae53ef6b9ed4de"
+  },
+  "provider_fixture": "A deterministic protected rare-disease API fixture is used because no real credential is bundled with the repository. The full ToolUniverse promotion and runtime paths are real; only network transport is replaced.",
+  "question": "Can a reviewed ToolUniverse operation use a protected API without persisting, returning, or fixing the credential into its contract?",
+  "runtime": {
+    "authentication_provenance": {
+      "credential_source": "environment",
+      "type": "api_key_header_env"
+    },
+    "initial_record_id": "RD-ALS",
+    "invalid_credential_error": "Credential environment variable 'TOOLUNIVERSE_VSD_RARE_DISEASE_KEY' is not a valid bounded value",
+    "loaded_tools": [
+      "VSDProtectedRareDiseaseEvidence"
+    ],
+    "missing_credential_error": "Required credential environment variable 'TOOLUNIVERSE_VSD_RARE_DISEASE_KEY' is not set",
+    "operation_sha256_after_rotation": "d9f22e4ffdaead4202c5f2416509c73a472f57ff5ef018fc23e018709a371595",
+    "operation_sha256_before_rotation": "d9f22e4ffdaead4202c5f2416509c73a472f57ff5ef018fc23e018709a371595",
+    "reflection_error": "Provider response reflected credential material",
+    "rotated_record_id": "RD-SMA",
+    "transport_log": [
+      {
+        "credential_slot": "initial",
+        "header_name": "X-Rare-Disease-Key",
+        "params": {
+          "sections": "genes|phenotypes|trials"
+        },
+        "record_id": "RD-ALS",
+        "timeout": 20.0
+      },
+      {
+        "credential_slot": "initial",
+        "header_name": "X-Rare-Disease-Key",
+        "params": {
+          "sections": "genes|phenotypes|trials"
+        },
+        "record_id": "RD-DMD",
+        "timeout": 20.0
+      },
+      {
+        "credential_slot": "initial",
+        "header_name": "X-Rare-Disease-Key",
+        "params": {
+          "sections": "genes|phenotypes|trials"
+        },
+        "record_id": "RD-SMA",
+        "timeout": 20.0
+      },
+      {
+        "credential_slot": "initial",
+        "header_name": "X-Rare-Disease-Key",
+        "params": {
+          "sections": "genes|phenotypes|trials"
+        },
+        "record_id": "RD-ALS",
+        "timeout": 20.0
+      },
+      {
+        "credential_slot": "rotated",
+        "header_name": "X-Rare-Disease-Key",
+        "params": {
+          "sections": "genes|phenotypes|trials"
+        },
+        "record_id": "RD-SMA",
+        "timeout": 20.0
+      },
+      {
+        "credential_slot": "reflected",
+        "header_name": "X-Rare-Disease-Key",
+        "params": {},
+        "record_id": "RD-ALS",
+        "timeout": 20.0
+      }
+    ]
+  },
+  "secret_persistence": {
+    "persisted_reference": "TOOLUNIVERSE_VSD_RARE_DISEASE_KEY",
+    "persisted_secret_count": 0,
+    "result_secret_count": 0
+  },
+  "title": "Environment-Backed Rare-Disease Credential Case Study"
+}

--- a/examples/vsd/artifacts/credential_reference_snapshot.md
+++ b/examples/vsd/artifacts/credential_reference_snapshot.md
@@ -1,0 +1,56 @@
+# Environment-Backed Rare-Disease Credential Case Study
+
+## Decision Question
+
+Can a reviewed ToolUniverse operation use a protected API without persisting, returning, or fixing the credential into its contract?
+
+**Result:** Yes. The protected header was derived from a reviewed OpenAPI scheme, read only at execution, rotated without changing the operation digest, and rejected when missing, malformed, or reflected by the provider.
+
+## Provider Boundary
+
+A deterministic protected rare-disease API fixture is used because no real credential is bundled with the repository. The full ToolUniverse promotion and runtime paths are real; only network transport is replaced.
+
+The OpenAPI inspector recognized one required `apiKey` header named `X-Rare-Disease-Key`. The inert candidate contains the header contract but no value. Promotion binds that contract to the environment reference `TOOLUNIVERSE_VSD_RARE_DISEASE_KEY`.
+
+## Promotion Evidence
+
+| Boundary | SHA-256 |
+| --- | --- |
+| Draft | `98cb65b06de746ef4bb13229701b62a89d1c9988e3ee37c9b6d8dd2499352939` |
+| Operation | `d9f22e4ffdaead4202c5f2416509c73a472f57ff5ef018fc23e018709a371595` |
+| Verification | `af0f010bc059a009edc44275596bd8982e93d9e7bab04b98b2ae53ef6b9ed4de` |
+| Approval | `627048f102a22863fccc5dfe568fd1b0fd9ae1695bbf74199cd7d3fd9f89333b` |
+| Publication | `6e46c2dda4472b19a7010ec395dbd60cba9bfdb738a72ec44dfc1c70b2cdd2f4` |
+
+Three authenticated verification cases retrieved ALS, Duchenne muscular dystrophy, and spinal muscular atrophy records with genes, phenotypes, and trial identifiers before approval and publication.
+
+## Runtime And Rotation
+
+A fresh ToolUniverse instance loaded `VSDProtectedRareDiseaseEvidence`, returned `RD-ALS`, then returned `RD-SMA` after credential rotation. The operation SHA-256 was unchanged because the reviewed contract stores only the environment reference.
+
+Missing and malformed values failed before transport. A provider response that reflected the exact runtime credential was rejected before schema validation or result construction.
+
+## End-to-End Assertions
+
+| Assertion | Result |
+| --- | --- |
+| `approved_publication_is_hash_bound` | PASS |
+| `candidate_remains_inert_before_promotion` | PASS |
+| `credential_environment_is_restored` | PASS |
+| `credential_reference_is_the_only_persisted_auth_material` | PASS |
+| `fresh_tooluniverse_executes_published_tool` | PASS |
+| `header_is_not_exposed_in_result_or_provenance` | PASS |
+| `invalid_credential_fails_before_transport` | PASS |
+| `missing_credential_fails_before_transport` | PASS |
+| `openapi_header_auth_is_recognized` | PASS |
+| `provider_reflection_is_rejected` | PASS |
+| `secret_rotation_preserves_operation_identity` | PASS |
+| `secret_values_are_absent_from_artifacts` | PASS |
+| `three_authenticated_verification_cases_pass` | PASS |
+| `transport_receives_only_reviewed_header` | PASS |
+
+## Secret Boundary
+
+No credential value appears in the draft, verification evidence, approval, publication, ToolUniverse result, provenance, or checked case artifact. The environment variable name is not a secret and remains in the reviewed contract so operators know what to configure.
+
+**Case audit SHA-256:** `0fd635055d4f7c06cf8568d9d83d09c5697b98021d7fe3ae8b6c5f535fc066d5`

--- a/examples/vsd/credential_reference_case_study.py
+++ b/examples/vsd/credential_reference_case_study.py
@@ -1,0 +1,590 @@
+"""Exercise environment-backed credentials through the full VSD promotion flow."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from tooluniverse import ToolUniverse, vsd_dynamic_rest, vsd_promotion
+from tooluniverse.vsd_openapi import inspect_openapi_document
+
+HERE = Path(__file__).resolve().parent
+ARTIFACTS = HERE / "artifacts"
+DEFAULT_JSON = ARTIFACTS / "credential_reference_snapshot.json"
+DEFAULT_MARKDOWN = ARTIFACTS / "credential_reference_snapshot.md"
+
+ENV_VAR = "TOOLUNIVERSE_VSD_RARE_DISEASE_KEY"
+TOOL_NAME = "VSDProtectedRareDiseaseEvidence"
+RECORDS = {
+    "RD-ALS": {
+        "record_id": "RD-ALS",
+        "disease": "Amyotrophic lateral sclerosis",
+        "genes": ["C9orf72", "SOD1", "TARDBP"],
+        "phenotypes": ["Muscle weakness", "Motor neuron degeneration"],
+        "trials": ["NCT05163886", "NCT05619783"],
+    },
+    "RD-DMD": {
+        "record_id": "RD-DMD",
+        "disease": "Duchenne muscular dystrophy",
+        "genes": ["DMD"],
+        "phenotypes": ["Progressive muscle weakness", "Elevated creatine kinase"],
+        "trials": ["NCT05096221", "NCT05429372"],
+    },
+    "RD-SMA": {
+        "record_id": "RD-SMA",
+        "disease": "Spinal muscular atrophy",
+        "genes": ["SMN1", "SMN2"],
+        "phenotypes": ["Hypotonia", "Proximal muscle weakness"],
+        "trials": ["NCT05337553", "NCT05794139"],
+    },
+}
+EXPECTED_ASSERTIONS = {
+    "approved_publication_is_hash_bound",
+    "candidate_remains_inert_before_promotion",
+    "credential_environment_is_restored",
+    "credential_reference_is_the_only_persisted_auth_material",
+    "fresh_tooluniverse_executes_published_tool",
+    "header_is_not_exposed_in_result_or_provenance",
+    "invalid_credential_fails_before_transport",
+    "missing_credential_fails_before_transport",
+    "openapi_header_auth_is_recognized",
+    "provider_reflection_is_rejected",
+    "secret_values_are_absent_from_artifacts",
+    "secret_rotation_preserves_operation_identity",
+    "three_authenticated_verification_cases_pass",
+    "transport_receives_only_reviewed_header",
+}
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _secret(label: str) -> str:
+    return hashlib.sha256(f"vsd-case:{label}".encode()).hexdigest()
+
+
+def _specification() -> dict[str, Any]:
+    record_schema = {
+        "type": "object",
+        "properties": {
+            "record_id": {"type": "string"},
+            "disease": {"type": "string"},
+            "genes": {"type": "array", "items": {"type": "string"}},
+            "phenotypes": {"type": "array", "items": {"type": "string"}},
+            "trials": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["record_id", "disease", "genes", "phenotypes", "trials"],
+        "additionalProperties": False,
+    }
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "Protected Rare Disease Evidence API", "version": "1.2.0"},
+        "servers": [{"url": "https://rare-registry.example.org/v1"}],
+        "security": [{"registryKey": []}],
+        "paths": {
+            "/evidence/{recordId}": {
+                "get": {
+                    "operationId": "getRareDiseaseEvidence",
+                    "summary": "Retrieve one protected rare-disease evidence record",
+                    "parameters": [
+                        {
+                            "name": "recordId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {
+                                "type": "string",
+                                "pattern": "^RD-(?:ALS|DMD|SMA)$",
+                            },
+                        },
+                        {
+                            "name": "sections",
+                            "in": "query",
+                            "style": "pipeDelimited",
+                            "explode": False,
+                            "schema": {
+                                "type": "array",
+                                "minItems": 1,
+                                "maxItems": 3,
+                                "uniqueItems": True,
+                                "items": {
+                                    "type": "string",
+                                    "enum": ["genes", "phenotypes", "trials"],
+                                },
+                            },
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Rare-disease evidence record",
+                            "content": {"application/json": {"schema": record_schema}},
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "registryKey": {
+                    "type": "apiKey",
+                    "in": "header",
+                    "name": "X-Rare-Disease-Key",
+                }
+            }
+        },
+    }
+
+
+def _cases() -> list[dict[str, Any]]:
+    return [
+        {
+            "arguments": {
+                "recordId": record_id,
+                "sections": ["genes", "phenotypes", "trials"],
+            },
+            "expect": {
+                "result_type": "object",
+                "required_fields": [
+                    "record_id",
+                    "disease",
+                    "genes",
+                    "phenotypes",
+                    "trials",
+                ],
+                "equals": {"record_id": record_id},
+                "required_paths": ["/genes/0", "/phenotypes/0", "/trials/0"],
+                "equals_paths": {},
+            },
+        }
+        for record_id in RECORDS
+    ]
+
+
+def _artifact_hashes(workspace: Path, draft_id: str) -> dict[str, str]:
+    paths = {
+        "draft": workspace / "drafts" / f"{draft_id}.json",
+        "evidence": workspace / "evidence" / f"{draft_id}.json",
+        "approval": workspace / "approvals" / f"{draft_id}.json",
+        "publication": workspace / "approved" / f"{TOOL_NAME}.json",
+    }
+    return {
+        name: hashlib.sha256(path.read_bytes()).hexdigest()
+        for name, path in paths.items()
+    }
+
+
+def run_case(workspace: Path) -> dict[str, Any]:
+    workspace = Path(workspace)
+    spec_path = workspace / "protected-rare-disease-openapi.json"
+    spec_path.parent.mkdir(parents=True, exist_ok=True)
+    spec_path.write_text(
+        json.dumps(_specification(), indent=2, sort_keys=True), encoding="utf-8"
+    )
+    initial_secret = _secret("initial")
+    rotated_secret = _secret("rotated")
+    reflected_secret = _secret("reflected")
+    secret_values = (initial_secret, rotated_secret, reflected_secret)
+    previous = os.environ.get(ENV_VAR)
+    transport_log: list[dict[str, Any]] = []
+    original_transport = vsd_dynamic_rest._safe_get_json
+
+    def fake_transport(url, params, *, timeout, headers):
+        assert set(headers) == {"X-Rare-Disease-Key"}
+        secret = headers["X-Rare-Disease-Key"]
+        slot = {
+            initial_secret: "initial",
+            rotated_secret: "rotated",
+            reflected_secret: "reflected",
+        }.get(secret)
+        if slot is None:
+            raise AssertionError("transport received an unknown credential")
+        record_id = url.rsplit("/", 1)[-1]
+        transport_log.append(
+            {
+                "credential_slot": slot,
+                "header_name": "X-Rare-Disease-Key",
+                "record_id": record_id,
+                "params": dict(params),
+                "timeout": timeout,
+            }
+        )
+        payload = dict(RECORDS[record_id])
+        if slot == "reflected":
+            payload["credential_echo"] = secret
+        return payload, {
+            "status_code": 200,
+            "content_type": "application/json",
+            "response_bytes": len(json.dumps(payload).encode()),
+            "redirects": 0,
+        }
+
+    missing_error = ""
+    invalid_error = ""
+    reflection_error = ""
+    calls_before_missing = 0
+    calls_after_missing = 0
+    calls_before_invalid = 0
+    calls_after_invalid = 0
+    try:
+        report = inspect_openapi_document(spec_path)
+        candidate = report["candidates"][0]
+        os.environ[ENV_VAR] = initial_secret
+        vsd_dynamic_rest._safe_get_json = fake_transport
+        draft = vsd_promotion.create_openapi_draft(
+            candidate,
+            tool_name=TOOL_NAME,
+            description=(
+                "Retrieve one authenticated reviewed rare-disease evidence record."
+            ),
+            include_parameters=["recordId", "sections"],
+            credential_env=ENV_VAR,
+            workspace=workspace,
+        )
+        evidence = vsd_promotion.verify_draft(
+            draft["draft_id"], _cases(), workspace=workspace
+        )
+        approval = vsd_promotion.approve_draft(
+            draft["draft_id"],
+            reviewed_by="Credential Case Study Reviewer",
+            decision_note=(
+                "Approved after three authenticated disease records passed all checks."
+            ),
+            workspace=workspace,
+        )
+        publication = vsd_promotion.publish_draft(
+            draft["draft_id"], workspace=workspace
+        )
+        tooluniverse = ToolUniverse()
+        try:
+            loaded = vsd_promotion.load_published_tools(
+                tooluniverse, workspace=workspace
+            )
+            first_result = tooluniverse.run_one_function(
+                {
+                    "name": TOOL_NAME,
+                    "arguments": {
+                        "recordId": "RD-ALS",
+                        "sections": ["genes", "phenotypes", "trials"],
+                    },
+                },
+                use_cache=False,
+            )
+            operation_sha256 = first_result["data"]["provenance"]["operation_sha256"]
+            os.environ[ENV_VAR] = rotated_secret
+            rotated_result = tooluniverse.run_one_function(
+                {
+                    "name": TOOL_NAME,
+                    "arguments": {
+                        "recordId": "RD-SMA",
+                        "sections": ["genes", "phenotypes", "trials"],
+                    },
+                },
+                use_cache=False,
+            )
+        finally:
+            tooluniverse.close()
+
+        direct_tool = vsd_dynamic_rest.VSDDynamicRESTTool(publication["config"])
+        os.environ.pop(ENV_VAR, None)
+        calls_before_missing = len(transport_log)
+        try:
+            direct_tool.run({"recordId": "RD-ALS"})
+        except vsd_dynamic_rest.VSDDynamicRESTError as exc:
+            missing_error = str(exc)
+        calls_after_missing = len(transport_log)
+        os.environ[ENV_VAR] = " invalid-credential-value"
+        calls_before_invalid = len(transport_log)
+        try:
+            direct_tool.run({"recordId": "RD-ALS"})
+        except vsd_dynamic_rest.VSDDynamicRESTError as exc:
+            invalid_error = str(exc)
+        calls_after_invalid = len(transport_log)
+        os.environ[ENV_VAR] = reflected_secret
+        try:
+            direct_tool.run({"recordId": "RD-ALS"})
+        except vsd_dynamic_rest.VSDDynamicRESTError as exc:
+            reflection_error = str(exc)
+    finally:
+        vsd_dynamic_rest._safe_get_json = original_transport
+        if previous is None:
+            os.environ.pop(ENV_VAR, None)
+        else:
+            os.environ[ENV_VAR] = previous
+
+    persisted_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in workspace.rglob("*.json")
+    )
+    result_text = json.dumps(
+        {"first": first_result, "rotated": rotated_result}, sort_keys=True
+    )
+    provenance = first_result["data"]["provenance"]
+    artifact_hashes = _artifact_hashes(workspace, draft["draft_id"])
+    assertions = {
+        "openapi_header_auth_is_recognized": (
+            report["promotable_count"] == 1
+            and candidate["auth"]
+            == {
+                "type": "api_key_header",
+                "scheme_name": "registryKey",
+                "header": "X-Rare-Disease-Key",
+            }
+        ),
+        "candidate_remains_inert_before_promotion": (
+            candidate["execution_allowed"] is False
+            and candidate["approval_state"] == "unreviewed_candidate"
+        ),
+        "credential_reference_is_the_only_persisted_auth_material": (
+            publication["config"]["vsd_operation"]["auth"]
+            == {
+                "type": "api_key_header_env",
+                "env_var": ENV_VAR,
+                "header": "X-Rare-Disease-Key",
+            }
+            and ENV_VAR in persisted_text
+        ),
+        "three_authenticated_verification_cases_pass": (
+            evidence["all_cases_passed"] is True and evidence["case_count"] == 3
+        ),
+        "approved_publication_is_hash_bound": (
+            approval["approval_sha256"] == publication["approval_sha256"]
+            and publication["operation_sha256"] == draft["operation_sha256"]
+            and all(len(value) == 64 for value in artifact_hashes.values())
+        ),
+        "fresh_tooluniverse_executes_published_tool": (
+            loaded == [TOOL_NAME]
+            and first_result["status"] == "success"
+            and first_result["data"]["result"]["record_id"] == "RD-ALS"
+        ),
+        "secret_rotation_preserves_operation_identity": (
+            rotated_result["data"]["result"]["record_id"] == "RD-SMA"
+            and rotated_result["data"]["provenance"]["operation_sha256"]
+            == operation_sha256
+            and transport_log[-2]["credential_slot"] == "rotated"
+        ),
+        "missing_credential_fails_before_transport": (
+            "not set" in missing_error and calls_after_missing == calls_before_missing
+        ),
+        "invalid_credential_fails_before_transport": (
+            "bearer token" not in invalid_error
+            and "not a valid bounded value" in invalid_error
+            and calls_after_invalid == calls_before_invalid
+        ),
+        "provider_reflection_is_rejected": (
+            reflection_error == "Provider response reflected credential material"
+            and transport_log[-1]["credential_slot"] == "reflected"
+        ),
+        "secret_values_are_absent_from_artifacts": all(
+            secret not in persisted_text and secret not in result_text
+            for secret in secret_values
+        ),
+        "header_is_not_exposed_in_result_or_provenance": (
+            "X-Rare-Disease-Key" not in result_text
+            and ENV_VAR not in result_text
+            and provenance["authentication"]
+            == {
+                "type": "api_key_header_env",
+                "credential_source": "environment",
+            }
+        ),
+        "transport_receives_only_reviewed_header": (
+            len(transport_log) == 6
+            and all(
+                entry["header_name"] == "X-Rare-Disease-Key" for entry in transport_log
+            )
+        ),
+        "credential_environment_is_restored": os.environ.get(ENV_VAR) == previous,
+    }
+    snapshot = {
+        "title": "Environment-Backed Rare-Disease Credential Case Study",
+        "question": (
+            "Can a reviewed ToolUniverse operation use a protected API without "
+            "persisting, returning, or fixing the credential into its contract?"
+        ),
+        "answer": (
+            "Yes. The protected header was derived from a reviewed OpenAPI scheme, "
+            "read only at execution, rotated without changing the operation digest, "
+            "and rejected when missing, malformed, or reflected by the provider."
+        ),
+        "provider_fixture": (
+            "A deterministic protected rare-disease API fixture is used because no "
+            "real credential is bundled with the repository. The full ToolUniverse "
+            "promotion and runtime paths are real; only network transport is replaced."
+        ),
+        "inspection": {
+            "source_document_sha256": report["source_document_sha256"],
+            "candidate_id": candidate["candidate_id"],
+            "candidate_sha256": candidate["candidate_sha256"],
+            "auth": candidate["auth"],
+            "blockers": candidate["blockers"],
+        },
+        "promotion": {
+            "draft_id": draft["draft_id"],
+            "draft_sha256": draft["draft_sha256"],
+            "operation_sha256": draft["operation_sha256"],
+            "verification_sha256": evidence["verification_sha256"],
+            "approval_sha256": approval["approval_sha256"],
+            "publication_sha256": publication["publication_sha256"],
+            "artifact_file_sha256": artifact_hashes,
+            "verification_case_count": evidence["case_count"],
+        },
+        "runtime": {
+            "loaded_tools": loaded,
+            "initial_record_id": first_result["data"]["result"]["record_id"],
+            "rotated_record_id": rotated_result["data"]["result"]["record_id"],
+            "operation_sha256_before_rotation": operation_sha256,
+            "operation_sha256_after_rotation": rotated_result["data"]["provenance"][
+                "operation_sha256"
+            ],
+            "authentication_provenance": provenance["authentication"],
+            "transport_log": transport_log,
+            "missing_credential_error": missing_error,
+            "invalid_credential_error": invalid_error,
+            "reflection_error": reflection_error,
+        },
+        "secret_persistence": {
+            "persisted_secret_count": sum(
+                secret in persisted_text for secret in secret_values
+            ),
+            "result_secret_count": sum(
+                secret in result_text for secret in secret_values
+            ),
+            "persisted_reference": ENV_VAR,
+        },
+        "end_to_end_assertions": assertions,
+    }
+    snapshot["audit_sha256"] = _digest(
+        {
+            key: value
+            for key, value in snapshot.items()
+            if key not in {"title", "question", "answer", "audit_sha256"}
+        }
+    )
+    validate_snapshot(snapshot)
+    return snapshot
+
+
+def validate_snapshot(snapshot: dict[str, Any]) -> None:
+    assertions = snapshot.get("end_to_end_assertions")
+    if not isinstance(assertions, dict) or set(assertions) != EXPECTED_ASSERTIONS:
+        raise ValueError("Snapshot does not contain the complete assertion set")
+    if not all(assertions.values()):
+        failed = sorted(name for name, passed in assertions.items() if not passed)
+        raise ValueError(f"End-to-end assertions failed: {failed!r}")
+    expected = _digest(
+        {
+            key: value
+            for key, value in snapshot.items()
+            if key not in {"title", "question", "answer", "audit_sha256"}
+        }
+    )
+    if snapshot.get("audit_sha256") != expected:
+        raise ValueError("Snapshot audit digest does not match its content")
+
+
+def _markdown(snapshot: dict[str, Any]) -> str:
+    runtime = snapshot["runtime"]
+    promotion = snapshot["promotion"]
+    lines = [
+        "# Environment-Backed Rare-Disease Credential Case Study",
+        "",
+        "## Decision Question",
+        "",
+        snapshot["question"],
+        "",
+        f"**Result:** {snapshot['answer']}",
+        "",
+        "## Provider Boundary",
+        "",
+        snapshot["provider_fixture"],
+        "",
+        "The OpenAPI inspector recognized one required `apiKey` header named "
+        "`X-Rare-Disease-Key`. The inert candidate contains the header contract but "
+        "no value. Promotion binds that contract to the environment reference "
+        f"`{snapshot['secret_persistence']['persisted_reference']}`.",
+        "",
+        "## Promotion Evidence",
+        "",
+        "| Boundary | SHA-256 |",
+        "| --- | --- |",
+        f"| Draft | `{promotion['draft_sha256']}` |",
+        f"| Operation | `{promotion['operation_sha256']}` |",
+        f"| Verification | `{promotion['verification_sha256']}` |",
+        f"| Approval | `{promotion['approval_sha256']}` |",
+        f"| Publication | `{promotion['publication_sha256']}` |",
+        "",
+        "Three authenticated verification cases retrieved ALS, Duchenne muscular "
+        "dystrophy, and spinal muscular atrophy records with genes, phenotypes, and "
+        "trial identifiers before approval and publication.",
+        "",
+        "## Runtime And Rotation",
+        "",
+        f"A fresh ToolUniverse instance loaded `{runtime['loaded_tools'][0]}`, returned "
+        f"`{runtime['initial_record_id']}`, then returned "
+        f"`{runtime['rotated_record_id']}` after credential rotation. The operation "
+        "SHA-256 was unchanged because the reviewed contract stores only the "
+        "environment reference.",
+        "",
+        "Missing and malformed values failed before transport. A provider response "
+        "that reflected the exact runtime credential was rejected before schema "
+        "validation or result construction.",
+        "",
+        "## End-to-End Assertions",
+        "",
+        "| Assertion | Result |",
+        "| --- | --- |",
+    ]
+    lines.extend(
+        f"| `{name}` | {'PASS' if passed else 'FAIL'} |"
+        for name, passed in sorted(snapshot["end_to_end_assertions"].items())
+    )
+    lines.extend(
+        [
+            "",
+            "## Secret Boundary",
+            "",
+            "No credential value appears in the draft, verification evidence, "
+            "approval, publication, ToolUniverse result, provenance, or checked case "
+            "artifact. The environment variable name is not a secret and remains in "
+            "the reviewed contract so operators know what to configure.",
+            "",
+            f"**Case audit SHA-256:** `{snapshot['audit_sha256']}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_artifacts(
+    snapshot: dict[str, Any],
+    json_path: Path = DEFAULT_JSON,
+    markdown_path: Path = DEFAULT_MARKDOWN,
+) -> None:
+    validate_snapshot(snapshot)
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(_markdown(snapshot), encoding="utf-8")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(
+        prefix="tooluniverse-vsd-credentials-"
+    ) as directory:
+        snapshot = run_case(Path(directory))
+    write_artifacts(snapshot)
+    print(json.dumps({"status": "passed", "audit_sha256": snapshot["audit_sha256"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tooluniverse/vsd_dynamic_rest.py
+++ b/src/tooluniverse/vsd_dynamic_rest.py
@@ -1,9 +1,10 @@
 """Validated runtime execution for explicitly reviewed public JSON operations.
 
 This module intentionally does not discover, persist, approve, or automatically
-load tools.  It provides the execution boundary used after an administrator has
-reviewed an operation definition.  Only HTTPS GET operations are supported so a
-generated tool cannot mutate an upstream service or transmit credentials.
+load tools. It provides the execution boundary used after an administrator has
+reviewed an operation definition. Only HTTPS GET operations are supported.
+Optional header credentials are read from narrowly named environment variables
+at execution time and are never embedded in the operation contract or result.
 """
 
 from __future__ import annotations
@@ -11,6 +12,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import os
 import re
 from datetime import datetime, timezone
 from typing import Any
@@ -27,10 +29,106 @@ _TOOL_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,127}$")
 _ARGUMENT_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
 _PATH_TOKEN_RE = re.compile(r"\{([A-Za-z][A-Za-z0-9_]{0,63})\}")
 _QUERY_NAME_RE = re.compile(r"^[A-Za-z0-9_.\[\]-]{1,128}$")
+_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]{1,128}$")
+_ENV_NAME_RE = re.compile(r"^TOOLUNIVERSE_VSD_[A-Z0-9_]{1,108}$")
+_FORBIDDEN_AUTH_HEADERS = {
+    "accept",
+    "accept-encoding",
+    "connection",
+    "content-length",
+    "content-type",
+    "cookie",
+    "host",
+    "origin",
+    "referer",
+    "transfer-encoding",
+    "user-agent",
+}
 
 
 class VSDDynamicRESTError(VSDPolicyError):
     """Raised when an operation or provider result violates its reviewed contract."""
+
+
+def _validated_auth(value: Any) -> dict[str, str]:
+    if value in (None, {"type": "none"}):
+        return {"type": "none"}
+    if not isinstance(value, dict):
+        raise VSDDynamicRESTError("auth must be a reviewed environment reference")
+    auth_type = value.get("type")
+    if auth_type == "bearer_env":
+        if set(value) != {"type", "env_var"}:
+            raise VSDDynamicRESTError("bearer_env auth has unsupported fields")
+        header = "Authorization"
+    elif auth_type == "api_key_header_env":
+        if set(value) != {"type", "env_var", "header"}:
+            raise VSDDynamicRESTError("api_key_header_env auth has unsupported fields")
+        header = value.get("header")
+        if not isinstance(header, str) or not _HEADER_NAME_RE.fullmatch(header):
+            raise VSDDynamicRESTError("API-key header must be a stable HTTP token")
+        normalized_header = header.casefold()
+        if (
+            normalized_header == "authorization"
+            or normalized_header in _FORBIDDEN_AUTH_HEADERS
+            or normalized_header.startswith(
+                ("proxy-", "sec-", "x-forwarded-", "content-")
+            )
+        ):
+            raise VSDDynamicRESTError("API-key header is prohibited")
+    else:
+        raise VSDDynamicRESTError(
+            "auth supports only none, bearer_env, or api_key_header_env"
+        )
+    env_var = value.get("env_var")
+    if not isinstance(env_var, str) or not _ENV_NAME_RE.fullmatch(env_var):
+        raise VSDDynamicRESTError(
+            "credential env_var must start with TOOLUNIVERSE_VSD_"
+        )
+    return {
+        "type": auth_type,
+        "env_var": env_var,
+        **({"header": header} if auth_type == "api_key_header_env" else {}),
+    }
+
+
+def _credential_headers(auth: dict[str, str]) -> tuple[dict[str, str], str | None]:
+    if auth["type"] == "none":
+        return {}, None
+    env_var = auth["env_var"]
+    secret = os.environ.get(env_var)
+    if secret is None:
+        raise VSDDynamicRESTError(
+            f"Required credential environment variable {env_var!r} is not set"
+        )
+    if (
+        not 8 <= len(secret) <= 4096
+        or secret != secret.strip()
+        or any(ord(character) < 32 or ord(character) > 126 for character in secret)
+    ):
+        raise VSDDynamicRESTError(
+            f"Credential environment variable {env_var!r} is not a valid bounded value"
+        )
+    if auth["type"] == "bearer_env":
+        if any(character.isspace() for character in secret):
+            raise VSDDynamicRESTError(
+                f"Credential environment variable {env_var!r} is not a bearer token"
+            )
+        return {"Authorization": f"Bearer {secret}"}, secret
+    return {auth["header"]: secret}, secret
+
+
+def _contains_secret(value: Any, secret: str) -> bool:
+    pending = [value]
+    while pending:
+        item = pending.pop()
+        if isinstance(item, str) and secret in item:
+            return True
+        if isinstance(item, dict):
+            pending.extend(item.keys())
+            pending.extend(item.values())
+        elif isinstance(item, list):
+            pending.extend(item)
+    return False
 
 
 def _schema_validator(schema: Any, *, field: str) -> Draft202012Validator:
@@ -204,10 +302,7 @@ def _validated_operation_config(config: Any) -> dict[str, Any]:
         raise VSDDynamicRESTError("timeout_seconds must be between 1 and 60")
     operation["response_schema"] = operation.get("response_schema", {})
     _schema_validator(operation["response_schema"], field="response_schema")
-    if operation.get("auth") not in (None, {"type": "none"}):
-        raise VSDDynamicRESTError(
-            "Dynamic VSD operations cannot carry credentials; use a dedicated tool"
-        )
+    operation["auth"] = _validated_auth(operation.get("auth"))
     return normalized
 
 
@@ -284,11 +379,15 @@ class VSDDynamicRESTTool(BaseTool):
 
         endpoint, query = _provider_request(self.tool_config, values)
         operation = self.tool_config["vsd_operation"]
-        payload, request = _safe_get_json(
-            endpoint,
-            query,
-            timeout=float(operation["timeout_seconds"]),
-        )
+        headers, secret = _credential_headers(operation["auth"])
+        request_kwargs: dict[str, Any] = {
+            "timeout": float(operation["timeout_seconds"])
+        }
+        if headers:
+            request_kwargs["headers"] = headers
+        payload, request = _safe_get_json(endpoint, query, **request_kwargs)
+        if secret is not None and _contains_secret(payload, secret):
+            raise VSDDynamicRESTError("Provider response reflected credential material")
         try:
             self._response_validator.validate(payload)
         except ValidationError as exc:
@@ -314,6 +413,14 @@ class VSDDynamicRESTTool(BaseTool):
                     "redirects": request["redirects"],
                     "payload_sha256": hashlib.sha256(canonical).hexdigest(),
                     "operation_sha256": self._operation_digest,
+                    "authentication": {
+                        "type": operation["auth"]["type"],
+                        "credential_source": (
+                            "none"
+                            if operation["auth"]["type"] == "none"
+                            else "environment"
+                        ),
+                    },
                 },
             },
         }

--- a/src/tooluniverse/vsd_openapi.py
+++ b/src/tooluniverse/vsd_openapi.py
@@ -20,7 +20,7 @@ import yaml
 from yaml.constructor import ConstructorError
 from yaml.events import AliasEvent
 
-from .vsd_dynamic_rest import VSDDynamicRESTError, _schema_validator
+from .vsd_dynamic_rest import VSDDynamicRESTError, _schema_validator, _validated_auth
 
 _FORMAT_VERSION = 1
 _MAX_DOCUMENT_BYTES = 1_000_000
@@ -455,6 +455,87 @@ def _response_schema(
     return schema, media_type, []
 
 
+def _authentication_descriptor(
+    operation: dict[str, Any], document: dict[str, Any]
+) -> tuple[dict[str, str] | None, list[str]]:
+    security = operation.get("security", document.get("security", []))
+    if security in (None, []):
+        return None, []
+    blockers = ["authentication_required"]
+    if not isinstance(security, list) or not 1 <= len(security) <= 20:
+        return None, [*blockers, "authentication_requirements_invalid"]
+    if any(requirement == {} for requirement in security):
+        return None, []
+    if len(security) != 1 or not isinstance(security[0], dict) or len(security[0]) != 1:
+        return None, [*blockers, "authentication_alternatives_unsupported"]
+    scheme_name, scopes = next(iter(security[0].items()))
+    if not isinstance(scheme_name, str) or not scheme_name or scopes != []:
+        return None, [*blockers, "authentication_scopes_unsupported"]
+    components = document.get("components")
+    schemes = (
+        components.get("securitySchemes") if isinstance(components, dict) else None
+    )
+    raw_scheme = schemes.get(scheme_name) if isinstance(schemes, dict) else None
+    try:
+        scheme = _resolved_object(raw_scheme, document, kind="security_scheme")
+    except VSDOpenAPIError as exc:
+        return None, [*blockers, f"authentication_scheme:{exc}"]
+    scheme_type = str(scheme.get("type") or "").casefold()
+    if scheme_type == "apikey" and str(scheme.get("in") or "").casefold() == "header":
+        header = scheme.get("name")
+        try:
+            normalized = _validated_auth(
+                {
+                    "type": "api_key_header_env",
+                    "env_var": "TOOLUNIVERSE_VSD_INSPECTION_PLACEHOLDER",
+                    "header": header,
+                }
+            )
+        except VSDDynamicRESTError as exc:
+            return None, [*blockers, f"authentication_scheme:{exc}"]
+        return {
+            "type": "api_key_header",
+            "scheme_name": _text(scheme_name),
+            "header": normalized["header"],
+        }, []
+    if scheme_type == "http" and str(scheme.get("scheme") or "").casefold() == "bearer":
+        return {
+            "type": "bearer",
+            "scheme_name": _text(scheme_name),
+        }, []
+    return None, [*blockers, "authentication_scheme_unsupported"]
+
+
+def _validate_auth_descriptor(value: Any) -> None:
+    if value is None:
+        return
+    if not isinstance(value, dict):
+        raise VSDOpenAPIError("OpenAPI candidate authentication is invalid")
+    auth_type = value.get("type")
+    scheme_name = value.get("scheme_name")
+    if not isinstance(scheme_name, str) or not scheme_name or len(scheme_name) > 2000:
+        raise VSDOpenAPIError("OpenAPI candidate authentication is invalid")
+    try:
+        if auth_type == "api_key_header" and set(value) == {
+            "type",
+            "scheme_name",
+            "header",
+        }:
+            _validated_auth(
+                {
+                    "type": "api_key_header_env",
+                    "env_var": "TOOLUNIVERSE_VSD_INSPECTION_PLACEHOLDER",
+                    "header": value.get("header"),
+                }
+            )
+            return
+        if auth_type == "bearer" and set(value) == {"type", "scheme_name"}:
+            return
+    except VSDDynamicRESTError as exc:
+        raise VSDOpenAPIError("OpenAPI candidate authentication is invalid") from exc
+    raise VSDOpenAPIError("OpenAPI candidate authentication is invalid")
+
+
 def _candidate_digest(body: dict[str, Any]) -> str:
     encoded = json.dumps(
         body, sort_keys=True, separators=(",", ":"), ensure_ascii=True
@@ -512,9 +593,10 @@ def inspect_openapi_document(
                 blockers.append("request_body_not_supported")
             if "callbacks" in operation:
                 blockers.append("callbacks_not_supported")
-            security = operation.get("security", document.get("security", []))
-            if security not in (None, []):
-                blockers.append("authentication_required")
+            auth, authentication_blockers = _authentication_descriptor(
+                operation, document
+            )
+            blockers.extend(authentication_blockers)
             try:
                 server_url = _server_url(
                     operation, path_item, document, server_index=server_index
@@ -565,6 +647,7 @@ def inspect_openapi_document(
                     if isinstance(tag, str)
                 ][:20],
                 "parameters": parameters,
+                "auth": auth,
                 "response_media_type": response_media_type,
                 "response_schema": response_schema,
                 "blockers": sorted(set(blockers)),
@@ -623,6 +706,7 @@ def validate_openapi_candidate(candidate: Any) -> dict[str, Any]:
     parameters = candidate.get("parameters")
     if not isinstance(parameters, list) or len(parameters) > _MAX_PARAMETERS:
         raise VSDOpenAPIError("OpenAPI candidate parameters are invalid")
+    _validate_auth_descriptor(candidate.get("auth"))
     argument_names: set[str] = set()
     path_names: set[str] = set()
     for parameter in parameters:

--- a/src/tooluniverse/vsd_promotion.py
+++ b/src/tooluniverse/vsd_promotion.py
@@ -20,6 +20,7 @@ from jsonschema.exceptions import ValidationError
 from .execute_function import ToolUniverse
 from .vsd_dynamic_rest import (
     VSDDynamicRESTError,
+    _validated_auth,
     operation_digest,
     register_reviewed_rest_tool,
 )
@@ -394,6 +395,7 @@ def build_openapi_tool_config(
     include_parameters: list[str] | None = None,
     fixed_query: dict[str, Any] | None = None,
     timeout_seconds: int | float = 20,
+    credential_env: str | None = None,
 ) -> dict[str, Any]:
     """Generate one narrow read-only tool from an inspected OpenAPI operation."""
     try:
@@ -484,6 +486,34 @@ def build_openapi_tool_config(
     ):
         raise VSDPromotionError("timeout_seconds must be between 1 and 60")
 
+    auth_descriptor = reviewed.get("auth")
+    if auth_descriptor is None:
+        if credential_env is not None:
+            raise VSDPromotionError(
+                "credential_env is not allowed for an anonymous OpenAPI operation"
+            )
+        auth = {"type": "none"}
+    else:
+        if not isinstance(credential_env, str) or not credential_env:
+            raise VSDPromotionError(
+                "credential_env is required for this authenticated OpenAPI operation"
+            )
+        if auth_descriptor["type"] == "api_key_header":
+            requested_auth = {
+                "type": "api_key_header_env",
+                "env_var": credential_env,
+                "header": auth_descriptor["header"],
+            }
+        else:
+            requested_auth = {
+                "type": "bearer_env",
+                "env_var": credential_env,
+            }
+        try:
+            auth = _validated_auth(requested_auth)
+        except VSDDynamicRESTError as exc:
+            raise VSDPromotionError(str(exc)) from exc
+
     input_definitions: dict[str, Any] = {}
     properties: dict[str, Any] = {}
     path_arguments: dict[str, str] = {}
@@ -547,7 +577,7 @@ def build_openapi_tool_config(
             "query_serialization": query_serialization,
             "fixed_query": fixed,
             "timeout_seconds": timeout_seconds,
-            "auth": {"type": "none"},
+            "auth": auth,
             "response_schema": reviewed["response_schema"],
         },
         "vsd_promotion": {
@@ -565,6 +595,7 @@ def build_openapi_tool_config(
             "response_media_type": reviewed["response_media_type"],
             "included_parameters": sorted(selected_names),
             "fixed_query": fixed,
+            "authentication": copy.deepcopy(auth_descriptor),
         },
     }
 
@@ -577,6 +608,7 @@ def create_openapi_draft(
     include_parameters: list[str] | None = None,
     fixed_query: dict[str, Any] | None = None,
     timeout_seconds: int | float = 20,
+    credential_env: str | None = None,
     workspace: str | Path | None = None,
 ) -> dict[str, Any]:
     """Create an inert, content-addressed draft from one OpenAPI candidate."""
@@ -587,6 +619,7 @@ def create_openapi_draft(
         include_parameters=include_parameters,
         fixed_query=fixed_query,
         timeout_seconds=timeout_seconds,
+        credential_env=credential_env,
     )
     return _create_draft_from_config(config, workspace=workspace)
 

--- a/src/tooluniverse/vsd_promotion_cli.py
+++ b/src/tooluniverse/vsd_promotion_cli.py
@@ -63,6 +63,7 @@ def build_parser() -> argparse.ArgumentParser:
     draft_openapi.add_argument("--include-parameters", type=_csv)
     draft_openapi.add_argument("--fixed-query-file", type=Path)
     draft_openapi.add_argument("--timeout-seconds", type=float, default=20)
+    draft_openapi.add_argument("--credential-env")
 
     verify = commands.add_parser("verify")
     verify.add_argument("draft_id")
@@ -123,6 +124,7 @@ def _execute(namespace: argparse.Namespace) -> Any:
             include_parameters=namespace.include_parameters,
             fixed_query=fixed_query,
             timeout_seconds=namespace.timeout_seconds,
+            credential_env=namespace.credential_env,
             workspace=workspace,
         )
     if namespace.command == "verify":

--- a/src/tooluniverse/vsd_tool.py
+++ b/src/tooluniverse/vsd_tool.py
@@ -54,6 +54,17 @@ _SECRET_PATH_RE = re.compile(
     r"AKIA[A-Z0-9]{12,}|eyJ[a-z0-9_-]{12,}\.[a-z0-9_-]{8,})",
     re.IGNORECASE,
 )
+_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]{1,128}$")
+_FORBIDDEN_REQUEST_HEADERS = {
+    "accept",
+    "accept-encoding",
+    "connection",
+    "content-length",
+    "cookie",
+    "host",
+    "proxy-authorization",
+    "transfer-encoding",
+}
 
 # Exact hosts only. Additional exact hosts require an explicit administrator or
 # user opt-in through TOOLUNIVERSE_VSD_ALLOWED_HOSTS.
@@ -374,6 +385,38 @@ def _validated_params(params: Any) -> dict[str, Any]:
     return validated
 
 
+def _validated_request_headers(headers: Any) -> dict[str, str]:
+    if headers is None:
+        return {}
+    if not isinstance(headers, dict) or len(headers) > 4:
+        raise VSDPolicyError("Request headers must contain at most four entries")
+    validated: dict[str, str] = {}
+    seen: set[str] = set()
+    for name, value in headers.items():
+        if not isinstance(name, str) or not _HEADER_NAME_RE.fullmatch(name):
+            raise VSDPolicyError("Request header names must be stable HTTP tokens")
+        normalized = name.casefold()
+        if (
+            normalized in seen
+            or normalized in _FORBIDDEN_REQUEST_HEADERS
+            or normalized.startswith(("proxy-", "sec-", "x-forwarded-"))
+        ):
+            raise VSDPolicyError(f"Request header {name!r} is prohibited")
+        if (
+            not isinstance(value, str)
+            or not 1 <= len(value) <= 4096
+            or any(ord(character) < 32 or ord(character) > 126 for character in value)
+        ):
+            raise VSDPolicyError(
+                f"Request header {name!r} must contain 1-4096 printable ASCII characters"
+            )
+        seen.add(normalized)
+        validated[name] = value
+    if sum(len(name) + len(value) for name, value in validated.items()) > 8192:
+        raise VSDPolicyError("Request headers exceed the 8 KiB limit")
+    return validated
+
+
 def _bounded_text(value: Any, *, field: str, maximum: int, fallback: str = "") -> str:
     text = str(value or fallback).strip()
     if len(text) > maximum:
@@ -491,6 +534,7 @@ def _safe_get_json(
     *,
     timeout: float = 20.0,
     session: requests.Session | None = None,
+    headers: dict[str, str] | None = None,
 ) -> tuple[Any, dict[str, Any]]:
     """GET JSON through a DNS-pinned HTTPS connection with bounded decoding."""
     if (
@@ -504,6 +548,7 @@ def _safe_get_json(
     normalized_url, hostname, addresses = _validated_source_target(url)
     pinned_address = addresses[0]
     validated_params = _validated_params(params)
+    validated_headers = _validated_request_headers(headers)
     owned_session = session is None
     http = session or requests.Session()
     http.trust_env = False
@@ -523,6 +568,7 @@ def _safe_get_json(
                 headers={
                     "Accept": "application/json",
                     "Accept-Encoding": "identity",
+                    **validated_headers,
                 },
                 timeout=Urllib3Timeout(
                     total=remaining,

--- a/tests/unit/test_vsd_credential_reference_case_study.py
+++ b/tests/unit/test_vsd_credential_reference_case_study.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+MODULE_PATH = (
+    Path(__file__).parents[2]
+    / "examples"
+    / "vsd"
+    / "credential_reference_case_study.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "vsd_credential_reference_case_study", MODULE_PATH
+)
+assert SPEC and SPEC.loader
+study = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = study
+SPEC.loader.exec_module(study)
+
+
+def test_credential_case_runs_full_protected_api_pipeline(tmp_path):
+    snapshot = study.run_case(tmp_path / "credential-workspace")
+    output_json = tmp_path / "snapshot.json"
+    output_markdown = tmp_path / "snapshot.md"
+    study.write_artifacts(snapshot, output_json, output_markdown)
+
+    assert set(snapshot["end_to_end_assertions"]) == study.EXPECTED_ASSERTIONS
+    assert all(snapshot["end_to_end_assertions"].values())
+    assert snapshot["promotion"]["verification_case_count"] == 3
+    assert snapshot["runtime"]["initial_record_id"] == "RD-ALS"
+    assert snapshot["runtime"]["rotated_record_id"] == "RD-SMA"
+    assert len(snapshot["runtime"]["transport_log"]) == 6
+    assert snapshot["secret_persistence"] == {
+        "persisted_secret_count": 0,
+        "result_secret_count": 0,
+        "persisted_reference": study.ENV_VAR,
+    }
+    assert json.loads(output_json.read_text(encoding="utf-8")) == snapshot
+    report = output_markdown.read_text(encoding="utf-8")
+    assert "Environment-Backed Rare-Disease Credential Case Study" in report
+    assert "Provider Boundary" in report
+    assert "Promotion Evidence" in report
+    assert "Runtime And Rotation" in report
+    assert "Secret Boundary" in report
+
+    tampered = copy.deepcopy(snapshot)
+    tampered["runtime"]["operation_sha256_after_rotation"] = "0" * 64
+    with pytest.raises(ValueError, match="audit digest"):
+        study.validate_snapshot(tampered)
+
+
+def test_checked_credential_artifact_is_synchronized_and_tamper_detecting():
+    snapshot = json.loads(study.DEFAULT_JSON.read_text(encoding="utf-8"))
+    study.validate_snapshot(snapshot)
+    assert set(snapshot["end_to_end_assertions"]) == study.EXPECTED_ASSERTIONS
+    assert all(snapshot["end_to_end_assertions"].values())
+    assert snapshot["secret_persistence"]["persisted_secret_count"] == 0
+    assert snapshot["secret_persistence"]["result_secret_count"] == 0
+
+    tampered = copy.deepcopy(snapshot)
+    tampered["runtime"]["transport_log"][0]["header_name"] = "X-Other-Key"
+    with pytest.raises(ValueError, match="audit digest"):
+        study.validate_snapshot(tampered)

--- a/tests/unit/test_vsd_dynamic_rest.py
+++ b/tests/unit/test_vsd_dynamic_rest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from copy import deepcopy
 
 import pytest
@@ -47,8 +48,8 @@ def _search_config() -> dict:
     }
 
 
-def test_rejects_mutating_or_authenticated_operations():
-    """Mutating methods and embedded credentials never reach the network."""
+def test_rejects_mutating_or_embedded_credentials():
+    """Mutating methods and embedded credential values never reach the network."""
     config = _search_config()
     config["vsd_operation"]["method"] = "POST"
     with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match="read-only"):
@@ -59,8 +60,152 @@ def test_rejects_mutating_or_authenticated_operations():
         "type": "api_key",
         "value": "must-not-be-embedded",
     }
-    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match="credentials"):
+    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match="auth"):
         vsd_dynamic_rest.VSDDynamicRESTTool(config)
+
+
+@pytest.mark.parametrize(
+    "auth, message",
+    [
+        (
+            {
+                "type": "api_key_header_env",
+                "env_var": "AWS_SECRET_ACCESS_KEY",
+                "header": "X-API-Key",
+            },
+            "TOOLUNIVERSE_VSD_",
+        ),
+        (
+            {
+                "type": "api_key_header_env",
+                "env_var": "TOOLUNIVERSE_VSD_TEST_KEY",
+                "header": "Authorization",
+            },
+            "prohibited",
+        ),
+        (
+            {
+                "type": "bearer_env",
+                "env_var": "TOOLUNIVERSE_VSD_TEST_KEY",
+                "value": "embedded-secret-value",
+            },
+            "unsupported fields",
+        ),
+        (
+            {
+                "type": "api_key_query_env",
+                "env_var": "TOOLUNIVERSE_VSD_TEST_KEY",
+            },
+            "supports only",
+        ),
+    ],
+)
+def test_rejects_unsafe_credential_references(auth, message):
+    config = _search_config()
+    config["vsd_operation"]["auth"] = auth
+    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match=message):
+        vsd_dynamic_rest.VSDDynamicRESTTool(config)
+
+
+def test_api_key_header_is_read_at_runtime_and_never_returned(monkeypatch):
+    config = _search_config()
+    config["vsd_operation"]["auth"] = {
+        "type": "api_key_header_env",
+        "env_var": "TOOLUNIVERSE_VSD_TRIALS_API_KEY",
+        "header": "X-API-Key",
+    }
+    secret = "runtime-api-key-value"
+    monkeypatch.setenv("TOOLUNIVERSE_VSD_TRIALS_API_KEY", secret)
+    captured = {}
+
+    def fake_get(url, params, *, timeout, headers):
+        captured.update(url=url, params=params, timeout=timeout, headers=headers)
+        return {"studies": []}, {
+            "status_code": 200,
+            "content_type": "application/json",
+            "response_bytes": 15,
+            "redirects": 0,
+        }
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", fake_get)
+    result = vsd_dynamic_rest.VSDDynamicRESTTool(config).run({"condition": "ALS"})
+    serialized = json.dumps(result, sort_keys=True)
+
+    assert captured["headers"] == {"X-API-Key": secret}
+    assert secret not in serialized
+    assert "X-API-Key" not in serialized
+    assert "TOOLUNIVERSE_VSD_TRIALS_API_KEY" not in serialized
+    assert result["data"]["provenance"]["authentication"] == {
+        "type": "api_key_header_env",
+        "credential_source": "environment",
+    }
+
+
+def test_bearer_token_rotates_without_changing_reviewed_contract(monkeypatch):
+    config = _search_config()
+    config["vsd_operation"]["auth"] = {
+        "type": "bearer_env",
+        "env_var": "TOOLUNIVERSE_VSD_TRIALS_BEARER",
+    }
+    headers_seen = []
+
+    def fake_get(url, params, *, timeout, headers):
+        headers_seen.append(headers)
+        return {"studies": []}, {
+            "status_code": 200,
+            "content_type": "application/json",
+            "response_bytes": 15,
+            "redirects": 0,
+        }
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", fake_get)
+    tool = vsd_dynamic_rest.VSDDynamicRESTTool(config)
+    digest = tool._operation_digest
+    monkeypatch.setenv("TOOLUNIVERSE_VSD_TRIALS_BEARER", "first-bearer-token")
+    tool.run({"condition": "ALS"})
+    monkeypatch.setenv("TOOLUNIVERSE_VSD_TRIALS_BEARER", "second-bearer-token")
+    tool.run({"condition": "ALS"})
+
+    assert headers_seen == [
+        {"Authorization": "Bearer first-bearer-token"},
+        {"Authorization": "Bearer second-bearer-token"},
+    ]
+    assert tool._operation_digest == digest
+
+
+def test_missing_invalid_or_reflected_credentials_fail_closed(monkeypatch):
+    config = _search_config()
+    config["vsd_operation"]["auth"] = {
+        "type": "bearer_env",
+        "env_var": "TOOLUNIVERSE_VSD_TRIALS_BEARER",
+    }
+    calls = []
+
+    def fake_get(url, params, *, timeout, headers):
+        calls.append(headers)
+        secret = headers["Authorization"].removeprefix("Bearer ")
+        return {"studies": [], "echo": secret}, {
+            "status_code": 200,
+            "content_type": "application/json",
+            "response_bytes": 50,
+            "redirects": 0,
+        }
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", fake_get)
+    tool = vsd_dynamic_rest.VSDDynamicRESTTool(config)
+    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match="not set"):
+        tool.run({"condition": "ALS"})
+    assert calls == []
+
+    monkeypatch.setenv("TOOLUNIVERSE_VSD_TRIALS_BEARER", "bad token spaces")
+    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match="bearer token"):
+        tool.run({"condition": "ALS"})
+    assert calls == []
+
+    monkeypatch.setenv("TOOLUNIVERSE_VSD_TRIALS_BEARER", "reflected-token-value")
+    with pytest.raises(vsd_dynamic_rest.VSDDynamicRESTError, match="reflected"):
+        tool.run({"condition": "ALS"})
+    assert len(calls) == 1
 
 
 def test_rejects_external_schema_references():

--- a/tests/unit/test_vsd_openapi.py
+++ b/tests/unit/test_vsd_openapi.py
@@ -107,6 +107,25 @@ def _candidate(tmp_path):
     return report["candidates"][0]
 
 
+def _authenticated_document(auth_type: str) -> dict:
+    document = _document()
+    components = document["components"]
+    if auth_type == "api_key":
+        components["securitySchemes"] = {
+            "trialKey": {"type": "apiKey", "in": "header", "name": "X-Trial-Key"}
+        }
+        security = [{"trialKey": []}]
+    elif auth_type == "bearer":
+        components["securitySchemes"] = {
+            "trialBearer": {"type": "http", "scheme": "bearer"}
+        }
+        security = [{"trialBearer": []}]
+    else:
+        raise AssertionError(auth_type)
+    document["paths"]["/studies/{nctId}"]["get"]["security"] = security
+    return document
+
+
 def _object_cases():
     return [
         {
@@ -236,6 +255,78 @@ def test_inspection_exposes_explicit_non_promotable_reasons(tmp_path):
         validate_openapi_candidate(by_method["GET"])
 
 
+@pytest.mark.parametrize(
+    "auth_type, expected",
+    [
+        (
+            "api_key",
+            {
+                "type": "api_key_header",
+                "scheme_name": "trialKey",
+                "header": "X-Trial-Key",
+            },
+        ),
+        (
+            "bearer",
+            {"type": "bearer", "scheme_name": "trialBearer"},
+        ),
+    ],
+)
+def test_inspection_supports_only_reviewable_header_authentication(
+    tmp_path, auth_type, expected
+):
+    candidate = inspect_openapi_document(
+        _write_document(tmp_path, _authenticated_document(auth_type))
+    )["candidates"][0]
+
+    assert candidate["blockers"] == []
+    assert candidate["auth"] == expected
+    assert validate_openapi_candidate(candidate)["auth"] == expected
+
+
+@pytest.mark.parametrize(
+    "scheme, security, blocker",
+    [
+        (
+            {"type": "apiKey", "in": "query", "name": "api_key"},
+            [{"unsafe": []}],
+            "authentication_scheme_unsupported",
+        ),
+        (
+            {"type": "http", "scheme": "basic"},
+            [{"unsafe": []}],
+            "authentication_scheme_unsupported",
+        ),
+        (
+            {"type": "oauth2", "flows": {}},
+            [{"unsafe": ["read"]}],
+            "authentication_scopes_unsupported",
+        ),
+        (
+            {"type": "apiKey", "in": "header", "name": "X-API-Key"},
+            [{"unsafe": []}, {}],
+            None,
+        ),
+    ],
+)
+def test_inspection_blocks_unsafe_auth_and_honors_anonymous_alternative(
+    tmp_path, scheme, security, blocker
+):
+    document = _document()
+    document["components"]["securitySchemes"] = {"unsafe": scheme}
+    document["paths"]["/studies/{nctId}"]["get"]["security"] = security
+    candidate = inspect_openapi_document(_write_document(tmp_path, document))[
+        "candidates"
+    ][0]
+
+    if blocker is None:
+        assert candidate["auth"] is None
+        assert candidate["blockers"] == []
+    else:
+        assert blocker in candidate["blockers"]
+        assert "authentication_required" in candidate["blockers"]
+
+
 def test_external_schema_reference_blocks_only_affected_operation(tmp_path):
     document = _document()
     schema = document["paths"]["/studies/{nctId}"]["get"]["responses"]["200"][
@@ -299,6 +390,44 @@ def test_generator_builds_narrow_mappings_and_serialization(tmp_path):
     )
     assert endpoint.endswith("/studies/NCT00522899")
     assert query == {"format": "json", "fields": "NCTId|BriefTitle"}
+
+
+@pytest.mark.parametrize("auth_type", ["api_key", "bearer"])
+def test_generator_requires_bounded_environment_reference_for_auth(tmp_path, auth_type):
+    candidate = inspect_openapi_document(
+        _write_document(tmp_path, _authenticated_document(auth_type))
+    )["candidates"][0]
+    kwargs = {
+        "candidate": candidate,
+        "tool_name": "GeneratedAuthenticatedTrialRecord",
+        "description": "Fetch one authenticated reviewed trial registry record.",
+    }
+    with pytest.raises(
+        vsd_promotion.VSDPromotionError, match="credential_env is required"
+    ):
+        vsd_promotion.build_openapi_tool_config(**kwargs)
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="TOOLUNIVERSE_VSD_"):
+        vsd_promotion.build_openapi_tool_config(
+            **kwargs, credential_env="UNSAFE_API_KEY"
+        )
+
+    config = vsd_promotion.build_openapi_tool_config(
+        **kwargs, credential_env="TOOLUNIVERSE_VSD_TRIAL_REGISTRY_KEY"
+    )
+    auth = config["vsd_operation"]["auth"]
+    assert auth["env_var"] == "TOOLUNIVERSE_VSD_TRIAL_REGISTRY_KEY"
+    assert "value" not in auth
+    assert config["vsd_promotion"]["authentication"] == candidate["auth"]
+
+
+def test_anonymous_candidate_rejects_unnecessary_credential_reference(tmp_path):
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="not allowed"):
+        vsd_promotion.build_openapi_tool_config(
+            _candidate(tmp_path),
+            tool_name="GeneratedTrialRecord",
+            description="Fetch one reviewed anonymous trial registry record.",
+            credential_env="TOOLUNIVERSE_VSD_UNUSED_KEY",
+        )
 
 
 def test_generator_rejects_unknown_conflicting_and_invalid_fixed_parameters(tmp_path):
@@ -369,6 +498,73 @@ def test_openapi_object_operation_completes_promotion_and_fresh_load(
     assert response["data"]["result"]["nctId"] == "NCT00522899"
 
 
+def test_authenticated_openapi_completes_promotion_without_persisting_secret(
+    tmp_path, monkeypatch
+):
+    candidate = inspect_openapi_document(
+        _write_document(tmp_path, _authenticated_document("api_key"))
+    )["candidates"][0]
+    env_var = "TOOLUNIVERSE_VSD_TRIAL_REGISTRY_KEY"
+    secret = "private-runtime-trial-key"
+    monkeypatch.setenv(env_var, secret)
+    calls = []
+
+    def authenticated_get(url, params, *, timeout, headers):
+        calls.append(headers)
+        assert headers == {"X-Trial-Key": secret}
+        return _fake_get(url, params, timeout=timeout)
+
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", authenticated_get)
+    workspace = tmp_path / "authenticated-promotion"
+    draft = vsd_promotion.create_openapi_draft(
+        candidate,
+        tool_name="GeneratedAuthenticatedTrialRecord",
+        description="Fetch one authenticated reviewed trial registry record.",
+        fixed_query={"format": "json"},
+        credential_env=env_var,
+        workspace=workspace,
+    )
+    evidence = vsd_promotion.verify_draft(
+        draft["draft_id"], _object_cases(), workspace=workspace
+    )
+    vsd_promotion.approve_draft(
+        draft["draft_id"],
+        reviewed_by="Credential Test Reviewer",
+        decision_note="Approved after three authenticated provider cases passed.",
+        workspace=workspace,
+    )
+    publication = vsd_promotion.publish_draft(draft["draft_id"], workspace=workspace)
+    tooluniverse = ToolUniverse()
+    try:
+        assert vsd_promotion.load_published_tools(
+            tooluniverse, workspace=workspace
+        ) == ["GeneratedAuthenticatedTrialRecord"]
+        result = tooluniverse.run_one_function(
+            {
+                "name": "GeneratedAuthenticatedTrialRecord",
+                "arguments": {"nctId": "NCT00522899"},
+            },
+            use_cache=False,
+        )
+    finally:
+        tooluniverse.close()
+
+    assert evidence["case_count"] == 3
+    assert len(calls) == 4
+    assert result["data"]["result"]["nctId"] == "NCT00522899"
+    assert publication["config"]["vsd_operation"]["auth"] == {
+        "type": "api_key_header_env",
+        "env_var": env_var,
+        "header": "X-Trial-Key",
+    }
+    persisted = "\n".join(
+        path.read_text(encoding="utf-8") for path in workspace.rglob("*.json")
+    )
+    assert secret not in persisted
+    assert secret not in json.dumps(result)
+    assert env_var in persisted
+
+
 def test_cli_inspects_selects_and_creates_openapi_draft(tmp_path):
     spec_path = _write_document(tmp_path)
     report = _execute(build_parser().parse_args(["inspect-openapi", str(spec_path)]))
@@ -399,3 +595,32 @@ def test_cli_inspects_selects_and_creates_openapi_draft(tmp_path):
     assert select_openapi_candidate(
         report, draft["config"]["vsd_promotion"]["candidate_id"]
     )
+
+
+def test_cli_requires_and_persists_only_authenticated_environment_reference(tmp_path):
+    spec_path = _write_document(tmp_path, _authenticated_document("bearer"))
+    report = _execute(build_parser().parse_args(["inspect-openapi", str(spec_path)]))
+    report_path = tmp_path / "authenticated-report.json"
+    report_path.write_text(json.dumps(report), encoding="utf-8")
+    env_var = "TOOLUNIVERSE_VSD_TRIAL_BEARER"
+
+    draft = _execute(
+        build_parser().parse_args(
+            [
+                "--workspace",
+                str(tmp_path / "promotion"),
+                "draft-openapi",
+                str(report_path),
+                "--tool-name",
+                "GeneratedAuthenticatedTrialRecord",
+                "--description",
+                "Fetch one authenticated reviewed trial registry record.",
+                "--credential-env",
+                env_var,
+            ]
+        )
+    )
+    assert draft["config"]["vsd_operation"]["auth"] == {
+        "type": "bearer_env",
+        "env_var": env_var,
+    }

--- a/tests/unit/test_vsd_transport_security.py
+++ b/tests/unit/test_vsd_transport_security.py
@@ -97,6 +97,52 @@ def test_request_pins_the_single_vetted_dns_result(monkeypatch):
     assert session.request[1]["headers"]["Accept-Encoding"] == "identity"
 
 
+def test_reviewed_auth_header_is_bounded_and_not_returned_in_metadata(monkeypatch):
+    monkeypatch.setattr(
+        vsd_tool,
+        "_resolve_public_addresses",
+        lambda host, port: ("93.184.216.34",),
+    )
+    session = _Session(_Response())
+    secret = "reviewed-secret-value"
+
+    _, metadata = vsd_tool._safe_get_json(
+        "https://api.fda.gov/drug/label.json",
+        session=session,
+        headers={"X-API-Key": secret},
+    )
+
+    assert session.request[1]["headers"]["X-API-Key"] == secret
+    assert secret not in json.dumps(metadata)
+    assert "X-API-Key" not in json.dumps(metadata)
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"Host": "attacker.example"},
+        {"Cookie": "session=private"},
+        {"X-Forwarded-For": "127.0.0.1"},
+        {"X-API-Key": "line-one\nline-two"},
+        {"Bad Header": "value"},
+    ],
+)
+def test_unsafe_request_headers_fail_before_network(monkeypatch, headers):
+    monkeypatch.setattr(
+        vsd_tool,
+        "_resolve_public_addresses",
+        lambda host, port: ("93.184.216.34",),
+    )
+    session = _Session(_Response())
+    with pytest.raises(vsd_tool.VSDPolicyError, match="header"):
+        vsd_tool._safe_get_json(
+            "https://api.fda.gov/drug/label.json",
+            session=session,
+            headers=headers,
+        )
+    assert session.request is None
+
+
 def test_pinned_adapter_preserves_tls_and_http_hostname():
     """IP pinning retains hostname validation and the original Host header."""
     adapter = vsd_tool._PinnedHTTPSAdapter("api.fda.gov", "93.184.216.34")


### PR DESCRIPTION
## Summary
- derive supported header API-key and HTTP bearer requirements from reviewed OpenAPI security schemes
- bind authenticated drafts to a narrowly named environment-variable reference without persisting credential values
- validate reviewed headers and runtime credential values before transport, support rotation without changing operation identity, and reject exact credential reflection in provider JSON
- keep query/cookie API keys, basic authentication, OAuth, scopes, ambiguous alternatives, and multiple simultaneous schemes blocked

## End-to-end evidence
The checked protected rare-disease study inspects an authenticated OpenAPI 3.1 operation, verifies ALS, Duchenne muscular dystrophy, and spinal muscular atrophy records, approves and publishes the exact hash chain, and loads the tool into a fresh ToolUniverse instance. It then rotates the credential, proves the operation digest remains stable, proves missing and malformed values fail before transport, rejects a reflected credential, and scans persisted JSON plus ToolUniverse results for every test credential value.

The provider is a deterministic protected fixture because the repository cannot include a live credential. Only network transport is replaced; inspection, drafting, verification, approval, publication, fresh loading, schema validation, and execution use the production paths.

## Verification
- `201` cumulative VSD unit tests passed
- `83` focused credential, OpenAPI, promotion, CLI, dynamic REST, and transport tests passed
- `14` end-to-end credential study assertions passed
- Ruff 0.14.5 formatting and lint passed

## Stack
This PR is stacked on #425. Review that dependency first.