### PR TITLE
Enable and isolate extended output hooks

### DIFF
--- a/src/tooluniverse/execute_function.py
+++ b/src/tooluniverse/execute_function.py
@@ -3200,6 +3200,9 @@ class ToolUniverse:
                         if tool_instance is not None
                         else "unknown"
                     ),
+                    "category": self.all_tool_dict.get(function_name, {}).get(
+                        "category"
+                    ),
                     "execution_time": time.time(),
                     "arguments": tool_arguments,
                 }
@@ -3384,6 +3387,7 @@ class ToolUniverse:
                     if tool_instance is not None
                     else "unknown"
                 ),
+                "category": self.all_tool_dict.get(function_name, {}).get("category"),
                 "execution_time": time.time(),
                 "arguments": tool_arguments,
             }

--- a/src/tooluniverse/extended_hooks.py
+++ b/src/tooluniverse/extended_hooks.py
@@ -6,8 +6,9 @@ hook types beyond summarization. It shows the pattern for creating
 new hook types while maintaining compatibility with the existing system.
 """
 
-import re
 import json
+import re
+from pathlib import Path
 from typing import Dict, Any, List
 from .output_hook import OutputHook
 
@@ -75,23 +76,8 @@ class FilteringHook(OutputHook):
             if not self.compiled_patterns:
                 return result
 
-            output_str = result if isinstance(result, str) else str(result)
-            filtered_output = output_str
-            filtered_count = 0
-
-            # Apply each filter pattern
-            for pattern in self.compiled_patterns:
-                matches = pattern.findall(filtered_output)
-                if matches:
-                    filtered_count += len(matches)
-                    if self.log_filtered_items:
-                        print(
-                            f"🔒 Filtered {len(matches)} items matching pattern: {pattern.pattern}"
-                        )
-
-                    filtered_output = pattern.sub(
-                        self.replacement_text, filtered_output
-                    )
+            value = result if self.preserve_structure else str(result)
+            filtered_output, filtered_count = self._filter_value(value)
 
             if filtered_count > 0:
                 print(
@@ -103,6 +89,49 @@ class FilteringHook(OutputHook):
         except Exception as e:
             print(f"Error in filtering hook: {str(e)}")
             return result
+
+    def _filter_value(self, value: Any) -> tuple[Any, int]:
+        """Filter string values recursively while preserving container types."""
+        if isinstance(value, str):
+            return self._filter_text(value)
+        if isinstance(value, dict):
+            filtered = {}
+            total = 0
+            for key, item in value.items():
+                filtered_item, count = self._filter_value(item)
+                filtered[key] = filtered_item
+                total += count
+            return filtered, total
+        if isinstance(value, list):
+            filtered_items = []
+            total = 0
+            for item in value:
+                filtered_item, count = self._filter_value(item)
+                filtered_items.append(filtered_item)
+                total += count
+            return filtered_items, total
+        if isinstance(value, tuple):
+            filtered_items = []
+            total = 0
+            for item in value:
+                filtered_item, count = self._filter_value(item)
+                filtered_items.append(filtered_item)
+                total += count
+            return tuple(filtered_items), total
+        return value, 0
+
+    def _filter_text(self, text: str) -> tuple[str, int]:
+        """Apply configured regular expressions to one string value."""
+        filtered = text
+        total = 0
+        for pattern in self.compiled_patterns:
+            filtered, count = pattern.subn(self.replacement_text, filtered)
+            total += count
+            if count and self.log_filtered_items:
+                print(
+                    f"Filtered {count} items matching pattern: {pattern.pattern}"
+                )
+        return filtered, total
 
 
 class FormattingHook(OutputHook):
@@ -411,7 +440,9 @@ class LoggingHook(OutputHook):
                     "output_length": len(str(result)),
                     "timestamp": context.get("execution_time", "unknown"),
                     "output_preview": str(result)[: self.max_log_size],
-                }
+                },
+                ensure_ascii=False,
+                default=str,
             )
         else:  # detailed
             return f"""
