### PR TITLE
BVBRC_search_amr: reject unrecognized parameters instead of silently ignoring them

### DIFF
--- a/src/tooluniverse/data/bvbrc_tools.json
+++ b/src/tooluniverse/data/bvbrc_tools.json
@@ -287,7 +287,8 @@
           "description": "Maximum number of results. Default: 25. Max: 100."
         }
       },
-      "required": []
+      "required": [],
+      "additionalProperties": false
     },
     "fields": {
       "data_type": "genome_amr",


### PR DESCRIPTION
## Summary
- The tool's own description already warns "There is no organism/species parameter" — but nothing enforced that
- A caller who (reasonably) guesses `organism="Klebsiella pneumoniae"` got no error: the parameter was silently dropped and the unfiltered, cross-species result set (including unrelated *E. coli* AMR records) was returned as if it had been scoped correctly, with no indication the filter never applied
- Add `additionalProperties: false` so passing an unrecognized parameter now fails validation with a clear, actionable error instead of silently producing misleadingly-scoped data

## Verification
- `tu run BVBRC_search_amr '{"organism":"Klebsiella pneumoniae","antibiotic":"meropenem","limit":3}'` now returns a clear validation error naming the unrecognized parameter, instead of silently mixed-species results
- `tu test BVBRC_search_amr` still passes with its documented parameters