### PR TITLE
Validate HTTP server startup safely

### DIFF
--- a/src/tooluniverse/http_api_server_cli.py
+++ b/src/tooluniverse/http_api_server_cli.py
@@ -17,6 +17,23 @@ import os
 import sys
 
 
+def _positive_int(value):
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def _port(value):
+    parsed = _positive_int(value)
+    if parsed > 65535:
+        raise argparse.ArgumentTypeError("must be between 1 and 65535")
+    return parsed
+
+
 def run_http_api_server():
     """Main entry point for the HTTP API server"""
     parser = argparse.ArgumentParser(
@@ -66,12 +83,12 @@ Note:
     )
 
     parser.add_argument(
-        "--port", type=int, default=8080, help="Port to bind to (default: 8080)"
+        "--port", type=_port, default=8080, help="Port to bind to (default: 8080)"
     )
 
     parser.add_argument(
         "--workers",
-        type=int,
+        type=_positive_int,
         default=1,
         help="Number of worker processes (default: 1). WARNING: Multiple workers create separate ToolUniverse instances, each consuming GPU memory. Use single worker with larger thread pool for GPU workloads.",
     )
@@ -91,12 +108,24 @@ Note:
 
     parser.add_argument(
         "--thread-pool-size",
-        type=int,
+        type=_positive_int,
         default=20,
         help="Size of thread pool for async execution per worker (default: 20). Increase this for higher concurrency instead of adding workers.",
     )
 
     args = parser.parse_args()
+    if args.reload and args.workers != 1:
+        parser.error("--reload requires --workers 1")
+
+    from .server_security import enforce_bind_security
+
+    try:
+        # Validate the bind before mutating process settings or advertising
+        # endpoints that will never be started.
+        enforce_bind_security(args.host)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     # Set thread pool size via environment variable
     os.environ["TOOLUNIVERSE_THREAD_POOL_SIZE"] = str(args.thread_pool_size)
@@ -140,12 +169,6 @@ Note:
 
     try:
         import uvicorn
-
-        from .server_security import enforce_bind_security
-
-        # Refuse to expose the server on a non-loopback interface unless a
-        # TOOLUNIVERSE_API_TOKEN is configured to require Bearer authentication.
-        enforce_bind_security(args.host)
 
         # Use import string when workers > 1 (required by uvicorn)
         if args.workers > 1 and not args.reload:

--- a/tests/unit/test_http_api_server_cli.py
+++ b/tests/unit/test_http_api_server_cli.py
@@ -1,0 +1,184 @@
+import sys
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse import http_api_server_cli as cli
+from tooluniverse import server_security
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clean_server_environment(monkeypatch):
+    monkeypatch.delenv("TOOLUNIVERSE_API_TOKEN", raising=False)
+    monkeypatch.delenv("TOOLUNIVERSE_THREAD_POOL_SIZE", raising=False)
+
+
+def _fake_server_module():
+    module = ModuleType("tooluniverse.http_api_server")
+    module.app = object()
+    return module
+
+
+def test_default_run_uses_loopback_single_worker_and_thread_pool(monkeypatch):
+    server_module = _fake_server_module()
+    monkeypatch.setattr(sys, "argv", ["tooluniverse-http-api"])
+
+    with (
+        patch.dict(sys.modules, {"tooluniverse.http_api_server": server_module}),
+        patch("uvicorn.run") as run,
+    ):
+        cli.run_http_api_server()
+
+    run.assert_called_once_with(
+        server_module.app,
+        host="127.0.0.1",
+        port=8080,
+        workers=1,
+        reload=False,
+        log_level="info",
+    )
+    assert cli.os.environ["TOOLUNIVERSE_THREAD_POOL_SIZE"] == "20"
+
+
+def test_multiple_workers_use_import_string_and_require_remote_token(monkeypatch):
+    monkeypatch.setenv("TOOLUNIVERSE_API_TOKEN", "secret")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "tooluniverse-http-api",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "9000",
+            "--workers",
+            "3",
+            "--thread-pool-size",
+            "8",
+            "--log-level",
+            "warning",
+        ],
+    )
+
+    with patch("uvicorn.run") as run:
+        cli.run_http_api_server()
+
+    run.assert_called_once_with(
+        "tooluniverse.http_api_server:app",
+        host="0.0.0.0",
+        port=9000,
+        workers=3,
+        log_level="warning",
+    )
+    assert cli.os.environ["TOOLUNIVERSE_THREAD_POOL_SIZE"] == "8"
+
+
+def test_reload_uses_app_object_and_one_worker(monkeypatch):
+    server_module = _fake_server_module()
+    monkeypatch.setattr(sys, "argv", ["tooluniverse-http-api", "--reload"])
+
+    with (
+        patch.dict(sys.modules, {"tooluniverse.http_api_server": server_module}),
+        patch("uvicorn.run") as run,
+    ):
+        cli.run_http_api_server()
+
+    assert run.call_args.kwargs["reload"] is True
+    assert run.call_args.kwargs["workers"] == 1
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["--port", "0"],
+        ["--port", "65536"],
+        ["--port", "not-a-number"],
+        ["--workers", "0"],
+        ["--workers", "-1"],
+        ["--thread-pool-size", "0"],
+        ["--thread-pool-size", "-1"],
+    ],
+)
+def test_invalid_numeric_arguments_exit_before_server_start(monkeypatch, arguments):
+    monkeypatch.setattr(sys, "argv", ["tooluniverse-http-api", *arguments])
+
+    with patch("uvicorn.run") as run, pytest.raises(SystemExit) as exc_info:
+        cli.run_http_api_server()
+
+    assert exc_info.value.code == 2
+    run.assert_not_called()
+    assert "TOOLUNIVERSE_THREAD_POOL_SIZE" not in cli.os.environ
+
+
+def test_reload_and_multiple_workers_are_rejected(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["tooluniverse-http-api", "--reload", "--workers", "2"],
+    )
+
+    with patch("uvicorn.run") as run, pytest.raises(SystemExit) as exc_info:
+        cli.run_http_api_server()
+
+    assert exc_info.value.code == 2
+    run.assert_not_called()
+    assert "TOOLUNIVERSE_THREAD_POOL_SIZE" not in cli.os.environ
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "", "   ", None])
+def test_unknown_or_wildcard_hosts_are_not_loopback(host):
+    assert server_security.is_loopback_host(host) is False
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_literal_loopback_hosts_remain_allowed(host):
+    assert server_security.is_loopback_host(host) is True
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", ""])
+def test_remote_or_empty_bind_without_token_fails_before_mutation(
+    monkeypatch, capsys, host
+):
+    monkeypatch.setattr(sys, "argv", ["tooluniverse-http-api", "--host", host])
+
+    with patch("uvicorn.run") as run, pytest.raises(SystemExit) as exc_info:
+        cli.run_http_api_server()
+
+    assert exc_info.value.code == 1
+    assert "Refusing to bind" in capsys.readouterr().err
+    run.assert_not_called()
+    assert "TOOLUNIVERSE_THREAD_POOL_SIZE" not in cli.os.environ
+
+
+def test_server_startup_error_returns_failure(monkeypatch, capsys):
+    server_module = _fake_server_module()
+    monkeypatch.setattr(sys, "argv", ["tooluniverse-http-api"])
+
+    with (
+        patch.dict(sys.modules, {"tooluniverse.http_api_server": server_module}),
+        patch("uvicorn.run", side_effect=RuntimeError("address in use")),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        cli.run_http_api_server()
+
+    assert exc_info.value.code == 1
+    assert "address in use" in capsys.readouterr().out
+
+
+def test_keyboard_interrupt_returns_successful_shutdown(monkeypatch, capsys):
+    server_module = _fake_server_module()
+    monkeypatch.setattr(sys, "argv", ["tooluniverse-http-api"])
+
+    with (
+        patch.dict(sys.modules, {"tooluniverse.http_api_server": server_module}),
+        patch("uvicorn.run", side_effect=KeyboardInterrupt),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        cli.run_http_api_server()
+
+    assert exc_info.value.code == 0
+    assert "Server stopped by user" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- validate port, worker, and thread-pool bounds before server startup
- reject the unsupported reload plus multi-worker combination explicitly
- run bind-security checks before mutating process settings or advertising endpoints
- treat empty, whitespace-only, and unknown bind hosts as non-loopback and require authentication
- add command-level coverage for single-worker, multi-worker, reload, authentication, failures, and shutdown

## Root cause

An empty host reaches Python socket binding as a wildcard address, but the shared guard classified it as loopback. This could allow an unauthenticated all-interface bind through the CLI. The previous CLI also accepted invalid numeric values and silently forced one worker when reload was combined with multiple workers.

## Validation

- Ruff checks passed for the CLI, bind guard, and new tests
- 36 focused HTTP CLI and bind-security tests passed
- verified every successful branch through the exact mocked Uvicorn call without opening a listener
- verified unsafe and invalid inputs exit before server startup and before setting the thread-pool environment variable
- `git diff --check`

The complete existing security-advisory file has one unrelated dependency-sensitive failure: this environment's NumPy imports an internal module that the sandbox allowlist currently rejects. The HTTP and bind-security subsets are clean.