### PR TITLE
Shard and aggregate the weekly tool sweep

### DIFF
--- a/.github/workflows/weekly-tool-healthcheck.yml
+++ b/.github/workflows/weekly-tool-healthcheck.yml
@@ -1,22 +1,15 @@
 name: Weekly Tool Health Check
 
-# Runs the full tool sweep (scripts/test_all_tools.py) against the live
-# external APIs once a week. This is a CANARY, not a gate: external APIs
-# drift (endpoints move, response schemas change, tokens expire) and that
-# breaks tools silently — this surfaces it so we can fix it proactively.
-#
-# It does NOT fail the workflow on tool failures; the value is the uploaded
-# report + the job summary. API-key-gated tools are expected to "fail" in
-# CI unless the corresponding repo secret is provided (see `env:` below).
-
+# This workflow is a live-API canary, not a merge gate. Each category is
+# assigned to exactly one stable shard, and aggregate artifacts remain useful
+# even when external services fail or one shard is interrupted.
 on:
   schedule:
-    # 06:00 UTC every Monday
     - cron: "0 6 * * 1"
   workflow_dispatch:
     inputs:
       pattern:
-        description: "Optional category pattern to scope the run (e.g. 'uniprot'). Empty = all tools."
+        description: "Optional category pattern to scope the run"
         required: false
         default: ""
 
@@ -29,19 +22,22 @@ concurrency:
 
 jobs:
   health-check:
-    name: Tool sweep (live APIs)
+    name: Tool sweep shard ${{ matrix.shard }}
     runs-on: ubuntu-latest
-    timeout-minutes: 350 # under the 6h hard limit; full sweep is network-bound
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        shard: [0, 1, 2, 3]
 
