### PR TITLE
Fix 5 tools returning result without a data key on success

### DIFF
--- a/src/tooluniverse/arxiv_tool.py
+++ b/src/tooluniverse/arxiv_tool.py
@@ -380,10 +380,10 @@ class ArXivPDFSnippetsTool(BaseTool):
                 total_chars += len(snippet)
                 found += 1
 
-        return {
-            "status": "success",
+        payload = {
             "pdf_url": final_pdf_url,
             "snippets": snippets,
             "snippets_count": len(snippets),
             "truncated": total_chars >= max_total_chars,
         }
+        return {"status": "success", **payload, "data": payload}

--- a/src/tooluniverse/dailymed_tool.py
+++ b/src/tooluniverse/dailymed_tool.py
@@ -205,7 +205,7 @@ class GetSPLBySetIDTool(BaseTool):
                 "detail": resp.text,
             }
 
-        return {"status": "success", "xml": resp.text}
+        return {"status": "success", "xml": resp.text, "data": {"xml": resp.text}}
 
 
 def _dedupe_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/src/tooluniverse/fda_pharmacogenomic_biomarkers_tool.py
+++ b/src/tooluniverse/fda_pharmacogenomic_biomarkers_tool.py
@@ -65,12 +65,12 @@ class FDAPharmacogenomicBiomarkersTool(BaseTool):
             # Apply limit
             limited_results = filtered_results[:limit]
 
-            return {
-                "status": "success",
+            payload = {
                 "count": len(filtered_results),
                 "shown": len(limited_results),
                 "results": limited_results,
             }
+            return {"status": "success", **payload, "data": payload}
 
         except Exception as e:
             return {

--- a/src/tooluniverse/pubtator_tool.py
+++ b/src/tooluniverse/pubtator_tool.py
@@ -134,7 +134,7 @@ class PubTatorTool(BaseTool):
                 ):
                     result["results"] = result["results"][:_limit]
             if isinstance(result, dict) and "status" not in result:
-                return {"status": "success", **result}
+                return {"status": "success", **result, "data": result}
             return result
         if "text" in ctype or "xml" in ctype:
             return response.text

--- a/src/tooluniverse/semantic_scholar_tool.py
+++ b/src/tooluniverse/semantic_scholar_tool.py
@@ -491,10 +491,10 @@ class SemanticScholarPDFSnippetsTool(BaseTool):
                 total_chars += len(snippet)
                 found += 1
 
-        return {
-            "status": "success",
+        payload = {
             "pdf_url": pdf_url,
             "snippets": snippets,
             "snippets_count": len(snippets),
             "truncated": total_chars >= max_total_chars,
         }
+        return {"status": "success", **payload, "data": payload}


### PR DESCRIPTION
## Summary
- `SemanticScholar_get_pdf_snippets`, `fda_pharmacogenomic_biomarkers`, `ArXiv_get_pdf_snippets`, `DailyMed_get_spl_by_setid`, and `PubTator3_LiteratureSearch` all built a valid success payload but never wrapped it in a `data` key, so `result["data"]` was unconditionally `None` on every call regardless of the query — not a stale test fixture, a real gap in the success-path return
- Wrapped the existing payload under `data` alongside the pre-existing top-level keys (kept for compatibility) to match the `return_schema` contract and every sibling method in these files

## Verification
- `tu test <ToolName>` passes for all 5 tools
- Confirmed sibling tools sharing the same generic implementation (`PubTator3_EntityAutocomplete`, `ArXiv_search_papers`) still pass after the change