### PR TITLE
Validate documentation examples recursively

### DIFF
--- a/docs/MCP_TASKS_GUIDE.md
+++ b/docs/MCP_TASKS_GUIDE.md
@@ -135,8 +135,10 @@ The system detects your execution context using `asyncio.get_running_loop()`:
 try:
     asyncio.get_running_loop()
     # Async context - use await
+    pass
 except RuntimeError:
     # Sync context - blocking execution
+    pass
 ```
 
 ### Execution Modes

--- a/docs/dev_docs/Adding_Tools_Tutorial.md
+++ b/docs/dev_docs/Adding_Tools_Tutorial.md
@@ -282,6 +282,8 @@ The `config` parameter in the decorator supports all standard ToolUniverse confi
        "custom_field": "value"
    }
 })
+class AdvancedTool:
+   ...
 ```
 
 .. _method-2-manual-registration:
@@ -821,7 +823,7 @@ return {
 1. Ensure file ends with `_tool.py`
 2. Check file is in the correct directory
 3. Verify the import doesn't fail:
-  ```python
+  ```bash
   python -c "from your_tool_module import YourTool"
   ```
 
@@ -856,6 +858,8 @@ return {
 2. Validate all inputs in `run()` method
 3. Return error details:
   ```python
+  try:
+      result = tool.run(arguments)
   except Exception as e:
       return {
           "error": str(e),

--- a/docs/dev_docs/FULLTEXT_ACCESS_GUIDE.md
+++ b/docs/dev_docs/FULLTEXT_ACCESS_GUIDE.md
@@ -270,7 +270,7 @@ Semantic Scholar and ArXiv have rate limits:
 import time
 
 for paper in papers:
-   snippets = tu.run({"name": "ArXiv_get_pdf_snippets", "arguments": {"arxiv_id": paper["arxiv_id"], terms=terms}})
+   snippets = tu.run({"name": "ArXiv_get_pdf_snippets", "arguments": {"arxiv_id": paper["arxiv_id"], "terms": terms}})
    # ArXiv requests 3s between calls
    time.sleep(3.1)
 ```
@@ -318,7 +318,7 @@ pip install 'markitdown[all]>=0.1.0'
 **Debug:**
 
 ```python
-results = tu.run({"name": "EuropePMC_search_articles", "arguments": {"query": "...", limit=10}})
+results = tu.run({"name": "EuropePMC_search_articles", "arguments": {"query": "...", "limit": 10}})
 
 for r in results:
    print(f"Title: {r['title']}")
@@ -339,7 +339,7 @@ for r in results:
 ```python
 # For Semantic Scholar: verify OA status
 if paper.get("open_access") and paper.get("open_access_pdf_url"):
-   # Proceed
+   process_open_access_pdf(paper["open_access_pdf_url"])
 
 # For ArXiv: ensure correct ID format
 arxiv_id = "2301.12345"  # Not "arXiv:2301.12345v1"

--- a/docs/dev_docs/SEARCHING_BIORXIV.md
+++ b/docs/dev_docs/SEARCHING_BIORXIV.md
@@ -63,6 +63,7 @@ result = tu.run({"name": "web_search", "arguments": {
 for item in (result or {}).get('data', []):
    # Parse DOI from URL or text
    # Then use BioRxiv_get_preprint
+   process_preprint_result(item)
 ```
 
 ### Option 3: Use Semantic Scholar
@@ -194,7 +195,7 @@ if search and search.get('status') == 'success':
        if doi and doi.startswith('10.1101/'):
            detailed = tu.run({"name": "BioRxiv_get_preprint", "arguments": {"doi": doi}})
            if detailed and detailed.get('status') == 'success':
-           preprints.append(detailed['data'])
+               preprints.append(detailed['data'])
 
 # 3. Access full text if needed
 for preprint in preprints:

--- a/docs/dev_docs/mcp_tool_registration_en.md
+++ b/docs/dev_docs/mcp_tool_registration_en.md
@@ -49,7 +49,7 @@ result = tu.tools.mcp_my_analyzer(
    operation="call_tool",
    tool_name="my_analyzer",
    tool_arguments={"data": "test data"}
-})
+)
 print(result)
 ```
 
@@ -62,6 +62,8 @@ print(result)
    config={"description": "External API wrapper"},
    mcp_config={"port": 8001}
 )
+def registered_tool(param):
+   return param
 class APIService:
    def run(self, arguments):
        import requests
@@ -118,18 +120,26 @@ class DataProcessor:
    },
    mcp_config={"port": 8001}
 )
+def registered_tool(param):
+   return param
 ```
 
 ### Multi-Server Setup
 ```python
 # Text tools on port 8001
 @register_mcp_tool(..., mcp_config={"port": 8001})
+def text_tool():
+   ...
 
 # Data tools on port 8002
 @register_mcp_tool(..., mcp_config={"port": 8002})
+def data_tool():
+   ...
 
 # File tools on port 8003
 @register_mcp_tool(..., mcp_config={"port": 8003})
+def file_tool():
+   ...
 ```
 
 ##  Common Mistakes