-    # Optional API keys. Tools that need a key will be skipped/failed unless
-    # the matching repo secret exists. Add more here as needed — an unset
-    # secret resolves to an empty string and is handled gracefully.
     env:
       NCBI_API_KEY: ${{ secrets.NCBI_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       WAQI_API_KEY: ${{ secrets.WAQI_API_KEY }}
       ONCOKB_API_KEY: ${{ secrets.ONCOKB_API_KEY }}
       SEMANTIC_SCHOLAR_API_KEY: ${{ secrets.SEMANTIC_SCHOLAR_API_KEY }}
+      SWEEP_PATTERN: ${{ inputs.pattern }}
 
     steps:
       - name: Checkout
@@ -52,13 +48,13 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libffi-dev libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libncurses5-dev libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev liblzma-dev libjpeg-dev libpng-dev libtiff-dev libwebp-dev libopenjp2-7-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libfontconfig1-dev libblas-dev liblapack-dev libatlas-base-dev gfortran libpoppler-cpp-dev libpoppler-dev libhdf5-dev libnetcdf-dev libgl1 libglib2.0-0 libsm6 libxext6 libxrender-dev libgomp1 libcairo2-dev libpango1.0-dev libpangocairo-1.0-0 libgdk-pixbuf2.0-dev shared-mime-info graphviz libgraphviz-dev
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
 
       - name: Install project
         run: uv pip install -e .[dev] --system
@@ -66,124 +62,80 @@ jobs:
       - name: Generate SDK
         run: python scripts/build_tools.py
 
-      - name: Run tool sweep (live APIs, does not fail the job)
+      - name: Run tool sweep
         id: sweep
         continue-on-error: true
+        timeout-minutes: 165
+        shell: bash
         run: |
-          PATTERN_ARG=""
-          if [ -n "${{ github.event.inputs.pattern }}" ]; then
-            PATTERN_ARG="--pattern ${{ github.event.inputs.pattern }}"
+          pattern_args=()
+          if [[ -n "$SWEEP_PATTERN" ]]; then
+            pattern_args+=(--pattern "$SWEEP_PATTERN")
           fi
-          # Tee stdout to a log. test_all_tools.py only writes the .md report
-          # at the very end, so if the job is killed mid-run (timeout, runner
-          # eviction) no report exists — but the live progress log still shows
-          # every category's pass/fail and is used as a fallback below.
           set -o pipefail
           python scripts/test_all_tools.py \
-            --skip-remote --skip-mcp --parallel \
-            --output TOOL_TEST_REPORT.md $PATTERN_ARG 2>&1 | tee sweep_output.log
+            --skip-remote --skip-mcp --parallel --max-workers 6 \
+            --shard-count 4 --shard-index "${{ matrix.shard }}" \
+            --output "TOOL_TEST_REPORT_${{ matrix.shard }}.md" \
+            --json-output "TOOL_TEST_RESULTS_${{ matrix.shard }}.json" \
+            "${pattern_args[@]}" 2>&1 | tee "sweep_output_${{ matrix.shard }}.log"
 
-      - name: Build job summary
+      - name: Upload shard artifacts
         if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tool-test-report-${{ matrix.shard }}
+          path: |
+            TOOL_TEST_REPORT_${{ matrix.shard }}.md
+            TOOL_TEST_RESULTS_${{ matrix.shard }}.json
+            sweep_output_${{ matrix.shard }}.log
+          if-no-files-found: warn
+          retention-days: 90
+
+  aggregate:
+    name: Aggregate tool sweep
+    if: always()
+    needs: health-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download shard artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: tool-test-report-*
+          merge-multiple: true
+
+      - name: Aggregate checkpoints
+        if: always()
+        continue-on-error: true
         run: |
-          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
-          import re, pathlib
+          python scripts/aggregate_tool_sweep.py TOOL_TEST_RESULTS_*.json \
+            --expected-shards 4 \
+            --baseline .github/known_failing_categories.txt \
+            --json-output TOOL_TEST_RESULTS.json \
+            --markdown-output TOOL_TEST_SUMMARY.md
 
-          report = pathlib.Path("TOOL_TEST_REPORT.md")
-          log = pathlib.Path("sweep_output.log")
-          print("# Weekly Tool Health Check\n")
+      - name: Publish job summary
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f TOOL_TEST_SUMMARY.md ]]; then
+            cat TOOL_TEST_SUMMARY.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "# Weekly Tool Health Check" >> "$GITHUB_STEP_SUMMARY"
+            echo "No aggregate summary was produced; inspect the shard logs." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
-          if not report.exists():
-              # The sweep did not finish (no .md report). Fall back to the live
-              # progress log so the run still reports something useful.
-              print(
-                  "Sweep did not complete — no final report (likely hit the job "
-                  "time limit or the runner was evicted). Falling back to the "
-                  "progress log.\n"
-              )
-              if not log.exists():
-                  print("No progress log either; check the run logs.")
-                  raise SystemExit(0)
-              logtext = log.read_text(errors="replace")
-              done = len(re.findall(r"\]\s+Testing\b", logtext))
-              ok = len(re.findall(r"✅\s+\d+\s+tests passed", logtext))
-              bad = sorted(set(re.findall(r"Testing (\S+)\.\.\..*?(?:❌|🔥)", logtext)))
-              print(f"- Categories started: **{done}**")
-              print(f"- Categories fully passed: **{ok}**")
-              if bad:
-                  print(f"\n## Categories with failures so far ({len(bad)})\n")
-                  print(", ".join(f"`{c}`" for c in bad))
-              raise SystemExit(0)
-
-          text = report.read_text(errors="replace")
-
-          # Headline numbers. Total is an executive-summary bullet; Passed/Failed
-          # are emoji-prefixed rows in the Overall Statistics table (the first
-          # such row is the overall one, before the per-category tables).
-          def grab_bullet(label):
-              m = re.search(rf"\*\*{re.escape(label)}\*\*:\s*([\d,]+)", text)
-              return m.group(1).replace(",", "") if m else "?"
-
-          def grab_table(label):
-              m = re.search(rf"\|[^|\n]*{re.escape(label)}[^|\n]*\|\s*([\d,]+)", text)
-              return m.group(1).replace(",", "") if m else "?"
-
-          total = grab_bullet("Total Test Examples")
-          passed = grab_table("Passed")
-          failed = grab_table("Failed")
-          print(f"- Total tests: **{total}**")
-          print(f"- Passed: **{passed}**")
-          print(f"- Failed: **{failed}**\n")
-
-          # List failing categories (### ❌ / 🔥 <name>, single trailing token).
-          fail_re = re.compile(r"^###\s+(❌|\U0001f525)\s+(\S+)\s*$", re.MULTILINE)
-          cats = sorted({m.group(2) for m in fail_re.finditer(text)})
-
-          # Diff against the known-failing baseline so the report highlights the
-          # one thing worth acting on: a category that failed but is NOT already
-          # a known/expected failure (usually an upstream API just changed).
-          baseline = set()
-          bl = pathlib.Path(".github/known_failing_categories.txt")
-          if bl.exists():
-              for line in bl.read_text().splitlines():
-                  tok = line.split("#", 1)[0].strip()
-                  if tok:
-                      baseline.add(tok)
-
-          new_fail = [c for c in cats if c not in baseline]
-          if new_fail:
-              print(f"## 🆕 NEW failing categories ({len(new_fail)}) — investigate\n")
-              print(", ".join(f"`{c}`" for c in new_fail))
-              print(
-                  "\n> These are not in `.github/known_failing_categories.txt`. A "
-                  "newly-failing category usually means an upstream API changed — "
-                  "reproduce, then fix or add it to the baseline."
-              )
-          elif cats:
-              print("No new failures — every failing category is a known/expected one. ✅")
-
-          if cats:
-              print(f"\n<details><summary>All failing categories ({len(cats)})</summary>\n")
-              print(", ".join(f"`{c}`" for c in cats))
-              recovered = sorted(baseline - set(cats))
-              if recovered:
-                  print(
-                      f"\nBaseline entries that PASSED this week ({len(recovered)}, "
-                      "candidates to prune from the baseline): "
-                      + ", ".join(f"`{c}`" for c in recovered)
-                  )
-              print("\n</details>")
-          else:
-              print("All categories passed. ✅")
-          PY
-
-      - name: Upload report and log
+      - name: Upload aggregate artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: tool-test-report
           path: |
