### PR TITLE
Add provider drift and lifecycle controls for VSD

### DIFF
--- a/examples/vsd/README.md
+++ b/examples/vsd/README.md
@@ -1,5 +1,73 @@
 # ToolUniverse VSD Validation Case Studies
 
+## Provider Drift And Publication Lifecycle
+
+Published VSD tools retain the exact provider contract that was reviewed, but
+provider OpenAPI documents can change later. The administrator-only
+`tooluniverse-vsd-lifecycle` CLI compares a local current OpenAPI file with the
+published operation and persists an inert, content-addressed assessment:
+
+- `unchanged` means the source document and inspected operation are identical.
+- `metadata_only` means documentation changed without changing request or
+  response validation behavior.
+- `review_required` means an input or response schema changed and a new draft,
+  verification run, and approval are required.
+- `breaking` means the operation disappeared, became policy-blocked, cannot be
+  reconstructed, or changed its endpoint, authentication, fixed query, or
+  argument mapping.
+
+`review_required` and `breaking` assessments recommend suspension, but an
+assessment cannot change state. An administrator must explicitly append a
+`suspended`, `active`, or `retired` event. Events are immutable, contiguous,
+hash-chained, bound to one exact publication digest, and can reference one
+validated assessment. Reactivation requires an `unchanged` or `metadata_only`
+assessment for that publication. Retirement is terminal for that publication.
+A newly reviewed replacement has a new publication digest and begins active.
+
+The publication loader validates the complete applicable history before it
+registers any tool. Suspended and retired publications are excluded from fresh
+ToolUniverse instances. A missing, modified, noncontiguous, or invalid event or
+referenced assessment fails the load before registration. Lifecycle changes do
+not remove a tool from an already-running instance; its host must restart or
+otherwise unload that instance.
+
+The checked protected rare-disease study promotes one authenticated operation,
+classifies unchanged, metadata-only, response-schema, endpoint, and unsafe-auth
+contracts, explicitly suspends the publication, proves fresh loading is empty,
+and proves a modified event fails closed. It then reassesses the repaired
+contract, explicitly activates it, executes two records across credential
+rotation, retires it, and proves both exclusion and terminal state. All six
+assessments remain inert, all three state events form one hash chain, and no
+credential value appears in an artifact or ToolUniverse result.
+
+Run the deterministic offline study from the repository root:
+
+```console
+PYTHONPATH=src python examples/vsd/lifecycle_drift_case_study.py
+```
+
+The study writes `artifacts/lifecycle_drift_snapshot.md` and its JSON audit
+snapshot. Its protected provider is deterministic because the repository
+cannot bundle a live credential; only network transport is replaced.
+
+A cron or release job can download a provider contract to a local file and run
+assessment separately from state decisions:
+
+```console
+tooluniverse-vsd-lifecycle --workspace ./vsd-review assess-openapi \
+  VSDProtectedEvidenceById current-provider-openapi.yaml
+tooluniverse-vsd-lifecycle --workspace ./vsd-review status \
+  VSDProtectedEvidenceById
+tooluniverse-vsd-lifecycle --workspace ./vsd-review suspend \
+  VSDProtectedEvidenceById --changed-by "Local Maintainer" \
+  --reason "Suspended while the changed provider contract is reviewed." \
+  --assessment-sha256 <assessment-sha256>
+```
+
+The CLI does not fetch contracts, make provider requests, change state based on
+an assessment, create a replacement draft, approve, publish, or transmit
+evidence. Those boundaries remain deliberate administrator actions.
+
 ## Environment-Backed Credentials For Reviewed APIs
 
 VSD can promote a reviewed OpenAPI operation that requires either one header

--- a/examples/vsd/artifacts/lifecycle_drift_snapshot.json
+++ b/examples/vsd/artifacts/lifecycle_drift_snapshot.json
@@ -1,0 +1,170 @@
+{
+  "answer": "Yes. Six inert assessments distinguished unchanged, metadata-only, review-required, and breaking contracts; explicit hash-bound state events controlled loading without modifying the approved publication.",
+  "audit_sha256": "9d35320f91ed03ec6ae7423c3193a8dfcd8cfcc611bea1bfb0d7defd2de09420",
+  "drift_assessments": {
+    "breaking_auth": {
+      "assessment_id": "7f64c456e52b518c",
+      "assessment_sha256": "7f64c456e52b518c14463fa5ded77810a5dd1d2ef3465dd72a1b618d816f23ae",
+      "blockers": [
+        "authentication_required",
+        "authentication_scheme_unsupported"
+      ],
+      "changes": [
+        "operation_policy"
+      ],
+      "classification": "breaking",
+      "suspension_recommended": true
+    },
+    "breaking_endpoint": {
+      "assessment_id": "61b2fc637c9ff48b",
+      "assessment_sha256": "61b2fc637c9ff48bfd2974fc5102dd317fa8d74bc4e1087d9a6105fbb2b0712e",
+      "blockers": [],
+      "changes": [
+        "endpoint"
+      ],
+      "classification": "breaking",
+      "suspension_recommended": true
+    },
+    "metadata_only": {
+      "assessment_id": "af8eef0ed9cc8a60",
+      "assessment_sha256": "af8eef0ed9cc8a6000596eb0c80ac30470d4bdbd1ed7706d4099bc41a17270fb",
+      "blockers": [],
+      "changes": [],
+      "classification": "metadata_only",
+      "suspension_recommended": false
+    },
+    "repaired": {
+      "assessment_id": "676211afbf9b470d",
+      "assessment_sha256": "676211afbf9b470d5e9db352b5ec21e353ab684ee21a1238a92663d25b33ef50",
+      "blockers": [],
+      "changes": [],
+      "classification": "unchanged",
+      "suspension_recommended": false
+    },
+    "review_required": {
+      "assessment_id": "7ff1b072bb52a95f",
+      "assessment_sha256": "7ff1b072bb52a95f39218962c3ccaa23cd789c17d5ecfe1176e627fe8e6ceb8d",
+      "blockers": [],
+      "changes": [
+        "response_validation"
+      ],
+      "classification": "review_required",
+      "suspension_recommended": true
+    },
+    "unchanged": {
+      "assessment_id": "e674c1a354763f56",
+      "assessment_sha256": "e674c1a354763f565013af38cde024b8169670d6485f79a4d114a7589d94d505",
+      "blockers": [],
+      "changes": [],
+      "classification": "unchanged",
+      "suspension_recommended": false
+    }
+  },
+  "end_to_end_assertions": {
+    "active_publication_executes_after_repair": true,
+    "all_assessments_are_inert_and_hash_bound": true,
+    "breaking_auth_drift_is_blocked": true,
+    "breaking_endpoint_drift_recommends_suspension": true,
+    "credential_environment_is_restored": true,
+    "credential_rotation_preserves_operation_identity": true,
+    "exact_contract_is_unchanged": true,
+    "explicit_suspension_prevents_fresh_loading": true,
+    "lifecycle_events_form_a_hash_chain": true,
+    "metadata_drift_does_not_recommend_suspension": true,
+    "publication_anchor_matches_current_history": true,
+    "response_drift_requires_new_review": true,
+    "retired_publication_cannot_be_loaded": true,
+    "retirement_is_terminal": true,
+    "secret_values_are_absent_from_artifacts": true,
+    "state_does_not_change_during_assessment": true,
+    "tampered_lifecycle_fails_before_registration": true,
+    "three_protected_verification_cases_pass": true,
+    "unchanged_repair_supports_explicit_activation": true
+  },
+  "lifecycle": {
+    "active_loaded_tools": [
+      "VSDLifecycleRareDiseaseEvidence"
+    ],
+    "anchor_id": "9f7d9e1a62fd6e8cbb1b1de73bfa24008bf7069fc2b94fb0411a0bcc3816fd89",
+    "assessment_sha256": [
+      "61b2fc637c9ff48bfd2974fc5102dd317fa8d74bc4e1087d9a6105fbb2b0712e",
+      "676211afbf9b470d5e9db352b5ec21e353ab684ee21a1238a92663d25b33ef50",
+      null
+    ],
+    "event_sha256": [
+      "b1469efe662cfff5d9c699df56033982827650f11621ff54559926e29ad54d53",
+      "a6e4d1ba35f86ac15b3a49312c77c956e52401d10643cfd7ab7ca9343077a9eb",
+      "4f1bdeb456c5e4be4afe4bbb51ae6df1f07458b275e71f8f090ba242623d75e7"
+    ],
+    "retired_loaded_tools": [],
+    "state_sha256": "1c4ee2aa2d0bfd3fc4e39c62223c5bcf5ae9594431a8b0a2ffe55fb71f59d2e4",
+    "states": [
+      "suspended",
+      "active",
+      "retired"
+    ],
+    "suspended_loaded_tools": [],
+    "tamper_error": "Lifecycle event 1 is invalid or has been modified",
+    "terminal_error": "Cannot transition publication from 'retired' to 'active'"
+  },
+  "promotion": {
+    "approval_sha256": "0719320ddfe68e1a7a7bdaa964505ef4b01e5c662c7ca4ebdc3f11913abc529b",
+    "draft_id": "vsdlifecyclerarediseaseevidence_ccf4d1677140",
+    "draft_sha256": "6eb25e7785b6638f7a3d87b895ac5154572c59f3a4bffbc0d54f3099b2c00949",
+    "operation_sha256": "ccf4d167714020295278d582aa7858473fc249017ae4aa767f909472147fc4dc",
+    "publication_sha256": "021c511b2b79bd5dca03cd5ecb28ef59e635472a1001ab99beac84350a2ddb30",
+    "verification_case_count": 3,
+    "verification_sha256": "5f8d0ee864d1c56ece5820f8bce8627734d1c5fc0b64a7562364f10ebe0ba715"
+  },
+  "provider_fixture": "A deterministic protected rare-disease provider replaces network transport. Inspection, promotion, verification, credential handling, lifecycle validation, fresh loading, and execution use production paths.",
+  "question": "Can ToolUniverse distinguish harmless provider documentation changes from contract drift and keep unsafe publications out of fresh runtimes?",
+  "runtime": {
+    "initial_record_id": "RD-DMD",
+    "operation_sha256_after_rotation": "ccf4d167714020295278d582aa7858473fc249017ae4aa767f909472147fc4dc",
+    "operation_sha256_before_rotation": "ccf4d167714020295278d582aa7858473fc249017ae4aa767f909472147fc4dc",
+    "rotated_record_id": "RD-SMA",
+    "transport_log": [
+      {
+        "credential_slot": "initial",
+        "endpoint_version": "v1",
+        "params": {},
+        "record_id": "RD-ALS",
+        "timeout": 20.0
+      },
+      {
+        "credential_slot": "initial",
+        "endpoint_version": "v1",
+        "params": {},
+        "record_id": "RD-DMD",
+        "timeout": 20.0
+      },
+      {
+        "credential_slot": "initial",
+        "endpoint_version": "v1",
+        "params": {},
+        "record_id": "RD-SMA",
+        "timeout": 20.0
+      },
+      {
+        "credential_slot": "initial",
+        "endpoint_version": "v1",
+        "params": {},
+        "record_id": "RD-DMD",
+        "timeout": 20.0
+      },
+      {
+        "credential_slot": "rotated",
+        "endpoint_version": "v1",
+        "params": {},
+        "record_id": "RD-SMA",
+        "timeout": 20.0
+      }
+    ]
+  },
+  "secret_boundary": {
+    "persisted_reference": "TOOLUNIVERSE_VSD_LIFECYCLE_CASE_KEY",
+    "persisted_secret_count": 0,
+    "result_secret_count": 0
+  },
+  "title": "Protected Rare-Disease Provider Drift And Lifecycle Case Study"
+}

