### PR TITLE
DisGeNET_search_disease: correct description that falsely claims free text works

### DIFF
--- a/src/tooluniverse/data/disgenet_tools.json
+++ b/src/tooluniverse/data/disgenet_tools.json
@@ -69,7 +69,7 @@
   },
   {
     "name": "DisGeNET_search_disease",
-    "description": "Search DisGeNET for genes associated with a disease. Query by disease name or UMLS CUI (e.g., C0006142 for breast cancer). Returns associated genes with scores and evidence. Requires DISGENET_API_KEY.",
+    "description": "Search DisGeNET for genes associated with a disease. Requires a UMLS CUI, NOT a free-text disease name (e.g. 'C0006142' for breast cancer, not 'breast cancer') -- resolve a disease name to its CUI first via umls_search_concepts. Returns associated genes with scores and evidence. Requires DISGENET_API_KEY.",
     "type": "DisGeNETTool",
     "parameter": {
       "type": "object",
@@ -81,7 +81,7 @@
         },
         "disease": {
           "type": "string",
-          "description": "Disease name or UMLS CUI (e.g., C0006142, breast cancer)"
+          "description": "UMLS CUI for the disease, e.g. 'C0006142' (breast cancer). Free-text disease names are NOT accepted -- resolve one via umls_search_concepts first."
         },
         "limit": {
           "type": "integer",


### PR DESCRIPTION
## Summary
- The tool's description and `disease` parameter both claimed a plain disease name would work (e.g. "disease name or UMLS CUI"), but the implementation is CUI-only by design — a free-text name (e.g. "rheumatoid arthritis") is always rejected with "not a UMLS CUI"
- Correct the description/parameter text to say a CUI is required and point callers at `umls_search_concepts` to resolve one, rather than promising behavior the tool doesn't have

## Verification
- `tu run DisGeNET_search_disease '{"disease":"rheumatoid arthritis"}'` still correctly errors (unchanged behavior — this PR only corrects the misleading docs, not the tool's actual CUI-only requirement)
- `tu test DisGeNET_search_disease` passes with a real CUI