### PR TITLE
Validate datastore CLI inputs and dispatch

### DIFF
--- a/src/tooluniverse/database_setup/cli.py
+++ b/src/tooluniverse/database_setup/cli.py
@@ -42,6 +42,65 @@ from .packager import pack_folder
 from tooluniverse.utils import get_user_cache_dir
 
 
+def positive_int(value):
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def unit_interval(value):
+    parsed = float(value)
+    if not 0.0 <= parsed <= 1.0:
+        raise argparse.ArgumentTypeError("must be between 0 and 1")
+    return parsed
+
+
+def collection_name(value):
+    """Reject names that could escape the default embeddings directory."""
+    if not value or value in {".", ".."} or "/" in value or "\\" in value:
+        raise argparse.ArgumentTypeError(
+            "must be a non-empty name without path separators"
+        )
+    return value
+
+
+def load_docs_json(json_file):
+    """Load and validate datastore document rows from JSON."""
+    try:
+        raw = json.loads(Path(json_file).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"Could not read document JSON: {exc}") from exc
+    if not isinstance(raw, list):
+        raise SystemExit("Document JSON must contain a list of document rows")
+
+    docs = []
+    for index, item in enumerate(raw):
+        if isinstance(item, dict):
+            key = item.get("doc_key")
+            text = item.get("text")
+            metadata = item.get("metadata", {})
+            text_hash = item.get("text_hash")
+        elif isinstance(item, (list, tuple)) and len(item) in {3, 4}:
+            key, text, metadata = item[:3]
+            text_hash = item[3] if len(item) == 4 else None
+        else:
+            raise SystemExit(
+                f"Document row {index} must be an object or a 3/4-item array"
+            )
+
+        if not isinstance(key, str) or not key:
+            raise SystemExit(f"Document row {index} requires a non-empty doc_key")
+        if not isinstance(text, str):
+            raise SystemExit(f"Document row {index} requires string text")
+        if not isinstance(metadata, dict):
+            raise SystemExit(f"Document row {index} metadata must be an object")
+        if text_hash is not None and not isinstance(text_hash, str):
+            raise SystemExit(f"Document row {index} text_hash must be a string or null")
+        docs.append((key, text, metadata, text_hash))
+    return docs
+
+
 def resolve_db_path(db_arg, collection):
     """Return resolved db path (user-specified or default cache dir)."""
     if db_arg:
@@ -78,6 +137,8 @@ def add_tool(json_file: str, name: str | None = None, overwrite: bool = False):
         name = src.name
     if not name.endswith(".json"):
         name = name + ".json"
+    if name in {".json", "..json"} or "/" in name or "\\" in name:
+        raise SystemExit("[ERROR] Tool filename must not contain path separators")
 
     dest = Path(USER_TOOLS_DIR) / name
     if dest.exists() and not overwrite:
@@ -97,13 +158,18 @@ def main():
     p = argparse.ArgumentParser(
         "tu-datastore", description="Manage local searchable datastores."
     )
-    sub = p.add_subparsers(dest="cmd")
+    sub = p.add_subparsers(dest="cmd", required=True)
 
     # --------------------------------------------------------------------------
     # build
     # --------------------------------------------------------------------------
     b = sub.add_parser("build", help="Build or extend a collection from JSON docs")
