### PR TITLE
PDBe-KB ligand_sites/interface_residues: fix silent truncation

### DIFF
--- a/src/tooluniverse/data/pdbe_kb_tools.json
+++ b/src/tooluniverse/data/pdbe_kb_tools.json
@@ -104,13 +104,17 @@
   },
   {
     "name": "PDBe_KB_get_ligand_sites",
-    "description": "Get ligand binding site residues for a UniProt protein from PDBe-KB. Returns all known ligands that bind the protein, with the specific residue positions (UniProt numbering) involved in binding, the PDB structures where binding was observed, and ligand metadata (scaffold, cofactor status, drug associations). Essential for understanding protein function, drug binding, and designing mutagenesis experiments. Example: P04637 (TP53) shows NAD binding at residue 382, zinc coordination at the DNA-binding domain.",
+    "description": "Get ligand binding site residues for a UniProt protein from PDBe-KB. Returns all known ligands that bind the protein, with the specific residue positions (UniProt numbering) involved in binding, the PDB structures where binding was observed, and ligand metadata (scaffold, cofactor status, drug associations). Essential for understanding protein function, drug binding, and designing mutagenesis experiments. Example: P04637 (TP53) shows NAD binding at residue 382, zinc coordination at the DNA-binding domain. Proteins with many known ligands (e.g. well-studied drug targets) are truncated to `max_ligands` entries by default -- check the response's `truncated` flag and raise `max_ligands` if a specific ligand of interest is missing.",
     "parameter": {
       "type": "object",
       "properties": {
         "uniprot_accession": {
           "type": "string",
           "description": "UniProt accession ID for the protein. Examples: 'P04637' (TP53), 'P00533' (EGFR), 'P38398' (BRCA1)."
+        },
+        "max_ligands": {
+          "type": "integer",
+          "description": "Maximum number of ligands to return (default 100). The underlying API does not guarantee ordering by clinical relevance, so pass a value >= total_ligands (from a prior call, or from the response's truncation_note) to guarantee a specific ligand isn't cut off."
         }
       },
       "required": [
@@ -232,6 +236,14 @@
                 "total_ligands": {
                   "type": "integer",
                   "description": "Total number of unique ligands"
+                },
+                "truncated": {
+                  "type": "boolean",
+                  "description": "True if fewer ligands were returned than total_ligands"
+                },
+                "truncation_note": {
+                  "type": "string",
+                  "description": "Explains the truncation and how to raise max_ligands to see all results"
                 }
               }
             },
@@ -264,13 +276,17 @@
   },
   {
     "name": "PDBe_KB_get_interface_residues",
-    "description": "Get protein-protein interaction interface residues for a UniProt protein from PDBe-KB. Returns residue positions (UniProt numbering) at interaction interfaces with other proteins, the identity of interaction partners, and PDB structures where each interface was observed. Essential for understanding protein complex formation, designing interface-disrupting mutations, and identifying functional hotspots. Example: P04637 (TP53) shows interaction interfaces with MDM2, p53BP2, and DNA.",
+    "description": "Get protein-protein interaction interface residues for a UniProt protein from PDBe-KB. Returns residue positions (UniProt numbering) at interaction interfaces with other proteins, the identity of interaction partners, and PDB structures where each interface was observed. Essential for understanding protein complex formation, designing interface-disrupting mutations, and identifying functional hotspots. Example: P04637 (TP53) shows interaction interfaces with MDM2, p53BP2, and DNA. Proteins with many known partners are truncated to `max_partners` entries by default -- check the response's `truncated` flag if a specific partner of interest is missing.",
     "parameter": {
       "type": "object",
       "properties": {
         "uniprot_accession": {
           "type": "string",
           "description": "UniProt accession ID for the protein. Examples: 'P04637' (TP53), 'P00533' (EGFR), 'P38398' (BRCA1)."
+        },
+        "max_partners": {
+          "type": "integer",
+          "description": "Maximum number of interaction partners to return (default 60). Pass a value >= total_partners (from a prior call) to guarantee a specific partner isn't cut off."
         }
       },
       "required": [
@@ -364,6 +380,14 @@
                 "total_partners": {
                   "type": "integer",
                   "description": "Total number of interaction partners"
+                },
+                "truncated": {
+                  "type": "boolean",
+                  "description": "True if fewer partners were returned than total_partners"
+                },
+                "truncation_note": {
+                  "type": "string",
+                  "description": "Explains the truncation and how to raise max_partners to see all results"
                 }
               }
             },

--- a/src/tooluniverse/pdbe_kb_tool.py
+++ b/src/tooluniverse/pdbe_kb_tool.py
@@ -132,9 +132,10 @@ class PDBe_KB_Tool(BaseTool):
 
         protein_data = data[acc]
         ligands = []
-        max_ligands = 50  # Limit output size
+        all_ligand_entries = protein_data.get("data", [])
+        max_ligands = arguments.get("max_ligands") or 100
 
-        for entry in protein_data.get("data", [])[:max_ligands]:
+        for entry in all_ligand_entries[:max_ligands]:
             binding_residues = []
             for res in entry.get("residues", [])[:20]:
                 binding_residues.append(
@@ -158,14 +159,25 @@ class PDBe_KB_Tool(BaseTool):
                 }
             )
 