--- a/examples/vsd/artifacts/lifecycle_drift_snapshot.md
+++ b/examples/vsd/artifacts/lifecycle_drift_snapshot.md
@@ -1,0 +1,73 @@
+# Protected Rare-Disease Provider Drift And Lifecycle Case Study
+
+## Decision Question
+
+Can ToolUniverse distinguish harmless provider documentation changes from contract drift and keep unsafe publications out of fresh runtimes?
+
+**Result:** Yes. Six inert assessments distinguished unchanged, metadata-only, review-required, and breaking contracts; explicit hash-bound state events controlled loading without modifying the approved publication.
+
+## Provider Boundary
+
+A deterministic protected rare-disease provider replaces network transport. Inspection, promotion, verification, credential handling, lifecycle validation, fresh loading, and execution use production paths.
+
+## Reviewed Publication
+
+The baseline protected operation passed three disease-specific cases before approval. The publication remains immutable throughout every lifecycle transition.
+
+| Evidence | SHA-256 |
+| --- | --- |
+| Draft | `6eb25e7785b6638f7a3d87b895ac5154572c59f3a4bffbc0d54f3099b2c00949` |
+| Verification | `5f8d0ee864d1c56ece5820f8bce8627734d1c5fc0b64a7562364f10ebe0ba715` |
+| Approval | `0719320ddfe68e1a7a7bdaa964505ef4b01e5c662c7ca4ebdc3f11913abc529b` |
+| Publication | `021c511b2b79bd5dca03cd5ecb28ef59e635472a1001ab99beac84350a2ddb30` |
+
+## Drift Classification
+
+| Contract | Classification | Changes or blockers | Suspend? |
+| --- | --- | --- | --- |
+| `unchanged` | `unchanged` | `none` | no |
+| `metadata_only` | `metadata_only` | `none` | no |
+| `review_required` | `review_required` | `response_validation` | yes |
+| `breaking_endpoint` | `breaking` | `endpoint` | yes |
+| `breaking_auth` | `breaking` | `operation_policy` | yes |
+| `repaired` | `unchanged` | `none` | no |
+
+Assessments are local, inert evidence. A recommendation never changes runtime state on its own.
+
+## Explicit Lifecycle
+
+The administrator explicitly suspended the publication using the breaking endpoint assessment. A fresh ToolUniverse instance loaded no tool. After the baseline contract was confirmed again, an explicit activation restored loading and two authenticated executions passed, including a credential rotation. Retirement then excluded the tool and could not be reversed for that publication.
+
+Lifecycle sequence: `suspended -> active -> retired`.
+
+A modified event failed validation before any registration. Each event links the previous event digest and the exact publication digest.
+
+## End-to-End Assertions
+
+| Assertion | Result |
+| --- | --- |
+| `active_publication_executes_after_repair` | PASS |
+| `all_assessments_are_inert_and_hash_bound` | PASS |
+| `breaking_auth_drift_is_blocked` | PASS |
+| `breaking_endpoint_drift_recommends_suspension` | PASS |
+| `credential_environment_is_restored` | PASS |
+| `credential_rotation_preserves_operation_identity` | PASS |
+| `exact_contract_is_unchanged` | PASS |
+| `explicit_suspension_prevents_fresh_loading` | PASS |
+| `lifecycle_events_form_a_hash_chain` | PASS |
+| `metadata_drift_does_not_recommend_suspension` | PASS |
+| `publication_anchor_matches_current_history` | PASS |
+| `response_drift_requires_new_review` | PASS |
+| `retired_publication_cannot_be_loaded` | PASS |
+| `retirement_is_terminal` | PASS |
+| `secret_values_are_absent_from_artifacts` | PASS |
+| `state_does_not_change_during_assessment` | PASS |
+| `tampered_lifecycle_fails_before_registration` | PASS |
+| `three_protected_verification_cases_pass` | PASS |
+| `unchanged_repair_supports_explicit_activation` | PASS |
+
+## Operational Boundary
+
+The lifecycle command reads a local OpenAPI file; it does not crawl, fetch, execute, suspend, activate, retire, or republish automatically. State is local to one VSD workspace and affects newly loaded ToolUniverse instances. Already-running instances must be restarted or otherwise unloaded by their host application.
+
+**Case audit SHA-256:** `9d35320f91ed03ec6ae7423c3193a8dfcd8cfcc611bea1bfb0d7defd2de09420`