@@ -428,7 +459,9 @@ Output Preview: {str(result)[: self.max_log_size]}{"..." if len(str(result)) > s
     def _write_log(self, log_entry: str):
         """Write the log entry to the configured destination."""
         if self.log_file:
-            with open(self.log_file, "a", encoding="utf-8") as f:
+            log_path = Path(self.log_file).expanduser()
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with log_path.open("a", encoding="utf-8") as f:
                 f.write(log_entry + "\n")
         else:
             print(f"📝 Log: {log_entry}")

--- a/src/tooluniverse/output_hook.py
+++ b/src/tooluniverse/output_hook.py
@@ -15,6 +15,7 @@ The hook system integrates seamlessly with ToolUniverse's existing architecture,
 leveraging AgenticTool and ComposeTool for intelligent output processing.
 """
 
+import copy
 import json
 from dataclasses import dataclass
 from typing import Dict, Any, List, Optional
@@ -464,9 +465,12 @@ class HookManager:
         self._excluded_patterns_cache = None
         self._load_hook_config()
 
-        # Validate LLM API keys before loading hooks
-        if not self._validate_llm_api_keys():
-            _logger.warning("LLM API keys not available. Hooks will be disabled.")
+        # Only summarization hooks require an LLM. Local hooks remain useful in
+        # environments without model credentials.
+        self._allow_unavailable_llm_hooks = False
+        self._llm_hooks_available = self._validate_llm_api_keys()
+        if not self._llm_hooks_available and not self._has_local_hooks():
+            _logger.warning("LLM API keys not available. LLM hooks will be disabled.")
             _logger.info(
                 "To enable hooks, please set LLM API keys environment variable."
             )
@@ -494,10 +498,17 @@ class HookManager:
                 # Non-fatal: we still proceed with disabled hooks
                 _logger.warning("Failed to preload hook tools without API keys: %s", _e)
 
-            # Do not proceed to create hook instances when disabled
+            # Do not proceed to create hook instances when every configured hook
+            # requires an unavailable LLM.
             # Keep hooks list empty and reflect flags
             self.hooks_enabled = self.enabled
             return
+
+        if not self._llm_hooks_available:
+            _logger.warning(
+                "LLM API keys not available. Local hooks will remain enabled; "
+                "summarization hooks will be skipped."
+            )
 
         self._load_hooks()
         self.hooks_enabled = self.enabled
@@ -539,16 +550,23 @@ class HookManager:
         sorted_hooks = sorted(self.hooks, key=lambda h: h.priority)
 
         for hook in sorted_hooks:
-            if not hook.enabled:
-                continue
+            try:
+                if not hook.enabled:
+                    continue
 
-            # Check if hook is applicable to current tool
-            if self._is_hook_applicable(hook, tool_name, context):
-                if hook.should_trigger(result, tool_name, arguments, context):
-                    _logger.debug(
-                        "Applying hook: %s for tool: %s", hook.name, tool_name
-                    )
-                    result = hook.process(result, tool_name, arguments, context)
+                # Check if hook is applicable to current tool
+                if self._is_hook_applicable(hook, tool_name, context):
+                    if hook.should_trigger(result, tool_name, arguments, context):
+                        _logger.debug(
+                            "Applying hook: %s for tool: %s", hook.name, tool_name
+                        )
+                        result = hook.process(result, tool_name, arguments, context)
+            except Exception:
+                _logger.exception(
+                    "Hook %s failed for tool %s; preserving the current result",
+                    hook.name,
+                    tool_name,
+                )
 
         return result
 
@@ -613,9 +631,12 @@ class HookManager:
     def enable_hooks(self):
         """Enable hooks and (re)load configurations and required tools."""
         self.toggle_hooks(True)
-        # Ensure tools and hooks are ready
-        self._ensure_hook_tools_loaded()
+        # This explicit API preserves the historical opt-in behavior: callers
+        # may configure the credential after constructing the manager.
+        self._allow_unavailable_llm_hooks = True
         self._load_hooks()
+        if any(isinstance(hook, SummarizationHook) for hook in self.hooks):
+            self._ensure_hook_tools_loaded()
 
     def disable_hooks(self):
         """Disable hooks and clear in-memory hook instances."""
@@ -715,34 +736,18 @@ class HookManager:
         """
         self.hooks = []
 
-        # Collect all hook configs first to determine required tools
-        all_hook_configs = []
+        # Work on copies because hook metadata and defaults are added while loading.
+        all_hook_configs = self._collect_hook_configs()
 
-        # Load global hooks
-        global_hooks = self.config.get("hooks", [])
-        for hook_config in global_hooks:
-            all_hook_configs.append(hook_config)
-
-        # Load tool-specific hooks
-        tool_specific_hooks = self.config.get("tool_specific_hooks", {})
-        for tool_name, tool_hook_config in tool_specific_hooks.items():
-            if tool_hook_config.get("enabled", True):
-                tool_hooks = tool_hook_config.get("hooks", [])
-                for hook_config in tool_hooks:
-                    hook_config["tool_name"] = tool_name
-                    all_hook_configs.append(hook_config)
-
-        # Load category-specific hooks
-        category_hooks = self.config.get("category_hooks", {})
-        for category_name, category_hook_config in category_hooks.items():
-            if category_hook_config.get("enabled", True):
-                category_hooks_list = category_hook_config.get("hooks", [])
-                for hook_config in category_hooks_list:
-                    hook_config["category"] = category_name
-                    all_hook_configs.append(hook_config)
-
-        # Auto-load required tools for hooks
-        self._auto_load_hook_tools(all_hook_configs)
+        # Do not initialize LLM-backed tools when only local hooks can run.
+        loadable_hook_configs = all_hook_configs
+        if not self._llm_hooks_available and not self._allow_unavailable_llm_hooks:
+            loadable_hook_configs = [
+                config
+                for config in all_hook_configs
+                if config.get("type", "SummarizationHook") != "SummarizationHook"
+            ]
+        self._auto_load_hook_tools(loadable_hook_configs)
 
         # Note: Hook tools will be pre-loaded when ToolUniverse.load_tools() is called
         # This is handled in the _load_pending_tools method
@@ -752,6 +757,38 @@ class HookManager:
             hook = self._create_hook_instance(hook_config)
             if hook:
                 self.hooks.append(hook)
+
+    def _collect_hook_configs(self) -> List[Dict[str, Any]]:
+        """Collect enabled hook definitions without mutating user configuration."""
+        all_hook_configs = copy.deepcopy(self.config.get("hooks", []))
+
+        for tool_name, tool_config in self.config.get(
+            "tool_specific_hooks", {}
+        ).items():
+            if not tool_config.get("enabled", True):
+                continue
+            for hook_config in copy.deepcopy(tool_config.get("hooks", [])):
+                hook_config["tool_name"] = tool_name
+                all_hook_configs.append(hook_config)
+
+        for category_name, category_config in self.config.get(
+            "category_hooks", {}
+        ).items():
+            if not category_config.get("enabled", True):
+                continue
+            for hook_config in copy.deepcopy(category_config.get("hooks", [])):
+                hook_config["category"] = category_name
+                all_hook_configs.append(hook_config)
+
+        return all_hook_configs
+
+    def _has_local_hooks(self) -> bool:
+        """Return whether at least one enabled hook does not require an LLM."""
+        return any(
+            hook.get("enabled", True)
+            and hook.get("type", "SummarizationHook") != "SummarizationHook"
+            for hook in self._collect_hook_configs()
+        )
 
     def _auto_load_hook_tools(self, hook_configs: List[Dict[str, Any]]):
         """
@@ -1001,8 +1038,10 @@ class HookManager:
             except Exception as e:
                 _logger.warning("Could not load pending hook tools: %s", e)
 
-        # Pre-load hook tools if they're available but not instantiated
-        self._ensure_hook_tools_loaded()
+        # Local hooks require no ToolUniverse tools. Avoid loading LLM-backed
+        # summarizers unless one is active.
+        if any(isinstance(hook, SummarizationHook) for hook in self.hooks):
+            self._ensure_hook_tools_loaded()
 
     def _is_hook_tool(self, tool_name: str) -> bool:
         """
@@ -1057,12 +1096,30 @@ class HookManager:
         enhanced_config = self._apply_hook_type_defaults(hook_config)
 
         if hook_type == "SummarizationHook":
+            if not getattr(self, "_llm_hooks_available", True) and not getattr(
+                self, "_allow_unavailable_llm_hooks", False
+            ):
+                _logger.warning(
+                    "Skipping summarization hook %s because no LLM API key is available",
+                    enhanced_config.get("name", "unnamed_hook"),
+                )
+                return None
             return SummarizationHook(enhanced_config, self.tooluniverse)
         elif hook_type == "FileSaveHook":
             # Merge hook_config with the main config for FileSaveHook
             file_save_config = enhanced_config.copy()
             file_save_config.update(enhanced_config.get("hook_config", {}))
             return FileSaveHook(file_save_config)
+        elif hook_type in {
+            "FilteringHook",
+            "FormattingHook",
+            "ValidationHook",
+            "LoggingHook",
+        }:
+            from .extended_hooks import HOOK_TYPE_REGISTRY
+
+            hook_class = HOOK_TYPE_REGISTRY[hook_type]
+            return hook_class(enhanced_config, self.tooluniverse)
         else:
             _logger.error("Unknown hook type: %s", hook_type)
             return None
@@ -1088,7 +1145,7 @@ class HookManager:
         )
 
         # Create enhanced configuration
