### PR TITLE
Bind VSD contracts to exact reviewed runtime operations

### DIFF
--- a/examples/vsd/README.md
+++ b/examples/vsd/README.md
@@ -1,5 +1,39 @@
 # ToolUniverse VSD Validation Case Studies
 
+## Cross-Format Source-To-Runtime Total Proof
+
+`cross_format_total_proof.py` connects the complete VSD stack in one ALS/DANDI
+growth loop. It audits the real ToolUniverse registry and the 50-source review
+catalog, separates an existing NIH RePORTER host from a DANDI capability gap,
+runs the bounded two-host scan twice, snapshots and inspects seven contract
+formats, and selects six DANDI operations while leaving the duplicate OpenAPI
+source unpromoted.
+
+Each selected operation is bound to its exact provider and format-specific
+identity before a draft can exist: GraphQL root field and arguments, Postman
+method and explicit template-variable map, WSDL endpoint/SOAPAction/body
+operation, protobuf authority/RPC/messages/streaming/descriptor, MCP declared
+tool, or AsyncAPI source endpoint/channel/payload schema. The portfolio then
+runs three representative cases per format, approves and publishes all six,
+loads them into a fresh ToolUniverse instance, and executes one final ALS
+request through every format. Eight cross-provider or cross-operation
+substitution attempts must fail before draft creation.
+
+The professional report also indexes sixteen concrete studies across PRs
+#416-#431, including registry reuse, dynamic REST, discovery, promotion, Docker,
+OpenAPI, workflow planning, private demand, credentials, lifecycle drift,
+multi-format contracts, reviewed runtime, and source intelligence. Run it from
+the repository root:
+
+```console
+PYTHONPATH=src python examples/vsd/cross_format_total_proof.py
+```
+
+Review `artifacts/cross_format_total_proof.md` and its machine-verifiable JSON
+counterpart. The checked proof contains 21 end-to-end assertions, 18 promotion
+verification executions, six final executions, and eight fail-closed
+substitution cases.
+
 ## Trusted-Source Intelligence And Review Handoff
 
 `source_intelligence_case_study.py` asks whether ToolUniverse can identify the

--- a/examples/vsd/artifacts/cross_format_total_proof.json
+++ b/examples/vsd/artifacts/cross_format_total_proof.json
@@ -1,0 +1,510 @@
+{
+  "adversarial_binding_cases": [
+    {
+      "case_id": "graphql_cross_provider",
+      "reason": "Reviewed runtime endpoint does not match the contract candidate",
+      "result": "rejected",
+      "source_format": "graphql"
+    },
+    {
+      "case_id": "postman_missing_parameter_map",
+      "reason": "Postman contract parameters must resolve every endpoint variable exactly",
+      "result": "rejected",
+      "source_format": "postman"
+    },
+    {
+      "case_id": "soap_action_substitution",
+      "reason": "Reviewed SOAPAction does not match the WSDL operation",
+      "result": "rejected",
+      "source_format": "wsdl"
+    },
+    {
+      "case_id": "soap_body_substitution",
+      "reason": "Reviewed SOAP body operation does not match the WSDL operation",
+      "result": "rejected",
+      "source_format": "wsdl"
+    },
+    {
+      "case_id": "grpc_rpc_substitution",
+      "reason": "gRPC method must occur exactly once in the reviewed descriptor set",
+      "result": "rejected",
+      "source_format": "protobuf"
+    },
+    {
+      "case_id": "mcp_undeclared_tool",
+      "reason": "Reviewed MCP tool is not declared by the contract candidate",
+      "result": "rejected",
+      "source_format": "mcp"
+    },
+    {
+      "case_id": "asyncapi_channel_substitution",
+      "reason": "Reviewed event channel or schema does not match the AsyncAPI candidate",
+      "result": "rejected",
+      "source_format": "asyncapi"
+    },
+    {
+      "case_id": "asyncapi_source_omission",
+      "reason": "Reviewed runtime endpoint does not match the contract candidate",
+      "result": "rejected",
+      "source_format": "asyncapi"
+    }
+  ],
+  "answer": "Yes. The case kept the already-covered NIH RePORTER interface out of promotion, selected six DANDI gap contracts, bound each to its exact provider and operation, passed eighteen verification executions, rejected eight substitution attempts, loaded six published tools into a fresh ToolUniverse instance, and executed a final ALS evidence request through each format.",
+  "audit_sha256": "0223d236556c284746e7acf5985f7fc2195f74de8ffcbe796d3dd4092e32c10b",
+  "end_to_end_assertions": {
+    "all_eight_substitution_attacks_were_rejected": true,
+    "all_prior_case_artifacts_or_ci_evidence_pass": true,
+    "all_six_publications_loaded_in_fresh_runtime": true,
+    "all_six_published_tools_executed": true,
+    "catalog_contains_50_review_only_sources": true,
+    "every_binding_names_its_contract_candidate": true,
+    "every_format_passed_three_verification_cases": true,
+    "every_promotion_has_exact_binding_hash": true,
+    "existing_reporter_source_was_not_promoted": true,
+    "grpc_binding_names_exact_descriptor_method": true,
+    "handoff_remained_local_and_unsubmitted": true,
+    "only_dandi_gap_candidates_were_promoted": true,
+    "portfolio_covers_every_prior_vsd_phase_pr": true,
+    "portfolio_includes_independent_docker_boundary": true,
+    "postman_template_has_explicit_parameter_map": true,
+    "seven_content_addressed_snapshots_exist": true,
+    "seven_formats_were_discovered": true,
+    "six_contract_formats_reached_promotion": true,
+    "source_intelligence_assertions_pass": true,
+    "two_tamper_detecting_cron_scans_exist": true,
+    "workflow_demand_credential_and_lifecycle_studies_are_present": true
+  },
+  "format": "vsd_cross_format_total_proof_v1",
+  "portfolio_case_count": 16,
+  "prior_case_studies": [
+    {
+      "all_checks_passed": true,
+      "artifact": "snapshot.json",
+      "artifact_sha256": "150cb5bf5a47f256cb316f4d774b982698270a1fe4b789a96fdc3edbf348a5ff",
+      "assertion_count": 6,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "public_health_foundation",
+      "phase": "reviewed source foundation",
+      "pull_request": 416,
+      "question": "Which Autauga County tracts warrant CHD evidence review without ranking people or making clinical claims?",
+      "result": "Six ToolUniverse calls combined reviewed CDC, WHO, FDA, PubMed, and trial evidence with explicit interpretation limits."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "dynamic_rest_als_snapshot.json",
+      "artifact_sha256": "36d2b2564777cb84fcec45c775ef19f7a6a8b7778647bf39df72e8d6338bd2c5",
+      "assertion_count": 3,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "dynamic_rest_als",
+      "phase": "reviewed dynamic REST",
+      "pull_request": 417,
+      "question": "Can a bounded generated ClinicalTrials.gov tool find active US ALS studies and retrieve one exact follow-up record?",
+      "result": "Two reviewed operations returned 20 search records and a consistent exact study detail."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "api_discovery_snapshot.json",
+      "artifact_sha256": "40e7a40e7a8b646eed21575409dd14ebc95c2e21494b6898928efa6f0c3ccccd",
+      "assertion_count": 4,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "api_discovery",
+      "phase": "catalog discovery",
+      "pull_request": 418,
+      "question": "Can demand for active cancer-trial fields identify one API-ready public dataset without executing it?",
+      "result": "One official NY dataset matched all six demanded capabilities and remained inert review material."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "tool_promotion_snapshot.json",
+      "artifact_sha256": "314447660d50e6731f9efb809cb80ef4036d1395335b5057a547a9cfe8bd72c3",
+      "assertion_count": 6,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "tool_promotion",
+      "phase": "verification and promotion",
+      "pull_request": 419,
+      "question": "Can one reviewed cancer dataset become two narrow tools only after representative verification?",
+      "result": "Two tools passed three cases each, were approved, published, freshly loaded, and executed."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": null,
+      "artifact_sha256": null,
+      "assertion_count": 30,
+      "evidence_boundary": "independent_real_container_ci",
+      "id": "docker_boundary",
+      "phase": "administrator-only Docker lifecycle",
+      "pull_request": 420,
+      "question": "Can a local inference service be provisioned without exposing Docker lifecycle control to an agent?",
+      "result": "Independent Linux CI proved a non-root, loopback-only, read-only, resource-bounded container lifecycle and exact payload hash."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "capability_coverage_snapshot.json",
+      "artifact_sha256": "6a609df6cc1b358e4d7b8492d86a08e7f86c28bc3c136c730a22583fd911ff3a",
+      "assertion_count": 4,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "capability_coverage",
+      "phase": "registry and workflow reuse",
+      "pull_request": 421,
+      "question": "Does ToolUniverse reuse an existing FDA tool or workflow before declaring a capability gap?",
+      "result": "Exact tools and a workflow were reused; only the intentional calibration request remained a discovery gap."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "openapi_als_snapshot.json",
+      "artifact_sha256": "5bcaf459ee431dc85e73bc0a679b315ac0dea1c4db217072154080fa5d89c7fb",
+      "assertion_count": 12,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "openapi_ingestion",
+      "phase": "OpenAPI inspection and promotion",
+      "pull_request": 423,
+      "question": "Can an ALS OpenAPI contract yield one selected read operation with exact provenance and fresh-runtime execution?",
+      "result": "Inspection, three-case verification, approval, publication, execution, and hash-chain validation passed."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "workflow_planning_snapshot.json",
+      "artifact_sha256": "9029051dc83ad4468945aa8c7f5d38fbc415a3906e75bf7ab013cd265edfd789",
+      "assertion_count": 12,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "workflow_planning",
+      "phase": "workflow-aware planning",
+      "pull_request": 424,
+      "question": "Can a multi-step ALS workflow distinguish reusable tools from the one missing step without executing during planning?",
+      "result": "Planning reused exact capabilities, isolated the gap, and changed only after explicit loading."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "demand_ledger_snapshot.json",
+      "artifact_sha256": "4595d89df2deebdc9efc08adcd71bede842768eb6439046d9969fc3acdd156eb",
+      "assertion_count": 13,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "demand_ledger",
+      "phase": "private unmet-demand ledger",
+      "pull_request": 425,
+      "question": "Can repeated missing needs be ranked locally and exported only as reviewed, sanitized proposals?",
+      "result": "Private observations were deduplicated, ranked, and explicitly exported without raw prompts."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "credential_reference_snapshot.json",
+      "artifact_sha256": "fb507eab0140918944fd2146ce8b40d48d59d768383a9c0effa91fec6d92b44c",
+      "assertion_count": 14,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "credential_reference",
+      "phase": "environment-backed credentials",
+      "pull_request": 426,
+      "question": "Can credentials rotate without changing the reviewed tool identity or leaking into artifacts?",
+      "result": "Initial and rotated credentials executed while configs, promotion records, results, and artifacts stayed secret-free."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "lifecycle_drift_snapshot.json",
+      "artifact_sha256": "be32d031a51f0292bc220c8e02b4c0b6c1a27640c76b7c07f959012585d8d5ee",
+      "assertion_count": 19,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "lifecycle_drift",
+      "phase": "suspension, drift, and recovery",
+      "pull_request": 427,
+      "question": "Can a published tool fail closed on contract drift and return only after reviewed recovery?",
+      "result": "Drift suspended loading, changed-schema evidence was reviewed, and recovery restored the exact tool."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "total_system_snapshot.json",
+      "artifact_sha256": "96ddf520f3ba584f263384dede4e310e5c3272061e49c7cd27e025c18588fdcc",
+      "assertion_count": 26,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "total_system",
+      "phase": "demand-to-runtime total system",
+      "pull_request": 428,
+      "question": "Can ALS demand move through discovery, review, promotion, use, resolution, suspension, and recovery as one system?",
+      "result": "The full demand-to-reviewed-tool loop passed with Docker preserved as an independent administrator boundary."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "multiformat_contract_snapshot.json",
+      "artifact_sha256": "bafe99b7be22d37ab0434fe752478becbd341d1ae5f8a2045c792e33cccb4a35",
+      "assertion_count": 27,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "multiformat_contracts",
+      "phase": "heterogeneous contract inspection",
+      "pull_request": 429,
+      "question": "Can six incompatible contract formats become an inert, content-addressed operation inventory?",
+      "result": "GraphQL, AsyncAPI, Postman, WSDL, protobuf, and MCP produced ten identified operations without execution."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "reviewed_runtime_snapshot.json",
+      "artifact_sha256": "73ab102b6f708ccdadc71d40916575fbf93f8af2f6e5d08de24af654ca9bc9d1",
+      "assertion_count": 33,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "reviewed_runtime",
+      "phase": "multi-protocol execution",
+      "pull_request": 430,
+      "question": "Can one rare-disease study execute reviewed GraphQL, REST, SOAP, gRPC, MCP, event, pagination, and response formats?",
+      "result": "Ten runtime cases and one full WSDL promotion case passed 33 assertions."
+    },
+    {
+      "all_checks_passed": true,
+      "artifact": "source_intelligence_snapshot.json",
+      "artifact_sha256": "cf1603032953a9b27a5891cd3c6c8866f547e54250885e4c47af074c93cb7ef8",
+      "assertion_count": 28,
+      "evidence_boundary": "checked_repository_artifact",
+      "id": "source_intelligence",
+      "phase": "organic source discovery and handoff",
+      "pull_request": 431,
+      "question": "Can official-source scanning find ALS interface gaps without duplicates, installation, or silent telemetry?",
+      "result": "Fifty sources, seven formats, two cron scans, seven snapshots, and one consent-bound local handoff passed 28 assertions."
+    }
+  ],
+  "promotion_stage": {
+    "loaded_tools": [
+      "VSDDandiAlsGraphQL",
+      "VSDDandiAlsGRPC",
+      "VSDDandiChangeEvent",
+      "VSDDandiDandisetREST",
+      "VSDDandiMetadataMCP",
+      "VSDDandiPreservationSOAP"
+    ],
+    "promoted_format_count": 6,
+    "records": [
+      {
+        "approval_sha256": "b55d713e00a6aedd3d7ebf54b68bf871ce6336bfcfc9de2e385c70de0fbce280",
+        "blockers_resolved": [],
+        "contract_binding": {
+          "binding_sha256": "10479bad6184df88fb51c030b2adb2ba9138b965031fd64965de4ec2e870d0e1",
+          "candidate_id": "5258ffea532f99e5",
+          "identity": {
+            "argument_variables": {
+              "diseaseTerm": "diseaseTerm",
+              "limit": "limit",
+              "recordingModality": "recordingModality",
+              "species": "species"
+            },
+            "endpoint": "https://api.dandiarchive.org/graphql",
+            "operation": "searchAlsElectrophysiology",
+            "root_field": "searchAlsElectrophysiology"
+          },
+          "parameter_map": {},
+          "source_format": "graphql",
+          "version": 1
+        },
+        "contract_candidate_id": "5258ffea532f99e5",
+        "draft_sha256": "e7c934bf3d484342a5725663f0e8f539e89a6baba0d56df1f8882251be03d6d5",
+        "final_result": {
+          "data": {
+            "searchAlsElectrophysiology": [
+              {
+                "id": "DANDI-ALS",
+                "name": "ALS motor-neuron electrophysiology",
+                "species": [
+                  "human"
+                ]
+              }
+            ]
+          }
+        },
+        "final_result_sha256": "0bede811bbd337cec362867215b00bc59d3acad19eafa2f4b701ba1744c21169",
+        "publication_sha256": "0d265773d29bc1483d2df3efa74434508d4aa0d897d7e2b08172223251f98c20",
+        "source_candidate_id": "8b0a9dd92107d112",
+        "source_document_sha256": "eaa8cb16c26b7af45b604bcc55c76bd16cbc9000aa234c8f2edd9aba327e9f4f",
+        "source_format": "graphql",
+        "tool_name": "VSDDandiAlsGraphQL",
+        "verification_case_count": 3,
+        "verification_sha256": "17d817c0d1a42da06d6a25abd53ff85e2e7c7dd56073f26dea048cb3631feb99"
+      },
+      {
+        "approval_sha256": "a8ef3f15b5cd15bbe54854f7638b90e9ad6e52c425d88f76bfc42e6ae4e862ce",
+        "blockers_resolved": [
+          "unresolved_postman_variable:dandisetId"
+        ],
+        "contract_binding": {
+          "binding_sha256": "968d53074f7410a265c7405b1413e303a7a2d7ebb6367cd6caa23e0d8afb9a7e",
+          "candidate_id": "77b2b38cfde95817",
+          "identity": {
+            "endpoint": "https://api.dandiarchive.org/api/dandisets/{dandiset_id}",
+            "operation": "Get dandiset"
+          },
+          "parameter_map": {
+            "dandisetId": "dandiset_id"
+          },
+          "source_format": "postman",
+          "version": 1
+        },
+        "contract_candidate_id": "77b2b38cfde95817",
+        "draft_sha256": "7587fffde1bc4a2c1aa867c669c20510dab2e1477ce61e8b650854bfadb1ade9",
+        "final_result": {
+          "dandiset_id": "000001",
+          "name": "ALS motor-neuron electrophysiology",
+          "status": "published"
+        },
+        "final_result_sha256": "bbcda30660be54c8efcd11069cdc20552dc849661a7f01738e2a0725c4fa4a9e",
+        "publication_sha256": "087ee6ddb8e54e0467d0e451fc34e8f32b3c7cd03b9f4755cbcbfc7bf6c0d862",
+        "source_candidate_id": "0bcde98740a1cb68",
+        "source_document_sha256": "431b094e9b7e21d8ffd15b8a8c24d2d7f19cd3d24a527aaafb0acedee0c54b8a",
+        "source_format": "postman",
+        "tool_name": "VSDDandiDandisetREST",
+        "verification_case_count": 3,
+        "verification_sha256": "1cd629ce70814e0ab171cb0b1a5cfe7d1941fc4a6240ac085e77d2b6c9e93a38"
+      },
+      {
+        "approval_sha256": "c4f9a0fe0f101d56a144162147583199d745c6bc50e01f4a5df7883d77bd7301",
+        "blockers_resolved": [
+          "soap_operation_requires_explicit_read_only_review"
+        ],
+        "contract_binding": {
+          "binding_sha256": "8dbf47b9c173647391715e77840d6c630282ad090bd8dfda6309b99bf96b10ea",
+          "candidate_id": "ce59c73b6db2d814",
+          "identity": {
+            "body_operation": "GetPreservationRecord",
+            "endpoint": "https://api.dandiarchive.org/soap",
+            "operation": "ArchivePort.GetPreservationRecord",
+            "soap_action": "urn:GetPreservationRecord"
+          },
+          "parameter_map": {},
+          "source_format": "wsdl",
+          "version": 1
+        },
+        "contract_candidate_id": "ce59c73b6db2d814",
+        "draft_sha256": "5648f86c08b5529527658134f4a5fc74c00afebc2a6396c7e7d2df77914be074",
+        "final_result": {
+          "Envelope": {
+            "Body": {
+              "PreservationRecord": {
+                "dandiset": "000001",
+                "status": "preserved"
+              }
+            }
+          }
+        },
+        "final_result_sha256": "50c785cedb17a54a55f93a56e98c563ef0eec3cfe1493d316f0d64f400ab54a5",
+        "publication_sha256": "b841f0bb73746403392ad2da133e45bc3e948045a3d9fc2a0f17e34e8e4e32dd",
+        "source_candidate_id": "337c09bea9551a8b",
+        "source_document_sha256": "4b06d56daff90719ccf4959deef3343e7ebc32f00287b38beff198e847fe932b",
+        "source_format": "wsdl",
+        "tool_name": "VSDDandiPreservationSOAP",
+        "verification_case_count": 3,
+        "verification_sha256": "ad16a0b4410ffbb01504f5bdccc40cfa2df605a18efa40637d9bb812a381348f"
+      },
+      {
+        "approval_sha256": "acc1471f8f5aa84dc76703968013fd3b48c07f5fc3337373dcbd698e9cdd3c75",
+        "blockers_resolved": [
+          "grpc_operation_requires_reviewed_channel"
+        ],
+        "contract_binding": {
+          "binding_sha256": "1e5ed56beea238bad1b7962c60705627d8cfc77649766ba6d6688b67bd4ed3cd",
+          "candidate_id": "8a78ae84471b57e8",
+          "identity": {
+            "endpoint": "api.dandiarchive.org:443",
+            "method": "/dandi.v1.DandisetService/SearchAlsDandisets",
+            "operation": "dandi.v1.DandisetService.SearchAlsDandisets",
+            "request_type": "dandi.v1.SearchRequest",
+            "response_type": "dandi.v1.DandisetMatch",
+            "streaming": "unary"
+          },
+          "parameter_map": {},
+          "source_format": "protobuf",
+          "version": 1
+        },
+        "contract_candidate_id": "8a78ae84471b57e8",
+        "draft_sha256": "3e1a4d8170b3fa67c96fc44b920d67bf1997d75741219c4595fc587aa35bb78d",
+        "final_result": {
+          "dandiset_id": "DANDI-ALS",
+          "name": "human electrophysiology evidence"
+        },
+        "final_result_sha256": "f6e343a501a986742c3f49143db9325a524cadb01355bf0c1be9bcbe1398f208",
+        "publication_sha256": "9cc7bbbe59b4cd7a8f8cbcd8623f17917e9de3dda11bc6deabdfbc63c9b1cc46",
+        "source_candidate_id": "2b085d7534524eec",
+        "source_document_sha256": "2bbc7a5a41c5b356c4f729ebd884cf8ceeac1408f04bfaef5fd724382b13e5fb",
+        "source_format": "protobuf",
+        "tool_name": "VSDDandiAlsGRPC",
+        "verification_case_count": 3,
+        "verification_sha256": "7b6372d085058844237a7388cc3d6f73ee13c4fde9cd92486d682f5622beb0a7"
+      },
+      {
+        "approval_sha256": "09a5d485f1a93d30816d3fb28a2454459a86c5df085302634c7e341e1a3a99ea",
+        "blockers_resolved": [],
+        "contract_binding": {
+          "binding_sha256": "ac4ae3b56190e92ef0a846be695d578e4a114461146dfd4fdba19f69553ea38f",
+          "candidate_id": "4676bbac08357799",
+          "identity": {
+            "endpoint": "https://api.dandiarchive.org/mcp",
+            "operation": "dandi-readonly",
+            "tool_name": "search_dandisets"
+          },
+          "parameter_map": {},
+          "source_format": "mcp",
+          "version": 1
+        },
+        "contract_candidate_id": "4676bbac08357799",
+        "draft_sha256": "c749c0bf915b4ee71112e59cbee032b1f6e4bf990407760ee45a069e8edb934e",
+        "final_result": {
+          "content": [
+            {
+              "text": "ALS matched human electrophysiology dandisets",
+              "type": "text"
+            }
+          ]
+        },
+        "final_result_sha256": "c10fd43209262d0af7c7fc694abc12128419915e519e4663408f57a9b67fdad5",
+        "publication_sha256": "3b36814862544b35623c6b99a006850f8b09101d99e8def3db6efcd3d63cdea8",
+        "source_candidate_id": "6c8bde3aca1532fe",
+        "source_document_sha256": "39c915c85d0c6a0d4198591dd11849f2356290927317330abb4eb7a7d482adc4",
+        "source_format": "mcp",
+        "tool_name": "VSDDandiMetadataMCP",
+        "verification_case_count": 3,
+        "verification_sha256": "7feb0e04ef08d948b94bad816ba4f50a0bba1134c0c465b5e82e08a58ffb59e0"
+      },
+      {
+        "approval_sha256": "31e10dc76a9251362419fad19852d8e9f633df3a0f6196a1d3c255be796709d0",
+        "blockers_resolved": [
+          "asyncapi_receive_requires_bounded_event_runtime"
+        ],
+        "contract_binding": {
+          "binding_sha256": "5d344f16a5977a2df29d1f25932ffe6604d2416f361646ba677b8c0ad1683b52",
+          "candidate_id": "4f2ca3173d22c668",
+          "identity": {
+            "action": "receive",
+            "channel": "dandisets/{dandisetId}/changes",
+            "endpoint": "https://api.dandiarchive.org",
+            "event_schema_sha256": "44f860514fbe91de1282931b5834fa300d476d2f7acb2d3c7f7289951fbf707a",
+            "operation": "receiveDandisetChange"
+          },
+          "parameter_map": {},
+          "source_format": "asyncapi",
+          "version": 1
+        },
+        "contract_candidate_id": "4f2ca3173d22c668",
+        "draft_sha256": "9b61690ce6af3b8c1e80bd35f5453bb3d8762eeb24f66bf39fb9d88a776a58b8",
+        "final_result": {
+          "changedAt": "2026-08-01T10:00:00Z",
+          "dandisetId": "000001",
+          "version": "0.26.0"
+        },
+        "final_result_sha256": "f52963356a5498c7c4e1f45dfc177230b874919b4acdce26d390135d0dbf52d3",
+        "publication_sha256": "e879154ae24885aec457d969ac62d3e5fc97ce3a04aa8f987548786b19440090",
+        "source_candidate_id": "3749e161339371d5",
+        "source_document_sha256": "579c0a9a5485da13aac72cdb0b35d211b9f1e4463705afd7d077f12e6f23a75f",
+        "source_format": "asyncapi",
+        "tool_name": "VSDDandiChangeEvent",
+        "verification_case_count": 3,
+        "verification_sha256": "9395352db609fddc66530ec7a7f112dd9248d22df0ec05ad17dc5e60c236c2c7"
+      }
+    ],
+    "verification_case_count": 18
+  },
+  "research_question": "Can a real ToolUniverse capability gap move from reviewed source discovery through bounded scanning, content-addressed inspection, exact contract binding, representative verification, approval, publication, fresh-runtime loading, and useful execution across every supported format without duplicating an existing source or widening authority?",
+  "source_stage": {
+    "catalog_source_count": 50,
+    "configured_host_count": 259,
+    "configured_tool_count": 2744,
+    "cron_scan_count": 2,
+    "discovered_format_count": 7,
+    "handoff_submitted": false,
+    "snapshot_count": 7,
+    "source_audit_sha256": "77f1c2387067a7d99252ca5625688cc9634c68f972fa0bb292f960de9962a268"
+  },
+  "title": "ALS source-to-reviewed-runtime cross-format total proof",
+  "version": 1
+}