+        result_data = {
+            "uniprot_accession": acc,
+            "protein_length": protein_data.get("length"),
+            "ligands": ligands,
+            "total_ligands": len(all_ligand_entries),
+        }
+        if len(all_ligand_entries) > max_ligands:
+            result_data["truncated"] = True
+            result_data["truncation_note"] = (
+                f"Returning {max_ligands} of {len(all_ligand_entries)} ligands. "
+                f"Pass max_ligands={len(all_ligand_entries)} to retrieve all of them. "
+                "The API does not guarantee ordering by clinical relevance, so "
+                "a specific ligand of interest (e.g. a named drug) may be cut off "
+                "at the default limit."
+            )
+
         return {
             "status": "success",
-            "data": {
-                "uniprot_accession": acc,
-                "protein_length": protein_data.get("length"),
-                "ligands": ligands,
-                "total_ligands": len(protein_data.get("data", [])),
-            },
+            "data": result_data,
             "metadata": {
                 "source": "PDBe-KB (PDBe Knowledge Base) Graph API",
             },
@@ -190,9 +202,10 @@ class PDBe_KB_Tool(BaseTool):
 
         protein_data = data[acc]
         partners = []
-        max_partners = 30
+        all_partner_entries = protein_data.get("data", [])
+        max_partners = arguments.get("max_partners") or 60
 
-        for entry in protein_data.get("data", [])[:max_partners]:
+        for entry in all_partner_entries[:max_partners]:
             interface_residues = []
             for res in entry.get("residues", [])[:30]:
                 interface_residues.append(
@@ -211,14 +224,23 @@ class PDBe_KB_Tool(BaseTool):
                 }
             )
 
+        result_data = {
+            "uniprot_accession": acc,
+            "protein_length": protein_data.get("length"),
+            "interaction_partners": partners,
+            "total_partners": len(all_partner_entries),
+        }
+        if len(all_partner_entries) > max_partners:
+            result_data["truncated"] = True
+            result_data["truncation_note"] = (
+                f"Returning {max_partners} of {len(all_partner_entries)} interaction "
+                f"partners. Pass max_partners={len(all_partner_entries)} to retrieve "
+                "all of them."
+            )
+
         return {
             "status": "success",
-            "data": {
-                "uniprot_accession": acc,
-                "protein_length": protein_data.get("length"),
-                "interaction_partners": partners,
-                "total_partners": len(protein_data.get("data", [])),
-            },
+            "data": result_data,
             "metadata": {
                 "source": "PDBe-KB (PDBe Knowledge Base) Graph API",
             },


### PR DESCRIPTION
## Summary
- Both `PDBe_KB_get_ligand_sites` and `PDBe_KB_get_interface_residues` hardcoded an output cap (50 ligands, 30 partners) with no transparency and no way to override it, while the response's own `total_ligands`/`total_partners` field reported the real, larger count — making the truncation invisible unless a caller happened to compare the two numbers
- For EGFR (P00533), the default cap silently dropped both erlotinib (AQ4) and gefitinib (IRE) — the two most clinically relevant kinase inhibitors — out of 245 known ligands
- Added optional `max_ligands`/`max_partners` parameters (higher defaults: 100 and 60) and top-level `truncated`/`truncation_note` fields when the cap is still hit, matching the project's existing truncation-transparency convention (see `CancerPrognosis_get_gene_expression`)

## Verification
- `tu run PDBe_KB_get_ligand_sites '{"uniprot_accession":"P00533"}'`: now correctly reports `truncated: true` with a note; `max_ligands=300` returns all 245 entries including AQ4 and IRE
- `python scripts/test_new_tools.py pdbe_kb`: schema-valid (on top of #454's schema fix)

**Note**: `tu test`/`scripts/test_new_tools.py` for these two tools currently fail independent of this change, due to a pre-existing `return_schema` envelope bug fixed separately in #454. This fix was verified directly via `tu run` + manual `jsonschema` validation against `result["data"]`, and is correct and mergeable regardless of #454's merge order.