### PR TITLE
Preserve Rhea reaction stoichiometry and compartments

### DIFF
--- a/src/tooluniverse/data/rhea_reaction_tools.json
+++ b/src/tooluniverse/data/rhea_reaction_tools.json
@@ -2,7 +2,7 @@
   {
     "type": "RheaReactionTool",
     "name": "Rhea_get_reaction",
-    "description": "Fetch the full structured detail of a single Rhea biochemical reaction by its Rhea identifier. Rhea (SIB Swiss Institute of Bioinformatics) is an expert-curated knowledgebase of chemical and transport reactions, all linked to ChEBI compounds and EC numbers. Given a Rhea id (e.g. '10280' or 'RHEA:10280'), returns the chemical equation, the parsed ChEBI participants split into reactants and products (each with ChEBI id + compound name), the list of EC enzyme numbers, the count of curated enzymes, PubMed reference IDs, KEGG and MetaCyc cross-references, and the curation status plus balanced and transport flags. Use this to retrieve mechanistic detail for one reaction after finding it with Rhea_search_reactions / Rhea_search_by_ec / Rhea_search_by_chebi. No API key required.",
+    "description": "Fetch the full structured detail of a single Rhea biochemical reaction by its Rhea identifier. Rhea (SIB Swiss Institute of Bioinformatics) is an expert-curated knowledgebase of chemical and transport reactions, all linked to ChEBI compounds and EC numbers. Given a Rhea id (e.g. '10280' or 'RHEA:10280'), returns the chemical equation; reactants and products with identifiers, stoichiometric coefficients, and transport compartments; EC enzyme numbers; the count of curated enzymes; PubMed references; KEGG and MetaCyc cross-references; and curation, balance, and transport flags. Use this to retrieve mechanistic detail for one reaction after finding it with Rhea_search_reactions / Rhea_search_by_ec / Rhea_search_by_chebi. No API key required.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -63,6 +63,17 @@
                     "type": "boolean",
                     "description": "True if this participant is a generic/polymer reactive part (e.g. a protein residue like \"L-tyrosyl-[protein]\") rather than a discrete ChEBI compound."
                   },
+                  "stoichiometry": {
+                    "type": "string",
+                    "description": "Stoichiometric coefficient as represented by Rhea, including symbolic values such as n or 2n. A participant with no displayed coefficient is returned as \"1\"."
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Transport compartment such as \"in\" or \"out\"; null when Rhea specifies no compartment."
+                  },
                   "rhea_comp_id": {
                     "type": "string",
                     "description": "Rhea generic-compound id, e.g. \"RHEA-COMP:10136\". Present only when is_generic is true."
@@ -88,6 +99,17 @@
                   "is_generic": {
                     "type": "boolean",
                     "description": "True if this participant is a generic/polymer reactive part (e.g. a protein residue like \"L-tyrosyl-[protein]\") rather than a discrete ChEBI compound."
+                  },
+                  "stoichiometry": {
+                    "type": "string",
+                    "description": "Stoichiometric coefficient as represented by Rhea, including symbolic values such as n or 2n. A participant with no displayed coefficient is returned as \"1\"."
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Transport compartment such as \"in\" or \"out\"; null when Rhea specifies no compartment."
                   },
                   "rhea_comp_id": {
                     "type": "string",
@@ -154,13 +176,19 @@
       },
       {
         "rhea_id": "29467"
+      },
+      {
+        "rhea_id": "RHEA:18353"
+      },
+      {
+        "rhea_id": "10256"
       }
     ]
   },
   {
     "type": "RheaReactionTool",
     "name": "Rhea_get_reaction_participants",
-    "description": "Return just the structured ChEBI participants (reactants and products) of a single Rhea biochemical reaction, given its Rhea identifier (e.g. '16505' or 'RHEA:16505'). Each participant carries its ChEBI compound id and name. Lightweight alternative to Rhea_get_reaction when only the substrate/product compound lists are needed, for example when building or annotating a metabolic network. No API key required.",
+    "description": "Return the structured reactants and products of one Rhea biochemical reaction, including each participant's identifier, name, stoichiometric coefficient, and transport compartment. This is a lightweight alternative to Rhea_get_reaction when building or annotating a metabolic network. No API key required.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -206,6 +234,17 @@
                     "type": "boolean",
                     "description": "True if this participant is a generic/polymer reactive part (e.g. a protein residue like \"L-tyrosyl-[protein]\") rather than a discrete ChEBI compound."
                   },