-    b.add_argument("--collection", required=True, help="Collection name (e.g. toy)")
+    b.add_argument(
+        "--collection",
+        required=True,
+        type=collection_name,
+        help="Collection name (e.g. toy)",
+    )
     b.add_argument("--docs-json", required=True, help="Path to JSON list of docs")
     b.add_argument("--db", required=False, help="Optional path to SQLite DB")
     b.add_argument(
@@ -120,7 +186,12 @@ def main():
     qb = sub.add_parser(
         "quickbuild", help="Build from a folder of text files (.txt/.md)"
     )
-    qb.add_argument("--name", required=True, help="Collection name (e.g. mydata)")
+    qb.add_argument(
+        "--name",
+        required=True,
+        type=collection_name,
+        help="Collection name (e.g. mydata)",
+    )
     qb.add_argument("--from-folder", required=True, help="Folder containing text files")
     qb.add_argument(
         "--provider", help="Embedding provider (openai, azure, huggingface, local)"
@@ -134,7 +205,12 @@ def main():
     # search
     # --------------------------------------------------------------------------
     s = sub.add_parser("search", help="Query an existing collection")
-    s.add_argument("--collection", required=True, help="Collection name (e.g. toy)")
+    s.add_argument(
+        "--collection",
+        required=True,
+        type=collection_name,
+        help="Collection name (e.g. toy)",
+    )
     s.add_argument("--query", required=True, help="Search query text")
     s.add_argument("--db", required=False, help="Optional path to SQLite DB")
     s.add_argument(
@@ -143,8 +219,8 @@ def main():
         choices=["keyword", "embedding", "hybrid"],
         help="Search method",
     )
-    s.add_argument("--top-k", default=10, type=int, help="Number of results")
-    s.add_argument("--alpha", default=0.5, type=float, help="Hybrid mix weight")
+    s.add_argument("--top-k", default=10, type=positive_int, help="Number of results")
+    s.add_argument("--alpha", default=0.5, type=unit_interval, help="Hybrid mix weight")
     s.add_argument("--provider", help="Embedding provider (optional)")
     s.add_argument("--model", help="Embedding model (optional)")
 
@@ -157,7 +233,7 @@ def main():
     sh_sub = sh.add_subparsers(dest="action", required=True)
 
     up = sh_sub.add_parser("upload", help="Upload collection artifacts to HF")
-    up.add_argument("--collection", required=True)
+    up.add_argument("--collection", required=True, type=collection_name)
     up.add_argument(
         "--repo", help="HF dataset repo ID (defaults to <username>/<collection>)"
     )
@@ -176,7 +252,7 @@ def main():
 
     down = sh_sub.add_parser("download", help="Download collection artifacts from HF")
     down.add_argument("--repo", required=True)
-    down.add_argument("--collection", required=True)
+    down.add_argument("--collection", required=True, type=collection_name)
     down.add_argument(
         "--overwrite", action="store_true", help="Overwrite existing index"
     )
@@ -209,21 +285,7 @@ def main():
     args = p.parse_args()
 
     if args.cmd == "build":
-        with open(args.docs_json) as f:
-            raw = json.load(f)
-        docs = [
-            (
-                (
-                    d.get("doc_key"),
-                    d.get("text"),
-                    d.get("metadata", {}),
-                    d.get("text_hash"),
-                )
-                if isinstance(d, dict)
-                else tuple(d)
-            )
-            for d in raw
-        ]
+        docs = load_docs_json(args.docs_json)
 
         provider, model = resolve_provider_model(args.provider, args.model)
         db_path = resolve_db_path(args.db, args.collection)
@@ -260,11 +322,14 @@ def main():
 
     elif args.cmd == "search":
         db_path = resolve_db_path(args.db, args.collection)
-        # Only require provider/model when embeddings are needed
         if args.method == "keyword":
             provider = model = None
         else:
-            provider, model = resolve_provider_model(args.provider, args.model)
+            # Existing collections record their embedding model. Leave values
+            # optional so the search pipeline can use stored metadata and its
+            # provider resolver when explicit overrides are not supplied.
+            provider = args.provider or os.getenv("EMBED_PROVIDER")
+            model = args.model or os.getenv("EMBED_MODEL")
         res = search(
             db_path=db_path,
             collection=args.collection,
@@ -298,6 +363,3 @@ def main():
             name=args.name,
             overwrite=args.overwrite,
         )
-
-    else:
-        p.print_help()

--- a/tests/unit/test_datastore_cli.py
+++ b/tests/unit/test_datastore_cli.py
@@ -1,0 +1,318 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tooluniverse.database_setup import cli
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clean_embedding_environment(monkeypatch):
+    monkeypatch.delenv("EMBED_PROVIDER", raising=False)
+    monkeypatch.delenv("EMBED_MODEL", raising=False)
+
+
+def _run(monkeypatch, *arguments):
+    monkeypatch.setattr(sys, "argv", ["tu-datastore", *arguments])
+    cli.main()
+
+
+def test_build_validates_and_normalizes_document_rows(monkeypatch, tmp_path):
+    docs_path = tmp_path / "docs.json"
+    docs_path.write_text(
+        json.dumps(
+            [
+                {"doc_key": "a", "text": "Alpha", "metadata": {"kind": "A"}},
+                ["b", "Beta", {"kind": "B"}],
+            ]
+        ),
+        encoding="utf-8",
+    )
+    db_path = tmp_path / "test.db"
+
+    with patch.object(cli, "build_collection") as build:
+        _run(
+            monkeypatch,
+            "build",
+            "--collection",
+            "study",
+            "--docs-json",
+            str(docs_path),
+            "--db",
+            str(db_path),
+            "--provider",
+            "local",
+            "--model",
+            "model-name",
+            "--overwrite",
+        )
+
+    build.assert_called_once_with(
+        db_path=str(db_path),
+        collection="study",
+        docs=[
+            ("a", "Alpha", {"kind": "A"}, None),
+            ("b", "Beta", {"kind": "B"}, None),
+        ],
+        embed_provider="local",
+        embed_model="model-name",
+        overwrite=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"doc_key": "a", "text": "Alpha"}, "must contain a list"),
+        ([{"text": "Alpha"}], "requires a non-empty doc_key"),
+        ([{"doc_key": "a", "text": 3}], "requires string text"),
+        ([{"doc_key": "a", "text": "Alpha", "metadata": []}], "metadata must be"),
+        ([["a", "Alpha"]], "3/4-item array"),
+        ([{"doc_key": "a", "text": "Alpha", "text_hash": 4}], "text_hash must"),
+    ],
+)
+def test_document_json_validation_fails_before_build(tmp_path, payload, message):
+    docs_path = tmp_path / "docs.json"
+    docs_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(SystemExit, match=message):
+        cli.load_docs_json(docs_path)
+
+
+def test_invalid_json_has_a_concise_error(tmp_path):
+    docs_path = tmp_path / "docs.json"
+    docs_path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="Could not read document JSON"):
+        cli.load_docs_json(docs_path)
+
+
+def test_quickbuild_dispatches_packaged_documents(monkeypatch, tmp_path):
+    docs = [("paper.md", "Evidence", {"source": "file"}, "hash")]
+    db_path = tmp_path / "quick.db"
+
+    with (
+        patch.object(cli, "pack_folder", return_value=docs) as pack,
+        patch.object(cli, "resolve_db_path", return_value=str(db_path)),
+        patch.object(cli, "build_collection") as build,
+    ):
+        _run(
+            monkeypatch,
+            "quickbuild",
+            "--name",
+            "papers",
+            "--from-folder",
+            str(tmp_path),
+            "--provider",
+            "local",
+            "--model",
+            "model-name",
+        )
+
+    pack.assert_called_once_with(str(tmp_path))
+    assert build.call_args.kwargs["docs"] == docs
+    assert build.call_args.kwargs["collection"] == "papers"
+
+
+def test_quickbuild_rejects_a_folder_without_supported_files(monkeypatch, tmp_path):
+    with (
+        patch.object(cli, "pack_folder", return_value=[]),
+        pytest.raises(SystemExit, match="No supported files found"),
+    ):
+        _run(
+            monkeypatch,
+            "quickbuild",
+            "--name",
+            "papers",
+            "--from-folder",
+            str(tmp_path),
+        )
+
+
+def test_keyword_search_never_requires_embedding_configuration(
+    monkeypatch, tmp_path, capsys
+):
+    db_path = tmp_path / "study.db"
+    result = [{"doc_key": "a", "score": 1.0}]
+
+    with patch.object(cli, "search", return_value=result) as search:
+        _run(
+            monkeypatch,
+            "search",
+            "--collection",
+            "study",
+            "--query",
+            "TP53",
+            "--db",
+            str(db_path),
+            "--method",
+            "keyword",
+        )
+
+    assert search.call_args.kwargs["embed_provider"] is None
+    assert search.call_args.kwargs["embed_model"] is None
+    assert json.loads(capsys.readouterr().out) == result
+
+
+def test_embedding_search_can_use_collection_metadata_without_cli_model(
+    monkeypatch, tmp_path
+):
+    db_path = tmp_path / "study.db"
+
+    with patch.object(cli, "search", return_value=[]) as search:
+        _run(
+            monkeypatch,
+            "search",
+            "--collection",
+            "study",
+            "--query",
+            "BRCA1",
+            "--db",
+            str(db_path),
+            "--method",
+            "embedding",
+        )
+
+    assert search.call_args.kwargs["embed_provider"] is None
+    assert search.call_args.kwargs["embed_model"] is None
+
+
+def test_search_uses_optional_embedding_environment_overrides(monkeypatch, tmp_path):
+    monkeypatch.setenv("EMBED_PROVIDER", "local")
+    monkeypatch.setenv("EMBED_MODEL", "environment-model")
+
+    with patch.object(cli, "search", return_value=[]) as search:
+        _run(
+            monkeypatch,
+            "search",
+            "--collection",
+            "study",
+            "--query",
+            "EGFR",
+            "--db",
+            str(tmp_path / "study.db"),
+        )
+
+    assert search.call_args.kwargs["embed_provider"] == "local"
+    assert search.call_args.kwargs["embed_model"] == "environment-model"
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        (),
+        ("search", "--collection", "study", "--query", "q", "--top-k", "0"),
+        ("search", "--collection", "study", "--query", "q", "--alpha", "-0.1"),
+        ("search", "--collection", "study", "--query", "q", "--alpha", "1.1"),
+        ("search", "--collection", "../escape", "--query", "q"),
+        ("build", "--collection", "a/b", "--docs-json", "docs.json"),
+    ],
+)
+def test_invalid_cli_inputs_exit_with_usage_error(monkeypatch, arguments):
+    monkeypatch.setattr(sys, "argv", ["tu-datastore", *arguments])
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 2
+
+
+def test_sync_upload_dispatches_all_options(monkeypatch):
+    with patch.object(cli, "sync_upload") as upload:
+        _run(
+            monkeypatch,
+            "sync-hf",
+            "upload",
+            "--collection",
+            "study",
+            "--repo",
+            "lab/study",
+            "--no-private",
+            "--tool-json",
+            "a.json",
+            "b.json",
+        )
+
+    upload.assert_called_once_with(
+        collection="study",
+        repo="lab/study",
+        private=False,
+        tool_json=["a.json", "b.json"],
+    )
+
+
+def test_sync_download_dispatches_all_options(monkeypatch):
+    with patch.object(cli, "sync_download") as download:
+        _run(
+            monkeypatch,
+            "sync-hf",
+            "download",
+            "--repo",
+            "lab/study",
+            "--collection",
+            "study",
+            "--overwrite",
+            "--include-tools",
+        )
+
+    download.assert_called_once_with(
+        repo="lab/study",
+        collection="study",
+        overwrite=True,
+        include_tools=True,
+    )
+
+
+def test_add_tool_copies_to_the_user_directory_and_requires_overwrite(
+    monkeypatch, tmp_path
+):
+    source = tmp_path / "source.json"
+    source.write_text('{"name": "Example"}', encoding="utf-8")
+    destination_dir = tmp_path / "user-tools"
+    monkeypatch.setattr(cli, "USER_TOOLS_DIR", str(destination_dir))
+
+    cli.add_tool(str(source), name="example")
+    destination = destination_dir / "example.json"
+    assert destination.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="already exists"):
+        cli.add_tool(str(source), name="example")
+
+    source.write_text('{"name": "Updated"}', encoding="utf-8")
+    cli.add_tool(str(source), name="example", overwrite=True)
+    assert json.loads(destination.read_text(encoding="utf-8"))["name"] == "Updated"
+
+
+@pytest.mark.parametrize("name", ["../escape", "folder/tool", "folder\\tool"])
+def test_add_tool_rejects_destination_path_traversal(monkeypatch, tmp_path, name):
+    source = tmp_path / "source.json"
+    source.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli, "USER_TOOLS_DIR", str(tmp_path / "user-tools"))
+
+    with pytest.raises(SystemExit, match="must not contain path separators"):
+        cli.add_tool(str(source), name=name)
+
+
+def test_provider_and_model_resolve_from_cli_or_environment(monkeypatch):
+    monkeypatch.setenv("EMBED_PROVIDER", "local")
+    monkeypatch.setenv("EMBED_MODEL", "environment-model")
+
+    assert cli.resolve_provider_model(None, None) == ("local", "environment-model")
+    assert cli.resolve_provider_model("openai", "explicit-model") == (
+        "openai",
+        "explicit-model",
+    )
+
+
+def test_default_database_path_uses_the_embeddings_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "get_user_cache_dir", lambda: str(tmp_path))
+
+    path = cli.resolve_db_path(None, "study")
+
+    assert path == str(tmp_path / "embeddings" / "study.db")
+    assert (tmp_path / "embeddings").is_dir()


### PR DESCRIPTION
## Summary

- require a datastore subcommand and validate collection names, result limits, and hybrid weights at the parser boundary
- validate document JSON structure and field types before starting an embedding build
- prevent default-path and registered-filename traversal
- let embedding and hybrid searches use stored collection metadata when provider/model overrides are absent
- add complete dispatch coverage for build, quickbuild, search, sync upload/download, and local tool registration

## Root causes

The CLI returned success when invoked without a subcommand, accepted malformed document rows until lower layers failed, and allowed collection names to escape the default embeddings directory. Search help described provider/model as optional, but the command required both before the pipeline could use the collection's recorded model.

## Validation

- Ruff checks passed for the datastore CLI and tests
- `pytest tests/unit/test_datastore_cli.py tests/test_database_setup -q --no-cov` (29 passed, 6 environment-dependent embedding tests skipped)
- ran an unmocked SQLite/FTS command-line search over TP53 and BRCA1 documents; the expected TP53 record was returned and serialized as valid JSON
- all Hugging Face operations were verified at the dispatch boundary with network calls mocked
- `git diff --check`