### PR TITLE
Repair PubChem structure request encoding

### DIFF
--- a/src/tooluniverse/data/pubchem_tools.json
+++ b/src/tooluniverse/data/pubchem_tools.json
@@ -329,6 +329,9 @@
     "test_examples": [
       {
         "smiles": "CC(=O)OC1=CC=CC=C1C(=O)O"
+      },
+      {
+        "smiles": "C/C=C/C"
       }
     ],
     "return_schema": {
@@ -435,6 +438,11 @@
       {
         "smiles": "CC(=O)OC1=CC=CC=C1C(=O)O",
         "threshold": 0.9
+      },
+      {
+        "smiles": "C/C=C/C",
+        "threshold": 0.9,
+        "max_results": 5
       }
     ],
     "return_schema": {

--- a/src/tooluniverse/data/pubchem_tox_tools.json
+++ b/src/tooluniverse/data/pubchem_tox_tools.json
@@ -218,7 +218,7 @@
                 "cid": 241
             },
             {
-                "compound_name": "methanol"
+                "compound_name": "hydrogen cyanide"
             }
         ],
         "return_schema": {

--- a/src/tooluniverse/pubchem_tool.py
+++ b/src/tooluniverse/pubchem_tool.py
@@ -3,6 +3,7 @@
 import base64
 import requests
 import re
+from urllib.parse import quote
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
@@ -71,7 +72,15 @@ class PubChemRESTTool(BaseTool):
         → "/compound/cid/2244/property/MolecularWeight,IUPACName/JSON"
         Finally returns "https://pubchem.ncbi.nlm.nih.gov/rest/pug" + concatenated path.
         """
+        arguments = dict(arguments)
         url_path = self.endpoint_template
+
+        # PubChem requires SMILES containing URL separators in a form-encoded
+        # POST body. Even percent-encoded slashes are decoded by the routing
+        # layer before the structure parser sees them.
+        if self._requires_smiles_post(arguments):
+            url_path = url_path.replace("/{smiles}", "")
+            arguments.pop("smiles")
 
         # Replace {property_list}. Prefer a caller-supplied `properties`
         # argument over the fixed config default so the caller can choose
@@ -89,8 +98,9 @@ class PubChemRESTTool(BaseTool):
             else:
                 prop_list = self.property_list or []
             if prop_list:
+                encoded_properties = [quote(str(prop), safe="") for prop in prop_list]
                 url_path = url_path.replace(
-                    "{property_list}", ",".join(map(str, prop_list))
+                    "{property_list}", ",".join(encoded_properties)
                 )
 
         # Find all placeholders {xxx} in template
@@ -118,11 +128,14 @@ class PubChemRESTTool(BaseTool):
                         f"Missing required parameter '{ph}' to replace placeholder in URL."
                     )
             val = arguments[ph]
-            # If input value is a list, join with commas
-            if isinstance(val, list):
-                val_str = ",".join(map(str, val))
+            if ph == "xref_types" and isinstance(val, str):
+                val = [item.strip() for item in val.split(",") if item.strip()]
+            # Encode each path/query placeholder component. Valid SMILES can
+            # contain '/', '#', and '?', which otherwise alter the URL route.
+            if isinstance(val, (list, tuple)):
+                val_str = ",".join(quote(str(item), safe="") for item in val)
             else:
-                val_str = str(val)
+                val_str = quote(str(val), safe="")
             url_path = url_path.replace(f"{{{ph}}}", val_str)
 
         # Handle xref_types parameter. Validate against PubChem's fixed
@@ -162,6 +175,15 @@ class PubChemRESTTool(BaseTool):
                 full_url += f"?Threshold={threshold}"
 
         return full_url
+
+    def _requires_smiles_post(self, arguments: dict) -> bool:
+        """Return whether a SMILES input must move from the path to POST data."""
+        smiles = arguments.get("smiles")
+        return (
+            "{smiles}" in self.endpoint_template
+            and isinstance(smiles, str)
+            and any(separator in smiles for separator in "/?#")
+        )
 
     @staticmethod
     def _parse_substance_payload(payload: dict) -> dict:
@@ -325,6 +347,7 @@ class PubChemRESTTool(BaseTool):
         return None
 
     def run(self, arguments: dict):
+        arguments = dict(arguments)
         # Substance (SID, depositor-level) record lookup is handled separately:
         # it parses the raw PC_Substances payload and merges linked CIDs.
         if self.substance_record:
@@ -345,6 +368,7 @@ class PubChemRESTTool(BaseTool):
                 return {"status": "error", "error": f"Parameter '{key}' is required."}
 
         # 2. Build URL
+        use_smiles_post = self._requires_smiles_post(arguments)
         try:
             url = self._build_url(arguments)
         except ValueError as e:
@@ -360,7 +384,14 @@ class PubChemRESTTool(BaseTool):
                 else:
                     url += f"?MaxRecords={max_records}"
 
-            resp = requests.get(url, timeout=30)
+            if use_smiles_post:
+                resp = requests.post(
+                    url,
+                    data={"smiles": arguments["smiles"]},
+                    timeout=30,
+                )
+            else:
+                resp = requests.get(url, timeout=30)
         except requests.Timeout:
             return {
                 "status": "error",

--- a/tests/unit/test_pubchem_path_encoding.py
+++ b/tests/unit/test_pubchem_path_encoding.py
@@ -1,0 +1,153 @@
+"""Regression tests for PubChem path-style input encoding."""
+
+import copy
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tooluniverse.pubchem_tool import PubChemRESTTool
+
+
+DATA_PATH = (
+    Path(__file__).parents[2]
+    / "src"
+    / "tooluniverse"
+    / "data"
+    / "pubchem_tools.json"
+)
+
+
+@pytest.fixture(scope="module")
+def configs():
+    return {
+        config["name"]: config
+        for config in json.loads(DATA_PATH.read_text(encoding="utf-8"))
+    }
+
+
+@pytest.mark.parametrize(
+    ("smiles", "encoded"),
+    [
+        ("N[C@@H](C)C(=O)O", "N%5BC%40%40H%5D%28C%29C%28%3DO%29O"),
+        ("C\\C=C\\C", "C%5CC%3DC%5CC"),
+    ],
+)
+def test_exact_smiles_path_encodes_reserved_characters(configs, smiles, encoded):
+    tool = PubChemRESTTool(configs["PubChem_get_CID_by_SMILES"])
+
+    url = tool._build_url({"smiles": smiles})
+
+    assert f"/compound/smiles/{encoded}/cids/JSON" in url
+    assert smiles not in url
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "PubChem_get_CID_by_SMILES",
+        "PubChem_search_compounds_by_substructure",
+        "PubChem_search_compounds_by_similarity",
+    ],
+)
+@pytest.mark.parametrize("smiles", ["C/C=C/C", "C#N", "C?C"])
+def test_url_separator_smiles_move_out_of_path(configs, tool_name, smiles):
+    tool = PubChemRESTTool(configs[tool_name])
+    arguments = {"smiles": smiles}
+    if tool_name == "PubChem_search_compounds_by_similarity":
+        arguments["threshold"] = 0.9
+
+    url = tool._build_url(arguments)
+
+    assert "{smiles}" not in url
+    assert smiles not in url
+    assert "/smiles/cids/JSON" in url
+    if "threshold" in arguments:
+        assert "Threshold=90" in url
+
+
+def test_multi_value_xrefs_keep_pubchem_comma_delimiter(configs):
+    tool = PubChemRESTTool(configs["PubChem_get_compound_xrefs_by_CID"])
+
+    list_url = tool._build_url(
+        {"cid": 2244, "xref_types": ["RegistryID", "PatentID"]}
+    )
+    string_url = tool._build_url(
+        {"cid": 2244, "xref_types": "RegistryID,PatentID"}
+    )
+
+    assert list_url == string_url
+    assert "/xrefs/RegistryID,PatentID/JSON" in list_url
+    assert "%2C" not in list_url
+
+
+def test_compound_names_and_vendor_sources_are_encoded(configs):
+    name_tool = PubChemRESTTool(configs["PubChem_get_CID_by_compound_name"])
+    source_tool = PubChemRESTTool(configs["PubChem_get_substances_by_source"])
+
+    name_url = name_tool._build_url({"name": "sodium chloride/solution"})
+    source_url = source_tool._build_url({"source": "Vendor A/B"})
+
+    assert "/name/sodium%20chloride%2Fsolution/cids/JSON" in name_url
+    assert "/sourceall/Vendor%20A%2FB/sids/JSON" in source_url
+
+
+def test_property_names_are_encoded_individually_and_comma_separated(configs):
+    tool = PubChemRESTTool(configs["PubChem_get_compound_properties_by_CID"])
+
+    url = tool._build_url(
+        {"cid": 2244, "properties": ["MolecularWeight", "Custom/Property"]}
+    )
+
+    assert "/property/MolecularWeight,Custom%2FProperty/JSON" in url
+
+
+def test_run_posts_reserved_smiles_and_preserves_caller_arguments(configs):
+    tool = PubChemRESTTool(configs["PubChem_get_CID_by_SMILES"])
+    arguments = {"smiles": "C/C=C/C"}
+    original = copy.deepcopy(arguments)
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"IdentifierList": {"CID": [62695]}}
+
+    with patch("tooluniverse.pubchem_tool.requests.get") as get, patch(
+        "tooluniverse.pubchem_tool.requests.post", return_value=response
+    ) as post:
+        result = tool.run(arguments)
+
+    assert result == {
+        "status": "success",
+        "data": {"IdentifierList": {"CID": [62695]}},
+    }
+    assert "/compound/smiles/cids/JSON" in post.call_args.args[0]
+    assert post.call_args.kwargs["data"] == {"smiles": "C/C=C/C"}
+    get.assert_not_called()
+    assert arguments == original
+
+
+def test_run_keeps_simple_smiles_on_get(configs):
+    tool = PubChemRESTTool(configs["PubChem_get_CID_by_SMILES"])
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"IdentifierList": {"CID": [5950]}}
+
+    with patch(
+        "tooluniverse.pubchem_tool.requests.get", return_value=response
+    ) as get, patch("tooluniverse.pubchem_tool.requests.post") as post:
+        result = tool.run({"smiles": "N[C@@H](C)C(=O)O"})
+
+    assert result["status"] == "success"
+    assert "%5BC%40%40H%5D" in get.call_args.args[0]
+    post.assert_not_called()
+
+
+def test_alias_expansion_does_not_mutate_caller_arguments(configs):
+    tool = PubChemRESTTool(configs["PubChem_get_CID_by_compound_name"])
+    arguments = {"compound_name": "sodium chloride"}
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"IdentifierList": {"CID": [5234]}}
+
+    with patch("tooluniverse.pubchem_tool.requests.get", return_value=response):
+        result = tool.run(arguments)
+
+    assert result["status"] == "success"
+    assert arguments == {"compound_name": "sodium chloride"}


### PR DESCRIPTION
## Summary
- encode PubChem path placeholders without changing list delimiters required by PUG REST
- send SMILES containing URL route separators as form-encoded POST data, as required by PubChem, while preserving GET requests for ordinary structures
- avoid mutating caller arguments and replace a stale live toxicity example with a currently supported compound
- add regression coverage for exact, substructure, similarity, xref, property, compound-name, and vendor-source requests

## Verification
- `python -m pytest tests/unit -k pubchem --no-cov -q`: 50 passed
- `python scripts/test_new_tools.py pubchem`: 33 tools, 52 live examples, 52 passed, 52 schema-valid
- repeated live checks: trans-2-butene resolved to CID 62695; 90% similarity returned five compounds; hydrogen cyanide returned four human-toxicity values
- Ruff passed for the implementation and new tests
- JSON parsing and `git diff --check` passed