--- a/examples/vsd/artifacts/cross_format_total_proof.md
+++ b/examples/vsd/artifacts/cross_format_total_proof.md
@@ -1,0 +1,95 @@
+# ALS Source-To-Reviewed-Runtime Cross-Format Total Proof
+
+## Research question
+
+Can a real ToolUniverse capability gap move from reviewed source discovery through bounded scanning, content-addressed inspection, exact contract binding, representative verification, approval, publication, fresh-runtime loading, and useful execution across every supported format without duplicating an existing source or widening authority?
+
+## Result
+
+Yes. The case kept the already-covered NIH RePORTER interface out of promotion, selected six DANDI gap contracts, bound each to its exact provider and operation, passed eighteen verification executions, rejected eight substitution attempts, loaded six published tools into a fresh ToolUniverse instance, and executed a final ALS evidence request through each format.
+
+## Connected end-to-end path
+
+1. Audit 2,744 configured tools, 259 configured hosts, and the review-only 50-source catalog.
+2. Separate the existing NIH RePORTER host from the missing DANDI capability.
+3. Crawl two explicit hosts under robots, host, page, depth, byte, and time bounds.
+4. Snapshot and inspect OpenAPI, GraphQL, AsyncAPI, Postman, WSDL, protobuf, and MCP documents without execution.
+5. Leave existing OpenAPI coverage alone; select six DANDI gap operations for review.
+6. Bind provider, operation, method, parameters, and format-specific identity into each promotion digest.
+7. Run three representative cases per operation, approve and publish, then load only into a fresh runtime.
+8. Execute the six resulting tools and preserve the independent administrator-only Docker boundary.
+
+## Six-format promotion and execution
+
+| Format | Tool | Exact bound identity | Verification cases | Final result SHA-256 |
+| --- | --- | --- | ---: | --- |
+| graphql | `VSDDandiAlsGraphQL` | `searchAlsElectrophysiology` | 3 | `0bede811bbd337cec362867215b00bc59d3acad19eafa2f4b701ba1744c21169` |
+| postman | `VSDDandiDandisetREST` | `Get dandiset` | 3 | `bbcda30660be54c8efcd11069cdc20552dc849661a7f01738e2a0725c4fa4a9e` |
+| wsdl | `VSDDandiPreservationSOAP` | `GetPreservationRecord` | 3 | `50c785cedb17a54a55f93a56e98c563ef0eec3cfe1493d316f0d64f400ab54a5` |
+| protobuf | `VSDDandiAlsGRPC` | `/dandi.v1.DandisetService/SearchAlsDandisets` | 3 | `f6e343a501a986742c3f49143db9325a524cadb01355bf0c1be9bcbe1398f208` |
+| mcp | `VSDDandiMetadataMCP` | `search_dandisets` | 3 | `c10fd43209262d0af7c7fc694abc12128419915e519e4663408f57a9b67fdad5` |
+| asyncapi | `VSDDandiChangeEvent` | `dandisets/{dandisetId}/changes` | 3 | `f52963356a5498c7c4e1f45dfc177230b874919b4acdce26d390135d0dbf52d3` |
+
+## Fail-closed substitution cases
+
+| Attempt | Format | Result | Boundary that rejected it |
+| --- | --- | --- | --- |
+| `graphql_cross_provider` | graphql | rejected | Reviewed runtime endpoint does not match the contract candidate |
+| `postman_missing_parameter_map` | postman | rejected | Postman contract parameters must resolve every endpoint variable exactly |
+| `soap_action_substitution` | wsdl | rejected | Reviewed SOAPAction does not match the WSDL operation |
+| `soap_body_substitution` | wsdl | rejected | Reviewed SOAP body operation does not match the WSDL operation |
+| `grpc_rpc_substitution` | protobuf | rejected | gRPC method must occur exactly once in the reviewed descriptor set |
+| `mcp_undeclared_tool` | mcp | rejected | Reviewed MCP tool is not declared by the contract candidate |
+| `asyncapi_channel_substitution` | asyncapi | rejected | Reviewed event channel or schema does not match the AsyncAPI candidate |
+| `asyncapi_source_omission` | asyncapi | rejected | Reviewed runtime endpoint does not match the contract candidate |
+
+## Sixteen professional case studies
+
+| PR | Phase and question | Concrete result | Checks/assertions |
+| --- | --- | --- | ---: |
+| [#416](https://github.com/mims-harvard/ToolUniverse/pull/416) | **reviewed source foundation**: Which Autauga County tracts warrant CHD evidence review without ranking people or making clinical claims? | Six ToolUniverse calls combined reviewed CDC, WHO, FDA, PubMed, and trial evidence with explicit interpretation limits. | 6 |
+| [#417](https://github.com/mims-harvard/ToolUniverse/pull/417) | **reviewed dynamic REST**: Can a bounded generated ClinicalTrials.gov tool find active US ALS studies and retrieve one exact follow-up record? | Two reviewed operations returned 20 search records and a consistent exact study detail. | 3 |
+| [#418](https://github.com/mims-harvard/ToolUniverse/pull/418) | **catalog discovery**: Can demand for active cancer-trial fields identify one API-ready public dataset without executing it? | One official NY dataset matched all six demanded capabilities and remained inert review material. | 4 |
+| [#419](https://github.com/mims-harvard/ToolUniverse/pull/419) | **verification and promotion**: Can one reviewed cancer dataset become two narrow tools only after representative verification? | Two tools passed three cases each, were approved, published, freshly loaded, and executed. | 6 |
+| [#420](https://github.com/mims-harvard/ToolUniverse/pull/420) | **administrator-only Docker lifecycle**: Can a local inference service be provisioned without exposing Docker lifecycle control to an agent? | Independent Linux CI proved a non-root, loopback-only, read-only, resource-bounded container lifecycle and exact payload hash. | 30 |
+| [#421](https://github.com/mims-harvard/ToolUniverse/pull/421) | **registry and workflow reuse**: Does ToolUniverse reuse an existing FDA tool or workflow before declaring a capability gap? | Exact tools and a workflow were reused; only the intentional calibration request remained a discovery gap. | 4 |
+| [#423](https://github.com/mims-harvard/ToolUniverse/pull/423) | **OpenAPI inspection and promotion**: Can an ALS OpenAPI contract yield one selected read operation with exact provenance and fresh-runtime execution? | Inspection, three-case verification, approval, publication, execution, and hash-chain validation passed. | 12 |
+| [#424](https://github.com/mims-harvard/ToolUniverse/pull/424) | **workflow-aware planning**: Can a multi-step ALS workflow distinguish reusable tools from the one missing step without executing during planning? | Planning reused exact capabilities, isolated the gap, and changed only after explicit loading. | 12 |
+| [#425](https://github.com/mims-harvard/ToolUniverse/pull/425) | **private unmet-demand ledger**: Can repeated missing needs be ranked locally and exported only as reviewed, sanitized proposals? | Private observations were deduplicated, ranked, and explicitly exported without raw prompts. | 13 |
+| [#426](https://github.com/mims-harvard/ToolUniverse/pull/426) | **environment-backed credentials**: Can credentials rotate without changing the reviewed tool identity or leaking into artifacts? | Initial and rotated credentials executed while configs, promotion records, results, and artifacts stayed secret-free. | 14 |
+| [#427](https://github.com/mims-harvard/ToolUniverse/pull/427) | **suspension, drift, and recovery**: Can a published tool fail closed on contract drift and return only after reviewed recovery? | Drift suspended loading, changed-schema evidence was reviewed, and recovery restored the exact tool. | 19 |
+| [#428](https://github.com/mims-harvard/ToolUniverse/pull/428) | **demand-to-runtime total system**: Can ALS demand move through discovery, review, promotion, use, resolution, suspension, and recovery as one system? | The full demand-to-reviewed-tool loop passed with Docker preserved as an independent administrator boundary. | 26 |
+| [#429](https://github.com/mims-harvard/ToolUniverse/pull/429) | **heterogeneous contract inspection**: Can six incompatible contract formats become an inert, content-addressed operation inventory? | GraphQL, AsyncAPI, Postman, WSDL, protobuf, and MCP produced ten identified operations without execution. | 27 |
+| [#430](https://github.com/mims-harvard/ToolUniverse/pull/430) | **multi-protocol execution**: Can one rare-disease study execute reviewed GraphQL, REST, SOAP, gRPC, MCP, event, pagination, and response formats? | Ten runtime cases and one full WSDL promotion case passed 33 assertions. | 33 |
+| [#431](https://github.com/mims-harvard/ToolUniverse/pull/431) | **organic source discovery and handoff**: Can official-source scanning find ALS interface gaps without duplicates, installation, or silent telemetry? | Fifty sources, seven formats, two cron scans, seven snapshots, and one consent-bound local handoff passed 28 assertions. | 28 |
+| This PR | **cross-format total proof**: Can every implemented phase operate as one source-to-runtime system? | Six promotions, eighteen verification runs, six final executions, and eight rejected substitutions. | 21 |
+
+## End-to-end assertions
+
+- `all_eight_substitution_attacks_were_rejected`: passed
+- `all_prior_case_artifacts_or_ci_evidence_pass`: passed
+- `all_six_publications_loaded_in_fresh_runtime`: passed
+- `all_six_published_tools_executed`: passed
+- `catalog_contains_50_review_only_sources`: passed
+- `every_binding_names_its_contract_candidate`: passed
+- `every_format_passed_three_verification_cases`: passed
+- `every_promotion_has_exact_binding_hash`: passed
+- `existing_reporter_source_was_not_promoted`: passed
+- `grpc_binding_names_exact_descriptor_method`: passed
+- `handoff_remained_local_and_unsubmitted`: passed
+- `only_dandi_gap_candidates_were_promoted`: passed
+- `portfolio_covers_every_prior_vsd_phase_pr`: passed
+- `portfolio_includes_independent_docker_boundary`: passed
+- `postman_template_has_explicit_parameter_map`: passed
+- `seven_content_addressed_snapshots_exist`: passed
+- `seven_formats_were_discovered`: passed
+- `six_contract_formats_reached_promotion`: passed
+- `source_intelligence_assertions_pass`: passed
+- `two_tamper_detecting_cron_scans_exist`: passed
+- `workflow_demand_credential_and_lifecycle_studies_are_present`: passed
+
+## Interpretation boundary
+
+This proves software behavior, provenance, review gates, bounded transport, and deterministic fixture execution. It does not certify a provider's scientific content, convert catalog membership into trust for execution, submit the local handoff, or expose Docker lifecycle operations to an agent.
+
+Audit SHA-256: `0223d236556c284746e7acf5985f7fc2195f74de8ffcbe796d3dd4092e32c10b`

--- a/examples/vsd/artifacts/reviewed_runtime_snapshot.json
+++ b/examples/vsd/artifacts/reviewed_runtime_snapshot.json
@@ -167,17 +167,17 @@
       "passed": true
     }
   ],
-  "case_sha256": "05e0870fe14c61d560e483fcec472c9eeeabfb28f1042587fbe37e56ab8bd310",
+  "case_sha256": "2abc19e009936ad730ccb3a547d143c95b8dec992654e2d52e1d84d684a99386",
   "case_title": "SMA multi-protocol evidence execution portfolio",
   "clinical_question": "Can ToolUniverse combine rare-disease genes, longitudinal motor scores, molecular diagnostics, trials, safety signals, literature, and variant classification when providers use incompatible reviewed protocols and formats?",
   "conclusion": "Yes. Ten runtime cases exercised reviewed GraphQL, REST, SOAP, gRPC, MCP, webhook, OAuth, multipart, pagination, JSON, CSV, XML, HTML, binary, and SSE contracts; an eleventh case completed draft-through-fresh-runtime promotion.",
   "format": "vsd_reviewed_runtime_case_v1",
   "promotion": {
-    "approval_sha256": "fcc46f4a36719b8598eedf1f45c268c323c94e6b3ef38388392d24f1f3e0cbf7",
+    "approval_sha256": "5be1b6eb9856d477dec92ca88b4c18a09660348ac9ebfdf0a86ad8e18efc34f6",
     "candidate_id": "c837126c2a40ae52",
     "candidate_sha256": "c837126c2a40ae5257d91e2e1b74bfbe4fc6853a24473f8eee537c9cdc256f0d",
-    "draft_id": "promotedsmnpanelsoap_75b3146b1be8",
-    "draft_sha256": "59deb42faa230b4c719b8bf134f392dd94938bda3783cba16285b87f24198979",
+    "draft_id": "promotedsmnpanelsoap_604cf84ac2f4",
+    "draft_sha256": "e595d99e514624c188a6234073d37ee1614c5ff8165d87e79f882dab804186b4",
     "final_sample": {
       "copyNumber": "1",
       "gene": "SMN1",
@@ -186,8 +186,8 @@
     "loaded_tools": [
       "PromotedSMNPanelSOAP"
     ],
-    "publication_sha256": "95a952b8f25b0d952f2bf707a2d3922154f44fb4d035328e65671c3f7dc22332",
-    "verification_sha256": "91b489377927340233a6e326cfd85ce039808c67cbd4f826579b02ffb7c4d250"
+    "publication_sha256": "29837486a20587e839f2356f79e693d8af8bbdf2d80063b25dce0c5191bd3108",
+    "verification_sha256": "d55d34507079363da22f84972961b570f80fb97848548909e9ba9757fcd02324"
   },
   "results": [
     {
@@ -242,7 +242,7 @@
       "transport": "http"
     },
     {
-      "operation_sha256": "39cc10d49f93b19e25f7e793e34944874a53986a58ba582731d774b25ada8a5b",
+      "operation_sha256": "43ce75cad5e8cf60328ed767eb0c9ec8fcb18bdc06061ba46e67bff23ef4736a",
       "page_count": 1,
       "payload_sha256": "b68f75b308893a75e7463c157af8e39c50c0f8f88efe2e7f4f52991f08dc0ba5",
       "protocol": "soap",

--- a/examples/vsd/artifacts/reviewed_runtime_snapshot.md
+++ b/examples/vsd/artifacts/reviewed_runtime_snapshot.md
@@ -23,8 +23,8 @@ Yes. Ten runtime cases exercised reviewed GraphQL, REST, SOAP, gRPC, MCP, webhoo
 
 ## Promotion proof
 
-Candidate `c837126c2a40ae52` was bound to draft `promotedsmnpanelsoap_75b3146b1be8`, verified with three cases, approved, published, loaded into a fresh ToolUniverse instance, and executed for sample `S-404`.
+Candidate `c837126c2a40ae52` was bound to draft `promotedsmnpanelsoap_604cf84ac2f4`, verified with three cases, approved, published, loaded into a fresh ToolUniverse instance, and executed for sample `S-404`.
 
-All 33 assertions passed. Case identity: `05e0870fe14c61d560e483fcec472c9eeeabfb28f1042587fbe37e56ab8bd310`.
+All 33 assertions passed. Case identity: `2abc19e009936ad730ccb3a547d143c95b8dec992654e2d52e1d84d684a99386`.
 
 Provider fixtures are deterministic because no provider credentials are bundled. Contract validation, request construction, response decoding, schema validation, provenance, promotion, publication, and loading use production code.

--- a/examples/vsd/cross_format_total_proof.py
+++ b/examples/vsd/cross_format_total_proof.py
@@ -1,0 +1,1194 @@
+"""Prove the complete VSD source-to-reviewed-runtime path across every format."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import json
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import urlsplit
+
+from google.protobuf import descriptor_pb2
+
+from tooluniverse import ToolUniverse, vsd_lifecycle, vsd_promotion
+from tooluniverse import vsd_reviewed_runtime as runtime
+from tooluniverse.vsd_contracts import inspect_contract_document
+
+try:
+    from . import source_intelligence_case_study as source_study
+except ImportError:  # Direct execution from examples/vsd.
+    import source_intelligence_case_study as source_study
+
+
+HERE = Path(__file__).resolve().parent
+ARTIFACTS = HERE / "artifacts"
+DEFAULT_JSON = ARTIFACTS / "cross_format_total_proof.json"
+DEFAULT_MARKDOWN = ARTIFACTS / "cross_format_total_proof.md"
+
+FORMAT_TOOL_NAMES = {
+    "graphql": "VSDDandiAlsGraphQL",
+    "postman": "VSDDandiDandisetREST",
+    "wsdl": "VSDDandiPreservationSOAP",
+    "protobuf": "VSDDandiAlsGRPC",
+    "mcp": "VSDDandiMetadataMCP",
+    "asyncapi": "VSDDandiChangeEvent",
+}
+
+SELECTED_OPERATIONS = {
+    "graphql": "searchAlsElectrophysiology",
+    "postman": "Get dandiset",
+    "wsdl": "ArchivePort.GetPreservationRecord",
+    "protobuf": "dandi.v1.DandisetService.SearchAlsDandisets",
+    "mcp": "dandi-readonly",
+    "asyncapi": "receiveDandisetChange",
+}
+
+PORTFOLIO_CASES = [
+    {
+        "id": "public_health_foundation",
+        "phase": "reviewed source foundation",
+        "pull_request": 416,
+        "artifact": "snapshot.json",
+        "question": "Which Autauga County tracts warrant CHD evidence review without ranking people or making clinical claims?",
+        "result": "Six ToolUniverse calls combined reviewed CDC, WHO, FDA, PubMed, and trial evidence with explicit interpretation limits.",
+    },
+    {
+        "id": "dynamic_rest_als",
+        "phase": "reviewed dynamic REST",
+        "pull_request": 417,
+        "artifact": "dynamic_rest_als_snapshot.json",
+        "question": "Can a bounded generated ClinicalTrials.gov tool find active US ALS studies and retrieve one exact follow-up record?",
+        "result": "Two reviewed operations returned 20 search records and a consistent exact study detail.",
+    },
+    {
+        "id": "api_discovery",
+        "phase": "catalog discovery",
+        "pull_request": 418,
+        "artifact": "api_discovery_snapshot.json",
+        "question": "Can demand for active cancer-trial fields identify one API-ready public dataset without executing it?",
+        "result": "One official NY dataset matched all six demanded capabilities and remained inert review material.",
+    },
+    {
+        "id": "tool_promotion",
+        "phase": "verification and promotion",
+        "pull_request": 419,
+        "artifact": "tool_promotion_snapshot.json",
+        "question": "Can one reviewed cancer dataset become two narrow tools only after representative verification?",
+        "result": "Two tools passed three cases each, were approved, published, freshly loaded, and executed.",
+    },
+    {
+        "id": "docker_boundary",
+        "phase": "administrator-only Docker lifecycle",
+        "pull_request": 420,
+        "artifact": None,
+        "question": "Can a local inference service be provisioned without exposing Docker lifecycle control to an agent?",
+        "result": "Independent Linux CI proved a non-root, loopback-only, read-only, resource-bounded container lifecycle and exact payload hash.",
+    },
+    {
+        "id": "capability_coverage",
+        "phase": "registry and workflow reuse",
+        "pull_request": 421,
+        "artifact": "capability_coverage_snapshot.json",
+        "question": "Does ToolUniverse reuse an existing FDA tool or workflow before declaring a capability gap?",
+        "result": "Exact tools and a workflow were reused; only the intentional calibration request remained a discovery gap.",
+    },
+    {
+        "id": "openapi_ingestion",
+        "phase": "OpenAPI inspection and promotion",
+        "pull_request": 423,
+        "artifact": "openapi_als_snapshot.json",
+        "question": "Can an ALS OpenAPI contract yield one selected read operation with exact provenance and fresh-runtime execution?",
+        "result": "Inspection, three-case verification, approval, publication, execution, and hash-chain validation passed.",
+    },
+    {
+        "id": "workflow_planning",
+        "phase": "workflow-aware planning",
+        "pull_request": 424,
+        "artifact": "workflow_planning_snapshot.json",
+        "question": "Can a multi-step ALS workflow distinguish reusable tools from the one missing step without executing during planning?",
+        "result": "Planning reused exact capabilities, isolated the gap, and changed only after explicit loading.",
+    },
+    {
+        "id": "demand_ledger",
+        "phase": "private unmet-demand ledger",
+        "pull_request": 425,
+        "artifact": "demand_ledger_snapshot.json",
+        "question": "Can repeated missing needs be ranked locally and exported only as reviewed, sanitized proposals?",
+        "result": "Private observations were deduplicated, ranked, and explicitly exported without raw prompts.",
+    },
+    {
+        "id": "credential_reference",
+        "phase": "environment-backed credentials",
+        "pull_request": 426,
+        "artifact": "credential_reference_snapshot.json",
+        "question": "Can credentials rotate without changing the reviewed tool identity or leaking into artifacts?",
+        "result": "Initial and rotated credentials executed while configs, promotion records, results, and artifacts stayed secret-free.",
+    },
+    {
+        "id": "lifecycle_drift",
+        "phase": "suspension, drift, and recovery",
+        "pull_request": 427,
+        "artifact": "lifecycle_drift_snapshot.json",
+        "question": "Can a published tool fail closed on contract drift and return only after reviewed recovery?",
+        "result": "Drift suspended loading, changed-schema evidence was reviewed, and recovery restored the exact tool.",
+    },
+    {
+        "id": "total_system",
+        "phase": "demand-to-runtime total system",
+        "pull_request": 428,
+        "artifact": "total_system_snapshot.json",
+        "question": "Can ALS demand move through discovery, review, promotion, use, resolution, suspension, and recovery as one system?",
+        "result": "The full demand-to-reviewed-tool loop passed with Docker preserved as an independent administrator boundary.",
+    },
+    {
+        "id": "multiformat_contracts",
+        "phase": "heterogeneous contract inspection",
+        "pull_request": 429,
+        "artifact": "multiformat_contract_snapshot.json",
+        "question": "Can six incompatible contract formats become an inert, content-addressed operation inventory?",
+        "result": "GraphQL, AsyncAPI, Postman, WSDL, protobuf, and MCP produced ten identified operations without execution.",
+    },
+    {
+        "id": "reviewed_runtime",
+        "phase": "multi-protocol execution",
+        "pull_request": 430,
+        "artifact": "reviewed_runtime_snapshot.json",
+        "question": "Can one rare-disease study execute reviewed GraphQL, REST, SOAP, gRPC, MCP, event, pagination, and response formats?",
+        "result": "Ten runtime cases and one full WSDL promotion case passed 33 assertions.",
+    },
+    {
+        "id": "source_intelligence",
+        "phase": "organic source discovery and handoff",
+        "pull_request": 431,
+        "artifact": "source_intelligence_snapshot.json",
+        "question": "Can official-source scanning find ALS interface gaps without duplicates, installation, or silent telemetry?",
+        "result": "Fifty sources, seven formats, two cron scans, seven snapshots, and one consent-bound local handoff passed 28 assertions.",
+    },
+]
+
+
+class _FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        value = cls(2026, 8, 3, 12, 0, 0, tzinfo=timezone.utc)
+        return value if tz else value.replace(tzinfo=None)
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode()
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _metadata(url: str, content_type: str, raw: bytes) -> dict[str, Any]:
+    return {
+        "url": url,
+        "status_code": 200,
+        "content_type": content_type,
+        "response_bytes": len(raw),
+        "headers": {"content-type": content_type},
+        "peer_ip": "203.0.113.30",
+        "redirects": 0,
+    }
+
+
+def _descriptor_set() -> str:
+    descriptor = descriptor_pb2.FileDescriptorProto(
+        name="dandisets.proto", package="dandi.v1", syntax="proto3"
+    )
+    request = descriptor.message_type.add(name="SearchRequest")
+    for number, name in enumerate(("disease_term", "species"), start=1):
+        request.field.add(
+            name=name,
+            number=number,
+            label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+            type=descriptor_pb2.FieldDescriptorProto.TYPE_STRING,
+        )
+    response = descriptor.message_type.add(name="DandisetMatch")
+    for number, name in enumerate(("dandiset_id", "name"), start=1):
+        response.field.add(
+            name=name,
+            number=number,
+            label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+            type=descriptor_pb2.FieldDescriptorProto.TYPE_STRING,
+        )
+    service = descriptor.service.add(name="DandisetService")
+    service.method.add(
+        name="SearchAlsDandisets",
+        input_type=".dandi.v1.SearchRequest",
+        output_type=".dandi.v1.DandisetMatch",
+    )
+    return base64.b64encode(
+        descriptor_pb2.FileDescriptorSet(file=[descriptor]).SerializeToString()
+    ).decode()
+
+
+def _http_config(
+    name: str,
+    description: str,
+    endpoint: str,
+    *,
+    protocol: str,
+    properties: dict[str, Any],
+    required: list[str],
+    request: dict[str, Any],
+    response: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "type": "VSDReviewedOperationTool",
+        "description": description,
+        "category": "special_tools",
+        "cacheable": False,
+        "parameter": {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+            "additionalProperties": False,
+        },
+        "return_schema": {"type": "object"},
+        "vsd_reviewed_operation": {
+            "version": 1,
+            "transport": "http",
+            "protocol": protocol,
+            "endpoint": endpoint,
+            "timeout_seconds": 20,
+            "auth": {"type": "none"},
+            "request": request,
+            "response": response,
+            "pagination": {"type": "none"},
+        },
+    }
+
+
+def _json_response() -> dict[str, Any]:
+    return {"format": "json", "schema": {"type": "object"}, "max_bytes": 100_000}
+
+
+def _source_candidates(
+    source_snapshot: dict[str, Any], workspace: Path
+) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+    candidates: dict[str, dict[str, Any]] = {}
+    source_ids: dict[str, str] = {}
+    snapshot_directory = workspace / "source" / "contract-snapshots"
+    for manifest in source_snapshot["snapshot_manifests"]:
+        source_format = manifest["format_hint"]
+        if source_format not in SELECTED_OPERATIONS:
+            continue
+        path = snapshot_directory / manifest["snapshot_file"]
+        endpoint = source_study._inspection_endpoint(source_format)
+        report = inspect_contract_document(
+            path,
+            format_hint=source_format,
+            **({"endpoint": endpoint} if endpoint else {}),
+        )
+        matches = [
+            candidate
+            for candidate in report["candidates"]
+            if candidate["name"] == SELECTED_OPERATIONS[source_format]
+        ]
+        if len(matches) != 1:
+            raise ValueError(f"Expected one selected {source_format} operation")
+        candidates[source_format] = matches[0]
+        source_ids[source_format] = manifest["candidate_id"]
+    if set(candidates) != set(SELECTED_OPERATIONS):
+        raise ValueError("Source scan did not yield every selected contract format")
+    return candidates, source_ids
+
+
+def _reviewed_configs(
+    candidates: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    graphql = _http_config(
+        FORMAT_TOOL_NAMES["graphql"],
+        "Find ALS electrophysiology dandisets through one reviewed GraphQL query.",
+        candidates["graphql"]["endpoint"],
+        protocol="graphql",
+        properties={
+            "disease_term": {"type": "string"},
+            "species": {"type": "string"},
+            "recording_modality": {"type": "string"},
+            "limit": {"type": "integer", "minimum": 1, "maximum": 20},
+        },
+        required=["disease_term", "species", "recording_modality", "limit"],
+        request={
+            "method": "POST",
+            "reviewed_read_only": True,
+            "body": {
+                "mode": "graphql",
+                "query": (
+                    "query SearchAls($diseaseTerm: String!, $species: String!, "
+                    "$recordingModality: String!, $limit: Int) { "
+                    "searchAlsElectrophysiology(diseaseTerm: $diseaseTerm, "
+                    "species: $species, recordingModality: $recordingModality, "
+                    "limit: $limit) { id name species } }"
+                ),
+                "operation_name": "SearchAls",
+                "arguments": {
+                    "disease_term": "diseaseTerm",
+                    "species": "species",
+                    "recording_modality": "recordingModality",
+                    "limit": "limit",
+                },
+            },
+        },
+        response=_json_response(),
+    )
+    postman = _http_config(
+        FORMAT_TOOL_NAMES["postman"],
+        "Retrieve one exact DANDI metadata record through a reviewed path mapping.",
+        f"https://{source_study.DANDI}/api/dandisets/{{dandiset_id}}",
+        protocol="rest",
+        properties={"dandiset_id": {"type": "string"}},
+        required=["dandiset_id"],
+        request={
+            "method": "GET",
+            "path_arguments": {"dandiset_id": "dandiset_id"},
+            "body": {"mode": "none"},
+        },
+        response=_json_response(),
+    )
+    postman["vsd_contract_parameters"] = {"dandisetId": "dandiset_id"}
+    wsdl = _http_config(
+        FORMAT_TOOL_NAMES["wsdl"],
+        "Retrieve one existing DANDI preservation record through reviewed SOAP.",
+        candidates["wsdl"]["endpoint"],
+        protocol="soap",
+        properties={"dandiset_id": {"type": "string"}},
+        required=["dandiset_id"],
+        request={
+            "method": "POST",
+            "reviewed_read_only": True,
+            "fixed_headers": {"SOAPAction": "urn:GetPreservationRecord"},
+            "body": {
+                "mode": "soap",
+                "envelope": (
+                    "<Envelope><Body><GetPreservationRecord>"
+                    "<dandiset>{dandiset_id}</dandiset>"
+                    "</GetPreservationRecord></Body></Envelope>"
+                ),
+                "arguments": {"dandiset_id": "dandiset"},
+            },
+        },
+        response={"format": "xml", "schema": {"type": "object"}},
+    )
+    grpc = {
+        "name": FORMAT_TOOL_NAMES["protobuf"],
+        "type": "VSDReviewedOperationTool",
+        "description": "Search ALS dandisets through one exact reviewed unary gRPC method.",
+        "parameter": {
+            "type": "object",
+            "properties": {"request": {"type": "object"}},
+            "required": ["request"],
+            "additionalProperties": False,
+        },
+        "vsd_reviewed_operation": {
+            "version": 1,
+            "transport": "grpc",
+            "protocol": "grpc",
+            "endpoint": f"{source_study.DANDI}:443",
+            "method": "/dandi.v1.DandisetService/SearchAlsDandisets",
+            "descriptor_set_base64": _descriptor_set(),
+            "request_type": "dandi.v1.SearchRequest",
+            "response_type": "dandi.v1.DandisetMatch",
+            "streaming": "unary",
+            "max_messages": 1,
+            "auth": {"type": "none"},
+            "response": {"format": "json", "schema": {"type": "object"}},
+        },
+    }
+    mcp = {
+        "name": FORMAT_TOOL_NAMES["mcp"],
+        "type": "VSDReviewedOperationTool",
+        "description": "Run one declared DANDI metadata search tool on the reviewed MCP server.",
+        "parameter": {
+            "type": "object",
+            "properties": {"arguments": {"type": "object"}},
+            "required": ["arguments"],
+            "additionalProperties": False,
+        },
+        "vsd_reviewed_operation": {
+            "version": 1,
+            "transport": "mcp",
+            "protocol": "mcp",
+            "endpoint": candidates["mcp"]["endpoint"],
+            "tool_name": "search_dandisets",
+            "auth": {"type": "none"},
+            "response": {"format": "json", "schema": {"type": "object"}},
+        },
+    }
+    asyncapi = {
+        "name": FORMAT_TOOL_NAMES["asyncapi"],
+        "type": "VSDReviewedOperationTool",
+        "description": "Validate one received DANDI change event against the reviewed channel.",
+        "parameter": {
+            "type": "object",
+            "properties": {"event": {"type": "object"}},
+            "required": ["event"],
+            "additionalProperties": False,
+        },
+        "vsd_reviewed_operation": {
+            "version": 1,
+            "transport": "event",
+            "protocol": "asyncapi",
+            "source_endpoint": candidates["asyncapi"]["endpoint"],
+            "channel": candidates["asyncapi"]["contract"]["channel"],
+            "event_argument": "event",
+            "event_schema": copy.deepcopy(candidates["asyncapi"]["input_schema"]),
+            "auth": {"type": "none"},
+            "response": {"format": "json", "schema": {"type": "object"}},
+        },
+    }
+    return {
+        "graphql": graphql,
+        "postman": postman,
+        "wsdl": wsdl,
+        "protobuf": grpc,
+        "mcp": mcp,
+        "asyncapi": asyncapi,
+    }
+
+
+def _fake_http(**kwargs):
+    url = kwargs["url"]
+    if url.endswith("/graphql"):
+        request = json.loads((kwargs["body"] or b"{}").decode())
+        disease = request["variables"]["diseaseTerm"]
+        raw = _canonical(
+            {
+                "data": {
+                    "searchAlsElectrophysiology": [
+                        {
+                            "id": f"DANDI-{disease.upper()}",
+                            "name": f"{disease} motor-neuron electrophysiology",
+                            "species": [request["variables"]["species"]],
+                        }
+                    ]
+                }
+            }
+        )
+        return raw, _metadata(url, "application/json", raw)
+    if "/api/dandisets/" in url:
+        dandiset_id = urlsplit(url).path.rsplit("/", 1)[-1]
+        raw = _canonical(
+            {
+                "dandiset_id": dandiset_id,
+                "name": "ALS motor-neuron electrophysiology",
+                "status": "published",
+            }
+        )
+        return raw, _metadata(url, "application/json", raw)
+    if url.endswith("/soap"):
+        body = (kwargs["body"] or b"").decode()
+        dandiset_id = body.split("<dandiset>", 1)[1].split("</dandiset>", 1)[0]
+        raw = (
+            "<Envelope><Body><PreservationRecord>"
+            f"<dandiset>{dandiset_id}</dandiset><status>preserved</status>"
+            "</PreservationRecord></Body></Envelope>"
+        ).encode()
+        return raw, _metadata(url, "text/xml", raw)
+    raise AssertionError(f"Unexpected HTTP route: {url}")
+
+
+def _fake_grpc(operation: dict[str, Any], request: dict[str, Any]):
+    del operation
+    return (
+        {
+            "dandiset_id": f"DANDI-{request['disease_term'].upper()}",
+            "name": f"{request['species']} electrophysiology evidence",
+        },
+        {"messages": 1, "elapsed_seconds": 0.01, "peer": source_study.DANDI},
+    )
+
+
+def _fake_mcp(operation: dict[str, Any], arguments: dict[str, Any]):
+    return (
+        {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"{arguments['condition']} matched "
+                        f"{arguments['species']} electrophysiology dandisets"
+                    ),
+                }
+            ]
+        },
+        {"tool_name": operation["tool_name"]},
+    )
+
+
+def _expect(path: str, value: Any, required_field: str) -> dict[str, Any]:
+    return {
+        "result_type": "object",
+        "required_fields": [required_field],
+        "equals": {},
+        "required_paths": [path],
+        "equals_paths": {path: value},
+    }
+
+
+def _cases() -> dict[str, dict[str, Any]]:
+    graphql = []
+    postman = []
+    wsdl = []
+    grpc = []
+    mcp = []
+    asyncapi = []
+    for disease, species, identifier in (
+        ("ALS", "human", "000001"),
+        ("SMA", "mouse", "000002"),
+        ("DMD", "human", "000003"),
+    ):
+        graphql.append(
+            {
+                "arguments": {
+                    "disease_term": disease,
+                    "species": species,
+                    "recording_modality": "intracellular electrophysiology",
+                    "limit": 5,
+                },
+                "expect": _expect(
+                    "/data/searchAlsElectrophysiology/0/id",
+                    f"DANDI-{disease}",
+                    "data",
+                ),
+            }
+        )
+        postman.append(
+            {
+                "arguments": {"dandiset_id": identifier},
+                "expect": _expect("/dandiset_id", identifier, "dandiset_id"),
+            }
+        )
+        wsdl.append(
+            {
+                "arguments": {"dandiset_id": identifier},
+                "expect": _expect(
+                    "/Envelope/Body/PreservationRecord/dandiset",
+                    identifier,
+                    "Envelope",
+                ),
+            }
+        )
+        grpc.append(
+            {
+                "arguments": {"request": {"disease_term": disease, "species": species}},
+                "expect": _expect("/dandiset_id", f"DANDI-{disease}", "dandiset_id"),
+            }
+        )
+        mcp.append(
+            {
+                "arguments": {"arguments": {"condition": disease, "species": species}},
+                "expect": {
+                    "result_type": "object",
+                    "required_fields": ["content"],
+                    "equals": {},
+                    "required_paths": ["/content/0/text"],
+                    "equals_paths": {},
+                },
+            }
+        )
+        event = {
+            "dandisetId": identifier,
+            "version": f"0.26.{len(asyncapi)}",
+            "changedAt": f"2026-08-0{len(asyncapi) + 1}T10:00:00Z",
+        }
+        asyncapi.append(
+            {
+                "arguments": {"event": event},
+                "expect": _expect("/dandisetId", identifier, "dandisetId"),
+            }
+        )
+    return {
+        "graphql": {"verification": graphql, "final": graphql[0]["arguments"]},
+        "postman": {"verification": postman, "final": postman[0]["arguments"]},
+        "wsdl": {"verification": wsdl, "final": wsdl[0]["arguments"]},
+        "protobuf": {"verification": grpc, "final": grpc[0]["arguments"]},
+        "mcp": {"verification": mcp, "final": mcp[0]["arguments"]},
+        "asyncapi": {"verification": asyncapi, "final": asyncapi[0]["arguments"]},
+    }
+
+
+def _assertion_result(document: dict[str, Any]) -> tuple[int, bool]:
+    values = document.get("end_to_end_assertions", document.get("assertions"))
+    if isinstance(values, dict):
+        return len(values), bool(values) and all(
+            value is True for value in values.values()
+        )
+    if isinstance(values, list):
+        return len(values), bool(values) and all(
+            isinstance(item, dict) and item.get("passed") is True for item in values
+        )
+    return 0, False
+
+
+def _special_artifact_proof(case_id: str, document: dict[str, Any]) -> tuple[int, bool]:
+    if case_id == "public_health_foundation":
+        calls = document.get("tooluniverse_execution", {}).get("calls", [])
+        return len(calls), len(calls) == 6 and all(
+            item.get("status") == "success" for item in calls
+        )
+    if case_id == "dynamic_rest_als":
+        return 3, (
+            document.get("search", {}).get("returned_records") == 20
+            and len(document.get("tool_contracts", [])) == 2
+            and bool(
+                document.get("detail_follow_up", {}).get("study", {}).get("nct_id")
+            )
+        )
+    if case_id == "api_discovery":
+        analysis = document.get("analysis", {})
+        selected = analysis.get("selected_candidate", {})
+        return 4, (
+            analysis.get("recommended_candidate_count") == 1
+            and selected.get("execution_allowed") is False
+            and selected.get("recommended_for_contract_review") is True
+            and selected.get("matched_capability_count") == 6
+        )
+    if case_id == "tool_promotion":
+        promotions = document.get("promotions", [])
+        return sum(item.get("case_count", 0) for item in promotions), (
+            len(document.get("loaded_tools", [])) == 2
+            and len(promotions) == 2
+            and all(item.get("case_count") == 3 for item in promotions)
+        )
+    return 0, False
+
+
+def _portfolio_evidence() -> list[dict[str, Any]]:
+    evidence = []
+    for definition in PORTFOLIO_CASES:
+        item = copy.deepcopy(definition)
+        artifact = definition["artifact"]
+        if artifact is None:
+            item.update(
+                {
+                    "artifact_sha256": None,
+                    "assertion_count": 30,
+                    "all_checks_passed": True,
+                    "evidence_boundary": "independent_real_container_ci",
+                }
+            )
+            evidence.append(item)
+            continue
+        path = ARTIFACTS / artifact
+        raw = path.read_bytes()
+        document = json.loads(raw)
+        assertion_count, passed = _assertion_result(document)
+        if assertion_count == 0:
+            assertion_count, passed = _special_artifact_proof(
+                definition["id"], document
+            )
+        if not passed:
+            raise ValueError(f"Portfolio artifact failed validation: {artifact}")
+        item.update(
+            {
+                "artifact_sha256": hashlib.sha256(raw).hexdigest(),
+                "assertion_count": assertion_count,
+                "all_checks_passed": True,
+                "evidence_boundary": "checked_repository_artifact",
+            }
+        )
+        evidence.append(item)
+    return evidence
+
+
+def _adversarial_cases(
+    candidates: dict[str, dict[str, Any]],
+    configs: dict[str, dict[str, Any]],
+    workspace: Path,
+) -> list[dict[str, str]]:
+    mutations: list[tuple[str, str, Callable[[dict[str, Any]], None]]] = [
+        (
+            "graphql_cross_provider",
+            "graphql",
+            lambda config: config["vsd_reviewed_operation"].update(
+                {"endpoint": "https://different.example.org/graphql"}
+            ),
+        ),
+        (
+            "postman_missing_parameter_map",
+            "postman",
+            lambda config: config.pop("vsd_contract_parameters"),
+        ),
+        (
+            "soap_action_substitution",
+            "wsdl",
+            lambda config: config["vsd_reviewed_operation"]["request"][
+                "fixed_headers"
+            ].update({"SOAPAction": "urn:DeletePreservationRecord"}),
+        ),
+        (
+            "soap_body_substitution",
+            "wsdl",
+            lambda config: config["vsd_reviewed_operation"]["request"]["body"].update(
+                {
+                    "envelope": (
+                        "<Envelope><Body><DeletePreservationRecord>"
+                        "<dandiset>{dandiset_id}</dandiset>"
+                        "</DeletePreservationRecord></Body></Envelope>"
+                    )
+                }
+            ),
+        ),
+        (
+            "grpc_rpc_substitution",
+            "protobuf",
+            lambda config: config["vsd_reviewed_operation"].update(
+                {"method": "/dandi.v1.DandisetService/StreamAlsDandisets"}
+            ),
+        ),
+        (
+            "mcp_undeclared_tool",
+            "mcp",
+            lambda config: config["vsd_reviewed_operation"].update(
+                {"tool_name": "delete_dandiset"}
+            ),
+        ),
+        (
+            "asyncapi_channel_substitution",
+            "asyncapi",
+            lambda config: config["vsd_reviewed_operation"].update(
+                {"channel": "administration/delete"}
+            ),
+        ),
+        (
+            "asyncapi_source_omission",
+            "asyncapi",
+            lambda config: config["vsd_reviewed_operation"].pop("source_endpoint"),
+        ),
+    ]
+    results = []
+    for case_id, source_format, mutate in mutations:
+        config = copy.deepcopy(configs[source_format])
+        mutate(config)
+        try:
+            vsd_promotion.create_reviewed_operation_draft(
+                candidates[source_format],
+                config,
+                resolved_blockers=candidates[source_format]["blockers"],
+                review_note=(
+                    "This deliberately mismatched configuration must fail before "
+                    "a draft or executable tool can be created."
+                ),
+                workspace=workspace / case_id,
+            )
+        except vsd_promotion.VSDPromotionError as exc:
+            results.append(
+                {
+                    "case_id": case_id,
+                    "source_format": source_format,
+                    "result": "rejected",
+                    "reason": str(exc),
+                }
+            )
+        else:  # pragma: no cover - the case exists to fail closed
+            raise AssertionError(f"Adversarial case unexpectedly passed: {case_id}")
+    return results
+
+
+def _promote_execute(
+    candidates: dict[str, dict[str, Any]],
+    source_ids: dict[str, str],
+    configs: dict[str, dict[str, Any]],
+    workspace: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    cases = _cases()
+    promotion_records = []
+    for source_format in FORMAT_TOOL_NAMES:
+        candidate = candidates[source_format]
+        draft = vsd_promotion.create_reviewed_operation_draft(
+            candidate,
+            configs[source_format],
+            resolved_blockers=candidate["blockers"],
+            review_note=(
+                "Reviewed the exact source snapshot, operation identity, input map, "
+                "provider endpoint, and bounded runtime configuration."
+            ),
+            workspace=workspace,
+        )
+        verification = vsd_promotion.verify_draft(
+            draft["draft_id"], cases[source_format]["verification"], workspace=workspace
+        )
+        approval = vsd_promotion.approve_draft(
+            draft["draft_id"],
+            reviewed_by="Cross-format Portfolio Reviewer",
+            decision_note=(
+                "Approved after exact contract binding and three representative "
+                "provider cases passed without credential or transport expansion."
+            ),
+            workspace=workspace,
+        )
+        publication = vsd_promotion.publish_draft(
+            draft["draft_id"], workspace=workspace
+        )
+        promotion_records.append(
+            {
+                "source_format": source_format,
+                "source_candidate_id": source_ids[source_format],
+                "contract_candidate_id": candidate["candidate_id"],
+                "source_document_sha256": candidate["source_document_sha256"],
+                "tool_name": configs[source_format]["name"],
+                "blockers_resolved": candidate["blockers"],
+                "contract_binding": draft["config"]["vsd_promotion"][
+                    "contract_binding"
+                ],
+                "draft_sha256": draft["draft_sha256"],
+                "verification_case_count": verification["case_count"],
+                "verification_sha256": verification["verification_sha256"],
+                "approval_sha256": approval["approval_sha256"],
+                "publication_sha256": publication["publication_sha256"],
+            }
+        )
+
+    universe = ToolUniverse()
+    try:
+        loaded = vsd_promotion.load_published_tools(universe, workspace=workspace)
+        for record in promotion_records:
+            source_format = record["source_format"]
+            response = universe.run_one_function(
+                {
+                    "name": record["tool_name"],
+                    "arguments": cases[source_format]["final"],
+                },
+                use_cache=False,
+            )
+            if response.get("status") != "success":
+                raise ValueError(f"Published {source_format} tool did not execute")
+            result = response["data"]["result"]
+            record["final_result_sha256"] = _digest(result)
+            record["final_result"] = result
+    finally:
+        universe.close()
+    return promotion_records, loaded
+
+
+def run_case(workspace: Path) -> dict[str, Any]:
+    workspace.mkdir(parents=True, exist_ok=True)
+    source_snapshot = source_study.run_case(workspace / "source")
+    candidates, source_ids = _source_candidates(source_snapshot, workspace)
+    configs = _reviewed_configs(candidates)
+    adversarial = _adversarial_cases(
+        candidates, configs, workspace / "rejected-bindings"
+    )
+    portfolio = _portfolio_evidence()
+
+    original_http = runtime._http_exchange
+    original_grpc = runtime._grpc_exchange
+    original_mcp = runtime._mcp_exchange
+    original_runtime_datetime = runtime.datetime
+    original_promotion_datetime = vsd_promotion.datetime
+    original_lifecycle_datetime = vsd_lifecycle.datetime
+    runtime._http_exchange = _fake_http
+    runtime._grpc_exchange = _fake_grpc
+    runtime._mcp_exchange = _fake_mcp
+    runtime.datetime = _FixedDateTime
+    vsd_promotion.datetime = _FixedDateTime
+    vsd_lifecycle.datetime = _FixedDateTime
+    try:
+        promotion_records, loaded = _promote_execute(
+            candidates,
+            source_ids,
+            configs,
+            workspace / "promotion",
+        )
+    finally:
+        runtime._http_exchange = original_http
+        runtime._grpc_exchange = original_grpc
+        runtime._mcp_exchange = original_mcp
+        runtime.datetime = original_runtime_datetime
+        vsd_promotion.datetime = original_promotion_datetime
+        vsd_lifecycle.datetime = original_lifecycle_datetime
+
+    promoted_formats = {record["source_format"] for record in promotion_records}
+    source_candidates = source_snapshot["scan_summary"]["candidates"]
+    assertions = {
+        "source_intelligence_assertions_pass": all(
+            source_snapshot["end_to_end_assertions"].values()
+        ),
+        "catalog_contains_50_review_only_sources": (
+            source_snapshot["real_registry_baseline"]["catalog_gap_count"] == 50
+        ),
+        "seven_formats_were_discovered": (
+            source_snapshot["scan_summary"]["candidate_count"] == 7
+        ),
+        "seven_content_addressed_snapshots_exist": (
+            len(source_snapshot["snapshot_manifests"]) == 7
+        ),
+        "two_tamper_detecting_cron_scans_exist": (
+            len(source_snapshot["cron_history"]["scan_ids"]) == 2
+        ),
+        "handoff_remained_local_and_unsubmitted": (
+            source_snapshot["demand_handoff"]["submitted"] is False
+        ),
+        "existing_reporter_source_was_not_promoted": all(
+            record["source_format"] != "openapi" for record in promotion_records
+        ),
+        "only_dandi_gap_candidates_were_promoted": all(
+            item["coverage"] == "candidate_gap"
+            for item in source_candidates
+            if item["format_hint"] in promoted_formats
+        ),
+        "six_contract_formats_reached_promotion": promoted_formats
+        == set(FORMAT_TOOL_NAMES),
+        "every_promotion_has_exact_binding_hash": all(
+            len(record["contract_binding"]["binding_sha256"]) == 64
+            for record in promotion_records
+        ),
+        "every_binding_names_its_contract_candidate": all(
+            record["contract_binding"]["candidate_id"]
+            == record["contract_candidate_id"]
+            for record in promotion_records
+        ),
+        "postman_template_has_explicit_parameter_map": next(
+            record
+            for record in promotion_records
+            if record["source_format"] == "postman"
+        )["contract_binding"]["parameter_map"]
+        == {"dandisetId": "dandiset_id"},
+        "grpc_binding_names_exact_descriptor_method": next(
+            record
+            for record in promotion_records
+            if record["source_format"] == "protobuf"
+        )["contract_binding"]["identity"]["method"]
+        == "/dandi.v1.DandisetService/SearchAlsDandisets",
+        "every_format_passed_three_verification_cases": all(
+            record["verification_case_count"] == 3 for record in promotion_records
+        ),
+        "all_six_publications_loaded_in_fresh_runtime": set(loaded)
+        == set(FORMAT_TOOL_NAMES.values()),
+        "all_six_published_tools_executed": all(
+            len(record["final_result_sha256"]) == 64 for record in promotion_records
+        ),
+        "all_eight_substitution_attacks_were_rejected": (
+            len(adversarial) == 8
+            and all(item["result"] == "rejected" for item in adversarial)
+        ),
+        "all_prior_case_artifacts_or_ci_evidence_pass": all(
+            item["all_checks_passed"] for item in portfolio
+        ),
+        "portfolio_covers_every_prior_vsd_phase_pr": len(portfolio) == 15,
+        "portfolio_includes_independent_docker_boundary": any(
+            item["id"] == "docker_boundary"
+            and item["evidence_boundary"] == "independent_real_container_ci"
+            for item in portfolio
+        ),
+        "workflow_demand_credential_and_lifecycle_studies_are_present": {
+            "workflow_planning",
+            "demand_ledger",
+            "credential_reference",
+            "lifecycle_drift",
+        }
+        <= {item["id"] for item in portfolio},
+    }
+    snapshot = {
+        "format": "vsd_cross_format_total_proof_v1",
+        "version": 1,
+        "title": "ALS source-to-reviewed-runtime cross-format total proof",
+        "research_question": (
+            "Can a real ToolUniverse capability gap move from reviewed source discovery "
+            "through bounded scanning, content-addressed inspection, exact contract "
+            "binding, representative verification, approval, publication, fresh-runtime "
+            "loading, and useful execution across every supported format without "
+            "duplicating an existing source or widening authority?"
+        ),
+        "answer": (
+            "Yes. The case kept the already-covered NIH RePORTER interface out of "
+            "promotion, selected six DANDI gap contracts, bound each to its exact "
+            "provider and operation, passed eighteen verification executions, rejected "
+            "eight substitution attempts, loaded six published tools into a fresh "
+            "ToolUniverse instance, and executed a final ALS evidence request through "
+            "each format."
+        ),
+        "source_stage": {
+            "catalog_source_count": 50,
+            "configured_tool_count": source_snapshot["real_registry_baseline"][
+                "tool_count"
+            ],
+            "configured_host_count": source_snapshot["real_registry_baseline"][
+                "host_count"
+            ],
+            "discovered_format_count": 7,
+            "snapshot_count": len(source_snapshot["snapshot_manifests"]),
+            "cron_scan_count": len(source_snapshot["cron_history"]["scan_ids"]),
+            "source_audit_sha256": source_snapshot["audit_sha256"],
+            "handoff_submitted": source_snapshot["demand_handoff"]["submitted"],
+        },
+        "promotion_stage": {
+            "promoted_format_count": len(promotion_records),
+            "verification_case_count": sum(
+                record["verification_case_count"] for record in promotion_records
+            ),
+            "loaded_tools": loaded,
+            "records": promotion_records,
+        },
+        "adversarial_binding_cases": adversarial,
+        "portfolio_case_count": len(portfolio) + 1,
+        "prior_case_studies": portfolio,
+        "end_to_end_assertions": assertions,
+    }
+    snapshot["audit_sha256"] = _digest(snapshot)
+    validate_snapshot(snapshot)
+    return snapshot
+
+
+def validate_snapshot(snapshot: dict[str, Any]) -> None:
+    if not isinstance(snapshot, dict) or snapshot.get("format") != (
+        "vsd_cross_format_total_proof_v1"
+    ):
+        raise ValueError("Cross-format total proof has an invalid format")
+    body = {key: value for key, value in snapshot.items() if key != "audit_sha256"}
+    if snapshot.get("audit_sha256") != _digest(body):
+        raise ValueError("Cross-format total proof audit digest does not match")
+    assertions = snapshot.get("end_to_end_assertions")
+    if (
+        not isinstance(assertions, dict)
+        or len(assertions) != 21
+        or not all(value is True for value in assertions.values())
+    ):
+        raise ValueError("Cross-format total proof assertions did not all pass")
+    records = snapshot.get("promotion_stage", {}).get("records")
+    if (
+        not isinstance(records, list)
+        or len(records) != 6
+        or {item.get("source_format") for item in records} != set(FORMAT_TOOL_NAMES)
+    ):
+        raise ValueError("Cross-format promotion record set is incomplete")
+
+
+def _markdown(snapshot: dict[str, Any]) -> str:
+    lines = [
+        "# ALS Source-To-Reviewed-Runtime Cross-Format Total Proof",
+        "",
+        "## Research question",
+        "",
+        snapshot["research_question"],
+        "",
+        "## Result",
+        "",
+        snapshot["answer"],
+        "",
+        "## Connected end-to-end path",
+        "",
+        "1. Audit 2,744 configured tools, 259 configured hosts, and the review-only 50-source catalog.",
+        "2. Separate the existing NIH RePORTER host from the missing DANDI capability.",
+        "3. Crawl two explicit hosts under robots, host, page, depth, byte, and time bounds.",
+        "4. Snapshot and inspect OpenAPI, GraphQL, AsyncAPI, Postman, WSDL, protobuf, and MCP documents without execution.",
+        "5. Leave existing OpenAPI coverage alone; select six DANDI gap operations for review.",
+        "6. Bind provider, operation, method, parameters, and format-specific identity into each promotion digest.",
+        "7. Run three representative cases per operation, approve and publish, then load only into a fresh runtime.",
+        "8. Execute the six resulting tools and preserve the independent administrator-only Docker boundary.",
+        "",
+        "## Six-format promotion and execution",
+        "",
+        "| Format | Tool | Exact bound identity | Verification cases | Final result SHA-256 |",
+        "| --- | --- | --- | ---: | --- |",
+    ]
+    for record in snapshot["promotion_stage"]["records"]:
+        identity = record["contract_binding"]["identity"]
+        bound = identity.get(
+            "method",
+            identity.get(
+                "root_field",
+                identity.get(
+                    "body_operation",
+                    identity.get(
+                        "tool_name", identity.get("channel", identity["operation"])
+                    ),
+                ),
+            ),
+        )
+        lines.append(
+            f"| {record['source_format']} | `{record['tool_name']}` | "
+            f"`{bound}` | {record['verification_case_count']} | "
+            f"`{record['final_result_sha256']}` |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Fail-closed substitution cases",
+            "",
+            "| Attempt | Format | Result | Boundary that rejected it |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    for item in snapshot["adversarial_binding_cases"]:
+        lines.append(
+            f"| `{item['case_id']}` | {item['source_format']} | {item['result']} | "
+            f"{item['reason']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Sixteen professional case studies",
+            "",
+            "| PR | Phase and question | Concrete result | Checks/assertions |",
+            "| --- | --- | --- | ---: |",
+        ]
+    )
+    for item in snapshot["prior_case_studies"]:
+        lines.append(
+            f"| [#{item['pull_request']}](https://github.com/mims-harvard/ToolUniverse/pull/{item['pull_request']}) "
+            f"| **{item['phase']}**: {item['question']} | {item['result']} | "
+            f"{item['assertion_count']} |"
+        )
+    lines.append(
+        "| This PR | **cross-format total proof**: Can every implemented phase operate as one source-to-runtime system? | Six promotions, eighteen verification runs, six final executions, and eight rejected substitutions. | 21 |"
+    )
+    lines.extend(
+        [
+            "",
+            "## End-to-end assertions",
+            "",
+        ]
+    )
+    for name, passed in sorted(snapshot["end_to_end_assertions"].items()):
+        lines.append(f"- `{name}`: {'passed' if passed else 'failed'}")
+    lines.extend(
+        [
+            "",
+            "## Interpretation boundary",
+            "",
+            "This proves software behavior, provenance, review gates, bounded transport, and deterministic fixture execution. It does not certify a provider's scientific content, convert catalog membership into trust for execution, submit the local handoff, or expose Docker lifecycle operations to an agent.",
+            "",
+            f"Audit SHA-256: `{snapshot['audit_sha256']}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_artifacts(
+    snapshot: dict[str, Any],
+    output_json: Path = DEFAULT_JSON,
+    output_markdown: Path = DEFAULT_MARKDOWN,
+) -> tuple[Path, Path]:
+    validate_snapshot(snapshot)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    output_markdown.write_text(_markdown(snapshot), encoding="utf-8")
+    return output_json, output_markdown
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="tooluniverse-vsd-cross-format-") as tmp:
+        snapshot = run_case(Path(tmp))
+    write_artifacts(snapshot)
+    print(json.dumps(snapshot, indent=2, sort_keys=True, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/vsd/reviewed_runtime_case_study.py
+++ b/examples/vsd/reviewed_runtime_case_study.py
@@ -183,7 +183,7 @@ def _configs() -> list[tuple[str, str, dict[str, Any], dict[str, Any]]]:
             "fixed_headers": {"SOAPAction": "urn:GetSMNPanel"},
             "body": {
                 "mode": "soap",
-                "envelope": "<Envelope><Body><GetPanel><sample>{sample_id}</sample></GetPanel></Body></Envelope>",
+                "envelope": "<Envelope><Body><GetSMNPanel><sample>{sample_id}</sample></GetSMNPanel></Body></Envelope>",
                 "arguments": {"sample_id": "sample"},
             },
         },

--- a/src/tooluniverse/vsd_contracts.py
+++ b/src/tooluniverse/vsd_contracts.py
@@ -66,6 +66,29 @@ _PROTO_FIELD_RE = re.compile(
     r"\b(?:optional\s+|required\s+|repeated\s+)?"
     r"([.A-Za-z_]\w*(?:\s*<[^;={}]+>)?)\s+([A-Za-z_]\w*)\s*=\s*(\d+)"
 )
+_CONTRACT_CANDIDATE_KEYS = {
+    "format",
+    "version",
+    "approval_state",
+    "execution_allowed",
+    "metadata_trust",
+    "source_format",
+    "source_document_sha256",
+    "kind",
+    "name",
+    "summary",
+    "protocol",
+    "endpoint",
+    "method",
+    "input_schema",
+    "output_schema",
+    "auth",
+    "blockers",
+    "warnings",
+    "contract",
+    "candidate_id",
+    "candidate_sha256",
+}
 
 
 class VSDContractError(ValueError):
@@ -236,6 +259,8 @@ def validate_contract_candidate(candidate: Any) -> dict[str, Any]:
     """Verify origin, integrity, bounds, and inert state of a candidate."""
     if not isinstance(candidate, dict):
         raise VSDContractError("Contract candidate must be an object")
+    if set(candidate) != _CONTRACT_CANDIDATE_KEYS:
+        raise VSDContractError("Contract candidate fields are invalid")
     if (
         candidate.get("format") != "vsd_contract_candidate_v1"
         or candidate.get("version") != _VERSION
@@ -454,17 +479,48 @@ def _asyncapi_servers(document: dict[str, Any]) -> dict[str, str]:
     return values
 
 
-def _schema_from_message(message: Any) -> dict[str, Any]:
+def _local_reference(document: dict[str, Any], reference: Any) -> Any:
+    if not isinstance(reference, str) or not reference.startswith("#/"):
+        return None
+    tokens = reference[2:].split("/")
+    if not 1 <= len(tokens) <= 20:
+        return None
+    value: Any = document
+    for token in tokens:
+        key = token.replace("~1", "/").replace("~0", "~")
+        if not isinstance(value, dict) or key not in value:
+            return None
+        value = value[key]
+    return value
+
+
+def _schema_from_message(
+    document: dict[str, Any], message: Any, seen: frozenset[str] = frozenset()
+) -> tuple[dict[str, Any], list[str]]:
     if not isinstance(message, dict):
-        return {}
+        return {}, []
+    reference = message.get("$ref")
+    if reference is not None:
+        if not isinstance(reference, str) or reference in seen:
+            return {}, ["asyncapi_message_reference_requires_local_resolution"]
+        resolved = _local_reference(document, reference)
+        if not isinstance(resolved, dict):
+            return {}, ["asyncapi_message_reference_requires_local_resolution"]
+        return _schema_from_message(document, resolved, seen | {reference})
     payload = message.get("payload")
     if isinstance(payload, dict):
-        return copy.deepcopy(payload)
+        return copy.deepcopy(payload), []
     one_of = message.get("oneOf")
     if isinstance(one_of, list):
-        schemas = [_schema_from_message(item) for item in one_of]
-        return {"oneOf": [item for item in schemas if item]}
-    return {}
+        schemas = []
+        blockers = []
+        for item in one_of:
+            schema, item_blockers = _schema_from_message(document, item, seen)
+            if schema:
+                schemas.append(schema)
+            blockers.extend(item_blockers)
+        return ({"oneOf": schemas} if schemas else {}), sorted(set(blockers))
+    return {}, []
 
 
 def _inspect_asyncapi(
@@ -528,11 +584,7 @@ def _inspect_asyncapi(
             message: Any = {}
             if isinstance(messages, list) and messages:
                 message = messages[0]
-                if isinstance(message, dict) and isinstance(message.get("$ref"), str):
-                    message_name = message["$ref"].split("/")[-1]
-                    message = (
-                        document.get("components", {}).get("messages", {}) or {}
-                    ).get(message_name, {})
+            message_schema, message_blockers = _schema_from_message(document, message)
             candidates.append(
                 _candidate(
                     source_format="asyncapi",
@@ -542,10 +594,11 @@ def _inspect_asyncapi(
                     summary=operation.get("summary") or operation.get("description"),
                     protocol="asyncapi",
                     endpoint=endpoint,
-                    input_schema=_schema_from_message(message),
-                    output_schema=_schema_from_message(message),
+                    input_schema=message_schema,
+                    output_schema=message_schema,
                     blockers=[
                         *endpoint_blockers,
+                        *message_blockers,
                         f"asyncapi_{action}_requires_bounded_event_runtime",
                     ],
                     contract={
@@ -573,13 +626,10 @@ def _inspect_asyncapi(
                 raw_endpoint = endpoint_override or next(iter(servers.values()), None)
             endpoint, endpoint_blockers = _https_endpoint(raw_endpoint)
             message = operation.get("message") or channel.get("messages", {})
-            if isinstance(message, dict) and "$ref" in message:
-                message_name = str(message["$ref"]).split("/")[-1]
-                message = (
-                    document.get("components", {}).get("messages", {}) or {}
-                ).get(message_name, {})
+            message_schema, message_blockers = _schema_from_message(document, message)
             blockers = [
                 *endpoint_blockers,
+                *message_blockers,
                 f"asyncapi_{action}_requires_bounded_event_runtime",
             ]
             candidates.append(
@@ -591,8 +641,8 @@ def _inspect_asyncapi(
                     summary=operation.get("summary") or operation.get("description"),
                     protocol="asyncapi",
                     endpoint=endpoint,
-                    input_schema=_schema_from_message(message),
-                    output_schema=_schema_from_message(message),
+                    input_schema=message_schema,
+                    output_schema=message_schema,
                     blockers=blockers,
                     contract={
                         "asyncapi_version": version,
@@ -693,6 +743,8 @@ def _inspect_postman(
             for query in url_object.get("query", []) or []:
                 if isinstance(query, dict) and isinstance(query.get("key"), str):
                     query_properties[query["key"]] = {"type": "string"}
+        for variable_name in unresolved:
+            query_properties.setdefault(variable_name, {"type": "string"})
         candidates.append(
             _candidate(
                 source_format="postman",

--- a/src/tooluniverse/vsd_promotion.py
+++ b/src/tooluniverse/vsd_promotion.py
@@ -15,7 +15,9 @@ from pathlib import Path
 from typing import Any, Iterator
 from urllib.parse import urlsplit
 
+from graphql import OperationType, parse as parse_graphql
 from jsonschema.exceptions import ValidationError
+from lxml import etree
 
 from .execute_function import ToolUniverse
 from .vsd_dynamic_rest import (
@@ -35,6 +37,7 @@ _MAX_PUBLISHED_TOOLS = 100
 _TOOL_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,44}$")
 _DRAFT_ID_RE = re.compile(r"^[a-z][a-z0-9_]{2,127}_[0-9a-f]{12}$")
 _FIELD_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+_CONTRACT_PARAMETER_RE = re.compile(r"^[A-Za-z0-9_.\[\]-]{1,128}$")
 _DATASET_ID_RE = re.compile(r"^[a-z0-9]{4}-[a-z0-9]{4}$")
 _PROMOTION_LOCK = threading.RLock()
 
@@ -147,6 +150,349 @@ def _review_text(value: Any, *, field: str, minimum: int, maximum: int) -> str:
     if any(ord(character) < 32 for character in text):
         raise VSDPromotionError(f"{field} contains control characters")
     return text
+
+
+def _normalized_reviewed_config(config: dict[str, Any]) -> dict[str, Any]:
+    from .vsd_reviewed_runtime import (
+        VSDReviewedRuntimeError,
+        _validated_operation_config,
+    )
+
+    try:
+        return _validated_operation_config(config)
+    except VSDReviewedRuntimeError as exc:
+        raise VSDPromotionError(str(exc)) from exc
+
+
+def _contract_parameter_map(value: Any) -> dict[str, str]:
+    if value is None:
+        return {}
+    if (
+        not isinstance(value, dict)
+        or len(value) > 32
+        or any(
+            not isinstance(source, str)
+            or not _CONTRACT_PARAMETER_RE.fullmatch(source)
+            or not isinstance(target, str)
+            or not _FIELD_RE.fullmatch(target)
+            for source, target in value.items()
+        )
+        or len(set(value.values())) != len(value)
+    ):
+        raise VSDPromotionError("vsd_contract_parameters must map unique identifiers")
+    return dict(sorted(value.items()))
+
+
+def _require_exact_endpoint(candidate: dict[str, Any], endpoint: Any) -> str:
+    expected = candidate.get("endpoint")
+    if not isinstance(expected, str) or not expected:
+        raise VSDPromotionError("Contract candidate has no bindable endpoint")
+    if endpoint != expected:
+        raise VSDPromotionError(
+            "Reviewed runtime endpoint does not match the contract candidate"
+        )
+    return expected
+
+
+def _graphql_binding(query: str) -> tuple[str, dict[str, str]]:
+    try:
+        document = parse_graphql(query)
+    except Exception as exc:
+        raise VSDPromotionError("Reviewed GraphQL query is invalid") from exc
+    operations = [
+        definition
+        for definition in document.definitions
+        if hasattr(definition, "operation")
+    ]
+    if (
+        len(operations) != 1
+        or operations[0].operation is not OperationType.QUERY
+        or len(operations[0].selection_set.selections) != 1
+    ):
+        raise VSDPromotionError(
+            "Contract-bound GraphQL must select exactly one query root field"
+        )
+    selection = operations[0].selection_set.selections[0]
+    name = getattr(getattr(selection, "name", None), "value", None)
+    if not isinstance(name, str):
+        raise VSDPromotionError("Contract-bound GraphQL root selection must be a field")
+    arguments: dict[str, str] = {}
+    for argument in getattr(selection, "arguments", ()):
+        argument_name = getattr(getattr(argument, "name", None), "value", None)
+        variable_name = getattr(
+            getattr(getattr(argument, "value", None), "name", None), "value", None
+        )
+        if (
+            not isinstance(argument_name, str)
+            or not isinstance(variable_name, str)
+            or argument_name in arguments
+        ):
+            raise VSDPromotionError(
+                "Contract-bound GraphQL root arguments must use unique variables"
+            )
+        arguments[argument_name] = variable_name
+    return name, arguments
+
+
+def _postman_endpoint(
+    candidate: dict[str, Any],
+    operation: dict[str, Any],
+    parameter_map: dict[str, str],
+) -> str:
+    endpoint = candidate.get("endpoint")
+    if not isinstance(endpoint, str) or not endpoint:
+        raise VSDPromotionError("Postman candidate has no bindable endpoint")
+    variables = sorted(
+        set(re.findall(r"\{\{([A-Za-z][A-Za-z0-9_]{0,63})\}\}", endpoint))
+    )
+    if set(parameter_map) != set(variables):
+        raise VSDPromotionError(
+            "Postman contract parameters must resolve every endpoint variable exactly"
+        )
+    path_arguments = operation["request"]["path_arguments"]
+    parameter_properties = set(operation.get("_parameter_properties", []))
+    expected = endpoint
+    for source in variables:
+        argument = parameter_map[source]
+        provider_name = path_arguments.get(argument)
+        if argument not in parameter_properties or provider_name is None:
+            raise VSDPromotionError(
+                "Postman contract parameter must bind one reviewed path argument"
+            )
+        expected = expected.replace(f"{{{{{source}}}}}", f"{{{provider_name}}}")
+    if "{{" in expected or "}}" in expected:
+        raise VSDPromotionError("Postman endpoint contains unresolved variables")
+    return expected
+
+
+def _soap_operation(envelope: str) -> str:
+    rendered = re.sub(r"\{[A-Za-z][A-Za-z0-9_]{0,63}\}", "value", envelope)
+    try:
+        root = etree.fromstring(
+            rendered.encode(),
+            parser=etree.XMLParser(
+                resolve_entities=False, no_network=True, load_dtd=False
+            ),
+        )
+    except etree.XMLSyntaxError as exc:
+        raise VSDPromotionError("Reviewed SOAP envelope is invalid") from exc
+    bodies = [
+        element for element in root.iter() if etree.QName(element).localname == "Body"
+    ]
+    children = [
+        child for body in bodies for child in body if isinstance(child.tag, str)
+    ]
+    if len(bodies) != 1 or len(children) != 1:
+        raise VSDPromotionError(
+            "Contract-bound SOAP envelope must contain exactly one body operation"
+        )
+    return etree.QName(children[0]).localname
+
+
+def _qualified_contract_type(package: Any, name: Any) -> str:
+    if not isinstance(name, str) or not name:
+        raise VSDPromotionError("gRPC contract message type is missing")
+    if not isinstance(package, str) or not package:
+        return name.lstrip(".")
+    prefix = f"{package}."
+    normalized = name.lstrip(".")
+    return normalized if normalized.startswith(prefix) else prefix + normalized
+
+
+def _bind_contract_candidate(
+    candidate: dict[str, Any],
+    normalized_config: dict[str, Any],
+    parameter_map: dict[str, str],
+) -> dict[str, Any]:
+    operation = normalized_config["vsd_reviewed_operation"]
+    properties = normalized_config["parameter"]["properties"]
+    operation["_parameter_properties"] = sorted(properties)
+    source_format = candidate["source_format"]
+    contract = candidate.get("contract")
+    if not isinstance(contract, dict):
+        raise VSDPromotionError("Contract candidate identity is invalid")
+    identity: dict[str, Any] = {
+        "endpoint": candidate.get("endpoint"),
+        "operation": candidate.get("name"),
+    }
+
+    if source_format == "graphql":
+        _require_exact_endpoint(candidate, operation.get("endpoint"))
+        if (
+            candidate.get("kind") != "graphql_query"
+            or contract.get("operation_type") != "query"
+            or operation["request"]["method"] != candidate.get("method")
+        ):
+            raise VSDPromotionError("GraphQL candidate is not the reviewed query")
+        body = operation["request"]["body"]
+        root_field, root_arguments = _graphql_binding(body["query"])
+        if root_field != contract.get("field") or root_field != candidate.get("name"):
+            raise VSDPromotionError(
+                "Reviewed GraphQL root field does not match the contract candidate"
+            )
+        input_schema = candidate.get("input_schema")
+        candidate_arguments = (
+            input_schema.get("properties") if isinstance(input_schema, dict) else None
+        )
+        required_arguments = (
+            set(input_schema.get("required", []))
+            if isinstance(input_schema, dict)
+            else set()
+        )
+        runtime_variables = set(body["arguments"].values()) | set(body["fixed"])
+        if (
+            not isinstance(candidate_arguments, dict)
+            or not required_arguments <= set(root_arguments)
+            or not set(root_arguments) <= set(candidate_arguments)
+            or set(root_arguments.values()) != runtime_variables
+        ):
+            raise VSDPromotionError(
+                "Reviewed GraphQL arguments do not match the contract field"
+            )
+        identity.update(
+            {"root_field": root_field, "argument_variables": root_arguments}
+        )
+    elif source_format == "postman":
+        expected_endpoint = _postman_endpoint(candidate, operation, parameter_map)
+        if operation.get("endpoint") != expected_endpoint:
+            raise VSDPromotionError(
+                "Reviewed runtime endpoint does not match the Postman request"
+            )
+        if operation["request"]["method"] != candidate.get("method"):
+            raise VSDPromotionError(
+                "Reviewed HTTP method does not match the Postman request"
+            )
+        input_schema = candidate.get("input_schema")
+        candidate_parameters = (
+            set(input_schema.get("properties", {}))
+            if isinstance(input_schema, dict)
+            else set()
+        )
+        reviewed_parameters = (
+            set(parameter_map)
+            | set(operation["request"]["query_arguments"].values())
+            | set(operation["request"]["fixed_query"])
+        )
+        if not reviewed_parameters <= candidate_parameters:
+            raise VSDPromotionError(
+                "Reviewed request parameters are absent from the Postman contract"
+            )
+        identity["endpoint"] = expected_endpoint
+    elif source_format == "wsdl":
+        _require_exact_endpoint(candidate, operation.get("endpoint"))
+        if operation["request"]["method"] != candidate.get("method"):
+            raise VSDPromotionError("Reviewed SOAP method does not match the WSDL")
+        headers = operation["request"]["fixed_headers"]
+        actions = [
+            value for name, value in headers.items() if name.casefold() == "soapaction"
+        ]
+        if actions != [contract.get("soap_action")]:
+            raise VSDPromotionError(
+                "Reviewed SOAPAction does not match the WSDL operation"
+            )
+        body_operation = _soap_operation(operation["request"]["body"]["envelope"])
+        if body_operation != contract.get("operation"):
+            raise VSDPromotionError(
+                "Reviewed SOAP body operation does not match the WSDL operation"
+            )
+        identity.update({"soap_action": actions[0], "body_operation": body_operation})
+    elif source_format == "protobuf":
+        endpoint = urlsplit(str(candidate.get("endpoint") or ""))
+        try:
+            endpoint_port = endpoint.port
+        except ValueError as exc:
+            raise VSDPromotionError(
+                "gRPC candidate endpoint has an invalid port"
+            ) from exc
+        if (
+            endpoint.scheme.casefold() != "https"
+            or not endpoint.hostname
+            or endpoint.username
+            or endpoint.password
+            or endpoint.query
+            or endpoint.fragment
+            or endpoint.path not in {"", "/"}
+            or endpoint_port not in {None, 443}
+        ):
+            raise VSDPromotionError(
+                "gRPC candidate endpoint is not a bindable authority"
+            )
+        expected_authority = f"{endpoint.hostname.casefold()}:443"
+        expected_method = (
+            f"/{contract.get('package') + '.' if contract.get('package') else ''}"
+            f"{contract.get('service')}/{contract.get('rpc')}"
+        )
+        expected_streaming = "server" if contract.get("server_streaming") else "unary"
+        if contract.get("client_streaming") is not False:
+            raise VSDPromotionError("Client-streaming gRPC candidates are unsupported")
+        if (
+            operation.get("endpoint", "").casefold() != expected_authority
+            or operation.get("method") != expected_method
+            or operation.get("request_type")
+            != _qualified_contract_type(
+                contract.get("package"), contract.get("input_type")
+            )
+            or operation.get("response_type")
+            != _qualified_contract_type(
+                contract.get("package"), contract.get("output_type")
+            )
+            or operation.get("streaming") != expected_streaming
+        ):
+            raise VSDPromotionError(
+                "Reviewed gRPC identity does not match the protobuf candidate"
+            )
+        identity.update(
+            {
+                "endpoint": expected_authority,
+                "method": expected_method,
+                "request_type": operation["request_type"],
+                "response_type": operation["response_type"],
+                "streaming": expected_streaming,
+            }
+        )
+    elif source_format == "mcp":
+        _require_exact_endpoint(candidate, operation.get("endpoint"))
+        declared = contract.get("declared_tools")
+        if not isinstance(declared, list) or operation.get("tool_name") not in declared:
+            raise VSDPromotionError(
+                "Reviewed MCP tool is not declared by the contract candidate"
+            )
+        identity["tool_name"] = operation["tool_name"]
+    elif source_format == "asyncapi":
+        _require_exact_endpoint(candidate, operation.get("source_endpoint"))
+        if contract.get("action") not in {"receive", "subscribe"}:
+            raise VSDPromotionError(
+                "Reviewed event runtime cannot bind an outbound AsyncAPI operation"
+            )
+        candidate_schema = candidate.get("input_schema")
+        if not isinstance(candidate_schema, dict) or not candidate_schema:
+            raise VSDPromotionError("AsyncAPI candidate has no bindable payload schema")
+        if (
+            operation.get("channel") != contract.get("channel")
+            or operation.get("event_schema") != candidate_schema
+        ):
+            raise VSDPromotionError(
+                "Reviewed event channel or schema does not match the AsyncAPI candidate"
+            )
+        identity.update(
+            {
+                "channel": operation["channel"],
+                "action": contract["action"],
+                "event_schema_sha256": _canonical_digest(operation["event_schema"]),
+            }
+        )
+    else:  # pragma: no cover - validate_contract_candidate owns this boundary
+        raise VSDPromotionError("Contract candidate format is unsupported")
+
+    operation.pop("_parameter_properties", None)
+    binding = {
+        "version": 1,
+        "source_format": source_format,
+        "candidate_id": candidate["candidate_id"],
+        "parameter_map": parameter_map,
+        "identity": identity,
+    }
+    return {**binding, "binding_sha256": _canonical_digest(binding)}
 
 
 def _candidate_fields(candidate: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -413,6 +759,11 @@ def create_reviewed_operation_draft(
             "resolved_blockers must explicitly acknowledge every candidate blocker"
         )
     note = _review_text(review_note, field="review_note", minimum=20, maximum=1000)
+    unbound = copy.deepcopy(config)
+    parameter_map = _contract_parameter_map(
+        unbound.pop("vsd_contract_parameters", None)
+    )
+    normalized = _normalized_reviewed_config(unbound)
     expected = {
         "graphql": ("http", "graphql"),
         "asyncapi": ("event", "asyncapi"),
@@ -421,7 +772,7 @@ def create_reviewed_operation_draft(
         "protobuf": ("grpc", "grpc"),
         "mcp": ("mcp", "mcp"),
     }
-    operation = config.get("vsd_reviewed_operation")
+    operation = normalized.get("vsd_reviewed_operation")
     if (
         not isinstance(operation, dict)
         or (operation.get("transport"), operation.get("protocol"))
@@ -430,7 +781,8 @@ def create_reviewed_operation_draft(
         raise VSDPromotionError(
             "Reviewed runtime transport does not match the contract format"
         )
-    bound = copy.deepcopy(config)
+    contract_binding = _bind_contract_candidate(reviewed, normalized, parameter_map)
+    bound = unbound
     bound["vsd_promotion"] = {
         "generator_version": _GENERATOR_VERSION,
         "source_type": "contract",
@@ -442,10 +794,11 @@ def create_reviewed_operation_draft(
         "candidate_kind": reviewed["kind"],
         "resolved_blockers": sorted(set(resolved_blockers)),
         "review_note": note,
+        "contract_binding": contract_binding,
     }
     try:
         _operation_digest(bound)
-    except VSDDynamicRESTError as exc:
+    except (VSDDynamicRESTError, ValueError) as exc:
         raise VSDPromotionError(str(exc)) from exc
     return _create_draft_from_config(bound, workspace=workspace)
 

--- a/src/tooluniverse/vsd_reviewed_runtime.py
+++ b/src/tooluniverse/vsd_reviewed_runtime.py
@@ -474,6 +474,47 @@ def _validated_http_request(
     }
 
 
+def _require_grpc_descriptor_identity(operation: dict[str, Any]) -> None:
+    try:
+        from google.protobuf import descriptor_pb2
+        from google.protobuf.message import DecodeError
+    except ImportError as exc:
+        raise VSDReviewedRuntimeError("protobuf runtime is not installed") from exc
+    descriptor_set = descriptor_pb2.FileDescriptorSet()
+    try:
+        descriptor_set.ParseFromString(
+            base64.b64decode(operation["descriptor_set_base64"], validate=True)
+        )
+    except (ValueError, DecodeError) as exc:
+        raise VSDReviewedRuntimeError("gRPC descriptor set is invalid") from exc
+    expected_path = operation["method"]
+    matches = []
+    for file_descriptor in descriptor_set.file:
+        for service in file_descriptor.service:
+            service_name = (
+                f"{file_descriptor.package}.{service.name}"
+                if file_descriptor.package
+                else service.name
+            )
+            for method in service.method:
+                if f"/{service_name}/{method.name}" == expected_path:
+                    matches.append(method)
+    if len(matches) != 1:
+        raise VSDReviewedRuntimeError(
+            "gRPC method must occur exactly once in the reviewed descriptor set"
+        )
+    method = matches[0]
+    if (
+        method.input_type.lstrip(".") != operation["request_type"]
+        or method.output_type.lstrip(".") != operation["response_type"]
+        or method.client_streaming
+        or ("server" if method.server_streaming else "unary") != operation["streaming"]
+    ):
+        raise VSDReviewedRuntimeError(
+            "gRPC method messages or streaming mode do not match the descriptor"
+        )
+
+
 def _validated_operation_config(config: Any) -> dict[str, Any]:
     if not isinstance(config, dict):
         raise VSDReviewedRuntimeError("Tool configuration must be an object")
@@ -625,6 +666,7 @@ def _validated_operation_config(config: Any) -> dict[str, Any]:
                 "max_messages": max_messages,
             }
         )
+        _require_grpc_descriptor_identity(normalized_operation)
         if set(properties) != {"request"}:
             raise VSDReviewedRuntimeError(
                 "gRPC tools expose exactly one request argument"
@@ -654,6 +696,16 @@ def _validated_operation_config(config: Any) -> dict[str, Any]:
         if normalized_operation["response"]["format"] != "json":
             raise VSDReviewedRuntimeError("MCP responses must use JSON normalization")
     else:
+        source_endpoint = operation.get("source_endpoint")
+        if source_endpoint is not None:
+            source_endpoint = _validated_endpoint(
+                source_endpoint, field="event source_endpoint"
+            )
+            if urlsplit(source_endpoint).query:
+                raise VSDReviewedRuntimeError(
+                    "Event source_endpoint cannot contain a query"
+                )
+            normalized_operation["source_endpoint"] = source_endpoint
         event_argument = operation.get("event_argument", "event")
         signature_argument = operation.get("signature_argument")
         if event_argument not in properties or not _ARGUMENT_RE.fullmatch(
@@ -1430,7 +1482,7 @@ class VSDReviewedOperationTool(BaseTool):
             method = "tools/call"
         else:
             result, request_metadata, secrets = _event_run(operation, values)
-            endpoint = operation["channel"]
+            endpoint = operation.get("source_endpoint", operation["channel"])
             method = "validate"
         if any(_contains_secret(result, secret) for secret in secrets):
             raise VSDReviewedRuntimeError("Runtime result contains credential material")

--- a/tests/unit/test_vsd_catalog_concurrency.py
+++ b/tests/unit/test_vsd_catalog_concurrency.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from tooluniverse import vsd_tool
+import tooluniverse.vsd_tool as vsd_tool
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_vsd_contract_runtime_binding.py
+++ b/tests/unit/test_vsd_contract_runtime_binding.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import json
+
+import pytest
+from google.protobuf import descriptor_pb2
+
+from examples.vsd.multiformat_contract_case_study import _documents
+from examples.vsd.reviewed_runtime_case_study import _http_config, _json_response
+from examples.vsd.source_intelligence_case_study import DANDI, _asyncapi, _postman
+from tooluniverse import vsd_promotion
+from tooluniverse.vsd_reviewed_runtime import VSDReviewedOperationTool
+from tooluniverse.vsd_contracts import (
+    VSDContractError,
+    inspect_contract_document,
+    validate_contract_candidate,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _candidate_map(tmp_path):
+    selected = {
+        "graphql": "disease",
+        "asyncapi": "receiveSignal",
+        "postman": "Participants/Motor trajectory",
+        "wsdl": "PanelPort.GetSMNPanel",
+        "protobuf": "variants.v1.VariantEvidenceService.GetEvidence",
+        "mcp": "literature",
+    }
+    candidates = {}
+    for definition in _documents():
+        path = tmp_path / definition["name"]
+        path.write_text(definition["contents"], encoding="utf-8")
+        report = inspect_contract_document(path, endpoint=definition.get("endpoint"))
+        for candidate in report["candidates"]:
+            if candidate["name"] == selected.get(candidate["source_format"]):
+                candidates[candidate["source_format"]] = candidate
+    assert set(candidates) == set(selected)
+    return candidates
+
+
+def _descriptor_set(*, service_name: str = "VariantEvidenceService") -> str:
+    descriptor = descriptor_pb2.FileDescriptorProto(
+        name="variants.proto", package="variants.v1", syntax="proto3"
+    )
+    request = descriptor.message_type.add(name="VariantRequest")
+    request.field.add(
+        name="hgvs",
+        number=1,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_STRING,
+    )
+    request.field.add(
+        name="assembly",
+        number=2,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_STRING,
+    )
+    response = descriptor.message_type.add(name="VariantEvidence")
+    response.field.add(
+        name="classification",
+        number=1,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_STRING,
+    )
+    response.field.add(
+        name="score",
+        number=2,
+        label=descriptor_pb2.FieldDescriptorProto.LABEL_OPTIONAL,
+        type=descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE,
+    )
+    service = descriptor.service.add(name=service_name)
+    service.method.add(
+        name="GetEvidence",
+        input_type=".variants.v1.VariantRequest",
+        output_type=".variants.v1.VariantEvidence",
+    )
+    return base64.b64encode(
+        descriptor_pb2.FileDescriptorSet(file=[descriptor]).SerializeToString()
+    ).decode()
+
+
+def _configs(candidates):
+    graphql = _http_config(
+        "BoundDiseaseGraphQL",
+        "Retrieve one disease through the exact reviewed GraphQL root field.",
+        candidates["graphql"]["endpoint"],
+        protocol="graphql",
+        properties={"filter": {"type": "object"}},
+        request={
+            "method": "POST",
+            "reviewed_read_only": True,
+            "body": {
+                "mode": "graphql",
+                "query": (
+                    "query Disease($filter: DiseaseFilter!) "
+                    "{ disease(filter: $filter) { id } }"
+                ),
+                "operation_name": "Disease",
+                "arguments": {"filter": "filter"},
+            },
+        },
+        response=_json_response(),
+    )
+    postman = _http_config(
+        "BoundMotorTrajectory",
+        "Retrieve the exact reviewed natural-history trajectory request.",
+        candidates["postman"]["endpoint"],
+        properties={
+            "participant": {"type": "string"},
+            "months": {"type": "string"},
+        },
+        request={
+            "method": "GET",
+            "query_arguments": {
+                "participant": "participant",
+                "months": "months",
+            },
+            "body": {"mode": "none"},
+        },
+        response=_json_response(),
+    )
+    wsdl = _http_config(
+        "BoundSMNPanel",
+        "Retrieve the exact reviewed molecular panel SOAP operation.",
+        candidates["wsdl"]["endpoint"],
+        protocol="soap",
+        properties={"sample_id": {"type": "string"}},
+        request={
+            "method": "POST",
+            "reviewed_read_only": True,
+            "fixed_headers": {"SOAPAction": "urn:GetSMNPanel"},
+            "body": {
+                "mode": "soap",
+                "envelope": (
+                    "<Envelope><Body><GetSMNPanel><sample>{sample_id}</sample>"
+                    "</GetSMNPanel></Body></Envelope>"
+                ),
+                "arguments": {"sample_id": "sample"},
+            },
+        },
+        response={"format": "xml", "schema": {"type": "object"}},
+    )
+    grpc = {
+        "name": "BoundVariantGRPC",
+        "type": "VSDReviewedOperationTool",
+        "description": "Retrieve the exact reviewed variant-evidence RPC operation.",
+        "parameter": {
+            "type": "object",
+            "properties": {"request": {"type": "object"}},
+            "required": ["request"],
+            "additionalProperties": False,
+        },
+        "vsd_reviewed_operation": {
+            "version": 1,
+            "transport": "grpc",
+            "protocol": "grpc",
+            "endpoint": "variants.example.org:443",
+            "method": "/variants.v1.VariantEvidenceService/GetEvidence",
+            "descriptor_set_base64": _descriptor_set(),
+            "request_type": "variants.v1.VariantRequest",
+            "response_type": "variants.v1.VariantEvidence",
+            "streaming": "unary",
+            "max_messages": 1,
+            "auth": {"type": "none"},
+            "response": {"format": "json", "schema": {"type": "object"}},
+        },
+    }
+    mcp = {
+        "name": "BoundLiteratureMCP",
+        "type": "VSDReviewedOperationTool",
+        "description": "Invoke one exact reviewed literature tool on the declared server.",
+        "parameter": {
+            "type": "object",
+            "properties": {"arguments": {"type": "object"}},
+            "required": ["arguments"],
+            "additionalProperties": False,
+        },
+        "vsd_reviewed_operation": {
+            "version": 1,
+            "transport": "mcp",
+            "protocol": "mcp",
+            "endpoint": candidates["mcp"]["endpoint"],
+            "tool_name": "search_sma_trials",
+            "auth": {"type": "none"},
+            "response": {"format": "json", "schema": {"type": "object"}},
+        },
+    }
+    event_schema = copy.deepcopy(candidates["asyncapi"]["input_schema"])
+    asyncapi = {
+        "name": "BoundSafetyEvent",
+        "type": "VSDReviewedOperationTool",
+        "description": "Validate one event from the exact reviewed AsyncAPI channel.",
+        "parameter": {
+            "type": "object",
+            "properties": {"event": {"type": "object"}},
+            "required": ["event"],
+            "additionalProperties": False,
+        },
+        "vsd_reviewed_operation": {
+            "version": 1,
+            "transport": "event",
+            "protocol": "asyncapi",
+            "source_endpoint": candidates["asyncapi"]["endpoint"],
+            "channel": candidates["asyncapi"]["contract"]["channel"],
+            "event_argument": "event",
+            "event_schema": event_schema,
+            "auth": {"type": "none"},
+            "response": {"format": "json", "schema": {"type": "object"}},
+        },
+    }
+    return {
+        "graphql": graphql,
+        "asyncapi": asyncapi,
+        "postman": postman,
+        "wsdl": wsdl,
+        "protobuf": grpc,
+        "mcp": mcp,
+    }
+
+
+def _draft(candidate, config, workspace):
+    return vsd_promotion.create_reviewed_operation_draft(
+        candidate,
+        config,
+        resolved_blockers=candidate["blockers"],
+        review_note=(
+            "The exact provider, operation identity, parameters, and runtime bounds "
+            "were reviewed against the content-addressed contract."
+        ),
+        workspace=workspace,
+    )
+
+
+def test_all_contract_formats_bind_exact_runtime_identity(tmp_path):
+    candidates = _candidate_map(tmp_path)
+    configs = _configs(candidates)
+    for source_format, candidate in candidates.items():
+        draft = _draft(candidate, configs[source_format], tmp_path / source_format)
+        binding = draft["config"]["vsd_promotion"]["contract_binding"]
+        assert binding["source_format"] == source_format
+        assert binding["candidate_id"] == candidate["candidate_id"]
+        assert len(binding["binding_sha256"]) == 64
+
+
+@pytest.mark.parametrize(
+    ("source_format", "mutation", "message"),
+    [
+        (
+            "graphql",
+            lambda config: config["vsd_reviewed_operation"].update(
+                {"endpoint": "https://wrong.example.org/graphql"}
+            ),
+            "endpoint",
+        ),
+        (
+            "postman",
+            lambda config: config["vsd_reviewed_operation"]["request"][
+                "query_arguments"
+            ].update({"participant": "invented"}),
+            "absent",
+        ),
+        (
+            "wsdl",
+            lambda config: config["vsd_reviewed_operation"]["request"][
+                "fixed_headers"
+            ].update({"SOAPAction": "urn:DifferentOperation"}),
+            "SOAPAction",
+        ),
+        (
+            "protobuf",
+            lambda config: config["vsd_reviewed_operation"].update(
+                {"method": "/variants.v1.VariantEvidenceService/WatchEvidence"}
+            ),
+            "descriptor",
+        ),
+        (
+            "mcp",
+            lambda config: config["vsd_reviewed_operation"].update(
+                {"tool_name": "undeclared_tool"}
+            ),
+            "not declared",
+        ),
+        (
+            "asyncapi",
+            lambda config: config["vsd_reviewed_operation"].update(
+                {"channel": "different/channel"}
+            ),
+            "channel",
+        ),
+    ],
+)
+def test_contract_binding_rejects_cross_provider_or_operation_substitution(
+    tmp_path, source_format, mutation, message
+):
+    candidates = _candidate_map(tmp_path)
+    config = copy.deepcopy(_configs(candidates)[source_format])
+    mutation(config)
+    with pytest.raises(vsd_promotion.VSDPromotionError, match=message):
+        _draft(candidates[source_format], config, tmp_path / "rejected")
+
+
+def test_postman_template_requires_explicit_complete_parameter_map(tmp_path):
+    path = tmp_path / "dandi.postman_collection.json"
+    path.write_bytes(_postman())
+    candidate = inspect_contract_document(path)["candidates"][0]
+    config = _http_config(
+        "BoundDandisetLookup",
+        "Retrieve one DANDI record through the explicitly mapped path variable.",
+        f"https://{DANDI}/api/dandisets/{{dandiset_id}}",
+        properties={"dandiset_id": {"type": "string"}},
+        request={
+            "method": "GET",
+            "path_arguments": {"dandiset_id": "dandiset_id"},
+            "body": {"mode": "none"},
+        },
+        response=_json_response(),
+    )
+    config["vsd_contract_parameters"] = {"dandisetId": "dandiset_id"}
+    draft = _draft(candidate, config, tmp_path / "mapped")
+    binding = draft["config"]["vsd_promotion"]["contract_binding"]
+    assert binding["parameter_map"] == {"dandisetId": "dandiset_id"}
+    assert binding["identity"]["endpoint"].endswith("/{dandiset_id}")
+
+    missing = copy.deepcopy(config)
+    missing.pop("vsd_contract_parameters")
+    with pytest.raises(
+        vsd_promotion.VSDPromotionError, match="every endpoint variable"
+    ):
+        _draft(candidate, missing, tmp_path / "missing")
+
+
+def test_grpc_descriptor_must_contain_exact_reviewed_rpc(tmp_path):
+    candidates = _candidate_map(tmp_path)
+    config = _configs(candidates)["protobuf"]
+    config["vsd_reviewed_operation"]["descriptor_set_base64"] = _descriptor_set(
+        service_name="DifferentService"
+    )
+    with pytest.raises(vsd_promotion.VSDPromotionError, match="descriptor"):
+        _draft(candidates["protobuf"], config, tmp_path / "bad-descriptor")
+
+
+def test_asyncapi_local_channel_message_reference_preserves_payload_schema(tmp_path):
+    path = tmp_path / "dandi.asyncapi.yaml"
+    path.write_bytes(_asyncapi())
+    candidate = inspect_contract_document(path)["candidates"][0]
+    assert candidate["input_schema"]["required"] == [
+        "dandisetId",
+        "version",
+        "changedAt",
+    ]
+    assert set(candidate["input_schema"]["properties"]) == {
+        "dandisetId",
+        "version",
+        "changedAt",
+    }
+
+
+def test_contract_candidate_rejects_unknown_field_with_recomputed_digest(tmp_path):
+    candidate = copy.deepcopy(_candidate_map(tmp_path)["graphql"])
+    candidate["hidden_instruction"] = "substitute another provider"
+    body = {
+        key: value
+        for key, value in candidate.items()
+        if key not in {"candidate_id", "candidate_sha256"}
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            body, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode()
+    ).hexdigest()
+    candidate.update({"candidate_id": digest[:16], "candidate_sha256": digest})
+    with pytest.raises(VSDContractError, match="fields"):
+        validate_contract_candidate(candidate)
+
+
+def test_bound_asyncapi_provenance_uses_source_endpoint_and_keeps_channel(tmp_path):
+    candidates = _candidate_map(tmp_path)
+    config = _configs(candidates)["asyncapi"]
+    event = {"drugId": "drug-1", "event": "infection", "caseCount": 4}
+    data = VSDReviewedOperationTool(config).run({"event": event})["data"]
+    assert data["result"] == event
+    assert data["provenance"]["provider"] == "safety.example.org"
+    assert data["provenance"]["endpoint"] == "https://safety.example.org"
+    assert data["provenance"]["runtime"]["channel"] == ("neuromuscular/safety/{drugId}")

--- a/tests/unit/test_vsd_cross_format_total_proof.py
+++ b/tests/unit/test_vsd_cross_format_total_proof.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from examples.vsd import cross_format_total_proof as study
+
+pytestmark = pytest.mark.unit
+
+
+def test_cross_format_total_proof_is_complete_and_deterministic(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOOLUNIVERSE_CACHE_PERSIST", "false")
+    first = study.run_case(tmp_path / "first")
+    second = study.run_case(tmp_path / "second")
+    assert first == second
+    assert first["portfolio_case_count"] == 16
+    assert first["promotion_stage"]["promoted_format_count"] == 6
+    assert first["promotion_stage"]["verification_case_count"] == 18
+    assert set(first["promotion_stage"]["loaded_tools"]) == set(
+        study.FORMAT_TOOL_NAMES.values()
+    )
+    assert len(first["adversarial_binding_cases"]) == 8
+    assert all(
+        item["result"] == "rejected" for item in first["adversarial_binding_cases"]
+    )
+    assert len(first["end_to_end_assertions"]) == 21
+    assert all(first["end_to_end_assertions"].values())
+
+    asyncapi = next(
+        item
+        for item in first["promotion_stage"]["records"]
+        if item["source_format"] == "asyncapi"
+    )
+    assert asyncapi["contract_binding"]["identity"]["event_schema_sha256"] != (
+        study._digest({})
+    )
+
+
+def test_checked_cross_format_artifacts_are_synchronized_and_tamper_evident():
+    snapshot = json.loads(study.DEFAULT_JSON.read_text(encoding="utf-8"))
+    study.validate_snapshot(snapshot)
+    assert study.DEFAULT_MARKDOWN.read_text(encoding="utf-8") == study._markdown(
+        snapshot
+    )
+    assert snapshot["portfolio_case_count"] == 16
+    assert len(snapshot["prior_case_studies"]) == 15
+    assert all(item["all_checks_passed"] for item in snapshot["prior_case_studies"])
+
+    tampered = copy.deepcopy(snapshot)
+    tampered["promotion_stage"]["records"][0]["tool_name"] = "SubstitutedTool"
+    with pytest.raises(ValueError, match="audit digest"):
+        study.validate_snapshot(tampered)
+
+    incomplete = copy.deepcopy(snapshot)
+    incomplete["end_to_end_assertions"].pop(
+        "all_eight_substitution_attacks_were_rejected"
+    )
+    incomplete["audit_sha256"] = study._digest(
+        {key: value for key, value in incomplete.items() if key != "audit_sha256"}
+    )
+    with pytest.raises(ValueError, match="assertions"):
+        study.validate_snapshot(incomplete)


### PR DESCRIPTION
## Purpose

Complete the stacked VSD implementation after #431 by proving that reviewed source discovery can reach a fresh ToolUniverse runtime across every supported non-OpenAPI contract format without widening the reviewed authority. The proof also exposed and fixes exact-binding gaps that smaller format-specific tests did not reveal.

This PR targets `vsd-organic-source-intelligence`; it contains only the final contract-to-runtime binding layer, its regressions, and the total-system study.

## Substantive fixes

- Bind every promoted generic contract candidate to the exact reviewed runtime endpoint, operation, parameters, and protocol identity, then preserve that binding under a SHA-256 digest in the promotion record.
- Validate GraphQL root fields and arguments, Postman method/URL/template-variable maps, WSDL SOAPAction and body operation, protobuf service/RPC/types/streaming, MCP manifest tool membership, and AsyncAPI source/channel/schema.
- Validate protobuf descriptor identity before execution: the exact method must occur once with the reviewed input/output types and streaming mode; client streaming remains unsupported.
- Include unresolved Postman URL variables in inspection so review must map every variable explicitly instead of silently inventing parameters.
- Resolve bounded local AsyncAPI JSON Pointers, including channel-level message references, while failing closed on cycles and missing references.
- Reject hidden extra fields in generic candidates even if an attacker recomputes the document digest.
- Preserve event source provenance separately from the runtime channel, fix the reviewed SOAP fixture to match its WSDL operation, and keep Windows process tests from loading the full 2,700-tool registry in every child.

## End-to-end validation

The ALS study starts from the real ToolUniverse inventory and asks whether already-covered NIH RePORTER evidence can be left alone while six missing DANDI interfaces move through bounded discovery, content-addressed inspection, exact review, representative verification, approval, publication, fresh-runtime loading, and useful execution.

Results:

- audited 2,744 configured tools, 259 configured hosts, and the 50-source review catalog
- scanned two explicit hosts twice under robots, host, page, depth, byte, and time limits
- found and snapshotted seven formats without executing them
- kept the already-covered OpenAPI source out of promotion
- promoted GraphQL, Postman/REST, WSDL/SOAP, protobuf/gRPC, MCP, and AsyncAPI operations only from the identified DANDI gap
- ran three representative verification cases per operation, for 18 verification executions
- loaded all six published tools in a fresh ToolUniverse instance and executed all six
- rejected eight deliberate authority substitutions across every format
- passed all 21 total-system assertions
- kept the source handoff local and unsubmitted and kept Docker as an independent administrator-only boundary

The checked artifact also links and summarizes 16 professional studies covering the entire stack from #416 through this PR:

- [Cross-format total proof](https://github.com/mims-harvard/ToolUniverse/blob/vsd-cross-format-total-proof/examples/vsd/artifacts/cross_format_total_proof.md)
- [Machine-verifiable proof](https://github.com/mims-harvard/ToolUniverse/blob/vsd-cross-format-total-proof/examples/vsd/artifacts/cross_format_total_proof.json)

Audit SHA-256: `0223d236556c284746e7acf5985f7fc2195f74de8ffcbe796d3dd4092e32c10b`

## Fail-closed evidence

The study rejects a cross-provider GraphQL endpoint, an unmapped Postman template, substituted SOAP action and body operation, a substituted gRPC RPC, an undeclared MCP tool, a substituted AsyncAPI channel, and an event configuration with its reviewed source omitted. Each rejection occurs before the candidate can be approved or loaded.

## Verification

- 287 cumulative VSD unit and integration tests passed
- 51 focused contract, runtime, lifecycle, source-intelligence, and total-proof tests passed
- 8 isolated process/concurrency tests passed on Windows
- 18 representative verification executions, 6 fresh-runtime executions, 8 deliberate rejections, and 21 end-to-end assertions passed
- Ruff 0.14.5 format and lint checks passed
- `uv lock --check` passed with 349 packages
- source distribution and wheel built successfully; the exact final wheel contains all changed runtime modules
- Python compilation and checked JSON parsing passed
- `git diff --check`, credential-pattern scanning, and prohibited-terminology scanning passed

## Boundary

This proves deterministic software behavior, provenance, review gates, and runtime binding. It does not certify a provider's scientific content, treat discovery-catalog membership as permission to execute, automatically submit source handoffs, or expose Docker lifecycle control to an agent.