-        enhanced_config = hook_config.copy()
+        enhanced_config = copy.deepcopy(hook_config)
 
         # Apply defaults to hook_config if not already specified
         if "hook_config" not in enhanced_config:
@@ -1155,9 +1212,7 @@ class HookManager:
 
         # Check category-specific hooks
         if "category" in hook.config:
-            # This would need to be implemented based on actual tool categorization
-            # For now, return True to apply category hooks to all tools
-            return True
+            return hook.config["category"] == context.get("category")
 
         # Global hooks apply to all tools
         return True

--- a/tests/unit/test_extended_hooks.py
+++ b/tests/unit/test_extended_hooks.py
@@ -1,0 +1,382 @@
+"""Behavioral tests for configurable local output hooks."""
+
+import copy
+import json
+
+import pytest
+
+from tooluniverse.agentic_tool import AgenticTool
+from tooluniverse.extended_hooks import (
+    FilteringHook,
+    FormattingHook,
+    LoggingHook,
+    ValidationHook,
+)
+from tooluniverse.output_hook import HookManager, OutputHook
+
+
+class _ToolUniverse:
+    all_tool_dict = {}
+    callable_functions = {}
+
+
+def _hook_config(hook_type, **hook_config):
+    return {
+        "name": hook_type.lower(),
+        "type": hook_type,
+        "hook_config": hook_config,
+    }
+
+
+def _manager(monkeypatch, config):
+    monkeypatch.setattr(AgenticTool, "has_any_api_keys", lambda: False)
+    return HookManager(config, _ToolUniverse())
+
+
+def test_filtering_preserves_nested_structure_and_input():
+    hook = FilteringHook(
+        _hook_config(
+            "FilteringHook",
+            filter_patterns=[r"[\w.+-]+@[\w.-]+"],
+            replacement_text="[REDACTED]",
+        )
+    )
+    source = {
+        "patient": {"contact": "person@example.org", "age": 52},
+        "evidence": ["curator@example.org", {"gene": "TP53"}],
+        "tuple": ("review@example.org", 7),
+    }
+    original = copy.deepcopy(source)
+
+    result = hook.process(source, "cancer_tool", {}, {})
+
+    assert result == {
+        "patient": {"contact": "[REDACTED]", "age": 52},
+        "evidence": ["[REDACTED]", {"gene": "TP53"}],
+        "tuple": ("[REDACTED]", 7),
+    }
+    assert source == original
+
+
+def test_filtering_can_flatten_output_when_requested():
+    hook = FilteringHook(
+        _hook_config(
+            "FilteringHook",
+            filter_patterns=["secret"],
+            preserve_structure=False,
+        )
+    )
+
+    result = hook.process({"value": "secret"}, "tool", {}, {})
+
+    assert isinstance(result, str)
+    assert "secret" not in result
+
+
+def test_filtering_ignores_invalid_patterns_and_keeps_non_strings(capsys):
+    hook = FilteringHook(
+        _hook_config("FilteringHook", filter_patterns=["(", "private"])
+    )
+
+    result = hook.process([4, None, "private"], "tool", {}, {})
+
+    assert result == [4, None, "[REDACTED]"]
+    assert "Invalid regex pattern" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ({"b": 2, "a": 1}, '{\n  "a": 1,\n  "b": 2\n}'),
+        (["first", "second"], "1. first\n2. second"),
+        ("short text", "short text"),
+        (42, 42),
+    ],
+)
+def test_formatting_supported_output_types(value, expected):
+    hook = FormattingHook(_hook_config("FormattingHook"))
+    assert hook.process(value, "tool", {}, {}) == expected
+
+
+def test_formatting_wraps_long_text_without_losing_words():
+    hook = FormattingHook(
+        _hook_config("FormattingHook", max_line_length=12)
+    )
+
+    result = hook.process("alpha beta gamma delta", "tool", {}, {})
+
+    assert result.splitlines() == ["alpha beta", "gamma delta"]
+
+
+def test_validation_fix_adds_required_fields_without_mutating_input():
+    hook = ValidationHook(
+        _hook_config(
+            "ValidationHook",
+            required_fields=["data", "provenance"],
+            error_action="fix",
+        )
+    )
+    source = {"data": [{"gene": "BRCA1"}]}
+
+    result = hook.process(source, "evidence_tool", {}, {})
+
+    assert result == {"data": [{"gene": "BRCA1"}], "provenance": None}
+    assert source == {"data": [{"gene": "BRCA1"}]}
+
+
+@pytest.mark.parametrize("action", ["warn", "fail"])
+def test_validation_non_fix_actions_preserve_output(action):
+    hook = ValidationHook(
+        _hook_config(
+            "ValidationHook", required_fields=["missing"], error_action=action
+        )
+    )
+    source = {"data": []}
+    assert hook.process(source, "tool", {}, {}) is source
+
+
+@pytest.mark.parametrize("log_format", ["simple", "detailed", "json"])
+def test_logging_formats_write_and_preserve_result(tmp_path, log_format):
+    log_path = tmp_path / "nested" / f"{log_format}.log"
+    hook = LoggingHook(
+        _hook_config(
+            "LoggingHook", log_format=log_format, log_file=str(log_path)
+        )
+    )
+    source = {"gene": "EGFR"}
+
+    result = hook.process(
+        source,
+        "cancer_evidence",
+        {"genes": {"TP53", "EGFR"}},
+        {"execution_time": 123},
+    )
+
+    assert result is source
+    content = log_path.read_text(encoding="utf-8")
+    assert "cancer_evidence" in content
+    if log_format == "json":
+        assert json.loads(content)["arguments"]["genes"] in (
+            "{'TP53', 'EGFR'}",
+            "{'EGFR', 'TP53'}",
+        )
+
+
+def test_logging_truncates_output_preview(tmp_path):
+    log_path = tmp_path / "audit.log"
+    hook = LoggingHook(
+        _hook_config(
+            "LoggingHook",
+            log_format="json",
+            log_file=str(log_path),
+            max_log_size=5,
+        )
+    )
+    hook.process("abcdefgh", "tool", {}, {})
+    assert json.loads(log_path.read_text(encoding="utf-8"))["output_preview"] == "abcde"
+
+
+@pytest.mark.parametrize(
+    ("hook_type", "hook_class"),
+    [
+        ("FilteringHook", FilteringHook),
+        ("FormattingHook", FormattingHook),
+        ("ValidationHook", ValidationHook),
+        ("LoggingHook", LoggingHook),
+    ],
+)
+def test_manager_constructs_extended_hook_types(monkeypatch, hook_type, hook_class):
+    manager = _manager(monkeypatch, {"hooks": [_hook_config(hook_type)]})
+    assert len(manager.hooks) == 1
+    assert isinstance(manager.hooks[0], hook_class)
+    assert manager.enabled
+
+
+def test_local_hooks_run_without_llm_credentials(monkeypatch):
+    manager = _manager(
+        monkeypatch,
+        {
+            "hooks": [
+                _hook_config(
+                    "FilteringHook",
+                    filter_patterns=["restricted"],
+                    replacement_text="approved",
+                )
+            ]
+        },
+    )
+    result = manager.apply_hooks(
+        {"status": "restricted"}, "tool", {}, {"category": "biomedical"}
+    )
+    assert result == {"status": "approved"}
+
+
+def test_mixed_config_skips_only_llm_hook_without_credentials(monkeypatch):
+    manager = _manager(
+        monkeypatch,
+        {
+            "hooks": [
+                _hook_config("SummarizationHook"),
+                _hook_config("ValidationHook", required_fields=["data"]),
+            ]
+        },
+    )
+    assert [type(hook) for hook in manager.hooks] == [ValidationHook]
+    assert manager.enabled
+
+
+def test_summarization_only_config_retains_disabled_behavior(monkeypatch):
+    manager = _manager(
+        monkeypatch, {"hooks": [_hook_config("SummarizationHook")]}
+    )
+    assert not manager.enabled
+    assert manager.hooks == []
+
+
+class _ExplodingHook(OutputHook):
+    def process(self, result, tool_name=None, arguments=None, context=None):
+        raise RuntimeError("hook failed")
+
+
+class _AppendHook(OutputHook):
+    def process(self, result, tool_name=None, arguments=None, context=None):
+        return result + self.config["suffix"]
+
+
+def test_hook_failures_are_isolated_and_priority_is_stable(caplog):
+    manager = object.__new__(HookManager)
+    manager.enabled = True
+    manager.config = {}
+    manager._pending_tools_to_load = []
+    manager._excluded_patterns_cache = None
+    manager.tooluniverse = _ToolUniverse()
+    manager.hooks = [
+        _AppendHook({"name": "last", "priority": 30, "suffix": "C"}),
+        _ExplodingHook({"name": "broken", "priority": 20}),
+        _AppendHook({"name": "first", "priority": 10, "suffix": "B"}),
+    ]
+
+    result = manager.apply_hooks("A", "tool", {}, {})
+
+    assert result == "ABC"
+    assert "preserving the current result" in caplog.text
+
+
+def test_tool_and_category_hooks_apply_only_to_matching_calls(monkeypatch):
+    config = {
+        "tool_specific_hooks": {
+            "target_tool": {
+                "hooks": [
+                    _hook_config(
+                        "FilteringHook",
+                        filter_patterns=["secret"],
+                        replacement_text="tool-match",
+                    )
+                ]
+            }
+        },
+        "category_hooks": {
+            "genomics": {
+                "hooks": [
+                    _hook_config(
+                        "FilteringHook",
+                        filter_patterns=["secret"],
+                        replacement_text="category-match",
+                    )
+                ]
+            }
+        },
+    }
+    manager = _manager(monkeypatch, config)
+
+    assert (
+        manager.apply_hooks("secret", "other", {}, {"category": "other"})
+        == "secret"
+    )
+    assert (
+        manager.apply_hooks("secret", "target_tool", {}, {"category": "other"})
+        == "tool-match"
+    )
+    assert (
+        manager.apply_hooks("secret", "other", {}, {"category": "genomics"})
+        == "category-match"
+    )
+
+
+def test_loading_hooks_does_not_mutate_nested_user_config(monkeypatch):
+    config = {
+        "tool_specific_hooks": {
+            "target": {
+                "hooks": [
+                    {
+                        "type": "FilteringHook",
+                        "hook_config": {"filter_patterns": ["private"]},
+                    }
+                ]
+            }
+        },
+        "hook_type_defaults": {"FilteringHook": {"unused": True}},
+    }
+    original = copy.deepcopy(config)
+
+    _manager(monkeypatch, config)
+
+    assert config == original
+
+
+def test_biomedical_pipeline_filters_validates_and_audits_without_llm(
+    monkeypatch, tmp_path
+):
+    log_path = tmp_path / "artifacts" / "cancer-evidence.jsonl"
+    config = {
+        "hooks": [
+            {
+                **_hook_config(
+                    "FilteringHook",
+                    filter_patterns=[r"[\w.+-]+@[\w.-]+"],
+                    replacement_text="[REDACTED]",
+                ),
+                "priority": 10,
+            },
+            {
+                **_hook_config(
+                    "ValidationHook",
+                    required_fields=["data", "provenance"],
+                    error_action="fix",
+                ),
+                "priority": 20,
+            },
+            {
+                **_hook_config(
+                    "LoggingHook",
+                    log_format="json",
+                    log_file=str(log_path),
+                ),
+                "priority": 30,
+            },
+        ]
+    }
+    manager = _manager(monkeypatch, config)
+    source = {
+        "data": [
+            {"gene": "TP53", "variant": "R175H", "curator": "a@lab.org"},
+            {"gene": "EGFR", "variant": "L858R", "curator": "b@lab.org"},
+        ]
+    }
+
+    result = manager.apply_hooks(
+        source,
+        "federated_cancer_evidence",
+        {"genes": ["TP53", "EGFR"]},
+        {"category": "oncology", "execution_time": 123},
+    )
+
+    assert result["provenance"] is None
+    assert [row["curator"] for row in result["data"]] == [
+        "[REDACTED]",
+        "[REDACTED]",
+    ]
+    assert source["data"][0]["curator"] == "a@lab.org"
+    audit = json.loads(log_path.read_text(encoding="utf-8"))
+    assert audit["tool_name"] == "federated_cancer_evidence"
+    assert "[REDACTED]" in audit["output_preview"]


### PR DESCRIPTION
## Summary
- wire filtering, formatting, validation, and logging hooks into HookManager
- keep local hooks operational without LLM credentials while preserving explicit summarization opt-in
- preserve nested result structures during filtering and isolate hook failures from scientific tool execution
- apply category hooks only to matching registered tool categories and avoid mutating caller configuration
- make JSON audit logging robust to non-serializable arguments and nested log paths

## Verification
- 26 focused extended-hook tests, including a TP53/EGFR evidence filtering, validation, and audit pipeline
- 19 existing hook and advanced-feature tests
- 13 existing hook integration tests
- Ruff checks on all changed Python files
- git diff --check