@@ -141,6 +151,8 @@ class DataProcessor:
    description="Tool description",  # Wrong!
    mcp_config={"port": 8001}
 )
+def incorrectly_registered_tool():
+   ...
 ```
 
 ###  Correct: New parameter format
@@ -153,6 +165,8 @@ class DataProcessor:
    },
    mcp_config={"port": 8001}
 )
+def correctly_registered_tool():
+   ...
 ```
 
 ###  Wrong: Missing run method
@@ -192,7 +206,7 @@ result = tu.tools.mcp_my_tool(
    operation="call_tool",
    tool_name="my_tool",
    tool_arguments={"param": "test"}
-})
+)
 print(result)
 ```
 
@@ -316,7 +330,7 @@ protein_result = tu.tools.mcp_protein_analyzer(
        "sequence": "MKWVTFISLLFLFSSAYSRGVFRRDAHKSEVAHRFKDLGEENFKALVLIAFAQYLQQCPFEDHVKLVNEVTEFAKTCVADESAENCDKSLHTLFGDKLCTVATLRETYGEMADCCAKQEPERNECFLQHKDDNPNLPRLVRPEVDVMCTAFHDNEETFLKKYLYEIARRHPYFYAPELLFFAKRYKAAFTECCQAADKAACLLPKLDELRDEGKASSAKQRLKCASLQKFGERAFKAWAVARLSQRFPKAEFAEVSKLVTDLTKVHTECCHGDLLECADDRADLAKYICENQDSISSKLKECCEKPLLEKSHCIAEVENDEMPADLPSLAADFVESKDVCKNYAEAKDVFLGMFLYEYARRHPDYSVVLLLRLAKTYETTLEKCCAAADPHECYAKVFDEFKPLVEEPQNLIKQNCELFEQLGEYKFQNALLVRYTKKVPQVSTPTLVEVSRNLGKVGSKCCKHPEAKRMPCAEDYLSVVLNQLCVLHEKTPVSDRVTKCCTESLVNRRPCFSALEVDETYVPKEFNAETFTFHADICTLSEKERQIKKQTALVELVKHKPKATKEQLKAVMDDFAAFVEKCCKADDKETCFAEEGKKLVAASQAALGL",
        "analysis_type": "detailed"
    }
-})
+)
 
 print("🧬 Protein Analysis Result:")
 print(protein_result)
@@ -474,7 +488,7 @@ def main():
        tool_arguments={
            "text": "This tool is amazing! The functionality is excellent and I think it's wonderful."
        }
-   })
+   )
    print(f"📝 Sentiment Analysis: {sentiment_result}")
 
    # Data statistics
@@ -484,7 +498,7 @@ def main():
        tool_arguments={
            "data": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
        }
-   })
+   )
    print(f"📊 Data Statistics: {stats_result}")
 
    # File analysis
@@ -494,7 +508,7 @@ def main():
        tool_arguments={
            "filepath": __file__  # Analyze current file
        }
-   })
+   )
    print(f"📁 File Analysis: {file_result}")
 
    # 4. Show connection status

--- a/docs/expand_tooluniverse/local_tools/local_tools_tutorial.rst
+++ b/docs/expand_tooluniverse/local_tools/local_tools_tutorial.rst
@@ -372,6 +372,8 @@ Add to your config:
            "base_url": "https://api.example.com"
        }
    })
+   class MyAPITool:
+       ...
 
 Then in your run method:
 
@@ -439,8 +441,11 @@ Naming Conflicts (Failed to initialize tool for validation)
 .. code-block:: python
 
    # Wrapper function must use snake_case
-   def my_tool(...):  # ✅ Good
-   def MyTool(...):  # ❌ Bad if class is also called MyTool
+   def my_tool(*args, **kwargs):  # ✅ Good
+       ...
+
+   def MyTool(*args, **kwargs):  # ❌ Bad if class is also called MyTool
+       ...
 
 **Convention**: Class names use PascalCase, wrapper functions use snake_case.
 

--- a/docs/guide/building_ai_scientists/mcp_name_shortening.rst
+++ b/docs/guide/building_ai_scientists/mcp_name_shortening.rst
@@ -260,7 +260,7 @@ ToolUniverse Constructor
 
     ToolUniverse(
         ...,
-        enable_name_shortening: bool = False
+        enable_name_shortening=False
     )
 
 **Parameters:**
@@ -281,7 +281,8 @@ Execute a tool function. Automatically accepts both shortened and original names
 
 .. code-block:: python
 
-    tu.run_one_function(function_call_json: dict, ...) -> dict
+    function_call_json: dict = {"name": "ExampleTool", "arguments": {}}
+    result: dict = tu.run_one_function(function_call_json)
 
 **Behavior:**
 

--- a/docs/guide/http_api.rst
+++ b/docs/guide/http_api.rst
@@ -146,10 +146,11 @@ The server uses Python introspection to automatically discover all public method
     import inspect
 
     # Automatically discovers ALL public methods
-    for name, method in inspect.getmembers(ToolUniverse, inspect.isfunction):
-        if not name.startswith('_'):
-            # Extract signature, parameters, docstring
-            # Methods are now callable via HTTP!
+for name, method in inspect.getmembers(ToolUniverse, inspect.isfunction):
+    if not name.startswith('_'):
+        # Extract signature, parameters, docstring
+        # Methods are now callable via HTTP!
+        register_http_method(name, method)
 
 **Result**: 49+ methods including ``load_tools``, ``prepare_tool_prompts``, ``tool_specification``, ``run_one_function``, etc.
 

--- a/docs/guide/literature_search_tools_tutorial.rst
+++ b/docs/guide/literature_search_tools_tutorial.rst
@@ -168,8 +168,8 @@ All literature search tools follow a similar usage pattern:
     result = tu.run({
         "name": "tool_name",
         "arguments": {
-        "query": "your search terms",
-        "limit": 5  # number of results
+            "query": "your search terms",
+            "limit": 5  # number of results
         }
     })
 
@@ -177,9 +177,9 @@ All literature search tools follow a similar usage pattern:
     if isinstance(result, list) and len(result) > 0:
         print(f"Found {len(result)} results")
         for i, paper in enumerate(result, 1):
-        print(f"{i}. {paper.get('title', 'No title')}")
-        print(f"   Authors: {', '.join(paper.get('authors', [])[:3])}")
-        print(f"   Year: {paper.get('year', 'Unknown')}")
+            print(f"{i}. {paper.get('title', 'No title')}")
+            print(f"   Authors: {', '.join(paper.get('authors', [])[:3])}")
+            print(f"   Year: {paper.get('year', 'Unknown')}")
         
         # Show data quality information
         if 'data_quality' in paper:
@@ -410,22 +410,22 @@ Search across multiple databases for comprehensive results:
         
         # Search different databases
         databases = [
-        ("ArXiv", "ArXiv_search_papers"),
-        ("Crossref", "Crossref_search_works"),
-        ("Semantic Scholar", "SemanticScholar_search_papers"),
-        ("OpenAlex", "openalex_literature_search")
+            ("ArXiv", "ArXiv_search_papers"),
+            ("Crossref", "Crossref_search_works"),
+            ("Semantic Scholar", "SemanticScholar_search_papers"),
+            ("OpenAlex", "openalex_literature_search")
         ]
         
         for db_name, tool_name in databases:
-        try:
-            result = tu.run({
-        "name": tool_name,
-        "arguments": {"query": query, "limit": max_results}
-            })
-            results[db_name] = result if isinstance(result, list) else []
-        except Exception as e:
-            print(f"Error searching {db_name}: {e}")
-            results[db_name] = []
+            try:
+                result = tu.run({
+                    "name": tool_name,
+                    "arguments": {"query": query, "limit": max_results}
+                })
+                results[db_name] = result if isinstance(result, list) else []
+            except Exception as e:
+                print(f"Error searching {db_name}: {e}")
+                results[db_name] = []
         
         return results
 
@@ -484,20 +484,20 @@ Always include proper error handling for robust applications:
     def safe_search(tool_name, arguments):
         """Safely search with error handling."""
         try:
-        result = tu.run({
-            "name": tool_name,
-            "arguments": arguments
-        })
-        
-        if isinstance(result, list):
-            return {"success": True, "data": result, "count": len(result)}
-        elif isinstance(result, dict) and "error" in result:
-            return {"success": False, "error": result["error"]}
-        else:
-            return {"success": False, "error": "Unexpected result format"}
+            result = tu.run({
+                "name": tool_name,
+                "arguments": arguments
+            })
+
+            if isinstance(result, list):
+                return {"success": True, "data": result, "count": len(result)}
+            elif isinstance(result, dict) and "error" in result:
+                return {"success": False, "error": result["error"]}
+            else:
+                return {"success": False, "error": "Unexpected result format"}
             
         except Exception as e:
-        return {"success": False, "error": str(e)}
+            return {"success": False, "error": str(e)}
 
     # Use safe search
     result = safe_search("ArXiv_search_papers", {
@@ -508,7 +508,7 @@ Always include proper error handling for robust applications:
     if result["success"]:
         print(f"Found {result['count']} papers")
         for paper in result["data"]:
-        print(f"- {paper.get('title', 'No title')}")
+            print(f"- {paper.get('title', 'No title')}")
     else:
         print(f"Search failed: {result['error']}")
 
@@ -571,26 +571,26 @@ Here's a complete example that demonstrates searching across multiple literature
         
         # Define tools to search
         search_tools = [
-        {
-            "name": "ArXiv_search_papers",
-            "description": "ArXiv Preprints",
-            "args": {"query": query, "limit": 2, "sort_by": "relevance"}
-        },
-        {
-            "name": "Crossref_search_works",
-            "description": "Crossref Articles", 
-            "args": {"query": query, "limit": 2}
-        },
-        {
-            "name": "SemanticScholar_search_papers",
-            "description": "Semantic Scholar",
-            "args": {"query": query, "limit": 2}
-        },
-        {
-            "name": "openalex_literature_search",
-            "description": "OpenAlex",
-            "args": {"search_keywords": query, "max_results": 2}
-        }
+            {
+                "name": "ArXiv_search_papers",
+                "description": "ArXiv Preprints",
+                "args": {"query": query, "limit": 2, "sort_by": "relevance"}
+            },
+            {
+                "name": "Crossref_search_works",
+                "description": "Crossref Articles",
+                "args": {"query": query, "limit": 2}
+            },
+            {
+                "name": "SemanticScholar_search_papers",
+                "description": "Semantic Scholar",
+                "args": {"query": query, "limit": 2}
+            },
+            {
+                "name": "openalex_literature_search",
+                "description": "OpenAlex",
+                "args": {"search_keywords": query, "max_results": 2}
+            }
         ]
         
         print(f"Searching for: '{query}'")
@@ -599,32 +599,32 @@ Here's a complete example that demonstrates searching across multiple literature
         all_results = []
         
         for tool in search_tools:
-        print(f"\nSearching {tool['description']}...")
-        
-        try:
-            result = tu.run({
-        "name": tool["name"],
-        "arguments": tool["args"]
-            })
+            print(f"\nSearching {tool['description']}...")
             
-            if isinstance(result, list) and len(result) > 0:
-        print(f"✅ Found {len(result)} results")
-        all_results.extend(result)
-        
-        # Show first result
-        first_paper = result[0]
-        print(f"📄 Sample: {first_paper.get('title', 'No title')[:60]}...")
-            else:
-        print(f"❌ No results or error: {result}")
-        
-        except Exception as e:
-            print(f"❌ Exception: {str(e)[:100]}...")
+            try:
+                result = tu.run({
+                    "name": tool["name"],
+                    "arguments": tool["args"]
+                })
+
+                if isinstance(result, list) and len(result) > 0:
+                    print(f"✅ Found {len(result)} results")
+                    all_results.extend(result)
+
+                    # Show first result
+                    first_paper = result[0]
+                    print(f"📄 Sample: {first_paper.get('title', 'No title')[:60]}...")
+                else:
+                    print(f"❌ No results or error: {result}")
+
+            except Exception as e:
+                print(f"❌ Exception: {str(e)[:100]}...")
         
         print(f"\n📊 Total papers found: {len(all_results)}")
         
         # Save results to file
         with open("literature_search_results.json", "w") as f:
-        json.dump(all_results, f, indent=2, ensure_ascii=False)
+            json.dump(all_results, f, indent=2, ensure_ascii=False)
         
         print("💾 Results saved to literature_search_results.json")
 
@@ -1070,34 +1070,34 @@ Here are examples showing the enhanced features of the optimized tools:
     def analyze_data_quality(results):
         """Analyze data quality across multiple tools."""
         if not isinstance(results, list):
-        return
+            return
         
         total_papers = len(results)
         quality_stats = {
-        'has_abstract': 0,
-        'has_authors': 0,
-        'has_doi': 0,
-        'has_citations': 0,
-        'has_keywords': 0
+            'has_abstract': 0,
+            'has_authors': 0,
+            'has_doi': 0,
+            'has_citations': 0,
+            'has_keywords': 0
         }
         
         for paper in results:
-        if 'data_quality' in paper:
-            for field, available in paper['data_quality'].items():
-        if field in quality_stats and available:
-            quality_stats[field] += 1
+            if 'data_quality' in paper:
+                for field, available in paper['data_quality'].items():
+                    if field in quality_stats and available:
+                        quality_stats[field] += 1
         
         print(f"Data Quality Analysis ({total_papers} papers):")
         for field, count in quality_stats.items():
-        percentage = (count / total_papers) * 100
-        print(f"  {field}: {count}/{total_papers} ({percentage:.1f}%)")
+            percentage = (count / total_papers) * 100
+            print(f"  {field}: {count}/{total_papers} ({percentage:.1f}%)")
     
     # Use with any search results
     result = tu.run({
         "name": "openalex_literature_search",
         "arguments": {
-        "search_keywords": "machine learning",
-        "max_results": 5
+            "search_keywords": "machine learning",
+            "max_results": 5
         }
     })
     

--- a/docs/tools/remote/immune_compass.md
+++ b/docs/tools/remote/immune_compass.md
@@ -174,11 +174,12 @@ Port: 7003 (configured to avoid conflicts with other biomedical tools)
 The server exposes one main tool function:
 
 ```python
