### PR TITLE
Fix self-review intent routing and opt-in scoring

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -45,7 +45,7 @@ claude plugin install tooluniverse@tooluniverse
   - `/tooluniverse:cross-validate` — verify a claim across 3+ independent databases
   - `/tooluniverse:compare` — N-way side-by-side comparison with domain-appropriate columns
   - `/tooluniverse:literature-sweep` — graded mini-review across PubMed + EuropePMC + Semantic Scholar
-  - `/tooluniverse:self-review` — generate weighted success criteria for a task and check work against them (what's missing / done well)
+  - `/tooluniverse:self-review` — review current or supplied work against its actual goal; qualitative by default, scoring only when requested
   - `/tooluniverse:setup-keys` — configure ToolUniverse API keys
 - **Research Agent**: `/tooluniverse:researcher` — same investigation, delegated to a forked-context subagent that returns one summary (use when you don't want intermediate tool-call output in your main thread).
 
@@ -79,7 +79,7 @@ For specific surfaces, use the right interaction below.
 | `/tooluniverse:cross-validate <claim>` | You have a specific testable claim and want to know how strongly it's supported. Forces 3+ independent databases, reports concordance per source. Use before publishing or acting on a fact. |
 | `/tooluniverse:compare <items>` | You want a side-by-side comparison of N items (drugs, targets, diseases, variants). Detects the domain, picks domain-appropriate columns, produces a tabular report. |
 | `/tooluniverse:literature-sweep <topic>` | Graded mini-review across PubMed + EuropePMC + Semantic Scholar with dedup, relevance scoring, and a recommended reading order. |
-| `/tooluniverse:self-review <task>` | You (or an agent) are about to do, are doing, or have finished a task and want the success criteria for it — then to check work against them. Decomposes the task into scenarios → perspectives → weighted YES/NO criteria (the Qworld Recursive Expansion Tree method); with work supplied, scores it and lists what's missing. Use for self-review, a definition-of-done checklist, or an evaluation rubric. |
+| `/tooluniverse:self-review [target or request]` | Review current or supplied work against the original goal and surface evidence-backed findings, strengths, gaps, and fixes. Plain eval/review requests stay qualitative; ask explicitly for a score, grade, weighted rubric, Qworld, or RET when numeric grading is wanted. Omit the argument to review the current work from conversation context. |
 | `/tooluniverse:setup-keys` | Set up ToolUniverse API keys — opens a setup page listing every key tools can use, with registration links, and saves them to a `.env` the MCP server, CLI, and SDK all read. |
 
 ### Launch the research agent

--- a/plugin/commands/self-review.md
+++ b/plugin/commands/self-review.md
@@ -1,21 +1,28 @@
 ---
 name: self-review
-description: Generate the success criteria for a task or question, then review work against them. Decomposes the task into scenarios → evaluation perspectives → weighted YES/NO criteria (the Qworld Recursive Expansion Tree method) and, if you supply the work, scores it criterion-by-criterion and lists what is missing or could be better. Use to self-review or check your own work, judge whether a task is done well or completely, build a definition-of-done / completeness checklist, or create an evaluation rubric / grading criteria for answers to a question.
-argument-hint: "[task, goal, or question to evaluate — optionally followed by the work to review]"
+description: Review current or supplied work against the user's actual goal, report evidence-backed strengths, gaps, risks, and fixes, and give a plain-language completion verdict. Qualitative by default; only score or grade when explicitly requested.
+argument-hint: "[work or review request; omit to review the current work]"
 ---
 
-Build the success criteria for this task and review work against them: $ARGUMENTS
+Apply the `tooluniverse-self-review` skill to this request: $ARGUMENTS
 
-Apply the full method by loading the `tooluniverse-self-review` skill, then run it on the input above.
+## Interpret the request
 
-## Input parsing
+- Treat `$ARGUMENTS` as the **evaluation instruction and optional target**, not
+  automatically as the task being evaluated.
+- If `$ARGUMENTS` is empty or refers to "current work", "this", or "what we have", recover
+  the original goal and current work from the conversation and available artifacts.
+- If an artifact, answer, file, diff, or section is supplied explicitly, review that target
+  against its stated or preceding goal.
+- Plain `eval`, `evaluate`, `review`, `assess`, or `check` requests are qualitative. Do not
+  generate points, grades, weighted criteria, or numeric totals unless `$ARGUMENTS`
+  explicitly asks for them.
+- If the request is to create an eval suite, test, grader, or benchmark, treat it as an
+  engineering task rather than running self-review.
 
-- Treat all of `$ARGUMENTS` as the **task / goal / question** to evaluate, unless it clearly also contains a **result to review** (a pasted answer, a draft, a "here is what I did" section). If a result is present, evaluate it against the generated criteria. If no result is present, run in **checklist mode** — produce the criteria only, no scoring. Do not invent a result to score.
+## Produce
 
-## What to produce
-
-Follow the `tooluniverse-self-review` skill exactly. In brief:
-
-1. Build the rubric with the Recursive Expansion Tree: scenarios → perspectives → concrete, binary (YES/NO) criteria. Complete every expansion round (3 for scenarios, 4 for perspectives, 3 for criteria), deduplicate, then run the polarity check and score calibration.
-2. Present a criteria table: `criterion_id`, `criterion`, `points`, `reasoning`. Keep criteria task-specific, binary, balanced (total positive points outweigh negative), and non-redundant.
-3. If work was supplied (review mode): give each criterion a YES/NO with a one-line evidence cite, report earned / max-positive / net score, and a ranked gap list (most important unmet criteria first) with a concrete fix for each. If no work was supplied (checklist mode): present the criteria as a definition-of-done checklist and state that no work was reviewed.
+By default, give a concise evidence-backed assessment with findings ordered by impact,
+meaningful strengths, prioritized fixes, and a plain-language completion verdict. Do not
+print RET scenarios, perspectives, criteria tables, or scoring machinery unless explicitly
+requested.

--- a/plugin/skills/tooluniverse-claude-code-plugin/SKILL.md
+++ b/plugin/skills/tooluniverse-claude-code-plugin/SKILL.md
@@ -100,7 +100,7 @@ The router skill auto-dispatches to the right specialized skill — no command p
 | **`/tooluniverse:compare`** | N-way side-by-side comparison with domain-appropriate columns | Slash command |
 | **`/tooluniverse:literature-sweep`** | Graded mini-review across PubMed + EuropePMC + Semantic Scholar | Slash command |
 | **`/tooluniverse:verify-references`** | Check that cited references are real and accurately described, including retraction status | Slash command |
-| **`/tooluniverse:self-review`** | Generate weighted success criteria for a task and check work against them (what's missing / done well) | Slash command |
+| **`/tooluniverse:self-review`** | Review current or supplied work against its actual goal; qualitative by default, with scoring only when explicitly requested | Slash command |
 | **`/tooluniverse:setup-keys`** | Configure ToolUniverse API keys | Slash command |
 | **`/tooluniverse:researcher`** | Same investigation as `research`, delegated to a forked subagent | Slash command |
 | **120+ skills** | Structured workflows (drug research, variant interpretation, pharmacovigilance, CRISPR screens, statistical modeling, etc.) | Auto-activate on matching questions |

--- a/plugin/skills/tooluniverse-self-review/SKILL.md
+++ b/plugin/skills/tooluniverse-self-review/SKILL.md
@@ -1,367 +1,159 @@
 ---
 name: tooluniverse-self-review
 description: >
-  Generate the success criteria for a task or question, then review work against them.
-  Given a task, goal, or open-ended question, decompose it into scenarios, evaluation
-  perspectives, and fine-grained weighted YES/NO criteria using the Recursive Expansion
-  Tree (RET) method; if work is supplied, score it criterion-by-criterion and surface
-  what is missing or could be better. Use when asked to self-review or check your own
-  work, judge whether a task is done well or completely, build a definition-of-done or
-  completeness checklist, create an evaluation rubric or grading criteria, score or grade
-  answers to a question, set up an LLM-as-judge rubric, or when the user mentions
-  self-review, completeness check, success criteria, evaluation criteria, scoring rubric,
-  Qworld, or the RET algorithm.
+  Review existing work against the user's actual goal and surface evidence-backed
+  strengths, gaps, risks, and next fixes. Use when asked to eval, evaluate, review,
+  assess, or check current/this/my/our work; decide whether a task is complete; build a
+  definition-of-done checklist or rubric; or perform grading, LLM-as-judge, Qworld, or
+  RET evaluation. Treat plain eval/review requests as qualitative: resolve "current
+  work" from the conversation, artifacts, files, or diff, and never assign numeric
+  scores unless the user explicitly requests scores, grades, points, ratings, weighted
+  criteria, Qworld, or RET. Do not use for implementing automated eval suites, tests,
+  graders, or benchmarks.
 disable-model-invocation: true
 ---
 
-# Self-Review: Task Success Criteria + Work Review
-
-Derive the criteria that define a good result for a specific task, then review work
-against them. Each task defines its own "evaluation world" -- a set of scenarios,
-perspectives, and criteria that capture what matters for judging results for that
-specific task. Built on the Qworld Recursive Expansion Tree (RET).
-
-## When to Use
-
-- An agent (or person) is about to do, is doing, or has finished a task and wants to know
-  what a good result must cover, or what is missing or weak.
-- You need a definition-of-done or completeness checklist for a task or goal.
-- You need an evaluation rubric / grading criteria for answers to an open-ended question.
-- You want to score or grade responses: LLM-as-judge, exam answers, candidate responses.
-
-## Inputs
-
-- **task** (required): the task, goal, or question to evaluate. If it is a multi-turn
-  conversation, treat the whole exchange as context and the last user message as the
-  primary intent. If it includes an image or retrieved web context, factor that in.
-- **work** (optional): a planned approach or a completed result to review. If no work is
-  supplied, run in **checklist mode** -- produce the criteria only, no scoring.
-
-## Core Principles
-
-1. **Task-specific**: Every scenario, perspective, and criterion must be derived from the
-   task's content, intent, and context. Never reuse a fixed set of dimensions across tasks.
-2. **Binary and verifiable**: Each final criterion must be answerable YES or NO by a reviewer.
-3. **Non-redundant**: At every level, check for overlap before adding new items.
-4. **Balanced**: Include both positive criteria (what a good result must do) and negative
-   criteria (what constitutes harmful or misleading content). Positive total points must
-   outweigh negative.
-5. **Coverage-driven**: At each level, repeatedly ask "what's missing?" to ensure the
-   evaluation space implied by the task is fully explored.
-
-## Algorithm Overview
-
-The RET builds a 3-level tree from the task:
-
-```
-Task / goal / question
-  -> Level 1: Scenarios (contextual framings that change what "good" means)
-       -> Level 2: Perspectives (evaluation dimensions per scenario)
-            -> Level 3: Criteria (concrete, binary rubric items with scores)
-```
-
-At each level, two operators apply:
-- **Hierarchical decomposition**: break a node into finer-grained children at the next level.
-- **Horizontal expansion**: ask "what else is missing?" and add sibling nodes for coverage.
-
-After the tree is built, **Phase B** reviews supplied work against the leaf criteria.
-
----
-
-## Step-by-Step Workflow
-
-Copy this checklist and track progress as you work:
-
-```
-Task Progress:
-- [ ] Step 1: Scenario grounding
-- [ ] Step 2: Scenario expansion (3 rounds)
-- [ ] Step 3: Perspective generation
-- [ ] Step 4: Perspective expansion (4 rounds)
-- [ ] Step 5: Perspective review and consolidation
-- [ ] Step 6: Criteria generation
-- [ ] Step 7: Criteria expansion (3 rounds)
-- [ ] Step 8: Criteria review and consolidation
-- [ ] Step 9: Polarity check
-- [ ] Step 10: Score calibration
-- [ ] Phase B: Review work against criteria (or emit checklist if no work supplied)
-```
-
----
-
-### Step 1: Scenario Grounding
-
-**Goal**: Identify the distinct real-world contexts in which this task could arise, where
-each context would materially change what constitutes a good result.
-
-**Method**:
-- Read the task carefully. Infer its domain, intent, audience, stakes, and implicit
-  constraints.
-- Ask: "In what different situations could someone pursue this task, and how would the
-  situation change what a good result looks like?"
-- Produce a minimal, non-redundant set of scenarios. Merge any that would lead to the same
-  evaluation criteria.
-
-**Output format** for each scenario:
-- `scenario_name`: short descriptive label
-- `scenario_description`: 3-5 sentences explaining what is unique about this context and
-  why it changes what "good" means
-
----
-
-### Step 2: Scenario Expansion (3 rounds)
-
-**Goal**: Ensure comprehensive coverage of the evaluation space at the scenario level.
-
-**Method** (repeat 3 times):
-1. Review all existing scenarios.
-2. Ask: "What contexts or framings are missing that would require different evaluation criteria?"
-3. Identify gaps along context axes (audience, setting, stakes, constraints, domain variation, etc.).
-4. Generate ONLY new scenarios that differ materially from all existing ones. Do not repeat
-   or rephrase existing scenarios.
-
-After each round, append new scenarios to the list.
-
----
-
-### Step 3: Perspective Generation
-
-**Goal**: For each scenario, derive the evaluation dimensions that matter for judging a
-result in that context.
-
-**Method**:
-- For EACH scenario, produce 4-7 non-overlapping evaluation perspectives.
-- Each perspective must be grounded in the scenario and the task. Derive perspectives
-  entirely from the task's content and context -- do not apply a pre-set list of dimensions.
-- Aim for maximally diverse themes, including unconventional angles that are specific to
-  this task.
-- Each perspective should be high-level enough to spawn multiple criteria, yet narrow
-  enough to avoid overlap with other perspectives.
-
-**Output format** for each perspective:
-- `perspective_name`: 2-5 word descriptive label
-- `perspective_description`: 3-5 sentences explaining what this perspective evaluates and
-  listing 3-5 specific sub-aspects it covers
-
----
-
-### Step 4: Perspective Expansion (4 rounds)
-
-**Goal**: Fill coverage gaps in the perspective set.
-
-**Method** (repeat 4 times):
-1. Review all perspectives across all scenarios.
-2. Map coverage across quality dimensions implied by the task.
-3. Ask: "What evaluation angles are missing that would yield materially different criteria?"
-4. Generate ONLY new perspectives that provide distinct evaluation value. Do not repeat
-   existing ones.
-
-After each round, append new perspectives to the collection.
-
----
-
-### Step 5: Perspective Review and Consolidation
-
-**Goal**: Produce a clean, non-redundant set of perspectives ready for criteria generation.
-
-**Method**:
-- If two perspectives target the same evaluation angle but under different scenarios,
-  combine scenario-specific details into each description but keep them as separate
-  perspectives.
-- Remove perspectives that are off-topic, redundant with others, or too vague to guide
-  concrete criteria generation.
-- Each kept perspective must contribute unique evaluation value for this task.
-- Assign each kept perspective a unique ID (p0, p1, p2, ...).
-
----
-
-### Step 6: Criteria Generation
-
-**Goal**: For each reviewed perspective, generate concrete, binary evaluation criteria.
-
-**Method**:
-- For EACH perspective, generate criteria that a reviewer can check YES or NO against a
-  result.
-- Cover all sub-aspects listed in the perspective description.
-
-**Criteria rules**:
-1. **Binary**: Each criterion must be answerable YES/NO.
-2. **Scenario-specific**: Explicitly reference features of the task and scenario. Make
-   criteria as detailed and specific as possible.
-3. **Self-contained**: Each criterion is a standalone statement in the form
-   [Verb + Specific Requirement]. Start with one clear action verb, then state the exact
-   required or forbidden content with qualifiers.
-4. **Balanced**: Include positive criteria (required content/behavior) and negative
-   criteria (harmful, misleading, or critically wrong content). Only add negative criteria
-   when the issue represents harmful, dangerous, or significantly quality-reducing behavior
-   -- not minor stylistic concerns.
-5. **Diverse**: Cover all sub-aspects of the perspective.
-
-**Negative criteria phrasing**: Describe the bad behavior directly. Instead of "Avoids
-doing X", write "Does X" (where X is the harmful behavior). The criterion text states the
-behavior; its negative score indicates that meeting it is bad.
-
-**Scoring standard**:
-- Positive: 1-10 (10 = critical safety/core requirement; 8-9 = important completeness;
-  5-7 = quality enhancer; 1-4 = minor nice-to-have)
-- Negative: -1 to -10 (-10 = dangerous/harmful; -8 to -9 = major omission or error;
-  -5 to -7 = quality issue; -1 to -4 = minor issue)
-
-**Output format** for each criterion:
-- `criterion`: the criterion text
-- `points`: integer score (positive or negative)
-- `reasoning`: 2-3 sentences explaining why this criterion matters for this task and why
-  it received this weight
-
----
-
-### Step 7: Criteria Expansion (3 rounds)
-
-**Goal**: Fill coverage gaps in the criteria set.
-
-**Method** (repeat 3 times):
-1. Review all existing criteria.
-2. Ask: "What concrete content or behavior, if present or absent in a result, would change
-   whether it passes or fails -- and is not yet covered?"
-3. Generate ONLY new criteria that are non-overlapping with existing ones.
-4. Follow the same rules and scoring standard as Step 6.
-
-After each round, append new criteria to the collection.
-
----
-
-### Step 8: Criteria Review and Consolidation
-
-**Goal**: Produce a concise, non-redundant final rubric.
-
-**Method**:
-- **Deduplicate and merge**: Combine criteria that assess the same aspect. Keep the most
-  precise wording and include all distinct details from merged criteria.
-- **Positive/negative overlap**: If a positive and negative criterion cover the same
-  aspect, keep only the positive.
-- **Neutralize fixed facts**: Replace hard-coded numbers, dates, versions, limits, or
-  placeholders with a requirement that the result states the current/official/latest value
-  or standard.
-- **Balance check**: Ensure total positive points outweigh total negative points. Retain
-  all distinct, non-overlapping items.
-- Assign each final criterion a unique ID (c0, c1, c2, ...).
-
----
-
-### Step 9: Polarity Check
-
-**Goal**: Verify that every criterion's score sign correctly reflects whether meeting it is
-good or bad.
-
-**Method**:
-- For each criterion, determine: does meeting this criterion improve the result (positive)
-  or indicate a problem (negative)?
-- A criterion that describes desirable behavior should have a positive score.
-- A criterion that describes harmful, wrong, or misleading behavior should have a negative
-  score.
-- Phrasing like "Avoids doing X" describes desirable behavior (positive). Phrasing like
-  "Does X" (where X is bad) describes undesirable behavior (negative).
-- Adjust the sign of points if misclassified. Do not change the criterion text.
-
----
-
-### Step 10: Score Calibration
-
-**Goal**: Ensure score magnitudes accurately reflect importance.
-
-**Method**:
-- Review each criterion's absolute score against the scoring standard from Step 6.
-- A more important or severe issue must always have a higher absolute score than a less
-  important one.
-- Adjust magnitudes where needed. Do not change the sign (positive/negative direction) or
-  the criterion text.
-- Verify the scoring standard is applied consistently:
-  - Positive: 10 = critical, 8-9 = important, 5-7 = quality, 1-4 = minor
-  - Negative: -10 = dangerous, -8 to -9 = major, -5 to -7 = moderate, -1 to -4 = minor
-
----
-
-### Phase B: Review Work Against Criteria
-
-**Goal**: Apply the finalized criteria to the actual work, or emit a checklist if none was
-supplied.
-
-**If no work was supplied (checklist mode)**:
-- State explicitly: "No work supplied -- criteria only (definition-of-done checklist)."
-- Present the criteria as a checklist the user can run against any future result.
-- Stop here; do not invent or assume a result to score.
-
-**If work was supplied (review mode)**:
-1. For EACH criterion, judge whether the work meets it: YES or NO, with a one-line cite of
-   the specific evidence in the work (quote or location) that justifies the verdict.
-2. Compute the score: sum the `points` of every criterion marked YES (positive criteria add,
-   negative criteria subtract). Report earned points, maximum positive points, and the
-   net total.
-3. Produce a ranked **gap list**: the unmet positive criteria and any met negative criteria,
-   ordered by absolute `points` (most important first). For each, give a one-line concrete
-   fix.
-4. Keep the review evidence-based. Do not credit a criterion the work does not actually
-   satisfy, and do not penalize for criteria outside the stated task.
-
----
-
-## Final Output Format
-
-Present results in this order:
-
-1. **Mode line**: "review mode" or "checklist mode (no work supplied)".
-2. **Scenarios**: list with IDs, names, descriptions.
-3. **Reviewed perspectives**: list with IDs, names, descriptions.
-4. **Criteria table**: each row has `criterion_id`, `criterion`, `points`, `reasoning`.
-5. **Summary statistics**: number of scenarios, perspectives, raw criteria, final criteria;
-   total positive and total negative points.
-6. **Review** (review mode only): per-criterion YES/NO + evidence, earned/max/net score,
-   and the ranked gap list with fixes.
-
----
-
-## Handling Special Inputs
-
-**Multi-turn conversations**: If the task is a conversation (user-assistant exchange), treat
-the full conversation as context. The last user message is typically the primary intent;
-earlier messages provide context that may affect evaluation dimensions.
-
-**Tasks with images**: If the task includes an image, factor image content into scenario
-analysis and criteria generation. Reference visual elements where relevant in criteria.
-
-**Tasks with retrieved web context**: If web-retrieved context is provided alongside the
-task, use it to inform factual grounding of scenarios and criteria. Do not limit analysis
-to only the retrieved content -- also apply general reasoning.
-
----
-
-## Key Constraints
-
-- **No fixed dimension lists**: Never apply a pre-defined set of evaluation dimensions.
-  Every scenario, perspective, and criterion must be freshly derived from the task.
-- **Expansion counts matter**: Complete all specified expansion rounds (3 for scenarios,
-  4 for perspectives, 3 for criteria). Skipping rounds reduces coverage.
-- **Deduplication is mandatory**: After each expansion phase and before finalization, check
-  for and remove redundant items.
-- **Criteria must be binary**: Every criterion in the final set must be checkable as YES or
-  NO. Do not produce criteria that require subjective degree judgments.
-- **Evidence-based review**: In review mode, every YES/NO must be backed by specific
-  evidence from the supplied work.
-
----
-
-## Citation
-
-This skill ports the Qworld method. If you use it in your work, please cite:
-
-```bibtex
-@misc{gao2026qworldquestionspecificevaluationcriteria,
-      title={Qworld: Question-Specific Evaluation Criteria for LLMs},
-      author={Shanghua Gao and Yuchang Su and Pengwei Sui and Curtis Ginder and Marinka Zitnik},
-      year={2026},
-      eprint={2603.23522},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2603.23522},
-}
-```
+# Self-Review: Understand the Target, Then Review
+
+Review the actual work the user means against the goal it was meant to satisfy. Default
+to a concise qualitative assessment. Scoring and the full Qworld Recursive Expansion
+Tree (RET) are opt-in.
+
+## Non-Negotiable Rules
+
+1. **Do not confuse the evaluation request with the evaluated task.** In requests such as
+   "eval current work", that sentence is an instruction to review. The task being judged
+   is the preceding user goal; the work is the current result, implementation, draft,
+   plan, or progress.
+2. **Do not equate `eval` with scoring.** `Eval`, `evaluate`, `review`, `assess`, and
+   `check` mean qualitative review unless the user explicitly asks for a score, grade,
+   rating, points, weighted rubric, Qworld, RET, or a numeric scale.
+3. **Do not invent work to review.** Inspect the conversation and available artifacts. If
+   evidence is unavailable, say what could not be verified.
+4. **Do not expose process by default.** Keep scenario expansion, perspective generation,
+   and rubric construction internal unless the user asked for those artifacts.
+5. **Review against the user's goal, not a generic quality template.** Derive the relevant
+   checks from the request, stated constraints, acceptance criteria, and risks.
+
+## Resolve the Review Target
+
+Separate three objects before reviewing:
+
+- **Evaluation instruction**: what the user is asking now (for example, "review this").
+- **Original goal**: the request, problem, or acceptance criteria the work should satisfy.
+- **Work product**: the answer, code, files, diff, plan, analysis, or current progress to
+  examine.
+
+Resolve the work product in this order:
+
+1. An explicitly named file, answer, commit, diff, section, or artifact.
+2. Pasted or attached content in the current message.
+3. The current repository implementation or working-tree diff when the conversation is
+   about code changes.
+4. The most recent assistant-produced deliverable relevant to the preceding user goal.
+5. The current plan or partial progress when the task is still underway.
+
+Interpret deictic phrases such as "current work", "this work", "what we have", "刚才的
+工作", and "当前工作" using that order. In a multi-turn conversation, the last user
+message is usually the evaluation instruction, **not** the original goal.
+
+Proceed without asking when the goal and work can be recovered confidently. Ask one
+short clarifying question only when there is no reviewable work or when multiple plausible
+targets would produce materially different reviews.
+
+## Choose One Mode
+
+| Mode | Trigger | Default output |
+|---|---|---|
+| **Qualitative review** (default) | "eval/review/check current work", "is this done?", "what is missing?" | Evidence-backed findings, strengths, gaps, fixes, and a completion verdict; no numbers |
+| **Checklist** | Explicit request for definition of done, success criteria, or completeness checklist without work to review | Task-specific checklist; no points |
+| **Rubric** | Explicit request for evaluation criteria or a rubric, but no scoring request | Binary or observable criteria grouped as must/should/could; no points |
+| **Scored evaluation** | Explicit request for score, grade, rating, points, weighted criteria, LLM-as-judge scoring, Qworld, RET, or a numeric scale | Evidence-backed scored review using the requested scale or RET |
+
+The phrase "evaluate this" alone selects **qualitative review**, even when a work product
+is present. The presence of work never turns scoring on by itself.
+
+Requests to **create or run evals**, implement a grader, write evaluation tests, or build a
+benchmark are engineering tasks, not self-review requests. Do not route those requests to
+this workflow merely because they contain the word `eval`.
+
+## Qualitative Review Workflow (Default)
+
+1. **Recover the goal.** Summarize the original goal and important constraints in one or
+   two sentences. Prefer explicit acceptance criteria over inferred preferences.
+2. **Inspect the work.** Use the actual conversation output, files, diff, test results, or
+   supplied artifact. For code, inspect relevant implementation and verification evidence;
+   do not judge from a summary alone when the files are available.
+3. **Derive focused checks internally.** Identify only the task-specific dimensions needed
+   to judge correctness, completeness, user intent, risks, and verification. Do not print a
+   large rubric unless asked.
+4. **Report findings by impact.** Lead with concrete problems or unmet requirements. For
+   each finding, cite the evidence and explain the consequence.
+5. **Acknowledge what works.** Note meaningful strengths briefly; do not pad the response
+   with generic praise.
+6. **Give prioritized fixes.** Recommend the smallest concrete actions that close the most
+   important gaps.
+7. **State a plain-language verdict.** Use `complete`, `mostly complete`, `partially
+   complete`, `not complete`, or `unable to verify`, with a short reason. Do not convert
+   the verdict into a number.
+
+### Default Review Shape
+
+Adapt the headings to the task and omit empty sections:
+
+1. **Overall assessment** — target, goal, and verdict.
+2. **Findings** — ordered by impact, with evidence.
+3. **What is working** — concise, specific strengths.
+4. **Recommended next actions** — prioritized fixes.
+
+For code review, prioritize actionable defects and regressions over summaries. Cite file
+paths and tight line ranges when possible. If no problems are found, say so directly and
+name any residual verification gaps.
+
+## Checklist and Unscored Rubric Modes
+
+- Derive criteria from the task rather than a fixed dimension list.
+- Keep each item observable and specific enough to check.
+- Use `must`, `should`, and `could` for importance when prioritization helps.
+- Do not attach numbers, weights, percentages, earned totals, or pass rates.
+- If work is also supplied, mark items `met`, `partially met`, `not met`, or
+  `not verifiable`, with brief evidence. These labels are not scores.
+- Do not generate scenarios or perspectives unless the user explicitly asks to see the
+  derivation.
+
+## Scored Evaluation Mode (Explicit Opt-In Only)
+
+Use this mode only when the request contains an unambiguous scoring signal listed above.
+
+- If the user supplies a scale or grading scheme, follow it.
+- If the user asks for Qworld, RET, a weighted rubric, or LLM-as-judge scoring without a
+  custom scheme, read and follow
+  [references/ret-scored-evaluation.md](references/ret-scored-evaluation.md).
+- Keep every verdict evidence-based. Do not award credit for absent evidence or penalize
+  criteria outside the original goal.
+- Explain what the score means and still provide the highest-impact gaps and fixes. A
+  number alone is not a useful review.
+
+## Examples of Correct Routing
+
+| User request | Correct interpretation |
+|---|---|
+| "Eval current work." | Review the current result against the preceding goal; qualitative, no score |
+| "Evaluate whether we finished the original request." | Inspect current artifacts and give a completion verdict; no score |
+| "What is missing from this implementation?" | Findings-first implementation review; no score |
+| "Make a definition-of-done checklist for this feature." | Checklist mode; no score |
+| "Create an evaluation rubric for these answers." | Unscored rubric unless weights or grading are requested |
+| "Score this answer from 1 to 10." | Scored mode on the requested scale |
+| "Apply Qworld/RET to grade these responses." | Full scored RET mode |
+| "Create an eval suite for this agent." | Out of scope for this skill; treat as an eval-engineering task |
+
+## Evidence and Honesty
+
+- Distinguish observed evidence from inference.
+- Do not claim tests passed unless their output is available.
+- Do not infer completion from a clean diff, a confident summary, or the existence of
+  files alone.
+- If the user requests evaluation while work is still running, review the available
+  progress and label unfinished parts rather than pretending the final result exists.
+- Keep the response proportional to the work. A small change should not produce a giant
+  framework dump.

--- a/plugin/skills/tooluniverse-self-review/references/ret-scored-evaluation.md
+++ b/plugin/skills/tooluniverse-self-review/references/ret-scored-evaluation.md
@@ -1,0 +1,118 @@
+# Qworld RET Scored Evaluation
+
+Use this reference only after the user explicitly requests scoring, grading, weighted
+criteria, LLM-as-judge scoring, Qworld, or the Recursive Expansion Tree (RET).
+
+## Inputs
+
+- **Original goal**: the task, question, constraints, and acceptance criteria.
+- **Work product**: the actual answer, implementation, artifact, or result to grade.
+- **Scale**: the user's requested scheme, or the default weighted scheme below.
+
+Never treat the evaluation instruction itself as the original goal. If the user says
+"score current work", recover the goal and work from the preceding conversation and
+available artifacts first.
+
+## Recursive Expansion Tree
+
+Build the rubric from the task:
+
+```text
+Original goal
+  -> scenarios that materially change what good means
+       -> task-specific evaluation perspectives
+            -> concrete, binary criteria
+```
+
+Keep this derivation internal unless the user asks to see it.
+
+### 1. Scenario grounding and expansion
+
+Identify a minimal non-redundant set of real contexts in which the task could arise and
+where the context changes what constitutes a good result. Expand three times by asking
+what materially different audience, setting, stakes, constraints, or domain variation is
+missing. Do not add paraphrases of existing scenarios.
+
+### 2. Perspective generation and expansion
+
+For each scenario, derive evaluation dimensions from the task itself. Do not use a fixed
+dimension list. Expand four times by asking which distinct evaluation angle would yield
+new criteria. Consolidate overlap and assign perspective IDs (`p0`, `p1`, ...).
+
+### 3. Criteria generation and expansion
+
+For each retained perspective, write self-contained criteria that are:
+
+- answerable `YES` or `NO`;
+- specific to the task and scenario;
+- observable in the work product;
+- non-redundant; and
+- phrased as one concrete required or forbidden behavior.
+
+Expand three times by asking what additional observable behavior would materially change
+the verdict. Then merge overlap and assign criterion IDs (`c0`, `c1`, ...).
+
+Include negative criteria only for harmful, misleading, or materially quality-reducing
+behavior—not minor style preferences. Phrase negative criteria as the bad behavior itself;
+the negative point value supplies the polarity.
+
+## Default Weighted Scheme
+
+Use this scheme only when the user did not provide another one:
+
+- Positive `1–10`: `10` critical safety/core requirement; `8–9` important completeness;
+  `5–7` meaningful quality; `1–4` minor enhancement.
+- Negative `-1–-10`: `-10` dangerous; `-8–-9` major error; `-5–-7` material quality
+  problem; `-1–-4` minor problem.
+
+For each criterion provide `criterion_id`, `criterion`, `points`, and a concise reason for
+the weight. Check that:
+
+1. desirable criteria have positive signs and harmful behaviors have negative signs;
+2. more important criteria have larger absolute weights;
+3. positive and negative criteria do not duplicate the same requirement; and
+4. total positive points exceed total negative magnitude.
+
+## Apply the Rubric
+
+For every criterion:
+
+1. Mark `YES` or `NO`.
+2. Cite the specific evidence or location supporting the verdict.
+3. Sum points only for criteria marked `YES`; positive items add and negative items
+   subtract.
+
+Report:
+
+- earned positive points and maximum positive points;
+- negative penalties triggered;
+- net total and the scale interpretation;
+- the most important unmet positive criteria and triggered negative criteria; and
+- one concrete fix for each high-impact gap.
+
+If there is no work product, do not fabricate a score. Return a weighted rubric and state
+that no work was graded.
+
+## Output Discipline
+
+- Show scenarios and perspectives only if the user asks for the full derivation.
+- Keep reasoning proportional; do not dump expansion logs.
+- Prefer evidence and actionable gaps over score theater.
+- If evidence is unavailable, mark the criterion `NO` or `not verifiable` according to the
+  user's grading policy and disclose the limitation.
+
+## Citation
+
+This method is based on Qworld:
+
+```bibtex
+@misc{gao2026qworldquestionspecificevaluationcriteria,
+      title={Qworld: Question-Specific Evaluation Criteria for LLMs},
+      author={Shanghua Gao and Yuchang Su and Pengwei Sui and Curtis Ginder and Marinka Zitnik},
+      year={2026},
+      eprint={2603.23522},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2603.23522},
+}
+```

--- a/plugin/skills/tooluniverse/SKILL.md
+++ b/plugin/skills/tooluniverse/SKILL.md
@@ -285,7 +285,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**custom tool**", "add my own tool", "local tool", "create tool", "extend ToolUniverse" | `Skill(skill="tooluniverse-custom-tool")` |
 | "**SDK**", "Python SDK", "build AI scientist", "programmatic access", "**import tooluniverse**", "**coding API**", "**tu build**", "**typed wrappers**" | `Skill(skill="tooluniverse-sdk")` |
 | "**install skills**", "missing skills", "skill not found", "add skills" | `Skill(skill="tooluniverse-install-skills")` |
-| "**self-review**", "check my work", "definition of done", "evaluation rubric", "success criteria", "grading criteria", "LLM-as-judge" | `Skill(skill="tooluniverse-self-review")` |
+| "**self-review**", "eval current work", "evaluate this work", "check my work", "is this complete", "definition of done", "evaluation rubric", "success criteria", "grading criteria", "LLM-as-judge" | `Skill(skill="tooluniverse-self-review")` |
 
 ---
 
@@ -305,10 +305,15 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 3. **Specificity Rule**: More specific beats general.
    - "cancer treatment" → precision-oncology (not disease-research)
 
-4. **Data Type Rule**: "get/retrieve/fetch" → retrieval skills.
+4. **Evaluation Intent Rule**: Route requests to review existing/current work to
+   `tooluniverse-self-review`, but do not route requests to create or run an eval suite,
+   grader, test, or benchmark there. Those are implementation tasks. Within self-review,
+   plain "eval" is qualitative; scoring requires an explicit score/grade/points request.
+
+5. **Data Type Rule**: "get/retrieve/fetch" → retrieval skills.
    - "get compound structure" → chemical-compound-retrieval (not drug-research)
 
-5. **Still ambiguous**: Ask user with AskUserQuestion.
+6. **Still ambiguous**: Ask user with AskUserQuestion.
 
 ---
 

--- a/plugins/tooluniverse/skills/tooluniverse-self-review/SKILL.md
+++ b/plugins/tooluniverse/skills/tooluniverse-self-review/SKILL.md
@@ -1,357 +1,150 @@
 ---
 
 name: tooluniverse-self-review
-description: "Generate the success criteria for a task or question, then review work against them. Given a task, goal, or open-ended question, decompose it into scenarios, evaluation perspectives, and fine-grained weighted YES/NO criteria using the Recursive Expansion Tree (RET) method; if work is supplied, score it criterion-by-criterion and surface what is missing or could be better. Use when asked to self-review or check your own work, judge whether a task is done well or completely, build a definition-of-done or completeness checklist, create an evaluation rubric or grading criteria, score or grade answers to a question, set up an LLM-as-judge rubric, or when the user mentions self-review, completeness check, success criteria, evaluation criteria, scoring rubric, Qworld, or the RET algorithm.\n"
+description: "Review existing work against the user's actual goal and surface evidence-backed strengths, gaps, risks, and next fixes. Use when asked to eval, evaluate, review, assess, or check current/this/my/our work; decide whether a task is complete; build a definition-of-done checklist or rubric; or perform grading, LLM-as-judge, Qworld, or RET evaluation. Treat plain eval/review requests as qualitative: resolve \"current work\" from the conversation, artifacts, files, or diff, and never assign numeric scores unless the user explicitly requests scores, grades, points, ratings, weighted criteria, Qworld, or RET. Do not use for implementing automated eval suites, tests, graders, or benchmarks.\n"
 ---
 
-# Self-Review: Task Success Criteria + Work Review
-
-Derive the criteria that define a good result for a specific task, then review work
-against them. Each task defines its own "evaluation world" -- a set of scenarios,
-perspectives, and criteria that capture what matters for judging results for that
-specific task. Built on the Qworld Recursive Expansion Tree (RET).
-
-## When to Use
-
-- An agent (or person) is about to do, is doing, or has finished a task and wants to know
-  what a good result must cover, or what is missing or weak.
-- You need a definition-of-done or completeness checklist for a task or goal.
-- You need an evaluation rubric / grading criteria for answers to an open-ended question.
-- You want to score or grade responses: LLM-as-judge, exam answers, candidate responses.
-
-## Inputs
-
-- **task** (required): the task, goal, or question to evaluate. If it is a multi-turn
-  conversation, treat the whole exchange as context and the last user message as the
-  primary intent. If it includes an image or retrieved web context, factor that in.
-- **work** (optional): a planned approach or a completed result to review. If no work is
-  supplied, run in **checklist mode** -- produce the criteria only, no scoring.
-
-## Core Principles
-
-1. **Task-specific**: Every scenario, perspective, and criterion must be derived from the
-   task's content, intent, and context. Never reuse a fixed set of dimensions across tasks.
-2. **Binary and verifiable**: Each final criterion must be answerable YES or NO by a reviewer.
-3. **Non-redundant**: At every level, check for overlap before adding new items.
-4. **Balanced**: Include both positive criteria (what a good result must do) and negative
-   criteria (what constitutes harmful or misleading content). Positive total points must
-   outweigh negative.
-5. **Coverage-driven**: At each level, repeatedly ask "what's missing?" to ensure the
-   evaluation space implied by the task is fully explored.
-
-## Algorithm Overview
-
-The RET builds a 3-level tree from the task:
-
-```
-Task / goal / question
-  -> Level 1: Scenarios (contextual framings that change what "good" means)
-       -> Level 2: Perspectives (evaluation dimensions per scenario)
-            -> Level 3: Criteria (concrete, binary rubric items with scores)
-```
-
-At each level, two operators apply:
-- **Hierarchical decomposition**: break a node into finer-grained children at the next level.
-- **Horizontal expansion**: ask "what else is missing?" and add sibling nodes for coverage.
-
-After the tree is built, **Phase B** reviews supplied work against the leaf criteria.
-
----
-
-## Step-by-Step Workflow
-
-Copy this checklist and track progress as you work:
-
-```
-Task Progress:
-- [ ] Step 1: Scenario grounding
-- [ ] Step 2: Scenario expansion (3 rounds)
-- [ ] Step 3: Perspective generation
-- [ ] Step 4: Perspective expansion (4 rounds)
-- [ ] Step 5: Perspective review and consolidation
-- [ ] Step 6: Criteria generation
-- [ ] Step 7: Criteria expansion (3 rounds)
-- [ ] Step 8: Criteria review and consolidation
-- [ ] Step 9: Polarity check
-- [ ] Step 10: Score calibration
-- [ ] Phase B: Review work against criteria (or emit checklist if no work supplied)
-```
-
----
-
-### Step 1: Scenario Grounding
-
-**Goal**: Identify the distinct real-world contexts in which this task could arise, where
-each context would materially change what constitutes a good result.
-
-**Method**:
-- Read the task carefully. Infer its domain, intent, audience, stakes, and implicit
-  constraints.
-- Ask: "In what different situations could someone pursue this task, and how would the
-  situation change what a good result looks like?"
-- Produce a minimal, non-redundant set of scenarios. Merge any that would lead to the same
-  evaluation criteria.
-
-**Output format** for each scenario:
-- `scenario_name`: short descriptive label
-- `scenario_description`: 3-5 sentences explaining what is unique about this context and
-  why it changes what "good" means
-
----
-
-### Step 2: Scenario Expansion (3 rounds)
-
-**Goal**: Ensure comprehensive coverage of the evaluation space at the scenario level.
-
-**Method** (repeat 3 times):
-1. Review all existing scenarios.
-2. Ask: "What contexts or framings are missing that would require different evaluation criteria?"
-3. Identify gaps along context axes (audience, setting, stakes, constraints, domain variation, etc.).
-4. Generate ONLY new scenarios that differ materially from all existing ones. Do not repeat
-   or rephrase existing scenarios.
-
-After each round, append new scenarios to the list.
-
----
-
-### Step 3: Perspective Generation
-
-**Goal**: For each scenario, derive the evaluation dimensions that matter for judging a
-result in that context.
-
-**Method**:
-- For EACH scenario, produce 4-7 non-overlapping evaluation perspectives.
-- Each perspective must be grounded in the scenario and the task. Derive perspectives
-  entirely from the task's content and context -- do not apply a pre-set list of dimensions.
-- Aim for maximally diverse themes, including unconventional angles that are specific to
-  this task.
-- Each perspective should be high-level enough to spawn multiple criteria, yet narrow
-  enough to avoid overlap with other perspectives.
-
-**Output format** for each perspective:
-- `perspective_name`: 2-5 word descriptive label
-- `perspective_description`: 3-5 sentences explaining what this perspective evaluates and
-  listing 3-5 specific sub-aspects it covers
-
----
-
-### Step 4: Perspective Expansion (4 rounds)
-
-**Goal**: Fill coverage gaps in the perspective set.
-
-**Method** (repeat 4 times):
-1. Review all perspectives across all scenarios.
-2. Map coverage across quality dimensions implied by the task.
-3. Ask: "What evaluation angles are missing that would yield materially different criteria?"
-4. Generate ONLY new perspectives that provide distinct evaluation value. Do not repeat
-   existing ones.
-
-After each round, append new perspectives to the collection.
-
----
-
-### Step 5: Perspective Review and Consolidation
-
-**Goal**: Produce a clean, non-redundant set of perspectives ready for criteria generation.
-
-**Method**:
-- If two perspectives target the same evaluation angle but under different scenarios,
-  combine scenario-specific details into each description but keep them as separate
-  perspectives.
-- Remove perspectives that are off-topic, redundant with others, or too vague to guide
-  concrete criteria generation.
-- Each kept perspective must contribute unique evaluation value for this task.
-- Assign each kept perspective a unique ID (p0, p1, p2, ...).
-
----
-
-### Step 6: Criteria Generation
-
-**Goal**: For each reviewed perspective, generate concrete, binary evaluation criteria.
-
-**Method**:
-- For EACH perspective, generate criteria that a reviewer can check YES or NO against a
-  result.
-- Cover all sub-aspects listed in the perspective description.
-
-**Criteria rules**:
-1. **Binary**: Each criterion must be answerable YES/NO.
-2. **Scenario-specific**: Explicitly reference features of the task and scenario. Make
-   criteria as detailed and specific as possible.
-3. **Self-contained**: Each criterion is a standalone statement in the form
-   [Verb + Specific Requirement]. Start with one clear action verb, then state the exact
-   required or forbidden content with qualifiers.
-4. **Balanced**: Include positive criteria (required content/behavior) and negative
-   criteria (harmful, misleading, or critically wrong content). Only add negative criteria
-   when the issue represents harmful, dangerous, or significantly quality-reducing behavior
-   -- not minor stylistic concerns.
-5. **Diverse**: Cover all sub-aspects of the perspective.
-
-**Negative criteria phrasing**: Describe the bad behavior directly. Instead of "Avoids
-doing X", write "Does X" (where X is the harmful behavior). The criterion text states the
-behavior; its negative score indicates that meeting it is bad.
-
-**Scoring standard**:
-- Positive: 1-10 (10 = critical safety/core requirement; 8-9 = important completeness;
-  5-7 = quality enhancer; 1-4 = minor nice-to-have)
-- Negative: -1 to -10 (-10 = dangerous/harmful; -8 to -9 = major omission or error;
-  -5 to -7 = quality issue; -1 to -4 = minor issue)
-
-**Output format** for each criterion:
-- `criterion`: the criterion text
-- `points`: integer score (positive or negative)
-- `reasoning`: 2-3 sentences explaining why this criterion matters for this task and why
-  it received this weight
-
----
-
-### Step 7: Criteria Expansion (3 rounds)
-
-**Goal**: Fill coverage gaps in the criteria set.
-
-**Method** (repeat 3 times):
-1. Review all existing criteria.
-2. Ask: "What concrete content or behavior, if present or absent in a result, would change
-   whether it passes or fails -- and is not yet covered?"
-3. Generate ONLY new criteria that are non-overlapping with existing ones.
-4. Follow the same rules and scoring standard as Step 6.
-
-After each round, append new criteria to the collection.
-
----
-
-### Step 8: Criteria Review and Consolidation
-
-**Goal**: Produce a concise, non-redundant final rubric.
-
-**Method**:
-- **Deduplicate and merge**: Combine criteria that assess the same aspect. Keep the most
-  precise wording and include all distinct details from merged criteria.
-- **Positive/negative overlap**: If a positive and negative criterion cover the same
-  aspect, keep only the positive.
-- **Neutralize fixed facts**: Replace hard-coded numbers, dates, versions, limits, or
-  placeholders with a requirement that the result states the current/official/latest value
-  or standard.
-- **Balance check**: Ensure total positive points outweigh total negative points. Retain
-  all distinct, non-overlapping items.
-- Assign each final criterion a unique ID (c0, c1, c2, ...).
-
----
-
-### Step 9: Polarity Check
-
-**Goal**: Verify that every criterion's score sign correctly reflects whether meeting it is
-good or bad.
-
-**Method**:
-- For each criterion, determine: does meeting this criterion improve the result (positive)
-  or indicate a problem (negative)?
-- A criterion that describes desirable behavior should have a positive score.
-- A criterion that describes harmful, wrong, or misleading behavior should have a negative
-  score.
-- Phrasing like "Avoids doing X" describes desirable behavior (positive). Phrasing like
-  "Does X" (where X is bad) describes undesirable behavior (negative).
-- Adjust the sign of points if misclassified. Do not change the criterion text.
-
----
-
-### Step 10: Score Calibration
-
-**Goal**: Ensure score magnitudes accurately reflect importance.
-
-**Method**:
-- Review each criterion's absolute score against the scoring standard from Step 6.
-- A more important or severe issue must always have a higher absolute score than a less
-  important one.
-- Adjust magnitudes where needed. Do not change the sign (positive/negative direction) or
-  the criterion text.
-- Verify the scoring standard is applied consistently:
-  - Positive: 10 = critical, 8-9 = important, 5-7 = quality, 1-4 = minor
-  - Negative: -10 = dangerous, -8 to -9 = major, -5 to -7 = moderate, -1 to -4 = minor
-
----
-
-### Phase B: Review Work Against Criteria
-
-**Goal**: Apply the finalized criteria to the actual work, or emit a checklist if none was
-supplied.
-
-**If no work was supplied (checklist mode)**:
-- State explicitly: "No work supplied -- criteria only (definition-of-done checklist)."
-- Present the criteria as a checklist the user can run against any future result.
-- Stop here; do not invent or assume a result to score.
-
-**If work was supplied (review mode)**:
-1. For EACH criterion, judge whether the work meets it: YES or NO, with a one-line cite of
-   the specific evidence in the work (quote or location) that justifies the verdict.
-2. Compute the score: sum the `points` of every criterion marked YES (positive criteria add,
-   negative criteria subtract). Report earned points, maximum positive points, and the
-   net total.
-3. Produce a ranked **gap list**: the unmet positive criteria and any met negative criteria,
-   ordered by absolute `points` (most important first). For each, give a one-line concrete
-   fix.
-4. Keep the review evidence-based. Do not credit a criterion the work does not actually
-   satisfy, and do not penalize for criteria outside the stated task.
-
----
-
-## Final Output Format
-
-Present results in this order:
-
-1. **Mode line**: "review mode" or "checklist mode (no work supplied)".
-2. **Scenarios**: list with IDs, names, descriptions.
-3. **Reviewed perspectives**: list with IDs, names, descriptions.
-4. **Criteria table**: each row has `criterion_id`, `criterion`, `points`, `reasoning`.
-5. **Summary statistics**: number of scenarios, perspectives, raw criteria, final criteria;
-   total positive and total negative points.
-6. **Review** (review mode only): per-criterion YES/NO + evidence, earned/max/net score,
-   and the ranked gap list with fixes.
-
----
-
-## Handling Special Inputs
-
-**Multi-turn conversations**: If the task is a conversation (user-assistant exchange), treat
-the full conversation as context. The last user message is typically the primary intent;
-earlier messages provide context that may affect evaluation dimensions.
-
-**Tasks with images**: If the task includes an image, factor image content into scenario
-analysis and criteria generation. Reference visual elements where relevant in criteria.
-
-**Tasks with retrieved web context**: If web-retrieved context is provided alongside the
-task, use it to inform factual grounding of scenarios and criteria. Do not limit analysis
-to only the retrieved content -- also apply general reasoning.
-
----
-
-## Key Constraints
-
-- **No fixed dimension lists**: Never apply a pre-defined set of evaluation dimensions.
-  Every scenario, perspective, and criterion must be freshly derived from the task.
-- **Expansion counts matter**: Complete all specified expansion rounds (3 for scenarios,
-  4 for perspectives, 3 for criteria). Skipping rounds reduces coverage.
-- **Deduplication is mandatory**: After each expansion phase and before finalization, check
-  for and remove redundant items.
-- **Criteria must be binary**: Every criterion in the final set must be checkable as YES or
-  NO. Do not produce criteria that require subjective degree judgments.
-- **Evidence-based review**: In review mode, every YES/NO must be backed by specific
-  evidence from the supplied work.
-
----
-
-## Citation
-
-This skill ports the Qworld method. If you use it in your work, please cite:
-
-```bibtex
-@misc{gao2026qworldquestionspecificevaluationcriteria,
-      title={Qworld: Question-Specific Evaluation Criteria for LLMs},
-      author={Shanghua Gao and Yuchang Su and Pengwei Sui and Curtis Ginder and Marinka Zitnik},
-      year={2026},
-      eprint={2603.23522},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2603.23522},
-}
-```
+# Self-Review: Understand the Target, Then Review
+
+Review the actual work the user means against the goal it was meant to satisfy. Default
+to a concise qualitative assessment. Scoring and the full Qworld Recursive Expansion
+Tree (RET) are opt-in.
+
+## Non-Negotiable Rules
+
+1. **Do not confuse the evaluation request with the evaluated task.** In requests such as
+   "eval current work", that sentence is an instruction to review. The task being judged
+   is the preceding user goal; the work is the current result, implementation, draft,
+   plan, or progress.
+2. **Do not equate `eval` with scoring.** `Eval`, `evaluate`, `review`, `assess`, and
+   `check` mean qualitative review unless the user explicitly asks for a score, grade,
+   rating, points, weighted rubric, Qworld, RET, or a numeric scale.
+3. **Do not invent work to review.** Inspect the conversation and available artifacts. If
+   evidence is unavailable, say what could not be verified.
+4. **Do not expose process by default.** Keep scenario expansion, perspective generation,
+   and rubric construction internal unless the user asked for those artifacts.
+5. **Review against the user's goal, not a generic quality template.** Derive the relevant
+   checks from the request, stated constraints, acceptance criteria, and risks.
+
+## Resolve the Review Target
+
+Separate three objects before reviewing:
+
+- **Evaluation instruction**: what the user is asking now (for example, "review this").
+- **Original goal**: the request, problem, or acceptance criteria the work should satisfy.
+- **Work product**: the answer, code, files, diff, plan, analysis, or current progress to
+  examine.
+
+Resolve the work product in this order:
+
+1. An explicitly named file, answer, commit, diff, section, or artifact.
+2. Pasted or attached content in the current message.
+3. The current repository implementation or working-tree diff when the conversation is
+   about code changes.
+4. The most recent assistant-produced deliverable relevant to the preceding user goal.
+5. The current plan or partial progress when the task is still underway.
+
+Interpret deictic phrases such as "current work", "this work", "what we have", "刚才的
+工作", and "当前工作" using that order. In a multi-turn conversation, the last user
+message is usually the evaluation instruction, **not** the original goal.
+
+Proceed without asking when the goal and work can be recovered confidently. Ask one
+short clarifying question only when there is no reviewable work or when multiple plausible
+targets would produce materially different reviews.
+
+## Choose One Mode
+
+| Mode | Trigger | Default output |
+|---|---|---|
+| **Qualitative review** (default) | "eval/review/check current work", "is this done?", "what is missing?" | Evidence-backed findings, strengths, gaps, fixes, and a completion verdict; no numbers |
+| **Checklist** | Explicit request for definition of done, success criteria, or completeness checklist without work to review | Task-specific checklist; no points |
+| **Rubric** | Explicit request for evaluation criteria or a rubric, but no scoring request | Binary or observable criteria grouped as must/should/could; no points |
+| **Scored evaluation** | Explicit request for score, grade, rating, points, weighted criteria, LLM-as-judge scoring, Qworld, RET, or a numeric scale | Evidence-backed scored review using the requested scale or RET |
+
+The phrase "evaluate this" alone selects **qualitative review**, even when a work product
+is present. The presence of work never turns scoring on by itself.
+
+Requests to **create or run evals**, implement a grader, write evaluation tests, or build a
+benchmark are engineering tasks, not self-review requests. Do not route those requests to
+this workflow merely because they contain the word `eval`.
+
+## Qualitative Review Workflow (Default)
+
+1. **Recover the goal.** Summarize the original goal and important constraints in one or
+   two sentences. Prefer explicit acceptance criteria over inferred preferences.
+2. **Inspect the work.** Use the actual conversation output, files, diff, test results, or
+   supplied artifact. For code, inspect relevant implementation and verification evidence;
+   do not judge from a summary alone when the files are available.
+3. **Derive focused checks internally.** Identify only the task-specific dimensions needed
+   to judge correctness, completeness, user intent, risks, and verification. Do not print a
+   large rubric unless asked.
+4. **Report findings by impact.** Lead with concrete problems or unmet requirements. For
+   each finding, cite the evidence and explain the consequence.
+5. **Acknowledge what works.** Note meaningful strengths briefly; do not pad the response
+   with generic praise.
+6. **Give prioritized fixes.** Recommend the smallest concrete actions that close the most
+   important gaps.
+7. **State a plain-language verdict.** Use `complete`, `mostly complete`, `partially
+   complete`, `not complete`, or `unable to verify`, with a short reason. Do not convert
+   the verdict into a number.
+
+### Default Review Shape
+
+Adapt the headings to the task and omit empty sections:
+
+1. **Overall assessment** — target, goal, and verdict.
+2. **Findings** — ordered by impact, with evidence.
+3. **What is working** — concise, specific strengths.
+4. **Recommended next actions** — prioritized fixes.
+
+For code review, prioritize actionable defects and regressions over summaries. Cite file
+paths and tight line ranges when possible. If no problems are found, say so directly and
+name any residual verification gaps.
+
+## Checklist and Unscored Rubric Modes
+
+- Derive criteria from the task rather than a fixed dimension list.
+- Keep each item observable and specific enough to check.
+- Use `must`, `should`, and `could` for importance when prioritization helps.
+- Do not attach numbers, weights, percentages, earned totals, or pass rates.
+- If work is also supplied, mark items `met`, `partially met`, `not met`, or
+  `not verifiable`, with brief evidence. These labels are not scores.
+- Do not generate scenarios or perspectives unless the user explicitly asks to see the
+  derivation.
+
+## Scored Evaluation Mode (Explicit Opt-In Only)
+
+Use this mode only when the request contains an unambiguous scoring signal listed above.
+
+- If the user supplies a scale or grading scheme, follow it.
+- If the user asks for Qworld, RET, a weighted rubric, or LLM-as-judge scoring without a
+  custom scheme, read and follow
+  [references/ret-scored-evaluation.md](references/ret-scored-evaluation.md).
+- Keep every verdict evidence-based. Do not award credit for absent evidence or penalize
+  criteria outside the original goal.
+- Explain what the score means and still provide the highest-impact gaps and fixes. A
+  number alone is not a useful review.
+
+## Examples of Correct Routing
+
+| User request | Correct interpretation |
+|---|---|
+| "Eval current work." | Review the current result against the preceding goal; qualitative, no score |
+| "Evaluate whether we finished the original request." | Inspect current artifacts and give a completion verdict; no score |
+| "What is missing from this implementation?" | Findings-first implementation review; no score |
+| "Make a definition-of-done checklist for this feature." | Checklist mode; no score |
+| "Create an evaluation rubric for these answers." | Unscored rubric unless weights or grading are requested |
+| "Score this answer from 1 to 10." | Scored mode on the requested scale |
+| "Apply Qworld/RET to grade these responses." | Full scored RET mode |
+| "Create an eval suite for this agent." | Out of scope for this skill; treat as an eval-engineering task |
+
+## Evidence and Honesty
+
+- Distinguish observed evidence from inference.
+- Do not claim tests passed unless their output is available.
+- Do not infer completion from a clean diff, a confident summary, or the existence of
+  files alone.
+- If the user requests evaluation while work is still running, review the available
+  progress and label unfinished parts rather than pretending the final result exists.
+- Keep the response proportional to the work. A small change should not produce a giant
+  framework dump.

--- a/plugins/tooluniverse/skills/tooluniverse-self-review/references/ret-scored-evaluation.md
+++ b/plugins/tooluniverse/skills/tooluniverse-self-review/references/ret-scored-evaluation.md
@@ -1,0 +1,118 @@
+# Qworld RET Scored Evaluation
+
+Use this reference only after the user explicitly requests scoring, grading, weighted
+criteria, LLM-as-judge scoring, Qworld, or the Recursive Expansion Tree (RET).
+
+## Inputs
+
+- **Original goal**: the task, question, constraints, and acceptance criteria.
+- **Work product**: the actual answer, implementation, artifact, or result to grade.
+- **Scale**: the user's requested scheme, or the default weighted scheme below.
+
+Never treat the evaluation instruction itself as the original goal. If the user says
+"score current work", recover the goal and work from the preceding conversation and
+available artifacts first.
+
+## Recursive Expansion Tree
+
+Build the rubric from the task:
+
+```text
+Original goal
+  -> scenarios that materially change what good means
+       -> task-specific evaluation perspectives
+            -> concrete, binary criteria
+```
+
+Keep this derivation internal unless the user asks to see it.
+
+### 1. Scenario grounding and expansion
+
+Identify a minimal non-redundant set of real contexts in which the task could arise and
+where the context changes what constitutes a good result. Expand three times by asking
+what materially different audience, setting, stakes, constraints, or domain variation is
+missing. Do not add paraphrases of existing scenarios.
+
+### 2. Perspective generation and expansion
+
+For each scenario, derive evaluation dimensions from the task itself. Do not use a fixed
+dimension list. Expand four times by asking which distinct evaluation angle would yield
+new criteria. Consolidate overlap and assign perspective IDs (`p0`, `p1`, ...).
+
+### 3. Criteria generation and expansion
+
+For each retained perspective, write self-contained criteria that are:
+
+- answerable `YES` or `NO`;
+- specific to the task and scenario;
+- observable in the work product;
+- non-redundant; and
+- phrased as one concrete required or forbidden behavior.
+
+Expand three times by asking what additional observable behavior would materially change
+the verdict. Then merge overlap and assign criterion IDs (`c0`, `c1`, ...).
+
+Include negative criteria only for harmful, misleading, or materially quality-reducing
+behavior—not minor style preferences. Phrase negative criteria as the bad behavior itself;
+the negative point value supplies the polarity.
+
+## Default Weighted Scheme
+
+Use this scheme only when the user did not provide another one:
+
+- Positive `1–10`: `10` critical safety/core requirement; `8–9` important completeness;
+  `5–7` meaningful quality; `1–4` minor enhancement.
+- Negative `-1–-10`: `-10` dangerous; `-8–-9` major error; `-5–-7` material quality
+  problem; `-1–-4` minor problem.
+
+For each criterion provide `criterion_id`, `criterion`, `points`, and a concise reason for
+the weight. Check that:
+
+1. desirable criteria have positive signs and harmful behaviors have negative signs;
+2. more important criteria have larger absolute weights;
+3. positive and negative criteria do not duplicate the same requirement; and
+4. total positive points exceed total negative magnitude.
+
+## Apply the Rubric
+
+For every criterion:
+
+1. Mark `YES` or `NO`.
+2. Cite the specific evidence or location supporting the verdict.
+3. Sum points only for criteria marked `YES`; positive items add and negative items
+   subtract.
+
+Report:
+
+- earned positive points and maximum positive points;
+- negative penalties triggered;
+- net total and the scale interpretation;
+- the most important unmet positive criteria and triggered negative criteria; and
+- one concrete fix for each high-impact gap.
+
+If there is no work product, do not fabricate a score. Return a weighted rubric and state
+that no work was graded.
+
+## Output Discipline
+
+- Show scenarios and perspectives only if the user asks for the full derivation.
+- Keep reasoning proportional; do not dump expansion logs.
+- Prefer evidence and actionable gaps over score theater.
+- If evidence is unavailable, mark the criterion `NO` or `not verifiable` according to the
+  user's grading policy and disclose the limitation.
+
+## Citation
+
+This method is based on Qworld:
+
+```bibtex
+@misc{gao2026qworldquestionspecificevaluationcriteria,
+      title={Qworld: Question-Specific Evaluation Criteria for LLMs},
+      author={Shanghua Gao and Yuchang Su and Pengwei Sui and Curtis Ginder and Marinka Zitnik},
+      year={2026},
+      eprint={2603.23522},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2603.23522},
+}
+```

--- a/plugins/tooluniverse/skills/tooluniverse/SKILL.md
+++ b/plugins/tooluniverse/skills/tooluniverse/SKILL.md
@@ -286,7 +286,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**custom tool**", "add my own tool", "local tool", "create tool", "extend ToolUniverse" | `Skill(skill="tooluniverse-custom-tool")` |
 | "**SDK**", "Python SDK", "build AI scientist", "programmatic access", "**import tooluniverse**", "**coding API**", "**tu build**", "**typed wrappers**" | `Skill(skill="tooluniverse-sdk")` |
 | "**install skills**", "missing skills", "skill not found", "add skills" | `Skill(skill="tooluniverse-install-skills")` |
-| "**self-review**", "check my work", "definition of done", "evaluation rubric", "success criteria", "grading criteria", "LLM-as-judge" | `Skill(skill="tooluniverse-self-review")` |
+| "**self-review**", "eval current work", "evaluate this work", "check my work", "is this complete", "definition of done", "evaluation rubric", "success criteria", "grading criteria", "LLM-as-judge" | `Skill(skill="tooluniverse-self-review")` |
 
 ---
 
@@ -306,10 +306,15 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 3. **Specificity Rule**: More specific beats general.
    - "cancer treatment" → precision-oncology (not disease-research)
 
-4. **Data Type Rule**: "get/retrieve/fetch" → retrieval skills.
+4. **Evaluation Intent Rule**: Route requests to review existing/current work to
+   `tooluniverse-self-review`, but do not route requests to create or run an eval suite,
+   grader, test, or benchmark there. Those are implementation tasks. Within self-review,
+   plain "eval" is qualitative; scoring requires an explicit score/grade/points request.
+
+5. **Data Type Rule**: "get/retrieve/fetch" → retrieval skills.
    - "get compound structure" → chemical-compound-retrieval (not drug-research)
 
-5. **Still ambiguous**: Ask user with AskUserQuestion.
+6. **Still ambiguous**: Ask user with AskUserQuestion.
 
 ---
 

--- a/skills/tooluniverse-claude-code-plugin/SKILL.md
+++ b/skills/tooluniverse-claude-code-plugin/SKILL.md
@@ -100,7 +100,7 @@ The router skill auto-dispatches to the right specialized skill — no command p
 | **`/tooluniverse:compare`** | N-way side-by-side comparison with domain-appropriate columns | Slash command |
 | **`/tooluniverse:literature-sweep`** | Graded mini-review across PubMed + EuropePMC + Semantic Scholar | Slash command |
 | **`/tooluniverse:verify-references`** | Check that cited references are real and accurately described, including retraction status | Slash command |
-| **`/tooluniverse:self-review`** | Generate weighted success criteria for a task and check work against them (what's missing / done well) | Slash command |
+| **`/tooluniverse:self-review`** | Review current or supplied work against its actual goal; qualitative by default, with scoring only when explicitly requested | Slash command |
 | **`/tooluniverse:setup-keys`** | Configure ToolUniverse API keys | Slash command |
 | **`/tooluniverse:researcher`** | Same investigation as `research`, delegated to a forked subagent | Slash command |
 | **120+ skills** | Structured workflows (drug research, variant interpretation, pharmacovigilance, CRISPR screens, statistical modeling, etc.) | Auto-activate on matching questions |

--- a/skills/tooluniverse-self-review/SKILL.md
+++ b/skills/tooluniverse-self-review/SKILL.md
@@ -1,367 +1,159 @@
 ---
 name: tooluniverse-self-review
 description: >
-  Generate the success criteria for a task or question, then review work against them.
-  Given a task, goal, or open-ended question, decompose it into scenarios, evaluation
-  perspectives, and fine-grained weighted YES/NO criteria using the Recursive Expansion
-  Tree (RET) method; if work is supplied, score it criterion-by-criterion and surface
-  what is missing or could be better. Use when asked to self-review or check your own
-  work, judge whether a task is done well or completely, build a definition-of-done or
-  completeness checklist, create an evaluation rubric or grading criteria, score or grade
-  answers to a question, set up an LLM-as-judge rubric, or when the user mentions
-  self-review, completeness check, success criteria, evaluation criteria, scoring rubric,
-  Qworld, or the RET algorithm.
+  Review existing work against the user's actual goal and surface evidence-backed
+  strengths, gaps, risks, and next fixes. Use when asked to eval, evaluate, review,
+  assess, or check current/this/my/our work; decide whether a task is complete; build a
+  definition-of-done checklist or rubric; or perform grading, LLM-as-judge, Qworld, or
+  RET evaluation. Treat plain eval/review requests as qualitative: resolve "current
+  work" from the conversation, artifacts, files, or diff, and never assign numeric
+  scores unless the user explicitly requests scores, grades, points, ratings, weighted
+  criteria, Qworld, or RET. Do not use for implementing automated eval suites, tests,
+  graders, or benchmarks.
 disable-model-invocation: true
 ---
 
-# Self-Review: Task Success Criteria + Work Review
-
-Derive the criteria that define a good result for a specific task, then review work
-against them. Each task defines its own "evaluation world" -- a set of scenarios,
-perspectives, and criteria that capture what matters for judging results for that
-specific task. Built on the Qworld Recursive Expansion Tree (RET).
-
-## When to Use
-
-- An agent (or person) is about to do, is doing, or has finished a task and wants to know
-  what a good result must cover, or what is missing or weak.
-- You need a definition-of-done or completeness checklist for a task or goal.
-- You need an evaluation rubric / grading criteria for answers to an open-ended question.
-- You want to score or grade responses: LLM-as-judge, exam answers, candidate responses.
-
-## Inputs
-
-- **task** (required): the task, goal, or question to evaluate. If it is a multi-turn
-  conversation, treat the whole exchange as context and the last user message as the
-  primary intent. If it includes an image or retrieved web context, factor that in.
-- **work** (optional): a planned approach or a completed result to review. If no work is
-  supplied, run in **checklist mode** -- produce the criteria only, no scoring.
-
-## Core Principles
-
-1. **Task-specific**: Every scenario, perspective, and criterion must be derived from the
-   task's content, intent, and context. Never reuse a fixed set of dimensions across tasks.
-2. **Binary and verifiable**: Each final criterion must be answerable YES or NO by a reviewer.
-3. **Non-redundant**: At every level, check for overlap before adding new items.
-4. **Balanced**: Include both positive criteria (what a good result must do) and negative
-   criteria (what constitutes harmful or misleading content). Positive total points must
-   outweigh negative.
-5. **Coverage-driven**: At each level, repeatedly ask "what's missing?" to ensure the
-   evaluation space implied by the task is fully explored.
-
-## Algorithm Overview
-
-The RET builds a 3-level tree from the task:
-
-```
-Task / goal / question
-  -> Level 1: Scenarios (contextual framings that change what "good" means)
-       -> Level 2: Perspectives (evaluation dimensions per scenario)
-            -> Level 3: Criteria (concrete, binary rubric items with scores)
-```
-
-At each level, two operators apply:
-- **Hierarchical decomposition**: break a node into finer-grained children at the next level.
-- **Horizontal expansion**: ask "what else is missing?" and add sibling nodes for coverage.
-
-After the tree is built, **Phase B** reviews supplied work against the leaf criteria.
-
----
-
-## Step-by-Step Workflow
-
-Copy this checklist and track progress as you work:
-
-```
-Task Progress:
-- [ ] Step 1: Scenario grounding
-- [ ] Step 2: Scenario expansion (3 rounds)
-- [ ] Step 3: Perspective generation
-- [ ] Step 4: Perspective expansion (4 rounds)
-- [ ] Step 5: Perspective review and consolidation
-- [ ] Step 6: Criteria generation
-- [ ] Step 7: Criteria expansion (3 rounds)
-- [ ] Step 8: Criteria review and consolidation
-- [ ] Step 9: Polarity check
-- [ ] Step 10: Score calibration
-- [ ] Phase B: Review work against criteria (or emit checklist if no work supplied)
-```
-
----
-
-### Step 1: Scenario Grounding
-
-**Goal**: Identify the distinct real-world contexts in which this task could arise, where
-each context would materially change what constitutes a good result.
-
-**Method**:
-- Read the task carefully. Infer its domain, intent, audience, stakes, and implicit
-  constraints.
-- Ask: "In what different situations could someone pursue this task, and how would the
-  situation change what a good result looks like?"
-- Produce a minimal, non-redundant set of scenarios. Merge any that would lead to the same
-  evaluation criteria.
-
-**Output format** for each scenario:
-- `scenario_name`: short descriptive label
-- `scenario_description`: 3-5 sentences explaining what is unique about this context and
-  why it changes what "good" means
-
----
-
-### Step 2: Scenario Expansion (3 rounds)
-
-**Goal**: Ensure comprehensive coverage of the evaluation space at the scenario level.
-
-**Method** (repeat 3 times):
-1. Review all existing scenarios.
-2. Ask: "What contexts or framings are missing that would require different evaluation criteria?"
-3. Identify gaps along context axes (audience, setting, stakes, constraints, domain variation, etc.).
-4. Generate ONLY new scenarios that differ materially from all existing ones. Do not repeat
-   or rephrase existing scenarios.
-
-After each round, append new scenarios to the list.
-
----
-
-### Step 3: Perspective Generation
-
-**Goal**: For each scenario, derive the evaluation dimensions that matter for judging a
-result in that context.
-
-**Method**:
-- For EACH scenario, produce 4-7 non-overlapping evaluation perspectives.
-- Each perspective must be grounded in the scenario and the task. Derive perspectives
-  entirely from the task's content and context -- do not apply a pre-set list of dimensions.
-- Aim for maximally diverse themes, including unconventional angles that are specific to
-  this task.
-- Each perspective should be high-level enough to spawn multiple criteria, yet narrow
-  enough to avoid overlap with other perspectives.
-
-**Output format** for each perspective:
-- `perspective_name`: 2-5 word descriptive label
-- `perspective_description`: 3-5 sentences explaining what this perspective evaluates and
-  listing 3-5 specific sub-aspects it covers
-
----
-
-### Step 4: Perspective Expansion (4 rounds)
-
-**Goal**: Fill coverage gaps in the perspective set.
-
-**Method** (repeat 4 times):
-1. Review all perspectives across all scenarios.
-2. Map coverage across quality dimensions implied by the task.
-3. Ask: "What evaluation angles are missing that would yield materially different criteria?"
-4. Generate ONLY new perspectives that provide distinct evaluation value. Do not repeat
-   existing ones.
-
-After each round, append new perspectives to the collection.
-
----
-
-### Step 5: Perspective Review and Consolidation
-
-**Goal**: Produce a clean, non-redundant set of perspectives ready for criteria generation.
-
-**Method**:
-- If two perspectives target the same evaluation angle but under different scenarios,
-  combine scenario-specific details into each description but keep them as separate
-  perspectives.
-- Remove perspectives that are off-topic, redundant with others, or too vague to guide
-  concrete criteria generation.
-- Each kept perspective must contribute unique evaluation value for this task.
-- Assign each kept perspective a unique ID (p0, p1, p2, ...).
-
----
-
-### Step 6: Criteria Generation
-
-**Goal**: For each reviewed perspective, generate concrete, binary evaluation criteria.
-
-**Method**:
-- For EACH perspective, generate criteria that a reviewer can check YES or NO against a
-  result.
-- Cover all sub-aspects listed in the perspective description.
-
-**Criteria rules**:
-1. **Binary**: Each criterion must be answerable YES/NO.
-2. **Scenario-specific**: Explicitly reference features of the task and scenario. Make
-   criteria as detailed and specific as possible.
-3. **Self-contained**: Each criterion is a standalone statement in the form
-   [Verb + Specific Requirement]. Start with one clear action verb, then state the exact
-   required or forbidden content with qualifiers.
-4. **Balanced**: Include positive criteria (required content/behavior) and negative
-   criteria (harmful, misleading, or critically wrong content). Only add negative criteria
-   when the issue represents harmful, dangerous, or significantly quality-reducing behavior
-   -- not minor stylistic concerns.
-5. **Diverse**: Cover all sub-aspects of the perspective.
-
-**Negative criteria phrasing**: Describe the bad behavior directly. Instead of "Avoids
-doing X", write "Does X" (where X is the harmful behavior). The criterion text states the
-behavior; its negative score indicates that meeting it is bad.
-
-**Scoring standard**:
-- Positive: 1-10 (10 = critical safety/core requirement; 8-9 = important completeness;
-  5-7 = quality enhancer; 1-4 = minor nice-to-have)
-- Negative: -1 to -10 (-10 = dangerous/harmful; -8 to -9 = major omission or error;
-  -5 to -7 = quality issue; -1 to -4 = minor issue)
-
-**Output format** for each criterion:
-- `criterion`: the criterion text
-- `points`: integer score (positive or negative)
-- `reasoning`: 2-3 sentences explaining why this criterion matters for this task and why
-  it received this weight
-
----
-
-### Step 7: Criteria Expansion (3 rounds)
-
-**Goal**: Fill coverage gaps in the criteria set.
-
-**Method** (repeat 3 times):
-1. Review all existing criteria.
-2. Ask: "What concrete content or behavior, if present or absent in a result, would change
-   whether it passes or fails -- and is not yet covered?"
-3. Generate ONLY new criteria that are non-overlapping with existing ones.
-4. Follow the same rules and scoring standard as Step 6.
-
-After each round, append new criteria to the collection.
-
----
-
-### Step 8: Criteria Review and Consolidation
-
-**Goal**: Produce a concise, non-redundant final rubric.
-
-**Method**:
-- **Deduplicate and merge**: Combine criteria that assess the same aspect. Keep the most
-  precise wording and include all distinct details from merged criteria.
-- **Positive/negative overlap**: If a positive and negative criterion cover the same
-  aspect, keep only the positive.
-- **Neutralize fixed facts**: Replace hard-coded numbers, dates, versions, limits, or
-  placeholders with a requirement that the result states the current/official/latest value
-  or standard.
-- **Balance check**: Ensure total positive points outweigh total negative points. Retain
-  all distinct, non-overlapping items.
-- Assign each final criterion a unique ID (c0, c1, c2, ...).
-
----
-
-### Step 9: Polarity Check
-
-**Goal**: Verify that every criterion's score sign correctly reflects whether meeting it is
-good or bad.
-
-**Method**:
-- For each criterion, determine: does meeting this criterion improve the result (positive)
-  or indicate a problem (negative)?
-- A criterion that describes desirable behavior should have a positive score.
-- A criterion that describes harmful, wrong, or misleading behavior should have a negative
-  score.
-- Phrasing like "Avoids doing X" describes desirable behavior (positive). Phrasing like
-  "Does X" (where X is bad) describes undesirable behavior (negative).
-- Adjust the sign of points if misclassified. Do not change the criterion text.
-
----
-
-### Step 10: Score Calibration
-
-**Goal**: Ensure score magnitudes accurately reflect importance.
-
-**Method**:
-- Review each criterion's absolute score against the scoring standard from Step 6.
-- A more important or severe issue must always have a higher absolute score than a less
-  important one.
-- Adjust magnitudes where needed. Do not change the sign (positive/negative direction) or
-  the criterion text.
-- Verify the scoring standard is applied consistently:
-  - Positive: 10 = critical, 8-9 = important, 5-7 = quality, 1-4 = minor
-  - Negative: -10 = dangerous, -8 to -9 = major, -5 to -7 = moderate, -1 to -4 = minor
-
----
-
-### Phase B: Review Work Against Criteria
-
-**Goal**: Apply the finalized criteria to the actual work, or emit a checklist if none was
-supplied.
-
-**If no work was supplied (checklist mode)**:
-- State explicitly: "No work supplied -- criteria only (definition-of-done checklist)."
-- Present the criteria as a checklist the user can run against any future result.
-- Stop here; do not invent or assume a result to score.
-
-**If work was supplied (review mode)**:
-1. For EACH criterion, judge whether the work meets it: YES or NO, with a one-line cite of
-   the specific evidence in the work (quote or location) that justifies the verdict.
-2. Compute the score: sum the `points` of every criterion marked YES (positive criteria add,
-   negative criteria subtract). Report earned points, maximum positive points, and the
-   net total.
-3. Produce a ranked **gap list**: the unmet positive criteria and any met negative criteria,
-   ordered by absolute `points` (most important first). For each, give a one-line concrete
-   fix.
-4. Keep the review evidence-based. Do not credit a criterion the work does not actually
-   satisfy, and do not penalize for criteria outside the stated task.
-
----
-
-## Final Output Format
-
-Present results in this order:
-
-1. **Mode line**: "review mode" or "checklist mode (no work supplied)".
-2. **Scenarios**: list with IDs, names, descriptions.
-3. **Reviewed perspectives**: list with IDs, names, descriptions.
-4. **Criteria table**: each row has `criterion_id`, `criterion`, `points`, `reasoning`.
-5. **Summary statistics**: number of scenarios, perspectives, raw criteria, final criteria;
-   total positive and total negative points.
-6. **Review** (review mode only): per-criterion YES/NO + evidence, earned/max/net score,
-   and the ranked gap list with fixes.
-
----
-
-## Handling Special Inputs
-
-**Multi-turn conversations**: If the task is a conversation (user-assistant exchange), treat
-the full conversation as context. The last user message is typically the primary intent;
-earlier messages provide context that may affect evaluation dimensions.
-
-**Tasks with images**: If the task includes an image, factor image content into scenario
-analysis and criteria generation. Reference visual elements where relevant in criteria.
-
-**Tasks with retrieved web context**: If web-retrieved context is provided alongside the
-task, use it to inform factual grounding of scenarios and criteria. Do not limit analysis
-to only the retrieved content -- also apply general reasoning.
-
----
-
-## Key Constraints
-
-- **No fixed dimension lists**: Never apply a pre-defined set of evaluation dimensions.
-  Every scenario, perspective, and criterion must be freshly derived from the task.
-- **Expansion counts matter**: Complete all specified expansion rounds (3 for scenarios,
-  4 for perspectives, 3 for criteria). Skipping rounds reduces coverage.
-- **Deduplication is mandatory**: After each expansion phase and before finalization, check
-  for and remove redundant items.
-- **Criteria must be binary**: Every criterion in the final set must be checkable as YES or
-  NO. Do not produce criteria that require subjective degree judgments.
-- **Evidence-based review**: In review mode, every YES/NO must be backed by specific
-  evidence from the supplied work.
-
----
-
-## Citation
-
-This skill ports the Qworld method. If you use it in your work, please cite:
-
-```bibtex
-@misc{gao2026qworldquestionspecificevaluationcriteria,
-      title={Qworld: Question-Specific Evaluation Criteria for LLMs},
-      author={Shanghua Gao and Yuchang Su and Pengwei Sui and Curtis Ginder and Marinka Zitnik},
-      year={2026},
-      eprint={2603.23522},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2603.23522},
-}
-```
+# Self-Review: Understand the Target, Then Review
+
+Review the actual work the user means against the goal it was meant to satisfy. Default
+to a concise qualitative assessment. Scoring and the full Qworld Recursive Expansion
+Tree (RET) are opt-in.
+
+## Non-Negotiable Rules
+
+1. **Do not confuse the evaluation request with the evaluated task.** In requests such as
+   "eval current work", that sentence is an instruction to review. The task being judged
+   is the preceding user goal; the work is the current result, implementation, draft,
+   plan, or progress.
+2. **Do not equate `eval` with scoring.** `Eval`, `evaluate`, `review`, `assess`, and
+   `check` mean qualitative review unless the user explicitly asks for a score, grade,
+   rating, points, weighted rubric, Qworld, RET, or a numeric scale.
+3. **Do not invent work to review.** Inspect the conversation and available artifacts. If
+   evidence is unavailable, say what could not be verified.
+4. **Do not expose process by default.** Keep scenario expansion, perspective generation,
+   and rubric construction internal unless the user asked for those artifacts.
+5. **Review against the user's goal, not a generic quality template.** Derive the relevant
+   checks from the request, stated constraints, acceptance criteria, and risks.
+
+## Resolve the Review Target
+
+Separate three objects before reviewing:
+
+- **Evaluation instruction**: what the user is asking now (for example, "review this").
+- **Original goal**: the request, problem, or acceptance criteria the work should satisfy.
+- **Work product**: the answer, code, files, diff, plan, analysis, or current progress to
+  examine.
+
+Resolve the work product in this order:
+
+1. An explicitly named file, answer, commit, diff, section, or artifact.
+2. Pasted or attached content in the current message.
+3. The current repository implementation or working-tree diff when the conversation is
+   about code changes.
+4. The most recent assistant-produced deliverable relevant to the preceding user goal.
+5. The current plan or partial progress when the task is still underway.
+
+Interpret deictic phrases such as "current work", "this work", "what we have", "刚才的
+工作", and "当前工作" using that order. In a multi-turn conversation, the last user
+message is usually the evaluation instruction, **not** the original goal.
+
+Proceed without asking when the goal and work can be recovered confidently. Ask one
+short clarifying question only when there is no reviewable work or when multiple plausible
+targets would produce materially different reviews.
+
+## Choose One Mode
+
+| Mode | Trigger | Default output |
+|---|---|---|
+| **Qualitative review** (default) | "eval/review/check current work", "is this done?", "what is missing?" | Evidence-backed findings, strengths, gaps, fixes, and a completion verdict; no numbers |
+| **Checklist** | Explicit request for definition of done, success criteria, or completeness checklist without work to review | Task-specific checklist; no points |
+| **Rubric** | Explicit request for evaluation criteria or a rubric, but no scoring request | Binary or observable criteria grouped as must/should/could; no points |
+| **Scored evaluation** | Explicit request for score, grade, rating, points, weighted criteria, LLM-as-judge scoring, Qworld, RET, or a numeric scale | Evidence-backed scored review using the requested scale or RET |
+
+The phrase "evaluate this" alone selects **qualitative review**, even when a work product
+is present. The presence of work never turns scoring on by itself.
+
+Requests to **create or run evals**, implement a grader, write evaluation tests, or build a
+benchmark are engineering tasks, not self-review requests. Do not route those requests to
+this workflow merely because they contain the word `eval`.
+
+## Qualitative Review Workflow (Default)
+
+1. **Recover the goal.** Summarize the original goal and important constraints in one or
+   two sentences. Prefer explicit acceptance criteria over inferred preferences.
+2. **Inspect the work.** Use the actual conversation output, files, diff, test results, or
+   supplied artifact. For code, inspect relevant implementation and verification evidence;
+   do not judge from a summary alone when the files are available.
+3. **Derive focused checks internally.** Identify only the task-specific dimensions needed
+   to judge correctness, completeness, user intent, risks, and verification. Do not print a
+   large rubric unless asked.
+4. **Report findings by impact.** Lead with concrete problems or unmet requirements. For
+   each finding, cite the evidence and explain the consequence.
+5. **Acknowledge what works.** Note meaningful strengths briefly; do not pad the response
+   with generic praise.
+6. **Give prioritized fixes.** Recommend the smallest concrete actions that close the most
+   important gaps.
+7. **State a plain-language verdict.** Use `complete`, `mostly complete`, `partially
+   complete`, `not complete`, or `unable to verify`, with a short reason. Do not convert
+   the verdict into a number.
+
+### Default Review Shape
+
+Adapt the headings to the task and omit empty sections:
+
+1. **Overall assessment** — target, goal, and verdict.
+2. **Findings** — ordered by impact, with evidence.
+3. **What is working** — concise, specific strengths.
+4. **Recommended next actions** — prioritized fixes.
+
+For code review, prioritize actionable defects and regressions over summaries. Cite file
+paths and tight line ranges when possible. If no problems are found, say so directly and
+name any residual verification gaps.
+
+## Checklist and Unscored Rubric Modes
+
+- Derive criteria from the task rather than a fixed dimension list.
+- Keep each item observable and specific enough to check.
+- Use `must`, `should`, and `could` for importance when prioritization helps.
+- Do not attach numbers, weights, percentages, earned totals, or pass rates.
+- If work is also supplied, mark items `met`, `partially met`, `not met`, or
+  `not verifiable`, with brief evidence. These labels are not scores.
+- Do not generate scenarios or perspectives unless the user explicitly asks to see the
+  derivation.
+
+## Scored Evaluation Mode (Explicit Opt-In Only)
+
+Use this mode only when the request contains an unambiguous scoring signal listed above.
+
+- If the user supplies a scale or grading scheme, follow it.
+- If the user asks for Qworld, RET, a weighted rubric, or LLM-as-judge scoring without a
+  custom scheme, read and follow
+  [references/ret-scored-evaluation.md](references/ret-scored-evaluation.md).
+- Keep every verdict evidence-based. Do not award credit for absent evidence or penalize
+  criteria outside the original goal.
+- Explain what the score means and still provide the highest-impact gaps and fixes. A
+  number alone is not a useful review.
+
+## Examples of Correct Routing
+
+| User request | Correct interpretation |
+|---|---|
+| "Eval current work." | Review the current result against the preceding goal; qualitative, no score |
+| "Evaluate whether we finished the original request." | Inspect current artifacts and give a completion verdict; no score |
+| "What is missing from this implementation?" | Findings-first implementation review; no score |
+| "Make a definition-of-done checklist for this feature." | Checklist mode; no score |
+| "Create an evaluation rubric for these answers." | Unscored rubric unless weights or grading are requested |
+| "Score this answer from 1 to 10." | Scored mode on the requested scale |
+| "Apply Qworld/RET to grade these responses." | Full scored RET mode |
+| "Create an eval suite for this agent." | Out of scope for this skill; treat as an eval-engineering task |
+
+## Evidence and Honesty
+
+- Distinguish observed evidence from inference.
+- Do not claim tests passed unless their output is available.
+- Do not infer completion from a clean diff, a confident summary, or the existence of
+  files alone.
+- If the user requests evaluation while work is still running, review the available
+  progress and label unfinished parts rather than pretending the final result exists.
+- Keep the response proportional to the work. A small change should not produce a giant
+  framework dump.

--- a/skills/tooluniverse-self-review/references/ret-scored-evaluation.md
+++ b/skills/tooluniverse-self-review/references/ret-scored-evaluation.md
@@ -1,0 +1,118 @@
+# Qworld RET Scored Evaluation
+
+Use this reference only after the user explicitly requests scoring, grading, weighted
+criteria, LLM-as-judge scoring, Qworld, or the Recursive Expansion Tree (RET).
+
+## Inputs
+
+- **Original goal**: the task, question, constraints, and acceptance criteria.
+- **Work product**: the actual answer, implementation, artifact, or result to grade.
+- **Scale**: the user's requested scheme, or the default weighted scheme below.
+
+Never treat the evaluation instruction itself as the original goal. If the user says
+"score current work", recover the goal and work from the preceding conversation and
+available artifacts first.
+
+## Recursive Expansion Tree
+
+Build the rubric from the task:
+
+```text
+Original goal
+  -> scenarios that materially change what good means
+       -> task-specific evaluation perspectives
+            -> concrete, binary criteria
+```
+
+Keep this derivation internal unless the user asks to see it.
+
+### 1. Scenario grounding and expansion
+
+Identify a minimal non-redundant set of real contexts in which the task could arise and
+where the context changes what constitutes a good result. Expand three times by asking
+what materially different audience, setting, stakes, constraints, or domain variation is
+missing. Do not add paraphrases of existing scenarios.
+
+### 2. Perspective generation and expansion
+
+For each scenario, derive evaluation dimensions from the task itself. Do not use a fixed
+dimension list. Expand four times by asking which distinct evaluation angle would yield
+new criteria. Consolidate overlap and assign perspective IDs (`p0`, `p1`, ...).
+
+### 3. Criteria generation and expansion
+
+For each retained perspective, write self-contained criteria that are:
+
+- answerable `YES` or `NO`;
+- specific to the task and scenario;
+- observable in the work product;
+- non-redundant; and
+- phrased as one concrete required or forbidden behavior.
+
+Expand three times by asking what additional observable behavior would materially change
+the verdict. Then merge overlap and assign criterion IDs (`c0`, `c1`, ...).
+
+Include negative criteria only for harmful, misleading, or materially quality-reducing
+behavior—not minor style preferences. Phrase negative criteria as the bad behavior itself;
+the negative point value supplies the polarity.
+
+## Default Weighted Scheme
+
+Use this scheme only when the user did not provide another one:
+
+- Positive `1–10`: `10` critical safety/core requirement; `8–9` important completeness;
+  `5–7` meaningful quality; `1–4` minor enhancement.
+- Negative `-1–-10`: `-10` dangerous; `-8–-9` major error; `-5–-7` material quality
+  problem; `-1–-4` minor problem.
+
+For each criterion provide `criterion_id`, `criterion`, `points`, and a concise reason for
+the weight. Check that:
+
+1. desirable criteria have positive signs and harmful behaviors have negative signs;
+2. more important criteria have larger absolute weights;
+3. positive and negative criteria do not duplicate the same requirement; and
+4. total positive points exceed total negative magnitude.
+
+## Apply the Rubric
+
+For every criterion:
+
+1. Mark `YES` or `NO`.
+2. Cite the specific evidence or location supporting the verdict.
+3. Sum points only for criteria marked `YES`; positive items add and negative items
+   subtract.
+
+Report:
+
+- earned positive points and maximum positive points;
+- negative penalties triggered;
+- net total and the scale interpretation;
+- the most important unmet positive criteria and triggered negative criteria; and
+- one concrete fix for each high-impact gap.
+
+If there is no work product, do not fabricate a score. Return a weighted rubric and state
+that no work was graded.
+
+## Output Discipline
+
+- Show scenarios and perspectives only if the user asks for the full derivation.
+- Keep reasoning proportional; do not dump expansion logs.
+- Prefer evidence and actionable gaps over score theater.
+- If evidence is unavailable, mark the criterion `NO` or `not verifiable` according to the
+  user's grading policy and disclose the limitation.
+
+## Citation
+
+This method is based on Qworld:
+
+```bibtex
+@misc{gao2026qworldquestionspecificevaluationcriteria,
+      title={Qworld: Question-Specific Evaluation Criteria for LLMs},
+      author={Shanghua Gao and Yuchang Su and Pengwei Sui and Curtis Ginder and Marinka Zitnik},
+      year={2026},
+      eprint={2603.23522},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2603.23522},
+}
+```

--- a/skills/tooluniverse/SKILL.md
+++ b/skills/tooluniverse/SKILL.md
@@ -285,7 +285,7 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 | "**custom tool**", "add my own tool", "local tool", "create tool", "extend ToolUniverse" | `Skill(skill="tooluniverse-custom-tool")` |
 | "**SDK**", "Python SDK", "build AI scientist", "programmatic access", "**import tooluniverse**", "**coding API**", "**tu build**", "**typed wrappers**" | `Skill(skill="tooluniverse-sdk")` |
 | "**install skills**", "missing skills", "skill not found", "add skills" | `Skill(skill="tooluniverse-install-skills")` |
-| "**self-review**", "check my work", "definition of done", "evaluation rubric", "success criteria", "grading criteria", "LLM-as-judge" | `Skill(skill="tooluniverse-self-review")` |
+| "**self-review**", "eval current work", "evaluate this work", "check my work", "is this complete", "definition of done", "evaluation rubric", "success criteria", "grading criteria", "LLM-as-judge" | `Skill(skill="tooluniverse-self-review")` |
 
 ---
 
@@ -305,10 +305,15 @@ These reminders are for fast pattern recognition during routing. Detailed `❌ W
 3. **Specificity Rule**: More specific beats general.
    - "cancer treatment" → precision-oncology (not disease-research)
 
-4. **Data Type Rule**: "get/retrieve/fetch" → retrieval skills.
+4. **Evaluation Intent Rule**: Route requests to review existing/current work to
+   `tooluniverse-self-review`, but do not route requests to create or run an eval suite,
+   grader, test, or benchmark there. Those are implementation tasks. Within self-review,
+   plain "eval" is qualitative; scoring requires an explicit score/grade/points request.
+
+5. **Data Type Rule**: "get/retrieve/fetch" → retrieval skills.
    - "get compound structure" → chemical-compound-retrieval (not drug-research)
 
-5. **Still ambiguous**: Ask user with AskUserQuestion.
+6. **Still ambiguous**: Ask user with AskUserQuestion.
 
 ---
 

--- a/tests/unit/test_self_review_skill.py
+++ b/tests/unit/test_self_review_skill.py
@@ -1,0 +1,67 @@
+"""Regression tests for self-review intent routing and scoring behavior."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL = REPO_ROOT / "skills" / "tooluniverse-self-review" / "SKILL.md"
+RET_REFERENCE = (
+    REPO_ROOT
+    / "skills"
+    / "tooluniverse-self-review"
+    / "references"
+    / "ret-scored-evaluation.md"
+)
+COMMAND = REPO_ROOT / "plugin" / "commands" / "self-review.md"
+ROUTER = REPO_ROOT / "skills" / "tooluniverse" / "SKILL.md"
+
+
+def _squash(text: str) -> str:
+    """Normalize Markdown wrapping so assertions test meaning, not line width."""
+    return " ".join(text.split())
+
+
+def test_plain_eval_defaults_to_qualitative_review():
+    text = _squash(SKILL.read_text(encoding="utf-8"))
+
+    assert "Do not equate `eval` with scoring" in text
+    assert "The presence of work never turns scoring on by itself" in text
+    assert '"Eval current work."' in text
+    assert "qualitative, no score" in text
+
+
+def test_current_work_is_not_the_evaluation_instruction():
+    text = _squash(SKILL.read_text(encoding="utf-8"))
+
+    assert "Do not confuse the evaluation request with the evaluated task" in text
+    assert "the last user message is usually the evaluation instruction" in text
+    assert "The most recent assistant-produced deliverable" in text
+
+
+def test_scoring_is_explicit_opt_in_and_progressively_disclosed():
+    skill_text = _squash(SKILL.read_text(encoding="utf-8"))
+    reference_text = _squash(RET_REFERENCE.read_text(encoding="utf-8"))
+
+    assert "Scored Evaluation Mode (Explicit Opt-In Only)" in skill_text
+    assert "references/ret-scored-evaluation.md" in skill_text
+    assert "Use this reference only after the user explicitly requests" in reference_text
+    assert "Scenario grounding and expansion" in reference_text
+
+
+def test_claude_command_preserves_default_review_semantics():
+    text = _squash(COMMAND.read_text(encoding="utf-8"))
+
+    assert "not automatically as the task being evaluated" in text
+    assert "Plain `eval`, `evaluate`, `review`, `assess`, or `check`" in text
+    assert "Do not" in text and "numeric totals unless" in text
+    assert "Build the success criteria for this task" not in text
+
+
+def test_eval_engineering_is_not_hijacked():
+    text = _squash(SKILL.read_text(encoding="utf-8"))
+    router_text = _squash(ROUTER.read_text(encoding="utf-8"))
+
+    assert "create or run evals" in text
+    assert "engineering tasks, not self-review requests" in text
+    assert "Evaluation Intent Rule" in router_text
+    assert "do not route requests to create or run an eval suite" in router_text


### PR DESCRIPTION
## Summary

- make plain `eval`, review, assess, and check requests qualitative by default
- recover the original goal and current work from conversation context and artifacts instead of treating the evaluation instruction as the evaluated task
- separate checklist, unscored rubric, and explicitly scored modes
- move Qworld/RET scoring machinery into an opt-in reference
- keep eval-suite, grader, test, and benchmark creation routed as engineering work
- update Claude command/docs, Codex routing copies, and regression coverage

## Root cause

The previous self-review workflow treated command arguments as the task to evaluate and eagerly generated a weighted RET rubric. As a result, requests such as “Eval current work” could be interpreted as a request to score the evaluation instruction itself, rather than review the preceding work against the user's actual goal.

## User impact

Natural-language review requests now produce concise, evidence-backed findings and a plain-language completion verdict without unwanted numbers. Numeric grading remains available when the user explicitly requests a score, grade, weighted rubric, Qworld, or RET.

## Validation

- `pytest -q tests/unit/test_self_review_skill.py tests/unit/test_codex_plugin.py tests/test_claude_code_plugin.py::TestSlashCommands`
- Codex generated skill passes `quick_validate.py`
- `git diff origin/main...HEAD --check`
- fresh-model forward tests covered qualitative current-work review, explicit 1–10 scoring, definition-of-done checklist generation, and eval-suite engineering routing