+                  "stoichiometry": {
+                    "type": "string",
+                    "description": "Stoichiometric coefficient as represented by Rhea, including symbolic values such as n or 2n. A participant with no displayed coefficient is returned as \"1\"."
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Transport compartment such as \"in\" or \"out\"; null when Rhea specifies no compartment."
+                  },
                   "rhea_comp_id": {
                     "type": "string",
                     "description": "Rhea generic-compound id, e.g. \"RHEA-COMP:10136\". Present only when is_generic is true."
@@ -231,6 +270,17 @@
                   "is_generic": {
                     "type": "boolean",
                     "description": "True if this participant is a generic/polymer reactive part (e.g. a protein residue like \"L-tyrosyl-[protein]\") rather than a discrete ChEBI compound."
+                  },
+                  "stoichiometry": {
+                    "type": "string",
+                    "description": "Stoichiometric coefficient as represented by Rhea, including symbolic values such as n or 2n. A participant with no displayed coefficient is returned as \"1\"."
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Transport compartment such as \"in\" or \"out\"; null when Rhea specifies no compartment."
                   },
                   "rhea_comp_id": {
                     "type": "string",
@@ -271,6 +321,12 @@
       },
       {
         "rhea_id": "RHEA:10280"
+      },
+      {
+        "rhea_id": "RHEA:18353"
+      },
+      {
+        "rhea_id": "10256"
       }
     ]
   }