-            TOOL_TEST_REPORT.md
-            sweep_output.log
+            TOOL_TEST_RESULTS.json
+            TOOL_TEST_SUMMARY.md
           if-no-files-found: warn
           retention-days: 90

--- a/scripts/README_TEST_ALL_TOOLS.md
+++ b/scripts/README_TEST_ALL_TOOLS.md
@@ -59,6 +59,9 @@ python scripts/test_all_tools.py --output MY_REPORT.md
 # Save progress and resume an interrupted sweep
 python scripts/test_all_tools.py --json-output TOOL_TEST_RESULTS.json
 python scripts/test_all_tools.py --json-output TOOL_TEST_RESULTS.json --resume
+
+# Run one stable shard with bounded concurrency
+python scripts/test_all_tools.py --parallel --max-workers 6 --shard-count 4 --shard-index 0
 ```
 
 ## Command Line Options
@@ -68,6 +71,9 @@ python scripts/test_all_tools.py --json-output TOOL_TEST_RESULTS.json --resume
 | `-v, --verbose` | Show detailed output for each test |
 | `--fail-fast` | Stop testing after first failure |
 | `--parallel` | Run tests in parallel (experimental) |
+| `--max-workers N` | Limit concurrent pattern subprocesses (default: 10) |
+| `--shard-count N` | Split sorted categories into N stable shards |
+| `--shard-index N` | Run one zero-based shard index |
 | `--output FILE` | Save report to specific file (default: `TOOL_TEST_REPORT.md`) |
 | `--json-output FILE` | Save an atomic machine-readable checkpoint (default: `TOOL_TEST_RESULTS.json`) |
 | `--resume` | Reuse completed categories from the JSON checkpoint |

--- a/scripts/aggregate_tool_sweep.py
+++ b/scripts/aggregate_tool_sweep.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Aggregate sharded tool-sweep checkpoints into one audited result."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+RESULT_STATES = (
+    "passed",
+    "failed",
+    "schema_error",
+    "no_tests",
+    "timeout",
+    "error",
+)
+FAILURE_STATES = {"failed", "schema_error", "timeout", "error"}
+
+
+def load_checkpoint(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"{path}: unsupported schema version")
+    if not isinstance(payload.get("results"), dict):
+        raise ValueError(f"{path}: results must be an object")
+    if not isinstance(payload.get("expected_patterns"), list):
+        raise ValueError(f"{path}: expected_patterns must be an array")
+    for pattern, result in payload["results"].items():
+        if not isinstance(result, dict) or result.get("state") not in RESULT_STATES:
+            raise ValueError(f"{path}: invalid result state for {pattern!r}")
+    return payload
+
+
+def aggregate_checkpoints(
+    checkpoint_paths: list[Path], expected_shards: int
+) -> dict[str, Any]:
+    """Merge checkpoints and retain all completeness/duplication failures."""
+    if expected_shards < 1:
+        raise ValueError("expected_shards must be at least 1")
+
+    errors: list[str] = []
+    shards: list[dict[str, Any]] = []
+    results: dict[str, dict[str, Any]] = {}
+    expected_patterns: set[str] = set()
+    shard_indices: set[int] = set()
+
+    if len(checkpoint_paths) != expected_shards:
+        errors.append(
+            f"Expected {expected_shards} shard checkpoint(s), found "
+            f"{len(checkpoint_paths)}"
+        )
+
+    for path in sorted(checkpoint_paths):
+        try:
+            payload = load_checkpoint(path)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            errors.append(str(exc))
+            continue
+
+        run = payload.get("run") or {}
+        shard_index = run.get("shard_index")
+        shard_count = run.get("shard_count")
+        if not isinstance(shard_index, int) or not isinstance(shard_count, int):
+            errors.append(f"{path}: missing integer shard metadata")
+        else:
+            if shard_count != expected_shards:
+                errors.append(
+                    f"{path}: shard_count={shard_count}, expected {expected_shards}"
+                )
+            if shard_index in shard_indices:
+                errors.append(f"{path}: duplicate shard_index {shard_index}")
+            if shard_index < 0 or shard_index >= expected_shards:
+                errors.append(f"{path}: shard_index {shard_index} is out of range")
+            shard_indices.add(shard_index)
+
+        for pattern in payload["expected_patterns"]:
+            if not isinstance(pattern, str):
+                errors.append(f"{path}: expected pattern names must be strings")
+                continue
+            if pattern in expected_patterns:
+                errors.append(f"{path}: duplicate expected pattern {pattern!r}")
+            expected_patterns.add(pattern)
+
+        for pattern, result in payload["results"].items():
+            if pattern in results:
+                errors.append(f"{path}: duplicate completed pattern {pattern!r}")
+            else:
+                results[pattern] = result
+
+        if not payload.get("complete"):
+            errors.append(f"{path}: shard did not complete")
+        shards.append(
+            {
+                "path": str(path),
+                "shard_index": shard_index,
+                "complete": bool(payload.get("complete")),
+                "completed_patterns": len(payload["results"]),
+                "expected_patterns": len(payload["expected_patterns"]),
+            }
+        )
+
+    missing_patterns = sorted(expected_patterns - set(results))
+    unexpected_patterns = sorted(set(results) - expected_patterns)
+    if missing_patterns:
+        errors.append(f"Missing {len(missing_patterns)} expected pattern result(s)")
+    if unexpected_patterns:
+        errors.append(f"Found {len(unexpected_patterns)} unexpected pattern result(s)")
+    missing_shard_indices = sorted(set(range(expected_shards)) - shard_indices)
+    if missing_shard_indices:
+        errors.append(f"Missing shard index(es): {missing_shard_indices}")
+
+    status_counts = {state: 0 for state in RESULT_STATES}
+    for result in results.values():
+        status_counts[result["state"]] += 1
+
+    complete = not errors and set(results) == expected_patterns
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "complete": complete,
+        "expected_shards": expected_shards,
+        "received_shards": len(shards),
+        "shards": sorted(shards, key=lambda shard: shard["shard_index"] or 0),
+        "expected_patterns": sorted(expected_patterns),
+        "completed_patterns": len(results),
+        "missing_patterns": missing_patterns,
+        "unexpected_patterns": unexpected_patterns,
+        "status_counts": status_counts,
+        "errors": errors,
+        "results": dict(sorted(results.items())),
+    }
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    results = payload["results"]
+    total_tests = sum(result.get("tests_run", 0) for result in results.values())
+    total_passed = sum(result.get("passed", 0) for result in results.values())
+    lines = [
+        "# Weekly Tool Health Check",
+        "",
+        f"- Complete: **{'yes' if payload['complete'] else 'no'}**",
+        f"- Shards received: **{payload['received_shards']}/{payload['expected_shards']}**",
+        f"- Categories completed: **{payload['completed_patterns']}**",
+        f"- Test examples executed: **{total_tests}**",
+        f"- Test examples passed: **{total_passed}**",
+        "",
+        "## Category States",
+        "",
+        "| State | Count |",
+        "|---|---:|",
+    ]
+    for state in RESULT_STATES:
+        lines.append(f"| `{state}` | {payload['status_counts'][state]} |")
+
+    if payload["errors"]:
+        lines.extend(["", "## Aggregation Problems", ""])
+        lines.extend(f"- {error}" for error in payload["errors"])
+
+    baseline = payload.get("baseline")
+    if baseline:
+        new_failures = baseline["new_failures"]
+        known_failures = baseline["known_failures"]
+        recovered = baseline["recovered"]
+        if new_failures:
+            lines.extend(["", f"## New Failing Categories ({len(new_failures)})", ""])
+            lines.append(", ".join(f"`{pattern}`" for pattern in new_failures))
+        if known_failures:
+            lines.extend(
+                ["", f"## Known Failing Categories ({len(known_failures)})", ""]
+            )
+            lines.append(", ".join(f"`{pattern}`" for pattern in known_failures))
+        if recovered:
+            lines.extend(
+                ["", f"## Baseline Categories That Passed ({len(recovered)})", ""]
+            )
+            lines.append(", ".join(f"`{pattern}`" for pattern in recovered))
+
+    attention = {
+        state: sorted(
+            pattern
+            for pattern, result in results.items()
+            if result.get("state") == state
+        )
+        for state in RESULT_STATES
+        if state != "passed"
+    }
+    for state, patterns in attention.items():
+        if patterns:
+            lines.extend(
+                ["", f"## {state.replace('_', ' ').title()} ({len(patterns)})", ""]
+            )
+            lines.append(", ".join(f"`{pattern}`" for pattern in patterns))
+
+    return "\n".join(lines) + "\n"
+
+
+def write_text_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_name(f"{path.name}.tmp")
+    temporary_path.write_text(content, encoding="utf-8")
+    temporary_path.replace(path)
+
+
+def add_baseline_comparison(payload: dict[str, Any], baseline_path: Path) -> None:
+    baseline = {
+        line.split("#", 1)[0].strip()
+        for line in baseline_path.read_text(encoding="utf-8").splitlines()
+        if line.split("#", 1)[0].strip()
+    }
+    failing = {
+        pattern
+        for pattern, result in payload["results"].items()
+        if result.get("state") in FAILURE_STATES
+    }
+    payload["baseline"] = {
+        "new_failures": sorted(failing - baseline),
+        "known_failures": sorted(failing & baseline),
+        "recovered": sorted((baseline & set(payload["expected_patterns"])) - failing),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("checkpoints", nargs="*", type=Path)
+    parser.add_argument("--expected-shards", type=int, required=True)
+    parser.add_argument("--json-output", type=Path, required=True)
+    parser.add_argument("--markdown-output", type=Path, required=True)
+    parser.add_argument("--baseline", type=Path)
+    args = parser.parse_args()
+
+    existing_paths = [path for path in args.checkpoints if path.is_file()]
+    payload = aggregate_checkpoints(existing_paths, args.expected_shards)
+    if args.baseline and args.baseline.is_file():
+        add_baseline_comparison(payload, args.baseline)
+    write_text_atomic(
+        args.json_output,
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+    )
+    write_text_atomic(args.markdown_output, render_markdown(payload))
+
+    failed = any(
+        result.get("state") in FAILURE_STATES for result in payload["results"].values()
+    )
+    return 0 if payload["complete"] and not failed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_all_tools.py
+++ b/scripts/test_all_tools.py
@@ -15,6 +15,9 @@ Options:
     --verbose       Show detailed output for each test
     --fail-fast     Stop testing after first failure
     --parallel      Run tests in parallel (faster but less readable output)
+    --max-workers   Bound concurrent pattern subprocesses
+    --shard-count   Split sorted categories into stable shards
+    --shard-index   Run one zero-based shard
     --output FILE   Save report to file (default: TOOL_TEST_REPORT.md)
     --json-output   Save atomic JSON progress (default: TOOL_TEST_RESULTS.json)
     --resume        Reuse completed categories from the JSON checkpoint
@@ -93,6 +96,7 @@ def write_checkpoint(
     expected_patterns: List[str],
     started_at: str,
     complete: bool,
+    run_metadata: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Atomically persist machine-readable progress after each category."""
     normalized_results = {
@@ -111,6 +115,7 @@ def write_checkpoint(
         "completed_patterns": len(normalized_results),
         "status_counts": status_counts,
         "results": normalized_results,
+        "run": run_metadata or {},
     }
     output_path.parent.mkdir(parents=True, exist_ok=True)
     temporary_path = output_path.with_name(f"{output_path.name}.tmp")
@@ -142,6 +147,15 @@ def load_checkpoint(output_path: Path) -> Dict[str, Dict[str, Any]]:
             raise ValueError(f"Checkpoint state mismatch for pattern {pattern!r}")
         validated[pattern] = normalized
     return validated
+
+
+def select_shard(patterns: List[str], shard_index: int, shard_count: int) -> List[str]:
+    """Assign sorted patterns to one stable, non-overlapping shard."""
+    if shard_count < 1:
+        raise ValueError("shard_count must be at least 1")
+    if shard_index < 0 or shard_index >= shard_count:
+        raise ValueError("shard_index must be between 0 and shard_count - 1")
+    return sorted(patterns)[shard_index::shard_count]
 
 
 def find_all_tool_configs(data_dir: Path) -> List[Path]:
@@ -522,6 +536,10 @@ def generate_report(
     # List failures
     issues_found = False
 
+    if not results:
+        lines.append("No tool categories were assigned to this shard.")
+        lines.append("")
+
     patterns_without_tests = [
         pattern
         for pattern, result in normalized_results.items()
@@ -597,7 +615,7 @@ def generate_report(
             lines.append(f"- **{pattern}**: {count} failure(s)")
         lines.append("")
 
-    if not issues_found:
+    if results and not issues_found:
         lines.append("✨ **No issues found!** All tools are working correctly.")
         lines.append("")
 
@@ -629,7 +647,7 @@ def generate_report(
         lines.append("   - Review error messages in detail")
         lines.append("")
 
-    if not issues_found:
+    if results and not issues_found:
         lines.append("✅ All tools validated successfully! No action needed.")
         lines.append("")
 
@@ -663,6 +681,24 @@ def main():
         "--parallel",
         action="store_true",
         help=f"Run tests in parallel across patterns (up to {DEFAULT_PARALLEL_WORKERS} workers)",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=DEFAULT_PARALLEL_WORKERS,
+        help="Maximum concurrent pattern subprocesses with --parallel",
+    )
+    parser.add_argument(
+        "--shard-count",
+        type=int,
+        default=1,
+        help="Split the sorted pattern list into this many stable shards",
+    )
+    parser.add_argument(
+        "--shard-index",
+        type=int,
+        default=0,
+        help="Zero-based shard to execute",
     )
     parser.add_argument(
         "--output", default="TOOL_TEST_REPORT.md", help="Output report filename"
@@ -700,6 +736,12 @@ def main():
     )
 
     args = parser.parse_args()
+    if args.max_workers < 1:
+        parser.error("--max-workers must be at least 1")
+    if args.shard_count < 1:
+        parser.error("--shard-count must be at least 1")
+    if args.shard_index < 0 or args.shard_index >= args.shard_count:
+        parser.error("--shard-index must be between 0 and --shard-count - 1")
 
     # Setup paths
     repo_root = Path(__file__).parent.parent
@@ -796,9 +838,21 @@ def main():
         if skipped_count > 0:
             print(f"⏭️  Skipped {skipped_count} tool(s)")
 
-    if not config_patterns:
+    if not config_patterns and args.shard_count == 1:
         print("❌ No tools remaining after filtering")
         sys.exit(1)
+
+    assigned_patterns = select_shard(
+        list(config_patterns), args.shard_index, args.shard_count
+    )
+    config_patterns = {
+        pattern: config_patterns[pattern] for pattern in assigned_patterns
+    }
+    if args.shard_count > 1:
+        print(
+            f"Shard {args.shard_index + 1}/{args.shard_count}: "
+            f"assigned {len(config_patterns)} pattern(s)"
+        )
 
     print(f"✅ Found {len(config_patterns)} unique tool patterns to test")
     print()
@@ -827,12 +881,18 @@ def main():
         }
         print(f"Resuming with {len(resumed_results)} completed pattern(s)")
 
+    run_metadata = {
+        "shard_index": args.shard_index,
+        "shard_count": args.shard_count,
+        "max_workers": args.max_workers,
+    }
     write_checkpoint(
         checkpoint_path,
         resumed_results,
         expected_patterns,
         started_at,
         complete=False,
+        run_metadata=run_metadata,
     )
 
     def save_progress(
@@ -844,6 +904,7 @@ def main():
             expected_patterns,
             started_at,
             complete=False,
+            run_metadata=run_metadata,
         )
 
     results = run_all_patterns(
@@ -852,6 +913,7 @@ def main():
         verbose=args.verbose,
         fail_fast=args.fail_fast,
         parallel=args.parallel,
+        max_workers=args.max_workers,
         initial_results=resumed_results,
         on_result=save_progress,
     )
@@ -864,6 +926,7 @@ def main():
         expected_patterns,
         started_at,
         complete=checkpoint_complete,
+        run_metadata=run_metadata,
     )
 
     print()
@@ -912,7 +975,9 @@ def main():
     ]
     if failed_categories or not checkpoint_complete:
         sys.exit(1)
-    if state_counts["no_tests"]:
+    if not expected_patterns:
+        print("\nThis shard has no assigned patterns.")
+    elif state_counts["no_tests"]:
         print("\nSweep completed with categories that have no executable tests.")
     else:
         print("\n✨ All tests passed!")

--- a/tests/unit/test_tool_sweep_sharding.py
+++ b/tests/unit/test_tool_sweep_sharding.py
@@ -1,0 +1,231 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+
+pytestmark = pytest.mark.unit
+REPO_ROOT = Path(__file__).parents[2]
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sweep = _load("tool_sweep_sharding", REPO_ROOT / "scripts" / "test_all_tools.py")
+aggregate = _load(
+    "aggregate_tool_sweep", REPO_ROOT / "scripts" / "aggregate_tool_sweep.py"
+)
+
+
+def _result(state="passed"):
+    results = {
+        "passed": {"tests_run": 1, "passed": 1, "failed": 0, "exit_code": 0},
+        "failed": {"tests_run": 1, "passed": 0, "failed": 1, "exit_code": 1},
+        "no_tests": {"tests_run": 0, "passed": 0, "failed": 0, "exit_code": 0},
+    }
+    return results[state]
+
+
+def _checkpoint(tmp_path, index, count, patterns, states=None, complete=True):
+    states = states or ["passed"] * len(patterns)
+    path = tmp_path / f"shard-{index}.json"
+    sweep.write_checkpoint(
+        path,
+        {
+            pattern: _result(state)
+            for pattern, state in zip(patterns, states, strict=True)
+        },
+        patterns,
+        "2026-01-01T00:00:00+00:00",
+        complete,
+        run_metadata={"shard_index": index, "shard_count": count},
+    )
+    return path
+
+
+def test_shards_are_stable_disjoint_and_exhaustive():
+    patterns = ["zeta", "alpha", "gamma", "beta", "theta", "delta"]
+
+    shards = [sweep.select_shard(patterns, index, 4) for index in range(4)]
+
+    flattened = [pattern for shard in shards for pattern in shard]
+    assert sorted(flattened) == sorted(patterns)
+    assert len(flattened) == len(set(flattened))
+    assert shards == [
+        ["alpha", "theta"],
+        ["beta", "zeta"],
+        ["delta"],
+        ["gamma"],
+    ]
+
+
+@pytest.mark.parametrize(
+    ("index", "count"),
+    [(-1, 4), (4, 4), (0, 0)],
+)
+def test_shard_selection_rejects_invalid_bounds(index, count):
+    with pytest.raises(ValueError):
+        sweep.select_shard(["alpha"], index, count)
+
+
+def test_checkpoint_records_shard_metadata(tmp_path):
+    path = _checkpoint(tmp_path, 2, 4, ["alpha"])
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert payload["run"] == {"shard_count": 4, "shard_index": 2}
+
+
+def test_aggregate_accepts_complete_shards_including_an_empty_shard(tmp_path):
+    paths = [
+        _checkpoint(tmp_path, 0, 4, ["alpha"]),
+        _checkpoint(tmp_path, 1, 4, ["beta"], ["no_tests"]),
+        _checkpoint(tmp_path, 2, 4, ["gamma"]),
+        _checkpoint(tmp_path, 3, 4, []),
+    ]
+
+    payload = aggregate.aggregate_checkpoints(paths, expected_shards=4)
+
+    assert payload["complete"] is True
+    assert payload["errors"] == []
+    assert payload["completed_patterns"] == 3
+    assert payload["status_counts"]["passed"] == 2
+    assert payload["status_counts"]["no_tests"] == 1
+
+
+def test_aggregate_reports_a_missing_or_interrupted_shard(tmp_path):
+    paths = [
+        _checkpoint(tmp_path, 0, 2, ["alpha"]),
+    ]
+
+    payload = aggregate.aggregate_checkpoints(paths, expected_shards=2)
+
+    assert payload["complete"] is False
+    assert "Expected 2 shard checkpoint(s), found 1" in payload["errors"]
+
+
+def test_aggregate_rejects_duplicate_pattern_assignment(tmp_path):
+    paths = [
+        _checkpoint(tmp_path, 0, 2, ["alpha"]),
+        _checkpoint(tmp_path, 1, 2, ["alpha"]),
+    ]
+
+    payload = aggregate.aggregate_checkpoints(paths, expected_shards=2)
+
+    assert payload["complete"] is False
+    assert any(
+        "duplicate expected pattern 'alpha'" in error for error in payload["errors"]
+    )
+    assert any(
+        "duplicate completed pattern 'alpha'" in error for error in payload["errors"]
+    )
+
+
+def test_aggregate_requires_the_exact_shard_index_set(tmp_path):
+    paths = [
+        _checkpoint(tmp_path, 0, 2, ["alpha"]),
+        _checkpoint(tmp_path, 2, 2, ["beta"]),
+    ]
+
+    payload = aggregate.aggregate_checkpoints(paths, expected_shards=2)
+
+    assert payload["complete"] is False
+    assert any("shard_index 2 is out of range" in error for error in payload["errors"])
+    assert "Missing shard index(es): [1]" in payload["errors"]
+
+
+def test_markdown_lists_failures_and_coverage_gaps(tmp_path):
+    path = _checkpoint(
+        tmp_path,
+        0,
+        1,
+        ["broken", "empty"],
+        ["failed", "no_tests"],
+    )
+    payload = aggregate.aggregate_checkpoints([path], expected_shards=1)
+
+    markdown = aggregate.render_markdown(payload)
+
+    assert "## Failed (1)" in markdown
+    assert "`broken`" in markdown
+    assert "## No Tests (1)" in markdown
+    assert "`empty`" in markdown
+
+
+def test_baseline_comparison_separates_new_known_and_recovered(tmp_path):
+    checkpoint = _checkpoint(
+        tmp_path,
+        0,
+        1,
+        ["known", "new", "recovered"],
+        ["failed", "failed", "passed"],
+    )
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text("known\nrecovered # old failure\n", encoding="utf-8")
+    payload = aggregate.aggregate_checkpoints([checkpoint], expected_shards=1)
+
+    aggregate.add_baseline_comparison(payload, baseline)
+
+    assert payload["baseline"] == {
+        "new_failures": ["new"],
+        "known_failures": ["known"],
+        "recovered": ["recovered"],
+    }
+    markdown = aggregate.render_markdown(payload)
+    assert "## New Failing Categories (1)" in markdown
+    assert "## Known Failing Categories (1)" in markdown
+    assert "## Baseline Categories That Passed (1)" in markdown
+
+
+def test_aggregate_cli_writes_artifacts_and_fails_for_test_failures(tmp_path):
+    checkpoint = _checkpoint(tmp_path, 0, 1, ["broken"], ["failed"])
+    json_output = tmp_path / "aggregate.json"
+    markdown_output = tmp_path / "aggregate.md"
+    argv = [
+        "aggregate_tool_sweep.py",
+        str(checkpoint),
+        "--expected-shards",
+        "1",
+        "--json-output",
+        str(json_output),
+        "--markdown-output",
+        str(markdown_output),
+    ]
+
+    with patch.object(sys, "argv", argv):
+        exit_code = aggregate.main()
+
+    assert exit_code == 1
+    assert json_output.is_file()
+    assert markdown_output.is_file()
+    assert not json_output.with_name("aggregate.json.tmp").exists()
+
+
+def test_weekly_workflow_bounds_concurrency_and_preserves_partial_results():
+    workflow_path = REPO_ROOT / ".github" / "workflows" / "weekly-tool-healthcheck.yml"
+    workflow = yaml.load(
+        workflow_path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader
+    )
+    health_check = workflow["jobs"]["health-check"]
+    run_step = next(step for step in health_check["steps"] if step.get("id") == "sweep")
+
+    assert health_check["strategy"]["max-parallel"] == "2"
+    assert health_check["strategy"]["matrix"]["shard"] == ["0", "1", "2", "3"]
+    assert run_step["timeout-minutes"] == "165"
+    assert "--max-workers 6" in run_step["run"]
+    assert "--shard-count 4" in run_step["run"]
+    assert any(
+        step.get("uses") == "actions/upload-artifact@v4"
+        and step.get("if") == "always()"
+        for step in health_check["steps"]
+    )


### PR DESCRIPTION
## Summary

- add deterministic `--shard-count` and `--shard-index` selection with configurable worker limits
- split the weekly live-API sweep into four non-overlapping shards while capping total concurrent category processes at 12
- preserve partial checkpoints by ending the sweep step before the job timeout and always uploading shard artifacts
- aggregate shard JSON into reviewed Markdown and JSON artifacts, detecting missing, interrupted, duplicate, or out-of-range shards
- retain known-failure comparison without claiming untested categories recovered

## Dependency

This PR targets `sufianta/tool-sweep-result-states` because it consumes the checkpoint schema introduced in #441. After #441 merges, this PR can be retargeted to `main` without changing its diff.

## Validation

- `ruff check scripts/test_all_tools.py scripts/aggregate_tool_sweep.py tests/unit/test_tool_sweep_sharding.py`
- `pytest tests/unit/test_tool_sweep_sharding.py tests/unit/test_test_all_tools_result_states.py tests/unit/test_test_all_tools_parallel.py -q` (32 passed)
- parsed the workflow YAML and asserted its matrix, concurrency ceiling, step timeout, and always-upload behavior
- ran four real CLI shards against `scientific_calculator`; the assigned shard passed 15/15 examples and the other three produced valid empty-shard checkpoints
- aggregated all four live checkpoints into complete JSON and Markdown artifacts
- verified a scoped run does not report untested baseline categories as recovered
- verified invalid shard bounds exit before tool loading
- `git diff --check`