### PR TITLE
Add multi-format VSD contract inspection

### DIFF
--- a/examples/vsd/README.md
+++ b/examples/vsd/README.md
@@ -1,5 +1,32 @@
 # ToolUniverse VSD Validation Case Studies
 
+## Multi-format Contract Inspection Portfolio
+
+`multiformat_contract_case_study.py` asks whether an SMA evidence workflow can
+inventory providers whose contracts are expressed as GraphQL SDL, AsyncAPI 3,
+a Postman collection, WSDL/SOAP, gRPC/protobuf, and an MCP manifest. Its six
+focused cases cover a rare-disease registry, post-market safety alerts, natural
+history motor scores, a molecular diagnostics laboratory, variant evidence,
+and literature synthesis. The proof produces ten content-addressed operation
+candidates and checks 27 properties without making a provider request.
+
+The result is deliberately not ten new tools. It is a reviewable inventory:
+GraphQL and Postman reads can be distinguished from mutations and writes;
+event transports remain closed; SOAP and gRPC operations require a reviewed
+runtime; and a local-command MCP server is identified and blocked. Every
+candidate remains inert, retains the exact local source hash, and states the
+specific work still required before execution can be considered.
+
+Run the deterministic offline portfolio from the repository root:
+
+```console
+PYTHONPATH=src python examples/vsd/multiformat_contract_case_study.py
+```
+
+Review `artifacts/multiformat_contract_snapshot.md` and its machine-verifiable
+JSON counterpart. The administrator CLI can inspect the same formats with
+`tooluniverse-vsd-contracts CONTRACT [--format FORMAT] [--endpoint HTTPS_URL]`.
+
 ## Total Demand-To-Reviewed-Tool System Proof
 
 `total_system_case_study.py` answers one complete operational question: can a

--- a/examples/vsd/artifacts/multiformat_contract_snapshot.json
+++ b/examples/vsd/artifacts/multiformat_contract_snapshot.json
@@ -1,0 +1,303 @@
+{
+  "assertion_count": 27,
+  "assertions": [
+    {
+      "assertion": "format_detected",
+      "case": "Rare-disease registry GraphQL",
+      "passed": true
+    },
+    {
+      "assertion": "operation_count_exact",
+      "case": "Rare-disease registry GraphQL",
+      "passed": true
+    },
+    {
+      "assertion": "reviewable_count_exact",
+      "case": "Rare-disease registry GraphQL",
+      "passed": true
+    },
+    {
+      "assertion": "all_candidates_inert",
+      "case": "Rare-disease registry GraphQL",
+      "passed": true
+    },
+    {
+      "assertion": "format_detected",
+      "case": "Post-market safety AsyncAPI",
+      "passed": true
+    },
+    {
+      "assertion": "operation_count_exact",
+      "case": "Post-market safety AsyncAPI",
+      "passed": true
+    },
+    {
+      "assertion": "reviewable_count_exact",
+      "case": "Post-market safety AsyncAPI",
+      "passed": true
+    },
+    {
+      "assertion": "all_candidates_inert",
+      "case": "Post-market safety AsyncAPI",
+      "passed": true
+    },
+    {
+      "assertion": "format_detected",
+      "case": "Natural-history cohort Postman collection",
+      "passed": true
+    },
+    {
+      "assertion": "operation_count_exact",
+      "case": "Natural-history cohort Postman collection",
+      "passed": true
+    },
+    {
+      "assertion": "reviewable_count_exact",
+      "case": "Natural-history cohort Postman collection",
+      "passed": true
+    },
+    {
+      "assertion": "all_candidates_inert",
+      "case": "Natural-history cohort Postman collection",
+      "passed": true
+    },
+    {
+      "assertion": "format_detected",
+      "case": "Molecular diagnostics WSDL",
+      "passed": true
+    },
+    {
+      "assertion": "operation_count_exact",
+      "case": "Molecular diagnostics WSDL",
+      "passed": true
+    },
+    {
+      "assertion": "reviewable_count_exact",
+      "case": "Molecular diagnostics WSDL",
+      "passed": true
+    },
+    {
+      "assertion": "all_candidates_inert",
+      "case": "Molecular diagnostics WSDL",
+      "passed": true
+    },
+    {
+      "assertion": "format_detected",
+      "case": "Variant evidence gRPC/protobuf",
+      "passed": true
+    },
+    {
+      "assertion": "operation_count_exact",
+      "case": "Variant evidence gRPC/protobuf",
+      "passed": true
+    },
+    {
+      "assertion": "reviewable_count_exact",
+      "case": "Variant evidence gRPC/protobuf",
+      "passed": true
+    },
+    {
+      "assertion": "all_candidates_inert",
+      "case": "Variant evidence gRPC/protobuf",
+      "passed": true
+    },
+    {
+      "assertion": "format_detected",
+      "case": "Literature synthesis MCP manifest",
+      "passed": true
+    },
+    {
+      "assertion": "operation_count_exact",
+      "case": "Literature synthesis MCP manifest",
+      "passed": true
+    },
+    {
+      "assertion": "reviewable_count_exact",
+      "case": "Literature synthesis MCP manifest",
+      "passed": true
+    },
+    {
+      "assertion": "all_candidates_inert",
+      "case": "Literature synthesis MCP manifest",
+      "passed": true
+    },
+    {
+      "assertion": "six_contract_formats_covered",
+      "case": "Portfolio",
+      "passed": true
+    },
+    {
+      "assertion": "unsafe_operations_have_blockers",
+      "case": "Portfolio",
+      "passed": true
+    },
+    {
+      "assertion": "source_and_candidate_provenance_complete",
+      "case": "Portfolio",
+      "passed": true
+    }
+  ],
+  "case_count": 6,
+  "case_sha256": "13259b09e2177b83969f210445f9ed1bbe8013e7d715f493bebc6612dc268e35",
+  "case_title": "Spinal muscular atrophy heterogeneous evidence intake",
+  "conclusion": "Yes. Ten operations across six formats were inventoried with exact source and candidate identities; safe read candidates were separated from mutations, event transports, SOAP, gRPC, and local MCP commands that require later explicit review.",
+  "format": "vsd_multiformat_contract_case_v1",
+  "operation_count": 10,
+  "research_question": "Can six incompatible provider contract formats be converted into a reviewable inventory for an SMA evidence workflow without executing provider calls, opening listeners, or running local commands?",
+  "results": [
+    {
+      "blocked_count": 1,
+      "candidate_count": 2,
+      "case": "Rare-disease registry GraphQL",
+      "operations": [
+        {
+          "blockers": [],
+          "candidate_id": "03147f8a41850d19",
+          "endpoint": "https://rare-registry.example.org/graphql",
+          "kind": "graphql_query",
+          "name": "disease"
+        },
+        {
+          "blockers": [
+            "graphql_mutation_requires_explicit_review"
+          ],
+          "candidate_id": "6c01afc2c15f1280",
+          "endpoint": "https://rare-registry.example.org/graphql",
+          "kind": "graphql_mutation",
+          "name": "curateDisease"
+        }
+      ],
+      "question": "Which genes and trials are linked to spinal muscular atrophy?",
+      "reviewable_count": 1,
+      "source_document_sha256": "3abc4155767e4d6c23302f598324441d98271b68d156fe126e07921dc48fd55a",
+      "source_format": "graphql"
+    },
+    {
+      "blocked_count": 1,
+      "candidate_count": 1,
+      "case": "Post-market safety AsyncAPI",
+      "operations": [
+        {
+          "blockers": [
+            "asyncapi_receive_requires_bounded_event_runtime"
+          ],
+          "candidate_id": "dbbbb308ea82a6ac",
+          "endpoint": "https://safety.example.org",
+          "kind": "asyncapi_receive",
+          "name": "receiveSignal"
+        }
+      ],
+      "question": "Can new respiratory safety signals be represented without opening a listener?",
+      "reviewable_count": 0,
+      "source_document_sha256": "c2f2e5ea4291ed2b475f4f2de5339e98644de7efe6b9dd010d4876351594a49e",
+      "source_format": "asyncapi"
+    },
+    {
+      "blocked_count": 1,
+      "candidate_count": 2,
+      "case": "Natural-history cohort Postman collection",
+      "operations": [
+        {
+          "blockers": [],
+          "candidate_id": "d9a67713555c6524",
+          "endpoint": "https://cohort.example.org/trajectory",
+          "kind": "postman_request",
+          "name": "Participants/Motor trajectory"
+        },
+        {
+          "blockers": [
+            "postman_non_read_method_requires_explicit_review",
+            "postman_raw_body_requires_review"
+          ],
+          "candidate_id": "01db9af0b0228b94",
+          "endpoint": "https://cohort.example.org/visits",
+          "kind": "postman_request",
+          "name": "Participants/Annotate visit"
+        }
+      ],
+      "question": "Which longitudinal motor scores are available for the SMA cohort?",
+      "reviewable_count": 1,
+      "source_document_sha256": "a2744c6c57ec4d2e4a3199598c43468ef85352b3462647d222b14f07169032eb",
+      "source_format": "postman"
+    },
+    {
+      "blocked_count": 1,
+      "candidate_count": 1,
+      "case": "Molecular diagnostics WSDL",
+      "operations": [
+        {
+          "blockers": [
+            "soap_operation_requires_explicit_read_only_review"
+          ],
+          "candidate_id": "ea860150538d7c23",
+          "endpoint": "https://diagnostics.example.org/soap",
+          "kind": "soap_operation",
+          "name": "PanelPort.GetSMNPanel"
+        }
+      ],
+      "question": "Can a legacy laboratory panel result be identified without invoking SOAP?",
+      "reviewable_count": 0,
+      "source_document_sha256": "b75a4c4c844ea54d95661b456d948145e72508669e816c561c79e3f1fc281208",
+      "source_format": "wsdl"
+    },
+    {
+      "blocked_count": 2,
+      "candidate_count": 2,
+      "case": "Variant evidence gRPC/protobuf",
+      "operations": [
+        {
+          "blockers": [
+            "grpc_operation_requires_reviewed_channel"
+          ],
+          "candidate_id": "791e0c8135e1f38c",
+          "endpoint": "https://variants.example.org",
+          "kind": "grpc_rpc",
+          "name": "variants.v1.VariantEvidenceService.GetEvidence"
+        },
+        {
+          "blockers": [
+            "grpc_operation_requires_reviewed_channel",
+            "grpc_server_stream_requires_bounded_runtime"
+          ],
+          "candidate_id": "6e709922fe97b334",
+          "endpoint": "https://variants.example.org",
+          "kind": "grpc_rpc",
+          "name": "variants.v1.VariantEvidenceService.WatchEvidence"
+        }
+      ],
+      "question": "Can SMN1 variant evidence and a streaming update be distinguished?",
+      "reviewable_count": 0,
+      "source_document_sha256": "818f3daa0ab668de2bb1997c3e892f5a8d3bdf75f598a94e37627d829b7f277d",
+      "source_format": "protobuf"
+    },
+    {
+      "blocked_count": 1,
+      "candidate_count": 2,
+      "case": "Literature synthesis MCP manifest",
+      "operations": [
+        {
+          "blockers": [],
+          "candidate_id": "16047e4987d26575",
+          "endpoint": "https://literature.example.org/mcp",
+          "kind": "mcp_server",
+          "name": "literature"
+        },
+        {
+          "blockers": [
+            "endpoint_missing",
+            "mcp_live_tool_listing_required",
+            "mcp_local_command_not_allowed"
+          ],
+          "candidate_id": "5634a649c2505ace",
+          "endpoint": "",
+          "kind": "mcp_server",
+          "name": "local-unreviewed"
+        }
+      ],
+      "question": "Can remote literature tools be inventoried without running a local server command?",
+      "reviewable_count": 1,
+      "source_document_sha256": "822192f01175d54582e6c911f8dc218d3adbb438caff524644d43f53e6f86ac4",
+      "source_format": "mcp"
+    }
+  ]
+}