--- a/src/tooluniverse/rhea_reaction_tool.py
+++ b/src/tooluniverse/rhea_reaction_tool.py
@@ -25,6 +25,7 @@ merges both into one structured record. No authentication required; free public
 access.
 """
 
+from html import unescape
 import re
 import requests
 from typing import Any, Dict, List
@@ -34,7 +35,7 @@ from .tool_registry import register_tool
 
 RHEA_BASE_URL = "https://www.rhea-db.org/rhea"
 
-# Pull "<a data-molid="chebi:25858">1,7-dimethylxanthine</a>" out of htmlequation.
+# Parse each participant block, including its coefficient and compartment.
 # Generic/polymer participants (e.g. protein-linked residues consumed or
 # produced by the reaction, like "L-tyrosyl-[protein]") aren't real ChEBI
 # compounds -- Rhea gives them a "rhea-comp:" id instead of a "chebi:" one.
@@ -43,7 +44,10 @@ RHEA_BASE_URL = "https://www.rhea-db.org/rhea"
 # live for RHEA:10596, whose htmlequation carries "rhea-comp:10136" and
 # "rhea-comp:20101" for its two protein-residue participants).
 _PARTICIPANT_RE = re.compile(
-    r'data-molid="(?P<ns>chebi|rhea-comp):(?P<molid>\d+)"[^>]*>(?P<name>.*?)</a>',
+    r'(?:<span class="stoichiometry">(?P<stoichiometry>.*?)</span>\s*)?'
+    r'<a\s+[^>]*data-molid="(?P<ns>chebi|rhea-comp):(?P<molid>\d+)"[^>]*>'
+    r'(?P<name>.*?)</a>\s*'
+    r'(?:<span class="location">(?P<location>.*?)</span>)?',
     re.IGNORECASE | re.DOTALL,
 )
 # Strip residual inline HTML tags (<i>, <small>, <sup>, <sub>) from names.
@@ -104,20 +108,23 @@ class RheaReactionTool(BaseTool):
         return text.strip()
 
     @staticmethod
-    def _clean_name(name: str) -> str:
-        return _TAG_RE.sub("", name).strip()
+    def _clean_text(value: str) -> str:
+        """Remove Rhea's display markup and decode HTML character entities."""
+        return unescape(_TAG_RE.sub("", value)).strip()
 
     def _parse_participants(
         self, html_equation: str
-    ) -> Dict[str, List[Dict[str, str]]]:
-        """Split htmlequation on ' = ' and extract ChEBI participants per side."""
-        reactants: List[Dict[str, str]] = []
-        products: List[Dict[str, str]] = []
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Extract participants without discarding coefficients or compartments."""
+        reactants: List[Dict[str, Any]] = []
+        products: List[Dict[str, Any]] = []
         if not html_equation:
             return {"reactants": reactants, "products": products}
 
         # The two reaction sides are separated by a bare ' = ' between spans.
-        parts = re.split(r"</span>\s*=\s*<span", html_equation, maxsplit=1)
+        parts = re.split(
+            r"(?<=</span>)\s*=\s*(?=<span)", html_equation, maxsplit=1
+        )
         if len(parts) == 2:
             left, right = parts[0], parts[1]
         else:
@@ -127,10 +134,19 @@ class RheaReactionTool(BaseTool):
         for side_html, bucket in ((left, reactants), (right, products)):
             for m in _PARTICIPANT_RE.finditer(side_html):
                 is_generic = m.group("ns").lower() == "rhea-comp"
+                location = self._clean_text(m.group("location") or "")
+                if location.startswith("(") and location.endswith(")"):
+                    location = location[1:-1].strip()
                 participant = {
                     "chebi_id": None if is_generic else f"CHEBI:{m.group('molid')}",
-                    "name": self._clean_name(m.group("name")),
+                    "name": self._clean_text(m.group("name")),
                     "is_generic": is_generic,
+                    # Rhea omits the coefficient for a single participant.
+                    # Keep this a string because symbolic values such as n and
+                    # 2n occur in polymer reactions.
+                    "stoichiometry": self._clean_text(m.group("stoichiometry") or "")
+                    or "1",
+                    "location": location or None,
                 }
                 if is_generic:
                     participant["rhea_comp_id"] = f"RHEA-COMP:{m.group('molid')}"

--- a/tests/unit/test_rhea_participant_structure.py
+++ b/tests/unit/test_rhea_participant_structure.py
@@ -1,0 +1,131 @@
+"""Regression coverage for scientific structure in Rhea participants."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tooluniverse.rhea_reaction_tool import RheaReactionTool
+
+
+pytestmark = pytest.mark.unit
+
+DATA_PATH = (
+    Path(__file__).parents[2]
+    / "src"
+    / "tooluniverse"
+    / "data"
+    / "rhea_reaction_tools.json"
+)
+
+# Shape captured from the live RHEA:18353 sodium/potassium ATPase response.
+_TRANSPORT_EQUATION = (
+    '<span class="participant"><span class="stoichiometry">2 </span>'
+    '<a data-molid="chebi:29103">K<small><sup>+</sup></small></a>'
+    '<span class="location"> (out)</span></span> + '
+    '<span class="participant"><span class="stoichiometry">3 </span>'
+    '<a data-molid="chebi:29101">Na<small><sup>+</sup></small></a>'
+    '<span class="location"> (in)</span></span> + '
+    '<span class="participant"><span class="stoichiometry"> </span>'
+    '<a data-molid="chebi:30616">ATP</a>'
+    '<span class="location"> </span></span> = '
+    '<span class="participant"><span class="stoichiometry">2 </span>'
+    '<a data-molid="chebi:29103">K<small><sup>+</sup></small></a>'
+    '<span class="location"> (in)</span></span> + '
+    '<span class="participant"><span class="stoichiometry">3 </span>'
+    '<a data-molid="chebi:29101">Na<small><sup>+</sup></small></a>'
+    '<span class="location"> (out)</span></span>'
+)
+
+# Representative live Rhea markup for symbolic polymer stoichiometry and
+# entity-encoded chemical names (RHEA:10256).
+_POLYMER_EQUATION = (
+    '<span class="participant"><span class="stoichiometry"> </span>'
+    '<a data-molid="rhea-comp:12983">'
+    '[(1&#8594;4)-6-phospho-&#945;-<small>D</small>-glucosyl]'
+    '<small><sub>(<i>n</i>)</sub></small></a>'
+    '<span class="location"> </span></span> + '
+    '<span class="participant"><span class="stoichiometry">n </span>'
+    '<a data-molid="chebi:30616">ATP</a>'
+    '<span class="location"> </span></span> = '
+    '<span class="participant"><span class="stoichiometry">2n </span>'
+    '<a data-molid="chebi:15378">H<small><sup>+</sup></small></a>'
+    '<span class="location"> </span></span>'
+)
+
+
+@pytest.fixture
+def tool():
+    return RheaReactionTool(
+        {"name": "rhea_participant_test", "fields": {"endpoint": "get_participants"}}
+    )
+
+
+def test_transport_participants_preserve_coefficients_and_compartments(tool):
+    parsed = tool._parse_participants(_TRANSPORT_EQUATION)
+
+    assert parsed["reactants"] == [
+        {
+            "chebi_id": "CHEBI:29103",
+            "name": "K+",
+            "is_generic": False,
+            "stoichiometry": "2",
+            "location": "out",
+        },
+        {
+            "chebi_id": "CHEBI:29101",
+            "name": "Na+",
+            "is_generic": False,
+            "stoichiometry": "3",
+            "location": "in",
+        },
+        {
+            "chebi_id": "CHEBI:30616",
+            "name": "ATP",
+            "is_generic": False,
+            "stoichiometry": "1",
+            "location": None,
+        },
+    ]
+    assert parsed["products"][0]["location"] == "in"
+    assert parsed["products"][1]["location"] == "out"
+    assert [item["stoichiometry"] for item in parsed["products"]] == ["2", "3"]
+
+
+def test_symbolic_stoichiometry_and_html_entities_are_preserved(tool):
+    parsed = tool._parse_participants(_POLYMER_EQUATION)
+
+    polymer, atp = parsed["reactants"]
+    assert polymer["name"] == "[(1\u21924)-6-phospho-\u03b1-D-glucosyl](n)"
+    assert polymer["rhea_comp_id"] == "RHEA-COMP:12983"
+    assert polymer["stoichiometry"] == "1"
+    assert atp["stoichiometry"] == "n"
+    assert parsed["products"][0]["stoichiometry"] == "2n"
+
+
+def test_empty_or_unsplittable_equations_remain_safe(tool):
+    assert tool._parse_participants("") == {"reactants": [], "products": []}
+
+    one_side = _TRANSPORT_EQUATION.split(" = ", maxsplit=1)[0]
+    parsed = tool._parse_participants(one_side)
+    assert len(parsed["reactants"]) == 3
+    assert parsed["products"] == []
+
+
+def test_every_participant_schema_declares_structured_fields():
+    configs = json.loads(DATA_PATH.read_text(encoding="utf-8"))
+
+    for config in configs:
+        success_schema = config["return_schema"]["oneOf"][0]
+        for side in ("reactants", "products"):
+            properties = success_schema["properties"][side]["items"]["properties"]
+            assert properties["stoichiometry"]["type"] == "string"
+            assert properties["location"]["type"] == ["string", "null"]
+
+
+def test_live_complex_examples_are_registered_for_both_endpoints():
+    configs = json.loads(DATA_PATH.read_text(encoding="utf-8"))
+
+    for config in configs:
+        ids = {example["rhea_id"].removeprefix("RHEA:") for example in config["test_examples"]}
+        assert {"18353", "10256"}.issubset(ids)


### PR DESCRIPTION
## Summary
- preserve each Rhea participant's stoichiometric coefficient, including symbolic values such as `n` and `2n`
- preserve transport compartments such as `in` and `out`, which are required to distinguish membrane-reaction direction
- decode Rhea's HTML character entities while retaining ChEBI and generic Rhea participant identifiers
- document the additive output fields and add complex live examples for a sodium/potassium ATPase and a polymer reaction

## Verification
- focused Rhea regression suite: 25 passed
- `python scripts/test_new_tools.py rhea`: 5 tools, 15 live examples, 15 passed, 15 schema-valid
- two repeated live scientific checks confirmed RHEA:18353 as 2 K+ out / 3 Na+ in to 2 K+ in / 3 Na+ out
- repeated live checks also preserved symbolic polymer coefficients for RHEA:10256 and transport compartments for RHEA:29467
- Ruff, JSON parsing, and `git diff --check` passed