### PR TITLE
Add end-to-end biomedical VSD evaluations

### DIFF
--- a/docs/dev_docs/VSD_API_DISCOVERY_VALIDATION.md
+++ b/docs/dev_docs/VSD_API_DISCOVERY_VALIDATION.md
@@ -153,6 +153,22 @@ tooluniverse-vsd-promote --workspace ./private-vsd-promotion \
   --review-note "Reviewed the exact response structure and three representative calls."
 ```
 
+## GA4GH Service Qualification Evaluation
+
+`examples/vsd/ga4gh_service_qualification_portfolio.py` applies the standard
+Service Info path to 15 registry implementations through one data-driven
+runner. It covers service-registry, DRS, TRS, WES, and RNAget records and
+retains both successful and unsuccessful qualification outcomes.
+
+The checked portfolio admits three services after nine registry-bound
+verification executions and rejects twelve before approval. Accepted tools
+complete publication, fresh-universe loading, final execution, and exact
+duplicate suppression. Rejected drafts include live-looking JSON with standard
+type drift as well as unavailable, redirecting, and non-JSON paths; none gains
+an approval or publication artifact. See
+`examples/vsd/artifacts/ga4gh_service_qualification_portfolio.md` and its JSON
+counterpart for the source-by-source evidence.
+
 ## Biomedical Evaluation Portfolio
 
 `examples/vsd/biomedical_evaluation_portfolio.py` applies the same orchestration

--- a/docs/dev_docs/VSD_API_DISCOVERY_VALIDATION.md
+++ b/docs/dev_docs/VSD_API_DISCOVERY_VALIDATION.md
@@ -153,6 +153,39 @@ tooluniverse-vsd-promote --workspace ./private-vsd-promotion \
   --review-note "Reviewed the exact response structure and three representative calls."
 ```
 
+## Biomedical Evaluation Portfolio
+
+`examples/vsd/biomedical_evaluation_portfolio.py` applies the same orchestration
+to five JSON scenarios rather than embedding scientific cases in runtime code.
+Each scenario supplies its research question, existing ToolUniverse roles,
+catalog query and record, OpenAPI operation, input selection, reviewed schema
+when required, representative cases, observations, limitations, and references.
+Adding a study does not change the discovery, inspection, promotion, runtime,
+planning, or reporting logic.
+
+The five checked workflows cover rare-disease identifier reconciliation,
+pan-cancer immune-checkpoint interactions, oncology combination review,
+virtual-cell perturbagen resolution, and tuberculosis radiomics readiness. In
+every case, the runner audits the real registry first and credits existing tools
+for their current roles. Only the missing exact operation is attributed to VSD.
+The lifecycle then proves inert discovery, catalog-to-contract binding, blocked
+early publication, at least three verification calls, approval, publication,
+absence from a fresh universe, explicit loading, execution, and replanning from
+`missing` to `existing_exact`.
+
+```console
+PYTHONPATH=src python examples/vsd/biomedical_evaluation_portfolio.py \
+  --mode replay
+PYTHONPATH=src python examples/vsd/biomedical_evaluation_portfolio.py \
+  --mode network_backed
+```
+
+Network-backed mode attempts the complete live path independently for every
+case. A failed catalog, contract, DNS, redirect, response-schema, or runtime
+boundary is recorded, and that case is rerun through its checked provider-shaped
+fixture. The Markdown and JSON artifacts label the resulting evidence mode, so
+replay output is never represented as a live scientific result.
+
 ## Fixed-Resource Promotion
 
 Machine-readable catalog distributions that have no operation contract can be

--- a/examples/vsd/README.md
+++ b/examples/vsd/README.md
@@ -10,6 +10,38 @@ omits only the JSON response schema; every other inspection blocker remains
 enforced. See
 `docs/dev_docs/VSD_API_DISCOVERY_VALIDATION.md` for the CLI and review contract.
 
+## Biomedical Evaluation Portfolio
+
+`biomedical_evaluation_portfolio.py` runs five scenario files through one
+parameterized implementation. The scenarios cover rare-disease identifier
+reconciliation, pan-cancer checkpoint interactions, oncology combination
+review, virtual-cell perturbagen resolution, and tuberculosis radiomics
+readiness. Domain questions, source records, operation selections, schemas,
+test inputs, expected observations, existing-tool roles, and limitations live
+in JSON scenario data; the runner contains no disease-, gene-, or drug-specific
+branches.
+
+Every case audits the real ToolUniverse registry, proves that one exact
+operation is missing, discovers a SmartAPI record, inspects the bound OpenAPI
+operation, blocks early publication, runs at least three verification calls,
+approves and publishes the hash chain, confirms the tool is absent from a fresh
+universe, loads it explicitly, executes it, and replans to `existing_exact`.
+The comparison deliberately credits existing ToolUniverse tools for the work
+they already perform and attributes only the newly executable operation to VSD.
+
+```console
+PYTHONPATH=src python examples/vsd/biomedical_evaluation_portfolio.py \
+  --mode replay
+PYTHONPATH=src python examples/vsd/biomedical_evaluation_portfolio.py \
+  --mode network_backed
+```
+
+The checked network-backed artifact is
+`artifacts/biomedical_evaluation_portfolio.md` with a tamper-evident JSON
+counterpart. A case that cannot complete the live safety and contract checks is
+clearly labeled as checked replay; the report does not silently substitute
+fixture evidence or describe it as live.
+
 ## Multi-Catalog Cancer Source Evaluation
 
 `multicatalog_cancer_case_study.py` evaluates the new catalog sources as a

--- a/examples/vsd/README.md
+++ b/examples/vsd/README.md
@@ -10,6 +10,35 @@ omits only the JSON response schema; every other inspection blocker remains
 enforced. See
 `docs/dev_docs/VSD_API_DISCOVERY_VALIDATION.md` for the CLI and review contract.
 
+## GA4GH Service Qualification Portfolio
+
+`ga4gh_service_qualification_portfolio.py` evaluates 15 implementations from
+the GA4GH Service Registry through one parameterized pipeline. The scenario
+data spans service-registry, DRS, TRS, WES, and RNAget records. The runner has
+no organization, standard, or endpoint-specific branch.
+
+For every record, ToolUniverse performs demand-based registry discovery and
+derives the standard `service-info` operation. The case then creates a sealed
+draft and proves that publication is unavailable before verification. Three
+services match the registered name and type across three calls; each is
+approved, published, loaded into a fresh ToolUniverse, executed, and removed
+from the next candidate list by exact registry deduplication. Twelve services
+fail before approval because the standard path is unavailable, returns an
+unexpected media type or redirect, or reports type metadata that differs from
+the registry. Those cases contain no approval or publication artifact.
+
+```console
+PYTHONPATH=src python examples/vsd/ga4gh_service_qualification_portfolio.py \
+  --mode replay
+PYTHONPATH=src python examples/vsd/ga4gh_service_qualification_portfolio.py \
+  --mode network_backed
+```
+
+The checked report is
+`artifacts/ga4gh_service_qualification_portfolio.md`, with a tamper-evident
+JSON counterpart. It distinguishes live evidence from checked replay for each
+service and records bounded fallback reasons.
+
 ## Biomedical Evaluation Portfolio
 
 `biomedical_evaluation_portfolio.py` runs five scenario files through one

--- a/examples/vsd/artifacts/biomedical_evaluation_portfolio.json
+++ b/examples/vsd/artifacts/biomedical_evaluation_portfolio.json
@@ -1,0 +1,735 @@
+{
+  "all_assertions_passed": true,
+  "case_count": 5,
+  "cases": [
+    {
+      "assertions": {
+        "catalog_and_openapi_service_roots_match": true,
+        "catalog_candidate_is_inert_and_hash_bound": true,
+        "complete_hash_chain_was_recorded": true,
+        "early_publication_was_blocked": true,
+        "existing_tool_roles_were_verified_in_the_registry": true,
+        "final_plan_resolved_the_exact_operation": true,
+        "initial_exact_operation_was_missing": true,
+        "publication_required_explicit_loading": true,
+        "three_or_more_verification_calls_passed": true
+      },
+      "case_id": "rare_disease_diagnostic_evidence",
+      "decision_context": "Normalize identifiers before combining phenotype, variant, natural-history, and trial evidence; the added annotations support evidence retrieval and do not establish a diagnosis.",
+      "evidence_mode": "replay",
+      "existing_tooluniverse_coverage": [
+        {
+          "config_sha256": "48952465b0677f7f5ec65eaf773c575bd6c3a7e08b1c5702691cf1d172c80e19",
+          "name": "Orphanet_get_natural_history",
+          "present": true,
+          "role": "Reuse curated rare-disease natural-history evidence."
+        },
+        {
+          "config_sha256": "d2173af5e4f943cf874edec662b89ab2ffee4cbef69b9e21f69f16bf3a165eb2",
+          "name": "HPO_get_diseases_by_phenotype",
+          "present": true,
+          "role": "Reuse phenotype-to-disease associations."
+        },
+        {
+          "config_sha256": "8d129131cec1ee4fdaffd6b35c798368b7cb2efe60ff84ca79a0e9af852f0660",
+          "name": "ClinVar_search_variants",
+          "present": true,
+          "role": "Reuse submitted variant interpretations."
+        }
+      ],
+      "governance": {
+        "early_publication_blocked": true,
+        "hash_chain": {
+          "approval_sha256": "ef994284b214334c53229ab65d99b1a0708cc9416aef3035360a4bc86daeb715",
+          "catalog_candidate_sha256": "cca8fd3463c502f8a46f0d794395ea6ced35e696045812ccea6712b47fc81077",
+          "draft_sha256": "c363aa942c6cb2af8e5029f6b87cf75d555bb5edf57a6e45216534ac990b3f7c",
+          "operation_candidate_sha256": "0c727f7ebe5c8bcaf8349aa265e30593e52e94a2707db7e365829e384d5314ee",
+          "publication_sha256": "cc37da87cd7568e1da8b392b112793e38e47488e083478c89dd30df637c102ba",
+          "source_document_sha256": "b5ab549ae8c60bdec3e9df62f2e5c6c5f228a8ebd707083d5feb7e5997160911",
+          "verification_sha256": "c4c3ecc0abffb2013f5c720d595d28c112c1274214e840e31672ef1e53f863a0"
+        },
+        "loaded_into_fresh_universe": [
+          "VSDTranslatorAnnotationLookup"
+        ],
+        "resolved_blockers": []
+      },
+      "limitations": [
+        "Annotation mappings are retrieval evidence, not a diagnostic conclusion.",
+        "Replay values are provider-shaped test evidence; live mode is required to assess current upstream content.",
+        "Conflicting or missing mappings still require domain review."
+      ],
+      "live_attempt": {
+        "completed": false,
+        "failure": {
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': \"Validation error: Provider response failed the reviewed schema: '_id' is a required property\", 'error_details': {'type': 'ToolValidationError', 'message': \"Validation error: Provider response failed the reviewed schema: ",
+          "type": "VSDPromotionError"
+        },
+        "fallback": "checked replay"
+      },
+      "references": [
+        {
+          "title": "Phenotype-driven rare genetic disease diagnosis",
+          "url": "https://www.nature.com/articles/s41746-025-01749-1"
+        },
+        {
+          "title": "NCATS Biomedical Data Translator",
+          "url": "https://ncats.nih.gov/research/research-activities/translator"
+        },
+        {
+          "title": "Human Phenotype Ontology",
+          "url": "https://hpo.jax.org/"
+        },
+        {
+          "title": "Orphanet",
+          "url": "https://www.orpha.net/"
+        }
+      ],
+      "research_question": "Can a diagnostic review reconcile disease, phenotype, and gene identifiers before comparing rare-disease cohort and variant evidence?",
+      "source": {
+        "catalog": "SmartAPI",
+        "catalog_candidate_id": "de5a6332d9b9e52f",
+        "catalog_query": "rare disease phenotype ontology annotation",
+        "catalog_record_id": "5a4c41bf2076b469a0e9cfcf2f2b8f29",
+        "inspection": {
+          "candidate_count": 1,
+          "mode": "replay",
+          "promotable_count": 1,
+          "source": "checked provider-shaped OpenAPI fixture",
+          "source_document_sha256": "b5ab549ae8c60bdec3e9df62f2e5c6c5f228a8ebd707083d5feb7e5997160911"
+        },
+        "operation_blockers": [],
+        "operation_id": "get_/{curieid}",
+        "operation_path": "/{curieid}",
+        "promotion_mode": "strict",
+        "service_endpoint": "https://biothings.transltr.io/annotator"
+      },
+      "title": "Rare-Disease Diagnostic Evidence Reconciliation",
+      "with_vsd": {
+        "executable_new_operation": true,
+        "planned_operation_classification": "existing_exact",
+        "published_tool": "VSDTranslatorAnnotationLookup",
+        "runtime": {
+          "item_count": null,
+          "observations": [
+            {
+              "label": "Normalized disease label",
+              "pointer": "/MONDO:0004976/0/disease_ontology/name",
+              "value": "amyotrophic lateral sclerosis"
+            },
+            {
+              "label": "Disease Ontology identifier",
+              "pointer": "/MONDO:0004976/0/disease_ontology/doid",
+              "value": "DOID:332"
+            },
+            {
+              "label": "GARD cross-reference",
+              "pointer": "/MONDO:0004976/0/xrefs/gard",
+              "value": "5786"
+            }
+          ],
+          "payload_sha256": "13ba679e02f8eb852b54fb745a551b5139df4979dd23e115c71c3d259fd2bcd1",
+          "provider": "biothings.transltr.io",
+          "result_type": "object",
+          "top_level_fields": [
+            "MONDO:0004976"
+          ]
+        },
+        "summary": "The workflow gains one verified CURIE annotation operation that returns cross-ontology labels and identifiers with runtime provenance, allowing existing evidence tools to receive consistent identifiers.",
+        "verification_case_count": 3
+      },
+      "without_vsd": {
+        "executable_new_operation": false,
+        "planned_operation_classification": "missing",
+        "planned_operation_matches": [],
+        "summary": "ToolUniverse already covers phenotype, natural-history, and variant evidence, but this exact registered annotation operation is absent, so the workflow must reconcile identifier namespaces outside the governed tool path."
+      }
+    },
+    {
+      "assertions": {
+        "catalog_and_openapi_service_roots_match": true,
+        "catalog_candidate_is_inert_and_hash_bound": true,
+        "complete_hash_chain_was_recorded": true,
+        "early_publication_was_blocked": true,
+        "existing_tool_roles_were_verified_in_the_registry": true,
+        "final_plan_resolved_the_exact_operation": true,
+        "initial_exact_operation_was_missing": true,
+        "publication_required_explicit_loading": true,
+        "three_or_more_verification_calls_passed": true
+      },
+      "case_id": "pan_cancer_immunotherapy_validation",
+      "decision_context": "Use cohort, expression, immune-study, and interaction evidence to prioritize checkpoint hypotheses for retrospective validation rather than treatment selection.",
+      "evidence_mode": "live",
+      "existing_tooluniverse_coverage": [
+        {
+          "config_sha256": "5509a866f37e95ec429c64c6ade3c62aacf12bae6e150da8f4a1cd3b6b98e7a2",
+          "name": "GDC_search_cases",
+          "present": true,
+          "role": "Reuse pan-cancer cohort construction."
+        },
+        {
+          "config_sha256": "f7f9b71908a41c710993291eb2615c8f24a72ba9449e306091026a1077636380",
+          "name": "GDC_get_gene_expression",
+          "present": true,
+          "role": "Reuse tumor expression measurements."
+        },
+        {
+          "config_sha256": "b5ab2926dde93e9d91f2e6d2bacb01a1cd8ed7313e815bc5195c1beb0bd8346e",
+          "name": "ImmPort_search_studies",
+          "present": true,
+          "role": "Reuse immune-study discovery."
+        }
+      ],
+      "governance": {
+        "early_publication_blocked": true,
+        "hash_chain": {
+          "approval_sha256": "0a4592f2ccb3d5f11cf44c96cba68a371689a279ab00c8ca2e0e4038d5be255e",
+          "catalog_candidate_sha256": "19e680b129b77b5e848bb987d4e30cc2ac9ee9c0091580dedd424153c0e8328f",
+          "draft_sha256": "30d745f70508c693d1a40be7d33952e9513ea9bc43a0762b2e1b64e071025179",
+          "operation_candidate_sha256": "893fc0df06fdf16893095acd637172e8ab47c2528c6dc71129bbf9ca762d2033",
+          "publication_sha256": "0d59c73e9605d04d79167f0d87e874b3e1dafec3c306df13bc83060779743a7a",
+          "source_document_sha256": "2f09d3791ed113d98819af407fcc5feb8e303f1846b9a9f658e275b2c73c2d9d",
+          "verification_sha256": "71673d035c21696517f448b98ed3969dd5d7bd4a96ee4839d8f8ac0dd216fbcf"
+        },
+        "loaded_into_fresh_universe": [
+          "VSDInnateDBInteractionQuery"
+        ],
+        "resolved_blockers": [
+          "json_response_missing"
+        ]
+      },
+      "limitations": [
+        "Molecular interactions do not establish response causality or clinical benefit.",
+        "The reviewed response schema is intentionally bounded to the stable BioThings envelope because the registry document omits that schema.",
+        "Cancer-type, treatment, and assay-specific validation remains necessary."
+      ],
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "references": [
+        {
+          "title": "Pan-cancer longitudinal immunotherapy analysis",
+          "url": "https://www.nature.com/articles/s41467-021-25432-7"
+        },
+        {
+          "title": "NCI Genomic Data Commons",
+          "url": "https://gdc.cancer.gov/"
+        },
+        {
+          "title": "InnateDB",
+          "url": "https://www.innatedb.com/"
+        },
+        {
+          "title": "ImmPort",
+          "url": "https://www.immport.org/"
+        }
+      ],
+      "research_question": "Can a pan-cancer response analysis add molecular interaction evidence for immune checkpoints after cohort and expression tools identify candidate markers?",
+      "source": {
+        "catalog": "SmartAPI",
+        "catalog_candidate_id": "239f6354f7bbbba8",
+        "catalog_query": "innate immune interaction",
+        "catalog_record_id": "e9eb40ff7ad712e4e6f4f04b964b5966",
+        "inspection": {
+          "candidate_count": 6,
+          "http_status": 200,
+          "mode": "live",
+          "payload_sha256": "19731aa85d8969f0f7d7d73b747ea72bcb6cdc58870d44832a3e1ba49f26ac24",
+          "promotable_count": 0,
+          "source": "SmartAPI metadata endpoint",
+          "source_document_sha256": "2f09d3791ed113d98819af407fcc5feb8e303f1846b9a9f658e275b2c73c2d9d"
+        },
+        "operation_blockers": [
+          "json_response_missing"
+        ],
+        "operation_id": "get_/query",
+        "operation_path": "/query",
+        "promotion_mode": "reviewed_response",
+        "service_endpoint": "https://biothings.transltr.io/innatedb"
+      },
+      "title": "Pan-Cancer Immunotherapy Evidence Validation",
+      "with_vsd": {
+        "executable_new_operation": true,
+        "planned_operation_classification": "existing_exact",
+        "published_tool": "VSDInnateDBInteractionQuery",
+        "runtime": {
+          "item_count": null,
+          "observations": [
+            {
+              "label": "Matching interaction records",
+              "pointer": "/total",
+              "value": 8
+            },
+            {
+              "label": "Queried checkpoint",
+              "pointer": "/hits/0/object/alias/hgnc_name",
+              "value": "PDCD1"
+            },
+            {
+              "label": "First interacting marker",
+              "pointer": "/hits/0/subject/alias/hgnc_name",
+              "value": "SOCS1"
+            }
+          ],
+          "payload_sha256": "60b660eedc0d7bdbc744e23aeddea35fd3762d11b45953847d841147d7a22a20",
+          "provider": "biothings.transltr.io",
+          "result_type": "object",
+          "top_level_fields": [
+            "hits",
+            "max_score",
+            "took",
+            "total"
+          ]
+        },
+        "summary": "The workflow adds a bounded, verified interaction query for PDCD1, CTLA4, and LAG3, so interaction provenance can be compared alongside cohort and expression evidence.",
+        "verification_case_count": 3
+      },
+      "without_vsd": {
+        "executable_new_operation": false,
+        "planned_operation_classification": "missing",
+        "planned_operation_matches": [],
+        "summary": "The registry can assemble cancer cohorts and expression evidence, but it lacks the exact InnateDB query operation, leaving checkpoint interaction support outside the planned ToolUniverse workflow."
+      }
+    },
+    {
+      "assertions": {
+        "catalog_and_openapi_service_roots_match": true,
+        "catalog_candidate_is_inert_and_hash_bound": true,
+        "complete_hash_chain_was_recorded": true,
+        "early_publication_was_blocked": true,
+        "existing_tool_roles_were_verified_in_the_registry": true,
+        "final_plan_resolved_the_exact_operation": true,
+        "initial_exact_operation_was_missing": true,
+        "publication_required_explicit_loading": true,
+        "three_or_more_verification_calls_passed": true
+      },
+      "case_id": "context_specific_drug_combinations",
+      "decision_context": "Combine target, dependency, synergy, and adverse-event evidence with curated interaction records to prioritize laboratory follow-up and safety review.",
+      "evidence_mode": "live",
+      "existing_tooluniverse_coverage": [
+        {
+          "config_sha256": "92cb1a50f3cf9a3d299404f1aa864d3e8b804d39d1f47a8193a06beef5cd6886",
+          "name": "ChEMBL_get_target_activities",
+          "present": true,
+          "role": "Reuse target activity evidence."
+        },
+        {
+          "config_sha256": "8f780801e9b36906c90ccbee1fd492bed9af1ba845c23ea7650020d9085b6524",
+          "name": "DepMap_get_gene_dependencies",
+          "present": true,
+          "role": "Reuse cancer-context dependency evidence."
+        },
+        {
+          "config_sha256": "692167c20813433ccb94ed0237ac23f772a7e1278f436407429f934543d49da1",
+          "name": "DrugSynergy_calculate_bliss",
+          "present": true,
+          "role": "Reuse measured combination-effect scoring."
+        },
+        {
+          "config_sha256": "670e52fedeef850da2535035e455a6dd8cb41668c9df2815032c84f30e0dfbb0",
+          "name": "FAERS_compare_drugs",
+          "present": true,
+          "role": "Reuse post-market safety signal comparison."
+        }
+      ],
+      "governance": {
+        "early_publication_blocked": true,
+        "hash_chain": {
+          "approval_sha256": "d2e991e8ee3a951eea6cbc60c8ccb6fad8bbb071b8d03d461e8a6e7312313fae",
+          "catalog_candidate_sha256": "e764c7d17a49ddb302988acd7c4856234a8b8935593ad9e500af3d9164e19278",
+          "draft_sha256": "1a9968718110a76f67d6569e6d5d8004b07885603ab9615c2b712eb1faf3a158",
+          "operation_candidate_sha256": "0f6fc89539760b27570aafde39481f02c368def9b2802e58db12814b99a21125",
+          "publication_sha256": "83c8ec7ca716b59890d94d624ba0f458fc4649e3b37b9da1f418098ef06d21c8",
+          "source_document_sha256": "61f2215c207992b242e20938fa6d447d680f4cfe98744669aa8ec79a52d4cc2c",
+          "verification_sha256": "658524695337104e94a81f2ed09a328b8896cb42bab7a1899225def4426e003f"
+        },
+        "loaded_into_fresh_universe": [
+          "VSDDDInterCombinationQuery"
+        ],
+        "resolved_blockers": [
+          "json_response_missing"
+        ]
+      },
+      "limitations": [
+        "Interaction severity is not an efficacy estimate and does not replace pharmacology review.",
+        "The example query verifies retrieval and governance, not a treatment recommendation.",
+        "The upstream specification omits the response schema, so publication depends on explicit reviewed-schema evidence."
+      ],
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "references": [
+        {
+          "title": "Context-specific drug combinations in lung cancer",
+          "url": "https://www.nature.com/articles/s41467-023-39528-9"
+        },
+        {
+          "title": "DDInter drug-drug interaction database",
+          "url": "https://academic.oup.com/nar/article/50/D1/D1200/6389535"
+        },
+        {
+          "title": "DepMap",
+          "url": "https://depmap.org/portal/"
+        },
+        {
+          "title": "ChEMBL",
+          "url": "https://www.ebi.ac.uk/chembl/"
+        }
+      ],
+      "research_question": "Can an oncology combination workflow add curated interaction severity before advancing experimentally promising drug pairs?",
+      "source": {
+        "catalog": "SmartAPI",
+        "catalog_candidate_id": "bd648307adbc85ea",
+        "catalog_query": "drug combination interaction oncology",
+        "catalog_record_id": "00fb85fc776279163199e6c50f6ddfc6",
+        "inspection": {
+          "candidate_count": 6,
+          "http_status": 200,
+          "mode": "live",
+          "payload_sha256": "81f73c33265a86351341d07059a0bfbb273e526c43aa564b8fb41e5b000d6002",
+          "promotable_count": 0,
+          "source": "SmartAPI metadata endpoint",
+          "source_document_sha256": "61f2215c207992b242e20938fa6d447d680f4cfe98744669aa8ec79a52d4cc2c"
+        },
+        "operation_blockers": [
+          "json_response_missing"
+        ],
+        "operation_id": "get_/query",
+        "operation_path": "/query",
+        "promotion_mode": "reviewed_response",
+        "service_endpoint": "https://biothings.transltr.io/ddinter"
+      },
+      "title": "Context-Specific Oncology Combination Review",
+      "with_vsd": {
+        "executable_new_operation": true,
+        "planned_operation_classification": "existing_exact",
+        "published_tool": "VSDDDInterCombinationQuery",
+        "runtime": {
+          "item_count": null,
+          "observations": [
+            {
+              "label": "Matching curated records",
+              "pointer": "/total",
+              "value": 1
+            },
+            {
+              "label": "First combination",
+              "pointer": "/hits/0/drug_b/name",
+              "value": "Idarubicin"
+            },
+            {
+              "label": "Interaction severity",
+              "pointer": "/hits/0/level",
+              "value": "Major"
+            }
+          ],
+          "payload_sha256": "d6e36a367b623414b4c7a8d7ccb11b3bc43472af35971aa04c34a370e0f7ab1a",
+          "provider": "biothings.transltr.io",
+          "result_type": "object",
+          "top_level_fields": [
+            "hits",
+            "max_score",
+            "took",
+            "total"
+          ]
+        },
+        "summary": "The workflow gains a bounded DDInter query that can flag curated interaction severity before experimental prioritization; it complements rather than replaces efficacy and safety analysis.",
+        "verification_case_count": 3
+      },
+      "without_vsd": {
+        "executable_new_operation": false,
+        "planned_operation_classification": "missing",
+        "planned_operation_matches": [],
+        "summary": "ToolUniverse can score observed synergy and retrieve target, dependency, and safety evidence, but it lacks this exact curated interaction query, so a promising pair can reach review without a DDInter severity check in the same workflow."
+      }
+    },
+    {
+      "assertions": {
+        "catalog_and_openapi_service_roots_match": true,
+        "catalog_candidate_is_inert_and_hash_bound": true,
+        "complete_hash_chain_was_recorded": true,
+        "early_publication_was_blocked": true,
+        "existing_tool_roles_were_verified_in_the_registry": true,
+        "final_plan_resolved_the_exact_operation": true,
+        "initial_exact_operation_was_missing": true,
+        "publication_required_explicit_loading": true,
+        "three_or_more_verification_calls_passed": true
+      },
+      "case_id": "virtual_cell_perturbation_selection",
+      "decision_context": "Resolve perturbagen names before selecting expression signatures, cell contexts, and training data for perturbation-response modeling.",
+      "evidence_mode": "replay",
+      "existing_tooluniverse_coverage": [
+        {
+          "config_sha256": "91504156dca34322661b896b2e522f4a5b34e89b0429bfba568304c35f4e0992",
+          "name": "CELLxGENE_get_cell_metadata",
+          "present": true,
+          "role": "Reuse single-cell context and cohort metadata."
+        },
+        {
+          "config_sha256": "10f3c61a0ca20788adda91d3d7146a7759a4a46f41fb44220239a68f39f91fee",
+          "name": "CELLxGENE_get_expression_data",
+          "present": true,
+          "role": "Reuse cell-level expression retrieval."
+        },
+        {
+          "config_sha256": "1447627f27ce9d92e2c995f8828033dbe5907ac42fb75c21b1afa715033a1795",
+          "name": "L1000FWD_sig_search",
+          "present": true,
+          "role": "Reuse the existing signature-search workflow after identifier resolution."
+        }
+      ],
+      "governance": {
+        "early_publication_blocked": true,
+        "hash_chain": {
+          "approval_sha256": "8a0fc1f425ccb002e0bf1dc5a88d69f8269847bae484eab04cb9600bdc5608b0",
+          "catalog_candidate_sha256": "fe5713d8ac98de91a23a7293e43021e8bc2ea0cb2334326f8079baf81ed4ca8f",
+          "draft_sha256": "b36951f79ad1ac4f2ae0d27652413b5ee238231e7a642fb9efad0d81281a5324",
+          "operation_candidate_sha256": "3f6a0d89e0c102cfaf619a5a3d8c1272f1ab4806e7750897aeeb9ebfd8051141",
+          "publication_sha256": "2f838f5553428844ffa2bebc4599f26821e64545910dd4d79e752442f8acd436",
+          "source_document_sha256": "7bb4a7a252196b31ce54cbd5d0793826c46d1482d5898b1e916bdac3ccc60277",
+          "verification_sha256": "1eb2ab373aa79ac1d27d72f248bbb3b179efbcacebdb000e881a6250b7bd2924"
+        },
+        "loaded_into_fresh_universe": [
+          "VSDL1000PerturbagenResolver"
+        ],
+        "resolved_blockers": []
+      },
+      "limitations": [
+        "Identifier resolution does not determine whether a perturbation is biologically appropriate for a model.",
+        "Signature quality, dose, duration, cell state, and batch effects require separate evaluation.",
+        "The provider may return multiple identifiers for one name; downstream selection must retain that ambiguity."
+      ],
+      "live_attempt": {
+        "completed": false,
+        "failure": {
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': 'Validation error: Source redirects are not allowed', 'error_details': {'type': 'ToolValidationError', 'message': 'Validation error: Source redirects are not allowed', 'retriable': False, 'next_steps': ['Check parameter t",
+          "type": "VSDPromotionError"
+        },
+        "fallback": "checked replay"
+      },
+      "references": [
+        {
+          "title": "Benchmarking single-cell perturbation response prediction",
+          "url": "https://www.nature.com/articles/s41592-025-02980-0"
+        },
+        {
+          "title": "L1000FWD",
+          "url": "https://maayanlab.cloud/L1000FWD/"
+        },
+        {
+          "title": "CELLxGENE Census",
+          "url": "https://chanzuckerberg.github.io/cellxgene-census/"
+        },
+        {
+          "title": "Virtual Cell Challenge",
+          "url": "https://virtualcellchallenge.org/"
+        }
+      ],
+      "research_question": "Can a virtual-cell preparation workflow resolve candidate perturbagens to dataset identifiers before retrieving signatures and single-cell context?",
+      "source": {
+        "catalog": "SmartAPI",
+        "catalog_candidate_id": "80b5adb4ee2b2fb2",
+        "catalog_query": "single cell gene expression perturbation",
+        "catalog_record_id": "235e75417247f07e5fed6acf3f345bb7",
+        "inspection": {
+          "candidate_count": 1,
+          "mode": "replay",
+          "promotable_count": 1,
+          "source": "checked provider-shaped OpenAPI fixture",
+          "source_document_sha256": "7bb4a7a252196b31ce54cbd5d0793826c46d1482d5898b1e916bdac3ccc60277"
+        },
+        "operation_blockers": [],
+        "operation_id": "synonyms",
+        "operation_path": "/synonyms/{query_string}",
+        "promotion_mode": "strict",
+        "service_endpoint": "https://maayanlab.cloud/L1000FWD"
+      },
+      "title": "Virtual-Cell Perturbation Dataset Selection",
+      "with_vsd": {
+        "executable_new_operation": true,
+        "planned_operation_classification": "existing_exact",
+        "published_tool": "VSDL1000PerturbagenResolver",
+        "runtime": {
+          "item_count": 1,
+          "observations": [
+            {
+              "label": "Resolved perturbagen name",
+              "pointer": "/0/Name",
+              "value": "TRAMETINIB"
+            },
+            {
+              "label": "Resolved L1000 perturbagen identifier",
+              "pointer": "/0/pert_id",
+              "value": "BRD-K12343256"
+            }
+          ],
+          "payload_sha256": "ac8f046716e0695940927f47044ec4ea3b8f1b880cceab4931a6722c2aecdb96",
+          "provider": "maayanlab.cloud",
+          "result_type": "array",
+          "top_level_fields": []
+        },
+        "summary": "The workflow adds only the missing synonym operation from the already known provider, turning drug names into stable perturbagen identifiers before existing signature and single-cell tools run.",
+        "verification_case_count": 3
+      },
+      "without_vsd": {
+        "executable_new_operation": false,
+        "planned_operation_classification": "missing",
+        "planned_operation_matches": [],
+        "summary": "ToolUniverse already performs L1000 signature search and CELLxGENE retrieval, but it does not expose the provider's synonym operation, so free-text perturbagen names must be resolved outside the planned tool chain."
+      }
+    },
+    {
+      "assertions": {
+        "catalog_and_openapi_service_roots_match": true,
+        "catalog_candidate_is_inert_and_hash_bound": true,
+        "complete_hash_chain_was_recorded": true,
+        "early_publication_was_blocked": true,
+        "existing_tool_roles_were_verified_in_the_registry": true,
+        "final_plan_resolved_the_exact_operation": true,
+        "initial_exact_operation_was_missing": true,
+        "publication_required_explicit_loading": true,
+        "three_or_more_verification_calls_passed": true
+      },
+      "case_id": "tuberculosis_resistance_integration",
+      "decision_context": "Gate an imaging branch on service readiness while existing tools assemble genome, resistance, drug, and study evidence; readiness does not authorize controlled-data access.",
+      "evidence_mode": "replay",
+      "existing_tooluniverse_coverage": [
+        {
+          "config_sha256": "fc98501791d9561e98306ae1766a75c31a31a7d2ce02ff6f91ae54f523d1eca9",
+          "name": "BVBRC_search_amr",
+          "present": true,
+          "role": "Reuse antimicrobial-resistance phenotype evidence."
+        },
+        {
+          "config_sha256": "2c4ad07eeb26391623f10402b38cf7555540143be5b7f088cb51beb1ae843398",
+          "name": "BVBRC_search_genomes",
+          "present": true,
+          "role": "Reuse pathogen genome metadata."
+        },
+        {
+          "config_sha256": "985607bc9e0c1c9f8613f31d09944a812b0b2fb7036f4a8dc64ee56fe681bf1d",
+          "name": "PharmGKB_search_drugs",
+          "present": true,
+          "role": "Reuse drug identifier and pharmacogenomic context."
+        },
+        {
+          "config_sha256": "dae5c42c916b6de8d1e3105949ed950644bc85c7e33ff0c1af1778fc54e2c882",
+          "name": "search_clinical_trials",
+          "present": true,
+          "role": "Reuse tuberculosis study discovery."
+        }
+      ],
+      "governance": {
+        "early_publication_blocked": true,
+        "hash_chain": {
+          "approval_sha256": "eaa221308acc71431fe721508af537a967c2a4eec3db2bae65783c8872da5e8d",
+          "catalog_candidate_sha256": "c639660a63004ff5d9cbabdbef259f1ff5c93cc1e28ea13f4562b46fc13a324d",
+          "draft_sha256": "4e96113f130c5e4411e7f967299b6674190541a6e6dfb4349c2b3bf897fbf4a3",
+          "operation_candidate_sha256": "e921c9c7956142a34ff71b1746483f289e5ab373042d99aaed7f07c07b0b49fb",
+          "publication_sha256": "75997d5756fcc41f3fe717aad5a73e5d1cbbc5355bf9b4c99c2c1f130c689aff",
+          "source_document_sha256": "6bf6f848aef93068f1975b6ca91f9e160f988b44df0914002ed9f25fd691e28e",
+          "verification_sha256": "6bbdd8c0753cc346e44c1312e742fb2d21d41816680b23a9780f425fffe0584a"
+        },
+        "loaded_into_fresh_universe": [
+          "VSDTBPortalsRadiomicsReadiness"
+        ],
+        "resolved_blockers": []
+      },
+      "limitations": [
+        "A health check establishes service readiness only; it does not validate a radiomics model or scientific result.",
+        "Controlled imaging data, consent, and authorization remain outside this tool.",
+        "The checked replay validates the lifecycle when the service is unreachable from the evaluation environment; current availability requires live mode."
+      ],
+      "live_attempt": {
+        "completed": false,
+        "failure": {
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': \"Validation error: Could not resolve source host 'ria.tbportals.niaid.nih.gov'\", 'error_details': {'type': 'ToolValidationError', 'message': \"Validation error: Could not resolve source host 'ria.tbportals.niaid.nih.gov'\",",
+          "type": "VSDPromotionError"
+        },
+        "fallback": "checked replay"
+      },
+      "references": [
+        {
+          "title": "NIAID TB Portals multi-domain data platform",
+          "url": "https://tbportals.niaid.nih.gov/what-are-the-tb-portals"
+        },
+        {
+          "title": "TB Portals data access policy",
+          "url": "https://tbportals.niaid.nih.gov/access-data"
+        },
+        {
+          "title": "BV-BRC antimicrobial resistance resources",
+          "url": "https://www.bv-brc.org/"
+        },
+        {
+          "title": "WHO tuberculosis data",
+          "url": "https://www.who.int/teams/global-tuberculosis-programme/data"
+        }
+      ],
+      "research_question": "Can a tuberculosis resistance workflow verify that a discovered radiomics service is available before combining genomic, antimicrobial-resistance, and imaging evidence?",
+      "source": {
+        "catalog": "SmartAPI",
+        "catalog_candidate_id": "a3ebe0d1765f8931",
+        "catalog_query": "TBPortals radiomics",
+        "catalog_record_id": "fc18c6cce884c23866beed24dce30a2d",
+        "inspection": {
+          "candidate_count": 1,
+          "mode": "replay",
+          "promotable_count": 1,
+          "source": "checked provider-shaped OpenAPI fixture",
+          "source_document_sha256": "6bf6f848aef93068f1975b6ca91f9e160f988b44df0914002ed9f25fd691e28e"
+        },
+        "operation_blockers": [],
+        "operation_id": "get_/health_check",
+        "operation_path": "/health_check",
+        "promotion_mode": "strict",
+        "service_endpoint": "https://ria.tbportals.niaid.nih.gov/"
+      },
+      "title": "Tuberculosis Resistance Evidence Integration",
+      "with_vsd": {
+        "executable_new_operation": true,
+        "planned_operation_classification": "existing_exact",
+        "published_tool": "VSDTBPortalsRadiomicsReadiness",
+        "runtime": {
+          "item_count": null,
+          "observations": [
+            {
+              "label": "Radiomics service status",
+              "pointer": "/status",
+              "value": "ok"
+            },
+            {
+              "label": "Service label",
+              "pointer": "/service",
+              "value": "TBPortals radiomics"
+            }
+          ],
+          "payload_sha256": "5ad2d7e7774a0ef7f8d05a993ed1d9cf389befd130f432df8c9657bc78f12766",
+          "provider": "ria.tbportals.niaid.nih.gov",
+          "result_type": "object",
+          "top_level_fields": [
+            "service",
+            "status"
+          ]
+        },
+        "summary": "The workflow gains a narrow readiness check bound to the cataloged service and contract; this prevents treating an unavailable imaging dependency as usable and does not create access to controlled images.",
+        "verification_case_count": 3
+      },
+      "without_vsd": {
+        "executable_new_operation": false,
+        "planned_operation_classification": "missing",
+        "planned_operation_matches": [],
+        "summary": "ToolUniverse can retrieve pathogen, resistance, drug, and trial evidence, but it has no exact operation for checking the cataloged radiomics service before the workflow enters its imaging branch."
+      }
+    }
+  ],
+  "format": "vsd_biomedical_evaluation_portfolio_v1",
+  "generated_at": "2026-08-02T09:11:15.540877+00:00",
+  "live_case_count": 2,
+  "portfolio_sha256": "036e12725bee5e98e700b5f94514ee6b9375bcab66a73b38165044047ba321f3",
+  "published_tool_count": 5,
+  "replay_case_count": 3,
+  "requested_mode": "network_backed",
+  "verification_execution_count": 15
+}

