### PR TITLE
Validate scientific MCP server startup

### DIFF
--- a/src/tooluniverse/server_security.py
+++ b/src/tooluniverse/server_security.py
@@ -25,7 +25,7 @@ import os
 API_TOKEN_ENV = "TOOLUNIVERSE_API_TOKEN"
 
 # Hostnames that resolve to the local machine only.
-_LOOPBACK_HOSTNAMES = {"localhost", ""}
+_LOOPBACK_HOSTNAMES = {"localhost"}
 
 
 def get_api_token():
@@ -39,8 +39,8 @@ def get_api_token():
 
 def is_loopback_host(host):
     """Return ``True`` if ``host`` only accepts connections from the local machine."""
-    if host is None:
-        return True
+    if host is None or not isinstance(host, str):
+        return False
     candidate = host.strip().lower()
     if candidate in _LOOPBACK_HOSTNAMES:
         return True

--- a/src/tooluniverse/smcp.py
+++ b/src/tooluniverse/smcp.py
@@ -1537,6 +1537,7 @@ class SMCP(FastMCP):
             self.logger.info("\n🛑 Server stopped by user")
         except Exception as e:
             self.logger.error(f"❌ Server error: {e}")
+            raise
         finally:
             # Cleanup
             asyncio.run(self.close())

--- a/src/tooluniverse/smcp_server.py
+++ b/src/tooluniverse/smcp_server.py
@@ -12,6 +12,30 @@ import sys
 from .smcp import SMCP
 
 
+def _valid_port(value: str) -> int:
+    """Parse a TCP port and reject values outside the bindable range."""
+    port = int(value)
+    if not 1 <= port <= 65535:
+        raise argparse.ArgumentTypeError("port must be between 1 and 65535")
+    return port
+
+
+def _positive_int(value: str) -> int:
+    """Parse a strictly positive integer for worker-count arguments."""
+    number = int(value)
+    if number < 1:
+        raise argparse.ArgumentTypeError("value must be at least 1")
+    return number
+
+
+def _enforce_cli_bind_security(transport: str, host: str) -> None:
+    """Fail before server construction for unsafe network bind requests."""
+    if transport in {"http", "sse"}:
+        from .server_security import enforce_bind_security
+
+        enforce_bind_security(host)
+
+
 def _add_profile_args(parser: argparse.ArgumentParser) -> None:
     """Add the shared --load / --workspace / --global argument group to *parser*."""
     group = parser.add_argument_group("Profile Configuration")
@@ -111,7 +135,7 @@ Examples:
         "--host", default="127.0.0.1", help="Server host address (default: 127.0.0.1)"
     )
     server_group.add_argument(
-        "--port", type=int, default=8000, help="Server port (default: 8000)"
+        "--port", type=_valid_port, default=8000, help="Server port (default: 8000)"
     )
     server_group.add_argument(
         "--name",
@@ -127,6 +151,7 @@ Examples:
     args = parser.parse_args()
 
     try:
+        _enforce_cli_bind_security("http", args.host)
         print("🚀 Starting ToolUniverse SMCP Server...")
         print("📡 Transport: streamable-http")
         print(f"🌐 Address: http://{args.host}:{args.port}")
@@ -349,7 +374,7 @@ Examples:
     )
     parser.add_argument(
         "--max-workers",
-        type=int,
+        type=_positive_int,
         default=5,
         help="Maximum worker threads for concurrent execution (default: 5)",
     )
@@ -769,7 +794,7 @@ Examples:
     )
     parser.add_argument(
         "--port",
-        type=int,
+        type=_valid_port,
         default=7000,
         help="Port to bind to for HTTP/SSE transport (default: 7000)",
     )
@@ -785,7 +810,7 @@ Examples:
     )
     parser.add_argument(
         "--max-workers",
-        type=int,
+        type=_positive_int,
         default=5,
         help="Maximum worker threads for concurrent execution (default: 5)",
     )
@@ -897,6 +922,7 @@ Examples:
         return
 
     try:
+        _enforce_cli_bind_security(args.transport, args.host)
         print(f"🚀 Starting {args.name}...")
         print(f"📡 Transport: {args.transport}")
         if args.transport in ["http", "sse"]:

--- a/tests/unit/test_smcp_server_cli.py
+++ b/tests/unit/test_smcp_server_cli.py
@@ -1,0 +1,314 @@
+"""CLI and startup-boundary tests for the scientific MCP server."""
+
+import json
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tooluniverse import server_security
+from tooluniverse import smcp_server
+from tooluniverse.smcp import SMCP
+
+
+class _FakeSMCP:
+    instances = []
+    run_error = None
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.run_calls = []
+        self.__class__.instances.append(self)
+
+    def run_simple(self, **kwargs):
+        self.run_calls.append(kwargs)
+        if self.__class__.run_error:
+            raise self.__class__.run_error
+
+
+@pytest.fixture(autouse=True)
+def _clean_cli_state(monkeypatch):
+    from tooluniverse import logging_config
+
+    _FakeSMCP.instances = []
+    _FakeSMCP.run_error = None
+    monkeypatch.delenv(server_security.API_TOKEN_ENV, raising=False)
+    monkeypatch.delenv("TOOLUNIVERSE_STDIO_MODE", raising=False)
+    monkeypatch.setattr(smcp_server, "SMCP", _FakeSMCP)
+    monkeypatch.setattr(logging_config, "reconfigure_for_stdio", MagicMock())
+
+
+def _invoke(monkeypatch, entrypoint, *arguments):
+    monkeypatch.setattr(sys, "argv", ["tooluniverse-test", *arguments])
+    entrypoint()
+    assert len(_FakeSMCP.instances) == 1
+    return _FakeSMCP.instances[0]
+
+
+def test_main_http_defaults_are_dispatched_without_opening_listener(monkeypatch):
+    server = _invoke(monkeypatch, smcp_server.run_smcp_server)
+
+    assert server.kwargs["name"] == "ToolUniverse SMCP Server"
+    assert server.kwargs["tool_categories"] is None
+    assert server.kwargs["search_enabled"] is True
+    assert server.kwargs["max_workers"] == 5
+    assert server.run_calls == [
+        {"transport": "http", "host": "127.0.0.1", "port": 7000}
+    ]
+
+
+def test_main_dispatches_full_scientific_server_configuration(monkeypatch, tmp_path):
+    hook_path = tmp_path / "hooks.json"
+    hook_path.write_text(json.dumps({"hooks": [{"type": "LoggingHook"}]}))
+
+    server = _invoke(
+        monkeypatch,
+        smcp_server.run_smcp_server,
+        "--transport",
+        "sse",
+        "--port",
+        "8123",
+        "--name",
+        "Genomics MCP",
+        "--categories",
+        "uniprot",
+        "opentarget",
+        "--exclude-tools",
+        "unsafe_tool",
+        "--exclude-categories",
+        "large_models",
+        "--include-tools",
+        "UniProt_get_entry_by_accession",
+        "--tools-file",
+        "selected-tools.txt",
+        "--tool-config-files",
+        "local:C:\\data\\tools.json",
+        "--include-tool-types",
+        "OpenTarget",
+        "--exclude-tool-types",
+        "AgenticTool",
+        "--load",
+        "./profile.yaml",
+        "--workspace",
+        "./workspace",
+        "--global",
+        "--no-search",
+        "--max-workers",
+        "9",
+        "--hook-config-file",
+        str(hook_path),
+        "--compact-mode",
+    )
+
+    assert server.kwargs == {
+        "name": "Genomics MCP",
+        "profile": "./profile.yaml",
+        "workspace": "./workspace",
+        "use_global": True,
+        "tool_categories": ["uniprot", "opentarget"],
+        "exclude_tools": ["unsafe_tool"],
+        "exclude_categories": ["large_models"],
+        "include_tools": ["UniProt_get_entry_by_accession"],
+        "tools_file": "selected-tools.txt",
+        "tool_config_files": {"local": "C:\\data\\tools.json"},
+        "include_tool_types": ["OpenTarget"],
+        "exclude_tool_types": ["AgenticTool"],
+        "search_enabled": False,
+        "max_workers": 9,
+        "hooks_enabled": True,
+        "hook_config": {"hooks": [{"type": "LoggingHook"}]},
+        "hook_type": None,
+        "compact_mode": True,
+    }
+    assert server.run_calls == [
+        {"transport": "sse", "host": "127.0.0.1", "port": 8123}
+    ]
+
+
+def test_stdio_entrypoint_keeps_protocol_on_stdio(monkeypatch):
+    from tooluniverse import logging_config
+
+    reconfigure = MagicMock()
+    monkeypatch.setattr(logging_config, "reconfigure_for_stdio", reconfigure)
+
+    server = _invoke(
+        monkeypatch,
+        smcp_server.run_stdio_server,
+        "--categories",
+        "uniprot",
+        "--max-workers",
+        "3",
+        "--hooks",
+        "--hook-type",
+        "FileSaveHook",
+    )
+
+    assert server.kwargs["tool_categories"] == ["uniprot"]
+    assert server.kwargs["max_workers"] == 3
+    assert server.kwargs["hooks_enabled"] is True
+    assert server.kwargs["hook_type"] == "FileSaveHook"
+    assert server.run_calls == [{"transport": "stdio"}]
+    assert reconfigure.call_count == 1
+    assert os.environ["TOOLUNIVERSE_STDIO_MODE"] == "1"
+
+
+def test_http_compatibility_entrypoint_uses_streamable_http(monkeypatch):
+    server = _invoke(
+        monkeypatch,
+        smcp_server.run_http_server,
+        "--port",
+        "8088",
+        "--compact-mode",
+        "--load",
+        "community/proteomics",
+    )
+
+    assert server.kwargs["auto_expose_tools"] is True
+    assert server.kwargs["profile"] == "community/proteomics"
+    assert server.kwargs["compact_mode"] is True
+    assert server.run_calls == [
+        {"transport": "http", "host": "127.0.0.1", "port": 8088}
+    ]
+
+
+@pytest.mark.parametrize("port", ["0", "-1", "65536", "not-a-port"])
+@pytest.mark.parametrize(
+    "entrypoint", [smcp_server.run_http_server, smcp_server.run_smcp_server]
+)
+def test_network_entrypoints_reject_invalid_ports(
+    monkeypatch, entrypoint, port, capsys
+):
+    monkeypatch.setattr(sys, "argv", ["tooluniverse-test", "--port", port])
+
+    with pytest.raises(SystemExit) as exc:
+        entrypoint()
+
+    assert exc.value.code == 2
+    assert _FakeSMCP.instances == []
+    assert "port" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("workers", ["0", "-2", "invalid"])
+@pytest.mark.parametrize(
+    "entrypoint", [smcp_server.run_stdio_server, smcp_server.run_smcp_server]
+)
+def test_worker_entrypoints_reject_nonpositive_counts(
+    monkeypatch, entrypoint, workers
+):
+    monkeypatch.setattr(
+        sys, "argv", ["tooluniverse-test", "--max-workers", workers]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        entrypoint()
+
+    assert exc.value.code == 2
+    assert _FakeSMCP.instances == []
+
+
+@pytest.mark.parametrize("host", ["", "0.0.0.0", "api.internal.example"])
+@pytest.mark.parametrize(
+    "entrypoint", [smcp_server.run_http_server, smcp_server.run_smcp_server]
+)
+def test_network_entrypoints_reject_unauthenticated_remote_or_wildcard_bind(
+    monkeypatch, entrypoint, host
+):
+    monkeypatch.setattr(sys, "argv", ["tooluniverse-test", "--host", host])
+
+    with pytest.raises(SystemExit) as exc:
+        entrypoint()
+
+    assert exc.value.code == 1
+    assert _FakeSMCP.instances == []
+
+
+def test_authenticated_remote_bind_reaches_server_dispatch(monkeypatch):
+    monkeypatch.setenv(server_security.API_TOKEN_ENV, "test-token")
+    server = _invoke(
+        monkeypatch,
+        smcp_server.run_smcp_server,
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8443",
+    )
+    assert server.run_calls[0]["host"] == "0.0.0.0"
+
+
+def test_stdio_transport_does_not_apply_network_bind_guard(monkeypatch):
+    server = _invoke(
+        monkeypatch,
+        smcp_server.run_smcp_server,
+        "--transport",
+        "stdio",
+        "--host",
+        "",
+    )
+    assert server.run_calls[0]["transport"] == "stdio"
+
+
+@pytest.mark.parametrize("host", ["", None])
+def test_empty_hosts_are_not_classified_as_loopback(host):
+    assert server_security.is_loopback_host(host) is False
+
+
+def test_invalid_tool_config_spec_fails_before_server_construction(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["tooluniverse-test", "--tool-config-files", "missing-separator"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        smcp_server.run_smcp_server()
+
+    assert exc.value.code == 1
+    assert _FakeSMCP.instances == []
+
+
+def test_server_start_failure_becomes_nonzero_cli_exit(monkeypatch):
+    _FakeSMCP.run_error = RuntimeError("bind failed")
+    monkeypatch.setattr(sys, "argv", ["tooluniverse-test"])
+
+    with pytest.raises(SystemExit) as exc:
+        smcp_server.run_smcp_server()
+
+    assert exc.value.code == 1
+
+
+@pytest.mark.parametrize("transport", ["http", "sse", "invalid"])
+def test_run_simple_propagates_startup_errors_and_closes(transport):
+    state = {"closed": False}
+
+    async def close():
+        state["closed"] = True
+
+    server = SimpleNamespace(
+        logger=MagicMock(),
+        name="Test MCP",
+        _exposed_tools=[],
+        search_enabled=True,
+        hooks_enabled=False,
+        hook_type=None,
+        hook_config=None,
+        run=MagicMock(side_effect=RuntimeError("startup failed")),
+        close=close,
+    )
+
+    with pytest.raises((RuntimeError, ValueError)):
+        SMCP.run_simple(server, transport=transport)
+
+    assert state["closed"] is True
+
+
+def test_default_stdio_entrypoint_adds_compact_mode_once(monkeypatch):
+    delegate = MagicMock()
+    monkeypatch.setattr(smcp_server, "run_stdio_server", delegate)
+    monkeypatch.setattr(sys, "argv", ["tooluniverse", "--verbose"])
+
+    smcp_server.run_default_stdio_server()
+
+    assert sys.argv.count("--compact-mode") == 1
+    delegate.assert_called_once_with()


### PR DESCRIPTION
## Summary
- validate TCP ports and worker counts before constructing the scientific MCP server
- reject unauthenticated remote and empty-host wildcard binds at every network CLI entry point
- propagate startup failures after cleanup so automation receives a nonzero exit
- cover full tool selection, profile, hook, compact-mode, HTTP, SSE, and stdio dispatch without opening test listeners

## Verification
- 34 focused CLI and startup-boundary tests
- 39 existing security tests outside one documented baseline NumPy allowlist failure
- 5 compatible existing stdio-mode tests; two Windows-specific baseline tests remain incompatible with pipe select/CP1252 decoding
- 5 existing SMCP workspace/profile tests
- Ruff checks on all changed Python files
- git diff --check