### PR TITLE
Stringify unmapped FAERS drugcharacterization codes

### DIFF
--- a/src/tooluniverse/openfda_adv_tool.py
+++ b/src/tooluniverse/openfda_adv_tool.py
@@ -144,11 +144,15 @@ class FDADrugAdverseEventTool(BaseTool):
                     if term and term.upper() != reaction_filter.upper():
                         continue
 
-                # Apply mapping if available
+                # Apply mapping if available. Fall back to the raw code as a
+                # string (not the original int/etc) so an FDA code absent
+                # from our mapping (e.g. an undocumented drugcharacterization
+                # value) still satisfies the documented "term is a string"
+                # contract instead of leaking a raw int through.
                 if self.return_fields_mapping:
                     mapped_term = self.return_fields_mapping.get(
                         self.count_field, {}
-                    ).get(str(term), term)
+                    ).get(str(term), str(term))
                     mapped_results.append({"term": mapped_term, "count": count})
                 else:
                     mapped_results.append({"term": term, "count": count})


### PR DESCRIPTION
## Summary
- FAERS count-endpoint tools' `drugcharacterization` enum mapping only covers openFDA's 3 documented codes (Suspect/Concomitant/Interacting)
- An undocumented 4th code leaked through `_post_process`'s fallback as a raw int, violating the schema's string-typed `term` field
- Stringify the fallback so any current or future unmapped code satisfies the type contract instead of only working for codes we happened to enumerate

## Verification
- `tu run FAERS_count_drug_characterization '{"medicinalproduct":"WARFARIN"}'` now shows `{"term": "4", "count": 1}` for the unmapped code instead of a raw int, with the 3 documented categories unaffected
- `tu test FAERS_count_drug_characterization` passes
- Full `fda_drug_adverse_event` pattern (24 tools, 31 tests): 100% pass, 0 schema-invalid