--- a/examples/vsd/lifecycle_drift_case_study.py
+++ b/examples/vsd/lifecycle_drift_case_study.py
@@ -1,0 +1,707 @@
+"""Exercise OpenAPI drift and publication lifecycle controls end to end."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from tooluniverse import ToolUniverse, vsd_dynamic_rest, vsd_promotion
+from tooluniverse.vsd_lifecycle import (
+    VSDLifecycleError,
+    assess_openapi_drift,
+    list_publication_states,
+    set_publication_state,
+)
+from tooluniverse.vsd_openapi import inspect_openapi_document
+
+HERE = Path(__file__).resolve().parent
+ARTIFACTS = HERE / "artifacts"
+DEFAULT_JSON = ARTIFACTS / "lifecycle_drift_snapshot.json"
+DEFAULT_MARKDOWN = ARTIFACTS / "lifecycle_drift_snapshot.md"
+
+ENV_VAR = "TOOLUNIVERSE_VSD_LIFECYCLE_CASE_KEY"
+TOOL_NAME = "VSDLifecycleRareDiseaseEvidence"
+RECORDS = {
+    "RD-ALS": {
+        "record_id": "RD-ALS",
+        "disease": "Amyotrophic lateral sclerosis",
+        "genes": ["C9orf72", "SOD1", "TARDBP"],
+        "phenotypes": ["Muscle weakness", "Motor neuron degeneration"],
+        "trials": ["NCT05163886", "NCT05619783"],
+    },
+    "RD-DMD": {
+        "record_id": "RD-DMD",
+        "disease": "Duchenne muscular dystrophy",
+        "genes": ["DMD"],
+        "phenotypes": ["Progressive muscle weakness", "Elevated creatine kinase"],
+        "trials": ["NCT05096221", "NCT05429372"],
+    },
+    "RD-SMA": {
+        "record_id": "RD-SMA",
+        "disease": "Spinal muscular atrophy",
+        "genes": ["SMN1", "SMN2"],
+        "phenotypes": ["Hypotonia", "Proximal muscle weakness"],
+        "trials": ["NCT05337553", "NCT05794139"],
+    },
+}
+EXPECTED_ASSERTIONS = {
+    "active_publication_executes_after_repair",
+    "all_assessments_are_inert_and_hash_bound",
+    "breaking_auth_drift_is_blocked",
+    "breaking_endpoint_drift_recommends_suspension",
+    "credential_environment_is_restored",
+    "credential_rotation_preserves_operation_identity",
+    "exact_contract_is_unchanged",
+    "explicit_suspension_prevents_fresh_loading",
+    "lifecycle_events_form_a_hash_chain",
+    "metadata_drift_does_not_recommend_suspension",
+    "publication_anchor_matches_current_history",
+    "response_drift_requires_new_review",
+    "retired_publication_cannot_be_loaded",
+    "retirement_is_terminal",
+    "secret_values_are_absent_from_artifacts",
+    "state_does_not_change_during_assessment",
+    "tampered_lifecycle_fails_before_registration",
+    "three_protected_verification_cases_pass",
+    "unchanged_repair_supports_explicit_activation",
+}
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _secret(label: str) -> str:
+    return hashlib.sha256(f"vsd-lifecycle:{label}".encode()).hexdigest()
+
+
+def _specification(
+    *,
+    version: str = "1.0.0",
+    summary: str = "Retrieve one protected rare-disease evidence record",
+    server_url: str = "https://rare-registry.example.org/v1",
+    auth_location: str = "header",
+    require_evidence_level: bool = False,
+) -> dict[str, Any]:
+    properties: dict[str, Any] = {
+        "record_id": {"type": "string"},
+        "disease": {"type": "string"},
+        "genes": {"type": "array", "items": {"type": "string"}},
+        "phenotypes": {"type": "array", "items": {"type": "string"}},
+        "trials": {"type": "array", "items": {"type": "string"}},
+    }
+    required = ["record_id", "disease", "genes", "phenotypes", "trials"]
+    if require_evidence_level:
+        properties["evidence_level"] = {"type": "string", "enum": ["reviewed"]}
+        required.append("evidence_level")
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "Protected Rare Disease Registry", "version": version},
+        "servers": [{"url": server_url}],
+        "security": [{"registryKey": []}],
+        "paths": {
+            "/evidence/{recordId}": {
+                "get": {
+                    "operationId": "getRareDiseaseEvidence",
+                    "summary": summary,
+                    "parameters": [
+                        {
+                            "name": "recordId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {
+                                "type": "string",
+                                "pattern": "^RD-(?:ALS|DMD|SMA)$",
+                            },
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Rare-disease evidence record",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": properties,
+                                        "required": required,
+                                        "additionalProperties": False,
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "registryKey": {
+                    "type": "apiKey",
+                    "in": auth_location,
+                    "name": (
+                        "X-Rare-Disease-Key"
+                        if auth_location == "header"
+                        else "registry_key"
+                    ),
+                }
+            }
+        },
+    }
+
+
+def _write_spec(workspace: Path, name: str, specification: dict[str, Any]) -> Path:
+    path = workspace / "provider-contracts" / f"{name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(specification, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    return path
+
+
+def _cases() -> list[dict[str, Any]]:
+    return [
+        {
+            "arguments": {"recordId": record_id},
+            "expect": {
+                "result_type": "object",
+                "required_fields": [
+                    "record_id",
+                    "disease",
+                    "genes",
+                    "phenotypes",
+                    "trials",
+                ],
+                "equals": {"record_id": record_id},
+                "required_paths": ["/genes/0", "/phenotypes/0", "/trials/0"],
+                "equals_paths": {},
+            },
+        }
+        for record_id in RECORDS
+    ]
+
+
+def run_case(workspace: Path) -> dict[str, Any]:
+    workspace = Path(workspace)
+    baseline_path = _write_spec(workspace, "baseline", _specification())
+    metadata_path = _write_spec(
+        workspace,
+        "metadata-only",
+        _specification(
+            version="1.0.1", summary="Retrieve one curated rare-disease record"
+        ),
+    )
+    response_path = _write_spec(
+        workspace,
+        "response-review",
+        _specification(require_evidence_level=True),
+    )
+    endpoint_path = _write_spec(
+        workspace,
+        "breaking-endpoint",
+        _specification(server_url="https://rare-registry.example.org/v2"),
+    )
+    auth_path = _write_spec(
+        workspace,
+        "blocked-query-auth",
+        _specification(auth_location="query"),
+    )
+    initial_secret = _secret("initial")
+    rotated_secret = _secret("rotated")
+    secrets = (initial_secret, rotated_secret)
+    previous_environment = os.environ.get(ENV_VAR)
+    original_transport = vsd_dynamic_rest._safe_get_json
+    transport_log: list[dict[str, Any]] = []
+
+    def fake_transport(url, params, *, timeout, headers):
+        secret = headers.get("X-Rare-Disease-Key")
+        slot = {initial_secret: "initial", rotated_secret: "rotated"}.get(secret)
+        if slot is None or set(headers) != {"X-Rare-Disease-Key"}:
+            raise AssertionError("transport did not receive the reviewed credential")
+        record_id = url.rsplit("/", 1)[-1]
+        transport_log.append(
+            {
+                "credential_slot": slot,
+                "record_id": record_id,
+                "endpoint_version": url.split("/")[-3],
+                "params": dict(params),
+                "timeout": timeout,
+            }
+        )
+        payload = copy.deepcopy(RECORDS[record_id])
+        return payload, {
+            "status_code": 200,
+            "content_type": "application/json",
+            "response_bytes": len(json.dumps(payload).encode()),
+            "redirects": 0,
+        }
+
+    tamper_error = ""
+    terminal_error = ""
+    try:
+        os.environ[ENV_VAR] = initial_secret
+        vsd_dynamic_rest._safe_get_json = fake_transport
+        report = inspect_openapi_document(baseline_path)
+        candidate = report["candidates"][0]
+        draft = vsd_promotion.create_openapi_draft(
+            candidate,
+            tool_name=TOOL_NAME,
+            description="Retrieve one reviewed protected rare-disease evidence record.",
+            include_parameters=["recordId"],
+            credential_env=ENV_VAR,
+            workspace=workspace,
+        )
+        evidence = vsd_promotion.verify_draft(
+            draft["draft_id"], _cases(), workspace=workspace
+        )
+        approval = vsd_promotion.approve_draft(
+            draft["draft_id"],
+            reviewed_by="Lifecycle Case Study Reviewer",
+            decision_note=(
+                "Approved after three protected rare-disease records passed."
+            ),
+            workspace=workspace,
+        )
+        publication = vsd_promotion.publish_draft(
+            draft["draft_id"], workspace=workspace
+        )
+
+        assessments = {
+            "unchanged": assess_openapi_drift(
+                TOOL_NAME, baseline_path, workspace=workspace
+            ),
+            "metadata_only": assess_openapi_drift(
+                TOOL_NAME, metadata_path, workspace=workspace
+            ),
+            "review_required": assess_openapi_drift(
+                TOOL_NAME, response_path, workspace=workspace
+            ),
+            "breaking_endpoint": assess_openapi_drift(
+                TOOL_NAME, endpoint_path, workspace=workspace
+            ),
+            "breaking_auth": assess_openapi_drift(
+                TOOL_NAME, auth_path, workspace=workspace
+            ),
+        }
+        state_after_assessment = list_publication_states(
+            TOOL_NAME, workspace=workspace
+        )["tools"][0]
+        suspended = set_publication_state(
+            TOOL_NAME,
+            "suspended",
+            changed_by="Lifecycle Case Study Reviewer",
+            reason="Suspended after the provider endpoint changed major versions.",
+            assessment_sha256=assessments["breaking_endpoint"]["assessment_sha256"],
+            workspace=workspace,
+        )
+
+        suspended_universe = ToolUniverse()
+        try:
+            suspended_loaded = vsd_promotion.load_published_tools(
+                suspended_universe, workspace=workspace
+            )
+            suspended_present = TOOL_NAME in suspended_universe.all_tool_dict
+        finally:
+            suspended_universe.close()
+
+        lifecycle_directory = (
+            workspace / "lifecycle" / TOOL_NAME / publication["publication_sha256"]
+        )
+        event_path = lifecycle_directory / "events" / "000001.json"
+        original_event = event_path.read_bytes()
+        changed_event = json.loads(original_event)
+        changed_event["reason"] = "tampered lifecycle reason"
+        event_path.write_text(json.dumps(changed_event), encoding="utf-8")
+        tampered_universe = ToolUniverse()
+        try:
+            try:
+                vsd_promotion.load_published_tools(
+                    tampered_universe, workspace=workspace
+                )
+            except VSDLifecycleError as exc:
+                tamper_error = str(exc)
+            tampered_present = TOOL_NAME in tampered_universe.all_tool_dict
+        finally:
+            tampered_universe.close()
+            event_path.write_bytes(original_event)
+
+        repaired = assess_openapi_drift(TOOL_NAME, baseline_path, workspace=workspace)
+        activated = set_publication_state(
+            TOOL_NAME,
+            "active",
+            changed_by="Lifecycle Case Study Reviewer",
+            reason="Restored after the original reviewed provider contract was confirmed.",
+            assessment_sha256=repaired["assessment_sha256"],
+            workspace=workspace,
+        )
+        active_universe = ToolUniverse()
+        try:
+            active_loaded = vsd_promotion.load_published_tools(
+                active_universe, workspace=workspace
+            )
+            initial_result = active_universe.run_one_function(
+                {"name": TOOL_NAME, "arguments": {"recordId": "RD-DMD"}},
+                use_cache=False,
+            )
+            operation_sha256 = initial_result["data"]["provenance"]["operation_sha256"]
+            os.environ[ENV_VAR] = rotated_secret
+            rotated_result = active_universe.run_one_function(
+                {"name": TOOL_NAME, "arguments": {"recordId": "RD-SMA"}},
+                use_cache=False,
+            )
+        finally:
+            active_universe.close()
+
+        retired = set_publication_state(
+            TOOL_NAME,
+            "retired",
+            changed_by="Lifecycle Case Study Reviewer",
+            reason="Retired after the protected registry integration was decommissioned.",
+            workspace=workspace,
+        )
+        retired_universe = ToolUniverse()
+        try:
+            retired_loaded = vsd_promotion.load_published_tools(
+                retired_universe, workspace=workspace
+            )
+            retired_present = TOOL_NAME in retired_universe.all_tool_dict
+        finally:
+            retired_universe.close()
+        try:
+            set_publication_state(
+                TOOL_NAME,
+                "active",
+                changed_by="Lifecycle Case Study Reviewer",
+                reason="A retired publication must not return to active service.",
+                workspace=workspace,
+            )
+        except VSDLifecycleError as exc:
+            terminal_error = str(exc)
+    finally:
+        vsd_dynamic_rest._safe_get_json = original_transport
+        if previous_environment is None:
+            os.environ.pop(ENV_VAR, None)
+        else:
+            os.environ[ENV_VAR] = previous_environment
+
+    persisted_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in workspace.rglob("*.json")
+    )
+    result_text = json.dumps(
+        {"initial": initial_result, "rotated": rotated_result}, sort_keys=True
+    )
+    events = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted((lifecycle_directory / "events").glob("*.json"))
+    ]
+    lifecycle_state = json.loads(
+        (lifecycle_directory / "state.json").read_text(encoding="utf-8")
+    )
+    assertions = {
+        "three_protected_verification_cases_pass": (
+            evidence["all_cases_passed"] is True and evidence["case_count"] == 3
+        ),
+        "exact_contract_is_unchanged": (
+            assessments["unchanged"]["classification"] == "unchanged"
+            and assessments["unchanged"]["changes"] == []
+        ),
+        "metadata_drift_does_not_recommend_suspension": (
+            assessments["metadata_only"]["classification"] == "metadata_only"
+            and assessments["metadata_only"]["suspension_recommended"] is False
+        ),
+        "response_drift_requires_new_review": (
+            assessments["review_required"]["classification"] == "review_required"
+            and assessments["review_required"]["changes"] == ["response_validation"]
+            and assessments["review_required"]["suspension_recommended"] is True
+        ),
+        "breaking_endpoint_drift_recommends_suspension": (
+            assessments["breaking_endpoint"]["classification"] == "breaking"
+            and assessments["breaking_endpoint"]["changes"] == ["endpoint"]
+            and assessments["breaking_endpoint"]["suspension_recommended"] is True
+        ),
+        "breaking_auth_drift_is_blocked": (
+            assessments["breaking_auth"]["classification"] == "breaking"
+            and "authentication_required" in assessments["breaking_auth"]["blockers"]
+        ),
+        "all_assessments_are_inert_and_hash_bound": all(
+            item["execution_allowed"] is False
+            and len(item["assessment_sha256"]) == 64
+            and item["assessment_id"] == item["assessment_sha256"][:16]
+            for item in [*assessments.values(), repaired]
+        ),
+        "state_does_not_change_during_assessment": (
+            state_after_assessment["state"] == "active"
+            and state_after_assessment["revision"] == 0
+        ),
+        "explicit_suspension_prevents_fresh_loading": (
+            suspended["state"] == "suspended"
+            and suspended_loaded == []
+            and suspended_present is False
+        ),
+        "tampered_lifecycle_fails_before_registration": (
+            "modified" in tamper_error and tampered_present is False
+        ),
+        "unchanged_repair_supports_explicit_activation": (
+            repaired["classification"] == "unchanged"
+            and activated["state"] == "active"
+            and activated["assessment_sha256"] == repaired["assessment_sha256"]
+        ),
+        "active_publication_executes_after_repair": (
+            active_loaded == [TOOL_NAME]
+            and initial_result["status"] == "success"
+            and initial_result["data"]["result"]["record_id"] == "RD-DMD"
+        ),
+        "credential_rotation_preserves_operation_identity": (
+            rotated_result["data"]["result"]["record_id"] == "RD-SMA"
+            and rotated_result["data"]["provenance"]["operation_sha256"]
+            == operation_sha256
+            and transport_log[-1]["credential_slot"] == "rotated"
+        ),
+        "retired_publication_cannot_be_loaded": (
+            retired["state"] == "retired"
+            and retired_loaded == []
+            and retired_present is False
+        ),
+        "retirement_is_terminal": (
+            "Cannot transition publication from 'retired' to 'active'" in terminal_error
+        ),
+        "lifecycle_events_form_a_hash_chain": (
+            len(events) == 3
+            and events[0]["previous_event_sha256"] is None
+            and events[1]["previous_event_sha256"] == events[0]["event_sha256"]
+            and events[2]["previous_event_sha256"] == events[1]["event_sha256"]
+            and [event["revision"] for event in events] == [1, 2, 3]
+        ),
+        "publication_anchor_matches_current_history": (
+            publication["lifecycle"]["anchor_id"] == lifecycle_state["anchor_id"]
+            and lifecycle_state["publication_sha256"]
+            == publication["publication_sha256"]
+            and lifecycle_state["revision"] == 3
+            and lifecycle_state["state"] == "retired"
+            and lifecycle_state["current_event_sha256"] == events[-1]["event_sha256"]
+        ),
+        "secret_values_are_absent_from_artifacts": all(
+            secret not in persisted_text and secret not in result_text
+            for secret in secrets
+        ),
+        "credential_environment_is_restored": (
+            os.environ.get(ENV_VAR) == previous_environment
+        ),
+    }
+    snapshot = {
+        "title": "Protected Rare-Disease Provider Drift And Lifecycle Case Study",
+        "question": (
+            "Can ToolUniverse distinguish harmless provider documentation changes "
+            "from contract drift and keep unsafe publications out of fresh runtimes?"
+        ),
+        "answer": (
+            "Yes. Six inert assessments distinguished unchanged, metadata-only, "
+            "review-required, and breaking contracts; explicit hash-bound state "
+            "events controlled loading without modifying the approved publication."
+        ),
+        "provider_fixture": (
+            "A deterministic protected rare-disease provider replaces network "
+            "transport. Inspection, promotion, verification, credential handling, "
+            "lifecycle validation, fresh loading, and execution use production paths."
+        ),
+        "promotion": {
+            "draft_id": draft["draft_id"],
+            "draft_sha256": draft["draft_sha256"],
+            "verification_sha256": evidence["verification_sha256"],
+            "approval_sha256": approval["approval_sha256"],
+            "publication_sha256": publication["publication_sha256"],
+            "operation_sha256": publication["operation_sha256"],
+            "verification_case_count": evidence["case_count"],
+        },
+        "drift_assessments": {
+            name: {
+                "assessment_id": item["assessment_id"],
+                "assessment_sha256": item["assessment_sha256"],
+                "classification": item["classification"],
+                "changes": item["changes"],
+                "blockers": item["blockers"],
+                "suspension_recommended": item["suspension_recommended"],
+            }
+            for name, item in {**assessments, "repaired": repaired}.items()
+        },
+        "lifecycle": {
+            "anchor_id": lifecycle_state["anchor_id"],
+            "state_sha256": lifecycle_state["state_sha256"],
+            "states": [event["state"] for event in events],
+            "event_sha256": [event["event_sha256"] for event in events],
+            "assessment_sha256": [event["assessment_sha256"] for event in events],
+            "suspended_loaded_tools": suspended_loaded,
+            "active_loaded_tools": active_loaded,
+            "retired_loaded_tools": retired_loaded,
+            "tamper_error": tamper_error,
+            "terminal_error": terminal_error,
+        },
+        "runtime": {
+            "initial_record_id": initial_result["data"]["result"]["record_id"],
+            "rotated_record_id": rotated_result["data"]["result"]["record_id"],
+            "operation_sha256_before_rotation": operation_sha256,
+            "operation_sha256_after_rotation": rotated_result["data"]["provenance"][
+                "operation_sha256"
+            ],
+            "transport_log": transport_log,
+        },
+        "secret_boundary": {
+            "persisted_secret_count": sum(
+                secret in persisted_text for secret in secrets
+            ),
+            "result_secret_count": sum(secret in result_text for secret in secrets),
+            "persisted_reference": ENV_VAR,
+        },
+        "end_to_end_assertions": assertions,
+    }
+    snapshot["audit_sha256"] = _digest(
+        {
+            key: value
+            for key, value in snapshot.items()
+            if key not in {"title", "question", "answer", "audit_sha256"}
+        }
+    )
+    validate_snapshot(snapshot)
+    return snapshot
+
+
+def validate_snapshot(snapshot: dict[str, Any]) -> None:
+    assertions = snapshot.get("end_to_end_assertions")
+    if not isinstance(assertions, dict) or set(assertions) != EXPECTED_ASSERTIONS:
+        raise ValueError("Snapshot does not contain the complete assertion set")
+    if not all(assertions.values()):
+        failed = sorted(name for name, passed in assertions.items() if not passed)
+        raise ValueError(f"End-to-end assertions failed: {failed!r}")
+    expected = _digest(
+        {
+            key: value
+            for key, value in snapshot.items()
+            if key not in {"title", "question", "answer", "audit_sha256"}
+        }
+    )
+    if snapshot.get("audit_sha256") != expected:
+        raise ValueError("Snapshot audit digest does not match its content")
+
+
+def _markdown(snapshot: dict[str, Any]) -> str:
+    promotion = snapshot["promotion"]
+    assessments = snapshot["drift_assessments"]
+    lifecycle = snapshot["lifecycle"]
+    lines = [
+        "# Protected Rare-Disease Provider Drift And Lifecycle Case Study",
+        "",
+        "## Decision Question",
+        "",
+        snapshot["question"],
+        "",
+        f"**Result:** {snapshot['answer']}",
+        "",
+        "## Provider Boundary",
+        "",
+        snapshot["provider_fixture"],
+        "",
+        "## Reviewed Publication",
+        "",
+        "The baseline protected operation passed three disease-specific cases before "
+        "approval. The publication remains immutable throughout every lifecycle "
+        "transition.",
+        "",
+        "| Evidence | SHA-256 |",
+        "| --- | --- |",
+        f"| Draft | `{promotion['draft_sha256']}` |",
+        f"| Verification | `{promotion['verification_sha256']}` |",
+        f"| Approval | `{promotion['approval_sha256']}` |",
+        f"| Publication | `{promotion['publication_sha256']}` |",
+        "",
+        "## Drift Classification",
+        "",
+        "| Contract | Classification | Changes or blockers | Suspend? |",
+        "| --- | --- | --- | --- |",
+    ]
+    for name, item in assessments.items():
+        evidence = item["changes"] or item["blockers"] or ["none"]
+        lines.append(
+            f"| `{name}` | `{item['classification']}` | "
+            f"`{', '.join(evidence)}` | "
+            f"{'yes' if item['suspension_recommended'] else 'no'} |"
+        )
+    lines.extend(
+        [
+            "",
+            "Assessments are local, inert evidence. A recommendation never changes "
+            "runtime state on its own.",
+            "",
+            "## Explicit Lifecycle",
+            "",
+            "The administrator explicitly suspended the publication using the "
+            "breaking endpoint assessment. A fresh ToolUniverse instance loaded no "
+            "tool. After the baseline contract was confirmed again, an explicit "
+            "activation restored loading and two authenticated executions passed, "
+            "including a credential rotation. Retirement then excluded the tool and "
+            "could not be reversed for that publication.",
+            "",
+            f"Lifecycle sequence: `{' -> '.join(lifecycle['states'])}`.",
+            "",
+            "A modified event failed validation before any registration. Each event "
+            "links the previous event digest and the exact publication digest.",
+            "",
+            "## End-to-End Assertions",
+            "",
+            "| Assertion | Result |",
+            "| --- | --- |",
+        ]
+    )
+    lines.extend(
+        f"| `{name}` | {'PASS' if passed else 'FAIL'} |"
+        for name, passed in sorted(snapshot["end_to_end_assertions"].items())
+    )
+    lines.extend(
+        [
+            "",
+            "## Operational Boundary",
+            "",
+            "The lifecycle command reads a local OpenAPI file; it does not crawl, "
+            "fetch, execute, suspend, activate, retire, or republish automatically. "
+            "State is local to one VSD workspace and affects newly loaded "
+            "ToolUniverse instances. Already-running instances must be restarted or "
+            "otherwise unloaded by their host application.",
+            "",
+            f"**Case audit SHA-256:** `{snapshot['audit_sha256']}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_artifacts(
+    snapshot: dict[str, Any],
+    json_path: Path = DEFAULT_JSON,
+    markdown_path: Path = DEFAULT_MARKDOWN,
+) -> None:
+    validate_snapshot(snapshot)
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(_markdown(snapshot), encoding="utf-8")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="tooluniverse-vsd-lifecycle-") as directory:
+        snapshot = run_case(Path(directory))
+    write_artifacts(snapshot)
+    print(json.dumps({"status": "passed", "audit_sha256": snapshot["audit_sha256"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ tooluniverse-doctor = "tooluniverse.doctor:main"
 tooluniverse-vsd-admin = "tooluniverse.vsd_admin_cli:main"
 tooluniverse-vsd-promote = "tooluniverse.vsd_promotion_cli:main"
 tooluniverse-vsd-demand = "tooluniverse.vsd_demand_cli:main"
+tooluniverse-vsd-lifecycle = "tooluniverse.vsd_lifecycle_cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/tooluniverse/vsd_lifecycle.py
+++ b/src/tooluniverse/vsd_lifecycle.py
@@ -1,0 +1,739 @@
+"""Local drift assessment and explicit lifecycle controls for published VSD tools."""
+
+from __future__ import annotations
+
+import copy
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .vsd_dynamic_rest import VSDDynamicRESTError, _validated_operation_config
+from .vsd_openapi import VSDOpenAPIError, inspect_openapi_document
+from .vsd_promotion import (
+    VSDPromotionError,
+    _atomic_write_json,
+    _canonical_digest,
+    _promotion_transaction,
+    _read_json,
+    _root,
+    _tool_name,
+    _validated_publication,
+    build_openapi_tool_config,
+)
+
+_ASSESSMENT_FORMAT = "vsd_openapi_drift_assessment_v1"
+_LIFECYCLE_FORMAT = "vsd_publication_lifecycle_event_v1"
+_LIFECYCLE_ANCHOR_FORMAT = "vsd_publication_lifecycle_anchor_v1"
+_LIFECYCLE_STATE_FORMAT = "vsd_publication_lifecycle_state_v1"
+_VERSION = 1
+_MAX_ASSESSMENTS = 1000
+_MAX_EVENTS = 1000
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_ANNOTATION_KEYS = {
+    "$comment",
+    "default",
+    "deprecated",
+    "description",
+    "examples",
+    "readOnly",
+    "title",
+    "writeOnly",
+}
+_SCHEMA_MAP_KEYS = {
+    "$defs",
+    "definitions",
+    "dependentSchemas",
+    "patternProperties",
+    "properties",
+}
+_SCHEMA_LIST_KEYS = {"allOf", "anyOf", "oneOf", "prefixItems"}
+_SCHEMA_VALUE_KEYS = {
+    "additionalProperties",
+    "contains",
+    "contentSchema",
+    "else",
+    "if",
+    "items",
+    "not",
+    "propertyNames",
+    "then",
+    "unevaluatedItems",
+    "unevaluatedProperties",
+}
+_STATES = {"active", "retired", "suspended"}
+_ALLOWED_TRANSITIONS = {
+    "active": {"retired", "suspended"},
+    "suspended": {"active", "retired"},
+    "retired": set(),
+}
+
+
+class VSDLifecycleError(VSDPromotionError):
+    """Raised when drift evidence or a publication lifecycle record is invalid."""
+
+
+def _review_text(value: Any, *, field: str, minimum: int, maximum: int) -> str:
+    text = str(value or "").strip()
+    if not minimum <= len(text) <= maximum:
+        raise VSDLifecycleError(f"{field} must contain {minimum}-{maximum} characters")
+    if any(ord(character) < 32 for character in text):
+        raise VSDLifecycleError(f"{field} contains control characters")
+    return text
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _load_publication(root: Path, tool_name: str) -> dict[str, Any]:
+    name = _tool_name(tool_name)
+    return _validated_publication(_read_json(root / "approved" / f"{name}.json"))
+
+
+def _validation_view(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return copy.deepcopy(value)
+    result: dict[str, Any] = {}
+    for key, item in value.items():
+        if key in _ANNOTATION_KEYS:
+            continue
+        if key in _SCHEMA_MAP_KEYS and isinstance(item, dict):
+            result[key] = {
+                name: _validation_view(schema) for name, schema in item.items()
+            }
+        elif key in _SCHEMA_LIST_KEYS and isinstance(item, list):
+            result[key] = [_validation_view(schema) for schema in item]
+        elif key in _SCHEMA_VALUE_KEYS and isinstance(item, dict):
+            result[key] = _validation_view(item)
+        else:
+            result[key] = copy.deepcopy(item)
+    return result
+
+
+def _execution_contract(config: dict[str, Any]) -> dict[str, Any]:
+    try:
+        normalized = _validated_operation_config(config)
+    except VSDDynamicRESTError as exc:
+        raise VSDLifecycleError("Published execution contract is invalid") from exc
+    operation = normalized["vsd_operation"]
+    return {
+        "method": operation["method"],
+        "endpoint": operation["endpoint"],
+        "path_arguments": operation.get("path_arguments", {}),
+        "query_arguments": operation.get("query_arguments", {}),
+        "query_serialization": operation.get("query_serialization", {}),
+        "fixed_query": operation.get("fixed_query", {}),
+        "auth": operation["auth"],
+        "input_validation": _validation_view(normalized["parameter"]),
+        "response_validation": _validation_view(operation["response_schema"]),
+    }
+
+
+def _contract_summary(config: dict[str, Any]) -> dict[str, Any]:
+    contract = _execution_contract(config)
+    return {
+        "execution_contract_sha256": _canonical_digest(contract),
+        "component_sha256": {
+            key: _canonical_digest(value) for key, value in sorted(contract.items())
+        },
+    }
+
+
+def _credential_env(publication: dict[str, Any]) -> str | None:
+    auth = publication["config"]["vsd_operation"]["auth"]
+    return None if auth["type"] == "none" else auth["env_var"]
+
+
+def _matching_candidate(
+    report: dict[str, Any], promotion: dict[str, Any]
+) -> dict[str, Any] | None:
+    matches = [
+        candidate
+        for candidate in report["candidates"]
+        if candidate.get("method") == promotion.get("method")
+        and candidate.get("path") == promotion.get("path")
+    ]
+    if len(matches) > 1:
+        raise VSDLifecycleError("OpenAPI inspection returned an ambiguous operation")
+    return matches[0] if matches else None
+
+
+def _assessment_body(
+    publication: dict[str, Any],
+    report: dict[str, Any],
+    *,
+    assessed_at: str,
+) -> dict[str, Any]:
+    config = publication["config"]
+    promotion = config.get("vsd_promotion")
+    if not isinstance(promotion, dict) or promotion.get("source_type") != "openapi":
+        raise VSDLifecycleError(
+            "Drift assessment supports only publications generated from OpenAPI"
+        )
+    baseline = {
+        "source_document_sha256": promotion.get("source_document_sha256"),
+        "candidate_sha256": promotion.get("candidate_sha256"),
+        **_contract_summary(config),
+    }
+    candidate = _matching_candidate(report, promotion)
+    observed: dict[str, Any] = {
+        "source_document_sha256": report["source_document_sha256"],
+        "candidate_id": None,
+        "candidate_sha256": None,
+        "execution_contract_sha256": None,
+        "component_sha256": {},
+    }
+    blockers: list[str] = []
+    changes: list[str] = []
+    classification = "breaking"
+    detail = "The reviewed operation is absent from the inspected document."
+
+    if candidate is None:
+        blockers = ["operation_missing"]
+        changes = ["operation"]
+    else:
+        observed["candidate_id"] = candidate["candidate_id"]
+        observed["candidate_sha256"] = candidate["candidate_sha256"]
+        blockers = list(candidate.get("blockers", []))
+        if blockers:
+            changes = ["operation_policy"]
+            detail = "The operation is present but no longer satisfies VSD policy."
+        else:
+            try:
+                new_config = build_openapi_tool_config(
+                    candidate,
+                    tool_name=publication["tool_name"],
+                    description=config["description"],
+                    include_parameters=promotion.get("included_parameters"),
+                    fixed_query=promotion.get("fixed_query"),
+                    timeout_seconds=config["vsd_operation"]["timeout_seconds"],
+                    credential_env=_credential_env(publication),
+                )
+                observed.update(_contract_summary(new_config))
+            except VSDPromotionError as exc:
+                blockers = [f"contract_reconstruction:{exc}"]
+                changes = ["operation_contract"]
+                detail = "The reviewed operation can no longer be reconstructed."
+            else:
+                baseline_components = baseline["component_sha256"]
+                observed_components = observed["component_sha256"]
+                changes = sorted(
+                    key
+                    for key in baseline_components
+                    if baseline_components[key] != observed_components.get(key)
+                )
+                if report["source_document_sha256"] == promotion.get(
+                    "source_document_sha256"
+                ) and candidate["candidate_sha256"] == promotion.get(
+                    "candidate_sha256"
+                ):
+                    classification = "unchanged"
+                    detail = (
+                        "The inspected source and reviewed operation are unchanged."
+                    )
+                elif not changes:
+                    classification = "metadata_only"
+                    detail = (
+                        "The source metadata changed without changing request or "
+                        "response validation behavior."
+                    )
+                elif set(changes) & {
+                    "auth",
+                    "endpoint",
+                    "fixed_query",
+                    "method",
+                    "path_arguments",
+                    "query_arguments",
+                    "query_serialization",
+                }:
+                    classification = "breaking"
+                    detail = (
+                        "The provider request contract changed at a transport, "
+                        "authentication, or argument-mapping boundary."
+                    )
+                else:
+                    classification = "review_required"
+                    detail = (
+                        "Input or response validation changed and requires a new "
+                        "draft, verification evidence, and approval."
+                    )
+
+    return {
+        "format": _ASSESSMENT_FORMAT,
+        "version": _VERSION,
+        "assessed_at": assessed_at,
+        "tool_name": publication["tool_name"],
+        "publication_sha256": publication["publication_sha256"],
+        "execution_allowed": False,
+        "baseline": baseline,
+        "observed": observed,
+        "classification": classification,
+        "changes": changes,
+        "blockers": blockers,
+        "suspension_recommended": classification in {"breaking", "review_required"},
+        "detail": detail,
+    }
+
+
+def validate_drift_assessment(value: Any) -> dict[str, Any]:
+    """Validate the content digest and safety boundary of one assessment artifact."""
+    if not isinstance(value, dict):
+        raise VSDLifecycleError("Drift assessment must be an object")
+    expected_keys = {
+        "assessment_id",
+        "assessment_sha256",
+        "assessed_at",
+        "baseline",
+        "blockers",
+        "changes",
+        "classification",
+        "detail",
+        "execution_allowed",
+        "format",
+        "observed",
+        "publication_sha256",
+        "suspension_recommended",
+        "tool_name",
+        "version",
+    }
+    body = {
+        key: item
+        for key, item in value.items()
+        if key not in {"assessment_id", "assessment_sha256"}
+    }
+    digest = _canonical_digest(body)
+    if (
+        value.get("format") != _ASSESSMENT_FORMAT
+        or set(value) != expected_keys
+        or value.get("version") != _VERSION
+        or value.get("execution_allowed") is not False
+        or value.get("assessment_sha256") != digest
+        or value.get("assessment_id") != digest[:16]
+        or value.get("classification")
+        not in {"breaking", "metadata_only", "review_required", "unchanged"}
+        or type(value.get("suspension_recommended")) is not bool
+        or not isinstance(value.get("changes"), list)
+        or not isinstance(value.get("blockers"), list)
+        or value.get("suspension_recommended")
+        != (value.get("classification") in {"breaking", "review_required"})
+        or not isinstance(value.get("assessed_at"), str)
+        or not isinstance(value.get("detail"), str)
+        or not isinstance(value.get("baseline"), dict)
+        or not isinstance(value.get("observed"), dict)
+        or not _DIGEST_RE.fullmatch(str(value.get("publication_sha256", "")))
+    ):
+        raise VSDLifecycleError("Drift assessment is invalid or has been modified")
+    _tool_name(value.get("tool_name"))
+    return copy.deepcopy(value)
+
+
+def assess_openapi_drift(
+    tool_name: str,
+    spec_file: str | Path,
+    *,
+    workspace: str | Path | None = None,
+    server_index: int = 0,
+) -> dict[str, Any]:
+    """Inspect a local OpenAPI file and persist an inert drift assessment."""
+    root = _root(workspace)
+    publication = _load_publication(root, tool_name)
+    try:
+        report = inspect_openapi_document(spec_file, server_index=server_index)
+    except VSDOpenAPIError as exc:
+        raise VSDLifecycleError(str(exc)) from exc
+    assessed_at = _timestamp()
+    body = _assessment_body(publication, report, assessed_at=assessed_at)
+    digest = _canonical_digest(body)
+    assessment = {
+        **body,
+        "assessment_id": digest[:16],
+        "assessment_sha256": digest,
+    }
+    validate_drift_assessment(assessment)
+    with _promotion_transaction(root):
+        current = _load_publication(root, tool_name)
+        if current["publication_sha256"] != publication["publication_sha256"]:
+            raise VSDLifecycleError(
+                "Publication changed while the drift assessment was being created"
+            )
+        directory = root / "assessments" / publication["tool_name"]
+        existing = sorted(directory.glob("*.json")) if directory.exists() else []
+        if len(existing) >= _MAX_ASSESSMENTS:
+            raise VSDLifecycleError("Assessment history reached its 1000-record limit")
+        path = directory / f"{assessment['assessment_sha256']}.json"
+        if path.exists():
+            raise VSDLifecycleError("Drift assessment artifact already exists")
+        _atomic_write_json(path, assessment)
+    return assessment
+
+
+def _publication_directory(root: Path, publication: dict[str, Any]) -> Path:
+    return (
+        root
+        / "lifecycle"
+        / _tool_name(publication["tool_name"])
+        / publication["publication_sha256"]
+    )
+
+
+def _event_paths(root: Path, publication: dict[str, Any]) -> list[Path]:
+    directory = _publication_directory(root, publication) / "events"
+    paths = sorted(directory.glob("*.json")) if directory.exists() else []
+    if len(paths) > _MAX_EVENTS:
+        raise VSDLifecycleError("Lifecycle history exceeds its 1000-record limit")
+    return paths
+
+
+def _load_history(root: Path, publication: dict[str, Any]) -> list[dict[str, Any]]:
+    history: list[dict[str, Any]] = []
+    previous_sha256: str | None = None
+    previous_state = "active"
+    tool_name = publication["tool_name"]
+    publication_sha256 = publication["publication_sha256"]
+    expected_keys = {
+        "assessment_sha256",
+        "changed_at",
+        "changed_by",
+        "event_sha256",
+        "format",
+        "previous_event_sha256",
+        "previous_state",
+        "publication_sha256",
+        "reason",
+        "revision",
+        "state",
+        "tool_name",
+        "version",
+    }
+    for revision, path in enumerate(_event_paths(root, publication), start=1):
+        if path.name != f"{revision:06d}.json":
+            raise VSDLifecycleError("Lifecycle revisions must be contiguous")
+        event = _read_json(path)
+        if not isinstance(event, dict):
+            raise VSDLifecycleError("Lifecycle event must be an object")
+        body = {key: value for key, value in event.items() if key != "event_sha256"}
+        digest = _canonical_digest(body)
+        if (
+            event.get("format") != _LIFECYCLE_FORMAT
+            or set(event) != expected_keys
+            or event.get("version") != _VERSION
+            or event.get("revision") != revision
+            or event.get("tool_name") != tool_name
+            or event.get("publication_sha256") != publication_sha256
+            or event.get("state") not in _STATES
+            or event.get("previous_event_sha256") != previous_sha256
+            or event.get("event_sha256") != digest
+            or event.get("previous_state") != previous_state
+            or event.get("state") not in _ALLOWED_TRANSITIONS[previous_state]
+            or not isinstance(event.get("changed_at"), str)
+            or not isinstance(event.get("changed_by"), str)
+            or not isinstance(event.get("reason"), str)
+        ):
+            raise VSDLifecycleError(
+                f"Lifecycle event {revision} is invalid or has been modified"
+            )
+        assessment_sha256 = event.get("assessment_sha256")
+        if assessment_sha256 is not None and not _DIGEST_RE.fullmatch(
+            str(assessment_sha256)
+        ):
+            raise VSDLifecycleError("Lifecycle assessment reference is invalid")
+        if assessment_sha256 is not None:
+            _find_assessment(
+                root,
+                tool_name,
+                assessment_sha256,
+                publication_sha256,
+            )
+        history.append(event)
+        previous_sha256 = digest
+        previous_state = event["state"]
+    return history
+
+
+def _state_body(
+    publication: dict[str, Any],
+    *,
+    state: str,
+    revision: int,
+    current_event_sha256: str | None,
+    updated_at: str,
+) -> dict[str, Any]:
+    return {
+        "format": _LIFECYCLE_STATE_FORMAT,
+        "version": _VERSION,
+        "anchor_id": publication["lifecycle"]["anchor_id"],
+        "tool_name": publication["tool_name"],
+        "publication_sha256": publication["publication_sha256"],
+        "state": state,
+        "revision": revision,
+        "current_event_sha256": current_event_sha256,
+        "updated_at": updated_at,
+    }
+
+
+def _write_state(
+    root: Path,
+    publication: dict[str, Any],
+    *,
+    state: str,
+    revision: int,
+    current_event_sha256: str | None,
+    updated_at: str,
+) -> dict[str, Any]:
+    body = _state_body(
+        publication,
+        state=state,
+        revision=revision,
+        current_event_sha256=current_event_sha256,
+        updated_at=updated_at,
+    )
+    record = {**body, "state_sha256": _canonical_digest(body)}
+    _atomic_write_json(_publication_directory(root, publication) / "state.json", record)
+    return record
+
+
+def _initialize_publication_lifecycle(
+    root: Path, publication: dict[str, Any]
+) -> dict[str, Any]:
+    """Create the state anchor required by a newly published record."""
+    lifecycle = publication.get("lifecycle")
+    if (
+        not isinstance(lifecycle, dict)
+        or lifecycle.get("format") != _LIFECYCLE_ANCHOR_FORMAT
+        or not _DIGEST_RE.fullmatch(str(lifecycle.get("anchor_id", "")))
+    ):
+        raise VSDLifecycleError("Publication lifecycle anchor is invalid")
+    path = _publication_directory(root, publication) / "state.json"
+    if path.exists():
+        raise VSDLifecycleError("Publication lifecycle state already exists")
+    return _write_state(
+        root,
+        publication,
+        state="active",
+        revision=0,
+        current_event_sha256=None,
+        updated_at=publication["published_at"],
+    )
+
+
+def _load_managed_state(
+    root: Path, publication: dict[str, Any]
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    try:
+        record = _read_json(_publication_directory(root, publication) / "state.json")
+    except VSDPromotionError as exc:
+        raise VSDLifecycleError("Publication lifecycle state is missing") from exc
+    if not isinstance(record, dict):
+        raise VSDLifecycleError("Publication lifecycle state must be an object")
+    expected_keys = {
+        "anchor_id",
+        "current_event_sha256",
+        "format",
+        "publication_sha256",
+        "revision",
+        "state",
+        "state_sha256",
+        "tool_name",
+        "updated_at",
+        "version",
+    }
+    body = {key: value for key, value in record.items() if key != "state_sha256"}
+    if (
+        set(record) != expected_keys
+        or record.get("format") != _LIFECYCLE_STATE_FORMAT
+        or record.get("version") != _VERSION
+        or record.get("anchor_id") != publication["lifecycle"]["anchor_id"]
+        or record.get("tool_name") != publication["tool_name"]
+        or record.get("publication_sha256") != publication["publication_sha256"]
+        or record.get("state") not in _STATES
+        or not isinstance(record.get("revision"), int)
+        or isinstance(record.get("revision"), bool)
+        or record["revision"] < 0
+        or not isinstance(record.get("updated_at"), str)
+        or record.get("state_sha256") != _canonical_digest(body)
+    ):
+        raise VSDLifecycleError("Publication lifecycle state is invalid or modified")
+    current_event_sha256 = record.get("current_event_sha256")
+    if current_event_sha256 is not None and not _DIGEST_RE.fullmatch(
+        str(current_event_sha256)
+    ):
+        raise VSDLifecycleError("Publication lifecycle event pointer is invalid")
+    history = _load_history(root, publication)
+    expected_state = history[-1]["state"] if history else "active"
+    expected_event = history[-1]["event_sha256"] if history else None
+    if (
+        record["revision"] != len(history)
+        or record["state"] != expected_state
+        or current_event_sha256 != expected_event
+    ):
+        raise VSDLifecycleError(
+            "Publication lifecycle state does not match its event history"
+        )
+    return record, history
+
+
+def _state_for_publication(root: Path, publication: dict[str, Any]) -> dict[str, Any]:
+    if publication.get("lifecycle") is None:
+        return {
+            "tool_name": publication["tool_name"],
+            "publication_sha256": publication["publication_sha256"],
+            "state": "active",
+            "revision": 0,
+            "event_sha256": None,
+            "assessment_sha256": None,
+            "lifecycle_managed": False,
+        }
+    current, history = _load_managed_state(root, publication)
+    event = history[-1] if history else None
+    return {
+        "tool_name": publication["tool_name"],
+        "publication_sha256": publication["publication_sha256"],
+        "state": current["state"],
+        "revision": current["revision"],
+        "event_sha256": current["current_event_sha256"],
+        "assessment_sha256": event["assessment_sha256"] if event else None,
+        "lifecycle_managed": True,
+    }
+
+
+def _find_assessment(
+    root: Path,
+    tool_name: str,
+    assessment_sha256: str,
+    publication_sha256: str,
+) -> dict[str, Any]:
+    if not _DIGEST_RE.fullmatch(str(assessment_sha256)):
+        raise VSDLifecycleError(
+            "assessment_sha256 must contain 64 lowercase hex digits"
+        )
+    path = root / "assessments" / tool_name / f"{assessment_sha256}.json"
+    try:
+        assessment = validate_drift_assessment(_read_json(path))
+    except VSDLifecycleError:
+        raise
+    except VSDPromotionError as exc:
+        raise VSDLifecycleError("Referenced drift assessment does not exist") from exc
+    if assessment["assessment_sha256"] != assessment_sha256:
+        raise VSDLifecycleError("Referenced drift assessment digest does not match")
+    if (
+        assessment["tool_name"] != tool_name
+        or assessment["publication_sha256"] != publication_sha256
+    ):
+        raise VSDLifecycleError("Drift assessment does not match this publication")
+    return assessment
+
+
+def set_publication_state(
+    tool_name: str,
+    state: str,
+    *,
+    changed_by: str,
+    reason: str,
+    assessment_sha256: str | None = None,
+    workspace: str | Path | None = None,
+) -> dict[str, Any]:
+    """Append one explicit, hash-chained lifecycle transition."""
+    if state not in _STATES:
+        raise VSDLifecycleError(f"state must be one of {sorted(_STATES)!r}")
+    reviewer = _review_text(changed_by, field="changed_by", minimum=2, maximum=100)
+    decision_reason = _review_text(reason, field="reason", minimum=20, maximum=1000)
+    root = _root(workspace)
+    with _promotion_transaction(root):
+        publication = _load_publication(root, tool_name)
+        if publication.get("lifecycle") is None:
+            raise VSDLifecycleError(
+                "Legacy publication must be republished before lifecycle control"
+            )
+        current_record, history = _load_managed_state(root, publication)
+        current = {
+            "state": current_record["state"],
+            "event_sha256": current_record["current_event_sha256"],
+        }
+        if state not in _ALLOWED_TRANSITIONS[current["state"]]:
+            raise VSDLifecycleError(
+                f"Cannot transition publication from {current['state']!r} to {state!r}"
+            )
+        assessment = None
+        if assessment_sha256 is not None:
+            assessment = _find_assessment(
+                root,
+                publication["tool_name"],
+                assessment_sha256,
+                publication["publication_sha256"],
+            )
+        if state == "active" and assessment is None:
+            raise VSDLifecycleError(
+                "Activating a suspended publication requires a drift assessment"
+            )
+        if state == "active" and assessment["classification"] not in {
+            "metadata_only",
+            "unchanged",
+        }:
+            raise VSDLifecycleError(
+                "Activation requires an unchanged or metadata-only assessment"
+            )
+        changed_at = _timestamp()
+        body = {
+            "format": _LIFECYCLE_FORMAT,
+            "version": _VERSION,
+            "revision": len(history) + 1,
+            "tool_name": publication["tool_name"],
+            "publication_sha256": publication["publication_sha256"],
+            "previous_state": current["state"],
+            "state": state,
+            "changed_at": changed_at,
+            "changed_by": reviewer,
+            "reason": decision_reason,
+            "assessment_sha256": assessment_sha256,
+            "previous_event_sha256": (history[-1]["event_sha256"] if history else None),
+        }
+        event = {**body, "event_sha256": _canonical_digest(body)}
+        path = (
+            _publication_directory(root, publication)
+            / "events"
+            / f"{event['revision']:06d}.json"
+        )
+        if len(history) >= _MAX_EVENTS or path.exists():
+            raise VSDLifecycleError("Lifecycle history reached its 1000-record limit")
+        _atomic_write_json(path, event)
+        _write_state(
+            root,
+            publication,
+            state=state,
+            revision=event["revision"],
+            current_event_sha256=event["event_sha256"],
+            updated_at=changed_at,
+        )
+    return event
+
+
+def list_publication_states(
+    tool_name: str | None = None, *, workspace: str | Path | None = None
+) -> dict[str, Any]:
+    """Return validated current lifecycle state for published tools."""
+    root = _root(workspace)
+    with _promotion_transaction(root):
+        if tool_name is not None:
+            publications = [_load_publication(root, tool_name)]
+        else:
+            approved = root / "approved"
+            paths = sorted(approved.glob("*.json")) if approved.exists() else []
+            publications = [_validated_publication(_read_json(path)) for path in paths]
+        states = [
+            _state_for_publication(root, publication) for publication in publications
+        ]
+    return {
+        "format": "vsd_publication_lifecycle_status_v1",
+        "execution_allowed": False,
+        "tools": states,
+    }
+
+
+__all__ = [
+    "VSDLifecycleError",
+    "assess_openapi_drift",
+    "list_publication_states",
+    "set_publication_state",
+    "validate_drift_assessment",
+]

--- a/src/tooluniverse/vsd_lifecycle_cli.py
+++ b/src/tooluniverse/vsd_lifecycle_cli.py
@@ -1,0 +1,78 @@
+"""Administrator CLI for local VSD drift assessments and lifecycle state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+from .vsd_lifecycle import (
+    assess_openapi_drift,
+    list_publication_states,
+    set_publication_state,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tooluniverse-vsd-lifecycle",
+        description=(
+            "Assess local OpenAPI drift and explicitly control published VSD tools. "
+            "These administrator operations are not agent-facing."
+        ),
+    )
+    parser.add_argument("--workspace", type=Path)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    assess = commands.add_parser("assess-openapi")
+    assess.add_argument("tool_name")
+    assess.add_argument("spec_file", type=Path)
+    assess.add_argument("--server-index", type=int, default=0)
+
+    status = commands.add_parser("status")
+    status.add_argument("tool_name", nargs="?")
+
+    for command in ("activate", "retire", "suspend"):
+        transition = commands.add_parser(command)
+        transition.add_argument("tool_name")
+        transition.add_argument("--changed-by", required=True)
+        transition.add_argument("--reason", required=True)
+        transition.add_argument("--assessment-sha256")
+    return parser
+
+
+def _execute(namespace: argparse.Namespace) -> Any:
+    workspace = namespace.workspace
+    if namespace.command == "assess-openapi":
+        return assess_openapi_drift(
+            namespace.tool_name,
+            namespace.spec_file,
+            workspace=workspace,
+            server_index=namespace.server_index,
+        )
+    if namespace.command == "status":
+        return list_publication_states(namespace.tool_name, workspace=workspace)
+    if namespace.command in {"activate", "retire", "suspend"}:
+        state = (
+            "active" if namespace.command == "activate" else namespace.command + "ed"
+        )
+        return set_publication_state(
+            namespace.tool_name,
+            state,
+            changed_by=namespace.changed_by,
+            reason=namespace.reason,
+            assessment_sha256=namespace.assessment_sha256,
+            workspace=workspace,
+        )
+    raise AssertionError(f"Unsupported command: {namespace.command}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    result = _execute(build_parser().parse_args(argv))
+    print(json.dumps(result, indent=2, sort_keys=True, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tooluniverse/vsd_promotion.py
+++ b/src/tooluniverse/vsd_promotion.py
@@ -998,17 +998,30 @@ def publish_draft(
         evidence = _load_evidence(root, draft)
         approval = _load_approval(root, draft, evidence)
         tool_name = _tool_name(draft["config"]["name"])
+        published_at = datetime.now(timezone.utc).isoformat()
+        lifecycle = {
+            "format": "vsd_publication_lifecycle_anchor_v1",
+            "anchor_id": _canonical_digest(
+                {
+                    "tool_name": tool_name,
+                    "draft_sha256": draft["draft_sha256"],
+                    "operation_sha256": draft["operation_sha256"],
+                    "published_at": published_at,
+                }
+            ),
+        }
         published_body = {
             "version": _PROMOTION_VERSION,
             "tool_name": tool_name,
             "draft_id": draft_id,
-            "published_at": datetime.now(timezone.utc).isoformat(),
+            "published_at": published_at,
             "draft_sha256": draft["draft_sha256"],
             "operation_sha256": draft["operation_sha256"],
             "verification_sha256": evidence["verification_sha256"],
             "approval_sha256": approval["approval_sha256"],
             "reviewed_by": approval["reviewed_by"],
             "decision_note": approval["decision_note"],
+            "lifecycle": lifecycle,
             "config": draft["config"],
         }
         published = {
@@ -1022,8 +1035,11 @@ def publish_draft(
             )
         if path.exists():
             existing = _read_json(path)
-            if existing.get("tool_name") != tool_name:
+            if not isinstance(existing, dict) or existing.get("tool_name") != tool_name:
                 raise VSDPromotionError("Published filename collides with another tool")
+        from .vsd_lifecycle import _initialize_publication_lifecycle
+
+        _initialize_publication_lifecycle(root, published)
         _atomic_write_json(path, published)
     return published
 
@@ -1045,6 +1061,14 @@ def _validated_publication(record: Any) -> dict[str, Any]:
     config = record.get("config")
     if not isinstance(config, dict) or config.get("name") != tool_name:
         raise VSDPromotionError("Published tool name does not match its configuration")
+    lifecycle = record.get("lifecycle")
+    if lifecycle is not None and (
+        not isinstance(lifecycle, dict)
+        or set(lifecycle) != {"format", "anchor_id"}
+        or lifecycle.get("format") != "vsd_publication_lifecycle_anchor_v1"
+        or not re.fullmatch(r"[0-9a-f]{64}", str(lifecycle.get("anchor_id", "")))
+    ):
+        raise VSDPromotionError("Published lifecycle anchor is invalid")
     try:
         digest = operation_digest(config)
     except VSDDynamicRESTError as exc:
@@ -1064,26 +1088,34 @@ def load_published_tools(
 ) -> list[str]:
     """Explicitly load valid published records into one ToolUniverse instance."""
     root = _root(workspace)
-    approved = root / "approved"
-    paths = sorted(approved.glob("*.json")) if approved.exists() else []
-    if len(paths) > _MAX_PUBLISHED_TOOLS:
-        raise VSDPromotionError("Approved tool count exceeds the configured limit")
-    records = [_validated_publication(_read_json(path)) for path in paths]
-    names = [record["tool_name"] for record in records]
-    if len({name.casefold() for name in names}) != len(names):
-        raise VSDPromotionError(
-            "Published tool names contain a case-insensitive collision"
-        )
-    for name in names:
-        if name in tooluniverse.all_tool_dict:
+    with _promotion_transaction(root):
+        approved = root / "approved"
+        paths = sorted(approved.glob("*.json")) if approved.exists() else []
+        if len(paths) > _MAX_PUBLISHED_TOOLS:
+            raise VSDPromotionError("Approved tool count exceeds the configured limit")
+        records = [_validated_publication(_read_json(path)) for path in paths]
+        from .vsd_lifecycle import _state_for_publication
+
+        active_records = [
+            record
+            for record in records
+            if _state_for_publication(root, record)["state"] == "active"
+        ]
+        names = [record["tool_name"] for record in active_records]
+        if len({name.casefold() for name in names}) != len(names):
             raise VSDPromotionError(
-                f"Published tool {name!r} would replace a loaded tool"
+                "Published tool names contain a case-insensitive collision"
             )
-    loaded: list[str] = []
-    for record in records:
-        name = record["tool_name"]
-        register_reviewed_rest_tool(tooluniverse, record["config"])
-        loaded.append(name)
+        for name in names:
+            if name in tooluniverse.all_tool_dict:
+                raise VSDPromotionError(
+                    f"Published tool {name!r} would replace a loaded tool"
+                )
+        loaded: list[str] = []
+        for record in active_records:
+            name = record["tool_name"]
+            register_reviewed_rest_tool(tooluniverse, record["config"])
+            loaded.append(name)
     return loaded
 
 

--- a/tests/unit/test_vsd_lifecycle.py
+++ b/tests/unit/test_vsd_lifecycle.py
@@ -1,0 +1,641 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from tooluniverse import (
+    ToolUniverse,
+    vsd_dynamic_rest,
+    vsd_lifecycle_cli,
+    vsd_promotion,
+)
+from tooluniverse.vsd_lifecycle import (
+    VSDLifecycleError,
+    _validation_view,
+    assess_openapi_drift,
+    list_publication_states,
+    set_publication_state,
+    validate_drift_assessment,
+)
+from tooluniverse.vsd_openapi import inspect_openapi_document
+
+pytestmark = pytest.mark.unit
+
+TOOL_NAME = "VSDProtectedRareDiseaseRecord"
+ENV_VAR = "TOOLUNIVERSE_VSD_LIFECYCLE_TEST_KEY"
+SECRET = "lifecycle-test-secret"
+RECORDS = {
+    "RD-ALS": {
+        "record_id": "RD-ALS",
+        "disease": "Amyotrophic lateral sclerosis",
+        "genes": ["C9orf72", "SOD1"],
+        "trials": ["NCT05163886"],
+    },
+    "RD-DMD": {
+        "record_id": "RD-DMD",
+        "disease": "Duchenne muscular dystrophy",
+        "genes": ["DMD"],
+        "trials": ["NCT05096221"],
+    },
+    "RD-SMA": {
+        "record_id": "RD-SMA",
+        "disease": "Spinal muscular atrophy",
+        "genes": ["SMN1", "SMN2"],
+        "trials": ["NCT05337553"],
+    },
+}
+
+
+def test_validation_view_removes_annotations_without_dropping_named_properties():
+    schema = {
+        "type": "object",
+        "description": "Root annotation",
+        "properties": {
+            "description": {
+                "type": "string",
+                "description": "Property annotation",
+            },
+            "default": {"type": "number", "default": 1},
+            "title": {"type": "boolean", "title": "A title"},
+        },
+        "required": ["description", "default", "title"],
+    }
+    assert _validation_view(schema) == {
+        "type": "object",
+        "properties": {
+            "description": {"type": "string"},
+            "default": {"type": "number"},
+            "title": {"type": "boolean"},
+        },
+        "required": ["description", "default", "title"],
+    }
+
+
+def _specification(
+    *,
+    api_version: str = "1.0.0",
+    summary: str = "Retrieve one protected rare-disease record",
+    server_url: str = "https://rare-registry.example.org/v1",
+    auth_location: str = "header",
+    path: str = "/evidence/{recordId}",
+    add_response_requirement: bool = False,
+    add_required_query: bool = False,
+) -> dict:
+    properties = {
+        "record_id": {"type": "string"},
+        "disease": {"type": "string"},
+        "genes": {"type": "array", "items": {"type": "string"}},
+        "trials": {"type": "array", "items": {"type": "string"}},
+    }
+    required = ["record_id", "disease", "genes", "trials"]
+    if add_response_requirement:
+        properties["evidence_level"] = {"type": "string", "enum": ["reviewed"]}
+        required.append("evidence_level")
+    parameters = [
+        {
+            "name": "recordId",
+            "in": "path",
+            "required": True,
+            "schema": {"type": "string", "pattern": "^RD-[A-Z]+$"},
+        }
+    ]
+    if add_required_query:
+        parameters.append(
+            {
+                "name": "tenant",
+                "in": "query",
+                "required": True,
+                "schema": {"type": "string", "minLength": 3},
+            }
+        )
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "Rare Disease Registry", "version": api_version},
+        "servers": [{"url": server_url}],
+        "security": [{"registryKey": []}],
+        "paths": {
+            path: {
+                "get": {
+                    "operationId": "getRareDiseaseEvidence",
+                    "summary": summary,
+                    "parameters": parameters,
+                    "responses": {
+                        "200": {
+                            "description": "Evidence record",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": properties,
+                                        "required": required,
+                                        "additionalProperties": False,
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "registryKey": {
+                    "type": "apiKey",
+                    "in": auth_location,
+                    "name": (
+                        "X-Rare-Disease-Key"
+                        if auth_location == "header"
+                        else "registry_key"
+                    ),
+                }
+            }
+        },
+    }
+
+
+def _write_spec(path: Path, specification: dict) -> Path:
+    path.write_text(json.dumps(specification), encoding="utf-8")
+    return path
+
+
+def _fake_get(url, params, *, timeout, headers):
+    assert params == {}
+    assert timeout == 20.0
+    assert headers == {"X-Rare-Disease-Key": SECRET}
+    record_id = url.rsplit("/", 1)[-1]
+    payload = copy.deepcopy(RECORDS[record_id])
+    return payload, {
+        "status_code": 200,
+        "content_type": "application/json",
+        "response_bytes": len(json.dumps(payload).encode()),
+        "redirects": 0,
+    }
+
+
+def _verification_cases() -> list[dict]:
+    return [
+        {
+            "arguments": {"recordId": record_id},
+            "expect": {
+                "result_type": "object",
+                "required_fields": ["record_id", "disease", "genes", "trials"],
+                "equals": {"record_id": record_id},
+                "required_paths": ["/genes/0", "/trials/0"],
+                "equals_paths": {},
+            },
+        }
+        for record_id in RECORDS
+    ]
+
+
+def _publish(tmp_path: Path, monkeypatch) -> tuple[dict, dict, Path]:
+    monkeypatch.setenv(ENV_VAR, SECRET)
+    monkeypatch.setattr(vsd_dynamic_rest, "_safe_get_json", _fake_get)
+    spec_path = _write_spec(tmp_path / "baseline.json", _specification())
+    report = inspect_openapi_document(spec_path)
+    draft = vsd_promotion.create_openapi_draft(
+        report["candidates"][0],
+        tool_name=TOOL_NAME,
+        description="Retrieve one reviewed protected rare-disease record by identifier.",
+        include_parameters=["recordId"],
+        credential_env=ENV_VAR,
+        workspace=tmp_path / "workspace",
+    )
+    evidence = vsd_promotion.verify_draft(
+        draft["draft_id"],
+        _verification_cases(),
+        workspace=tmp_path / "workspace",
+    )
+    vsd_promotion.approve_draft(
+        draft["draft_id"],
+        reviewed_by="Lifecycle Test Reviewer",
+        decision_note="Approved after three representative protected records passed.",
+        workspace=tmp_path / "workspace",
+    )
+    publication = vsd_promotion.publish_draft(
+        draft["draft_id"], workspace=tmp_path / "workspace"
+    )
+    assert evidence["all_cases_passed"] is True
+    return draft, publication, spec_path
+
+
+def test_assessment_distinguishes_metadata_validation_and_breaking_drift(
+    tmp_path, monkeypatch
+):
+    _, publication, baseline_path = _publish(tmp_path, monkeypatch)
+    workspace = tmp_path / "workspace"
+    unchanged = assess_openapi_drift(TOOL_NAME, baseline_path, workspace=workspace)
+    metadata = assess_openapi_drift(
+        TOOL_NAME,
+        _write_spec(
+            tmp_path / "metadata.json",
+            _specification(
+                api_version="1.0.1", summary="Retrieve reviewed registry evidence"
+            ),
+        ),
+        workspace=workspace,
+    )
+    response_drift = assess_openapi_drift(
+        TOOL_NAME,
+        _write_spec(
+            tmp_path / "response-drift.json",
+            _specification(add_response_requirement=True),
+        ),
+        workspace=workspace,
+    )
+    endpoint_drift = assess_openapi_drift(
+        TOOL_NAME,
+        _write_spec(
+            tmp_path / "endpoint-drift.json",
+            _specification(server_url="https://rare-registry.example.org/v2"),
+        ),
+        workspace=workspace,
+    )
+    blocked_auth = assess_openapi_drift(
+        TOOL_NAME,
+        _write_spec(
+            tmp_path / "query-auth.json",
+            _specification(auth_location="query"),
+        ),
+        workspace=workspace,
+    )
+    missing_operation = assess_openapi_drift(
+        TOOL_NAME,
+        _write_spec(
+            tmp_path / "missing-operation.json",
+            _specification(path="/replacement/{recordId}"),
+        ),
+        workspace=workspace,
+    )
+    new_required_parameter = assess_openapi_drift(
+        TOOL_NAME,
+        _write_spec(
+            tmp_path / "new-required.json",
+            _specification(add_required_query=True),
+        ),
+        workspace=workspace,
+    )
+
+    assert unchanged["classification"] == "unchanged"
+    assert unchanged["suspension_recommended"] is False
+    assert metadata["classification"] == "metadata_only"
+    assert metadata["changes"] == []
+    assert response_drift["classification"] == "review_required"
+    assert response_drift["changes"] == ["response_validation"]
+    assert endpoint_drift["classification"] == "breaking"
+    assert endpoint_drift["changes"] == ["endpoint"]
+    assert blocked_auth["classification"] == "breaking"
+    assert "authentication_required" in blocked_auth["blockers"]
+    assert missing_operation["classification"] == "breaking"
+    assert missing_operation["blockers"] == ["operation_missing"]
+    assert new_required_parameter["classification"] == "breaking"
+    assert new_required_parameter["blockers"][0].startswith("contract_reconstruction:")
+    assert all(
+        item["publication_sha256"] == publication["publication_sha256"]
+        for item in (
+            unchanged,
+            metadata,
+            response_drift,
+            endpoint_drift,
+            blocked_auth,
+            missing_operation,
+            new_required_parameter,
+        )
+    )
+    assert len(list((workspace / "assessments" / TOOL_NAME).glob("*.json"))) == 7
+
+
+def test_lifecycle_suspends_restores_retires_and_is_publication_bound(
+    tmp_path, monkeypatch
+):
+    draft, publication, baseline_path = _publish(tmp_path, monkeypatch)
+    workspace = tmp_path / "workspace"
+    breaking = assess_openapi_drift(
+        TOOL_NAME,
+        _write_spec(
+            tmp_path / "breaking.json",
+            _specification(server_url="https://rare-registry.example.org/v2"),
+        ),
+        workspace=workspace,
+    )
+    suspended = set_publication_state(
+        TOOL_NAME,
+        "suspended",
+        changed_by="Lifecycle Test Reviewer",
+        reason="Suspended because the reviewed provider endpoint changed versions.",
+        assessment_sha256=breaking["assessment_sha256"],
+        workspace=workspace,
+    )
+    assert suspended["revision"] == 1
+    assert (
+        list_publication_states(TOOL_NAME, workspace=workspace)["tools"][0]["state"]
+        == "suspended"
+    )
+
+    blocked_universe = ToolUniverse()
+    try:
+        assert (
+            vsd_promotion.load_published_tools(blocked_universe, workspace=workspace)
+            == []
+        )
+        assert TOOL_NAME not in blocked_universe.all_tool_dict
+    finally:
+        blocked_universe.close()
+
+    with pytest.raises(VSDLifecycleError, match="requires a drift assessment"):
+        set_publication_state(
+            TOOL_NAME,
+            "active",
+            changed_by="Lifecycle Test Reviewer",
+            reason="An activation without current contract evidence must be rejected.",
+            workspace=workspace,
+        )
+    with pytest.raises(VSDLifecycleError, match="unchanged or metadata-only"):
+        set_publication_state(
+            TOOL_NAME,
+            "active",
+            changed_by="Lifecycle Test Reviewer",
+            reason="Breaking provider evidence must not reactivate the publication.",
+            assessment_sha256=breaking["assessment_sha256"],
+            workspace=workspace,
+        )
+    event_directory = (
+        workspace
+        / "lifecycle"
+        / TOOL_NAME
+        / publication["publication_sha256"]
+        / "events"
+    )
+    assert len(list(event_directory.glob("*.json"))) == 1
+
+    repaired = assess_openapi_drift(TOOL_NAME, baseline_path, workspace=workspace)
+    activated = set_publication_state(
+        TOOL_NAME,
+        "active",
+        changed_by="Lifecycle Test Reviewer",
+        reason="Restored after the original reviewed provider contract was confirmed.",
+        assessment_sha256=repaired["assessment_sha256"],
+        workspace=workspace,
+    )
+    assert activated["revision"] == 2
+    assert activated["previous_event_sha256"] == suspended["event_sha256"]
+
+    active_universe = ToolUniverse()
+    try:
+        assert vsd_promotion.load_published_tools(
+            active_universe, workspace=workspace
+        ) == [TOOL_NAME]
+        result = active_universe.run_one_function(
+            {"name": TOOL_NAME, "arguments": {"recordId": "RD-ALS"}},
+            use_cache=False,
+        )
+    finally:
+        active_universe.close()
+    assert result["status"] == "success"
+    assert result["data"]["result"]["record_id"] == "RD-ALS"
+
+    retired = set_publication_state(
+        TOOL_NAME,
+        "retired",
+        changed_by="Lifecycle Test Reviewer",
+        reason="Retired after the reviewed registry integration was decommissioned.",
+        workspace=workspace,
+    )
+    assert retired["revision"] == 3
+    with pytest.raises(VSDLifecycleError, match="Cannot transition"):
+        set_publication_state(
+            TOOL_NAME,
+            "active",
+            changed_by="Lifecycle Test Reviewer",
+            reason="This terminal publication must not be restored after retirement.",
+            workspace=workspace,
+        )
+    retired_universe = ToolUniverse()
+    try:
+        assert (
+            vsd_promotion.load_published_tools(retired_universe, workspace=workspace)
+            == []
+        )
+    finally:
+        retired_universe.close()
+
+    replacement = vsd_promotion.publish_draft(
+        draft["draft_id"], workspace=workspace, replace=True
+    )
+    assert replacement["publication_sha256"] != publication["publication_sha256"]
+    replacement_status = list_publication_states(TOOL_NAME, workspace=workspace)[
+        "tools"
+    ][0]
+    assert replacement_status["state"] == "active"
+    assert replacement_status["revision"] == 0
+    with pytest.raises(VSDLifecycleError, match="does not match this publication"):
+        set_publication_state(
+            TOOL_NAME,
+            "suspended",
+            changed_by="Lifecycle Test Reviewer",
+            reason="A stale assessment must not control a replacement publication.",
+            assessment_sha256=breaking["assessment_sha256"],
+            workspace=workspace,
+        )
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    [
+        "assessment",
+        "assessment_missing",
+        "event",
+        "event_missing",
+        "state",
+        "state_missing",
+    ],
+)
+def test_loader_fails_before_registration_when_lifecycle_evidence_is_tampered(
+    tmp_path, monkeypatch, artifact
+):
+    _, publication, _ = _publish(tmp_path, monkeypatch)
+    workspace = tmp_path / "workspace"
+    assessment = assess_openapi_drift(
+        TOOL_NAME,
+        _write_spec(
+            tmp_path / "breaking.json",
+            _specification(server_url="https://rare-registry.example.org/v2"),
+        ),
+        workspace=workspace,
+    )
+    set_publication_state(
+        TOOL_NAME,
+        "suspended",
+        changed_by="Lifecycle Test Reviewer",
+        reason="Suspended because the provider request contract changed versions.",
+        assessment_sha256=assessment["assessment_sha256"],
+        workspace=workspace,
+    )
+    lifecycle_directory = (
+        workspace / "lifecycle" / TOOL_NAME / publication["publication_sha256"]
+    )
+    if artifact.startswith("assessment"):
+        path = next((workspace / "assessments" / TOOL_NAME).glob("*.json"))
+    elif artifact.startswith("event"):
+        path = lifecycle_directory / "events" / "000001.json"
+    else:
+        path = lifecycle_directory / "state.json"
+    if artifact.endswith("_missing"):
+        path.unlink()
+    else:
+        record = json.loads(path.read_text(encoding="utf-8"))
+        if artifact == "assessment":
+            record["detail"] = "tampered"
+        elif artifact == "event":
+            record["reason"] = "tampered"
+        else:
+            record["revision"] = 0
+        path.write_text(json.dumps(record), encoding="utf-8")
+
+    tooluniverse = ToolUniverse()
+    try:
+        with pytest.raises(VSDLifecycleError):
+            vsd_promotion.load_published_tools(tooluniverse, workspace=workspace)
+        assert TOOL_NAME not in tooluniverse.all_tool_dict
+    finally:
+        tooluniverse.close()
+
+
+def test_drift_assessment_validation_rejects_content_changes(tmp_path, monkeypatch):
+    _, _, baseline_path = _publish(tmp_path, monkeypatch)
+    assessment = assess_openapi_drift(
+        TOOL_NAME, baseline_path, workspace=tmp_path / "workspace"
+    )
+    validate_drift_assessment(assessment)
+
+    changed = copy.deepcopy(assessment)
+    changed["classification"] = "breaking"
+    with pytest.raises(VSDLifecycleError, match="modified"):
+        validate_drift_assessment(changed)
+
+    extra = copy.deepcopy(assessment)
+    extra["unexpected"] = True
+    body = {
+        key: value
+        for key, value in extra.items()
+        if key not in {"assessment_id", "assessment_sha256"}
+    }
+    digest = vsd_promotion._canonical_digest(body)
+    extra["assessment_id"] = digest[:16]
+    extra["assessment_sha256"] = digest
+    with pytest.raises(VSDLifecycleError, match="modified"):
+        validate_drift_assessment(extra)
+
+
+def test_invalid_transitions_and_review_fields_fail_without_writing(
+    tmp_path, monkeypatch
+):
+    _publish(tmp_path, monkeypatch)
+    workspace = tmp_path / "workspace"
+    with pytest.raises(VSDLifecycleError, match="state must"):
+        set_publication_state(
+            TOOL_NAME,
+            "paused",
+            changed_by="Reviewer",
+            reason="An unsupported state must not be recorded in lifecycle history.",
+            workspace=workspace,
+        )
+    with pytest.raises(VSDLifecycleError, match="reason"):
+        set_publication_state(
+            TOOL_NAME,
+            "suspended",
+            changed_by="Reviewer",
+            reason="too short",
+            workspace=workspace,
+        )
+    with pytest.raises(VSDLifecycleError, match="assessment_sha256"):
+        set_publication_state(
+            TOOL_NAME,
+            "suspended",
+            changed_by="Reviewer",
+            reason="A malformed assessment reference must not be accepted here.",
+            assessment_sha256="not-a-digest",
+            workspace=workspace,
+        )
+    status = list_publication_states(TOOL_NAME, workspace=workspace)["tools"][0]
+    assert status["state"] == "active"
+    assert status["revision"] == 0
+
+
+def test_legacy_publication_loads_but_cannot_claim_lifecycle_control(
+    tmp_path, monkeypatch
+):
+    _, publication, _ = _publish(tmp_path, monkeypatch)
+    workspace = tmp_path / "workspace"
+    path = workspace / "approved" / f"{TOOL_NAME}.json"
+    legacy = json.loads(path.read_text(encoding="utf-8"))
+    legacy.pop("lifecycle")
+    body = {key: value for key, value in legacy.items() if key != "publication_sha256"}
+    legacy["publication_sha256"] = vsd_promotion._canonical_digest(body)
+    path.write_text(json.dumps(legacy), encoding="utf-8")
+
+    status = list_publication_states(TOOL_NAME, workspace=workspace)["tools"][0]
+    assert status["state"] == "active"
+    assert status["lifecycle_managed"] is False
+    tooluniverse = ToolUniverse()
+    try:
+        assert vsd_promotion.load_published_tools(
+            tooluniverse, workspace=workspace
+        ) == [TOOL_NAME]
+    finally:
+        tooluniverse.close()
+    with pytest.raises(VSDLifecycleError, match="Legacy publication"):
+        set_publication_state(
+            TOOL_NAME,
+            "suspended",
+            changed_by="Legacy Test Reviewer",
+            reason="A legacy publication needs republishing before lifecycle control.",
+            workspace=workspace,
+        )
+    assert publication["lifecycle"]["format"].endswith("_v1")
+
+
+def test_lifecycle_cli_assesses_suspends_and_reports_status(
+    tmp_path, monkeypatch, capsys
+):
+    _publish(tmp_path, monkeypatch)
+    workspace = tmp_path / "workspace"
+    changed_spec = _write_spec(
+        tmp_path / "changed.json",
+        _specification(server_url="https://rare-registry.example.org/v2"),
+    )
+    base = ["--workspace", str(workspace)]
+
+    assert (
+        vsd_lifecycle_cli.main(base + ["assess-openapi", TOOL_NAME, str(changed_spec)])
+        == 0
+    )
+    assessment = json.loads(capsys.readouterr().out)
+    assert assessment["classification"] == "breaking"
+
+    assert (
+        vsd_lifecycle_cli.main(
+            base
+            + [
+                "suspend",
+                TOOL_NAME,
+                "--changed-by",
+                "Lifecycle CLI Reviewer",
+                "--reason",
+                "Suspended after the provider endpoint changed major versions.",
+                "--assessment-sha256",
+                assessment["assessment_sha256"],
+            ]
+        )
+        == 0
+    )
+    event = json.loads(capsys.readouterr().out)
+    assert event["state"] == "suspended"
+
+    assert vsd_lifecycle_cli.main(base + ["status", TOOL_NAME]) == 0
+    status = json.loads(capsys.readouterr().out)
+    assert status["execution_allowed"] is False
+    assert status["tools"][0]["state"] == "suspended"

--- a/tests/unit/test_vsd_lifecycle_drift_case_study.py
+++ b/tests/unit/test_vsd_lifecycle_drift_case_study.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+MODULE_PATH = (
+    Path(__file__).parents[2] / "examples" / "vsd" / "lifecycle_drift_case_study.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "vsd_lifecycle_drift_case_study", MODULE_PATH
+)
+assert SPEC and SPEC.loader
+study = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = study
+SPEC.loader.exec_module(study)
+
+
+def test_lifecycle_case_runs_drift_state_and_runtime_pipeline(tmp_path):
+    snapshot = study.run_case(tmp_path / "lifecycle-workspace")
+    output_json = tmp_path / "snapshot.json"
+    output_markdown = tmp_path / "snapshot.md"
+    study.write_artifacts(snapshot, output_json, output_markdown)
+
+    assert set(snapshot["end_to_end_assertions"]) == study.EXPECTED_ASSERTIONS
+    assert all(snapshot["end_to_end_assertions"].values())
+    assert snapshot["promotion"]["verification_case_count"] == 3
+    assert {
+        name: item["classification"]
+        for name, item in snapshot["drift_assessments"].items()
+    } == {
+        "unchanged": "unchanged",
+        "metadata_only": "metadata_only",
+        "review_required": "review_required",
+        "breaking_endpoint": "breaking",
+        "breaking_auth": "breaking",
+        "repaired": "unchanged",
+    }
+    assert snapshot["lifecycle"]["states"] == [
+        "suspended",
+        "active",
+        "retired",
+    ]
+    assert snapshot["lifecycle"]["suspended_loaded_tools"] == []
+    assert snapshot["lifecycle"]["active_loaded_tools"] == [study.TOOL_NAME]
+    assert snapshot["lifecycle"]["retired_loaded_tools"] == []
+    assert len(snapshot["runtime"]["transport_log"]) == 5
+    assert snapshot["secret_boundary"]["persisted_secret_count"] == 0
+    assert snapshot["secret_boundary"]["result_secret_count"] == 0
+    assert json.loads(output_json.read_text(encoding="utf-8")) == snapshot
+    report = output_markdown.read_text(encoding="utf-8")
+    assert "Provider Drift And Lifecycle Case Study" in report
+    assert "Reviewed Publication" in report
+    assert "Drift Classification" in report
+    assert "Explicit Lifecycle" in report
+    assert "Operational Boundary" in report
+
+    tampered = copy.deepcopy(snapshot)
+    tampered["lifecycle"]["states"][1] = "suspended"
+    with pytest.raises(ValueError, match="audit digest"):
+        study.validate_snapshot(tampered)
+
+
+def test_checked_lifecycle_artifact_is_synchronized_and_tamper_detecting():
+    snapshot = json.loads(study.DEFAULT_JSON.read_text(encoding="utf-8"))
+    study.validate_snapshot(snapshot)
+    assert set(snapshot["end_to_end_assertions"]) == study.EXPECTED_ASSERTIONS
+    assert all(snapshot["end_to_end_assertions"].values())
+    assert len(snapshot["drift_assessments"]) == 6
+    assert len(snapshot["lifecycle"]["event_sha256"]) == 3
+
+    tampered = copy.deepcopy(snapshot)
+    tampered["drift_assessments"]["breaking_endpoint"]["suspension_recommended"] = False
+    with pytest.raises(ValueError, match="audit digest"):
+        study.validate_snapshot(tampered)


### PR DESCRIPTION
## Summary
- compare a published OpenAPI-derived operation with a local current provider contract and classify it as unchanged, metadata-only, review-required, or breaking
- persist inert, content-addressed assessments without fetching, executing, changing state, or exposing provider contract contents
- add explicit active, suspended, and terminal retired states bound to one exact publication
- anchor new publications to a required state pointer and immutable event chain so missing, modified, or noncontiguous state, events, and referenced assessments fail before registration
- require an unchanged or metadata-only assessment before reactivating a suspended publication while preserving backward-compatible loading for legacy publications

## End-to-end evidence
The checked protected rare-disease study promotes an authenticated operation after three disease-specific cases. It assesses an exact contract, documentation-only changes, response-schema drift, endpoint drift, and an unsafe authentication change; proves assessment alone does not alter state; explicitly suspends the publication; proves a fresh ToolUniverse instance does not load it; and proves lifecycle tampering fails before registration.

The study then confirms the repaired baseline contract, explicitly reactivates the publication, executes two protected records across credential rotation, retires the publication, and proves both exclusion and terminal state. Nineteen end-to-end assertions validate the publication anchor, event hash chain, credential boundary, and final audit digest.

## Verification
- `216` cumulative VSD unit tests passed
- `33` focused lifecycle, promotion, CLI, credential, and case-study tests passed
- `19` lifecycle case-study assertions passed
- lifecycle module reached `91%` line coverage in the cumulative run
- Ruff 0.14.5 formatting and lint passed

## Operational boundary
The CLI reads a local OpenAPI file. It does not crawl or fetch provider contracts, execute candidates, automatically change lifecycle state, create replacement drafts, approve, publish, or transmit evidence. State affects fresh loads; a host must restart or unload an already-running ToolUniverse instance.

## Stack
This PR is stacked on #426. Review that dependency first.