--- a/examples/vsd/artifacts/multiformat_contract_snapshot.md
+++ b/examples/vsd/artifacts/multiformat_contract_snapshot.md
@@ -1,0 +1,22 @@
+# Multi-format VSD Contract Proof
+
+## Research question
+
+Can six incompatible provider contract formats be converted into a reviewable inventory for an SMA evidence workflow without executing provider calls, opening listeners, or running local commands?
+
+## Result
+
+Yes. Ten operations across six formats were inventoried with exact source and candidate identities; safe read candidates were separated from mutations, event transports, SOAP, gRPC, and local MCP commands that require later explicit review.
+
+| Case | Format | Operations | Reviewable | Blocked |
+| --- | --- | ---: | ---: | ---: |
+| Rare-disease registry GraphQL | `graphql` | 2 | 1 | 1 |
+| Post-market safety AsyncAPI | `asyncapi` | 1 | 0 | 1 |
+| Natural-history cohort Postman collection | `postman` | 2 | 1 | 1 |
+| Molecular diagnostics WSDL | `wsdl` | 1 | 0 | 1 |
+| Variant evidence gRPC/protobuf | `protobuf` | 2 | 0 | 2 |
+| Literature synthesis MCP manifest | `mcp` | 2 | 1 | 1 |
+
+All 27 assertions passed. Case identity: `13259b09e2177b83969f210445f9ed1bbe8013e7d715f493bebc6612dc268e35`.
+
+The inspection used only local contract files. No provider request, listener, RPC channel, or local MCP command was executed.