--- a/examples/vsd/artifacts/biomedical_evaluation_portfolio.md
+++ b/examples/vsd/artifacts/biomedical_evaluation_portfolio.md
@@ -1,0 +1,245 @@
+# Biomedical VSD Evaluation Portfolio
+
+## Evaluation Summary
+
+Five research workflows were evaluated through the same registry-first pipeline. The run published 5 narrowly scoped tools after 15 verification executions; all recorded assertions passed.
+
+- Requested evidence mode: `network_backed`
+- Live cases: `2`
+- Checked-replay cases: `3`
+- Portfolio SHA-256: `036e12725bee5e98e700b5f94514ee6b9375bcab66a73b38165044047ba321f3`
+
+## 1. Rare-Disease Diagnostic Evidence Reconciliation
+
+**Question.** Can a diagnostic review reconcile disease, phenotype, and gene identifiers before comparing rare-disease cohort and variant evidence?
+
+**Decision context.** Normalize identifiers before combining phenotype, variant, natural-history, and trial evidence; the added annotations support evidence retrieval and do not establish a diagnosis.
+
+**Evidence qualification.** This case completed in `replay` mode. The live attempt stopped at a governed boundary (`VSDPromotionError`), so the checked replay is reported and no live result is claimed.
+
+### Existing ToolUniverse Coverage
+
+- `Orphanet_get_natural_history`: Reuse curated rare-disease natural-history evidence.
+- `HPO_get_diseases_by_phenotype`: Reuse phenotype-to-disease associations.
+- `ClinVar_search_variants`: Reuse submitted variant interpretations.
+
+### Gap And Source Qualification
+
+The baseline planner classified the required operation as `missing`. SmartAPI query `rare disease phenotype ontology annotation` selected record `5a4c41bf2076b469a0e9cfcf2f2b8f29`, and inspection selected `get_/{curieid}` at `/{curieid}`.
+
+Promotion mode was `strict`. The candidate, source document, operation, draft, verification, approval, and publication identities are retained in the JSON artifact.
+
+### Comparison
+
+**Without VSD.** ToolUniverse already covers phenotype, natural-history, and variant evidence, but this exact registered annotation operation is absent, so the workflow must reconcile identifier namespaces outside the governed tool path.
+
+**With VSD.** The workflow gains one verified CURIE annotation operation that returns cross-ontology labels and identifiers with runtime provenance, allowing existing evidence tools to receive consistent identifiers.
+
+The final planner classified the exact operation as `existing_exact` after `3` verification calls and explicit loading of `VSDTranslatorAnnotationLookup`.
+
+### Observed Result
+
+- Normalized disease label: `"amyotrophic lateral sclerosis"`
+- Disease Ontology identifier: `"DOID:332"`
+- GARD cross-reference: `"5786"`
+
+### Limitations
+
+- Annotation mappings are retrieval evidence, not a diagnostic conclusion.
+- Replay values are provider-shaped test evidence; live mode is required to assess current upstream content.
+- Conflicting or missing mappings still require domain review.
+
+### References
+
+- [Phenotype-driven rare genetic disease diagnosis](https://www.nature.com/articles/s41746-025-01749-1)
+- [NCATS Biomedical Data Translator](https://ncats.nih.gov/research/research-activities/translator)
+- [Human Phenotype Ontology](https://hpo.jax.org/)
+- [Orphanet](https://www.orpha.net/)
+
+## 2. Pan-Cancer Immunotherapy Evidence Validation
+
+**Question.** Can a pan-cancer response analysis add molecular interaction evidence for immune checkpoints after cohort and expression tools identify candidate markers?
+
+**Decision context.** Use cohort, expression, immune-study, and interaction evidence to prioritize checkpoint hypotheses for retrospective validation rather than treatment selection.
+
+**Evidence qualification.** This case completed in `live` mode.
+
+### Existing ToolUniverse Coverage
+
+- `GDC_search_cases`: Reuse pan-cancer cohort construction.
+- `GDC_get_gene_expression`: Reuse tumor expression measurements.
+- `ImmPort_search_studies`: Reuse immune-study discovery.
+
+### Gap And Source Qualification
+
+The baseline planner classified the required operation as `missing`. SmartAPI query `innate immune interaction` selected record `e9eb40ff7ad712e4e6f4f04b964b5966`, and inspection selected `get_/query` at `/query`.
+
+Promotion mode was `reviewed_response`. The candidate, source document, operation, draft, verification, approval, and publication identities are retained in the JSON artifact.
+
+### Comparison
+
+**Without VSD.** The registry can assemble cancer cohorts and expression evidence, but it lacks the exact InnateDB query operation, leaving checkpoint interaction support outside the planned ToolUniverse workflow.
+
+**With VSD.** The workflow adds a bounded, verified interaction query for PDCD1, CTLA4, and LAG3, so interaction provenance can be compared alongside cohort and expression evidence.
+
+The final planner classified the exact operation as `existing_exact` after `3` verification calls and explicit loading of `VSDInnateDBInteractionQuery`.
+
+### Observed Result
+
+- Matching interaction records: `8`
+- Queried checkpoint: `"PDCD1"`
+- First interacting marker: `"SOCS1"`
+
+### Limitations
+
+- Molecular interactions do not establish response causality or clinical benefit.
+- The reviewed response schema is intentionally bounded to the stable BioThings envelope because the registry document omits that schema.
+- Cancer-type, treatment, and assay-specific validation remains necessary.
+
+### References
+
+- [Pan-cancer longitudinal immunotherapy analysis](https://www.nature.com/articles/s41467-021-25432-7)
+- [NCI Genomic Data Commons](https://gdc.cancer.gov/)
+- [InnateDB](https://www.innatedb.com/)
+- [ImmPort](https://www.immport.org/)
+
+## 3. Context-Specific Oncology Combination Review
+
+**Question.** Can an oncology combination workflow add curated interaction severity before advancing experimentally promising drug pairs?
+
+**Decision context.** Combine target, dependency, synergy, and adverse-event evidence with curated interaction records to prioritize laboratory follow-up and safety review.
+
+**Evidence qualification.** This case completed in `live` mode.
+
+### Existing ToolUniverse Coverage
+
+- `ChEMBL_get_target_activities`: Reuse target activity evidence.
+- `DepMap_get_gene_dependencies`: Reuse cancer-context dependency evidence.
+- `DrugSynergy_calculate_bliss`: Reuse measured combination-effect scoring.
+- `FAERS_compare_drugs`: Reuse post-market safety signal comparison.
+
+### Gap And Source Qualification
+
+The baseline planner classified the required operation as `missing`. SmartAPI query `drug combination interaction oncology` selected record `00fb85fc776279163199e6c50f6ddfc6`, and inspection selected `get_/query` at `/query`.
+
+Promotion mode was `reviewed_response`. The candidate, source document, operation, draft, verification, approval, and publication identities are retained in the JSON artifact.
+
+### Comparison
+
+**Without VSD.** ToolUniverse can score observed synergy and retrieve target, dependency, and safety evidence, but it lacks this exact curated interaction query, so a promising pair can reach review without a DDInter severity check in the same workflow.
+
+**With VSD.** The workflow gains a bounded DDInter query that can flag curated interaction severity before experimental prioritization; it complements rather than replaces efficacy and safety analysis.
+
+The final planner classified the exact operation as `existing_exact` after `3` verification calls and explicit loading of `VSDDDInterCombinationQuery`.
+
+### Observed Result
+
+- Matching curated records: `1`
+- First combination: `"Idarubicin"`
+- Interaction severity: `"Major"`
+
+### Limitations
+
+- Interaction severity is not an efficacy estimate and does not replace pharmacology review.
+- The example query verifies retrieval and governance, not a treatment recommendation.
+- The upstream specification omits the response schema, so publication depends on explicit reviewed-schema evidence.
+
+### References
+
+- [Context-specific drug combinations in lung cancer](https://www.nature.com/articles/s41467-023-39528-9)
+- [DDInter drug-drug interaction database](https://academic.oup.com/nar/article/50/D1/D1200/6389535)
+- [DepMap](https://depmap.org/portal/)
+- [ChEMBL](https://www.ebi.ac.uk/chembl/)
+
+## 4. Virtual-Cell Perturbation Dataset Selection
+
+**Question.** Can a virtual-cell preparation workflow resolve candidate perturbagens to dataset identifiers before retrieving signatures and single-cell context?
+
+**Decision context.** Resolve perturbagen names before selecting expression signatures, cell contexts, and training data for perturbation-response modeling.
+
+**Evidence qualification.** This case completed in `replay` mode. The live attempt stopped at a governed boundary (`VSDPromotionError`), so the checked replay is reported and no live result is claimed.
+
+### Existing ToolUniverse Coverage
+
+- `CELLxGENE_get_cell_metadata`: Reuse single-cell context and cohort metadata.
+- `CELLxGENE_get_expression_data`: Reuse cell-level expression retrieval.
+- `L1000FWD_sig_search`: Reuse the existing signature-search workflow after identifier resolution.
+
+### Gap And Source Qualification
+
+The baseline planner classified the required operation as `missing`. SmartAPI query `single cell gene expression perturbation` selected record `235e75417247f07e5fed6acf3f345bb7`, and inspection selected `synonyms` at `/synonyms/{query_string}`.
+
+Promotion mode was `strict`. The candidate, source document, operation, draft, verification, approval, and publication identities are retained in the JSON artifact.
+
+### Comparison
+
+**Without VSD.** ToolUniverse already performs L1000 signature search and CELLxGENE retrieval, but it does not expose the provider's synonym operation, so free-text perturbagen names must be resolved outside the planned tool chain.
+
+**With VSD.** The workflow adds only the missing synonym operation from the already known provider, turning drug names into stable perturbagen identifiers before existing signature and single-cell tools run.
+
+The final planner classified the exact operation as `existing_exact` after `3` verification calls and explicit loading of `VSDL1000PerturbagenResolver`.
+
+### Observed Result
+
+- Resolved perturbagen name: `"TRAMETINIB"`
+- Resolved L1000 perturbagen identifier: `"BRD-K12343256"`
+
+### Limitations
+
+- Identifier resolution does not determine whether a perturbation is biologically appropriate for a model.
+- Signature quality, dose, duration, cell state, and batch effects require separate evaluation.
+- The provider may return multiple identifiers for one name; downstream selection must retain that ambiguity.
+
+### References
+
+- [Benchmarking single-cell perturbation response prediction](https://www.nature.com/articles/s41592-025-02980-0)
+- [L1000FWD](https://maayanlab.cloud/L1000FWD/)
+- [CELLxGENE Census](https://chanzuckerberg.github.io/cellxgene-census/)
+- [Virtual Cell Challenge](https://virtualcellchallenge.org/)
+
+## 5. Tuberculosis Resistance Evidence Integration
+
+**Question.** Can a tuberculosis resistance workflow verify that a discovered radiomics service is available before combining genomic, antimicrobial-resistance, and imaging evidence?
+
+**Decision context.** Gate an imaging branch on service readiness while existing tools assemble genome, resistance, drug, and study evidence; readiness does not authorize controlled-data access.
+
+**Evidence qualification.** This case completed in `replay` mode. The live attempt stopped at a governed boundary (`VSDPromotionError`), so the checked replay is reported and no live result is claimed.
+
+### Existing ToolUniverse Coverage
+
+- `BVBRC_search_amr`: Reuse antimicrobial-resistance phenotype evidence.
+- `BVBRC_search_genomes`: Reuse pathogen genome metadata.
+- `PharmGKB_search_drugs`: Reuse drug identifier and pharmacogenomic context.
+- `search_clinical_trials`: Reuse tuberculosis study discovery.
+
+### Gap And Source Qualification
+
+The baseline planner classified the required operation as `missing`. SmartAPI query `TBPortals radiomics` selected record `fc18c6cce884c23866beed24dce30a2d`, and inspection selected `get_/health_check` at `/health_check`.
+
+Promotion mode was `strict`. The candidate, source document, operation, draft, verification, approval, and publication identities are retained in the JSON artifact.
+
+### Comparison
+
+**Without VSD.** ToolUniverse can retrieve pathogen, resistance, drug, and trial evidence, but it has no exact operation for checking the cataloged radiomics service before the workflow enters its imaging branch.
+
+**With VSD.** The workflow gains a narrow readiness check bound to the cataloged service and contract; this prevents treating an unavailable imaging dependency as usable and does not create access to controlled images.
+
+The final planner classified the exact operation as `existing_exact` after `3` verification calls and explicit loading of `VSDTBPortalsRadiomicsReadiness`.
+
+### Observed Result
+
+- Radiomics service status: `"ok"`
+- Service label: `"TBPortals radiomics"`
+
+### Limitations
+
+- A health check establishes service readiness only; it does not validate a radiomics model or scientific result.
+- Controlled imaging data, consent, and authorization remain outside this tool.
+- The checked replay validates the lifecycle when the service is unreachable from the evaluation environment; current availability requires live mode.
+
+### References
+
+- [NIAID TB Portals multi-domain data platform](https://tbportals.niaid.nih.gov/what-are-the-tb-portals)
+- [TB Portals data access policy](https://tbportals.niaid.nih.gov/access-data)
+- [BV-BRC antimicrobial resistance resources](https://www.bv-brc.org/)
+- [WHO tuberculosis data](https://www.who.int/teams/global-tuberculosis-programme/data)

--- a/examples/vsd/artifacts/ga4gh_service_qualification_portfolio.json
+++ b/examples/vsd/artifacts/ga4gh_service_qualification_portfolio.json
@@ -1,0 +1,989 @@
+{
+  "accepted_count": 3,
+  "all_assertions_passed": true,
+  "case_count": 15,
+  "cases": [
+    {
+      "candidate_id": "629f064e4c2b1b67",
+      "case_id": "ga4gh_registry_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:22:55.006295+00:00"
+      },
+      "catalog_query": "GA4GH standards registry",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "GA4GH Standards and Implementations Registry",
+      "registered_type": {
+        "artifact": "service-registry",
+        "group": "org.ga4gh",
+        "version": "1.0.0"
+      },
+      "registry_record_id": "org.ga4gh.registry",
+      "service_info_endpoint": "https://registry.ga4gh.org/v1/service-info",
+      "service_root": "https://registry.ga4gh.org/v1",
+      "with_vsd": {
+        "assertions": {
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert_until_review": true,
+          "complete_hash_chain_was_recorded": true,
+          "early_publication_was_blocked": true,
+          "fresh_runtime_execution_succeeded": true,
+          "post_load_discovery_suppressed_the_exact_operation": true,
+          "publication_required_explicit_loading": true,
+          "three_conformance_executions_passed": true
+        },
+        "failure": null,
+        "final_execution_count": 1,
+        "governance": {
+          "early_publication_blocked": true,
+          "hash_chain": {
+            "approval_sha256": "56ee0d44ffb16c61305efdf883590c6e8f3dfa2e8f27802cc9b24f08240512ef",
+            "catalog_candidate_sha256": "5e3ff35180fe578932ece4ec72bd645c79dec8e2ed3fe39b287365d43b48e28d",
+            "draft_sha256": "3f3fdb094e2279b23decd614d8b3ac361a09696d45ea380d972244280f57ecb5",
+            "publication_sha256": "3c019ee27b2273954e0e0bbe8ad8a15d0fe09e3b36ecdc1acf731a58642cc4a0",
+            "verification_sha256": "207bb08cdc5088e05f1ecc0abdac31bee9b58294461b1287b6310af1ca54b5f2"
+          },
+          "loaded_into_fresh_universe": [
+            "ReviewedGA4GHRegistryInfo"
+          ],
+          "registered_duplicate_count": 1
+        },
+        "observed_service": {
+          "id": "org.ga4gh.registry",
+          "name": "GA4GH Standards and Implementations Registry",
+          "payload_sha256": "79bd47639405e91860a3067f3f3483832edb8bad75a56f9b1d18447f961bec98",
+          "type": {
+            "artifact": "service-registry",
+            "group": "org.ga4gh",
+            "version": "1.0.0"
+          }
+        },
+        "published_tool": "ReviewedGA4GHRegistryInfo",
+        "qualification": "accepted",
+        "verification_execution_count": 3
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "df5661ac79508e71",
+      "case_id": "ncbi_drs_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:23:48.314546+00:00"
+      },
+      "catalog_query": "NCBI DRS",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "NCBI Data Repository Service",
+      "registered_type": {
+        "artifact": "drs",
+        "group": "org.ga4gh",
+        "version": "1.2.0"
+      },
+      "registry_record_id": "gov.nih.nlm.ncbi.drs",
+      "service_info_endpoint": "https://locate.be-md.ncbi.nlm.nih.gov/ga4gh/drs/v1/service-info",
+      "service_root": "https://locate.be-md.ncbi.nlm.nih.gov/ga4gh/drs/v1",
+      "with_vsd": {
+        "assertions": {
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert_until_review": true,
+          "complete_hash_chain_was_recorded": true,
+          "early_publication_was_blocked": true,
+          "fresh_runtime_execution_succeeded": true,
+          "post_load_discovery_suppressed_the_exact_operation": true,
+          "publication_required_explicit_loading": true,
+          "three_conformance_executions_passed": true
+        },
+        "failure": null,
+        "final_execution_count": 1,
+        "governance": {
+          "early_publication_blocked": true,
+          "hash_chain": {
+            "approval_sha256": "a13e1731365974e63ff9803a14b0bf1b7cff0f4e3b82c1d7e51ce5871f8c6933",
+            "catalog_candidate_sha256": "43d3e9a8560bfaff6f2e2cca6afdb5b2ffbe7837987c0314d1ab8cc1428b7081",
+            "draft_sha256": "ce30f2b2a698f4aabb15d01143d688d211e49fa1c459727ba0e1a633344492a4",
+            "publication_sha256": "e2752058b60797ca8904e844094af33e1c01131f991e9430fad116abc9bb646e",
+            "verification_sha256": "44ee1856b45c1be7858f4dde76abb77df65dbcf92b7fd61ea5e15ceb99136cd8"
+          },
+          "loaded_into_fresh_universe": [
+            "ReviewedNCBIDRSServiceInfo"
+          ],
+          "registered_duplicate_count": 1
+        },
+        "observed_service": {
+          "id": "ncbi.drs",
+          "name": "NCBI Data Repository Service",
+          "payload_sha256": "1ba752d31825db148249ebe1a11c38db2d262059bcf093cc3028ecc5cf59c8e6",
+          "type": {
+            "artifact": "drs",
+            "group": "org.ga4gh",
+            "version": "1.2.0"
+          }
+        },
+        "published_tool": "ReviewedNCBIDRSServiceInfo",
+        "qualification": "accepted",
+        "verification_execution_count": 3
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "14dd7a80ef4ac84b",
+      "case_id": "dockstore_trs_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:24:55.207342+00:00"
+      },
+      "catalog_query": "Dockstore TRS",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "Dockstore",
+      "registered_type": {
+        "artifact": "trs",
+        "group": "org.ga4gh",
+        "version": "2.0.1"
+      },
+      "registry_record_id": "org.dockstore.dockstoreapi",
+      "service_info_endpoint": "https://dockstore.org/api/ga4gh/trs/v2/service-info",
+      "service_root": "https://dockstore.org/api/ga4gh/trs/v2",
+      "with_vsd": {
+        "assertions": {
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert_until_review": true,
+          "complete_hash_chain_was_recorded": true,
+          "early_publication_was_blocked": true,
+          "fresh_runtime_execution_succeeded": true,
+          "post_load_discovery_suppressed_the_exact_operation": true,
+          "publication_required_explicit_loading": true,
+          "three_conformance_executions_passed": true
+        },
+        "failure": null,
+        "final_execution_count": 1,
+        "governance": {
+          "early_publication_blocked": true,
+          "hash_chain": {
+            "approval_sha256": "e8a38daae63451569a61313937dc94c21d3dac2b7a09d7236a1d12315f686508",
+            "catalog_candidate_sha256": "043c0ca7c15ddad052bcb369c7fa9c6bfaec217ea403937590c1135502f298b9",
+            "draft_sha256": "06c17c42abf945657d4b5e2bcd2a0fa3b7b8f54ea7ce3d393e5c7e8eb23dfd78",
+            "publication_sha256": "beede88528db60e7d43b6579483cea21f2b73d9681d4a1a6fcc81a9c38df7ef4",
+            "verification_sha256": "620ff766335d29cf9f3d6e520113c62de809af3d9b64905e48e2e8299a0c0e2c"
+          },
+          "loaded_into_fresh_universe": [
+            "ReviewedDockstoreTRSServiceInfo"
+          ],
+          "registered_duplicate_count": 1
+        },
+        "observed_service": {
+          "id": "1",
+          "name": "Dockstore",
+          "payload_sha256": "b6c2adfc29ee475934da365f7cb88e19ff4b73e52a5ad4ada734671aed55deb0",
+          "type": {
+            "artifact": "TRS",
+            "group": "org.ga4gh",
+            "version": "2.0.1"
+          }
+        },
+        "published_tool": "ReviewedDockstoreTRSServiceInfo",
+        "qualification": "accepted",
+        "verification_execution_count": 3
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "6f1c71bf43fe5ab7",
+      "case_id": "cavatica_wes_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:25:11.658883+00:00"
+      },
+      "catalog_query": "Cavatica WES",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "Cavatica GA4GH WES API",
+      "registered_type": {
+        "artifact": "wes",
+        "group": "org.ga4gh",
+        "version": "1.0.0"
+      },
+      "registry_record_id": "com.sbgenomics.cavatica-ga4gh-api.wes",
+      "service_info_endpoint": "https://cavatica-ga4gh-api.sbgenomics.com/ga4gh/wes/v1/service-info",
+      "service_root": "https://cavatica-ga4gh-api.sbgenomics.com/ga4gh/wes/v1",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "registered_metadata_mismatch",
+          "message": "Verification case 0 row 0 failed JSON pointer equality assertions",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidatecavaticawesserviceinfo_6c45b143a468"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "b81fee8dc2e37310",
+      "case_id": "cgc_wes_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:25:25.934697+00:00"
+      },
+      "catalog_query": "CGC WES",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "CGC GA4GH WES API",
+      "registered_type": {
+        "artifact": "wes",
+        "group": "org.ga4gh",
+        "version": "1.0.0"
+      },
+      "registry_record_id": "com.sbgenomics.cgc-ga4gh-api.wes",
+      "service_info_endpoint": "https://cgc-ga4gh-api.sbgenomics.com/ga4gh/wes/v1/service-info",
+      "service_root": "https://cgc-ga4gh-api.sbgenomics.com/ga4gh/wes/v1",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "registered_metadata_mismatch",
+          "message": "Verification case 0 row 0 failed JSON pointer equality assertions",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidatecgcwesserviceinfo_07d7c4b80ff3"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "821922bf385cb457",
+      "case_id": "bdc_wes_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:25:34.445115+00:00"
+      },
+      "catalog_query": "BioData Catalyst WES",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "BDC GA4GH WES API",
+      "registered_type": {
+        "artifact": "wes",
+        "group": "org.ga4gh",
+        "version": "1.0.0"
+      },
+      "registry_record_id": "gov.nih.nhlbi.biodatacatalyst.sb.ga4gh-api.wes",
+      "service_info_endpoint": "https://ga4gh-api.sb.biodatacatalyst.nhlbi.nih.gov/ga4gh/wes/v1/service-info",
+      "service_root": "https://ga4gh-api.sb.biodatacatalyst.nhlbi.nih.gov/ga4gh/wes/v1",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "registered_metadata_mismatch",
+          "message": "Verification case 0 row 0 failed JSON pointer equality assertions",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidatebdcwesserviceinfo_507909b0fd31"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "654c3920a73481db",
+      "case_id": "cavatica_drs_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:25:40.482810+00:00"
+      },
+      "catalog_query": "Cavatica DRS",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "Cavatica DRS API",
+      "registered_type": {
+        "artifact": "drs",
+        "group": "org.ga4gh",
+        "version": "1.3.0"
+      },
+      "registry_record_id": "com.sb.cavatica.drs",
+      "service_info_endpoint": "https://cavatica-ga4gh-api.sbgenomics.com/service-info",
+      "service_root": "https://cavatica-ga4gh-api.sbgenomics.com/",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "execution_failure",
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': 'Validation error: Provider request failed', 'error_details': {'type': 'ToolValidationError', 'message': 'Validation error: Provider request failed', 'retriable': False, 'next_steps': ['Check parameter types and values', 'Review tool documentation', 'Verify required parameters are provided'], 'details': {}}}",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidatecavaticadrsserviceinfo_bc91d222e460"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "949f34f2e1f42fe9",
+      "case_id": "cgc_drs_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:25:57.982516+00:00"
+      },
+      "catalog_query": "Cancer Genomics Cloud DRS",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "Cancer Genomics Cloud DRS API",
+      "registered_type": {
+        "artifact": "drs",
+        "group": "org.ga4gh",
+        "version": "1.3.0"
+      },
+      "registry_record_id": "com.sb.cgc.drs",
+      "service_info_endpoint": "https://cgc-ga4gh-api.sbgenomics.com/service-info",
+      "service_root": "https://cgc-ga4gh-api.sbgenomics.com/",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "execution_failure",
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': 'Validation error: Provider request failed', 'error_details': {'type': 'ToolValidationError', 'message': 'Validation error: Provider request failed', 'retriable': False, 'next_steps': ['Check parameter types and values', 'Review tool documentation', 'Verify required parameters are provided'], 'details': {}}}",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidatecgcdrsserviceinfo_2a8813de78ba"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "b7f9fe008a100fe8",
+      "case_id": "bdc_drs_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:26:06.855399+00:00"
+      },
+      "catalog_query": "BioData Catalyst DRS",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "BioData Catalyst powered by Seven Bridges DRS API",
+      "registered_type": {
+        "artifact": "drs",
+        "group": "org.ga4gh",
+        "version": "1.3.0"
+      },
+      "registry_record_id": "com.sb.bdc.drs",
+      "service_info_endpoint": "https://ga4gh-api.sb.biodatacatalyst.nhlbi.nih.gov/service-info",
+      "service_root": "https://ga4gh-api.sb.biodatacatalyst.nhlbi.nih.gov/",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "execution_failure",
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': 'Validation error: Provider request failed', 'error_details': {'type': 'ToolValidationError', 'message': 'Validation error: Provider request failed', 'retriable': False, 'next_steps': ['Check parameter types and values', 'Review tool documentation', 'Verify required parameters are provided'], 'details': {}}}",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidatebdcdrsserviceinfo_f8f2b6b030fb"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "a2826c59994b5a5d",
+      "case_id": "crg_rnaget_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:26:38.595996+00:00"
+      },
+      "catalog_query": "CRG RNAget",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "CRG RNAget Reference Implementation",
+      "registered_type": {
+        "artifact": "rnaget",
+        "group": "org.ga4gh",
+        "version": "1.0.0"
+      },
+      "registry_record_id": "eu.crg.rnaget",
+      "service_info_endpoint": "https://genome.crg.cat/rnaget/service-info",
+      "service_root": "https://genome.crg.cat/rnaget",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "execution_failure",
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': 'Validation error: Provider request failed', 'error_details': {'type': 'ToolValidationError', 'message': 'Validation error: Provider request failed', 'retriable': False, 'next_steps': ['Check parameter types and values', 'Review tool documentation', 'Verify required parameters are provided'], 'details': {}}}",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidatecrgrnagetserviceinfo_2ada31fa31d2"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "98329acb74d202c6",
+      "case_id": "anvil_drs_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:26:45.509840+00:00"
+      },
+      "catalog_query": "AnVIL DRS",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "NHGRI AnVIL",
+      "registered_type": {
+        "artifact": "drs",
+        "group": "org.ga4gh",
+        "version": "1.3.0"
+      },
+      "registry_record_id": "bio.terra.data",
+      "service_info_endpoint": "https://data.terra.bio/service-info",
+      "service_root": "https://data.terra.bio/",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "response_media_type_mismatch",
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': \"Validation error: Provider content type 'text/html' does not match json\", 'error_details': {'type': 'ToolValidationError', 'message': \"Validation error: Provider content type 'text/html' does not match json\", 'retriable': False, 'next_steps': ['Check parameter types and values', 'Review tool documentation', 'Verify required parameters are provided'], 'details': {}}}",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidateanvildrsserviceinfo_d37f078d645e"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "9bc5689c4fdd0dd8",
+      "case_id": "gen3_drs_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:27:12.612854+00:00"
+      },
+      "catalog_query": "Gen3 Data Hub DRS",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "Gen3 Data Hub",
+      "registered_type": {
+        "artifact": "drs",
+        "group": "org.ga4gh",
+        "version": "1.2.0"
+      },
+      "registry_record_id": "io.datacommons.gen3.drs",
+      "service_info_endpoint": "https://gen3.datacommons.io/service-info",
+      "service_root": "https://gen3.datacommons.io/",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "response_media_type_mismatch",
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': \"Validation error: Provider content type 'text/html' does not match json\", 'error_details': {'type': 'ToolValidationError', 'message': \"Validation error: Provider content type 'text/html' does not match json\", 'retriable': False, 'next_steps': ['Check parameter types and values', 'Review tool documentation', 'Verify required parameters are provided'], 'details': {}}}",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidategen3drsserviceinfo_af6e2f471d15"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "39ccae3937970e55",
+      "case_id": "nci_crdc_drs_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:27:29.845573+00:00"
+      },
+      "catalog_query": "NCI CRDC DRS",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "NCI CRDC",
+      "registered_type": {
+        "artifact": "drs",
+        "group": "org.ga4gh",
+        "version": "1.2.0"
+      },
+      "registry_record_id": "io.datacommons.nci-crdc.drs",
+      "service_info_endpoint": "https://nci-crdc.datacommons.io/service-info",
+      "service_root": "https://nci-crdc.datacommons.io/",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "response_media_type_mismatch",
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': \"Validation error: Provider content type 'text/html' does not match json\", 'error_details': {'type': 'ToolValidationError', 'message': \"Validation error: Provider content type 'text/html' does not match json\", 'retriable': False, 'next_steps': ['Check parameter types and values', 'Review tool documentation', 'Verify required parameters are provided'], 'details': {}}}",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidatencicrdcdrsserviceinfo_35cf8ebfd577"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "b6688940d858444a",
+      "case_id": "viral_ai_drs_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:27:45.216421+00:00"
+      },
+      "catalog_query": "Viral AI DRS",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "Viral AI",
+      "registered_type": {
+        "artifact": "drs",
+        "group": "org.ga4gh",
+        "version": "1.3.0"
+      },
+      "registry_record_id": "ai.viral",
+      "service_info_endpoint": "https://viral.ai/service-info",
+      "service_root": "https://viral.ai/",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "redirect_rejected",
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': 'Validation error: Provider redirects are not allowed', 'error_details': {'type': 'ToolValidationError', 'message': 'Validation error: Provider redirects are not allowed', 'retriable': False, 'next_steps': ['Check parameter types and values', 'Review tool documentation', 'Verify required parameters are provided'], 'details': {}}}",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidateviralaidrsserviceinfo_f0c2a391f75a"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    },
+    {
+      "candidate_id": "b7821aebd9677a19",
+      "case_id": "nhs_drs_service_info",
+      "catalog_provenance": {
+        "endpoint": "https://registry.ga4gh.org/v1/services",
+        "http_status": 200,
+        "payload_sha256": "dcac9380b166adf0f1a86bcff476cc05ea282301b71b0870ca3baf46a10aa948",
+        "response_bytes": 24732,
+        "retrieved_at": "2026-08-02T17:28:00.555380+00:00"
+      },
+      "catalog_query": "NHS genomic DRS",
+      "evidence_mode": "live",
+      "live_attempt": {
+        "completed": true,
+        "fallback": null
+      },
+      "registered_name": "NHS Genomic Data Access & Management",
+      "registered_type": {
+        "artifact": "drs",
+        "group": "org.ga4gh",
+        "version": "1.4.0"
+      },
+      "registry_record_id": "api.service.nhs.uk/genomic-data-access",
+      "service_info_endpoint": "https://sandbox.api.service.nhs.uk/genomic-data-access/service-info",
+      "service_root": "https://sandbox.api.service.nhs.uk/genomic-data-access",
+      "with_vsd": {
+        "assertions": {
+          "approval_without_evidence_was_blocked": true,
+          "candidate_binding_was_hash_sealed": true,
+          "candidate_remained_inert": true,
+          "early_publication_was_blocked": true,
+          "no_approval_was_recorded": true,
+          "no_publication_was_recorded": true,
+          "qualification_failed_closed": true
+        },
+        "failure": {
+          "category": "execution_failure",
+          "message": "Verification case 0 did not execute successfully: {'status': 'error', 'error': 'Validation error: Provider request failed', 'error_details': {'type': 'ToolValidationError', 'message': 'Validation error: Provider request failed', 'retriable': False, 'next_steps': ['Check parameter types and values', 'Review tool documentation', 'Verify required parameters are provided'], 'details': {}}}",
+          "type": "VSDPromotionError"
+        },
+        "final_execution_count": 0,
+        "governance": {
+          "approval_blocked": true,
+          "early_publication_blocked": true,
+          "promotion_state": {
+            "approvals": [],
+            "approved": [],
+            "drafts": [
+              "candidatenhsdrsserviceinfo_76b8eee6d4de"
+            ],
+            "evidence": []
+          }
+        },
+        "published_tool": null,
+        "qualification": "rejected",
+        "verification_execution_count": 0
+      },
+      "without_vsd": {
+        "catalog_record_discovered": true,
+        "executable_service_info_tool": false,
+        "qualification_evidence": false
+      }
+    }
+  ],
+  "final_execution_count": 3,
+  "format": "vsd_ga4gh_service_qualification_portfolio_v1",
+  "generated_at": "2026-08-02T17:28:18.323292+00:00",
+  "live_case_count": 15,
+  "portfolio_sha256": "8f20711089278a292c9f88d86fd40c8fa3fbc4f887f2d7d104f3408013e63243",
+  "published_tool_count": 3,
+  "rejected_count": 12,
+  "replay_case_count": 0,
+  "requested_mode": "network_backed",
+  "verification_execution_count": 9
+}

--- a/examples/vsd/artifacts/ga4gh_service_qualification_portfolio.md
+++ b/examples/vsd/artifacts/ga4gh_service_qualification_portfolio.md
@@ -1,0 +1,55 @@
+# GA4GH Service Qualification Portfolio
+
+## Scope
+
+This evaluation asked whether an official registry entry was sufficient to create a usable ToolUniverse operation. VSD derived only the standard Service Info path, then required live response structure and registered service-type agreement before approval.
+
+The same parameterized runner evaluated every service; organization names, URLs, expected outcomes, and replay responses are scenario data.
+
+## Results
+
+- Evaluated services: `15`
+- Accepted and published: `3`
+- Rejected before approval: `12`
+- Verification executions: `9`
+- Fresh-universe executions: `3`
+- Live cases: `15`
+- Checked-replay cases: `0`
+- Portfolio SHA-256: `8f20711089278a292c9f88d86fd40c8fa3fbc4f887f2d7d104f3408013e63243`
+
+| Registry record | Standard | Endpoint | Result | Evidence |
+| --- | --- | --- | --- | --- |
+| org.ga4gh.registry | service-registry 1.0.0 | https://registry.ga4gh.org/v1/service-info | accepted | 3 conformance calls, publication, fresh load, and final execution |
+| gov.nih.nlm.ncbi.drs | drs 1.2.0 | https://locate.be-md.ncbi.nlm.nih.gov/ga4gh/drs/v1/service-info | accepted | 3 conformance calls, publication, fresh load, and final execution |
+| org.dockstore.dockstoreapi | trs 2.0.1 | https://dockstore.org/api/ga4gh/trs/v2/service-info | accepted | 3 conformance calls, publication, fresh load, and final execution |
+| com.sbgenomics.cavatica-ga4gh-api.wes | wes 1.0.0 | https://cavatica-ga4gh-api.sbgenomics.com/ga4gh/wes/v1/service-info | rejected | registered metadata mismatch |
+| com.sbgenomics.cgc-ga4gh-api.wes | wes 1.0.0 | https://cgc-ga4gh-api.sbgenomics.com/ga4gh/wes/v1/service-info | rejected | registered metadata mismatch |
+| gov.nih.nhlbi.biodatacatalyst.sb.ga4gh-api.wes | wes 1.0.0 | https://ga4gh-api.sb.biodatacatalyst.nhlbi.nih.gov/ga4gh/wes/v1/service-info | rejected | registered metadata mismatch |
+| com.sb.cavatica.drs | drs 1.3.0 | https://cavatica-ga4gh-api.sbgenomics.com/service-info | rejected | execution failure |
+| com.sb.cgc.drs | drs 1.3.0 | https://cgc-ga4gh-api.sbgenomics.com/service-info | rejected | execution failure |
+| com.sb.bdc.drs | drs 1.3.0 | https://ga4gh-api.sb.biodatacatalyst.nhlbi.nih.gov/service-info | rejected | execution failure |
+| eu.crg.rnaget | rnaget 1.0.0 | https://genome.crg.cat/rnaget/service-info | rejected | execution failure |
+| bio.terra.data | drs 1.3.0 | https://data.terra.bio/service-info | rejected | response media type mismatch |
+| io.datacommons.gen3.drs | drs 1.2.0 | https://gen3.datacommons.io/service-info | rejected | response media type mismatch |
+| io.datacommons.nci-crdc.drs | drs 1.2.0 | https://nci-crdc.datacommons.io/service-info | rejected | response media type mismatch |
+| ai.viral | drs 1.3.0 | https://viral.ai/service-info | rejected | redirect rejected |
+| api.service.nhs.uk/genomic-data-access | drs 1.4.0 | https://sandbox.api.service.nhs.uk/genomic-data-access/service-info | rejected | execution failure |
+
+## Lifecycle Evidence
+
+Every discovered candidate was non-executable and content-addressed. All 15 drafts were blocked from publication before verification. The three conforming services passed registry-bound assertions three times, were explicitly approved and published, remained absent from a fresh ToolUniverse until loaded, executed successfully after loading, and were suppressed from the next discovery result as exact duplicates.
+
+The other 12 candidates produced no approval or publication artifact. They included valid JSON with service-type drift, unavailable standard paths, HTML responses at API-looking URLs, and a redirect.
+
+## Interpretation
+
+Without VSD, the registry supplies useful leads but does not establish that their standard metadata operation is reachable or still agrees with the registered contract. With VSD, conforming leads become narrow, auditable ToolUniverse operations while stale or inconsistent records fail before approval. In this snapshot, indiscriminate registration would have treated all 15 records as usable; qualification admitted three and prevented 12 unsupported additions.
+
+## Reproduction
+
+```console
+PYTHONPATH=src python examples/vsd/ga4gh_service_qualification_portfolio.py --mode replay
+PYTHONPATH=src python examples/vsd/ga4gh_service_qualification_portfolio.py --mode network_backed
+```
+
+Replay uses checked provider-shaped responses. Network-backed mode labels each service independently as live or checked replay and records the bounded reason for any fallback.

--- a/examples/vsd/biomedical_evaluation_portfolio.py
+++ b/examples/vsd/biomedical_evaluation_portfolio.py
@@ -1,0 +1,938 @@
+"""Run parameterized biomedical evaluations of governed VSD registry growth."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+from urllib.parse import urlsplit
+
+import tooluniverse.vsd_discovery as vsd_discovery
+import tooluniverse.vsd_dynamic_rest as vsd_dynamic_rest
+from tooluniverse import ToolUniverse
+from tooluniverse.vsd_coverage import _registry_tools
+from tooluniverse.vsd_dynamic_rest import _provider_request
+from tooluniverse.vsd_openapi import inspect_openapi_document
+from tooluniverse.vsd_planning import plan_workflow
+from tooluniverse.vsd_promotion import (
+    VSDPromotionError,
+    approve_draft,
+    create_catalog_openapi_draft,
+    create_reviewed_catalog_openapi_draft,
+    load_published_tools,
+    publish_draft,
+    verify_draft,
+)
+from tooluniverse.vsd_tool import _safe_get_json
+
+HERE = Path(__file__).resolve().parent
+STUDIES = HERE / "biomedical_studies"
+SCENARIOS = STUDIES / "scenarios"
+FIXTURES = STUDIES / "fixtures"
+ARTIFACTS = HERE / "artifacts"
+DEFAULT_JSON = ARTIFACTS / "biomedical_evaluation_portfolio.json"
+DEFAULT_MARKDOWN = ARTIFACTS / "biomedical_evaluation_portfolio.md"
+
+_CASE_ID_RE = re.compile(r"^[a-z][a-z0-9_]{2,63}$")
+_TOOL_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,44}$")
+_REQUIRED_SCENARIO_FIELDS = {
+    "case_id",
+    "title",
+    "research_question",
+    "decision_context",
+    "catalog_query",
+    "catalog_record_id",
+    "service_endpoint",
+    "specification_fixture",
+    "response_fixture",
+    "operation_id",
+    "promotion_mode",
+    "tool_name",
+    "tool_description",
+    "include_parameters",
+    "fixed_query",
+    "review_note",
+    "response_schema",
+    "workflow_capability",
+    "verification_cases",
+    "runtime_arguments",
+    "observations",
+    "reused_tools",
+    "without_vsd",
+    "with_vsd",
+    "limitations",
+    "references",
+}
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _bounded_fixture(name: Any) -> Path:
+    if not isinstance(name, str) or Path(name).name != name or not name.endswith(
+        ".json"
+    ):
+        raise ValueError("Scenario fixture names must be local JSON filenames")
+    path = (FIXTURES / name).resolve()
+    if path.parent != FIXTURES.resolve() or not path.is_file():
+        raise ValueError(f"Scenario fixture does not exist: {name!r}")
+    return path
+
+
+def validate_scenario(value: Any) -> dict[str, Any]:
+    """Validate one data-only evaluation scenario before any network activity."""
+    if not isinstance(value, dict) or set(value) != _REQUIRED_SCENARIO_FIELDS:
+        raise ValueError("Scenario structure is invalid")
+    case_id = value["case_id"]
+    if not isinstance(case_id, str) or not _CASE_ID_RE.fullmatch(case_id):
+        raise ValueError("Scenario case_id is invalid")
+    if not isinstance(value["tool_name"], str) or not _TOOL_NAME_RE.fullmatch(
+        value["tool_name"]
+    ):
+        raise ValueError("Scenario tool_name is invalid")
+    for field in (
+        "title",
+        "research_question",
+        "decision_context",
+        "catalog_query",
+        "catalog_record_id",
+        "service_endpoint",
+        "operation_id",
+        "tool_description",
+        "review_note",
+    ):
+        text = value[field]
+        if not isinstance(text, str) or not text.strip() or len(text) > 2000:
+            raise ValueError(f"Scenario {field} is invalid")
+    endpoint = urlsplit(value["service_endpoint"])
+    if (
+        endpoint.scheme != "https"
+        or not endpoint.hostname
+        or endpoint.username
+        or endpoint.password
+        or endpoint.query
+        or endpoint.fragment
+    ):
+        raise ValueError("Scenario service_endpoint must be canonical HTTPS")
+    _bounded_fixture(value["specification_fixture"])
+    _bounded_fixture(value["response_fixture"])
+    if value["promotion_mode"] not in {"strict", "reviewed_response"}:
+        raise ValueError("Scenario promotion_mode is invalid")
+    if not isinstance(value["include_parameters"], list) or any(
+        not isinstance(item, str) for item in value["include_parameters"]
+    ):
+        raise ValueError("Scenario include_parameters is invalid")
+    if not isinstance(value["fixed_query"], dict):
+        raise ValueError("Scenario fixed_query is invalid")
+    response_schema = value["response_schema"]
+    if value["promotion_mode"] == "strict" and response_schema is not None:
+        raise ValueError("Strict scenarios obtain their response schema from OpenAPI")
+    if value["promotion_mode"] == "reviewed_response" and not isinstance(
+        response_schema, dict
+    ):
+        raise ValueError("Reviewed-response scenarios require a response schema")
+    capability = value["workflow_capability"]
+    if (
+        not isinstance(capability, dict)
+        or set(capability)
+        != {"step_id", "description", "required_inputs", "output_fields"}
+        or not _CASE_ID_RE.fullmatch(str(capability["step_id"]))
+        or not isinstance(capability["description"], str)
+        or not isinstance(capability["required_inputs"], list)
+        or not isinstance(capability["output_fields"], list)
+    ):
+        raise ValueError("Scenario workflow_capability is invalid")
+    cases = value["verification_cases"]
+    if not isinstance(cases, list) or not 3 <= len(cases) <= 20:
+        raise ValueError("Scenario requires 3-20 verification cases")
+    if any(
+        not isinstance(case, dict)
+        or set(case) != {"arguments", "expect"}
+        or not isinstance(case["arguments"], dict)
+        or not isinstance(case["expect"], dict)
+        for case in cases
+    ):
+        raise ValueError("Scenario verification cases are invalid")
+    if not isinstance(value["runtime_arguments"], dict):
+        raise ValueError("Scenario runtime_arguments is invalid")
+    responses = _json(_bounded_fixture(value["response_fixture"]))
+    if (
+        not isinstance(responses, list)
+        or len(responses) < len(cases)
+        or any(
+            not isinstance(item, dict)
+            or set(item) != {"arguments", "payload"}
+            or not isinstance(item["arguments"], dict)
+            for item in responses
+        )
+    ):
+        raise ValueError("Scenario replay responses are invalid")
+    available = {_digest(item["arguments"]) for item in responses}
+    required = {_digest(case["arguments"]) for case in cases}
+    required.add(_digest(value["runtime_arguments"]))
+    if not required <= available:
+        raise ValueError("Scenario replay responses do not cover every execution")
+    for field in (
+        "observations",
+        "reused_tools",
+        "limitations",
+        "references",
+    ):
+        if not isinstance(value[field], list) or not value[field]:
+            raise ValueError(f"Scenario {field} must be a non-empty list")
+    if any(
+        not isinstance(item, dict)
+        or set(item) != {"label", "pointer"}
+        or not isinstance(item["label"], str)
+        or not item["label"].strip()
+        or not isinstance(item["pointer"], str)
+        or (item["pointer"] and not item["pointer"].startswith("/"))
+        for item in value["observations"]
+    ):
+        raise ValueError("Scenario observations are invalid")
+    if any(
+        not isinstance(item, dict)
+        or set(item) != {"name", "role"}
+        or not isinstance(item["name"], str)
+        or not _TOOL_NAME_RE.fullmatch(item["name"])
+        or not isinstance(item["role"], str)
+        or not item["role"].strip()
+        for item in value["reused_tools"]
+    ):
+        raise ValueError("Scenario reused_tools entries are invalid")
+    if any(
+        not isinstance(item, str) or not item.strip() or len(item) > 1000
+        for item in value["limitations"]
+    ):
+        raise ValueError("Scenario limitations are invalid")
+    if any(
+        not isinstance(item, dict)
+        or set(item) != {"title", "url"}
+        or not isinstance(item["title"], str)
+        or not item["title"].strip()
+        or not isinstance(item["url"], str)
+        or urlsplit(item["url"]).scheme != "https"
+        or not urlsplit(item["url"]).hostname
+        for item in value["references"]
+    ):
+        raise ValueError("Scenario references are invalid")
+    for field in ("without_vsd", "with_vsd"):
+        if (
+            not isinstance(value[field], dict)
+            or set(value[field]) != {"summary"}
+            or not isinstance(value[field]["summary"], str)
+            or not value[field]["summary"].strip()
+        ):
+            raise ValueError(f"Scenario {field} must contain one summary")
+    return json.loads(json.dumps(value))
+
+
+def load_scenarios() -> list[dict[str, Any]]:
+    scenarios = [validate_scenario(_json(path)) for path in sorted(SCENARIOS.glob("*.json"))]
+    if len(scenarios) != 5 or len({item["case_id"] for item in scenarios}) != 5:
+        raise ValueError("The portfolio must contain five unique scenarios")
+    return scenarios
+
+
+def _tool_data(
+    universe: ToolUniverse, tool_name: str, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    result = universe.run_one_function(
+        {"name": tool_name, "arguments": arguments}, use_cache=False
+    )
+    if not isinstance(result, dict) or result.get("status") != "success":
+        raise RuntimeError(f"{tool_name} failed")
+    data = result.get("data")
+    if not isinstance(data, dict):
+        raise RuntimeError(f"{tool_name} returned an invalid envelope")
+    return data
+
+
+def _request_metadata(url: str, payload: Any) -> dict[str, Any]:
+    return {
+        "url": url,
+        "status_code": 200,
+        "content_type": "application/json",
+        "response_bytes": len(_canonical(payload)),
+        "peer_ip": "93.184.216.34",
+        "redirects": 0,
+    }
+
+
+def _same_service(left: str, right: str) -> bool:
+    first = urlsplit(left)
+    second = urlsplit(right)
+    return (
+        first.scheme,
+        (first.hostname or "").casefold().rstrip("."),
+        first.port,
+        (first.path or "/").rstrip("/") or "/",
+    ) == (
+        second.scheme,
+        (second.hostname or "").casefold().rstrip("."),
+        second.port,
+        (second.path or "/").rstrip("/") or "/",
+    )
+
+
+@contextmanager
+def _replay_catalog(specification: dict[str, Any]) -> Iterator[None]:
+    original = vsd_discovery._safe_get_json
+    payload = {"total": 1, "hits": [specification]}
+
+    def fetch(url, params=None, **kwargs):
+        del params, kwargs
+        return payload, _request_metadata(url, payload)
+
+    vsd_discovery._safe_get_json = fetch
+    try:
+        yield
+    finally:
+        vsd_discovery._safe_get_json = original
+
+
+@contextmanager
+def _allowed_service_host(endpoint: str) -> Iterator[None]:
+    host = (urlsplit(endpoint).hostname or "").casefold().rstrip(".")
+    previous = os.environ.get("TOOLUNIVERSE_VSD_ALLOWED_HOSTS")
+    configured = {item.strip() for item in (previous or "").split(",") if item.strip()}
+    configured.add(host)
+    os.environ["TOOLUNIVERSE_VSD_ALLOWED_HOSTS"] = ",".join(sorted(configured))
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("TOOLUNIVERSE_VSD_ALLOWED_HOSTS", None)
+        else:
+            os.environ["TOOLUNIVERSE_VSD_ALLOWED_HOSTS"] = previous
+
+
+def _discovery(
+    universe: ToolUniverse,
+    scenario: dict[str, Any],
+    specification: dict[str, Any],
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    arguments = {
+        "query": scenario["catalog_query"],
+        "providers": ["smartapi"],
+        "exclude_registered": True,
+        "limit": 10,
+    }
+    if mode == "replay":
+        with _replay_catalog(specification):
+            return _tool_data(universe, "VSDDiscoverAPICandidates", arguments)
+    return _tool_data(universe, "VSDDiscoverAPICandidates", arguments)
+
+
+def _select_catalog_candidate(
+    discovery: dict[str, Any], scenario: dict[str, Any]
+) -> dict[str, Any]:
+    matches = [
+        item
+        for item in discovery.get("candidates", [])
+        if item.get("catalog_record_id") == scenario["catalog_record_id"]
+        and _same_service(item.get("api_endpoint", ""), scenario["service_endpoint"])
+    ]
+    if len(matches) != 1:
+        raise RuntimeError("Discovery did not return the exact scenario catalog record")
+    return matches[0]
+
+
+def _inspect(
+    catalog_candidate: dict[str, Any],
+    scenario: dict[str, Any],
+    workspace: Path,
+    *,
+    mode: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if mode == "replay":
+        path = _bounded_fixture(scenario["specification_fixture"])
+        transport = {
+            "mode": "replay",
+            "source": "checked provider-shaped OpenAPI fixture",
+        }
+    else:
+        payload, request = _safe_get_json(
+            catalog_candidate["specification_url"],
+            max_response_bytes=10_000_000,
+        )
+        path = workspace / "inspected-openapi.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+            encoding="utf-8",
+        )
+        transport = {
+            "mode": "live",
+            "source": "SmartAPI metadata endpoint",
+            "http_status": request["status_code"],
+            "payload_sha256": hashlib.sha256(_canonical(payload)).hexdigest(),
+        }
+    report = inspect_openapi_document(path)
+    matches = [
+        item
+        for item in report["candidates"]
+        if item["operation_id"] == scenario["operation_id"]
+    ]
+    if len(matches) != 1:
+        raise RuntimeError("OpenAPI inspection did not find the exact operation")
+    return matches[0], {
+        **transport,
+        "source_document_sha256": report["source_document_sha256"],
+        "candidate_count": report["candidate_count"],
+        "promotable_count": report["promotable_count"],
+    }
+
+
+def _workflow(
+    universe: ToolUniverse,
+    scenario: dict[str, Any],
+    operation: dict[str, Any],
+) -> dict[str, Any]:
+    capability = scenario["workflow_capability"]
+    endpoint = operation["server_url"] + "/" + operation["path"].lstrip("/")
+    return plan_workflow(
+        universe,
+        goal=scenario["research_question"],
+        capabilities=[
+            {
+                **capability,
+                "provider": urlsplit(endpoint).hostname,
+                "method": "GET",
+                "endpoint": endpoint,
+                "operation_id": f"openapi.{operation['candidate_id']}",
+            },
+            {
+                "step_id": "evidence_synthesis",
+                "description": scenario["decision_context"],
+                "fulfillment": "agent",
+                "depends_on": [capability["step_id"]],
+            },
+        ],
+        limit=5,
+    )["data"]
+
+
+def _step(plan: dict[str, Any], step_id: str) -> dict[str, Any]:
+    return next(item for item in plan["steps"] if item["step_id"] == step_id)
+
+
+def _registry_evidence(
+    universe: ToolUniverse, scenario: dict[str, Any]
+) -> list[dict[str, Any]]:
+    registry = {
+        item.get("name"): item
+        for item in _registry_tools(universe)
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    }
+    evidence = []
+    for requested in scenario["reused_tools"]:
+        if not isinstance(requested, dict) or set(requested) != {"name", "role"}:
+            raise ValueError("Scenario reused_tools entries are invalid")
+        config = registry.get(requested["name"])
+        if config is None:
+            raise RuntimeError(f"Existing tool is absent: {requested['name']}")
+        evidence.append(
+            {
+                "name": requested["name"],
+                "role": requested["role"],
+                "present": True,
+                "config_sha256": _digest(config),
+            }
+        )
+    return evidence
+
+
+def _draft(
+    scenario: dict[str, Any],
+    catalog_candidate: dict[str, Any],
+    operation: dict[str, Any],
+    workspace: Path,
+) -> dict[str, Any]:
+    common = {
+        "catalog_candidate": catalog_candidate,
+        "operation_candidate": operation,
+        "tool_name": scenario["tool_name"],
+        "description": scenario["tool_description"],
+        "review_note": scenario["review_note"],
+        "include_parameters": scenario["include_parameters"],
+        "fixed_query": scenario["fixed_query"],
+        "workspace": workspace,
+    }
+    if scenario["promotion_mode"] == "strict":
+        return create_catalog_openapi_draft(**common)
+    return create_reviewed_catalog_openapi_draft(
+        **common,
+        response_schema=scenario["response_schema"],
+        resolved_blockers=["json_response_missing"],
+    )
+
+
+def _replay_exchange(
+    config: dict[str, Any], scenario: dict[str, Any]
+):
+    responses = _json(_bounded_fixture(scenario["response_fixture"]))
+    requests: dict[tuple[str, str], Any] = {}
+    for item in responses:
+        endpoint, query = _provider_request(config, item["arguments"])
+        requests[(endpoint, _digest(query))] = item["payload"]
+
+    def fetch(url, params, *, timeout, **kwargs):
+        del timeout, kwargs
+        key = (url, _digest(params))
+        if key not in requests:
+            raise RuntimeError("Replay transport received an unreviewed request")
+        payload = requests[key]
+        return payload, _request_metadata(url, payload)
+
+    return fetch
+
+
+@contextmanager
+def _runtime_transport(
+    config: dict[str, Any], scenario: dict[str, Any], *, mode: str
+) -> Iterator[None]:
+    original = vsd_dynamic_rest._safe_get_json
+    if mode == "replay":
+        vsd_dynamic_rest._safe_get_json = _replay_exchange(config, scenario)
+    try:
+        yield
+    finally:
+        vsd_dynamic_rest._safe_get_json = original
+
+
+def _pointer(value: Any, pointer: str) -> Any:
+    if not isinstance(pointer, str) or (pointer and not pointer.startswith("/")):
+        raise ValueError("Observation pointer is invalid")
+    current = value
+    for raw in pointer.split("/")[1:] if pointer else []:
+        token = raw.replace("~1", "/").replace("~0", "~")
+        if isinstance(current, dict) and token in current:
+            current = current[token]
+        elif isinstance(current, list) and token.isdigit() and int(token) < len(current):
+            current = current[int(token)]
+        else:
+            return None
+    return current
+
+
+def _runtime_summary(
+    data: dict[str, Any], scenario: dict[str, Any]
+) -> dict[str, Any]:
+    result = data["result"]
+    observations = []
+    for observation in scenario["observations"]:
+        if not isinstance(observation, dict) or set(observation) != {
+            "label",
+            "pointer",
+        }:
+            raise ValueError("Scenario observation is invalid")
+        observations.append(
+            {
+                "label": observation["label"],
+                "pointer": observation["pointer"],
+                "value": _pointer(result, observation["pointer"]),
+            }
+        )
+    return {
+        "result_type": "array" if isinstance(result, list) else "object",
+        "item_count": len(result) if isinstance(result, list) else None,
+        "top_level_fields": sorted(result) if isinstance(result, dict) else [],
+        "payload_sha256": data["provenance"]["payload_sha256"],
+        "provider": data["provenance"]["provider"],
+        "observations": observations,
+    }
+
+
+def _run_once(
+    scenario: dict[str, Any], workspace: Path, *, mode: str
+) -> dict[str, Any]:
+    specification = _json(_bounded_fixture(scenario["specification_fixture"]))
+    initial = ToolUniverse()
+    try:
+        initial.load_tools(include_tools=["VSDDiscoverAPICandidates"], quiet=True)
+        reused = _registry_evidence(initial, scenario)
+        discovery = _discovery(initial, scenario, specification, mode=mode)
+        catalog_candidate = _select_catalog_candidate(discovery, scenario)
+        operation, inspection = _inspect(
+            catalog_candidate, scenario, workspace, mode=mode
+        )
+        initial_plan = _workflow(initial, scenario, operation)
+    finally:
+        initial.close()
+
+    promotion_workspace = workspace / "promotion"
+    draft = _draft(
+        scenario,
+        catalog_candidate,
+        operation,
+        promotion_workspace,
+    )
+    early_publication_blocked = False
+    try:
+        publish_draft(draft["draft_id"], workspace=promotion_workspace)
+    except VSDPromotionError:
+        early_publication_blocked = True
+
+    with _allowed_service_host(scenario["service_endpoint"]), _runtime_transport(
+        draft["config"], scenario, mode=mode
+    ):
+        evidence = verify_draft(
+            draft["draft_id"],
+            scenario["verification_cases"],
+            workspace=promotion_workspace,
+        )
+        approval = approve_draft(
+            draft["draft_id"],
+            reviewed_by="Biomedical Evaluation Reviewer",
+            decision_note=(
+                "Approved after the exact catalog binding and all representative "
+                "verification cases passed."
+            ),
+            workspace=promotion_workspace,
+        )
+        publication = publish_draft(
+            draft["draft_id"], workspace=promotion_workspace
+        )
+        runtime = ToolUniverse()
+        runtime.load_tools(include_tools=["VSDDiscoverAPICandidates"], quiet=True)
+        try:
+            absent_before_load = scenario["tool_name"] not in runtime.all_tool_dict
+            loaded = load_published_tools(runtime, workspace=promotion_workspace)
+            result = _tool_data(
+                runtime, scenario["tool_name"], scenario["runtime_arguments"]
+            )
+            final_plan = _workflow(runtime, scenario, operation)
+        finally:
+            runtime.close()
+
+    step_id = scenario["workflow_capability"]["step_id"]
+    initial_step = _step(initial_plan, step_id)
+    final_step = _step(final_plan, step_id)
+    hash_chain = {
+        "catalog_candidate_sha256": catalog_candidate["candidate_sha256"],
+        "source_document_sha256": operation["source_document_sha256"],
+        "operation_candidate_sha256": operation["candidate_sha256"],
+        "draft_sha256": draft["draft_sha256"],
+        "verification_sha256": evidence["verification_sha256"],
+        "approval_sha256": approval["approval_sha256"],
+        "publication_sha256": publication["publication_sha256"],
+    }
+    assertions = {
+        "catalog_candidate_is_inert_and_hash_bound": (
+            catalog_candidate["execution_allowed"] is False
+            and len(catalog_candidate["candidate_sha256"]) == 64
+        ),
+        "catalog_and_openapi_service_roots_match": (
+            _same_service(catalog_candidate["api_endpoint"], operation["server_url"])
+        ),
+        "existing_tool_roles_were_verified_in_the_registry": all(
+            item["present"] for item in reused
+        ),
+        "initial_exact_operation_was_missing": (
+            initial_step["classification"] != "existing_exact"
+        ),
+        "early_publication_was_blocked": early_publication_blocked,
+        "three_or_more_verification_calls_passed": (
+            evidence["all_cases_passed"] is True and evidence["case_count"] >= 3
+        ),
+        "publication_required_explicit_loading": (
+            absent_before_load and loaded == [scenario["tool_name"]]
+        ),
+        "final_plan_resolved_the_exact_operation": (
+            final_step["classification"] == "existing_exact"
+        ),
+        "complete_hash_chain_was_recorded": all(
+            isinstance(value, str) and len(value) == 64
+            for value in hash_chain.values()
+        ),
+    }
+    if not all(assertions.values()):
+        failed = sorted(name for name, passed in assertions.items() if not passed)
+        raise RuntimeError(f"Scenario assertions failed: {failed!r}")
+    return {
+        "case_id": scenario["case_id"],
+        "title": scenario["title"],
+        "research_question": scenario["research_question"],
+        "decision_context": scenario["decision_context"],
+        "evidence_mode": mode,
+        "source": {
+            "catalog": "SmartAPI",
+            "catalog_query": scenario["catalog_query"],
+            "catalog_record_id": catalog_candidate["catalog_record_id"],
+            "catalog_candidate_id": catalog_candidate["candidate_id"],
+            "service_endpoint": catalog_candidate["api_endpoint"],
+            "operation_id": operation["operation_id"],
+            "operation_path": operation["path"],
+            "operation_blockers": operation["blockers"],
+            "promotion_mode": scenario["promotion_mode"],
+            "inspection": inspection,
+        },
+        "existing_tooluniverse_coverage": reused,
+        "without_vsd": {
+            **scenario["without_vsd"],
+            "planned_operation_classification": initial_step["classification"],
+            "planned_operation_matches": [
+                item["name"] for item in initial_step["matches"]
+            ],
+            "executable_new_operation": False,
+        },
+        "with_vsd": {
+            **scenario["with_vsd"],
+            "planned_operation_classification": final_step["classification"],
+            "published_tool": scenario["tool_name"],
+            "verification_case_count": evidence["case_count"],
+            "executable_new_operation": True,
+            "runtime": _runtime_summary(result, scenario),
+        },
+        "governance": {
+            "early_publication_blocked": early_publication_blocked,
+            "resolved_blockers": publication["config"]["vsd_promotion"].get(
+                "resolved_blockers", []
+            ),
+            "loaded_into_fresh_universe": loaded,
+            "hash_chain": hash_chain,
+        },
+        "limitations": scenario["limitations"],
+        "references": scenario["references"],
+        "assertions": assertions,
+    }
+
+
+def _safe_failure(exc: Exception) -> dict[str, str]:
+    message = " ".join(str(exc).split())[:300]
+    return {"type": type(exc).__name__, "message": message}
+
+
+def run_portfolio(
+    *,
+    workspace: Path,
+    mode: str = "replay",
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Run all five scenarios through one reusable evaluation pipeline."""
+    if mode not in {"replay", "live", "network_backed"}:
+        raise ValueError("mode must be replay, live, or network_backed")
+    scenarios = load_scenarios()
+    results = []
+    for scenario in scenarios:
+        case_workspace = workspace / scenario["case_id"]
+        fallback = None
+        if mode == "network_backed":
+            try:
+                result = _run_once(scenario, case_workspace / "live", mode="live")
+            except Exception as exc:
+                fallback = _safe_failure(exc)
+                result = _run_once(
+                    scenario, case_workspace / "replay", mode="replay"
+                )
+        else:
+            result = _run_once(scenario, case_workspace, mode=mode)
+        if fallback is not None:
+            result["live_attempt"] = {
+                "completed": False,
+                "fallback": "checked replay",
+                "failure": fallback,
+            }
+        elif mode in {"live", "network_backed"}:
+            result["live_attempt"] = {"completed": True, "fallback": None}
+        results.append(result)
+
+    body = {
+        "format": "vsd_biomedical_evaluation_portfolio_v1",
+        "generated_at": generated_at or datetime.now(timezone.utc).isoformat(),
+        "requested_mode": mode,
+        "case_count": len(results),
+        "live_case_count": sum(item["evidence_mode"] == "live" for item in results),
+        "replay_case_count": sum(
+            item["evidence_mode"] == "replay" for item in results
+        ),
+        "published_tool_count": len(results),
+        "verification_execution_count": sum(
+            item["with_vsd"]["verification_case_count"] for item in results
+        ),
+        "all_assertions_passed": all(
+            all(item["assertions"].values()) for item in results
+        ),
+        "cases": results,
+    }
+    return {**body, "portfolio_sha256": _digest(body)}
+
+
+def validate_portfolio(artifact: Any) -> dict[str, Any]:
+    if not isinstance(artifact, dict) or artifact.get("format") != (
+        "vsd_biomedical_evaluation_portfolio_v1"
+    ):
+        raise ValueError("Portfolio artifact format is invalid")
+    body = {key: value for key, value in artifact.items() if key != "portfolio_sha256"}
+    if artifact.get("portfolio_sha256") != _digest(body):
+        raise ValueError("Portfolio artifact digest does not match its content")
+    if (
+        artifact.get("case_count") != 5
+        or artifact.get("published_tool_count") != 5
+        or artifact.get("verification_execution_count", 0) < 15
+        or artifact.get("all_assertions_passed") is not True
+    ):
+        raise ValueError("Portfolio artifact is incomplete")
+    return json.loads(json.dumps(artifact))
+
+
+def render_markdown(artifact: dict[str, Any]) -> str:
+    validate_portfolio(artifact)
+    lines = [
+        "# Biomedical VSD Evaluation Portfolio",
+        "",
+        "## Evaluation Summary",
+        "",
+        (
+            f"Five research workflows were evaluated through the same registry-first "
+            f"pipeline. The run published {artifact['published_tool_count']} narrowly "
+            f"scoped tools after {artifact['verification_execution_count']} verification "
+            f"executions; all recorded assertions passed."
+        ),
+        "",
+        f"- Requested evidence mode: `{artifact['requested_mode']}`",
+        f"- Live cases: `{artifact['live_case_count']}`",
+        f"- Checked-replay cases: `{artifact['replay_case_count']}`",
+        f"- Portfolio SHA-256: `{artifact['portfolio_sha256']}`",
+        "",
+    ]
+    for index, case in enumerate(artifact["cases"], start=1):
+        lines.extend(
+            [
+                f"## {index}. {case['title']}",
+                "",
+                f"**Question.** {case['research_question']}",
+                "",
+                f"**Decision context.** {case['decision_context']}",
+                "",
+                (
+                    f"**Evidence qualification.** This case completed in "
+                    f"`{case['evidence_mode']}` mode."
+                    + (
+                        f" The live attempt stopped at a governed boundary "
+                        f"(`{case['live_attempt']['failure']['type']}`), so the "
+                        f"checked replay is reported and no live result is claimed."
+                        if case.get("live_attempt", {}).get("completed") is False
+                        else ""
+                    )
+                ),
+                "",
+                "### Existing ToolUniverse Coverage",
+                "",
+            ]
+        )
+        for item in case["existing_tooluniverse_coverage"]:
+            lines.append(f"- `{item['name']}`: {item['role']}")
+        lines.extend(
+            [
+                "",
+                "### Gap And Source Qualification",
+                "",
+                (
+                    f"The baseline planner classified the required operation as "
+                    f"`{case['without_vsd']['planned_operation_classification']}`. "
+                    f"SmartAPI query `{case['source']['catalog_query']}` selected "
+                    f"record `{case['source']['catalog_record_id']}`, and inspection "
+                    f"selected `{case['source']['operation_id']}` at "
+                    f"`{case['source']['operation_path']}`."
+                ),
+                "",
+                (
+                    f"Promotion mode was `{case['source']['promotion_mode']}`. The "
+                    f"candidate, source document, operation, draft, verification, "
+                    f"approval, and publication identities are retained in the JSON "
+                    f"artifact."
+                ),
+                "",
+                "### Comparison",
+                "",
+                f"**Without VSD.** {case['without_vsd']['summary']}",
+                "",
+                f"**With VSD.** {case['with_vsd']['summary']}",
+                "",
+                (
+                    f"The final planner classified the exact operation as "
+                    f"`{case['with_vsd']['planned_operation_classification']}` after "
+                    f"`{case['with_vsd']['verification_case_count']}` verification calls "
+                    f"and explicit loading of `{case['with_vsd']['published_tool']}`."
+                ),
+                "",
+                "### Observed Result",
+                "",
+            ]
+        )
+        for observation in case["with_vsd"]["runtime"]["observations"]:
+            value = json.dumps(observation["value"], sort_keys=True, ensure_ascii=True)
+            lines.append(f"- {observation['label']}: `{value}`")
+        lines.extend(["", "### Limitations", ""])
+        lines.extend(f"- {item}" for item in case["limitations"])
+        lines.extend(["", "### References", ""])
+        lines.extend(
+            f"- [{item['title']}]({item['url']})" for item in case["references"]
+        )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_artifacts(
+    artifact: dict[str, Any], output_json: Path, output_markdown: Path
+) -> tuple[Path, Path]:
+    validate_portfolio(artifact)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_markdown.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(
+        json.dumps(artifact, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    output_markdown.write_text(render_markdown(artifact), encoding="utf-8")
+    return output_json, output_markdown
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode", choices=("replay", "live", "network_backed"), default="replay"
+    )
+    parser.add_argument("--workspace", type=Path)
+    parser.add_argument("--output-json", type=Path, default=DEFAULT_JSON)
+    parser.add_argument("--output-markdown", type=Path, default=DEFAULT_MARKDOWN)
+    arguments = parser.parse_args()
+    if arguments.workspace is None:
+        with tempfile.TemporaryDirectory(prefix="vsd-biomedical-portfolio-") as root:
+            artifact = run_portfolio(workspace=Path(root), mode=arguments.mode)
+    else:
+        artifact = run_portfolio(
+            workspace=arguments.workspace, mode=arguments.mode
+        )
+    write_artifacts(artifact, arguments.output_json, arguments.output_markdown)
+    print(json.dumps({"portfolio_sha256": artifact["portfolio_sha256"]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/vsd/biomedical_studies/fixtures/drug_combination_openapi.json
+++ b/examples/vsd/biomedical_studies/fixtures/drug_combination_openapi.json
@@ -1,0 +1,27 @@
+{
+  "_id": "00fb85fc776279163199e6c50f6ddfc6",
+  "_meta": {"last_updated": "2026-07-20T00:00:00Z"},
+  "openapi": "3.0.3",
+  "info": {
+    "title": "BioThings DDInter API",
+    "version": "1.0.0",
+    "description": "Drug combination interaction severity evidence for oncology treatment evaluation.",
+    "contact": {"name": "BioThings"},
+    "license": {"name": "Source-specific terms"}
+  },
+  "servers": [{"url": "https://biothings.transltr.io/ddinter"}],
+  "tags": [{"name": "drug combination"}, {"name": "interaction"}, {"name": "oncology"}],
+  "paths": {
+    "/query": {
+      "get": {
+        "operationId": "get_/query",
+        "summary": "Query curated drug-drug interactions",
+        "parameters": [
+          {"name": "q", "in": "query", "required": true, "schema": {"type": "string", "minLength": 2}},
+          {"name": "size", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 20}}
+        ],
+        "responses": {"200": {"description": "BioThings query response"}}
+      }
+    }
+  }
+}

--- a/examples/vsd/biomedical_studies/fixtures/drug_combination_responses.json
+++ b/examples/vsd/biomedical_studies/fixtures/drug_combination_responses.json
@@ -1,0 +1,47 @@
+[
+  {
+    "arguments": {"q": "drug_a.name:\"Arsenic trioxide\" AND drug_b.name:Idarubicin"},
+    "payload": {
+      "took": 2,
+      "total": 1,
+      "hits": [
+        {
+          "_id": "DDInter120_DDInter1458_Major",
+          "drug_a": {"name": "Arsenic trioxide", "chembl": "CHEMBL1200978"},
+          "drug_b": {"name": "Idarubicin"},
+          "level": "Major"
+        }
+      ]
+    }
+  },
+  {
+    "arguments": {"q": "drug_a.name:Trametinib"},
+    "payload": {
+      "took": 1,
+      "total": 12,
+      "hits": [
+        {
+          "_id": "DDInter_Trametinib_Encorafenib_Moderate",
+          "drug_a": {"name": "Trametinib"},
+          "drug_b": {"name": "Encorafenib"},
+          "level": "Moderate"
+        }
+      ]
+    }
+  },
+  {
+    "arguments": {"q": "drug_a.name:Olaparib"},
+    "payload": {
+      "took": 1,
+      "total": 119,
+      "hits": [
+        {
+          "_id": "DDInter_Olaparib_Ixazomib_Moderate",
+          "drug_a": {"name": "Olaparib"},
+          "drug_b": {"name": "Ixazomib"},
+          "level": "Moderate"
+        }
+      ]
+    }
+  }
+]

--- a/examples/vsd/biomedical_studies/fixtures/immunotherapy_openapi.json
+++ b/examples/vsd/biomedical_studies/fixtures/immunotherapy_openapi.json
@@ -1,0 +1,27 @@
+{
+  "_id": "e9eb40ff7ad712e4e6f4f04b964b5966",
+  "_meta": {"last_updated": "2026-07-20T00:00:00Z"},
+  "openapi": "3.0.3",
+  "info": {
+    "title": "BioThings InnateDB API",
+    "version": "1.0.0",
+    "description": "Tumor immune and innate immune molecular interaction evidence for pan-cancer analysis.",
+    "contact": {"name": "BioThings"},
+    "license": {"name": "Source-specific terms"}
+  },
+  "servers": [{"url": "https://biothings.transltr.io/innatedb"}],
+  "tags": [{"name": "tumor immune"}, {"name": "interaction"}],
+  "paths": {
+    "/query": {
+      "get": {
+        "operationId": "get_/query",
+        "summary": "Query immune molecular interactions",
+        "parameters": [
+          {"name": "q", "in": "query", "required": true, "schema": {"type": "string", "minLength": 2}},
+          {"name": "size", "in": "query", "required": false, "schema": {"type": "integer", "minimum": 1, "maximum": 20}}
+        ],
+        "responses": {"200": {"description": "BioThings query response"}}
+      }
+    }
+  }
+}

--- a/examples/vsd/biomedical_studies/fixtures/immunotherapy_responses.json
+++ b/examples/vsd/biomedical_studies/fixtures/immunotherapy_responses.json
@@ -1,0 +1,47 @@
+[
+  {
+    "arguments": {"q": "PDCD1"},
+    "payload": {
+      "took": 1,
+      "total": 8,
+      "hits": [
+        {
+          "_id": "innatedb:PDCD1:interaction:1",
+          "object": {"alias": {"hgnc_name": "PDCD1"}, "interactor_type": {"label": "protein"}},
+          "relation": {"detection_method": "identification by antibody", "source": "InnateDB"},
+          "subject": {"alias": {"hgnc_name": "PD-L1"}}
+        }
+      ]
+    }
+  },
+  {
+    "arguments": {"q": "CTLA4"},
+    "payload": {
+      "took": 1,
+      "total": 5,
+      "hits": [
+        {
+          "_id": "innatedb:CTLA4:interaction:1",
+          "object": {"alias": {"hgnc_name": "CTLA4"}, "interactor_type": {"label": "protein"}},
+          "relation": {"detection_method": "affinity chromatography", "source": "InnateDB"},
+          "subject": {"alias": {"hgnc_name": "CD80"}}
+        }
+      ]
+    }
+  },
+  {
+    "arguments": {"q": "LAG3"},
+    "payload": {
+      "took": 1,
+      "total": 3,
+      "hits": [
+        {
+          "_id": "innatedb:LAG3:interaction:1",
+          "object": {"alias": {"hgnc_name": "LAG3"}, "interactor_type": {"label": "protein"}},
+          "relation": {"detection_method": "two hybrid", "source": "InnateDB"},
+          "subject": {"alias": {"hgnc_name": "HLA-DRA"}}
+        }
+      ]
+    }
+  }
+]

--- a/examples/vsd/biomedical_studies/fixtures/rare_disease_openapi.json
+++ b/examples/vsd/biomedical_studies/fixtures/rare_disease_openapi.json
@@ -1,0 +1,40 @@
+{
+  "_id": "5a4c41bf2076b469a0e9cfcf2f2b8f29",
+  "_meta": {"last_updated": "2026-07-20T00:00:00Z"},
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Translator Annotation Service",
+    "version": "1.0.0",
+    "description": "Cross-ontology annotation service for rare disease, phenotype, and gene identifiers.",
+    "contact": {"name": "NCATS Biomedical Data Translator"},
+    "license": {"name": "CC0-1.0"}
+  },
+  "servers": [{"url": "https://biothings.transltr.io/annotator"}],
+  "tags": [{"name": "rare disease"}, {"name": "phenotype"}, {"name": "ontology"}],
+  "paths": {
+    "/{curieid}": {
+      "get": {
+        "operationId": "get_/{curieid}",
+        "summary": "Retrieve cross-ontology annotations for one CURIE",
+        "parameters": [
+          {
+            "name": "curieid",
+            "in": "path",
+            "required": true,
+            "schema": {"type": "string", "minLength": 3, "maxLength": 100}
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Annotation groups keyed by input CURIE",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/vsd/biomedical_studies/fixtures/rare_disease_responses.json
+++ b/examples/vsd/biomedical_studies/fixtures/rare_disease_responses.json
@@ -1,0 +1,31 @@
+[
+  {
+    "arguments": {"curieid": "MONDO:0004976"},
+    "payload": {
+      "MONDO:0004976": [
+        {
+          "query": "MONDO:0004976",
+          "disease_ontology": {"doid": "DOID:332", "name": "amyotrophic lateral sclerosis"},
+          "mondo": {"label": "amyotrophic lateral sclerosis"},
+          "xrefs": {"gard": "5786", "mesh": "D000690"}
+        }
+      ]
+    }
+  },
+  {
+    "arguments": {"curieid": "HP:0001250"},
+    "payload": {
+      "HP:0001250": [
+        {"query": "HP:0001250", "hpo": {"label": "Seizure"}, "ontology": "Human Phenotype Ontology"}
+      ]
+    }
+  },
+  {
+    "arguments": {"curieid": "NCBIGene:2034"},
+    "payload": {
+      "NCBIGene:2034": [
+        {"query": "NCBIGene:2034", "gene": {"symbol": "EPAS1"}, "taxon": "NCBITaxon:9606"}
+      ]
+    }
+  }
+]

--- a/examples/vsd/biomedical_studies/fixtures/tuberculosis_openapi.json
+++ b/examples/vsd/biomedical_studies/fixtures/tuberculosis_openapi.json
@@ -1,0 +1,36 @@
+{
+  "_id": "fc18c6cce884c23866beed24dce30a2d",
+  "_meta": {"last_updated": "2026-07-20T00:00:00Z"},
+  "openapi": "3.0.3",
+  "info": {
+    "title": "TBPortals Radiomics Image Analysis API",
+    "version": "1.0.0",
+    "description": "Tuberculosis radiomics service readiness for resistance evidence workflows.",
+    "contact": {"name": "NIAID TB Portals"},
+    "license": {"name": "Public research API"}
+  },
+  "servers": [{"url": "https://ria.tbportals.niaid.nih.gov"}],
+  "tags": [{"name": "tuberculosis"}, {"name": "radiomics"}, {"name": "resistance"}],
+  "paths": {
+    "/health_check": {
+      "get": {
+        "operationId": "get_/health_check",
+        "summary": "Check radiomics service readiness",
+        "responses": {
+          "200": {
+            "description": "Service status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {"status": {"type": "string"}, "service": {"type": "string"}},
+                  "required": ["status"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/vsd/biomedical_studies/fixtures/tuberculosis_responses.json
+++ b/examples/vsd/biomedical_studies/fixtures/tuberculosis_responses.json
@@ -1,0 +1,5 @@
+[
+  {"arguments": {}, "payload": {"status": "ok", "service": "TBPortals radiomics"}},
+  {"arguments": {}, "payload": {"status": "ok", "service": "TBPortals radiomics"}},
+  {"arguments": {}, "payload": {"status": "ok", "service": "TBPortals radiomics"}}
+]

--- a/examples/vsd/biomedical_studies/fixtures/virtual_cell_openapi.json
+++ b/examples/vsd/biomedical_studies/fixtures/virtual_cell_openapi.json
@@ -1,0 +1,42 @@
+{
+  "_id": "235e75417247f07e5fed6acf3f345bb7",
+  "_meta": {"last_updated": "2026-07-20T00:00:00Z"},
+  "openapi": "3.0.3",
+  "info": {
+    "title": "L1000FWD",
+    "version": "1.0.0",
+    "description": "Single-cell and gene-expression perturbation resource with perturbagen identifier resolution.",
+    "contact": {"name": "Ma'ayan Laboratory"},
+    "license": {"name": "Public research API"}
+  },
+  "servers": [{"url": "https://maayanlab.cloud/L1000FWD"}],
+  "tags": [{"name": "single cell"}, {"name": "gene expression"}, {"name": "perturbation"}],
+  "paths": {
+    "/synonyms/{query_string}": {
+      "get": {
+        "operationId": "synonyms",
+        "summary": "Resolve a perturbagen name to L1000 identifiers",
+        "parameters": [
+          {"name": "query_string", "in": "path", "required": true, "schema": {"type": "string", "minLength": 2, "maxLength": 100}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching perturbagen identifiers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {"Name": {"type": "string"}, "pert_id": {"type": "string"}},
+                    "required": ["Name", "pert_id"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/vsd/biomedical_studies/fixtures/virtual_cell_responses.json
+++ b/examples/vsd/biomedical_studies/fixtures/virtual_cell_responses.json
@@ -1,0 +1,17 @@
+[
+  {
+    "arguments": {"query_string": "trametinib"},
+    "payload": [{"Name": "TRAMETINIB", "pert_id": "BRD-K12343256"}]
+  },
+  {
+    "arguments": {"query_string": "selumetinib"},
+    "payload": [{"Name": "SELUMETINIB", "pert_id": "BRD-K57080016"}]
+  },
+  {
+    "arguments": {"query_string": "vemurafenib"},
+    "payload": [
+      {"Name": "VEMURAFENIB", "pert_id": "BRD-K56343971"},
+      {"Name": "VEMURAFENIB", "pert_id": "BRD-U73308409"}
+    ]
+  }
+]

--- a/examples/vsd/biomedical_studies/scenarios/01_rare_disease.json
+++ b/examples/vsd/biomedical_studies/scenarios/01_rare_disease.json
@@ -1,0 +1,67 @@
+{
+  "case_id": "rare_disease_diagnostic_evidence",
+  "title": "Rare-Disease Diagnostic Evidence Reconciliation",
+  "research_question": "Can a diagnostic review reconcile disease, phenotype, and gene identifiers before comparing rare-disease cohort and variant evidence?",
+  "decision_context": "Normalize identifiers before combining phenotype, variant, natural-history, and trial evidence; the added annotations support evidence retrieval and do not establish a diagnosis.",
+  "catalog_query": "rare disease phenotype ontology annotation",
+  "catalog_record_id": "5a4c41bf2076b469a0e9cfcf2f2b8f29",
+  "service_endpoint": "https://biothings.transltr.io/annotator",
+  "specification_fixture": "rare_disease_openapi.json",
+  "response_fixture": "rare_disease_responses.json",
+  "operation_id": "get_/{curieid}",
+  "promotion_mode": "strict",
+  "tool_name": "VSDTranslatorAnnotationLookup",
+  "tool_description": "Retrieve reviewed cross-ontology annotations for one biomedical CURIE.",
+  "include_parameters": ["curieid"],
+  "fixed_query": {},
+  "review_note": "Reviewed the exact SmartAPI record, service root, GET path, identifier input, and declared JSON response contract.",
+  "response_schema": null,
+  "workflow_capability": {
+    "step_id": "identifier_reconciliation",
+    "description": "retrieve cross-ontology disease phenotype and gene annotations for one CURIE",
+    "required_inputs": ["curieid"],
+    "output_fields": ["query", "ontology", "cross_references"]
+  },
+  "verification_cases": [
+    {
+      "arguments": {"curieid": "MONDO:0004976"},
+      "expect": {"result_type": "object", "required_fields": [], "required_paths": ["/MONDO:0004976/0/disease_ontology/name"], "equals_paths": {"/MONDO:0004976/0/disease_ontology/name": "amyotrophic lateral sclerosis"}}
+    },
+    {
+      "arguments": {"curieid": "HP:0001250"},
+      "expect": {"result_type": "object", "required_fields": [], "required_paths": ["/HP:0001250/0/hpo/label"], "equals_paths": {"/HP:0001250/0/hpo/label": "Seizure"}}
+    },
+    {
+      "arguments": {"curieid": "NCBIGene:2034"},
+      "expect": {"result_type": "object", "required_fields": [], "required_paths": ["/NCBIGene:2034/0/gene/symbol"], "equals_paths": {"/NCBIGene:2034/0/gene/symbol": "EPAS1"}}
+    }
+  ],
+  "runtime_arguments": {"curieid": "MONDO:0004976"},
+  "observations": [
+    {"label": "Normalized disease label", "pointer": "/MONDO:0004976/0/disease_ontology/name"},
+    {"label": "Disease Ontology identifier", "pointer": "/MONDO:0004976/0/disease_ontology/doid"},
+    {"label": "GARD cross-reference", "pointer": "/MONDO:0004976/0/xrefs/gard"}
+  ],
+  "reused_tools": [
+    {"name": "Orphanet_get_natural_history", "role": "Reuse curated rare-disease natural-history evidence."},
+    {"name": "HPO_get_diseases_by_phenotype", "role": "Reuse phenotype-to-disease associations."},
+    {"name": "ClinVar_search_variants", "role": "Reuse submitted variant interpretations."}
+  ],
+  "without_vsd": {
+    "summary": "ToolUniverse already covers phenotype, natural-history, and variant evidence, but this exact registered annotation operation is absent, so the workflow must reconcile identifier namespaces outside the governed tool path."
+  },
+  "with_vsd": {
+    "summary": "The workflow gains one verified CURIE annotation operation that returns cross-ontology labels and identifiers with runtime provenance, allowing existing evidence tools to receive consistent identifiers."
+  },
+  "limitations": [
+    "Annotation mappings are retrieval evidence, not a diagnostic conclusion.",
+    "Replay values are provider-shaped test evidence; live mode is required to assess current upstream content.",
+    "Conflicting or missing mappings still require domain review."
+  ],
+  "references": [
+    {"title": "Phenotype-driven rare genetic disease diagnosis", "url": "https://www.nature.com/articles/s41746-025-01749-1"},
+    {"title": "NCATS Biomedical Data Translator", "url": "https://ncats.nih.gov/research/research-activities/translator"},
+    {"title": "Human Phenotype Ontology", "url": "https://hpo.jax.org/"},
+    {"title": "Orphanet", "url": "https://www.orpha.net/"}
+  ]
+}

--- a/examples/vsd/biomedical_studies/scenarios/02_immunotherapy.json
+++ b/examples/vsd/biomedical_studies/scenarios/02_immunotherapy.json
@@ -1,0 +1,66 @@
+{
+  "case_id": "pan_cancer_immunotherapy_validation",
+  "title": "Pan-Cancer Immunotherapy Evidence Validation",
+  "research_question": "Can a pan-cancer response analysis add molecular interaction evidence for immune checkpoints after cohort and expression tools identify candidate markers?",
+  "decision_context": "Use cohort, expression, immune-study, and interaction evidence to prioritize checkpoint hypotheses for retrospective validation rather than treatment selection.",
+  "catalog_query": "innate immune interaction",
+  "catalog_record_id": "e9eb40ff7ad712e4e6f4f04b964b5966",
+  "service_endpoint": "https://biothings.transltr.io/innatedb",
+  "specification_fixture": "immunotherapy_openapi.json",
+  "response_fixture": "immunotherapy_responses.json",
+  "operation_id": "get_/query",
+  "promotion_mode": "reviewed_response",
+  "tool_name": "VSDInnateDBInteractionQuery",
+  "tool_description": "Query reviewed innate-immune molecular interaction records by marker.",
+  "include_parameters": ["q"],
+  "fixed_query": {"size": 3},
+  "review_note": "Reviewed the anonymous read-only query, bounded result size, and observed BioThings response envelope for three checkpoint markers.",
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "took": {"type": "integer", "minimum": 0},
+      "total": {"type": "integer", "minimum": 0},
+      "hits": {"type": "array", "items": {"type": "object"}, "maxItems": 20}
+    },
+    "required": ["took", "total", "hits"]
+  },
+  "workflow_capability": {
+    "step_id": "checkpoint_interactions",
+    "description": "retrieve innate immune molecular interaction evidence for one checkpoint marker",
+    "required_inputs": ["q"],
+    "output_fields": ["total", "hits", "relation", "subject", "object"]
+  },
+  "verification_cases": [
+    {"arguments": {"q": "PDCD1"}, "expect": {"result_type": "object", "required_fields": ["took", "total", "hits"], "required_paths": ["/hits/0/object/alias/hgnc_name"], "equals_paths": {"/hits/0/object/alias/hgnc_name": "PDCD1"}}},
+    {"arguments": {"q": "CTLA4"}, "expect": {"result_type": "object", "required_fields": ["took", "total", "hits"], "required_paths": ["/hits/0/_id"]}},
+    {"arguments": {"q": "LAG3"}, "expect": {"result_type": "object", "required_fields": ["took", "total", "hits"], "required_paths": ["/hits/0/_id"]}}
+  ],
+  "runtime_arguments": {"q": "PDCD1"},
+  "observations": [
+    {"label": "Matching interaction records", "pointer": "/total"},
+    {"label": "Queried checkpoint", "pointer": "/hits/0/object/alias/hgnc_name"},
+    {"label": "First interacting marker", "pointer": "/hits/0/subject/alias/hgnc_name"}
+  ],
+  "reused_tools": [
+    {"name": "GDC_search_cases", "role": "Reuse pan-cancer cohort construction."},
+    {"name": "GDC_get_gene_expression", "role": "Reuse tumor expression measurements."},
+    {"name": "ImmPort_search_studies", "role": "Reuse immune-study discovery."}
+  ],
+  "without_vsd": {
+    "summary": "The registry can assemble cancer cohorts and expression evidence, but it lacks the exact InnateDB query operation, leaving checkpoint interaction support outside the planned ToolUniverse workflow."
+  },
+  "with_vsd": {
+    "summary": "The workflow adds a bounded, verified interaction query for PDCD1, CTLA4, and LAG3, so interaction provenance can be compared alongside cohort and expression evidence."
+  },
+  "limitations": [
+    "Molecular interactions do not establish response causality or clinical benefit.",
+    "The reviewed response schema is intentionally bounded to the stable BioThings envelope because the registry document omits that schema.",
+    "Cancer-type, treatment, and assay-specific validation remains necessary."
+  ],
+  "references": [
+    {"title": "Pan-cancer longitudinal immunotherapy analysis", "url": "https://www.nature.com/articles/s41467-021-25432-7"},
+    {"title": "NCI Genomic Data Commons", "url": "https://gdc.cancer.gov/"},
+    {"title": "InnateDB", "url": "https://www.innatedb.com/"},
+    {"title": "ImmPort", "url": "https://www.immport.org/"}
+  ]
+}

--- a/examples/vsd/biomedical_studies/scenarios/03_drug_combination.json
+++ b/examples/vsd/biomedical_studies/scenarios/03_drug_combination.json
@@ -1,0 +1,67 @@
+{
+  "case_id": "context_specific_drug_combinations",
+  "title": "Context-Specific Oncology Combination Review",
+  "research_question": "Can an oncology combination workflow add curated interaction severity before advancing experimentally promising drug pairs?",
+  "decision_context": "Combine target, dependency, synergy, and adverse-event evidence with curated interaction records to prioritize laboratory follow-up and safety review.",
+  "catalog_query": "drug combination interaction oncology",
+  "catalog_record_id": "00fb85fc776279163199e6c50f6ddfc6",
+  "service_endpoint": "https://biothings.transltr.io/ddinter",
+  "specification_fixture": "drug_combination_openapi.json",
+  "response_fixture": "drug_combination_responses.json",
+  "operation_id": "get_/query",
+  "promotion_mode": "reviewed_response",
+  "tool_name": "VSDDDInterCombinationQuery",
+  "tool_description": "Query reviewed curated drug-drug interaction records for a combination hypothesis.",
+  "include_parameters": ["q"],
+  "fixed_query": {"size": 5},
+  "review_note": "Reviewed the anonymous read-only query, bounded result size, and observed DDInter response envelope across three oncology drugs.",
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "took": {"type": "integer", "minimum": 0},
+      "total": {"type": "integer", "minimum": 0},
+      "hits": {"type": "array", "items": {"type": "object"}, "maxItems": 20}
+    },
+    "required": ["took", "total", "hits"]
+  },
+  "workflow_capability": {
+    "step_id": "combination_interaction_review",
+    "description": "retrieve curated drug interaction severity for an oncology combination query",
+    "required_inputs": ["q"],
+    "output_fields": ["total", "hits", "drug_a", "drug_b", "level"]
+  },
+  "verification_cases": [
+    {"arguments": {"q": "drug_a.name:\"Arsenic trioxide\" AND drug_b.name:Idarubicin"}, "expect": {"result_type": "object", "required_fields": ["total", "hits"], "equals": {"total": 1}, "equals_paths": {"/hits/0/level": "Major"}}},
+    {"arguments": {"q": "drug_a.name:Trametinib"}, "expect": {"result_type": "object", "required_fields": ["total", "hits"], "required_paths": ["/hits/0/drug_a/name", "/hits/0/level"], "equals_paths": {"/hits/0/drug_a/name": "Trametinib"}}},
+    {"arguments": {"q": "drug_a.name:Olaparib"}, "expect": {"result_type": "object", "required_fields": ["total", "hits"], "required_paths": ["/hits/0/drug_a/name", "/hits/0/level"], "equals_paths": {"/hits/0/drug_a/name": "Olaparib"}}}
+  ],
+  "runtime_arguments": {"q": "drug_a.name:\"Arsenic trioxide\" AND drug_b.name:Idarubicin"},
+  "observations": [
+    {"label": "Matching curated records", "pointer": "/total"},
+    {"label": "First combination", "pointer": "/hits/0/drug_b/name"},
+    {"label": "Interaction severity", "pointer": "/hits/0/level"}
+  ],
+  "reused_tools": [
+    {"name": "ChEMBL_get_target_activities", "role": "Reuse target activity evidence."},
+    {"name": "DepMap_get_gene_dependencies", "role": "Reuse cancer-context dependency evidence."},
+    {"name": "DrugSynergy_calculate_bliss", "role": "Reuse measured combination-effect scoring."},
+    {"name": "FAERS_compare_drugs", "role": "Reuse post-market safety signal comparison."}
+  ],
+  "without_vsd": {
+    "summary": "ToolUniverse can score observed synergy and retrieve target, dependency, and safety evidence, but it lacks this exact curated interaction query, so a promising pair can reach review without a DDInter severity check in the same workflow."
+  },
+  "with_vsd": {
+    "summary": "The workflow gains a bounded DDInter query that can flag curated interaction severity before experimental prioritization; it complements rather than replaces efficacy and safety analysis."
+  },
+  "limitations": [
+    "Interaction severity is not an efficacy estimate and does not replace pharmacology review.",
+    "The example query verifies retrieval and governance, not a treatment recommendation.",
+    "The upstream specification omits the response schema, so publication depends on explicit reviewed-schema evidence."
+  ],
+  "references": [
+    {"title": "Context-specific drug combinations in lung cancer", "url": "https://www.nature.com/articles/s41467-023-39528-9"},
+    {"title": "DDInter drug-drug interaction database", "url": "https://academic.oup.com/nar/article/50/D1/D1200/6389535"},
+    {"title": "DepMap", "url": "https://depmap.org/portal/"},
+    {"title": "ChEMBL", "url": "https://www.ebi.ac.uk/chembl/"}
+  ]
+}

--- a/examples/vsd/biomedical_studies/scenarios/04_virtual_cell.json
+++ b/examples/vsd/biomedical_studies/scenarios/04_virtual_cell.json
@@ -1,0 +1,57 @@
+{
+  "case_id": "virtual_cell_perturbation_selection",
+  "title": "Virtual-Cell Perturbation Dataset Selection",
+  "research_question": "Can a virtual-cell preparation workflow resolve candidate perturbagens to dataset identifiers before retrieving signatures and single-cell context?",
+  "decision_context": "Resolve perturbagen names before selecting expression signatures, cell contexts, and training data for perturbation-response modeling.",
+  "catalog_query": "single cell gene expression perturbation",
+  "catalog_record_id": "235e75417247f07e5fed6acf3f345bb7",
+  "service_endpoint": "https://maayanlab.cloud/L1000FWD",
+  "specification_fixture": "virtual_cell_openapi.json",
+  "response_fixture": "virtual_cell_responses.json",
+  "operation_id": "synonyms",
+  "promotion_mode": "strict",
+  "tool_name": "VSDL1000PerturbagenResolver",
+  "tool_description": "Resolve one reviewed perturbagen name to L1000 identifiers.",
+  "include_parameters": ["query_string"],
+  "fixed_query": {},
+  "review_note": "Reviewed the exact SmartAPI service root, read-only synonym path, perturbagen input, and declared array response schema.",
+  "response_schema": null,
+  "workflow_capability": {
+    "step_id": "perturbagen_resolution",
+    "description": "resolve one perturbagen name to L1000 perturbation identifiers",
+    "required_inputs": ["query_string"],
+    "output_fields": ["Name", "pert_id"]
+  },
+  "verification_cases": [
+    {"arguments": {"query_string": "trametinib"}, "expect": {"result_type": "array", "min_items": 1, "max_items": 5, "required_fields": ["Name", "pert_id"], "equals_paths": {"/pert_id": "BRD-K12343256"}}},
+    {"arguments": {"query_string": "selumetinib"}, "expect": {"result_type": "array", "min_items": 1, "max_items": 5, "required_fields": ["Name", "pert_id"], "equals_paths": {"/pert_id": "BRD-K57080016"}}},
+    {"arguments": {"query_string": "vemurafenib"}, "expect": {"result_type": "array", "min_items": 1, "max_items": 5, "required_fields": ["Name", "pert_id"], "required_paths": ["/pert_id"]}}
+  ],
+  "runtime_arguments": {"query_string": "trametinib"},
+  "observations": [
+    {"label": "Resolved perturbagen name", "pointer": "/0/Name"},
+    {"label": "Resolved L1000 perturbagen identifier", "pointer": "/0/pert_id"}
+  ],
+  "reused_tools": [
+    {"name": "CELLxGENE_get_cell_metadata", "role": "Reuse single-cell context and cohort metadata."},
+    {"name": "CELLxGENE_get_expression_data", "role": "Reuse cell-level expression retrieval."},
+    {"name": "L1000FWD_sig_search", "role": "Reuse the existing signature-search workflow after identifier resolution."}
+  ],
+  "without_vsd": {
+    "summary": "ToolUniverse already performs L1000 signature search and CELLxGENE retrieval, but it does not expose the provider's synonym operation, so free-text perturbagen names must be resolved outside the planned tool chain."
+  },
+  "with_vsd": {
+    "summary": "The workflow adds only the missing synonym operation from the already known provider, turning drug names into stable perturbagen identifiers before existing signature and single-cell tools run."
+  },
+  "limitations": [
+    "Identifier resolution does not determine whether a perturbation is biologically appropriate for a model.",
+    "Signature quality, dose, duration, cell state, and batch effects require separate evaluation.",
+    "The provider may return multiple identifiers for one name; downstream selection must retain that ambiguity."
+  ],
+  "references": [
+    {"title": "Benchmarking single-cell perturbation response prediction", "url": "https://www.nature.com/articles/s41592-025-02980-0"},
+    {"title": "L1000FWD", "url": "https://maayanlab.cloud/L1000FWD/"},
+    {"title": "CELLxGENE Census", "url": "https://chanzuckerberg.github.io/cellxgene-census/"},
+    {"title": "Virtual Cell Challenge", "url": "https://virtualcellchallenge.org/"}
+  ]
+}

--- a/examples/vsd/biomedical_studies/scenarios/05_tuberculosis.json
+++ b/examples/vsd/biomedical_studies/scenarios/05_tuberculosis.json
@@ -1,0 +1,58 @@
+{
+  "case_id": "tuberculosis_resistance_integration",
+  "title": "Tuberculosis Resistance Evidence Integration",
+  "research_question": "Can a tuberculosis resistance workflow verify that a discovered radiomics service is available before combining genomic, antimicrobial-resistance, and imaging evidence?",
+  "decision_context": "Gate an imaging branch on service readiness while existing tools assemble genome, resistance, drug, and study evidence; readiness does not authorize controlled-data access.",
+  "catalog_query": "TBPortals radiomics",
+  "catalog_record_id": "fc18c6cce884c23866beed24dce30a2d",
+  "service_endpoint": "https://ria.tbportals.niaid.nih.gov",
+  "specification_fixture": "tuberculosis_openapi.json",
+  "response_fixture": "tuberculosis_responses.json",
+  "operation_id": "get_/health_check",
+  "promotion_mode": "strict",
+  "tool_name": "VSDTBPortalsRadiomicsReadiness",
+  "tool_description": "Check the reviewed TB Portals radiomics service readiness endpoint.",
+  "include_parameters": [],
+  "fixed_query": {},
+  "review_note": "Reviewed the exact SmartAPI record, anonymous health-check operation, no-input request, and declared JSON status schema.",
+  "response_schema": null,
+  "workflow_capability": {
+    "step_id": "radiomics_service_readiness",
+    "description": "check the TB radiomics service readiness endpoint before an imaging branch",
+    "required_inputs": [],
+    "output_fields": ["status", "service"]
+  },
+  "verification_cases": [
+    {"arguments": {}, "expect": {"result_type": "object", "required_fields": ["status"], "equals": {"status": "ok"}}},
+    {"arguments": {}, "expect": {"result_type": "object", "required_fields": ["status", "service"], "equals_paths": {"/status": "ok"}}},
+    {"arguments": {}, "expect": {"result_type": "object", "required_fields": ["status"], "required_paths": ["/service"]}}
+  ],
+  "runtime_arguments": {},
+  "observations": [
+    {"label": "Radiomics service status", "pointer": "/status"},
+    {"label": "Service label", "pointer": "/service"}
+  ],
+  "reused_tools": [
+    {"name": "BVBRC_search_amr", "role": "Reuse antimicrobial-resistance phenotype evidence."},
+    {"name": "BVBRC_search_genomes", "role": "Reuse pathogen genome metadata."},
+    {"name": "PharmGKB_search_drugs", "role": "Reuse drug identifier and pharmacogenomic context."},
+    {"name": "search_clinical_trials", "role": "Reuse tuberculosis study discovery."}
+  ],
+  "without_vsd": {
+    "summary": "ToolUniverse can retrieve pathogen, resistance, drug, and trial evidence, but it has no exact operation for checking the cataloged radiomics service before the workflow enters its imaging branch."
+  },
+  "with_vsd": {
+    "summary": "The workflow gains a narrow readiness check bound to the cataloged service and contract; this prevents treating an unavailable imaging dependency as usable and does not create access to controlled images."
+  },
+  "limitations": [
+    "A health check establishes service readiness only; it does not validate a radiomics model or scientific result.",
+    "Controlled imaging data, consent, and authorization remain outside this tool.",
+    "The checked replay validates the lifecycle when the service is unreachable from the evaluation environment; current availability requires live mode."
+  ],
+  "references": [
+    {"title": "NIAID TB Portals multi-domain data platform", "url": "https://tbportals.niaid.nih.gov/what-are-the-tb-portals"},
+    {"title": "TB Portals data access policy", "url": "https://tbportals.niaid.nih.gov/access-data"},
+    {"title": "BV-BRC antimicrobial resistance resources", "url": "https://www.bv-brc.org/"},
+    {"title": "WHO tuberculosis data", "url": "https://www.who.int/teams/global-tuberculosis-programme/data"}
+  ]
+}

--- a/examples/vsd/ga4gh_service_qualification/scenarios.json
+++ b/examples/vsd/ga4gh_service_qualification/scenarios.json
@@ -1,0 +1,333 @@
+[
+  {
+    "case_id": "ga4gh_registry_service_info",
+    "catalog_query": "GA4GH standards registry",
+    "tool_name": "ReviewedGA4GHRegistryInfo",
+    "expected_qualification": "accepted",
+    "registry_record": {
+      "id": "org.ga4gh.registry",
+      "name": "GA4GH Standards and Implementations Registry",
+      "type": {"group": "org.ga4gh", "artifact": "service-registry", "version": "1.0.0"},
+      "organization": {"id": "org.ga4gh", "name": "Global Alliance for Genomics and Health", "url": "https://ga4gh.org"},
+      "version": "1.0.0",
+      "url": "https://registry.ga4gh.org/v1",
+      "description": "Registry of GA4GH standards and implementations.",
+      "documentationUrl": "https://ga4gh.github.io/ga4gh-registry/docs/index.html"
+    },
+    "replay_transport": {
+      "status_code": 200,
+      "content_type": "application/json;charset=UTF-8",
+      "payload": {
+        "id": "org.ga4gh.registry",
+        "name": "GA4GH Standards and Implementations Registry",
+        "type": {"group": "org.ga4gh", "artifact": "service-registry", "version": "1.0.0"},
+        "organization": {"id": "org.ga4gh", "name": "Global Alliance for Genomics and Health", "url": "https://ga4gh.org"},
+        "version": "1.0.0",
+        "url": "https://registry.ga4gh.org/v1"
+      }
+    }
+  },
+  {
+    "case_id": "ncbi_drs_service_info",
+    "catalog_query": "NCBI DRS",
+    "tool_name": "ReviewedNCBIDRSServiceInfo",
+    "expected_qualification": "accepted",
+    "registry_record": {
+      "id": "gov.nih.nlm.ncbi.drs",
+      "name": "NCBI Data Repository Service",
+      "type": {"group": "org.ga4gh", "artifact": "drs", "version": "1.2.0"},
+      "organization": {"id": "gov.nih.nlm.ncbi", "name": "dbGaP at NCBI/NLM/NIH", "url": "https://locate.be-md.ncbi.nlm.nih.gov/ga4gh/drs/v1/"},
+      "version": "v1",
+      "url": "https://locate.be-md.ncbi.nlm.nih.gov/ga4gh/drs/v1/",
+      "description": "Data Repository Service for sequence records available through NCBI.",
+      "documentationUrl": "https://locate.be-md.ncbi.nlm.nih.gov/ga4gh/drs/v1/",
+      "environment": "Production"
+    },
+    "replay_transport": {
+      "status_code": 200,
+      "content_type": "application/json",
+      "payload": {
+        "id": "ncbi.drs",
+        "name": "NCBI Data Repository Service",
+        "type": {"artifact": "drs", "group": "org.ga4gh", "version": "1.2.0"},
+        "organization": {"id": "ror:02meqm098", "name": "National Center for Biotechnology Information", "url": "https://locate.ncbi.nlm.nih.gov"},
+        "version": "drs-v.5acd2b1f949",
+        "environment": "production"
+      }
+    }
+  },
+  {
+    "case_id": "dockstore_trs_service_info",
+    "catalog_query": "Dockstore TRS",
+    "tool_name": "ReviewedDockstoreTRSServiceInfo",
+    "expected_qualification": "accepted",
+    "registry_record": {
+      "id": "org.dockstore.dockstoreapi",
+      "name": "Dockstore",
+      "type": {"group": "org.ga4gh", "artifact": "trs", "version": "2.0.1"},
+      "organization": {"id": "org.dockstore", "name": "Dockstore", "url": "https://dockstore.org"},
+      "version": "1.15.0",
+      "url": "https://dockstore.org/api/ga4gh/trs/v2/",
+      "description": "Tool Registry Service implementation for tools and workflows.",
+      "documentationUrl": "https://dockstore.org/api/static/swagger-ui/index.html"
+    },
+    "replay_transport": {
+      "status_code": 200,
+      "content_type": "application/json;charset=utf-8",
+      "payload": {
+        "id": "1",
+        "name": "Dockstore",
+        "type": {"artifact": "TRS", "group": "org.ga4gh", "version": "2.0.1"},
+        "organization": {"name": "Dockstore", "url": "https://dockstore.org"},
+        "version": "1.19.2",
+        "environment": "prod"
+      }
+    }
+  },
+  {
+    "case_id": "cavatica_wes_service_info",
+    "catalog_query": "Cavatica WES",
+    "tool_name": "CandidateCavaticaWESServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "com.sbgenomics.cavatica-ga4gh-api.wes",
+      "name": "Cavatica GA4GH WES API",
+      "type": {"group": "org.ga4gh", "artifact": "wes", "version": "1.0.0"},
+      "organization": {"id": "com.sb", "name": "Seven Bridges", "url": "https://www.sevenbridges.com"},
+      "version": "1.0.1.4",
+      "url": "https://cavatica-ga4gh-api.sbgenomics.com/ga4gh/wes/v1/",
+      "description": "Workflow Execution Service implementation.",
+      "documentationUrl": "https://docs.cavatica.org/wes-api-overview",
+      "environment": "production"
+    },
+    "replay_transport": {
+      "status_code": 200,
+      "content_type": "application/json",
+      "payload": {
+        "id": "com.sbgenomics.cavatica-ga4gh-api.wes",
+        "name": "Cavatica GA4GH WES API",
+        "type": {"artifact": "wes", "version": "1.0.1", "group": "com.sevenbridges"},
+        "organization": {"name": "Seven Bridges", "url": "https://www.sevenbridges.com"},
+        "version": "1.0.1.4"
+      }
+    }
+  },
+  {
+    "case_id": "cgc_wes_service_info",
+    "catalog_query": "CGC WES",
+    "tool_name": "CandidateCGCWESServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "com.sbgenomics.cgc-ga4gh-api.wes",
+      "name": "CGC GA4GH WES API",
+      "type": {"group": "org.ga4gh", "artifact": "wes", "version": "1.0.0"},
+      "organization": {"id": "com.sb", "name": "Seven Bridges", "url": "https://www.sevenbridges.com"},
+      "version": "1.0.1.4",
+      "url": "https://cgc-ga4gh-api.sbgenomics.com/ga4gh/wes/v1/",
+      "description": "Workflow Execution Service implementation.",
+      "documentationUrl": "https://docs.cancergenomicscloud.org/wes-api-overview",
+      "environment": "production"
+    },
+    "replay_transport": {
+      "status_code": 200,
+      "content_type": "application/json",
+      "payload": {
+        "id": "com.sbgenomics.cgc-ga4gh-api.wes",
+        "name": "CGC GA4GH WES API",
+        "type": {"artifact": "wes", "version": "1.0.1", "group": "com.sevenbridges"},
+        "organization": {"name": "Seven Bridges", "url": "https://www.sevenbridges.com"},
+        "version": "1.0.1.4"
+      }
+    }
+  },
+  {
+    "case_id": "bdc_wes_service_info",
+    "catalog_query": "BioData Catalyst WES",
+    "tool_name": "CandidateBDCWESServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "gov.nih.nhlbi.biodatacatalyst.sb.ga4gh-api.wes",
+      "name": "BDC GA4GH WES API",
+      "type": {"group": "org.ga4gh", "artifact": "wes", "version": "1.0.0"},
+      "organization": {"id": "com.sb", "name": "Seven Bridges", "url": "https://www.sevenbridges.com"},
+      "version": "1.0.1.4",
+      "url": "https://ga4gh-api.sb.biodatacatalyst.nhlbi.nih.gov/ga4gh/wes/v1/",
+      "description": "Workflow Execution Service implementation.",
+      "documentationUrl": "https://sb-biodatacatalyst.readme.io/wes-api-overview",
+      "environment": "production"
+    },
+    "replay_transport": {
+      "status_code": 200,
+      "content_type": "application/json",
+      "payload": {
+        "id": "gov.nih.nhlbi.biodatacatalyst.sb.ga4gh-api.wes",
+        "name": "BDC GA4GH WES API",
+        "type": {"artifact": "wes", "version": "1.0.1", "group": "com.sevenbridges"},
+        "organization": {"name": "Seven Bridges", "url": "https://www.sevenbridges.com"},
+        "version": "1.0.1.4"
+      }
+    }
+  },
+  {
+    "case_id": "cavatica_drs_service_info",
+    "catalog_query": "Cavatica DRS",
+    "tool_name": "CandidateCavaticaDRSServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "com.sb.cavatica.drs",
+      "name": "Cavatica DRS API",
+      "type": {"group": "org.ga4gh", "artifact": "drs", "version": "1.3.0"},
+      "organization": {"id": "com.sb.cavatica", "name": "Velsera1", "url": "https://velsera.com/"},
+      "version": "1.0.0",
+      "url": "https://cavatica-ga4gh-api.sbgenomics.com",
+      "description": "Cavatica Data Repository Service.",
+      "documentationUrl": "https://docs.cavatica.org/reference/drs-api-overview",
+      "environment": "Production"
+    },
+    "replay_transport": {"status_code": 404, "content_type": "text/html", "body": "Not Found"}
+  },
+  {
+    "case_id": "cgc_drs_service_info",
+    "catalog_query": "Cancer Genomics Cloud DRS",
+    "tool_name": "CandidateCGCDRSServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "com.sb.cgc.drs",
+      "name": "Cancer Genomics Cloud DRS API",
+      "type": {"group": "org.ga4gh", "artifact": "drs", "version": "1.3.0"},
+      "organization": {"id": "com.sb.cgc", "name": "Velsera", "url": "https://velsera.com/"},
+      "version": "1.0.0",
+      "url": "https://cgc-ga4gh-api.sbgenomics.com",
+      "description": "Cancer Genomics Cloud Data Repository Service.",
+      "documentationUrl": "https://docs.cancergenomicscloud.org/docs/drs-api-overview",
+      "environment": "Production"
+    },
+    "replay_transport": {"status_code": 404, "content_type": "text/html", "body": "Not Found"}
+  },
+  {
+    "case_id": "bdc_drs_service_info",
+    "catalog_query": "BioData Catalyst DRS",
+    "tool_name": "CandidateBDCDRSServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "com.sb.bdc.drs",
+      "name": "BioData Catalyst powered by Seven Bridges DRS API",
+      "type": {"group": "org.ga4gh", "artifact": "drs", "version": "1.3.0"},
+      "organization": {"id": "com.sb.bdc", "name": "Velsera2", "url": "https://velsera.com/"},
+      "version": "1.0.0",
+      "url": "https://ga4gh-api.sb.biodatacatalyst.nhlbi.nih.gov",
+      "description": "BioData Catalyst Data Repository Service.",
+      "documentationUrl": "https://sb-biodatacatalyst.readme.io/reference/drs-api",
+      "environment": "Production"
+    },
+    "replay_transport": {"status_code": 404, "content_type": "text/html", "body": "Not Found"}
+  },
+  {
+    "case_id": "crg_rnaget_service_info",
+    "catalog_query": "CRG RNAget",
+    "tool_name": "CandidateCRGRNAgetServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "eu.crg.rnaget",
+      "name": "CRG RNAget Reference Implementation",
+      "type": {"group": "org.ga4gh", "artifact": "rnaget", "version": "1.0.0"},
+      "organization": {"id": "eu.crg", "name": "Centre for Genomic Regulation", "url": "https://www.crg.eu/"},
+      "version": "1.0.0",
+      "url": "https://genome.crg.cat/rnaget",
+      "description": "RNAget reference implementation.",
+      "documentationUrl": "https://genome.crg.cat/rnaget",
+      "environment": "production"
+    },
+    "replay_transport": {"status_code": 404, "content_type": "text/html; charset=utf-8", "body": "Not Found"}
+  },
+  {
+    "case_id": "anvil_drs_service_info",
+    "catalog_query": "AnVIL DRS",
+    "tool_name": "CandidateAnvilDRSServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "bio.terra.data",
+      "name": "NHGRI AnVIL",
+      "type": {"group": "org.ga4gh", "artifact": "drs", "version": "1.3.0"},
+      "organization": {"id": "org.anvilproject", "name": "NHGRI AnVIL", "url": "https://anvilproject.org/"},
+      "version": "2.323.0",
+      "url": "https://data.terra.bio/",
+      "description": "Cloud-based genomic data sharing and analysis service.",
+      "documentationUrl": "https://anvilproject.org/learn/find-data/requesting-data-access",
+      "environment": "Production"
+    },
+    "replay_transport": {"status_code": 200, "content_type": "text/html; charset=UTF-8", "body": "<!doctype html><title>Terra</title>"}
+  },
+  {
+    "case_id": "gen3_drs_service_info",
+    "catalog_query": "Gen3 Data Hub DRS",
+    "tool_name": "CandidateGen3DRSServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "io.datacommons.gen3.drs",
+      "name": "Gen3 Data Hub",
+      "type": {"group": "org.ga4gh", "artifact": "drs", "version": "1.2.0"},
+      "organization": {"id": "io.datacommons.gen3", "name": "Gen3 Data Hub", "url": "https://gen3.datacommons.io/"},
+      "version": "5.1.3",
+      "url": "https://gen3.datacommons.io/",
+      "description": "Data Repository Service implementation.",
+      "documentationUrl": "https://gen3.org/resources/user/access-data/",
+      "environment": "Production"
+    },
+    "replay_transport": {"status_code": 200, "content_type": "text/html", "body": "<!doctype html><title>Gen3</title>"}
+  },
+  {
+    "case_id": "nci_crdc_drs_service_info",
+    "catalog_query": "NCI CRDC DRS",
+    "tool_name": "CandidateNCICRDCDRSServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "io.datacommons.nci-crdc.drs",
+      "name": "NCI CRDC",
+      "type": {"group": "org.ga4gh", "artifact": "drs", "version": "1.2.0"},
+      "organization": {"id": "io.datacommons.nci-crdc", "name": "NCI CRDC", "url": "https://nci-crdc.datacommons.io/"},
+      "version": "2025.09",
+      "url": "https://nci-crdc.datacommons.io/",
+      "description": "Cancer Research Data Commons repository service.",
+      "documentationUrl": "https://gen3.org/resources/user/access-data/",
+      "environment": "Production"
+    },
+    "replay_transport": {"status_code": 200, "content_type": "text/html", "body": "<!doctype html><title>NCI CRDC</title>"}
+  },
+  {
+    "case_id": "viral_ai_drs_service_info",
+    "catalog_query": "Viral AI DRS",
+    "tool_name": "CandidateViralAIDRSServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "ai.viral",
+      "name": "Viral AI",
+      "type": {"group": "org.ga4gh", "artifact": "drs", "version": "1.3.0"},
+      "organization": {"id": "com.dnastack", "name": "DNAstack", "url": "https://dnastack.com"},
+      "version": "N/A (SaaS)",
+      "url": "https://viral.ai",
+      "description": "Genomic surveillance and infectious-disease data repository service.",
+      "documentationUrl": "https://docs.omics.ai/products/command-line-interface/usage-examples",
+      "environment": "Production"
+    },
+    "replay_transport": {"status_code": 302, "content_type": "", "body": ""}
+  },
+  {
+    "case_id": "nhs_drs_service_info",
+    "catalog_query": "NHS genomic DRS",
+    "tool_name": "CandidateNHSDRSServiceInfo",
+    "expected_qualification": "rejected",
+    "registry_record": {
+      "id": "api.service.nhs.uk/genomic-data-access",
+      "name": "NHS Genomic Data Access & Management",
+      "type": {"group": "org.ga4gh", "artifact": "drs", "version": "1.4.0"},
+      "organization": {"id": "api.service.nhs.uk/genomic-data-access", "name": "NHS Genomic Medicine Service / Genomics England", "url": "https://www.genomicsengland.co.uk/"},
+      "version": "beta",
+      "url": "https://sandbox.api.service.nhs.uk/genomic-data-access",
+      "description": "Development Data Repository Service for genomic data access.",
+      "documentationUrl": "https://digital.nhs.uk/developer/api-catalogue/genomic-data-access-and-management",
+      "environment": "Development"
+    },
+    "replay_transport": {"status_code": 404, "content_type": "text/plain", "body": "Not Found"}
+  }
+]

--- a/examples/vsd/ga4gh_service_qualification_portfolio.py
+++ b/examples/vsd/ga4gh_service_qualification_portfolio.py
@@ -1,0 +1,784 @@
+"""Qualify standard GA4GH Service Info operations through the VSD lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+from urllib.parse import urlsplit
+
+import tooluniverse.vsd_discovery as vsd_discovery
+import tooluniverse.vsd_reviewed_runtime as reviewed_runtime
+from tooluniverse import ToolUniverse
+from tooluniverse.vsd_promotion import (
+    VSDPromotionError,
+    approve_draft,
+    create_ga4gh_service_info_draft,
+    ga4gh_service_info_verification_cases,
+    list_promotion_state,
+    load_published_tools,
+    publish_draft,
+    verify_draft,
+)
+from tooluniverse.vsd_reviewed_runtime import VSDReviewedRuntimeError
+
+HERE = Path(__file__).resolve().parent
+SCENARIO_FILE = HERE / "ga4gh_service_qualification" / "scenarios.json"
+ARTIFACTS = HERE / "artifacts"
+DEFAULT_JSON = ARTIFACTS / "ga4gh_service_qualification_portfolio.json"
+DEFAULT_MARKDOWN = ARTIFACTS / "ga4gh_service_qualification_portfolio.md"
+
+_CASE_ID_RE = re.compile(r"^[a-z][a-z0-9_]{2,63}$")
+_TOOL_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{2,44}$")
+_REQUIRED_FIELDS = {
+    "case_id",
+    "catalog_query",
+    "tool_name",
+    "expected_qualification",
+    "registry_record",
+    "replay_transport",
+}
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _safe_error(exc: Exception) -> dict[str, str]:
+    message = " ".join(str(exc).split())[:500]
+    lowered = message.casefold()
+    if "case-insensitive json pointer" in lowered or "pointer equality" in lowered:
+        category = "registered_metadata_mismatch"
+    elif "content type" in lowered:
+        category = "response_media_type_mismatch"
+    elif "redirect" in lowered:
+        category = "redirect_rejected"
+    elif "http" in lowered and any(
+        code in lowered for code in ("400", "401", "403", "404", "500", "502", "503")
+    ):
+        category = "http_status_failure"
+    else:
+        category = "execution_failure"
+    return {"type": type(exc).__name__, "category": category, "message": message}
+
+
+def _validate_registry_record(record: Any) -> dict[str, Any]:
+    if not isinstance(record, dict):
+        raise ValueError("registry_record must be an object")
+    required = {"id", "name", "type", "organization", "version", "url"}
+    service_type = record.get("type")
+    if (
+        not required <= set(record)
+        or any(
+            not isinstance(record.get(field), str) or not record[field]
+            for field in ("id", "name", "version", "url")
+        )
+        or not isinstance(service_type, dict)
+        or set(service_type) != {"group", "artifact", "version"}
+        or any(
+            not isinstance(value, str) or not value for value in service_type.values()
+        )
+        or not isinstance(record.get("organization"), dict)
+    ):
+        raise ValueError("registry_record is incomplete")
+    return json.loads(json.dumps(record))
+
+
+def _validate_transport(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError("replay_transport must be an object")
+    status = value.get("status_code")
+    content_type = value.get("content_type")
+    if (
+        isinstance(status, bool)
+        or not isinstance(status, int)
+        or not 100 <= status <= 599
+        or not isinstance(content_type, str)
+        or not isinstance(
+            value.get("payload", value.get("body", "")), (dict, list, str)
+        )
+    ):
+        raise ValueError("replay_transport is invalid")
+    if ("payload" in value) == ("body" in value):
+        raise ValueError("replay_transport must contain exactly one response body")
+    return json.loads(json.dumps(value))
+
+
+def load_scenarios() -> list[dict[str, Any]]:
+    values = json.loads(SCENARIO_FILE.read_text(encoding="utf-8"))
+    if not isinstance(values, list) or len(values) != 15:
+        raise ValueError("The portfolio requires 15 service scenarios")
+    scenarios = []
+    for value in values:
+        if not isinstance(value, dict) or set(value) != _REQUIRED_FIELDS:
+            raise ValueError("Scenario structure is invalid")
+        case_id = value["case_id"]
+        tool_name = value["tool_name"]
+        query = value["catalog_query"]
+        expected = value["expected_qualification"]
+        if (
+            not isinstance(case_id, str)
+            or not _CASE_ID_RE.fullmatch(case_id)
+            or not isinstance(tool_name, str)
+            or not _TOOL_NAME_RE.fullmatch(tool_name)
+            or not isinstance(query, str)
+            or not 2 <= len(query) <= 200
+            or expected not in {"accepted", "rejected"}
+        ):
+            raise ValueError("Scenario identity is invalid")
+        scenarios.append(
+            {
+                **value,
+                "registry_record": _validate_registry_record(value["registry_record"]),
+                "replay_transport": _validate_transport(value["replay_transport"]),
+            }
+        )
+    if len({item["case_id"] for item in scenarios}) != len(scenarios):
+        raise ValueError("Scenario case IDs must be unique")
+    if len({item["tool_name"].casefold() for item in scenarios}) != len(scenarios):
+        raise ValueError("Scenario tool names must be unique")
+    return scenarios
+
+
+def _request_metadata(url: str, payload: Any, content_type: str) -> dict[str, Any]:
+    encoded = _canonical(payload)
+    return {
+        "url": url,
+        "status_code": 200,
+        "content_type": content_type,
+        "response_bytes": len(encoded),
+        "peer_ip": "93.184.216.34",
+        "redirects": 0,
+    }
+
+
+@contextmanager
+def _catalog_transport(scenarios: list[dict[str, Any]], *, mode: str) -> Iterator[None]:
+    if mode == "live":
+        yield
+        return
+    original = vsd_discovery._safe_get_json
+    payload = [item["registry_record"] for item in scenarios]
+
+    def fetch(url, params=None, **kwargs):
+        del params, kwargs
+        return payload, _request_metadata(url, payload, "application/json")
+
+    vsd_discovery._safe_get_json = fetch
+    try:
+        yield
+    finally:
+        vsd_discovery._safe_get_json = original
+
+
+@contextmanager
+def _service_transport(scenario: dict[str, Any], *, mode: str) -> Iterator[None]:
+    if mode == "live":
+        yield
+        return
+    original = reviewed_runtime._http_exchange
+    transport = scenario["replay_transport"]
+
+    def exchange(**kwargs):
+        status = transport["status_code"]
+        if 300 <= status < 400:
+            raise VSDReviewedRuntimeError("Provider redirect is prohibited")
+        if status != 200:
+            raise VSDReviewedRuntimeError(f"Provider returned HTTP status {status}")
+        value = transport.get("payload", transport.get("body", ""))
+        raw = _canonical(value) if "payload" in transport else value.encode("utf-8")
+        return raw, {
+            "url": kwargs["url"],
+            "status_code": status,
+            "content_type": transport["content_type"],
+            "response_bytes": len(raw),
+            "headers": {},
+            "peer_ip": "93.184.216.34",
+            "redirects": 0,
+        }
+
+    reviewed_runtime._http_exchange = exchange
+    try:
+        yield
+    finally:
+        reviewed_runtime._http_exchange = original
+
+
+@contextmanager
+def _allowed_service_host(endpoint: str) -> Iterator[None]:
+    host = (urlsplit(endpoint).hostname or "").casefold().rstrip(".")
+    previous = os.environ.get("TOOLUNIVERSE_VSD_ALLOWED_HOSTS")
+    allowed = {item.strip() for item in (previous or "").split(",") if item.strip()}
+    allowed.add(host)
+    os.environ["TOOLUNIVERSE_VSD_ALLOWED_HOSTS"] = ",".join(sorted(allowed))
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("TOOLUNIVERSE_VSD_ALLOWED_HOSTS", None)
+        else:
+            os.environ["TOOLUNIVERSE_VSD_ALLOWED_HOSTS"] = previous
+
+
+def _tool_data(
+    universe: ToolUniverse, name: str, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    response = universe.run_one_function(
+        {"name": name, "arguments": arguments}, use_cache=False
+    )
+    if not isinstance(response, dict) or response.get("status") != "success":
+        raise RuntimeError(f"Tool {name!r} did not complete successfully")
+    data = response.get("data")
+    if not isinstance(data, dict):
+        raise RuntimeError(f"Tool {name!r} returned an invalid result envelope")
+    return data
+
+
+def _discover(
+    universe: ToolUniverse,
+    scenario: dict[str, Any],
+    scenarios: list[dict[str, Any]],
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    with _catalog_transport(scenarios, mode=mode):
+        return _tool_data(
+            universe,
+            "VSDDiscoverAPICandidates",
+            {
+                "query": scenario["catalog_query"],
+                "providers": ["ga4gh_registry"],
+                "exclude_registered": True,
+                "limit": 20,
+            },
+        )
+
+
+def _select_candidate(discovery: dict[str, Any], registry_id: str) -> dict[str, Any]:
+    matches = []
+    for candidate in discovery.get("candidates", []):
+        source_ids = {
+            item.get("record_id")
+            for item in candidate.get("catalog_sources", [])
+            if isinstance(item, dict)
+        }
+        if registry_id in source_ids:
+            matches.append(candidate)
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"Discovery did not return one candidate for registry record {registry_id!r}"
+        )
+    return matches[0]
+
+
+def _catalog_provenance(discovery: dict[str, Any]) -> dict[str, Any]:
+    providers = discovery.get("provider_results")
+    if not isinstance(providers, list) or len(providers) != 1:
+        raise RuntimeError("Discovery did not record one catalog provider")
+    provenance = providers[0].get("provenance")
+    required = {
+        "endpoint",
+        "retrieved_at",
+        "http_status",
+        "response_bytes",
+        "payload_sha256",
+    }
+    if not isinstance(provenance, dict) or not required <= set(provenance):
+        raise RuntimeError("Discovery catalog provenance is incomplete")
+    return {field: provenance[field] for field in sorted(required)}
+
+
+def _blocked_before_verification(draft_id: str, workspace: Path) -> bool:
+    try:
+        publish_draft(draft_id, workspace=workspace)
+    except VSDPromotionError:
+        return True
+    return False
+
+
+def _run_rejected_case(
+    scenario: dict[str, Any],
+    candidate: dict[str, Any],
+    draft: dict[str, Any],
+    workspace: Path,
+    *,
+    mode: str,
+    early_publication_blocked: bool,
+) -> dict[str, Any]:
+    verification_error: dict[str, str] | None = None
+    with (
+        _allowed_service_host(candidate["api_endpoint"]),
+        _service_transport(scenario, mode=mode),
+    ):
+        try:
+            verify_draft(
+                draft["draft_id"],
+                ga4gh_service_info_verification_cases(candidate),
+                workspace=workspace,
+            )
+        except Exception as exc:
+            verification_error = _safe_error(exc)
+    if verification_error is None:
+        raise RuntimeError(
+            "Qualification outcome changed; the scenario requires review before approval"
+        )
+    approval_blocked = False
+    try:
+        approve_draft(
+            draft["draft_id"],
+            reviewed_by="GA4GH Qualification Reviewer",
+            decision_note="This operation must not be approved without conforming evidence.",
+            workspace=workspace,
+        )
+    except VSDPromotionError:
+        approval_blocked = True
+    state = list_promotion_state(workspace=workspace)
+    assertions = {
+        "candidate_remained_inert": candidate["execution_allowed"] is False,
+        "candidate_binding_was_hash_sealed": len(candidate["candidate_sha256"]) == 64,
+        "early_publication_was_blocked": early_publication_blocked,
+        "qualification_failed_closed": verification_error is not None,
+        "approval_without_evidence_was_blocked": approval_blocked,
+        "no_approval_was_recorded": state["approvals"] == [],
+        "no_publication_was_recorded": state["approved"] == [],
+    }
+    if not all(assertions.values()):
+        raise RuntimeError("Rejected qualification case did not fail closed")
+    return {
+        "qualification": "rejected",
+        "verification_execution_count": 0,
+        "final_execution_count": 0,
+        "published_tool": None,
+        "failure": verification_error,
+        "governance": {
+            "early_publication_blocked": early_publication_blocked,
+            "approval_blocked": approval_blocked,
+            "promotion_state": state,
+        },
+        "assertions": assertions,
+    }
+
+
+def _run_accepted_case(
+    scenario: dict[str, Any],
+    candidate: dict[str, Any],
+    draft: dict[str, Any],
+    workspace: Path,
+    scenarios: list[dict[str, Any]],
+    *,
+    mode: str,
+    early_publication_blocked: bool,
+) -> dict[str, Any]:
+    with (
+        _allowed_service_host(candidate["api_endpoint"]),
+        _service_transport(scenario, mode=mode),
+    ):
+        evidence = verify_draft(
+            draft["draft_id"],
+            ga4gh_service_info_verification_cases(candidate),
+            workspace=workspace,
+        )
+        approval = approve_draft(
+            draft["draft_id"],
+            reviewed_by="GA4GH Qualification Reviewer",
+            decision_note=(
+                "Approved after three executions matched the registered service name "
+                "and standard type."
+            ),
+            workspace=workspace,
+        )
+        publication = publish_draft(draft["draft_id"], workspace=workspace)
+        runtime = ToolUniverse()
+        runtime.load_tools(include_tools=["VSDDiscoverAPICandidates"], quiet=True)
+        try:
+            absent_before_load = scenario["tool_name"] not in runtime.all_tool_dict
+            loaded = load_published_tools(runtime, workspace=workspace)
+            final = _tool_data(runtime, scenario["tool_name"], {})
+            post_discovery = _discover(runtime, scenario, scenarios, mode=mode)
+        finally:
+            runtime.close()
+
+    requested_id = scenario["registry_record"]["id"]
+    requested_candidates = [
+        item
+        for item in post_discovery.get("candidates", [])
+        if requested_id
+        in {
+            source.get("record_id")
+            for source in item.get("catalog_sources", [])
+            if isinstance(source, dict)
+        }
+    ]
+    result = final["result"]
+    hash_chain = {
+        "catalog_candidate_sha256": candidate["candidate_sha256"],
+        "draft_sha256": draft["draft_sha256"],
+        "verification_sha256": evidence["verification_sha256"],
+        "approval_sha256": approval["approval_sha256"],
+        "publication_sha256": publication["publication_sha256"],
+    }
+    assertions = {
+        "candidate_remained_inert_until_review": candidate["execution_allowed"]
+        is False,
+        "candidate_binding_was_hash_sealed": len(candidate["candidate_sha256"]) == 64,
+        "early_publication_was_blocked": early_publication_blocked,
+        "three_conformance_executions_passed": evidence["case_count"] == 3,
+        "publication_required_explicit_loading": (
+            absent_before_load and loaded == [scenario["tool_name"]]
+        ),
+        "fresh_runtime_execution_succeeded": isinstance(result, dict),
+        "post_load_discovery_suppressed_the_exact_operation": (
+            requested_candidates == []
+            and post_discovery["registered_duplicate_count"] >= 1
+        ),
+        "complete_hash_chain_was_recorded": all(
+            isinstance(value, str) and len(value) == 64 for value in hash_chain.values()
+        ),
+    }
+    if not all(assertions.values()):
+        failed = sorted(name for name, passed in assertions.items() if not passed)
+        raise RuntimeError(f"Accepted qualification assertions failed: {failed!r}")
+    return {
+        "qualification": "accepted",
+        "verification_execution_count": evidence["case_count"],
+        "final_execution_count": 1,
+        "published_tool": scenario["tool_name"],
+        "failure": None,
+        "observed_service": {
+            "id": result.get("id"),
+            "name": result.get("name"),
+            "type": result.get("type"),
+            "payload_sha256": final["provenance"]["payload_sha256"],
+        },
+        "governance": {
+            "early_publication_blocked": early_publication_blocked,
+            "loaded_into_fresh_universe": loaded,
+            "registered_duplicate_count": post_discovery["registered_duplicate_count"],
+            "hash_chain": hash_chain,
+        },
+        "assertions": assertions,
+    }
+
+
+def _run_once(
+    scenario: dict[str, Any],
+    scenarios: list[dict[str, Any]],
+    workspace: Path,
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    initial = ToolUniverse()
+    initial.load_tools(include_tools=["VSDDiscoverAPICandidates"], quiet=True)
+    try:
+        discovery = _discover(initial, scenario, scenarios, mode=mode)
+        candidate = _select_candidate(discovery, scenario["registry_record"]["id"])
+        catalog_provenance = _catalog_provenance(discovery)
+    finally:
+        initial.close()
+
+    promotion_workspace = workspace / "promotion"
+    draft = create_ga4gh_service_info_draft(
+        candidate,
+        tool_name=scenario["tool_name"],
+        description=(
+            "Return the reviewed standard service metadata for this registered "
+            "GA4GH implementation."
+        ),
+        review_note=(
+            "Reviewed the registry identity, derived Service Info path, response "
+            "boundary, and required service-type assertions."
+        ),
+        workspace=promotion_workspace,
+    )
+    early_blocked = _blocked_before_verification(draft["draft_id"], promotion_workspace)
+    if scenario["expected_qualification"] == "accepted":
+        try:
+            qualification = _run_accepted_case(
+                scenario,
+                candidate,
+                draft,
+                promotion_workspace,
+                scenarios,
+                mode=mode,
+                early_publication_blocked=early_blocked,
+            )
+        except Exception as exc:
+            state = list_promotion_state(workspace=promotion_workspace)
+            if state["approved"]:
+                raise
+            raise RuntimeError(
+                f"Expected conforming service failed qualification: {_safe_error(exc)}"
+            ) from exc
+    else:
+        qualification = _run_rejected_case(
+            scenario,
+            candidate,
+            draft,
+            promotion_workspace,
+            mode=mode,
+            early_publication_blocked=early_blocked,
+        )
+    return {
+        "case_id": scenario["case_id"],
+        "evidence_mode": mode,
+        "catalog_query": scenario["catalog_query"],
+        "registry_record_id": scenario["registry_record"]["id"],
+        "registered_name": candidate["service_binding"]["registered_name"],
+        "registered_type": candidate["service_binding"]["registered_type"],
+        "service_root": candidate["service_binding"]["service_root"],
+        "service_info_endpoint": candidate["api_endpoint"],
+        "candidate_id": candidate["candidate_id"],
+        "catalog_provenance": catalog_provenance,
+        "without_vsd": {
+            "catalog_record_discovered": True,
+            "executable_service_info_tool": False,
+            "qualification_evidence": False,
+        },
+        "with_vsd": qualification,
+    }
+
+
+def run_portfolio(
+    *,
+    workspace: Path,
+    mode: str = "replay",
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    if mode not in {"replay", "live", "network_backed"}:
+        raise ValueError("mode must be replay, live, or network_backed")
+    scenarios = load_scenarios()
+    results = []
+    for scenario in scenarios:
+        case_workspace = workspace / scenario["case_id"]
+        fallback = None
+        if mode == "network_backed":
+            try:
+                result = _run_once(
+                    scenario, scenarios, case_workspace / "live", mode="live"
+                )
+            except Exception as exc:
+                fallback = _safe_error(exc)
+                result = _run_once(
+                    scenario, scenarios, case_workspace / "replay", mode="replay"
+                )
+        else:
+            result = _run_once(scenario, scenarios, case_workspace, mode=mode)
+        if fallback is not None:
+            result["live_attempt"] = {
+                "completed": False,
+                "fallback": "checked replay",
+                "failure": fallback,
+            }
+        elif mode in {"live", "network_backed"}:
+            result["live_attempt"] = {"completed": True, "fallback": None}
+        results.append(result)
+
+    body = {
+        "format": "vsd_ga4gh_service_qualification_portfolio_v1",
+        "generated_at": generated_at or datetime.now(timezone.utc).isoformat(),
+        "requested_mode": mode,
+        "case_count": len(results),
+        "live_case_count": sum(item["evidence_mode"] == "live" for item in results),
+        "replay_case_count": sum(item["evidence_mode"] == "replay" for item in results),
+        "accepted_count": sum(
+            item["with_vsd"]["qualification"] == "accepted" for item in results
+        ),
+        "rejected_count": sum(
+            item["with_vsd"]["qualification"] == "rejected" for item in results
+        ),
+        "published_tool_count": sum(
+            item["with_vsd"]["published_tool"] is not None for item in results
+        ),
+        "verification_execution_count": sum(
+            item["with_vsd"]["verification_execution_count"] for item in results
+        ),
+        "final_execution_count": sum(
+            item["with_vsd"]["final_execution_count"] for item in results
+        ),
+        "all_assertions_passed": all(
+            all(item["with_vsd"]["assertions"].values()) for item in results
+        ),
+        "cases": results,
+    }
+    return {**body, "portfolio_sha256": _digest(body)}
+
+
+def validate_portfolio(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict) or value.get("format") != (
+        "vsd_ga4gh_service_qualification_portfolio_v1"
+    ):
+        raise ValueError("Portfolio artifact format is invalid")
+    body = {key: item for key, item in value.items() if key != "portfolio_sha256"}
+    if value.get("portfolio_sha256") != _digest(body):
+        raise ValueError("Portfolio artifact digest does not match its content")
+    if (
+        value.get("case_count") != 15
+        or value.get("accepted_count") != 3
+        or value.get("rejected_count") != 12
+        or value.get("published_tool_count") != 3
+        or value.get("verification_execution_count") != 9
+        or value.get("final_execution_count") != 3
+        or value.get("all_assertions_passed") is not True
+    ):
+        raise ValueError("Portfolio artifact is incomplete")
+    return json.loads(json.dumps(value))
+
+
+def render_markdown(value: dict[str, Any]) -> str:
+    artifact = validate_portfolio(value)
+    lines = [
+        "# GA4GH Service Qualification Portfolio",
+        "",
+        "## Scope",
+        "",
+        (
+            "This evaluation asked whether an official registry entry was sufficient "
+            "to create a usable ToolUniverse operation. VSD derived only the standard "
+            "Service Info path, then required live response structure and registered "
+            "service-type agreement before approval."
+        ),
+        "",
+        "The same parameterized runner evaluated every service; organization names, "
+        "URLs, expected outcomes, and replay responses are scenario data.",
+        "",
+        "## Results",
+        "",
+        f"- Evaluated services: `{artifact['case_count']}`",
+        f"- Accepted and published: `{artifact['accepted_count']}`",
+        f"- Rejected before approval: `{artifact['rejected_count']}`",
+        f"- Verification executions: `{artifact['verification_execution_count']}`",
+        f"- Fresh-universe executions: `{artifact['final_execution_count']}`",
+        f"- Live cases: `{artifact['live_case_count']}`",
+        f"- Checked-replay cases: `{artifact['replay_case_count']}`",
+        f"- Portfolio SHA-256: `{artifact['portfolio_sha256']}`",
+        "",
+        "| Registry record | Standard | Endpoint | Result | Evidence |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for case in artifact["cases"]:
+        service_type = case["registered_type"]
+        outcome = case["with_vsd"]["qualification"]
+        failure = case["with_vsd"].get("failure")
+        evidence = (
+            "3 conformance calls, publication, fresh load, and final execution"
+            if outcome == "accepted"
+            else failure["category"].replace("_", " ")
+        )
+        lines.append(
+            "| "
+            + " | ".join(
+                (
+                    case["registry_record_id"],
+                    f"{service_type['artifact']} {service_type['version']}",
+                    case["service_info_endpoint"],
+                    outcome,
+                    evidence,
+                )
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Lifecycle Evidence",
+            "",
+            (
+                "Every discovered candidate was non-executable and content-addressed. "
+                "All 15 drafts were blocked from publication before verification. The "
+                "three conforming services passed registry-bound assertions three "
+                "times, were explicitly approved and published, remained absent from "
+                "a fresh ToolUniverse until loaded, executed successfully after loading, "
+                "and were suppressed from the next discovery result as exact duplicates."
+            ),
+            "",
+            (
+                "The other 12 candidates produced no approval or publication artifact. "
+                "They included valid JSON with service-type drift, unavailable standard "
+                "paths, HTML responses at API-looking URLs, and a redirect."
+            ),
+            "",
+            "## Interpretation",
+            "",
+            (
+                "Without VSD, the registry supplies useful leads but does not establish "
+                "that their standard metadata operation is reachable or still agrees "
+                "with the registered contract. With VSD, conforming leads become narrow, "
+                "auditable ToolUniverse operations while stale or inconsistent records "
+                "fail before approval. In this snapshot, indiscriminate registration "
+                "would have treated all 15 records as usable; qualification admitted "
+                "three and prevented 12 unsupported additions."
+            ),
+            "",
+            "## Reproduction",
+            "",
+            "```console",
+            "PYTHONPATH=src python examples/vsd/ga4gh_service_qualification_portfolio.py --mode replay",
+            "PYTHONPATH=src python examples/vsd/ga4gh_service_qualification_portfolio.py --mode network_backed",
+            "```",
+            "",
+            (
+                "Replay uses checked provider-shaped responses. Network-backed mode "
+                "labels each service independently as live or checked replay and records "
+                "the bounded reason for any fallback."
+            ),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_artifacts(
+    artifact: dict[str, Any], json_path: Path, markdown_path: Path
+) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(
+        json.dumps(artifact, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    markdown_path.write_text(render_markdown(artifact), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Evaluate GA4GH Service Info candidates through the VSD lifecycle."
+    )
+    parser.add_argument(
+        "--mode", choices=("replay", "live", "network_backed"), default="replay"
+    )
+    parser.add_argument("--workspace", type=Path)
+    parser.add_argument("--output-json", type=Path, default=DEFAULT_JSON)
+    parser.add_argument("--output-markdown", type=Path, default=DEFAULT_MARKDOWN)
+    arguments = parser.parse_args()
+    if arguments.workspace is None:
+        with tempfile.TemporaryDirectory(prefix="vsd-ga4gh-qualification-") as root:
+            artifact = run_portfolio(workspace=Path(root), mode=arguments.mode)
+    else:
+        artifact = run_portfolio(
+            workspace=arguments.workspace.resolve(), mode=arguments.mode
+        )
+    write_artifacts(
+        artifact, arguments.output_json.resolve(), arguments.output_markdown.resolve()
+    )
+    print(json.dumps(artifact, indent=2, sort_keys=True, ensure_ascii=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_vsd_biomedical_evaluation_portfolio.py
+++ b/tests/unit/test_vsd_biomedical_evaluation_portfolio.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).parents[2]
+    / "examples"
+    / "vsd"
+    / "biomedical_evaluation_portfolio.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "vsd_biomedical_evaluation_portfolio", MODULE_PATH
+)
+study = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = study
+SPEC.loader.exec_module(study)
+
+pytestmark = pytest.mark.unit
+
+
+def test_five_scenarios_are_data_driven_and_cover_existing_registry_tools():
+    scenarios = study.load_scenarios()
+
+    assert len(scenarios) == 5
+    assert {item["promotion_mode"] for item in scenarios} == {
+        "strict",
+        "reviewed_response",
+    }
+    assert sum(len(item["reused_tools"]) for item in scenarios) == 17
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    for scientific_literal in (
+        "MONDO:0004976",
+        "PDCD1",
+        "Arsenic trioxide",
+        "BRD-K12343256",
+        "tuberculosis_resistance_integration",
+    ):
+        assert scientific_literal not in source
+
+
+def test_replay_portfolio_runs_all_lifecycle_boundaries_and_writes_artifacts(
+    tmp_path,
+):
+    artifact = study.run_portfolio(
+        workspace=tmp_path / "workspace",
+        mode="replay",
+        generated_at="2026-08-02T12:00:00+00:00",
+    )
+    output_json = tmp_path / "portfolio.json"
+    output_markdown = tmp_path / "portfolio.md"
+    study.write_artifacts(artifact, output_json, output_markdown)
+
+    assert artifact["case_count"] == 5
+    assert artifact["published_tool_count"] == 5
+    assert artifact["verification_execution_count"] == 15
+    assert artifact["all_assertions_passed"] is True
+    assert all(
+        case["without_vsd"]["planned_operation_classification"] == "missing"
+        and case["with_vsd"]["planned_operation_classification"]
+        == "existing_exact"
+        and all(case["assertions"].values())
+        for case in artifact["cases"]
+    )
+    reviewed = [
+        case
+        for case in artifact["cases"]
+        if case["source"]["promotion_mode"] == "reviewed_response"
+    ]
+    assert len(reviewed) == 2
+    assert all(
+        case["governance"]["resolved_blockers"] == ["json_response_missing"]
+        for case in reviewed
+    )
+    assert study.validate_portfolio(json.loads(output_json.read_text())) == artifact
+    assert output_markdown.read_text(encoding="utf-8") == study.render_markdown(
+        artifact
+    )
+    serialized = output_json.read_text(encoding="utf-8")
+    assert "C:\\Users" not in serialized
+    assert "TOOLUNIVERSE_VSD_ALLOWED_HOSTS" not in serialized
+
+
+def test_portfolio_digest_detects_tampering():
+    artifact = json.loads(
+        (study.DEFAULT_JSON).read_text(encoding="utf-8")
+    )
+    altered = copy.deepcopy(artifact)
+    altered["cases"][0]["with_vsd"]["runtime"]["observations"][0]["value"] = (
+        "changed"
+    )
+
+    with pytest.raises(ValueError, match="digest"):
+        study.validate_portfolio(altered)
+
+
+def test_checked_network_backed_artifacts_are_complete_and_synchronized():
+    artifact = json.loads(study.DEFAULT_JSON.read_text(encoding="utf-8"))
+
+    study.validate_portfolio(artifact)
+    assert artifact["requested_mode"] == "network_backed"
+    assert artifact["live_case_count"] == 2
+    assert artifact["replay_case_count"] == 3
+    assert artifact["live_case_count"] + artifact["replay_case_count"] == 5
+    assert all(
+        case["evidence_mode"] == "live"
+        or (
+            case["live_attempt"]["completed"] is False
+            and case["live_attempt"]["fallback"] == "checked replay"
+        )
+        for case in artifact["cases"]
+    )
+    assert study.DEFAULT_MARKDOWN.read_text(encoding="utf-8") == (
+        study.render_markdown(artifact)
+    )
+
+
+def test_virtual_cell_case_extends_an_existing_provider_without_replacing_it():
+    artifact = json.loads(study.DEFAULT_JSON.read_text(encoding="utf-8"))
+    case = next(
+        item
+        for item in artifact["cases"]
+        if item["case_id"] == "virtual_cell_perturbation_selection"
+    )
+
+    assert any(
+        item["name"] == "L1000FWD_sig_search"
+        for item in case["existing_tooluniverse_coverage"]
+    )
+    assert case["with_vsd"]["published_tool"] == "VSDL1000PerturbagenResolver"
+    assert case["source"]["operation_path"] == "/synonyms/{query_string}"

--- a/tests/unit/test_vsd_ga4gh_service_qualification_portfolio.py
+++ b/tests/unit/test_vsd_ga4gh_service_qualification_portfolio.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).parents[2]
+    / "examples"
+    / "vsd"
+    / "ga4gh_service_qualification_portfolio.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "vsd_ga4gh_service_qualification_portfolio", MODULE_PATH
+)
+study = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = study
+SPEC.loader.exec_module(study)
+
+pytestmark = pytest.mark.unit
+
+
+def test_scenarios_are_data_driven_and_span_multiple_ga4gh_standards():
+    scenarios = study.load_scenarios()
+
+    assert len(scenarios) == 15
+    assert sum(item["expected_qualification"] == "accepted" for item in scenarios) == 3
+    assert {item["registry_record"]["type"]["artifact"] for item in scenarios} == {
+        "service-registry",
+        "drs",
+        "trs",
+        "wes",
+        "rnaget",
+    }
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    assert all(item["registry_record"]["id"] not in source for item in scenarios)
+    assert all(item["registry_record"]["url"] not in source for item in scenarios)
+
+
+@pytest.mark.timeout(420)
+def test_replay_portfolio_exercises_acceptance_rejection_and_registry_growth(
+    tmp_path,
+):
+    artifact = study.run_portfolio(
+        workspace=tmp_path / "workspace",
+        mode="replay",
+        generated_at="2026-08-02T12:00:00+00:00",
+    )
+    output_json = tmp_path / "portfolio.json"
+    output_markdown = tmp_path / "portfolio.md"
+    study.write_artifacts(artifact, output_json, output_markdown)
+
+    assert artifact["case_count"] == 15
+    assert artifact["accepted_count"] == 3
+    assert artifact["rejected_count"] == 12
+    assert artifact["verification_execution_count"] == 9
+    assert artifact["final_execution_count"] == 3
+    assert artifact["all_assertions_passed"] is True
+    accepted = [
+        item
+        for item in artifact["cases"]
+        if item["with_vsd"]["qualification"] == "accepted"
+    ]
+    rejected = [
+        item
+        for item in artifact["cases"]
+        if item["with_vsd"]["qualification"] == "rejected"
+    ]
+    assert all(
+        item["with_vsd"]["governance"]["registered_duplicate_count"] >= 1
+        and item["with_vsd"]["published_tool"]
+        and len(item["catalog_provenance"]["payload_sha256"]) == 64
+        for item in accepted
+    )
+    assert all(
+        item["with_vsd"]["governance"]["promotion_state"]["approved"] == []
+        and item["with_vsd"]["published_tool"] is None
+        for item in rejected
+    )
+    assert {item["with_vsd"]["failure"]["category"] for item in rejected} == {
+        "registered_metadata_mismatch",
+        "http_status_failure",
+        "response_media_type_mismatch",
+        "redirect_rejected",
+    }
+    assert study.validate_portfolio(json.loads(output_json.read_text())) == artifact
+    assert output_markdown.read_text(encoding="utf-8") == study.render_markdown(
+        artifact
+    )
+
+
+def test_portfolio_digest_detects_tampering():
+    artifact = json.loads(study.DEFAULT_JSON.read_text(encoding="utf-8"))
+    altered = copy.deepcopy(artifact)
+    altered["accepted_count"] = 15
+
+    with pytest.raises(ValueError, match="digest"):
+        study.validate_portfolio(altered)
+
+
+def test_checked_artifacts_are_complete_synchronized_and_path_free():
+    artifact = json.loads(study.DEFAULT_JSON.read_text(encoding="utf-8"))
+
+    study.validate_portfolio(artifact)
+    assert artifact["live_case_count"] + artifact["replay_case_count"] == 15
+    assert artifact["accepted_count"] + artifact["rejected_count"] == 15
+    assert all(
+        item["catalog_provenance"]["http_status"] == 200
+        and len(item["catalog_provenance"]["payload_sha256"]) == 64
+        for item in artifact["cases"]
+    )
+    assert study.DEFAULT_MARKDOWN.read_text(encoding="utf-8") == (
+        study.render_markdown(artifact)
+    )
+    serialized = study.DEFAULT_JSON.read_text(encoding="utf-8")
+    assert "C:\\Users" not in serialized
+    assert "TOOLUNIVERSE_VSD_ALLOWED_HOSTS" not in serialized


### PR DESCRIPTION
## Summary

- add parameterized, data-driven evaluations that audit and reuse the ToolUniverse registry before attributing a new capability to VSD
- exercise inert discovery, exact contract or standards binding, verification, approval, publication, explicit fresh-runtime loading, execution, replanning, and duplicate suppression
- retain provider-shaped fixtures and tamper-evident JSON/Markdown evidence so live failures and replay use are explicit and reproducible
- add a live 15-service GA4GH qualification portfolio spanning Service Registry, DRS, TRS, WES, and RNAget implementations without provider- or scientific-domain branches in the runner

## Biomedical workflow portfolio

| Workflow | Existing ToolUniverse coverage reused | Narrow operation added | Checked evidence |
| --- | --- | --- | --- |
| Rare-disease diagnostic evidence | Orphanet, HPO, ClinVar | cross-ontology CURIE annotation | checked replay after the live provider violated its declared response schema |
| Pan-cancer immunotherapy | GDC cohort/expression, ImmPort | checkpoint interaction query | live |
| Context-specific drug combinations | ChEMBL, DepMap, Bliss, FAERS | pairwise interaction review | live |
| Virtual-cell perturbation selection | CELLxGENE, L1000FWD signature search | perturbagen synonym resolution | checked replay after the source redirected |
| Tuberculosis resistance integration | BV-BRC AMR/genomes, PharmGKB, clinical trials | radiomics service readiness | checked replay after DNS resolution failed in the evaluation environment |

Each study credits existing tools first and adds only one missing exact operation. The report separates existing coverage, newly qualified capability, scientific interpretation, and operational limitations.

## GA4GH qualification portfolio

The additional portfolio evaluates 15 registered biomedical services across five GA4GH standard families. Each source record declares its registry identity, registered metadata, service root, expected response properties, and provenance in validated scenario data. The runner contains no organization-, service-, endpoint-, disease-, gene-, or standard-specific branch.

For every case, the same orchestration:

1. expresses a capability demand and confirms the exact operation is initially missing;
2. discovers the registered service as an inert, content-addressed candidate;
3. derives only the standard, input-free `GET /service-info` operation;
4. proves publication is blocked before verification and approval;
5. executes bounded live verification and validates the response against the registered identity;
6. approves and publishes only a conforming candidate;
7. confirms the tool remains absent from a fresh ToolUniverse until explicitly loaded;
8. executes the loaded tool through the normal ToolUniverse interface;
9. replans the original demand to `existing_exact` and suppresses the exact endpoint on rediscovery;
10. retains catalog, payload, draft, verification, approval, publication, and final-response hashes.

The checked run was generated on 2026-08-02 and used live network responses for all 15 services with no replay fallback:

- **3 accepted and published:** GA4GH Registry Service Info, NCBI DRS Service Info, and Dockstore TRS Service Info
- **12 rejected before approval:** 3 registered metadata mismatches, 5 execution failures or unavailable paths, 3 response media mismatches, and 1 redirect rejection
- **9 verification executions:** three independent calls for each accepted operation
- **3 fresh-runtime executions:** one for each published tool through a newly loaded ToolUniverse
- **0 rejected publications:** every rejected case has no approval or publication artifact
- **all portfolio assertions passed**

These outcomes demonstrate both sides of the boundary: VSD can turn a trusted registry identity into a narrowly useful ToolUniverse metadata operation when the live service proves conformance, and it refuses publication when registry metadata and runtime behavior do not agree. Registry membership alone is never treated as approval.

## Generic design

Scientific questions, catalog records, operation selections, schemas, inputs, expected observations, existing-tool roles, limitations, and references live in validated scenario JSON. The runners contain no hardcoded branches for the organizations, services, standards, diseases, genes, or drugs represented by those scenarios, and tests assert that scenario registry IDs and URLs are absent from the GA4GH runner source.

The implementation does not generate arbitrary service-specific data operations from a registry URL. The GA4GH path qualifies only `/service-info`; other capabilities require an inspectable contract or an explicit reviewed operation definition.

## Evidence

### Five biomedical workflows

- [reviewer-readable report](https://github.com/mims-harvard/ToolUniverse/blob/vsd-biomedical-evaluation-portfolio/examples/vsd/artifacts/biomedical_evaluation_portfolio.md)
- [tamper-evident ledger](https://github.com/mims-harvard/ToolUniverse/blob/vsd-biomedical-evaluation-portfolio/examples/vsd/artifacts/biomedical_evaluation_portfolio.json), SHA-256 `036e12725bee5e98e700b5f94514ee6b9375bcab66a73b38165044047ba321f3`
- [parameterized runner](https://github.com/mims-harvard/ToolUniverse/blob/vsd-biomedical-evaluation-portfolio/examples/vsd/biomedical_evaluation_portfolio.py)
- [scenario and fixture directory](https://github.com/mims-harvard/ToolUniverse/tree/vsd-biomedical-evaluation-portfolio/examples/vsd/biomedical_studies)

### Fifteen-service live qualification

- [reviewer-readable report](https://github.com/mims-harvard/ToolUniverse/blob/vsd-biomedical-evaluation-portfolio/examples/vsd/artifacts/ga4gh_service_qualification_portfolio.md)
- [tamper-evident ledger](https://github.com/mims-harvard/ToolUniverse/blob/vsd-biomedical-evaluation-portfolio/examples/vsd/artifacts/ga4gh_service_qualification_portfolio.json), SHA-256 `8f20711089278a292c9f88d86fd40c8fa3fbc4f887f2d7d104f3408013e63243`
- [generic runner](https://github.com/mims-harvard/ToolUniverse/blob/vsd-biomedical-evaluation-portfolio/examples/vsd/ga4gh_service_qualification_portfolio.py)
- [validated scenarios](https://github.com/mims-harvard/ToolUniverse/blob/vsd-biomedical-evaluation-portfolio/examples/vsd/ga4gh_service_qualification/scenarios.json)
- [end-to-end, synchronization, tamper, and genericity tests](https://github.com/mims-harvard/ToolUniverse/blob/vsd-biomedical-evaluation-portfolio/tests/unit/test_vsd_ga4gh_service_qualification_portfolio.py)

## Validation

- complete VSD suite: **352 passed across 43 files**
- 15-service replay evaluation: **15/15 cases completed in 126 seconds**
- portfolio-focused tests: **4 passed**
- live artifact: **15/15 live probes; no checked-replay fallback used**
- deterministic replay, artifact synchronization, tamper rejection, scenario validation, and generic-runner checks: passed
- Ruff, formatting, `git diff --check`, path checks, and credential-pattern checks: passed
- combined reviewer branch: **362 non-concurrency VSD/Docker tests passed; 8 process-concurrency tests passed separately after one transient memory-allocation failure in the initial all-at-once run**

The live report is a dated conformance observation, not a permanent statement about an external service. Exact timestamps, URLs, response status/media, registered metadata, observed metadata, rejection reasons, and hashes are retained so the run can be reviewed and repeated.

## Stack and combined review

This PR is intentionally based on #433 because it evaluates the expanded reviewed-catalog discovery and standards qualification paths. The [combined evaluation branch](https://github.com/mims-harvard/ToolUniverse/tree/vsd-complete-evaluation-suite) contains current `main`, every pending VSD phase through this PR, the earlier evaluation portfolios, and the independent administrator-only Docker implementation.
