### PR TITLE
Fix Python executor sandbox regressions

### DIFF
--- a/src/tooluniverse/data/python_executor_tools.json
+++ b/src/tooluniverse/data/python_executor_tools.json
@@ -30,7 +30,7 @@
         "dependencies": {
           "type": "array",
           "items": {"type": "string"},
-          "description": "List of Python packages that the code depends on. Will be checked and optionally installed before execution."
+          "description": "List of exact Python distribution package names, as accepted by pip, that the code depends on (for example, scikit-learn or onnxruntime-gpu). Distribution names are checked and optionally installed before execution; do not use import submodule names."
         },
         "auto_install_dependencies": {
           "type": "boolean",
@@ -186,7 +186,7 @@
         "dependencies": {
           "type": "array",
           "items": {"type": "string"},
-          "description": "List of Python packages that the script depends on. Will be checked and optionally installed before execution."
+          "description": "List of exact Python distribution package names, as accepted by pip, that the script depends on (for example, scikit-learn or onnxruntime-gpu). Distribution names are checked and optionally installed before execution; do not use import submodule names."
         },
         "auto_install_dependencies": {
           "type": "boolean",

--- a/src/tooluniverse/data/python_executor_tools.json
+++ b/src/tooluniverse/data/python_executor_tools.json
@@ -27,11 +27,6 @@
           "description": "Variable name to extract as result from the executed code",
           "default": "result"
         },
-        "allowed_imports": {
-          "type": "array",
-          "items": {"type": "string"},
-          "description": "Additional allowed modules beyond the default safe set (math, json, datetime, etc.)"
-        },
         "dependencies": {
           "type": "array",
           "items": {"type": "string"},

--- a/src/tooluniverse/python_executor_tool.py
+++ b/src/tooluniverse/python_executor_tool.py
@@ -8,12 +8,15 @@ This module provides two specialized tools for executing Python code:
 
 import ast
 import io
+import locale
 import os
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 import traceback
+from importlib import metadata as importlib_metadata
 from typing import Any, Dict, List, Optional
 
 from .base_tool import BaseTool
@@ -219,6 +222,21 @@ class BasePythonExecutor:
         if "allowed_imports" in tool_config:
             self.allowed_modules.update(tool_config["allowed_imports"])
 
+    def _is_module_allowed(self, name: str) -> bool:
+        """Return whether *name* is an allowed module or one of its submodules."""
+        if name in self.allowed_modules:
+            return True
+
+        for allowed in self.allowed_modules:
+            prefix = f"{allowed}."
+            if name.startswith(prefix):
+                submodule_parts = name[len(prefix) :].split(".")
+                return not any(
+                    self._is_dangerous_attribute(part) for part in submodule_parts
+                )
+
+        return False
+
     @staticmethod
     def _is_dunder(name: Any) -> bool:
         """Return True for double-underscore names like ``__class__``.
@@ -323,7 +341,7 @@ class BasePythonExecutor:
         # Create safe __import__ function
         def safe_import(name, globals=None, locals=None, fromlist=(), level=0):
             """Safe import function that only allows pre-approved modules."""
-            if name in self.allowed_modules:
+            if self._is_module_allowed(name):
                 return __import__(name, globals, locals, fromlist, level)
             else:
                 raise ImportError(
@@ -515,64 +533,29 @@ class BasePythonExecutor:
         print(f"📦 Checking dependencies: {dependencies}")
 
         for package in dependencies:
-            # Try multiple import strategies
-            import_success = False
+            # Dependencies are distribution names passed to pip, not necessarily
+            # import-package names. Checking imports conflates distributions that
+            # expose the same module (for example onnxruntime and
+            # onnxruntime-gpu), so consult installed distribution metadata.
+            distribution_names = [package]
+            if "." in package:
+                distribution_names.append(package.split(".")[0])
 
-            # Strategy 1: Direct package name
-            try:
-                __import__(package.replace("-", "_"))
-                print(f"   ✅ {package} is installed (direct import)")
-                import_success = True
-            except ImportError:
-                pass
-
-            # Strategy 2: Try common submodule patterns
-            if not import_success:
-                patterns = [
-                    package.replace("-", "_"),
-                    package.replace("-", ""),
-                    package.split("-")[0],  # For packages like 'keggtools' -> 'kegg'
-                ]
-
-                for pattern in patterns:
-                    try:
-                        __import__(pattern)
-                        print(f"   ✅ {package} is installed (as {pattern})")
-                        import_success = True
-                        break
-                    except ImportError:
-                        continue
-
-            # Strategy 3: Check if it's a submodule (e.g., keggtools.api)
-            if not import_success and "." in package:
+            installed_distribution = None
+            for distribution_name in distribution_names:
                 try:
-                    __import__(package)
-                    print(f"   ✅ {package} is installed (submodule)")
-                    import_success = True
-                except ImportError:
-                    pass
+                    importlib_metadata.version(distribution_name)
+                    installed_distribution = distribution_name
+                    break
+                except importlib_metadata.PackageNotFoundError:
+                    continue
 
-            # Strategy 4: Check parent package for submodules
-            if not import_success and "." in package:
-                parent_package = package.split(".")[0]
-                try:
-                    parent_module = __import__(parent_package)
-                    # Try to access the submodule
-                    submodule_name = package.split(".")[1]
-                    if hasattr(parent_module, submodule_name):
-                        print(
-                            f"   ✅ {package} is available (submodule of {parent_package})"
-                        )
-                        import_success = True
-                    else:
-                        # Try importing the submodule directly
-                        __import__(package)
-                        print(f"   ✅ {package} is installed (submodule)")
-                        import_success = True
-                except ImportError:
-                    pass
-
-            if not import_success:
+            if installed_distribution:
+                print(
+                    f"   ✅ {package} is installed "
+                    f"(distribution: {installed_distribution})"
+                )
+            else:
                 print(f"   ❌ {package} is not installed")
                 missing_packages.append(package)
 
@@ -634,11 +617,11 @@ class BasePythonExecutor:
 
                     # Verify installation
                     try:
-                        __import__(package_to_install.replace("-", "_"))
-                        print(f"   ✅ {package_to_install} import verified")
-                    except ImportError:
+                        importlib_metadata.version(package_to_install)
+                        print(f"   ✅ {package_to_install} installation verified")
+                    except importlib_metadata.PackageNotFoundError:
                         print(
-                            f"   ⚠️ {package_to_install} installed but import may need different name"
+                            f"   ⚠️ {package_to_install} installed but distribution metadata was not found"
                         )
                 else:
                     print(
@@ -697,6 +680,16 @@ class PythonCodeExecutor(BasePythonExecutor, BaseTool):
             # boundary configured via tool_config["allowed_imports"]. It must
             # NOT be widened by caller-supplied arguments, or a caller could
             # allowlist os/subprocess and disable the sandbox before it runs.
+            if "allowed_imports" in arguments:
+                error_response = self._format_error_response(
+                    ValueError(
+                        "allowed_imports cannot be set per call; import permissions "
+                        "must be configured by the server administrator"
+                    ),
+                    "SecurityError",
+                    execution_time=0,
+                )
+                return {"status": "error", "data": error_response}
 
             # Check AST safety
             is_safe, ast_warnings = self._check_ast_safety(code)
@@ -875,46 +868,61 @@ class PythonScriptRunner(BasePythonExecutor, BaseTool):
             # Execute in subprocess
             start_time = time.time()
 
-            try:
-                result = subprocess.run(
-                    cmd,
-                    cwd=working_dir,
-                    env=restricted_env,
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                )
-
-                execution_time = time.time() - start_time
-
-                if result.returncode == 0:
-                    success_response = self._format_success_response(
-                        f"Script executed successfully "
-                        f"(exit code: {result.returncode})",
-                        result.stdout,
-                        result.stderr,
-                        execution_time,
-                        code_lines=0,  # Not easily measurable for external scripts
+            # File-backed output avoids waiting for pipe EOF after the child
+            # has exited. That can hang on Windows when another process
+            # inherits a duplicate pipe writer. It also lets us return output
+            # already written when the process times out.
+            with (
+                tempfile.TemporaryFile() as stdout_file,
+                tempfile.TemporaryFile() as stderr_file,
+            ):
+                try:
+                    result = subprocess.run(
+                        cmd,
+                        cwd=working_dir,
+                        env=restricted_env,
+                        stdin=subprocess.DEVNULL,
+                        stdout=stdout_file,
+                        stderr=stderr_file,
+                        close_fds=True,
+                        timeout=timeout,
                     )
-                    return {"status": "success", "data": success_response}
-                else:
+                except subprocess.TimeoutExpired:
+                    execution_time = time.time() - start_time
+                    stdout = self._read_subprocess_output(stdout_file)
+                    stderr = self._read_subprocess_output(stderr_file)
                     error_response = self._format_error_response(
-                        RuntimeError(
-                            f"Script failed with exit code {result.returncode}"
+                        TimeoutError(
+                            f"Script execution timed out after {timeout} seconds"
                         ),
-                        "RuntimeError",
-                        result.stdout,
-                        result.stderr,
+                        "TimeoutError",
+                        stdout,
+                        stderr,
                         execution_time,
                     )
                     return {"status": "error", "data": error_response}
 
-            except subprocess.TimeoutExpired:
-                execution_time = time.time() - start_time
+                stdout = self._read_subprocess_output(stdout_file)
+                stderr = self._read_subprocess_output(stderr_file)
+
+            execution_time = time.time() - start_time
+
+            if result.returncode == 0:
+                success_response = self._format_success_response(
+                    f"Script executed successfully (exit code: {result.returncode})",
+                    stdout,
+                    stderr,
+                    execution_time,
+                    code_lines=0,  # Not easily measurable for external scripts
+                )
+                return {"status": "success", "data": success_response}
+            else:
                 error_response = self._format_error_response(
-                    TimeoutError(f"Script execution timed out after {timeout} seconds"),
-                    "TimeoutError",
-                    execution_time=execution_time,
+                    RuntimeError(f"Script failed with exit code {result.returncode}"),
+                    "RuntimeError",
+                    stdout,
+                    stderr,
+                    execution_time,
                 )
                 return {"status": "error", "data": error_response}
 
@@ -923,3 +931,12 @@ class PythonScriptRunner(BasePythonExecutor, BaseTool):
                 e, type(e).__name__, execution_time=0
             )
             return {"status": "error", "data": error_response}
+
+    @staticmethod
+    def _read_subprocess_output(output_file) -> str:
+        """Read a binary subprocess capture using the platform text encoding."""
+        output_file.flush()
+        output_file.seek(0)
+        return output_file.read().decode(
+            locale.getpreferredencoding(False), errors="replace"
+        )

--- a/src/tooluniverse/python_executor_tool.py
+++ b/src/tooluniverse/python_executor_tool.py
@@ -277,6 +277,38 @@ class BasePythonExecutor:
                     ):
                         warnings.append(f"Forbidden import: {alias.name}")
 
+            elif isinstance(node, ast.ImportFrom):
+                module_name = node.module or ""
+                module_parts = module_name.split(".") if module_name else []
+                module_root = module_parts[0] if module_parts else ""
+
+                if (
+                    module_root in self.FORBIDDEN_AST_NODES["Import"]
+                    and module_root not in self.allowed_modules
+                ):
+                    warnings.append(f"Forbidden import: {module_name}")
+
+                dangerous_module_parts = [
+                    part
+                    for part in module_parts[1:]
+                    if self._is_dangerous_attribute(part)
+                ]
+                if dangerous_module_parts:
+                    warnings.append(
+                        f"Forbidden import path (sandbox escape): {module_name}"
+                    )
+
+                for alias in node.names:
+                    if alias.name == "*":
+                        warnings.append(
+                            "Forbidden wildcard import: imported names cannot be "
+                            "validated safely"
+                        )
+                    elif self._is_dangerous_attribute(alias.name):
+                        warnings.append(
+                            f"Forbidden imported name (sandbox escape): {alias.name}"
+                        )
+
             # Check for forbidden function calls
             elif isinstance(node, ast.Call):
                 if isinstance(node.func, ast.Name):
@@ -510,13 +542,6 @@ class BasePythonExecutor:
             },
         }
 
-    def _get_package_to_install(self, package: str) -> str:
-        """Get the actual package name to install (parent package for submodules)"""
-        if "." in package:
-            # For submodules like 'keggtools.keggrest', install the parent package 'keggtools'
-            return package.split(".")[0]
-        return package
-
     def _check_and_install_dependencies(
         self,
         dependencies: List[str],
@@ -537,25 +562,10 @@ class BasePythonExecutor:
             # import-package names. Checking imports conflates distributions that
             # expose the same module (for example onnxruntime and
             # onnxruntime-gpu), so consult installed distribution metadata.
-            distribution_names = [package]
-            if "." in package:
-                distribution_names.append(package.split(".")[0])
-
-            installed_distribution = None
-            for distribution_name in distribution_names:
-                try:
-                    importlib_metadata.version(distribution_name)
-                    installed_distribution = distribution_name
-                    break
-                except importlib_metadata.PackageNotFoundError:
-                    continue
-
-            if installed_distribution:
-                print(
-                    f"   ✅ {package} is installed "
-                    f"(distribution: {installed_distribution})"
-                )
-            else:
+            try:
+                importlib_metadata.version(package)
+                print(f"   ✅ {package} distribution is installed")
+            except importlib_metadata.PackageNotFoundError:
                 print(f"   ❌ {package} is not installed")
                 missing_packages.append(package)
 
@@ -564,11 +574,10 @@ class BasePythonExecutor:
 
         print(f"\n⚠️  Missing packages: {missing_packages}")
 
-        # Get packages to actually install (parent packages for submodules)
-        packages_to_install = [
-            self._get_package_to_install(pkg) for pkg in missing_packages
-        ]
-        packages_to_install = list(set(packages_to_install))  # Remove duplicates
+        # Preserve exact distribution identities and caller order. Distribution
+        # names may legitimately contain dots, so they must not be truncated as
+        # though they were import submodules.
+        packages_to_install = list(dict.fromkeys(missing_packages))
 
         # Handle missing packages
         if not auto_install:
@@ -934,9 +943,10 @@ class PythonScriptRunner(BasePythonExecutor, BaseTool):
 
     @staticmethod
     def _read_subprocess_output(output_file) -> str:
-        """Read a binary subprocess capture using the platform text encoding."""
+        """Read binary subprocess output with ``text=True`` newline semantics."""
         output_file.flush()
         output_file.seek(0)
-        return output_file.read().decode(
+        output = output_file.read().decode(
             locale.getpreferredencoding(False), errors="replace"
         )
+        return output.replace("\r\n", "\n").replace("\r", "\n")

--- a/src/tooluniverse/tools/python_code_executor.py
+++ b/src/tooluniverse/tools/python_code_executor.py
@@ -13,7 +13,6 @@ def python_code_executor(
     arguments: Optional[dict[str, Any]] = None,
     timeout: Optional[int] = 30,
     return_variable: Optional[str] = "result",
-    allowed_imports: Optional[list[str]] = None,
     dependencies: Optional[list[str]] = None,
     auto_install_dependencies: Optional[bool] = False,
     require_confirmation: Optional[bool] = True,
@@ -35,8 +34,6 @@ def python_code_executor(
         Execution timeout in seconds
     return_variable : str
         Variable name to extract as result from the executed code
-    allowed_imports : list[str]
-        Additional allowed modules beyond the default safe set (math, json, datetime,...
     dependencies : list[str]
         List of Python packages that the code depends on. Will be checked and optiona...
     auto_install_dependencies : bool
@@ -64,7 +61,6 @@ def python_code_executor(
             "arguments": arguments,
             "timeout": timeout,
             "return_variable": return_variable,
-            "allowed_imports": allowed_imports,
             "dependencies": dependencies,
             "auto_install_dependencies": auto_install_dependencies,
             "require_confirmation": require_confirmation,

--- a/src/tooluniverse/tools/python_code_executor.py
+++ b/src/tooluniverse/tools/python_code_executor.py
@@ -35,7 +35,7 @@ def python_code_executor(
     return_variable : str
         Variable name to extract as result from the executed code
     dependencies : list[str]
-        List of Python packages that the code depends on. Will be checked and optiona...
+        List of exact Python distribution package names, as accepted by pip, that the...
     auto_install_dependencies : bool
         Whether to automatically install missing dependencies without user confirmation
     require_confirmation : bool

--- a/src/tooluniverse/tools/python_script_runner.py
+++ b/src/tooluniverse/tools/python_script_runner.py
@@ -38,7 +38,7 @@ def python_script_runner(
     env_vars : dict[str, Any]
         Environment variables to set for script execution
     dependencies : list[str]
-        List of Python packages that the script depends on. Will be checked and optio...
+        List of exact Python distribution package names, as accepted by pip, that the...
     auto_install_dependencies : bool
         Whether to automatically install missing dependencies without user confirmation
     require_confirmation : bool

--- a/tests/unit/test_python_executor_regressions.py
+++ b/tests/unit/test_python_executor_regressions.py
@@ -1,0 +1,154 @@
+"""Regression tests for Python executor sandbox and subprocess behavior."""
+
+import json
+import time
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.python_executor_tool import PythonCodeExecutor, PythonScriptRunner
+
+pytestmark = pytest.mark.unit
+
+
+def _code_executor():
+    return PythonCodeExecutor({"name": "python_code_executor"})
+
+
+def _script_runner():
+    return PythonScriptRunner({"name": "python_script_runner"})
+
+
+def test_allowed_imports_is_not_exposed_in_tool_schema():
+    """The MCP schema must not advertise caller-controlled import permissions."""
+    config_path = (
+        Path(__file__).parents[2]
+        / "src"
+        / "tooluniverse"
+        / "data"
+        / "python_executor_tools.json"
+    )
+    config = json.loads(config_path.read_text())
+
+    assert "allowed_imports" not in config[0]["parameter"]["properties"]
+
+
+def test_caller_allowed_imports_is_rejected_explicitly():
+    """Legacy calls that bypass schema validation must receive a clear error."""
+    result = _code_executor().run(
+        {
+            "code": "import time\nresult = time.time()",
+            "allowed_imports": ["time"],
+        }
+    )
+
+    assert result["status"] == "error"
+    assert result["data"]["error_type"] == "SecurityError"
+    assert "cannot be set per call" in result["data"]["error"]
+
+
+def test_allowed_package_submodules_are_importable():
+    """Allowlisting a package must also allow its internal submodules."""
+    executor = _code_executor()
+    safe_import = executor._create_safe_globals()["__builtins__"]["__import__"]
+
+    imported = safe_import("numpy._core._methods")
+
+    assert imported.__name__ == "numpy"
+
+
+def test_module_prefix_must_end_at_package_boundary():
+    """A package-name prefix without a dot must not bypass the allowlist."""
+    executor = _code_executor()
+    safe_import = executor._create_safe_globals()["__builtins__"]["__import__"]
+
+    with pytest.raises(ImportError, match="is not allowed"):
+        safe_import("numpymalicious")
+
+
+def test_dangerous_allowed_package_submodule_remains_blocked():
+    """Package-prefix matching must not expose an FFI sandbox escape."""
+    executor = _code_executor()
+    safe_import = executor._create_safe_globals()["__builtins__"]["__import__"]
+
+    with pytest.raises(ImportError, match="is not allowed"):
+        safe_import("numpy.ctypeslib")
+
+
+def test_script_runner_completes_and_captures_output(tmp_path):
+    """A trivial script must exit promptly and return its stdout."""
+    script = tmp_path / "trivial.py"
+    script.write_text('print("hello")\n')
+
+    started = time.monotonic()
+    result = _script_runner().run(
+        {
+            "script_path": str(script),
+            "working_directory": str(tmp_path),
+            "timeout": 5,
+        }
+    )
+
+    assert time.monotonic() - started < 5
+    assert result["status"] == "success"
+    assert result["data"]["stdout"] == "hello\n"
+
+
+def test_script_runner_returns_partial_output_on_timeout(tmp_path):
+    """Output flushed before a timeout must be returned to the caller."""
+    script = tmp_path / "timeout.py"
+    script.write_text(
+        "import sys\n"
+        "import time\n"
+        'print("stdout-before-timeout", flush=True)\n'
+        'print("stderr-before-timeout", file=sys.stderr, flush=True)\n'
+        "time.sleep(10)\n"
+    )
+
+    result = _script_runner().run(
+        {
+            "script_path": str(script),
+            "working_directory": str(tmp_path),
+            "timeout": 0.2,
+        }
+    )
+
+    assert result["status"] == "error"
+    assert result["data"]["error_type"] == "TimeoutError"
+    assert result["data"]["stdout"] == "stdout-before-timeout\n"
+    assert result["data"]["stderr"] == "stderr-before-timeout\n"
+
+
+def test_dependency_check_distinguishes_cpu_and_gpu_distributions(monkeypatch):
+    """The CPU distribution must not satisfy an onnxruntime-gpu dependency."""
+
+    def fake_version(distribution_name):
+        if distribution_name == "onnxruntime":
+            return "1.28.0"
+        raise importlib_metadata.PackageNotFoundError(distribution_name)
+
+    monkeypatch.setattr(importlib_metadata, "version", fake_version)
+
+    result = _code_executor()._check_and_install_dependencies(
+        ["onnxruntime-gpu"], auto_install=False, require_confirmation=True
+    )
+
+    assert result["success"] is False
+    assert result["missing_packages"] == ["onnxruntime-gpu"]
+    assert result["packages_to_install"] == ["onnxruntime-gpu"]
+
+
+def test_dependency_check_accepts_exact_distribution(monkeypatch):
+    """An exact installed distribution name must satisfy the dependency check."""
+
+    def fake_version(distribution_name):
+        if distribution_name == "onnxruntime":
+            return "1.28.0"
+        raise importlib_metadata.PackageNotFoundError(distribution_name)
+
+    monkeypatch.setattr(importlib_metadata, "version", fake_version)
+
+    result = _code_executor()._check_and_install_dependencies(["onnxruntime"])
+
+    assert result["success"] is True

--- a/tests/unit/test_python_executor_regressions.py
+++ b/tests/unit/test_python_executor_regressions.py
@@ -2,6 +2,7 @@
 
 import json
 import time
+from concurrent.futures import ThreadPoolExecutor
 from importlib import metadata as importlib_metadata
 from pathlib import Path
 
@@ -76,6 +77,50 @@ def test_dangerous_allowed_package_submodule_remains_blocked():
         safe_import("numpy.ctypeslib")
 
 
+@pytest.mark.parametrize(
+    "code",
+    [
+        "from numpy import ctypeslib\nresult = 1",
+        "from numpy.ctypeslib import load_library\nresult = 1",
+        "from random import _os\nresult = _os.name",
+        "from collections import _sys\nresult = 1",
+    ],
+)
+def test_dangerous_from_imports_are_blocked(code):
+    """ImportFrom aliases must not bypass dangerous module-pivot checks."""
+    result = _code_executor().run({"code": code})
+
+    assert result["status"] == "error"
+    assert result["data"]["error_type"] == "SecurityError"
+    assert "Forbidden import" in result["data"]["error"]
+
+
+def test_wildcard_from_import_is_blocked():
+    """Wildcard imports must not inject unvalidated dangerous module aliases."""
+    result = _code_executor().run(
+        {"code": "from numpy import *\nresult = int(array([1, 2]).sum())"}
+    )
+
+    assert result["status"] == "error"
+    assert result["data"]["error_type"] == "SecurityError"
+    assert "Forbidden wildcard import" in result["data"]["error"]
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        ("from numpy import array\nresult = int(array([1, 2]).sum())", 3),
+        ("from numpy._core import _methods\nresult = 1", 1),
+    ],
+)
+def test_safe_from_imports_still_work(code, expected):
+    """The ImportFrom hardening must preserve ordinary scientific imports."""
+    result = _code_executor().run({"code": code})
+
+    assert result["status"] == "success", result["data"].get("error")
+    assert result["data"]["result"] == expected
+
+
 def test_script_runner_completes_and_captures_output(tmp_path):
     """A trivial script must exit promptly and return its stdout."""
     script = tmp_path / "trivial.py"
@@ -120,6 +165,79 @@ def test_script_runner_returns_partial_output_on_timeout(tmp_path):
     assert result["data"]["stderr"] == "stderr-before-timeout\n"
 
 
+def test_script_runner_preserves_output_on_nonzero_exit(tmp_path):
+    """A failed child must still return both diagnostic output streams."""
+    script = tmp_path / "failure.py"
+    script.write_text(
+        "import sys\n"
+        'print("stdout-before-failure")\n'
+        'print("stderr-before-failure", file=sys.stderr)\n'
+        "raise SystemExit(7)\n"
+    )
+
+    result = _script_runner().run(
+        {
+            "script_path": str(script),
+            "working_directory": str(tmp_path),
+            "timeout": 5,
+        }
+    )
+
+    assert result["status"] == "error"
+    assert result["data"]["error_type"] == "RuntimeError"
+    assert result["data"]["stdout"] == "stdout-before-failure\n"
+    assert result["data"]["stderr"] == "stderr-before-failure\n"
+
+
+def test_subprocess_output_keeps_text_mode_newline_normalization(tmp_path):
+    """File-backed capture must retain the old text-mode newline behavior."""
+    capture_path = tmp_path / "capture.bin"
+    capture_path.write_bytes(b"first\r\nsecond\rthird\n")
+
+    with capture_path.open("rb") as capture:
+        output = PythonScriptRunner._read_subprocess_output(capture)
+
+    assert output == "first\nsecond\nthird\n"
+
+
+def test_script_runner_handles_output_larger_than_pipe_buffers(tmp_path):
+    """Large stdout/stderr payloads must complete without a pipe deadlock."""
+    script = tmp_path / "large_output.py"
+    script.write_text(
+        'import sys\nsys.stdout.write("x" * 262144)\nsys.stderr.write("y" * 262144)\n'
+    )
+
+    result = _script_runner().run(
+        {
+            "script_path": str(script),
+            "working_directory": str(tmp_path),
+            "timeout": 5,
+        }
+    )
+
+    assert result["status"] == "success"
+    assert result["data"]["stdout"] == "x" * 262144
+    assert result["data"]["stderr"] == "y" * 262144
+
+
+def test_script_runner_supports_concurrent_calls(tmp_path):
+    """Concurrent runner calls must keep captures isolated and terminate."""
+    script = tmp_path / "concurrent.py"
+    script.write_text('print("concurrent-output")\n')
+    runner = _script_runner()
+    arguments = {
+        "script_path": str(script),
+        "working_directory": str(tmp_path),
+        "timeout": 5,
+    }
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: runner.run(arguments), range(16)))
+
+    assert all(result["status"] == "success" for result in results)
+    assert all(result["data"]["stdout"] == "concurrent-output\n" for result in results)
+
+
 def test_dependency_check_distinguishes_cpu_and_gpu_distributions(monkeypatch):
     """The CPU distribution must not satisfy an onnxruntime-gpu dependency."""
 
@@ -152,3 +270,22 @@ def test_dependency_check_accepts_exact_distribution(monkeypatch):
     result = _code_executor()._check_and_install_dependencies(["onnxruntime"])
 
     assert result["success"] is True
+
+
+def test_dependency_check_does_not_truncate_dotted_distribution(monkeypatch):
+    """An installed parent distribution must not satisfy a dotted name."""
+
+    def fake_version(distribution_name):
+        if distribution_name == "example":
+            return "1.0.0"
+        raise importlib_metadata.PackageNotFoundError(distribution_name)
+
+    monkeypatch.setattr(importlib_metadata, "version", fake_version)
+
+    result = _code_executor()._check_and_install_dependencies(
+        ["example.plugin"], auto_install=False, require_confirmation=True
+    )
+
+    assert result["success"] is False
+    assert result["missing_packages"] == ["example.plugin"]
+    assert result["packages_to_install"] == ["example.plugin"]

--- a/tests/unit/test_security_advisory_fixes.py
+++ b/tests/unit/test_security_advisory_fixes.py
@@ -37,10 +37,11 @@ def _run(code, **extra):
 
 
 def test_caller_cannot_widen_import_allowlist():
-    """`allowed_imports` in call arguments must not enable `import os`."""
+    """`allowed_imports` in call arguments must be explicitly rejected."""
     result = _run("import os\nprint(os.getuid())", allowed_imports=["os", "subprocess"])
     assert result["status"] == "error"
-    assert "Forbidden import: os" in result["data"]["error"]
+    assert result["data"]["error_type"] == "SecurityError"
+    assert "allowed_imports cannot be set per call" in result["data"]["error"]
 
 
 def test_server_config_allowlist_still_respected():


### PR DESCRIPTION
## Summary

Fix four reported regressions in `python_code_executor` and `python_script_runner`:

- remove the caller-facing `allowed_imports` parameter and explicitly reject legacy calls that try to set it, while preserving server-side allowlist configuration as the trust boundary
- allow safe submodules of allowlisted packages (for example `numpy._core._methods`) while blocking dangerous module paths, explicit imported names, and wildcard-import injection such as `from numpy import ctypeslib` and `from numpy import *`
- capture script output in temporary files instead of pipes, preventing Windows pipe-handle EOF hangs and preserving stdout/stderr on timeout and nonzero exit
- check exact dependency distribution metadata rather than guessed import names, so a CPU-only `onnxruntime` installation does not satisfy `onnxruntime-gpu` and dotted distribution names are not truncated

The JSON descriptions and both generated executor wrappers were refreshed.

## Root causes

1. A prior sandbox hardening correctly stopped per-call allowlist expansion, but the public schema and generated wrapper still advertised the parameter, making it a silent no-op.
2. The safe importer used exact module-name matching, so legitimate lazy imports below an allowlisted package could be rejected. Prefix matching also required corresponding AST checks so `ImportFrom` and wildcard imports could not expose dangerous transitive modules.
3. `subprocess.run(capture_output=True)` depended on pipe EOF and the timeout handler discarded captured output. File-backed output avoids pipe-buffer and inherited-writer deadlocks while retaining diagnostics.
4. Dependency detection normalized distribution names into import candidates and truncated dotted names, conflating distinct distributions and changing caller-supplied package identities.

## Impact

Callers now get an explicit security error for obsolete `allowed_imports` use, supported scientific packages can import safe internal modules, unsafe import pivots remain blocked, scripts no longer depend on pipe EOF and retain diagnostics, and optional dependencies are reported by exact distribution identity.

## Validation

- [x] `PYTHONPATH=src pytest -o addopts='' tests/unit/test_python_executor_regressions.py tests/unit/test_security_advisory_fixes.py tests/unit/test_generate_tools_types.py -q` — 80 passed
- [x] subprocess stress coverage: 256 KiB on each output stream, 16 concurrent calls, timeout partial output, nonzero-exit diagnostics, and Windows-compatible newline normalization
- [x] import-security coverage: legitimate NumPy lazy/from imports; dangerous submodule, imported-name, prefix, and wildcard-import rejection
- [x] dependency coverage: exact CPU/GPU distribution distinction and dotted distribution identity preservation
- [x] `PYTHONPATH=src python scripts/test_new_tools.py python_executor -v` — 7/7 examples passed; schemas valid
- [x] generated wrapper/type tests — 18 passed
- [x] `ruff check`, `ruff format --check`, `compileall`, and `git diff --check`