--- a/examples/vsd/multiformat_contract_case_study.py
+++ b/examples/vsd/multiformat_contract_case_study.py
@@ -1,0 +1,383 @@
+"""Deterministic multi-format VSD contract inspection portfolio."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tooluniverse.vsd_contracts import (
+    inspect_contract_document,
+    validate_contract_candidate,
+)
+
+ARTIFACT_DIR = Path(__file__).with_name("artifacts")
+JSON_ARTIFACT = ARTIFACT_DIR / "multiformat_contract_snapshot.json"
+MARKDOWN_ARTIFACT = ARTIFACT_DIR / "multiformat_contract_snapshot.md"
+
+
+def _documents() -> list[dict[str, Any]]:
+    return [
+        {
+            "case": "Rare-disease registry GraphQL",
+            "question": "Which genes and trials are linked to spinal muscular atrophy?",
+            "name": "registry.graphql",
+            "endpoint": "https://rare-registry.example.org/graphql",
+            "contents": """
+                input DiseaseFilter { mondoId: ID!, minEvidence: Float }
+                type GeneEvidence { gene: String!, score: Float!, trials: [ID!]! }
+                type Disease { id: ID!, label: String!, evidence: [GeneEvidence!]! }
+                type Query { disease(filter: DiseaseFilter!): Disease }
+                type Mutation { curateDisease(id: ID!, note: String!): Boolean! }
+            """,
+            "expected_format": "graphql",
+            "expected_candidates": 2,
+            "expected_reviewable": 1,
+        },
+        {
+            "case": "Post-market safety AsyncAPI",
+            "question": "Can new respiratory safety signals be represented without opening a listener?",
+            "name": "safety.yaml",
+            "contents": yaml.safe_dump(
+                {
+                    "asyncapi": "3.0.0",
+                    "info": {"title": "Safety alerts", "version": "1"},
+                    "servers": {
+                        "prod": {
+                            "host": "safety.example.org",
+                            "protocol": "https",
+                        }
+                    },
+                    "channels": {
+                        "alerts": {
+                            "address": "neuromuscular/safety/{drugId}",
+                            "servers": [{"$ref": "#/servers/prod"}],
+                        }
+                    },
+                    "operations": {
+                        "receiveSignal": {
+                            "action": "receive",
+                            "channel": {"$ref": "#/channels/alerts"},
+                            "messages": [{"$ref": "#/components/messages/signal"}],
+                        }
+                    },
+                    "components": {
+                        "messages": {
+                            "signal": {
+                                "payload": {
+                                    "type": "object",
+                                    "properties": {
+                                        "drugId": {"type": "string"},
+                                        "event": {"type": "string"},
+                                        "caseCount": {"type": "integer"},
+                                    },
+                                    "required": ["drugId", "event", "caseCount"],
+                                }
+                            }
+                        }
+                    },
+                },
+                sort_keys=True,
+            ),
+            "expected_format": "asyncapi",
+            "expected_candidates": 1,
+            "expected_reviewable": 0,
+        },
+        {
+            "case": "Natural-history cohort Postman collection",
+            "question": "Which longitudinal motor scores are available for the SMA cohort?",
+            "name": "cohort.postman_collection.json",
+            "contents": json.dumps(
+                {
+                    "info": {
+                        "name": "SMA natural history",
+                        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+                    },
+                    "variable": [
+                        {"key": "baseUrl", "value": "https://cohort.example.org"}
+                    ],
+                    "item": [
+                        {
+                            "name": "Participants",
+                            "item": [
+                                {
+                                    "name": "Motor trajectory",
+                                    "request": {
+                                        "method": "GET",
+                                        "url": {
+                                            "raw": "{{baseUrl}}/trajectory",
+                                            "query": [
+                                                {"key": "participant", "value": ""},
+                                                {"key": "months", "value": ""},
+                                            ],
+                                        },
+                                    },
+                                },
+                                {
+                                    "name": "Annotate visit",
+                                    "request": {
+                                        "method": "POST",
+                                        "url": "{{baseUrl}}/visits",
+                                        "body": {"mode": "raw", "raw": "{}"},
+                                    },
+                                },
+                            ],
+                        }
+                    ],
+                },
+                sort_keys=True,
+            ),
+            "expected_format": "postman",
+            "expected_candidates": 2,
+            "expected_reviewable": 1,
+        },
+        {
+            "case": "Molecular diagnostics WSDL",
+            "question": "Can a legacy laboratory panel result be identified without invoking SOAP?",
+            "name": "diagnostics.wsdl",
+            "contents": """<?xml version="1.0"?>
+                <definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" name="DiagnosticLab">
+                  <portType name="PanelPort"><operation name="GetSMNPanel">
+                    <input message="GetSMNPanelRequest"/><output message="GetSMNPanelResponse"/>
+                  </operation></portType>
+                  <binding name="PanelBinding" type="PanelPort"><operation name="GetSMNPanel">
+                    <soap:operation soapAction="urn:GetSMNPanel"/>
+                  </operation></binding>
+                  <service name="DiagnosticLab"><port name="PanelPort" binding="PanelBinding">
+                    <soap:address location="https://diagnostics.example.org/soap"/>
+                  </port></service>
+                </definitions>""",
+            "expected_format": "wsdl",
+            "expected_candidates": 1,
+            "expected_reviewable": 0,
+        },
+        {
+            "case": "Variant evidence gRPC/protobuf",
+            "question": "Can SMN1 variant evidence and a streaming update be distinguished?",
+            "name": "variants.proto",
+            "endpoint": "https://variants.example.org",
+            "contents": """
+                syntax = "proto3";
+                package variants.v1;
+                message VariantRequest { string hgvs = 1; string assembly = 2; }
+                message VariantEvidence { string classification = 1; double score = 2; }
+                service VariantEvidenceService {
+                  rpc GetEvidence(VariantRequest) returns (VariantEvidence);
+                  rpc WatchEvidence(VariantRequest) returns (stream VariantEvidence);
+                }
+            """,
+            "expected_format": "protobuf",
+            "expected_candidates": 2,
+            "expected_reviewable": 0,
+        },
+        {
+            "case": "Literature synthesis MCP manifest",
+            "question": "Can remote literature tools be inventoried without running a local server command?",
+            "name": "literature.mcp.json",
+            "contents": json.dumps(
+                {
+                    "mcpServers": {
+                        "literature": {
+                            "url": "https://literature.example.org/mcp",
+                            "transport": "http",
+                            "tools": [
+                                {"name": "search_sma_trials"},
+                                {"name": "summarize_smn2_evidence"},
+                            ],
+                        },
+                        "local-unreviewed": {
+                            "command": "python",
+                            "args": ["server.py"],
+                        },
+                    }
+                },
+                sort_keys=True,
+            ),
+            "expected_format": "mcp",
+            "expected_candidates": 2,
+            "expected_reviewable": 1,
+        },
+    ]
+
+
+def run_case() -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    assertions: list[dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="tooluniverse-vsd-contracts-") as directory:
+        root = Path(directory)
+        for definition in _documents():
+            path = root / definition["name"]
+            path.write_text(definition["contents"], encoding="utf-8")
+            report = inspect_contract_document(
+                path, endpoint=definition.get("endpoint")
+            )
+            for candidate in report["candidates"]:
+                validate_contract_candidate(candidate)
+            observed = {
+                "case": definition["case"],
+                "question": definition["question"],
+                "source_format": report["source_format"],
+                "source_document_sha256": report["source_document_sha256"],
+                "candidate_count": report["candidate_count"],
+                "reviewable_count": report["reviewable_count"],
+                "blocked_count": report["blocked_count"],
+                "operations": [
+                    {
+                        "candidate_id": item["candidate_id"],
+                        "name": item["name"],
+                        "kind": item["kind"],
+                        "endpoint": item["endpoint"],
+                        "blockers": item["blockers"],
+                    }
+                    for item in report["candidates"]
+                ],
+            }
+            results.append(observed)
+            checks = {
+                "format_detected": report["source_format"]
+                == definition["expected_format"],
+                "operation_count_exact": report["candidate_count"]
+                == definition["expected_candidates"],
+                "reviewable_count_exact": report["reviewable_count"]
+                == definition["expected_reviewable"],
+                "all_candidates_inert": all(
+                    item["execution_allowed"] is False
+                    and item["approval_state"] == "unreviewed_candidate"
+                    for item in report["candidates"]
+                ),
+            }
+            for check, passed in checks.items():
+                assertions.append(
+                    {"case": definition["case"], "assertion": check, "passed": passed}
+                )
+
+    assertions.extend(
+        [
+            {
+                "case": "Portfolio",
+                "assertion": "six_contract_formats_covered",
+                "passed": {item["source_format"] for item in results}
+                == {"graphql", "asyncapi", "postman", "wsdl", "protobuf", "mcp"},
+            },
+            {
+                "case": "Portfolio",
+                "assertion": "unsafe_operations_have_blockers",
+                "passed": all(
+                    operation["blockers"]
+                    for result in results
+                    for operation in result["operations"]
+                    if operation["kind"]
+                    in {
+                        "graphql_mutation",
+                        "asyncapi_receive",
+                        "soap_operation",
+                        "grpc_rpc",
+                    }
+                ),
+            },
+            {
+                "case": "Portfolio",
+                "assertion": "source_and_candidate_provenance_complete",
+                "passed": all(
+                    len(result["source_document_sha256"]) == 64
+                    and all(
+                        len(item["candidate_id"]) == 16 for item in result["operations"]
+                    )
+                    for result in results
+                ),
+            },
+        ]
+    )
+    if not all(item["passed"] for item in assertions):
+        raise AssertionError([item for item in assertions if not item["passed"]])
+    report_body = {
+        "format": "vsd_multiformat_contract_case_v1",
+        "case_title": "Spinal muscular atrophy heterogeneous evidence intake",
+        "research_question": (
+            "Can six incompatible provider contract formats be converted into a "
+            "reviewable inventory for an SMA evidence workflow without executing "
+            "provider calls, opening listeners, or running local commands?"
+        ),
+        "conclusion": (
+            "Yes. Ten operations across six formats were inventoried with exact "
+            "source and candidate identities; safe read candidates were separated "
+            "from mutations, event transports, SOAP, gRPC, and local MCP commands "
+            "that require later explicit review."
+        ),
+        "case_count": len(results),
+        "operation_count": sum(item["candidate_count"] for item in results),
+        "assertion_count": len(assertions),
+        "results": results,
+        "assertions": assertions,
+    }
+    return {
+        **report_body,
+        "case_sha256": hashlib.sha256(
+            json.dumps(report_body, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest(),
+    }
+
+
+def _markdown(report: dict[str, Any]) -> str:
+    rows = []
+    for result in report["results"]:
+        rows.append(
+            f"| {result['case']} | `{result['source_format']}` | "
+            f"{result['candidate_count']} | {result['reviewable_count']} | "
+            f"{result['blocked_count']} |"
+        )
+    return "\n".join(
+        [
+            "# Multi-format VSD Contract Proof",
+            "",
+            "## Research question",
+            "",
+            report["research_question"],
+            "",
+            "## Result",
+            "",
+            report["conclusion"],
+            "",
+            "| Case | Format | Operations | Reviewable | Blocked |",
+            "| --- | --- | ---: | ---: | ---: |",
+            *rows,
+            "",
+            f"All {report['assertion_count']} assertions passed. Case identity: "
+            f"`{report['case_sha256']}`.",
+            "",
+            "The inspection used only local contract files. No provider request, "
+            "listener, RPC channel, or local MCP command was executed.",
+            "",
+        ]
+    )
+
+
+def main() -> None:
+    report = run_case()
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    JSON_ARTIFACT.write_text(
+        json.dumps(report, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    MARKDOWN_ARTIFACT.write_text(_markdown(report), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "status": "passed",
+                "cases": report["case_count"],
+                "operations": report["operation_count"],
+                "assertions": report["assertion_count"],
+                "case_sha256": report["case_sha256"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,7 @@ tooluniverse-vsd-admin = "tooluniverse.vsd_admin_cli:main"
 tooluniverse-vsd-promote = "tooluniverse.vsd_promotion_cli:main"
 tooluniverse-vsd-demand = "tooluniverse.vsd_demand_cli:main"
 tooluniverse-vsd-lifecycle = "tooluniverse.vsd_lifecycle_cli:main"
+tooluniverse-vsd-contracts = "tooluniverse.vsd_contracts_cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/tooluniverse/vsd_contracts.py
+++ b/src/tooluniverse/vsd_contracts.py
@@ -1,0 +1,1004 @@
+"""Bounded, local-only inspection for API contract formats used by VSD.
+
+Inspection is intentionally separate from execution. Every operation emitted by
+this module is inert, content-addressed, and carries explicit blockers that a
+later administrator-reviewed promotion step must resolve.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import urlsplit
+
+import yaml
+from graphql import GraphQLSchema, build_client_schema, build_schema
+from graphql.type import (
+    GraphQLArgument,
+    GraphQLEnumType,
+    GraphQLInputObjectType,
+    GraphQLList,
+    GraphQLNonNull,
+    GraphQLScalarType,
+)
+from lxml import etree
+
+from .vsd_openapi import inspect_openapi_document
+
+_VERSION = 1
+_MAX_FILE_BYTES = 1_000_000
+_MAX_DEPTH = 100
+_MAX_NODES = 50_000
+_MAX_CANDIDATES = 500
+_MAX_TEXT = 2_000
+_FORMAT_ALIASES = {
+    "gql": "graphql",
+    "graphqls": "graphql",
+    "yml": "asyncapi",
+    "postman_collection": "postman",
+    "proto": "protobuf",
+    "mcp": "mcp",
+    "xml": "wsdl",
+}
+_FORMAT_SUFFIXES = {
+    ".graphql": "graphql",
+    ".graphqls": "graphql",
+    ".gql": "graphql",
+    ".postman_collection.json": "postman",
+    ".wsdl": "wsdl",
+    ".proto": "protobuf",
+    ".mcp.json": "mcp",
+}
+_PROTO_COMMENT_RE = re.compile(r"//[^\n]*|/\*.*?\*/", re.DOTALL)
+_PROTO_SERVICE_RE = re.compile(r"\bservice\s+([A-Za-z_]\w*)\s*\{(.*?)\}", re.DOTALL)
+_PROTO_RPC_RE = re.compile(
+    r"\brpc\s+([A-Za-z_]\w*)\s*\(\s*(stream\s+)?([.A-Za-z_]\w*)\s*\)"
+    r"\s*returns\s*\(\s*(stream\s+)?([.A-Za-z_]\w*)\s*\)\s*"
+    r"(?:\{(.*?)\}|;)",
+    re.DOTALL,
+)
+_PROTO_MESSAGE_RE = re.compile(r"\bmessage\s+([A-Za-z_]\w*)\s*\{(.*?)\}", re.DOTALL)
+_PROTO_FIELD_RE = re.compile(
+    r"\b(?:optional\s+|required\s+|repeated\s+)?"
+    r"([.A-Za-z_]\w*(?:\s*<[^;={}]+>)?)\s+([A-Za-z_]\w*)\s*=\s*(\d+)"
+)
+
+
+class VSDContractError(ValueError):
+    """Raised when a contract cannot cross the local inspection boundary."""
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _text(value: Any, *, maximum: int = _MAX_TEXT) -> str:
+    if not isinstance(value, str):
+        return ""
+    return " ".join(value.split())[:maximum]
+
+
+def _walk_bounds(value: Any) -> None:
+    stack = [(value, 0)]
+    nodes = 0
+    while stack:
+        current, depth = stack.pop()
+        nodes += 1
+        if nodes > _MAX_NODES:
+            raise VSDContractError("Contract exceeds the node limit")
+        if depth > _MAX_DEPTH:
+            raise VSDContractError("Contract exceeds the nesting depth limit")
+        if isinstance(current, dict):
+            for key, child in current.items():
+                if not isinstance(key, str):
+                    raise VSDContractError("Contract object keys must be strings")
+                stack.append((child, depth + 1))
+        elif isinstance(current, list):
+            stack.extend((child, depth + 1) for child in current)
+        elif not isinstance(current, (str, int, float, bool, type(None))):
+            raise VSDContractError("Contract contains an unsupported value")
+
+
+def _read_bytes(path: str | Path) -> tuple[Path, bytes, str]:
+    source = Path(path)
+    try:
+        size = source.stat().st_size
+    except OSError as exc:
+        raise VSDContractError(f"Cannot read contract: {exc}") from exc
+    if size <= 0:
+        raise VSDContractError("Contract is empty")
+    if size > _MAX_FILE_BYTES:
+        raise VSDContractError("Contract exceeds the 1 MB limit")
+    try:
+        raw = source.read_bytes()
+    except OSError as exc:
+        raise VSDContractError(f"Cannot read contract: {exc}") from exc
+    return source, raw, hashlib.sha256(raw).hexdigest()
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise VSDContractError(f"Duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+class _StrictSafeLoader(yaml.SafeLoader):
+    pass
+
+
+def _yaml_mapping(loader: _StrictSafeLoader, node: yaml.Node, deep: bool = False):
+    pairs = loader.construct_pairs(node, deep=deep)
+    return _reject_duplicate_keys(pairs)
+
+
+_StrictSafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _yaml_mapping
+)
+
+
+def _structured(raw: bytes, *, yaml_allowed: bool) -> dict[str, Any]:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise VSDContractError("Contract must be UTF-8") from exc
+    try:
+        if yaml_allowed:
+            if "&" in text or "*" in text:
+                # Anchors and aliases make provenance review needlessly ambiguous.
+                for token in yaml.scan(text):
+                    if isinstance(token, (yaml.AnchorToken, yaml.AliasToken)):
+                        raise VSDContractError(
+                            "YAML aliases and anchors are not allowed"
+                        )
+            value = yaml.load(text, Loader=_StrictSafeLoader)
+        else:
+            value = json.loads(text, object_pairs_hook=_reject_duplicate_keys)
+    except VSDContractError:
+        raise
+    except (json.JSONDecodeError, yaml.YAMLError) as exc:
+        raise VSDContractError(f"Contract is not valid structured data: {exc}") from exc
+    if not isinstance(value, dict):
+        raise VSDContractError("Contract root must be an object")
+    _walk_bounds(value)
+    return value
+
+
+def _https_endpoint(value: Any) -> tuple[str, list[str]]:
+    if not isinstance(value, str) or not value.strip():
+        return "", ["endpoint_missing"]
+    endpoint = value.strip()
+    parsed = urlsplit(endpoint)
+    if (
+        parsed.scheme.casefold() != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.fragment
+    ):
+        return endpoint, ["endpoint_must_be_https"]
+    return endpoint, []
+
+
+def _candidate(
+    *,
+    source_format: str,
+    document_sha256: str,
+    kind: str,
+    name: str,
+    protocol: str,
+    endpoint: str = "",
+    method: str = "",
+    summary: str = "",
+    input_schema: Any = None,
+    output_schema: Any = None,
+    auth: Any = None,
+    blockers: list[str] | None = None,
+    warnings: list[str] | None = None,
+    contract: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    body = {
+        "format": "vsd_contract_candidate_v1",
+        "version": _VERSION,
+        "approval_state": "unreviewed_candidate",
+        "execution_allowed": False,
+        "metadata_trust": "untrusted_contract_metadata",
+        "source_format": source_format,
+        "source_document_sha256": document_sha256,
+        "kind": _text(kind, maximum=100),
+        "name": _text(name, maximum=300),
+        "summary": _text(summary),
+        "protocol": _text(protocol, maximum=100),
+        "endpoint": endpoint,
+        "method": method.upper(),
+        "input_schema": input_schema if isinstance(input_schema, dict) else {},
+        "output_schema": output_schema if isinstance(output_schema, dict) else {},
+        "auth": auth if isinstance(auth, dict) else {"type": "unspecified"},
+        "blockers": sorted(set(blockers or [])),
+        "warnings": sorted(set(warnings or [])),
+        "contract": contract or {},
+    }
+    _walk_bounds(body)
+    digest = _digest(body)
+    return {**body, "candidate_id": digest[:16], "candidate_sha256": digest}
+
+
+def validate_contract_candidate(candidate: Any) -> dict[str, Any]:
+    """Verify origin, integrity, bounds, and inert state of a candidate."""
+    if not isinstance(candidate, dict):
+        raise VSDContractError("Contract candidate must be an object")
+    if (
+        candidate.get("format") != "vsd_contract_candidate_v1"
+        or candidate.get("version") != _VERSION
+        or candidate.get("approval_state") != "unreviewed_candidate"
+        or candidate.get("execution_allowed") is not False
+        or candidate.get("metadata_trust") != "untrusted_contract_metadata"
+    ):
+        raise VSDContractError("Candidate did not come from the contract boundary")
+    body = {
+        key: value
+        for key, value in candidate.items()
+        if key not in {"candidate_id", "candidate_sha256"}
+    }
+    _walk_bounds(body)
+    digest = _digest(body)
+    if (
+        candidate.get("candidate_sha256") != digest
+        or candidate.get("candidate_id") != digest[:16]
+    ):
+        raise VSDContractError("Contract candidate digest does not match its content")
+    if candidate.get("source_format") not in {
+        "graphql",
+        "asyncapi",
+        "postman",
+        "wsdl",
+        "protobuf",
+        "mcp",
+    }:
+        raise VSDContractError("Contract candidate format is unsupported")
+    if not re.fullmatch(r"[0-9a-f]{64}", str(candidate.get("source_document_sha256"))):
+        raise VSDContractError("Contract candidate source digest is invalid")
+    if not isinstance(candidate.get("blockers"), list):
+        raise VSDContractError("Contract candidate blockers are invalid")
+    return copy.deepcopy(candidate)
+
+
+def _report(
+    source: Path,
+    source_format: str,
+    document_sha256: str,
+    candidates: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if not candidates:
+        raise VSDContractError("Contract contains no inspectable operations")
+    if len(candidates) > _MAX_CANDIDATES:
+        raise VSDContractError("Contract exceeds the operation limit")
+    return {
+        "format": "vsd_contract_inspection_v1",
+        "version": _VERSION,
+        "source_file": source.name,
+        "source_format": source_format,
+        "source_document_sha256": document_sha256,
+        "candidate_count": len(candidates),
+        "reviewable_count": sum(not item["blockers"] for item in candidates),
+        "blocked_count": sum(bool(item["blockers"]) for item in candidates),
+        "candidates": candidates,
+    }
+
+
+def _graphql_type_schema(value: Any, seen: set[str] | None = None) -> dict[str, Any]:
+    required = isinstance(value, GraphQLNonNull)
+    current = value.of_type if required else value
+    if isinstance(current, GraphQLList):
+        schema: dict[str, Any] = {
+            "type": "array",
+            "items": _graphql_type_schema(current.of_type, seen),
+        }
+    elif isinstance(current, GraphQLScalarType):
+        scalar_type = {
+            "Boolean": "boolean",
+            "Float": "number",
+            "Int": "integer",
+        }.get(current.name, "string")
+        schema = {"type": scalar_type}
+    elif isinstance(current, GraphQLEnumType):
+        schema = {"type": "string", "enum": sorted(current.values)}
+    elif isinstance(current, GraphQLInputObjectType):
+        visited = set(seen or set())
+        if current.name in visited:
+            return {"type": "object", "additionalProperties": False}
+        visited.add(current.name)
+        properties = {
+            name: _graphql_type_schema(field.type, visited)
+            for name, field in current.fields.items()
+        }
+        required_fields = [
+            name
+            for name, field in current.fields.items()
+            if isinstance(field.type, GraphQLNonNull)
+        ]
+        schema = {
+            "type": "object",
+            "properties": properties,
+            "additionalProperties": False,
+        }
+        if required_fields:
+            schema["required"] = sorted(required_fields)
+    else:
+        schema = {"type": "string", "description": f"GraphQL type {current}"}
+    if not required:
+        schema = {**schema, "nullable": True}
+    return schema
+
+
+def _graphql_arguments(arguments: dict[str, GraphQLArgument]) -> dict[str, Any]:
+    properties = {
+        name: _graphql_type_schema(argument.type)
+        for name, argument in arguments.items()
+    }
+    required = [
+        name
+        for name, argument in arguments.items()
+        if isinstance(argument.type, GraphQLNonNull)
+    ]
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        schema["required"] = sorted(required)
+    return schema
+
+
+def _inspect_graphql(
+    source: Path, raw: bytes, document_sha256: str, endpoint_override: str | None
+) -> dict[str, Any]:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise VSDContractError("GraphQL contract must be UTF-8") from exc
+    try:
+        stripped = text.lstrip()
+        if stripped.startswith("{"):
+            payload = _structured(raw, yaml_allowed=False)
+            introspection = payload.get("data", payload)
+            if "__schema" not in introspection:
+                raise VSDContractError("GraphQL JSON must contain introspection data")
+            schema = build_client_schema(introspection)
+        else:
+            schema = build_schema(text)
+    except VSDContractError:
+        raise
+    except Exception as exc:
+        raise VSDContractError(f"GraphQL schema is invalid: {exc}") from exc
+    endpoint, endpoint_blockers = _https_endpoint(endpoint_override)
+    candidates: list[dict[str, Any]] = []
+    roots: list[tuple[str, Any]] = [
+        ("query", schema.query_type),
+        ("mutation", schema.mutation_type),
+        ("subscription", schema.subscription_type),
+    ]
+    for operation_type, root in roots:
+        if root is None:
+            continue
+        for name, field in sorted(root.fields.items()):
+            blockers = list(endpoint_blockers)
+            if operation_type != "query":
+                blockers.append(f"graphql_{operation_type}_requires_explicit_review")
+            output_type = str(field.type)
+            candidates.append(
+                _candidate(
+                    source_format="graphql",
+                    document_sha256=document_sha256,
+                    kind=f"graphql_{operation_type}",
+                    name=name,
+                    summary=field.description or name,
+                    protocol="graphql",
+                    endpoint=endpoint,
+                    method="POST",
+                    input_schema=_graphql_arguments(field.args),
+                    output_schema={"graphql_type": output_type},
+                    blockers=blockers,
+                    contract={
+                        "operation_type": operation_type,
+                        "root_type": root.name,
+                        "field": name,
+                        "deprecated_reason": field.deprecation_reason,
+                    },
+                    warnings=["deprecated_field"] if field.deprecation_reason else [],
+                )
+            )
+    return _report(source, "graphql", document_sha256, candidates)
+
+
+def _asyncapi_servers(document: dict[str, Any]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for name, server in (document.get("servers") or {}).items():
+        if not isinstance(server, dict):
+            continue
+        host = server.get("host") or server.get("url")
+        protocol = _text(server.get("protocol"), maximum=50)
+        if isinstance(host, str):
+            if "://" not in host and protocol in {"http", "https", "ws", "wss"}:
+                host = f"{protocol}://{host}"
+            values[str(name)] = host
+    return values
+
+
+def _schema_from_message(message: Any) -> dict[str, Any]:
+    if not isinstance(message, dict):
+        return {}
+    payload = message.get("payload")
+    if isinstance(payload, dict):
+        return copy.deepcopy(payload)
+    one_of = message.get("oneOf")
+    if isinstance(one_of, list):
+        schemas = [_schema_from_message(item) for item in one_of]
+        return {"oneOf": [item for item in schemas if item]}
+    return {}
+
+
+def _inspect_asyncapi(
+    source: Path, raw: bytes, document_sha256: str, endpoint_override: str | None
+) -> dict[str, Any]:
+    document = _structured(raw, yaml_allowed=True)
+    version = document.get("asyncapi")
+    if not isinstance(version, str) or not version.startswith(("2.", "3.")):
+        raise VSDContractError("Only AsyncAPI 2.x and 3.x documents are supported")
+    servers = _asyncapi_servers(document)
+    channels = document.get("channels")
+    if not isinstance(channels, dict) or not channels:
+        raise VSDContractError("AsyncAPI channels must be a non-empty object")
+    candidates: list[dict[str, Any]] = []
+    if version.startswith("3."):
+        operations = document.get("operations")
+        if not isinstance(operations, dict) or not operations:
+            raise VSDContractError("AsyncAPI 3.x operations must be a non-empty object")
+        for operation_key, operation in sorted(operations.items()):
+            if not isinstance(operation, dict):
+                continue
+            action = operation.get("action")
+            if action not in {"send", "receive"}:
+                continue
+            channel_reference = operation.get("channel")
+            if isinstance(channel_reference, dict) and isinstance(
+                channel_reference.get("$ref"), str
+            ):
+                channel_key = channel_reference["$ref"].split("/")[-1]
+                channel = channels.get(channel_key, {})
+            elif isinstance(channel_reference, dict):
+                channel_key = str(operation_key)
+                channel = channel_reference
+            else:
+                channel_key = str(operation_key)
+                channel = {}
+            address = (
+                channel.get("address", channel_key)
+                if isinstance(channel, dict)
+                else channel_key
+            )
+            server_reference = (
+                channel.get("servers", [None])[0]
+                if isinstance(channel, dict)
+                and isinstance(channel.get("servers"), list)
+                and channel.get("servers")
+                else None
+            )
+            server_name = (
+                server_reference.get("$ref", "").split("/")[-1]
+                if isinstance(server_reference, dict)
+                else str(server_reference or "")
+            )
+            raw_endpoint = (
+                endpoint_override
+                or servers.get(server_name)
+                or next(iter(servers.values()), None)
+            )
+            endpoint, endpoint_blockers = _https_endpoint(raw_endpoint)
+            messages = operation.get("messages")
+            message: Any = {}
+            if isinstance(messages, list) and messages:
+                message = messages[0]
+                if isinstance(message, dict) and isinstance(message.get("$ref"), str):
+                    message_name = message["$ref"].split("/")[-1]
+                    message = (
+                        document.get("components", {}).get("messages", {}) or {}
+                    ).get(message_name, {})
+            candidates.append(
+                _candidate(
+                    source_format="asyncapi",
+                    document_sha256=document_sha256,
+                    kind=f"asyncapi_{action}",
+                    name=operation.get("operationId") or str(operation_key),
+                    summary=operation.get("summary") or operation.get("description"),
+                    protocol="asyncapi",
+                    endpoint=endpoint,
+                    input_schema=_schema_from_message(message),
+                    output_schema=_schema_from_message(message),
+                    blockers=[
+                        *endpoint_blockers,
+                        f"asyncapi_{action}_requires_bounded_event_runtime",
+                    ],
+                    contract={
+                        "asyncapi_version": version,
+                        "action": action,
+                        "channel": _text(address, maximum=500),
+                    },
+                )
+            )
+        return _report(source, "asyncapi", document_sha256, candidates)
+
+    for channel_name, channel in sorted(channels.items()):
+        if not isinstance(channel, dict):
+            continue
+        address = channel.get("address", channel_name)
+        for action in ("publish", "subscribe"):
+            operation = channel.get(action)
+            if not isinstance(operation, dict):
+                continue
+            server_names = operation.get("servers") or channel.get("servers") or []
+            if isinstance(server_names, list) and server_names:
+                server_name = str(server_names[0]).split("/")[-1]
+                raw_endpoint = servers.get(server_name)
+            else:
+                raw_endpoint = endpoint_override or next(iter(servers.values()), None)
+            endpoint, endpoint_blockers = _https_endpoint(raw_endpoint)
+            message = operation.get("message") or channel.get("messages", {})
+            if isinstance(message, dict) and "$ref" in message:
+                message_name = str(message["$ref"]).split("/")[-1]
+                message = (
+                    document.get("components", {}).get("messages", {}) or {}
+                ).get(message_name, {})
+            blockers = [
+                *endpoint_blockers,
+                f"asyncapi_{action}_requires_bounded_event_runtime",
+            ]
+            candidates.append(
+                _candidate(
+                    source_format="asyncapi",
+                    document_sha256=document_sha256,
+                    kind=f"asyncapi_{action}",
+                    name=operation.get("operationId") or f"{action}_{channel_name}",
+                    summary=operation.get("summary") or operation.get("description"),
+                    protocol="asyncapi",
+                    endpoint=endpoint,
+                    input_schema=_schema_from_message(message),
+                    output_schema=_schema_from_message(message),
+                    blockers=blockers,
+                    contract={
+                        "asyncapi_version": version,
+                        "action": action,
+                        "channel": _text(address, maximum=500),
+                    },
+                )
+            )
+    return _report(source, "asyncapi", document_sha256, candidates)
+
+
+def _postman_variables(document: dict[str, Any]) -> dict[str, str]:
+    variables: dict[str, str] = {}
+    for item in document.get("variable", []) or []:
+        if not isinstance(item, dict) or not isinstance(item.get("key"), str):
+            continue
+        value = item.get("value")
+        if isinstance(value, (str, int, float, bool)):
+            variables[item["key"]] = str(value)
+    return variables
+
+
+def _postman_replace(value: str, variables: dict[str, str]) -> tuple[str, list[str]]:
+    unresolved: list[str] = []
+
+    def replace(match: re.Match[str]) -> str:
+        key = match.group(1).strip()
+        if key not in variables:
+            unresolved.append(key)
+            return match.group(0)
+        return variables[key]
+
+    return re.sub(r"\{\{([^{}]+)\}\}", replace, value), unresolved
+
+
+def _postman_items(items: Any, prefix: str = ""):
+    if not isinstance(items, list):
+        return
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = _text(item.get("name"), maximum=300)
+        current = f"{prefix}/{name}".strip("/")
+        if isinstance(item.get("item"), list):
+            yield from _postman_items(item["item"], current)
+        elif isinstance(item.get("request"), dict):
+            yield current, item["request"]
+
+
+def _postman_url(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return str(value.get("raw") or "")
+    return ""
+
+
+def _postman_auth(request: dict[str, Any], document: dict[str, Any]) -> dict[str, Any]:
+    auth = request.get("auth", document.get("auth"))
+    if auth is None:
+        return {"type": "none"}
+    if not isinstance(auth, dict):
+        return {"type": "invalid"}
+    return {"type": _text(auth.get("type"), maximum=80) or "unspecified"}
+
+
+def _inspect_postman(
+    source: Path, raw: bytes, document_sha256: str, endpoint_override: str | None
+) -> dict[str, Any]:
+    del endpoint_override
+    document = _structured(raw, yaml_allowed=False)
+    schema = str((document.get("info") or {}).get("schema") or "")
+    if "schema.getpostman.com" not in schema:
+        raise VSDContractError(
+            "Only Postman collection 2.0/2.1 documents are supported"
+        )
+    variables = _postman_variables(document)
+    candidates: list[dict[str, Any]] = []
+    for name, request in _postman_items(document.get("item")):
+        method = str(request.get("method") or "GET").upper()
+        resolved_url, unresolved = _postman_replace(
+            _postman_url(request.get("url")), variables
+        )
+        endpoint, endpoint_blockers = _https_endpoint(resolved_url)
+        auth = _postman_auth(request, document)
+        blockers = list(endpoint_blockers)
+        blockers.extend(f"unresolved_postman_variable:{item}" for item in unresolved)
+        if method not in {"GET", "HEAD"}:
+            blockers.append("postman_non_read_method_requires_explicit_review")
+        body = request.get("body")
+        if isinstance(body, dict) and body.get("mode"):
+            blockers.append(f"postman_{body['mode']}_body_requires_review")
+        if auth["type"] not in {"none", "bearer", "apikey", "oauth2"}:
+            blockers.append(f"unsupported_postman_auth:{auth['type']}")
+        query_properties: dict[str, Any] = {}
+        url_object = request.get("url")
+        if isinstance(url_object, dict):
+            for query in url_object.get("query", []) or []:
+                if isinstance(query, dict) and isinstance(query.get("key"), str):
+                    query_properties[query["key"]] = {"type": "string"}
+        candidates.append(
+            _candidate(
+                source_format="postman",
+                document_sha256=document_sha256,
+                kind="postman_request",
+                name=name,
+                summary=request.get("description")
+                if isinstance(request.get("description"), str)
+                else name,
+                protocol="https",
+                endpoint=endpoint,
+                method=method,
+                input_schema={
+                    "type": "object",
+                    "properties": query_properties,
+                    "additionalProperties": False,
+                },
+                auth=auth,
+                blockers=blockers,
+                contract={
+                    "collection": _text((document.get("info") or {}).get("name")),
+                    "body_mode": body.get("mode") if isinstance(body, dict) else None,
+                },
+            )
+        )
+    return _report(source, "postman", document_sha256, candidates)
+
+
+def _inspect_wsdl(
+    source: Path, raw: bytes, document_sha256: str, endpoint_override: str | None
+) -> dict[str, Any]:
+    if re.search(rb"<!DOCTYPE|<!ENTITY", raw, re.IGNORECASE):
+        raise VSDContractError("WSDL DTDs and entities are not allowed")
+    parser = etree.XMLParser(
+        resolve_entities=False,
+        no_network=True,
+        load_dtd=False,
+        recover=False,
+        huge_tree=False,
+    )
+    try:
+        root = etree.fromstring(raw, parser=parser)
+    except etree.XMLSyntaxError as exc:
+        raise VSDContractError(f"WSDL XML is invalid: {exc}") from exc
+    local = etree.QName(root).localname
+    if local not in {"definitions", "description"}:
+        raise VSDContractError("WSDL root must be definitions or description")
+    ns = {key or "wsdl": value for key, value in root.nsmap.items() if value}
+    wsdl_uri = etree.QName(root).namespace
+    ns["w"] = wsdl_uri
+    addresses = root.xpath(
+        ".//*[local-name()='service']/*[local-name()='port']/*[local-name()='address']/@location"
+    )
+    endpoint, endpoint_blockers = _https_endpoint(
+        endpoint_override or (addresses[0] if addresses else None)
+    )
+    actions: dict[str, str] = {}
+    for operation in root.xpath(
+        ".//*[local-name()='binding']/*[local-name()='operation']"
+    ):
+        name = operation.get("name")
+        action = operation.xpath("./*[local-name()='operation']/@soapAction")
+        if name:
+            actions[name] = action[0] if action else ""
+    candidates: list[dict[str, Any]] = []
+    for port_type in root.xpath(
+        ".//*[local-name()='portType'] | .//*[local-name()='interface']"
+    ):
+        interface = port_type.get("name") or "service"
+        for operation in port_type.xpath("./*[local-name()='operation']"):
+            name = operation.get("name")
+            if not name:
+                continue
+            inputs = operation.xpath("./*[local-name()='input']/@message")
+            outputs = operation.xpath("./*[local-name()='output']/@message")
+            candidates.append(
+                _candidate(
+                    source_format="wsdl",
+                    document_sha256=document_sha256,
+                    kind="soap_operation",
+                    name=f"{interface}.{name}",
+                    summary=operation.get("documentation") or name,
+                    protocol="soap",
+                    endpoint=endpoint,
+                    method="POST",
+                    blockers=[
+                        *endpoint_blockers,
+                        "soap_operation_requires_explicit_read_only_review",
+                    ],
+                    contract={
+                        "wsdl_version": "2.0" if local == "description" else "1.1",
+                        "interface": interface,
+                        "operation": name,
+                        "soap_action": actions.get(name, ""),
+                        "input_message": inputs[0] if inputs else "",
+                        "output_message": outputs[0] if outputs else "",
+                    },
+                )
+            )
+    return _report(source, "wsdl", document_sha256, candidates)
+
+
+def _proto_messages(text: str) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for name, body in _PROTO_MESSAGE_RE.findall(text):
+        properties: dict[str, Any] = {}
+        for field_type, field_name, field_number in _PROTO_FIELD_RE.findall(body):
+            properties[field_name] = {
+                "protobuf_type": " ".join(field_type.split()),
+                "field_number": int(field_number),
+            }
+        result[name] = {"type": "object", "properties": properties}
+    return result
+
+
+def _inspect_protobuf(
+    source: Path, raw: bytes, document_sha256: str, endpoint_override: str | None
+) -> dict[str, Any]:
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise VSDContractError("Protobuf source must be UTF-8") from exc
+    text = _PROTO_COMMENT_RE.sub("", text)
+    if not re.search(r"\bsyntax\s*=\s*['\"]proto[23]['\"]\s*;", text):
+        raise VSDContractError("Protobuf source must declare proto2 or proto3 syntax")
+    package_match = re.search(
+        r"\bpackage\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*;", text
+    )
+    package = package_match.group(1) if package_match else ""
+    messages = _proto_messages(text)
+    endpoint, endpoint_blockers = _https_endpoint(endpoint_override)
+    candidates: list[dict[str, Any]] = []
+    for service, body in _PROTO_SERVICE_RE.findall(text):
+        for (
+            name,
+            client_stream,
+            input_type,
+            server_stream,
+            output_type,
+            options,
+        ) in _PROTO_RPC_RE.findall(body):
+            blockers = [*endpoint_blockers, "grpc_operation_requires_reviewed_channel"]
+            if client_stream:
+                blockers.append("grpc_client_stream_requires_bounded_runtime")
+            if server_stream:
+                blockers.append("grpc_server_stream_requires_bounded_runtime")
+            full_name = ".".join(part for part in (package, service, name) if part)
+            candidates.append(
+                _candidate(
+                    source_format="protobuf",
+                    document_sha256=document_sha256,
+                    kind="grpc_rpc",
+                    name=full_name,
+                    summary=name,
+                    protocol="grpc",
+                    endpoint=endpoint,
+                    method="RPC",
+                    input_schema=messages.get(
+                        input_type.split(".")[-1], {"protobuf_type": input_type}
+                    ),
+                    output_schema=messages.get(
+                        output_type.split(".")[-1], {"protobuf_type": output_type}
+                    ),
+                    blockers=blockers,
+                    contract={
+                        "package": package,
+                        "service": service,
+                        "rpc": name,
+                        "input_type": input_type,
+                        "output_type": output_type,
+                        "client_streaming": bool(client_stream),
+                        "server_streaming": bool(server_stream),
+                        "options_sha256": hashlib.sha256(options.encode()).hexdigest(),
+                    },
+                )
+            )
+    return _report(source, "protobuf", document_sha256, candidates)
+
+
+def _mcp_servers(document: dict[str, Any]) -> dict[str, Any]:
+    raw = document.get("mcpServers", document.get("servers"))
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(document.get("server"), dict):
+        return {"server": document["server"]}
+    return {}
+
+
+def _inspect_mcp(
+    source: Path, raw: bytes, document_sha256: str, endpoint_override: str | None
+) -> dict[str, Any]:
+    document = _structured(raw, yaml_allowed=False)
+    servers = _mcp_servers(document)
+    captured_tools = document.get("tools")
+    if not servers and not isinstance(captured_tools, list):
+        raise VSDContractError("MCP manifest must contain servers or captured tools")
+    candidates: list[dict[str, Any]] = []
+    if isinstance(captured_tools, list):
+        endpoint, endpoint_blockers = _https_endpoint(
+            endpoint_override or document.get("serverUrl")
+        )
+        for tool in captured_tools:
+            if not isinstance(tool, dict) or not isinstance(tool.get("name"), str):
+                continue
+            candidates.append(
+                _candidate(
+                    source_format="mcp",
+                    document_sha256=document_sha256,
+                    kind="mcp_tool",
+                    name=tool["name"],
+                    summary=tool.get("description"),
+                    protocol="mcp",
+                    endpoint=endpoint,
+                    method="tools/call",
+                    input_schema=tool.get("inputSchema"),
+                    output_schema=tool.get("outputSchema"),
+                    blockers=[
+                        *endpoint_blockers,
+                        "mcp_tool_requires_live_identity_verification",
+                    ],
+                    contract={
+                        "server_name": _text(document.get("serverName"), maximum=300)
+                    },
+                )
+            )
+    for name, server in sorted(servers.items()):
+        if not isinstance(server, dict):
+            continue
+        endpoint, endpoint_blockers = _https_endpoint(server.get("url"))
+        blockers = list(endpoint_blockers)
+        if server.get("command") or server.get("args"):
+            blockers.append("mcp_local_command_not_allowed")
+        if not isinstance(server.get("tools"), list):
+            blockers.append("mcp_live_tool_listing_required")
+        candidates.append(
+            _candidate(
+                source_format="mcp",
+                document_sha256=document_sha256,
+                kind="mcp_server",
+                name=str(name),
+                summary=server.get("description"),
+                protocol="mcp",
+                endpoint=endpoint,
+                method="tools/list",
+                blockers=blockers,
+                contract={
+                    "transport": _text(server.get("transport") or "http", maximum=50),
+                    "declared_tools": [
+                        _text(item.get("name"), maximum=300)
+                        for item in server.get("tools", [])
+                        if isinstance(item, dict)
+                    ][:500],
+                },
+            )
+        )
+    return _report(source, "mcp", document_sha256, candidates)
+
+
+def detect_contract_format(path: str | Path, raw: bytes | None = None) -> str:
+    """Detect a supported format from an unambiguous suffix or document marker."""
+    source = Path(path)
+    lower_name = source.name.casefold()
+    for suffix, source_format in _FORMAT_SUFFIXES.items():
+        if lower_name.endswith(suffix):
+            return source_format
+    if raw is None:
+        _, raw, _ = _read_bytes(source)
+    prefix = raw[:100_000].lstrip()
+    if prefix.startswith(b"<") and re.search(
+        rb"<(?:\w+:)?(?:definitions|description)\b", prefix
+    ):
+        return "wsdl"
+    if re.search(rb"\bsyntax\s*=\s*['\"]proto[23]['\"]", prefix):
+        return "protobuf"
+    if prefix.startswith(b"{"):
+        document = _structured(raw, yaml_allowed=False)
+        if "openapi" in document:
+            return "openapi"
+        if "asyncapi" in document:
+            return "asyncapi"
+        schema = str((document.get("info") or {}).get("schema") or "")
+        if "schema.getpostman.com" in schema:
+            return "postman"
+        if "__schema" in document or "__schema" in (document.get("data") or {}):
+            return "graphql"
+        if any(
+            key in document for key in ("mcpServers", "server", "serverUrl", "tools")
+        ):
+            return "mcp"
+    try:
+        document = _structured(raw, yaml_allowed=True)
+    except VSDContractError:
+        document = {}
+    if "openapi" in document:
+        return "openapi"
+    if "asyncapi" in document:
+        return "asyncapi"
+    raise VSDContractError("Contract format could not be detected; pass format_hint")
+
+
+def inspect_contract_document(
+    path: str | Path,
+    *,
+    format_hint: str | None = None,
+    endpoint: str | None = None,
+) -> dict[str, Any]:
+    """Inspect one local contract without network access or code execution."""
+    source, raw, document_sha256 = _read_bytes(path)
+    hint = str(format_hint or "").casefold().lstrip(".")
+    source_format = (
+        _FORMAT_ALIASES.get(hint, hint) if hint else detect_contract_format(source, raw)
+    )
+    if source_format == "openapi":
+        if endpoint is not None:
+            raise VSDContractError("OpenAPI endpoints come from the reviewed document")
+        return inspect_openapi_document(source)
+    handlers: dict[str, Callable[[Path, bytes, str, str | None], dict[str, Any]]] = {
+        "graphql": _inspect_graphql,
+        "asyncapi": _inspect_asyncapi,
+        "postman": _inspect_postman,
+        "wsdl": _inspect_wsdl,
+        "protobuf": _inspect_protobuf,
+        "mcp": _inspect_mcp,
+    }
+    handler = handlers.get(source_format)
+    if handler is None:
+        raise VSDContractError(f"Unsupported contract format: {source_format!r}")
+    return handler(source, raw, document_sha256, endpoint)

--- a/src/tooluniverse/vsd_contracts_cli.py
+++ b/src/tooluniverse/vsd_contracts_cli.py
@@ -1,0 +1,61 @@
+"""Administrator CLI for local, inert multi-format contract inspection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .vsd_contracts import VSDContractError, inspect_contract_document
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="tooluniverse-vsd-contracts")
+    parser.add_argument("contract", type=Path, help="Local contract file")
+    parser.add_argument(
+        "--format",
+        choices=[
+            "openapi",
+            "graphql",
+            "asyncapi",
+            "postman",
+            "wsdl",
+            "protobuf",
+            "mcp",
+        ],
+        dest="format_hint",
+        help="Override automatic format detection",
+    )
+    parser.add_argument(
+        "--endpoint",
+        help="Reviewed HTTPS endpoint when the format does not embed one",
+    )
+    parser.add_argument("--output", type=Path, help="Write the report to this file")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    namespace = build_parser().parse_args(argv)
+    try:
+        report = inspect_contract_document(
+            namespace.contract,
+            format_hint=namespace.format_hint,
+            endpoint=namespace.endpoint,
+        )
+        rendered = (
+            json.dumps(report, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+        )
+        if namespace.output:
+            namespace.output.write_text(rendered, encoding="utf-8")
+        else:
+            sys.stdout.write(rendered)
+        return 0
+    except (OSError, VSDContractError, ValueError) as exc:
+        sys.stderr.write(json.dumps({"status": "error", "error": str(exc)}) + "\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_vsd_contracts.py
+++ b/tests/unit/test_vsd_contracts.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+
+import pytest
+import yaml
+
+from tooluniverse.vsd_contracts import (
+    VSDContractError,
+    detect_contract_format,
+    inspect_contract_document,
+    validate_contract_candidate,
+)
+from tooluniverse.vsd_contracts_cli import main
+
+pytestmark = pytest.mark.unit
+
+
+def _write(tmp_path, name: str, contents: str | bytes):
+    path = tmp_path / name
+    if isinstance(contents, bytes):
+        path.write_bytes(contents)
+    else:
+        path.write_text(contents, encoding="utf-8")
+    return path
+
+
+def test_graphql_sdl_inspects_queries_and_blocks_mutations(tmp_path):
+    path = _write(
+        tmp_path,
+        "rare-disease.graphql",
+        """
+        enum EvidenceLevel { DEFINITIVE STRONG MODERATE }
+        input DiseaseFilter { mondoId: ID!, minEvidence: EvidenceLevel }
+        type GeneEvidence { gene: String!, score: Float! }
+        type Disease { id: ID!, genes: [GeneEvidence!]! }
+        type Query {
+          disease(filter: DiseaseFilter!): Disease
+          searchDiseases(term: String!, limit: Int): [Disease!]!
+        }
+        type Mutation { nominateGene(diseaseId: ID!, gene: String!): Boolean! }
+        """,
+    )
+    report = inspect_contract_document(
+        path, endpoint="https://registry.example.org/graphql"
+    )
+
+    assert report["source_format"] == "graphql"
+    assert report["candidate_count"] == 3
+    disease = next(item for item in report["candidates"] if item["name"] == "disease")
+    mutation = next(
+        item for item in report["candidates"] if item["name"] == "nominateGene"
+    )
+    assert disease["blockers"] == []
+    assert disease["input_schema"]["required"] == ["filter"]
+    assert disease["input_schema"]["properties"]["filter"]["properties"]["minEvidence"][
+        "enum"
+    ] == ["DEFINITIVE", "MODERATE", "STRONG"]
+    assert mutation["blockers"] == ["graphql_mutation_requires_explicit_review"]
+    assert validate_contract_candidate(disease) == disease
+
+
+def test_graphql_introspection_json_is_supported(tmp_path):
+    from graphql import build_schema, get_introspection_query, graphql_sync
+
+    schema = build_schema("type Query { variant(id: ID!): String! }")
+    result = graphql_sync(schema, get_introspection_query()).data
+    path = _write(tmp_path, "schema.json", json.dumps({"data": result}))
+    report = inspect_contract_document(
+        path,
+        format_hint="graphql",
+        endpoint="https://genomics.example.org/graphql",
+    )
+    assert report["candidate_count"] == 1
+    assert report["candidates"][0]["name"] == "variant"
+
+
+def test_asyncapi_v2_preserves_event_schema_and_blocks_network_runtime(tmp_path):
+    document = {
+        "asyncapi": "2.6.0",
+        "info": {"title": "Clinical alerts", "version": "1.0.0"},
+        "servers": {
+            "production": {
+                "url": "https://events.example.org",
+                "protocol": "https",
+            }
+        },
+        "channels": {
+            "rare-disease/alerts": {
+                "subscribe": {
+                    "operationId": "receiveRareDiseaseAlert",
+                    "message": {
+                        "payload": {
+                            "type": "object",
+                            "properties": {
+                                "patientKey": {"type": "string"},
+                                "mondoId": {"type": "string"},
+                                "severity": {"type": "integer"},
+                            },
+                            "required": ["patientKey", "mondoId", "severity"],
+                        }
+                    },
+                }
+            }
+        },
+    }
+    path = _write(tmp_path, "alerts.yaml", yaml.safe_dump(document))
+    report = inspect_contract_document(path)
+    candidate = report["candidates"][0]
+    assert candidate["contract"]["channel"] == "rare-disease/alerts"
+    assert candidate["output_schema"]["required"] == [
+        "patientKey",
+        "mondoId",
+        "severity",
+    ]
+    assert "asyncapi_subscribe_requires_bounded_event_runtime" in candidate["blockers"]
+
+
+def test_asyncapi_v3_operation_references_are_supported(tmp_path):
+    document = {
+        "asyncapi": "3.0.0",
+        "info": {"title": "Variant events", "version": "2"},
+        "servers": {"production": {"host": "events.example.org", "protocol": "https"}},
+        "channels": {
+            "variantAlerts": {
+                "address": "variants/{variantId}/alerts",
+                "servers": [{"$ref": "#/servers/production"}],
+            }
+        },
+        "operations": {
+            "receiveVariantAlert": {
+                "action": "receive",
+                "channel": {"$ref": "#/channels/variantAlerts"},
+                "messages": [{"$ref": "#/components/messages/variantAlert"}],
+            }
+        },
+        "components": {
+            "messages": {
+                "variantAlert": {
+                    "payload": {
+                        "type": "object",
+                        "properties": {"variantId": {"type": "string"}},
+                    }
+                }
+            }
+        },
+    }
+    path = _write(tmp_path, "asyncapi.json", json.dumps(document))
+    candidate = inspect_contract_document(path)["candidates"][0]
+    assert candidate["kind"] == "asyncapi_receive"
+    assert candidate["endpoint"] == "https://events.example.org"
+    assert candidate["contract"]["channel"] == "variants/{variantId}/alerts"
+    assert candidate["output_schema"]["properties"]["variantId"] == {"type": "string"}
+
+
+def test_postman_collection_resolves_declared_variables_but_not_secrets(tmp_path):
+    document = {
+        "info": {
+            "name": "Oncology evidence",
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        },
+        "variable": [{"key": "baseUrl", "value": "https://evidence.example.org"}],
+        "item": [
+            {
+                "name": "Evidence",
+                "item": [
+                    {
+                        "name": "Find variants",
+                        "request": {
+                            "method": "GET",
+                            "url": {
+                                "raw": "{{baseUrl}}/variants?gene={{gene}}",
+                                "query": [{"key": "gene", "value": "{{gene}}"}],
+                            },
+                        },
+                    },
+                    {
+                        "name": "Submit review",
+                        "request": {
+                            "method": "POST",
+                            "url": "{{baseUrl}}/review",
+                            "body": {"mode": "raw", "raw": "{}"},
+                        },
+                    },
+                ],
+            }
+        ],
+    }
+    path = _write(tmp_path, "oncology.postman_collection.json", json.dumps(document))
+    report = inspect_contract_document(path)
+    get, post = report["candidates"]
+    assert get["name"] == "Evidence/Find variants"
+    assert "unresolved_postman_variable:gene" in get["blockers"]
+    assert "postman_non_read_method_requires_explicit_review" in post["blockers"]
+    assert "postman_raw_body_requires_review" in post["blockers"]
+
+
+def test_wsdl_inspects_soap_operation_without_resolving_external_entities(tmp_path):
+    path = _write(
+        tmp_path,
+        "laboratory.wsdl",
+        """<?xml version="1.0"?>
+        <definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+          xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" name="LabService">
+          <portType name="LabPort">
+            <operation name="GetGeneticPanel">
+              <input message="GetPanelRequest"/><output message="GetPanelResponse"/>
+            </operation>
+          </portType>
+          <binding name="LabBinding" type="LabPort">
+            <operation name="GetGeneticPanel">
+              <soap:operation soapAction="urn:GetGeneticPanel"/>
+            </operation>
+          </binding>
+          <service name="LabService"><port name="LabPort" binding="LabBinding">
+            <soap:address location="https://lab.example.org/soap"/>
+          </port></service>
+        </definitions>""",
+    )
+    candidate = inspect_contract_document(path)["candidates"][0]
+    assert candidate["name"] == "LabPort.GetGeneticPanel"
+    assert candidate["contract"]["soap_action"] == "urn:GetGeneticPanel"
+    assert candidate["blockers"] == [
+        "soap_operation_requires_explicit_read_only_review"
+    ]
+
+    malicious = _write(
+        tmp_path,
+        "external.wsdl",
+        '<!DOCTYPE x [<!ENTITY file SYSTEM "file:///etc/passwd">]><definitions/>',
+    )
+    with pytest.raises(VSDContractError, match="DTDs and entities"):
+        inspect_contract_document(malicious)
+
+
+def test_protobuf_inspects_unary_and_streaming_rpcs(tmp_path):
+    path = _write(
+        tmp_path,
+        "genomics.proto",
+        """
+        syntax = "proto3";
+        package genomics.v1;
+        message VariantRequest { string variant_id = 1; repeated string transcript = 2; }
+        message Evidence { string gene = 1; double score = 2; }
+        service VariantService {
+          rpc GetEvidence(VariantRequest) returns (Evidence);
+          rpc WatchEvidence(VariantRequest) returns (stream Evidence);
+        }
+        """,
+    )
+    report = inspect_contract_document(path, endpoint="https://grpc.example.org")
+    assert report["candidate_count"] == 2
+    unary, streaming = report["candidates"]
+    assert unary["name"] == "genomics.v1.VariantService.GetEvidence"
+    assert unary["input_schema"]["properties"]["variant_id"]["field_number"] == 1
+    assert "grpc_server_stream_requires_bounded_runtime" in streaming["blockers"]
+
+
+def test_mcp_manifest_distinguishes_remote_tools_from_local_commands(tmp_path):
+    document = {
+        "mcpServers": {
+            "literature": {
+                "url": "https://mcp.example.org/mcp",
+                "transport": "http",
+                "tools": [{"name": "search_trials"}],
+            },
+            "unsafe-local": {"command": "python", "args": ["server.py"]},
+        }
+    }
+    path = _write(tmp_path, "research.mcp.json", json.dumps(document))
+    report = inspect_contract_document(path)
+    remote, local = report["candidates"]
+    assert remote["name"] == "literature"
+    assert remote["contract"]["declared_tools"] == ["search_trials"]
+    assert "mcp_local_command_not_allowed" in local["blockers"]
+
+
+def test_detection_validation_integrity_and_bounds_fail_closed(tmp_path):
+    gql = _write(tmp_path, "schema.gql", "type Query { ping: String }")
+    assert detect_contract_format(gql) == "graphql"
+
+    candidate = inspect_contract_document(
+        gql, endpoint="https://api.example.org/graphql"
+    )["candidates"][0]
+    modified = deepcopy(candidate)
+    modified["endpoint"] = "https://attacker.example.org/graphql"
+    with pytest.raises(VSDContractError, match="digest"):
+        validate_contract_candidate(modified)
+
+    duplicate = _write(
+        tmp_path, "duplicate.json", '{"asyncapi":"2.6.0","asyncapi":"3.0.0"}'
+    )
+    with pytest.raises(VSDContractError, match="Duplicate"):
+        inspect_contract_document(duplicate, format_hint="asyncapi")
+
+    large = _write(tmp_path, "large.proto", b"x" * 1_000_001)
+    with pytest.raises(VSDContractError, match="1 MB"):
+        inspect_contract_document(large)
+
+
+def test_cli_writes_deterministic_report(tmp_path, capsys):
+    path = _write(tmp_path, "schema.graphql", "type Query { disease(id: ID!): String }")
+    output = tmp_path / "report.json"
+    args = [
+        str(path),
+        "--endpoint",
+        "https://api.example.org/graphql",
+        "--output",
+        str(output),
+    ]
+    assert main(args) == 0
+    first = output.read_bytes()
+    assert main(args) == 0
+    assert output.read_bytes() == first
+    assert json.loads(first)["candidate_count"] == 1
+    assert capsys.readouterr().err == ""
+
+
+def test_openapi_is_delegated_to_existing_hardened_inspector(tmp_path):
+    document = {
+        "openapi": "3.0.3",
+        "info": {"title": "Disease API", "version": "1"},
+        "servers": [{"url": "https://api.example.org"}],
+        "paths": {
+            "/disease": {
+                "get": {
+                    "operationId": "getDisease",
+                    "responses": {
+                        "200": {
+                            "description": "ok",
+                            "content": {
+                                "application/json": {"schema": {"type": "object"}}
+                            },
+                        }
+                    },
+                }
+            }
+        },
+    }
+    path = _write(tmp_path, "openapi.json", json.dumps(document))
+    report = inspect_contract_document(path)
+    assert report["format"] == "vsd_openapi_inspection_v1"
+    assert report["promotable_count"] == 1

--- a/tests/unit/test_vsd_multiformat_contract_case_study.py
+++ b/tests/unit/test_vsd_multiformat_contract_case_study.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from examples.vsd.multiformat_contract_case_study import run_case
+
+pytestmark = pytest.mark.unit
+
+
+def test_multiformat_case_study_is_complete_and_deterministic():
+    first = run_case()
+    second = run_case()
+    assert first == second
+    assert first["case_count"] == 6
+    assert first["operation_count"] == 10
+    assert first["assertion_count"] == 27
+    assert all(item["passed"] for item in first["assertions"])


### PR DESCRIPTION
## Purpose
Extend VSD's local inspection boundary beyond OpenAPI without making unreviewed provider operations executable.

## Formats
- GraphQL SDL and introspection JSON, including input objects, enums, queries, mutations, and subscriptions
- AsyncAPI 2.x and 3.x, including 3.x operation/channel/message references
- Postman collection 2.0/2.1 with bounded variable resolution
- WSDL 1.1/2.0 operation and SOAP action inventory with DTD/entity rejection
- gRPC/protobuf service, RPC, message, and streaming inventory
- MCP remote manifests and captured tool inventories, with local command servers blocked
- OpenAPI delegated to the existing hardened inspector

## Safety and review boundaries
Every new candidate is inert, content-addressed, tied to the exact local document hash, and carries explicit blockers. Inspection performs no network request, opens no listener or RPC channel, and runs no MCP command. Files are UTF-8, limited to 1 MB, depth and node bounded, duplicate-key checked, and parsed with safe YAML/XML settings.

## Evidence
The SMA heterogeneous evidence portfolio contains six focused cases: rare-disease GraphQL, safety-event AsyncAPI, cohort Postman, diagnostic-lab WSDL, variant gRPC, and literature MCP. It inventories 10 operations and passes 27 deterministic assertions.

Artifacts:
- `examples/vsd/artifacts/multiformat_contract_snapshot.md`
- `examples/vsd/artifacts/multiformat_contract_snapshot.json`

Verification:
- 232 cumulative VSD tests passed
- 12 focused parser and case-study tests passed
- Ruff 0.14.5 check and format check passed
- `git diff --check` passed