-run_compass_prediction(
+def run_compass_prediction(
     gene_expression_data_path: str,
     threshold: float = 0.5,
     root_path: str = None
-)
+):
+    ...
 ```
 
 **Parameters:**

--- a/docs/validate_examples.py
+++ b/docs/validate_examples.py
@@ -1,132 +1,322 @@
 #!/usr/bin/env python3
-"""
-文档示例验证脚本
-自动验证文档中的所有代码示例是否能正确执行
-"""
+"""Validate Python examples embedded in the ToolUniverse documentation."""
 
+from __future__ import annotations
+
+import argparse
 import ast
+import json
 import re
 import sys
-import os
+import textwrap
+from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Iterable
 
 
-def extract_code_blocks(rst_file):
-    """提取RST文件中的Python代码块"""
-    with open(rst_file, "r", encoding="utf-8") as f:
-        content = f.read()
-
-    # 匹配 .. code-block:: python 后的代码
-    pattern = r".. code-block:: python\s*\n\n((?:   .*\n)*)"
-    matches = re.findall(pattern, content, re.MULTILINE)
-
-    code_blocks = []
-    for match in matches:
-        # 移除缩进
-        lines = match.split("\n")
-        cleaned_lines = [line[3:] if line.startswith("   ") else line for line in lines]
-        code = "\n".join(cleaned_lines).strip()
-        if code:
-            code_blocks.append(code)
-
-    return code_blocks
+PYTHON_LANGUAGES = {"py", "python", "python3"}
+DOCUMENT_SUFFIXES = {".md", ".rst"}
+EXCLUDED_DIRECTORIES = {".git", ".venv", "_build", "locale"}
 
 
-def validate_python_syntax(code):
-    """验证Python代码语法"""
-    try:
-        ast.parse(code)
-        return True, None
-    except SyntaxError as e:
-        return False, str(e)
+@dataclass(frozen=True)
+class CodeBlock:
+    path: str
+    line: int
+    code: str
 
 
-def check_imports_availability(code):
-    """检查导入是否可用"""
-    try:
-        # 模拟导入检查
-        import_pattern = r"from\s+(\S+)\s+import|import\s+(\S+)"
-        imports = re.findall(import_pattern, code)
-
-        unavailable_imports = []
-        for from_module, import_module in imports:
-            module = from_module or import_module
-            if module.startswith("tooluniverse"):
-                # 检查tooluniverse模块
-                try:
-                    exec(f"import {module}")
-                except ImportError:
-                    unavailable_imports.append(module)
-
-        return len(unavailable_imports) == 0, unavailable_imports
-    except Exception as e:
-        return False, [str(e)]
+@dataclass(frozen=True)
+class ValidationIssue:
+    path: str
+    line: int
+    kind: str
+    message: str
 
 
-def main():
-    """主函数"""
-    docs_dir = Path(__file__).parent
-    rst_files = list(docs_dir.glob("*.rst"))
+@dataclass(frozen=True)
+class ValidationSummary:
+    files_checked: int
+    blocks_checked: int
+    issues: tuple[ValidationIssue, ...]
 
-    total_files = 0
-    total_code_blocks = 0
-    syntax_errors = 0
-    import_errors = 0
+    @property
+    def valid(self) -> bool:
+        return self.blocks_checked > 0 and not self.issues
 
-    print("🔍 验证文档中的代码示例...")
-    print("=" * 50)
 
-    for rst_file in rst_files:
-        total_files += 1
-        print(f"\n📄 检查文件: {rst_file.name}")
+def _dedent(lines: list[str]) -> str:
+    return textwrap.dedent("\n".join(lines)).strip()
 
-        code_blocks = extract_code_blocks(rst_file)
-        total_code_blocks += len(code_blocks)
 
-        if not code_blocks:
-            print("   ℹ️  无代码块")
+def extract_rst_code_blocks(text: str, path: str) -> list[CodeBlock]:
+    """Extract Python ``code`` and ``code-block`` directives from RST text."""
+    lines = text.splitlines()
+    blocks: list[CodeBlock] = []
+    directive = re.compile(
+        r"^(?P<indent>\s*)\.\.\s+(?:code|code-block)::\s*"
+        r"(?P<language>\S+)\s*$"
+    )
+    index = 0
+
+    while index < len(lines):
+        match = directive.match(lines[index])
+        if not match or match.group("language").lower() not in PYTHON_LANGUAGES:
+            index += 1
             continue
 
-        for i, code in enumerate(code_blocks, 1):
-            print(f"   📝 代码块 {i}:")
-
-            # 语法检查
-            is_valid, error = validate_python_syntax(code)
-            if not is_valid:
-                syntax_errors += 1
-                print(f"      ❌ 语法错误: {error}")
+        base_indent = len(match.group("indent"))
+        cursor = index + 1
+        while cursor < len(lines):
+            stripped = lines[cursor].strip()
+            indent = len(lines[cursor]) - len(lines[cursor].lstrip())
+            if not stripped or (indent > base_indent and stripped.startswith(":")):
+                cursor += 1
                 continue
+            break
 
-            # 导入检查
-            imports_ok, missing = check_imports_availability(code)
-            if not imports_ok:
-                import_errors += 1
-                print(f"      ⚠️  导入问题: {missing}")
-            else:
-                print(f"      ✅ 代码有效")
+        code_start = cursor
+        code_indent = (
+            len(lines[cursor]) - len(lines[cursor].lstrip())
+            if cursor < len(lines)
+            else base_indent + 1
+        )
+        code_lines: list[str] = []
+        while cursor < len(lines):
+            line = lines[cursor]
+            if not line.strip():
+                code_lines.append("")
+                cursor += 1
+                continue
+            indent = len(line) - len(line.lstrip())
+            if indent < code_indent:
+                break
+            code_lines.append(line)
+            cursor += 1
 
-    # 统计报告
-    print("\n" + "=" * 50)
-    print("📊 验证结果统计:")
-    print(f"   📄 检查文件数: {total_files}")
-    print(f"   📝 代码块总数: {total_code_blocks}")
-    print(f"   ❌ 语法错误数: {syntax_errors}")
-    print(f"   ⚠️  导入错误数: {import_errors}")
+        code = _dedent(code_lines)
+        if code:
+            blocks.append(CodeBlock(path=path, line=code_start + 1, code=code))
+        index = max(cursor, index + 1)
 
-    success_rate = (
-        (total_code_blocks - syntax_errors - import_errors) / max(total_code_blocks, 1)
-    ) * 100
-    print(f"   ✅ 成功率: {success_rate:.1f}%")
+    return blocks
 
-    if syntax_errors > 0 or import_errors > 0:
-        print("\n💡 建议:")
-        print("   1. 修复语法错误的代码示例")
-        print("   2. 确保所有导入路径正确")
-        print("   3. 添加实际可执行的示例")
-        return 1
+
+def extract_markdown_code_blocks(text: str, path: str) -> list[CodeBlock]:
+    """Extract Python fenced blocks from Markdown and MyST documents."""
+    lines = text.splitlines()
+    blocks: list[CodeBlock] = []
+    opener = re.compile(
+        r"^\s*(?P<fence>`{3,}|~{3,})\s*"
+        r"(?:\{code-block\}\s*)?(?P<language>[A-Za-z0-9_+-]+)\s*$"
+    )
+    index = 0
+
+    while index < len(lines):
+        match = opener.match(lines[index])
+        if not match or match.group("language").lower() not in PYTHON_LANGUAGES:
+            index += 1
+            continue
+
+        fence = match.group("fence")
+        fence_char = re.escape(fence[0])
+        closer = re.compile(rf"^\s*{fence_char}{{{len(fence)},}}\s*$")
+        code_start = index + 1
+        cursor = code_start
+        code_lines: list[str] = []
+        while cursor < len(lines) and not closer.match(lines[cursor]):
+            code_lines.append(lines[cursor])
+            cursor += 1
+
+        code = _dedent(code_lines)
+        if code:
+            blocks.append(CodeBlock(path=path, line=code_start + 1, code=code))
+        index = cursor + 1 if cursor < len(lines) else cursor
+
+    return blocks
+
+
+def iter_document_files(docs_dir: Path) -> Iterable[Path]:
+    for path in sorted(docs_dir.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in DOCUMENT_SUFFIXES:
+            continue
+        if any(
+            part in EXCLUDED_DIRECTORIES for part in path.relative_to(docs_dir).parts
+        ):
+            continue
+        yield path
+
+
+def extract_code_blocks(path: Path, docs_dir: Path) -> list[CodeBlock]:
+    relative = path.relative_to(docs_dir).as_posix()
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".rst":
+        return extract_rst_code_blocks(text, relative)
+    return extract_markdown_code_blocks(text, relative)
+
+
+def _tooluniverse_imports(tree: ast.AST) -> set[str]:
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return {module for module in modules if module.split(".", 1)[0] == "tooluniverse"}
+
+
+def _module_exists(module: str, package_root: Path) -> bool:
+    parts = module.split(".")
+    if not parts or parts[0] != "tooluniverse":
+        return True
+    if len(parts) == 1:
+        return package_root.is_dir()
+    target = package_root.joinpath(*parts[1:])
+    return target.with_suffix(".py").is_file() or (
+        target.is_dir() and (target / "__init__.py").is_file()
+    )
+
+
+def validate_block(
+    block: CodeBlock,
+    check_imports: bool = True,
+    package_root: Path | None = None,
+) -> list[ValidationIssue]:
+    try:
+        tree = ast.parse(block.code, filename=f"{block.path}:{block.line}")
+    except SyntaxError as exc:
+        relative_line = exc.lineno or 1
+        return [
+            ValidationIssue(
+                path=block.path,
+                line=block.line + relative_line - 1,
+                kind="syntax",
+                message=exc.msg,
+            )
+        ]
+
+    if not check_imports:
+        return []
+
+    issues: list[ValidationIssue] = []
+    package_root = (
+        package_root or Path(__file__).resolve().parents[1] / "src" / "tooluniverse"
+    )
+    for module in sorted(_tooluniverse_imports(tree)):
+        if not _module_exists(module, package_root):
+            issues.append(
+                ValidationIssue(
+                    path=block.path,
+                    line=block.line,
+                    kind="import",
+                    message=f"module is unavailable: {module}",
+                )
+            )
+    return issues
+
+
+def validate_documentation(
+    docs_dir: Path, check_imports: bool = False
+) -> ValidationSummary:
+    files = list(iter_document_files(docs_dir))
+    blocks: list[CodeBlock] = []
+    issues: list[ValidationIssue] = []
+
+    for path in files:
+        try:
+            blocks.extend(extract_code_blocks(path, docs_dir))
+        except UnicodeDecodeError as exc:
+            issues.append(
+                ValidationIssue(
+                    path=path.relative_to(docs_dir).as_posix(),
+                    line=1,
+                    kind="encoding",
+                    message=str(exc),
+                )
+            )
+
+    for block in blocks:
+        issues.extend(
+            validate_block(
+                block,
+                check_imports=check_imports,
+                package_root=docs_dir.parent / "src" / "tooluniverse",
+            )
+        )
+
+    if not blocks:
+        issues.append(
+            ValidationIssue(
+                path=".",
+                line=1,
+                kind="coverage",
+                message="no Python documentation examples were discovered",
+            )
+        )
+
+    return ValidationSummary(
+        files_checked=len(files),
+        blocks_checked=len(blocks),
+        issues=tuple(issues),
+    )
+
+
+def _summary_dict(summary: ValidationSummary) -> dict:
+    return {
+        "valid": summary.valid,
+        "files_checked": summary.files_checked,
+        "blocks_checked": summary.blocks_checked,
+        "issue_count": len(summary.issues),
+        "issues": [asdict(issue) for issue in summary.issues],
+    }
+
+
+def _print_text(summary: ValidationSummary) -> None:
+    print("ToolUniverse documentation example validation")
+    print(f"Files checked: {summary.files_checked}")
+    print(f"Python blocks checked: {summary.blocks_checked}")
+    print(f"Issues: {len(summary.issues)}")
+    for issue in summary.issues:
+        rendered = f"{issue.path}:{issue.line}: {issue.kind}: {issue.message}"
+        encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+        rendered = rendered.encode(encoding, errors="backslashreplace").decode(encoding)
+        print(rendered)
+    print("Result: PASS" if summary.valid else "Result: FAIL")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate Python examples in RST and MyST documentation."
+    )
+    parser.add_argument(
+        "--docs-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent,
+        help="Documentation root to scan recursively.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "text"),
+        default="text",
+        dest="output_format",
+    )
+    parser.add_argument(
+        "--check-imports",
+        action="store_true",
+        help="Also check ToolUniverse module paths without importing package code.",
+    )
+    args = parser.parse_args(argv)
+
+    docs_dir = args.docs_dir.resolve()
+    if not docs_dir.is_dir():
+        parser.error(f"documentation directory does not exist: {docs_dir}")
+
+    summary = validate_documentation(docs_dir, check_imports=args.check_imports)
+    if args.output_format == "json":
+        print(json.dumps(_summary_dict(summary), indent=2, sort_keys=True))
     else:
-        print("\n🎉 所有代码示例验证通过！")
-        return 0
+        _print_text(summary)
+    return 0 if summary.valid else 1
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_documentation_example_validation.py
+++ b/tests/unit/test_documentation_example_validation.py
@@ -1,0 +1,150 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[2] / "docs" / "validate_examples.py"
+SPEC = importlib.util.spec_from_file_location("validate_examples", SCRIPT)
+validate_examples = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = validate_examples
+SPEC.loader.exec_module(validate_examples)
+
+
+def test_extracts_rst_python_blocks_with_directive_options():
+    heading_underline = "=" * len("Heading")
+    text = f"""
+Heading
+{heading_underline}
+
+.. code-block:: python
+   :caption: Example
+
+   from tooluniverse import ToolUniverse
+   value = 1
+
+Following text.
+"""
+
+    blocks = validate_examples.extract_rst_code_blocks(text, "guide/example.rst")
+
+    assert len(blocks) == 1
+    assert blocks[0].path == "guide/example.rst"
+    assert blocks[0].line == 8
+    assert blocks[0].code == "from tooluniverse import ToolUniverse\nvalue = 1"
+
+
+@pytest.mark.parametrize(
+    "opening",
+    ["```python", "~~~py", "```{code-block} python"],
+)
+def test_extracts_markdown_and_myst_python_fences(opening):
+    fence = "~~~" if opening.startswith("~") else "```"
+    text = f"# Example\n\n{opening}\nanswer = 42\n{fence}\n"
+
+    blocks = validate_examples.extract_markdown_code_blocks(text, "guide/example.md")
+
+    assert len(blocks) == 1
+    assert blocks[0].line == 4
+    assert blocks[0].code == "answer = 42"
+
+
+def test_recursive_discovery_excludes_build_and_translation_outputs(tmp_path):
+    (tmp_path / "guide").mkdir()
+    (tmp_path / "guide" / "page.rst").write_text("Page\n====\n", encoding="utf-8")
+    (tmp_path / "_build").mkdir()
+    (tmp_path / "_build" / "generated.rst").write_text("Generated", encoding="utf-8")
+    (tmp_path / "locale").mkdir()
+    (tmp_path / "locale" / "translated.md").write_text("Translated", encoding="utf-8")
+
+    files = list(validate_examples.iter_document_files(tmp_path))
+
+    assert [path.relative_to(tmp_path).as_posix() for path in files] == [
+        "guide/page.rst"
+    ]
+
+
+def test_reports_exact_syntax_error_location():
+    block = validate_examples.CodeBlock(
+        path="guide/broken.md", line=12, code="value = 1\nif True print(value)"
+    )
+
+    issues = validate_examples.validate_block(block, check_imports=False)
+
+    assert issues == [
+        validate_examples.ValidationIssue(
+            path="guide/broken.md",
+            line=13,
+            kind="syntax",
+            message="invalid syntax",
+        )
+    ]
+
+
+def test_checks_modules_without_executing_documentation_code(tmp_path):
+    package_root = tmp_path / "tooluniverse"
+    package_root.mkdir()
+    (package_root / "__init__.py").write_text("raise RuntimeError('not imported')")
+    block = validate_examples.CodeBlock(
+        path="guide/imports.rst",
+        line=4,
+        code="from tooluniverse.missing import Example\nraise RuntimeError('not executed')",
+    )
+
+    issues = validate_examples.validate_block(block, package_root=package_root)
+
+    assert issues[0].kind == "import"
+
+
+def test_validation_fails_when_no_python_examples_exist(tmp_path):
+    (tmp_path / "index.rst").write_text("Title\n=====\n", encoding="utf-8")
+
+    summary = validate_examples.validate_documentation(tmp_path)
+
+    assert not summary.valid
+    assert summary.blocks_checked == 0
+    assert summary.issues[0].kind == "coverage"
+
+
+def test_validation_scans_nested_rst_and_markdown(tmp_path):
+    guide = tmp_path / "guide"
+    guide.mkdir()
+    (guide / "one.rst").write_text(
+        ".. code:: python\n\n   first = 1\n", encoding="utf-8"
+    )
+    (guide / "two.md").write_text("```python\nsecond = 2\n```\n", encoding="utf-8")
+
+    summary = validate_examples.validate_documentation(tmp_path, check_imports=False)
+
+    assert summary.valid
+    assert summary.files_checked == 2
+    assert summary.blocks_checked == 2
+    assert summary.issues == ()
+
+
+def test_json_output_is_machine_readable(tmp_path, capsys):
+    (tmp_path / "example.md").write_text(
+        "```python\nvalue = 1\n```\n", encoding="utf-8"
+    )
+
+    result = validate_examples.main(
+        [
+            "--docs-dir",
+            str(tmp_path),
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 0
+    assert payload == {
+        "blocks_checked": 1,
+        "files_checked": 1,
+        "issue_count": 0,
+        "issues": [],
+        "valid": True,
+    }


### PR DESCRIPTION
## Summary

- validate Python examples recursively across RST, Markdown, and MyST documentation
- report file and line locations for syntax and local import errors in text or JSON form
- correct malformed examples exposed by the expanded scan
- add focused unit coverage for extraction, exclusions, diagnostics, imports, and command-line behavior

## Why

The previous validator inspected only two top-level RST files and found no examples, so a successful result did not exercise the documentation tree. This change turns it into a meaningful repository-wide check without executing documentation code or importing optional dependencies.

## Validation

- `ruff check docs/validate_examples.py tests/unit/test_documentation_example_validation.py`
- `ruff format --check docs/validate_examples.py tests/unit/test_documentation_example_validation.py`
- `pytest tests/unit/test_documentation_example_validation.py tests/unit/test_documentation_core.py -q` (44 passed)
- `python docs/validate_examples.py` (260 files, 1,354 Python blocks, zero issues)
- `python docs/validate_examples.py --check-imports --format json` (zero issues)
- `git diff --check`