### PR TITLE
Consolidated fixes: return_schema envelope bug (~485 tools), 5 code-level bugs, 4 independently-discovered tool bugs

### DIFF
--- a/scripts/test_new_tools.py
+++ b/scripts/test_new_tools.py
@@ -112,15 +112,22 @@ def _schema_describes_envelope(schema: Dict[str, Any]) -> bool:
     """Heuristic: schema describes the {status,data,error,metadata} envelope.
 
     Many tool configs declare return_schema at the envelope level (top-level
-    properties include 'data' or 'status'). For those, validating the
-    unwrapped result.get('data') against the schema always fails ("Schema
-    Mismatch: At root: ..."). Detect that style and validate the full result
-    instead. Inner-data schemas (no 'data'/'status' at top) keep the
-    historical unwrapped behaviour.
+    properties include 'data'). For those, validating the unwrapped
+    result.get('data') against the schema always fails ("Schema Mismatch:
+    At root: ..."). Detect that style and validate the full result instead.
+    Inner-data schemas (no 'data' at top) keep the historical unwrapped
+    behaviour.
 
     Looking for 'error' alone is NOT enough — many inner-data schemas pair an
     inner array with a {'error': str} error wrapper but still describe the
     inner data shape, not the envelope.
+
+    Looking for 'status' alone is NOT enough either — a correctly-shaped
+    inner-data schema's *error* branch legitimately mirrors the tool's real
+    error response, {"status": "error", "error": "..."}, without describing
+    the envelope at all. Treating 'status' as an envelope signal on its own
+    misclassifies that branch and validates the full result against a schema
+    meant only for the unwrapped payload, so require 'data' specifically.
     """
     if not isinstance(schema, dict):
         return False
@@ -129,7 +136,7 @@ def _schema_describes_envelope(schema: Dict[str, Any]) -> bool:
         if not isinstance(br, dict):
             continue
         props = br.get("properties") or {}
-        if "data" in props or "status" in props:
+        if "data" in props:
             return True
     return False
 

--- a/scripts/test_new_tools.py
+++ b/scripts/test_new_tools.py
@@ -108,39 +108,6 @@ def validate_against_schema(
         return False, str(e)
 
 
-def _schema_describes_envelope(schema: Dict[str, Any]) -> bool:
-    """Heuristic: schema describes the {status,data,error,metadata} envelope.
-
-    Many tool configs declare return_schema at the envelope level (top-level
-    properties include 'data'). For those, validating the unwrapped
-    result.get('data') against the schema always fails ("Schema Mismatch:
-    At root: ..."). Detect that style and validate the full result instead.
-    Inner-data schemas (no 'data' at top) keep the historical unwrapped
-    behaviour.
-
-    Looking for 'error' alone is NOT enough — many inner-data schemas pair an
-    inner array with a {'error': str} error wrapper but still describe the
-    inner data shape, not the envelope.
-
-    Looking for 'status' alone is NOT enough either — a correctly-shaped
-    inner-data schema's *error* branch legitimately mirrors the tool's real
-    error response, {"status": "error", "error": "..."}, without describing
-    the envelope at all. Treating 'status' as an envelope signal on its own
-    misclassifies that branch and validates the full result against a schema
-    meant only for the unwrapped payload, so require 'data' specifically.
-    """
-    if not isinstance(schema, dict):
-        return False
-    branches = schema.get("oneOf") or schema.get("anyOf") or [schema]
-    for br in branches:
-        if not isinstance(br, dict):
-            continue
-        props = br.get("properties") or {}
-        if "data" in props:
-            return True
-    return False
-
-
 def format_result(val: Any, max_len: int = 100) -> str:
     """Format result for display."""
     s = str(val)
@@ -324,15 +291,20 @@ def run_tests(
 
                     if success:
                         stats["passed"] += 1
-                        # Validate Schema: envelope-style schemas describe the
-                        # whole {status,data,...} return; inner-data schemas
-                        # describe only the data payload. Pick the right target.
-                        validation_target = (
-                            result if _schema_describes_envelope(schema) else data
-                        )
-                        is_valid, schema_err = validate_against_schema(
-                            validation_target, schema
-                        )
+                        # return_schema describes the unwrapped data payload,
+                        # never the {status,data,...} envelope — matches
+                        # cli.py's `tu test` exactly (see devtu-fix-tool/
+                        # SKILL.md: "Schema validates the data field content,
+                        # NOT the full response"). A prior envelope-detection
+                        # heuristic here tried to auto-pick the validation
+                        # target, but any tool whose own payload legitimately
+                        # has a field named "status" or "data" (e.g. ENCODE's
+                        # own "status": "released", or IDR's own nested
+                        # "data" key) fooled it into validating the wrong
+                        # target. The real fix is upstream: correct schemas
+                        # to describe `data` directly, not paper over
+                        # incorrect ones here.
+                        is_valid, schema_err = validate_against_schema(data, schema)
                         if is_valid:
                             stats["schema_valid"] += 1
                             if args.verbose:

--- a/src/tooluniverse/arxiv_tool.py
+++ b/src/tooluniverse/arxiv_tool.py
@@ -380,10 +380,10 @@ class ArXivPDFSnippetsTool(BaseTool):
                 total_chars += len(snippet)
                 found += 1
 
-        return {
-            "status": "success",
+        payload = {
             "pdf_url": final_pdf_url,
             "snippets": snippets,
             "snippets_count": len(snippets),
             "truncated": total_chars >= max_total_chars,
         }
+        return {"status": "success", **payload, "data": payload}

--- a/src/tooluniverse/dailymed_tool.py
+++ b/src/tooluniverse/dailymed_tool.py
@@ -205,7 +205,7 @@ class GetSPLBySetIDTool(BaseTool):
                 "detail": resp.text,
             }
 
-        return {"status": "success", "xml": resp.text}
+        return {"status": "success", "xml": resp.text, "data": {"xml": resp.text}}
 
 
 def _dedupe_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/src/tooluniverse/data/allen_brain_tools.json
+++ b/src/tooluniverse/data/allen_brain_tools.json
@@ -584,137 +584,100 @@
       }
     ],
     "return_schema": {
-      "oneOf": [
-        {
-          "type": "object",
-          "description": "Per-structure quantified expression values for the ISH dataset",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "integer",
-                    "description": "StructureUnionize record ID"
-                  },
-                  "section_data_set_id": {
-                    "type": "integer",
-                    "description": "Source ISH experiment (SectionDataSet) ID"
-                  },
-                  "structure_id": {
-                    "type": "integer",
-                    "description": "Allen Brain Atlas structure (brain region) ID"
-                  },
-                  "expression_energy": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Expression energy = sum of expressing pixel intensity / total pixels (intensity x density)"
-                  },
-                  "expression_density": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Fraction of pixels in the structure that express the gene"
-                  },
-                  "sum_expressing_pixels": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Total number of expressing pixels in the structure"
-                  },
-                  "sum_expressing_pixel_intensity": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "sum_pixels": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "sum_pixel_intensity": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "voxel_energy_mean": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "voxel_energy_cv": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "structure": {
-                    "type": [
-                      "object",
-                      "null"
-                    ],
-                    "description": "Linked brain structure record (present when include_structure=true)",
-                    "properties": {
-                      "id": {
-                        "type": "integer"
-                      },
-                      "acronym": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "section_data_set_id": {
-                  "type": "integer"
-                }
+      "type": "array",
+      "description": "Per-structure quantified expression values for the ISH dataset",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "StructureUnionize record ID"
+          },
+          "section_data_set_id": {
+            "type": "integer",
+            "description": "Source ISH experiment (SectionDataSet) ID"
+          },
+          "structure_id": {
+            "type": "integer",
+            "description": "Allen Brain Atlas structure (brain region) ID"
+          },
+          "expression_energy": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Expression energy = sum of expressing pixel intensity / total pixels (intensity x density)"
+          },
+          "expression_density": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Fraction of pixels in the structure that express the gene"
+          },
+          "sum_expressing_pixels": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Total number of expressing pixels in the structure"
+          },
+          "sum_expressing_pixel_intensity": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "sum_pixels": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "sum_pixel_intensity": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "voxel_energy_mean": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "voxel_energy_cv": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "structure": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "Linked brain structure record (present when include_structure=true)",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "acronym": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
           }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "error": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "error"
-          ]
         }
-      ]
+      }
     }
   }
 ]

--- a/src/tooluniverse/data/alliance_genome_tools.json
+++ b/src/tooluniverse/data/alliance_genome_tools.json
@@ -31,158 +31,133 @@
         {
           "type": "object",
           "properties": {
-            "data": {
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "symbol": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "species": {
               "type": "object",
               "properties": {
-                "id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "symbol": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
                 "name": {
                   "type": [
                     "string",
                     "null"
                   ]
                 },
-                "species": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "short_name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "taxon_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "data_provider": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
-                },
-                "gene_synopsis": {
+                "short_name": {
                   "type": [
                     "string",
                     "null"
                   ]
                 },
-                "automated_gene_synopsis": {
+                "taxon_id": {
                   "type": [
                     "string",
                     "null"
                   ]
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "so_term": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "genomic_location": {
-                  "type": "object",
-                  "properties": {
-                    "chromosome": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "start": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "end": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "assembly": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "strand": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
-                },
-                "cross_references": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_gene_id": {
-                  "type": "string"
                 },
                 "data_provider": {
                   "type": [
                     "string",
                     "null"
                   ]
+                }
+              }
+            },
+            "gene_synopsis": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "automated_gene_synopsis": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "so_term": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "genomic_location": {
+              "type": "object",
+              "properties": {
+                "chromosome": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "source": {
-                  "type": "string"
+                "start": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "end": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "assembly": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "strand": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "cross_references": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -233,64 +208,42 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "primary_key": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "name_key": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "category": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "primary_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "category": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -345,58 +298,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "phenotype_statement": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "source": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "phenotype_statement": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -452,76 +377,48 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "disease_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "disease_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "association_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query_disease_id": {
-                  "type": "string"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "source": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "disease_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "disease_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "association_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -569,56 +466,37 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "disease_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "definition": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "category": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
+            "disease_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "definition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_disease_id": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
-              }
+            "category": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -678,91 +556,69 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "ortholog_count": {
-                  "type": "integer"
-                },
-                "orthologs": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "ortholog_gene_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "ortholog_symbol": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "ortholog_species": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "stringency": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "has_disease_annotations": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      },
-                      "has_expression_annotations": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      },
-                      "methods": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
+            "ortholog_count": {
+              "type": "integer"
+            },
+            "orthologs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ortholog_gene_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ortholog_symbol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ortholog_species": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "stringency": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "has_disease_annotations": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "has_expression_annotations": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "methods": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
-                  }
-                },
-                "paralog_count": {
-                  "type": "integer"
-                },
-                "paralogs": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "stringency": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
+            "paralog_count": {
+              "type": "integer"
+            },
+            "paralogs": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -821,82 +677,54 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "subject_gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "subject_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "interactor_gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "interactor_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "interactor_species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "interaction_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "references": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "source": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "subject_gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subject_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interactor_gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interactor_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interactor_species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interaction_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "references": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -950,114 +778,95 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "allele_count": {
-                  "type": "integer"
-                },
-                "alleles": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "allele_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "symbol": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "category": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "alteration_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "has_disease": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      },
-                      "has_phenotype": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      },
-                      "variant_locations": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                },
-                "model_count": {
-                  "type": "integer"
-                },
-                "models": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "model_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "model_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "subtype": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "data_provider": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
+            "allele_count": {
+              "type": "integer"
+            },
+            "alleles": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "allele_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "symbol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "category": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "alteration_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "has_disease": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "has_phenotype": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "variant_locations": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
+            "model_count": {
+              "type": "integer"
+            },
+            "models": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "model_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "model_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "subtype": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "data_provider": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/alphafold_tools.json
+++ b/src/tooluniverse/data/alphafold_tools.json
@@ -32,218 +32,207 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "toolUsed": {
-                    "type": "string"
-                  },
-                  "providerId": {
-                    "type": "string"
-                  },
-                  "entityType": {
-                    "type": "string"
-                  },
-                  "isUniProt": {
-                    "type": "boolean"
-                  },
-                  "modelEntityId": {
-                    "type": "string"
-                  },
-                  "modelCreatedDate": {
-                    "type": "string"
-                  },
-                  "sequenceVersionDate": {
-                    "type": "string"
-                  },
-                  "globalMetricValue": {
-                    "type": "number"
-                  },
-                  "fractionPlddtVeryLow": {
-                    "type": "number"
-                  },
-                  "fractionPlddtLow": {
-                    "type": "number"
-                  },
-                  "fractionPlddtConfident": {
-                    "type": "number"
-                  },
-                  "fractionPlddtVeryHigh": {
-                    "type": "number"
-                  },
-                  "latestVersion": {
-                    "type": "integer"
-                  },
-                  "allVersions": {
-                    "type": "array",
-                    "items": {
-                      "type": "integer"
-                    }
-                  },
-                  "sequence": {
-                    "type": "string"
-                  },
-                  "sequenceStart": {
-                    "type": "integer"
-                  },
-                  "sequenceEnd": {
-                    "type": "integer"
-                  },
-                  "sequenceChecksum": {
-                    "type": "string"
-                  },
-                  "isUniProtReviewed": {
-                    "type": "boolean"
-                  },
-                  "gene": {
-                    "type": "string"
-                  },
-                  "uniprotAccession": {
-                    "type": "string"
-                  },
-                  "uniprotId": {
-                    "type": "string"
-                  },
-                  "uniprotDescription": {
-                    "type": "string"
-                  },
-                  "taxId": {
-                    "type": "integer"
-                  },
-                  "organismScientificName": {
-                    "type": "string"
-                  },
-                  "isUniProtReferenceProteome": {
-                    "type": "boolean"
-                  },
-                  "organismCommonNames": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "organismSynonyms": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "geneSynonyms": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "proteinFullNames": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "proteinShortNames": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "complexName": {
-                    "type": "string"
-                  },
-                  "stoichiometry": {
-                    "type": "number"
-                  },
-                  "ipTM": {
-                    "type": "number"
-                  },
-                  "ipSAE": {
-                    "type": "number"
-                  },
-                  "keywords": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "taxonomyLineage": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "functions": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "alternativeNames": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "catalyticActivities": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "bcifUrl": {
-                    "type": "string"
-                  },
-                  "cifUrl": {
-                    "type": "string"
-                  },
-                  "pdbUrl": {
-                    "type": "string"
-                  },
-                  "paeImageUrl": {
-                    "type": "string"
-                  },
-                  "paeDocUrl": {
-                    "type": "string"
-                  },
-                  "amAnnotationsUrl": {
-                    "type": "string"
-                  },
-                  "amAnnotationsHg19Url": {
-                    "type": "string"
-                  },
-                  "amAnnotationsHg38Url": {
-                    "type": "string"
-                  },
-                  "entryId": {
-                    "type": "string"
-                  },
-                  "isReviewed": {
-                    "type": "boolean"
-                  },
-                  "isReferenceProteome": {
-                    "type": "boolean"
-                  },
-                  "uniprotStart": {
-                    "type": "integer"
-                  },
-                  "uniprotEnd": {
-                    "type": "integer"
-                  },
-                  "uniprotSequence": {
-                    "type": "string"
-                  }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "toolUsed": {
+                "type": "string"
+              },
+              "providerId": {
+                "type": "string"
+              },
+              "entityType": {
+                "type": "string"
+              },
+              "isUniProt": {
+                "type": "boolean"
+              },
+              "modelEntityId": {
+                "type": "string"
+              },
+              "modelCreatedDate": {
+                "type": "string"
+              },
+              "sequenceVersionDate": {
+                "type": "string"
+              },
+              "globalMetricValue": {
+                "type": "number"
+              },
+              "fractionPlddtVeryLow": {
+                "type": "number"
+              },
+              "fractionPlddtLow": {
+                "type": "number"
+              },
+              "fractionPlddtConfident": {
+                "type": "number"
+              },
+              "fractionPlddtVeryHigh": {
+                "type": "number"
+              },
+              "latestVersion": {
+                "type": "integer"
+              },
+              "allVersions": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
                 }
+              },
+              "sequence": {
+                "type": "string"
+              },
+              "sequenceStart": {
+                "type": "integer"
+              },
+              "sequenceEnd": {
+                "type": "integer"
+              },
+              "sequenceChecksum": {
+                "type": "string"
+              },
+              "isUniProtReviewed": {
+                "type": "boolean"
+              },
+              "gene": {
+                "type": "string"
+              },
+              "uniprotAccession": {
+                "type": "string"
+              },
+              "uniprotId": {
+                "type": "string"
+              },
+              "uniprotDescription": {
+                "type": "string"
+              },
+              "taxId": {
+                "type": "integer"
+              },
+              "organismScientificName": {
+                "type": "string"
+              },
+              "isUniProtReferenceProteome": {
+                "type": "boolean"
+              },
+              "organismCommonNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "organismSynonyms": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "geneSynonyms": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "proteinFullNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "proteinShortNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "complexName": {
+                "type": "string"
+              },
+              "stoichiometry": {
+                "type": "number"
+              },
+              "ipTM": {
+                "type": "number"
+              },
+              "ipSAE": {
+                "type": "number"
+              },
+              "keywords": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "taxonomyLineage": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "functions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "alternativeNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "catalyticActivities": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "bcifUrl": {
+                "type": "string"
+              },
+              "cifUrl": {
+                "type": "string"
+              },
+              "pdbUrl": {
+                "type": "string"
+              },
+              "paeImageUrl": {
+                "type": "string"
+              },
+              "paeDocUrl": {
+                "type": "string"
+              },
+              "amAnnotationsUrl": {
+                "type": "string"
+              },
+              "amAnnotationsHg19Url": {
+                "type": "string"
+              },
+              "amAnnotationsHg38Url": {
+                "type": "string"
+              },
+              "entryId": {
+                "type": "string"
+              },
+              "isReviewed": {
+                "type": "boolean"
+              },
+              "isReferenceProteome": {
+                "type": "boolean"
+              },
+              "uniprotStart": {
+                "type": "integer"
+              },
+              "uniprotEnd": {
+                "type": "integer"
+              },
+              "uniprotSequence": {
+                "type": "string"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/alphagenome_tools.json
+++ b/src/tooluniverse/data/alphagenome_tools.json
@@ -78,30 +78,19 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "variant": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "variant": {
-                  "type": "string"
-                },
-                "output_type": {
-                  "type": "string"
-                },
-                "scores": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  }
-                }
+            "output_type": {
+              "type": "string"
+            },
+            "scores": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -209,27 +198,16 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "interval": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "interval": {
-                  "type": "string"
-                },
-                "tracks": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  }
-                }
+            "tracks": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/bgee_tools.json
+++ b/src/tooluniverse/data/bgee_tools.json
@@ -29,93 +29,68 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Ensembl gene ID"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene symbol"
-                  },
-                  "description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene description"
-                  },
-                  "species_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "NCBI taxonomy ID"
-                  },
-                  "species_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Scientific species name"
-                  },
-                  "common_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Common species name"
-                  },
-                  "gene_biotype": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene biotype (e.g., protein_coding)"
-                  },
-                  "match_source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "How the match was found (name, description, etc.)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "total_matches": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Ensembl gene ID"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene symbol"
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene description"
+              },
+              "species_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "NCBI taxonomy ID"
+              },
+              "species_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Scientific species name"
+              },
+              "common_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Common species name"
+              },
+              "gene_biotype": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene biotype (e.g., protein_coding)"
+              },
+              "match_source": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "How the match was found (name, description, etc.)"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -168,95 +143,61 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tissue_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Uberon or CL ontology ID"
-                  },
-                  "tissue_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Anatomical entity name"
-                  },
-                  "expression_score": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Expression score (0-100)"
-                  },
-                  "score_confidence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Confidence level (high/low)"
-                  },
-                  "expression_state": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "expressed or not expressed"
-                  },
-                  "quality": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Quality rating (gold/silver/bronze)"
-                  },
-                  "data_types": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Data types supporting expression call"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tissue_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Uberon or CL ontology ID"
+              },
+              "tissue_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Anatomical entity name"
+              },
+              "expression_score": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Expression score (0-100)"
+              },
+              "score_confidence": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Confidence level (high/low)"
+              },
+              "expression_state": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "expressed or not expressed"
+              },
+              "quality": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Quality rating (gold/silver/bronze)"
+              },
+              "data_types": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 },
-                "gene_id": {
-                  "type": "string"
-                },
-                "species_id": {
-                  "type": "string"
-                },
-                "total_calls": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "data_types": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
+                "description": "Data types supporting expression call"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -290,73 +231,54 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "species_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "NCBI taxonomy ID"
-                  },
-                  "genus": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Genus name"
-                  },
-                  "species_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Species epithet"
-                  },
-                  "common_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Common name"
-                  },
-                  "genome_version": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Genome assembly version"
-                  },
-                  "full_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Full binomial name"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_species": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "species_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "NCBI taxonomy ID"
+              },
+              "genus": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Genus name"
+              },
+              "species_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Species epithet"
+              },
+              "common_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Common name"
+              },
+              "genome_version": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Genome assembly version"
+              },
+              "full_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Full binomial name"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/bioimage_archive_tools.json
+++ b/src/tooluniverse/data/bioimage_archive_tools.json
@@ -45,86 +45,58 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "accession": {
-                    "type": "string",
-                    "description": "Study accession (e.g., S-BIAD634)"
-                  },
-                  "title": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Study title"
-                  },
-                  "author": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Author(s)"
-                  },
-                  "release_date": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Release date"
-                  },
-                  "type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Study type"
-                  },
-                  "links": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of linked resources"
-                  },
-                  "files": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of files"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_hits": {
-                  "type": "integer"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "page_size": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession": {
+                "type": "string",
+                "description": "Study accession (e.g., S-BIAD634)"
+              },
+              "title": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Study title"
+              },
+              "author": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Author(s)"
+              },
+              "release_date": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Release date"
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Study type"
+              },
+              "links": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of linked resources"
+              },
+              "files": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of files"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -172,77 +144,58 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "title": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "release_date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "organism": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "imaging_method": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "attributes": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "section_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
+            "accession": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "accession": {
-                  "type": "string"
-                }
-              }
+            "type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "release_date": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organism": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "imaging_method": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "attributes": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "section_type": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -297,61 +250,39 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "accession": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "author": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "release_date": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_hits": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession": {
+                "type": "string"
+              },
+              "title": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "author": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "release_date": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/biomodels_tools.json
+++ b/src/tooluniverse/data/biomodels_tools.json
@@ -258,32 +258,18 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "hits": {
-                  "type": "integer",
-                  "description": "Total number of model identifiers in the registry"
-                },
-                "models": {
-                  "type": "array",
-                  "description": "Array of all BioModels identifier strings",
-                  "items": {
-                    "type": "string"
-                  }
-                }
+            "hits": {
+              "type": "integer",
+              "description": "Total number of model identifiers in the registry"
+            },
+            "models": {
+              "type": "array",
+              "description": "Array of all BioModels identifier strings",
+              "items": {
+                "type": "string"
               }
-            },
-            "url": {
-              "type": "string"
-            },
-            "count": {
-              "type": "integer"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/bioportal_tools.json
+++ b/src/tooluniverse/data/bioportal_tools.json
@@ -53,76 +53,65 @@
         "return_schema": {
             "oneOf": [
                 {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "label": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Preferred label/name of the concept"
-                                    },
-                                    "id": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Short concept identifier (e.g., DOID_1909)"
-                                    },
-                                    "full_id": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Full IRI of the concept (e.g., http://purl.obolibrary.org/obo/DOID_1909)"
-                                    },
-                                    "synonyms": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "description": "Alternative names for this concept"
-                                    },
-                                    "definition": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Definition of the concept"
-                                    },
-                                    "ontology": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Source ontology acronym"
-                                    },
-                                    "obsolete": {
-                                        "type": "boolean",
-                                        "description": "Whether this term is obsolete"
-                                    },
-                                    "match_type": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Type of match (prefLabel, synonym, etc.)"
-                                    }
-                                }
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Preferred label/name of the concept"
+                            },
+                            "id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Short concept identifier (e.g., DOID_1909)"
+                            },
+                            "full_id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Full IRI of the concept (e.g., http://purl.obolibrary.org/obo/DOID_1909)"
+                            },
+                            "synonyms": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "Alternative names for this concept"
+                            },
+                            "definition": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Definition of the concept"
+                            },
+                            "ontology": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Source ontology acronym"
+                            },
+                            "obsolete": {
+                                "type": "boolean",
+                                "description": "Whether this term is obsolete"
+                            },
+                            "match_type": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Type of match (prefLabel, synonym, etc.)"
                             }
-                        },
-                        "metadata": {
-                            "type": "object"
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "object",
@@ -177,64 +166,53 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "label": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Preferred label of the concept"
-                                },
-                                "id": {
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "description": "Full IRI of the concept"
-                                },
-                                "synonyms": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "description": "All synonym names"
-                                },
-                                "definitions": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "description": "Definitions from the ontology"
-                                },
-                                "obsolete": {
-                                    "type": "boolean",
-                                    "description": "Whether this term is obsolete"
-                                },
-                                "cui": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "description": "UMLS Concept Unique Identifiers"
-                                },
-                                "semantic_type": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "description": "UMLS semantic types"
-                                }
-                            }
+                        "label": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "Preferred label of the concept"
                         },
-                        "metadata": {
-                            "type": "object"
+                        "id": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "Full IRI of the concept"
+                        },
+                        "synonyms": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "description": "All synonym names"
+                        },
+                        "definitions": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "description": "Definitions from the ontology"
+                        },
+                        "obsolete": {
+                            "type": "boolean",
+                            "description": "Whether this term is obsolete"
+                        },
+                        "cui": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "description": "UMLS Concept Unique Identifiers"
+                        },
+                        "semantic_type": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "description": "UMLS semantic types"
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "object",
@@ -297,72 +275,61 @@
         "return_schema": {
             "oneOf": [
                 {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "matched_text": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Text span that was matched"
-                                    },
-                                    "from": {
-                                        "type": [
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "Start position in text (1-indexed)"
-                                    },
-                                    "to": {
-                                        "type": [
-                                            "integer",
-                                            "null"
-                                        ],
-                                        "description": "End position in text (1-indexed)"
-                                    },
-                                    "match_type": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Match type: PREF (preferred label) or SYN (synonym)"
-                                    },
-                                    "concept_label": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Preferred label of matched concept"
-                                    },
-                                    "concept_id": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Short concept identifier"
-                                    },
-                                    "concept_full_id": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Full IRI of matched concept"
-                                    }
-                                }
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "matched_text": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Text span that was matched"
+                            },
+                            "from": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "description": "Start position in text (1-indexed)"
+                            },
+                            "to": {
+                                "type": [
+                                    "integer",
+                                    "null"
+                                ],
+                                "description": "End position in text (1-indexed)"
+                            },
+                            "match_type": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Match type: PREF (preferred label) or SYN (synonym)"
+                            },
+                            "concept_label": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Preferred label of matched concept"
+                            },
+                            "concept_id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Short concept identifier"
+                            },
+                            "concept_full_id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Full IRI of matched concept"
                             }
-                        },
-                        "metadata": {
-                            "type": "object"
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "object",
@@ -431,62 +398,51 @@
         "return_schema": {
             "oneOf": [
                 {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "label": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Preferred label of the concept"
-                                    },
-                                    "id": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Short concept identifier"
-                                    },
-                                    "full_id": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Full IRI of the concept"
-                                    },
-                                    "synonyms": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "description": "Alternative names (up to 3)"
-                                    },
-                                    "definition": {
-                                        "type": [
-                                            "string",
-                                            "null"
-                                        ],
-                                        "description": "Definition of the concept"
-                                    },
-                                    "obsolete": {
-                                        "type": "boolean",
-                                        "description": "Whether this term is obsolete"
-                                    }
-                                }
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "label": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Preferred label of the concept"
+                            },
+                            "id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Short concept identifier"
+                            },
+                            "full_id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Full IRI of the concept"
+                            },
+                            "synonyms": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "Alternative names (up to 3)"
+                            },
+                            "definition": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Definition of the concept"
+                            },
+                            "obsolete": {
+                                "type": "boolean",
+                                "description": "Whether this term is obsolete"
                             }
-                        },
-                        "metadata": {
-                            "type": "object"
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "object",

--- a/src/tooluniverse/data/biosamples_tools.json
+++ b/src/tooluniverse/data/biosamples_tools.json
@@ -31,59 +31,37 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "taxon_id": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "status": {
-                  "type": "string"
-                },
-                "release_date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "update_date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "characteristics": {
-                  "type": "object"
-                }
-              }
+            "accession": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "name": {
+              "type": "string"
+            },
+            "taxon_id": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "release_date": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "update_date": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "characteristics": {
+              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -145,73 +123,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "accession": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "taxon_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "status": {
-                    "type": "string"
-                  },
-                  "key_characteristics": {
-                    "type": "object"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_elements": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "total_pages": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "current_page": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "taxon_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "key_characteristics": {
+                "type": "object"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -273,58 +208,27 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "accession": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "taxon_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "key_characteristics": {
-                    "type": "object"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_elements": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "filter": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "taxon_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "key_characteristics": {
+                "type": "object"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -369,53 +273,45 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "accession": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": ["string", "null"]
-                },
-                "relationships": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "source": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "target": {
-                        "type": "string"
-                      },
-                      "direction": {
-                        "type": "string"
-                      },
-                      "related_accession": {
-                        "type": ["string", "null"]
-                      }
-                    }
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "relationships": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  },
+                  "direction": {
+                    "type": "string"
+                  },
+                  "related_accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
-                },
-                "relationship_count": {
-                  "type": "integer"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "relationship_count": {
+              "type": "integer"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -445,7 +341,10 @@
           "description": "Free-text query to compute facets over. Examples: 'cancer', 'liver', 'Homo sapiens'."
         },
         "max_values": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum number of top values to return per facet (1-50, default 10)."
         }
       },
@@ -471,55 +370,56 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "facets": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "attribute": {
-                        "type": ["string", "null"]
-                      },
-                      "type": {
-                        "type": ["string", "null"]
-                      },
-                      "count": {
-                        "type": ["integer", "null"]
-                      },
-                      "top_values": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "label": {
-                              "type": ["string", "null"]
-                            },
-                            "count": {
-                              "type": ["integer", "null"]
-                            }
-                          }
+            "facets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "attribute": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "top_values": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "label": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "count": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
                         }
                       }
                     }
                   }
-                },
-                "external_reference_data_facets": {
-                  "type": "array"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "external_reference_data_facets": {
+              "type": "array"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/biothings_tools.json
+++ b/src/tooluniverse/data/biothings_tools.json
@@ -699,18 +699,7 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "object"
-            },
-            "metadata": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "object"
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/bvbrc_tools.json
+++ b/src/tooluniverse/data/bvbrc_tools.json
@@ -32,92 +32,73 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "genome_id": {
-                  "type": "string"
-                },
-                "genome_name": {
-                  "type": "string"
-                },
-                "organism_name": {
-                  "type": "string"
-                },
-                "taxon_id": {
-                  "type": "integer"
-                },
-                "genome_length": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "gc_content": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "contigs": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "genome_status": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "isolation_country": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "host_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "disease": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "collection_date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "completion_date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
+            "genome_id": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_genome_id": {
-                  "type": "string"
-                }
-              }
+            "genome_name": {
+              "type": "string"
+            },
+            "organism_name": {
+              "type": "string"
+            },
+            "taxon_id": {
+              "type": "integer"
+            },
+            "genome_length": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "gc_content": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "contigs": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "genome_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "isolation_country": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "host_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "disease": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "collection_date": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "completion_date": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -173,70 +154,48 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "genome_id": {
-                    "type": "string"
-                  },
-                  "genome_name": {
-                    "type": "string"
-                  },
-                  "organism_name": {
-                    "type": "string"
-                  },
-                  "taxon_id": {
-                    "type": "integer"
-                  },
-                  "genome_length": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "genome_status": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "host_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "disease": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "genome_id": {
+                "type": "string"
+              },
+              "genome_name": {
+                "type": "string"
+              },
+              "organism_name": {
+                "type": "string"
+              },
+              "taxon_id": {
+                "type": "integer"
+              },
+              "genome_length": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "genome_status": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "host_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "disease": {
+                "type": [
+                  "array",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -308,98 +267,67 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "genome_id": {
-                    "type": "string"
-                  },
-                  "genome_name": {
-                    "type": "string"
-                  },
-                  "antibiotic": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "resistant_phenotype": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "measurement": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "measurement_value": {
-                    "type": [
-                      "string",
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "measurement_unit": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "laboratory_typing_method": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "computational_method": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "evidence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query_antibiotic": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "query_genome_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "genome_id": {
+                "type": "string"
+              },
+              "genome_name": {
+                "type": "string"
+              },
+              "antibiotic": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "resistant_phenotype": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "measurement": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "measurement_value": {
+                "type": [
+                  "string",
+                  "number",
+                  "null"
+                ]
+              },
+              "measurement_unit": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "laboratory_typing_method": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "computational_method": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "evidence": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -478,100 +406,69 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "patric_id": {
-                    "type": "string"
-                  },
-                  "genome_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "product": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "feature_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "aa_length": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "accession": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "start": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "end": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "strand": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query_gene": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "query_product": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "patric_id": {
+                "type": "string"
+              },
+              "genome_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "product": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "feature_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "aa_length": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "accession": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "start": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "end": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "strand": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -650,94 +547,63 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "epitope_id": {
-                    "type": "string"
-                  },
-                  "epitope_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "epitope_sequence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "organism": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "protein_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "start": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "end": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "bcell_assays": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "tcell_assays": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query_taxon_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "query_protein_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "epitope_id": {
+                "type": "string"
+              },
+              "epitope_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "epitope_sequence": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "organism": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "protein_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "start": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "end": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "bcell_assays": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "tcell_assays": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -817,92 +683,61 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "sample_identifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "collection_date": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "geographic_group": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "host_group": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "host_species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "subtype": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "collection_country": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "pathogen_test_result": {
-                    "type": [
-                      "array",
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query_subtype": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "query_geographic_group": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "sample_identifier": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "collection_date": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "geographic_group": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "host_group": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "host_species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subtype": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "collection_country": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pathogen_test_result": {
+                "type": [
+                  "array",
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -981,103 +816,72 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "feature_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "product": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "property": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "evidence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "organism": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "source_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "taxon_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "genome_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query_gene": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "query_property": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "feature_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "product": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "property": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "evidence": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "organism": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "taxon_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "genome_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1126,89 +930,70 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "pdb_id": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "resolution": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "method": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "gene": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "organism_name": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "product": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "uniprotkb_accession": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "pmid": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "release_date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "taxon_id": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                }
-              }
+            "pdb_id": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_pdb_id": {
-                  "type": "string"
-                }
-              }
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "resolution": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "method": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "gene": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "organism_name": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "product": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "uniprotkb_accession": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "pmid": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "release_date": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "taxon_id": {
+              "type": [
+                "array",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1280,88 +1065,57 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "pdb_id": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "organism_name": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "gene": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "method": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "resolution": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "release_date": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "pmid": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query_taxon_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "query_gene": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pdb_id": {
+                "type": "string"
+              },
+              "title": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "organism_name": {
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "gene": {
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "method": {
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "resolution": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "release_date": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pmid": {
+                "type": [
+                  "array",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1410,65 +1164,46 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "taxon_id": {
-                  "type": "string"
-                },
-                "taxon_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "taxon_rank": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "genomes": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "lineage_names": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "lineage_ids": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "other_names": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                }
-              }
+            "taxon_id": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_taxon_id": {
-                  "type": "string"
-                }
-              }
+            "taxon_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "taxon_rank": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "genomes": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "lineage_names": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "lineage_ids": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "other_names": {
+              "type": [
+                "array",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1524,67 +1259,45 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "taxon_id": {
-                    "type": "string"
-                  },
-                  "taxon_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "taxon_rank": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "genomes": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "lineage_names": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "other_names": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "taxon_id": {
+                "type": "string"
+              },
+              "taxon_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "taxon_rank": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "genomes": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "lineage_names": {
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "other_names": {
+                "type": [
+                  "array",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1663,119 +1376,88 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "pathway_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "pathway_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "pathway_class": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "genome_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "genome_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ec_number": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ec_description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "taxon_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "gene": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene symbol for this pathway/EC record, e.g. \"fadD15\". Distinguishes genuinely different genes sharing the same EC number/pathway from true duplicate rows."
-                  },
-                  "feature_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "BV-BRC feature id for this record, e.g. \"RefSeq.83332.12.NC_000962.CDS.2448160.2449962.fwd\"."
-                  },
-                  "product": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene product/protein description."
-                  },
-                  "annotation": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Annotation source, e.g. \"RefSeq\" or \"PATRIC\" -- the same EC/pathway is often independently annotated by multiple sources."
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query_taxon_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "query_pathway_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pathway_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pathway_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pathway_class": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "genome_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "genome_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ec_number": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ec_description": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "taxon_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "gene": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene symbol for this pathway/EC record, e.g. \"fadD15\". Distinguishes genuinely different genes sharing the same EC number/pathway from true duplicate rows."
+              },
+              "feature_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "BV-BRC feature id for this record, e.g. \"RefSeq.83332.12.NC_000962.CDS.2448160.2449962.fwd\"."
+              },
+              "product": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene product/protein description."
+              },
+              "annotation": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Annotation source, e.g. \"RefSeq\" or \"PATRIC\" -- the same EC/pathway is often independently annotated by multiple sources."
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1861,97 +1543,66 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "subsystem_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "subsystem_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "superclass": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "class": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "subclass": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "genome_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "role_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "taxon_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "genome_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query_taxon_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "query_subsystem_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "subsystem_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subsystem_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "superclass": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "class": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subclass": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "genome_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "role_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "taxon_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "genome_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/bvbrc_tools.json
+++ b/src/tooluniverse/data/bvbrc_tools.json
@@ -246,7 +246,8 @@
           "description": "Maximum number of results. Default: 25. Max: 100."
         }
       },
-      "required": []
+      "required": [],
+      "additionalProperties": false
     },
     "fields": {
       "data_type": "genome_amr",

--- a/src/tooluniverse/data/cath_tools.json
+++ b/src/tooluniverse/data/cath_tools.json
@@ -31,96 +31,77 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "cath_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "CATH ID"
-                },
-                "superfamily_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Superfamily ID"
-                },
-                "classification_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Name of the CATH node"
-                },
-                "classification_description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Description"
-                },
-                "example_domain_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Example PDB domain ID"
-                },
-                "num_s35_families": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Number of S35 sequence families"
-                },
-                "num_s60_families": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Number of S60 sequence families"
-                },
-                "num_s95_families": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Number of S95 sequence families"
-                },
-                "num_s100_domains": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Number of S100 (near-identical) domains"
-                },
-                "total_domain_count": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Total number of classified domains"
-                }
-              }
+            "cath_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "CATH ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                }
-              }
+            "superfamily_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Superfamily ID"
+            },
+            "classification_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Name of the CATH node"
+            },
+            "classification_description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Description"
+            },
+            "example_domain_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Example PDB domain ID"
+            },
+            "num_s35_families": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Number of S35 sequence families"
+            },
+            "num_s60_families": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Number of S60 sequence families"
+            },
+            "num_s95_families": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Number of S95 sequence families"
+            },
+            "num_s100_domains": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Number of S100 (near-identical) domains"
+            },
+            "total_domain_count": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Total number of classified domains"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -168,89 +149,70 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "domain_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Query domain ID"
-                },
-                "cath_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Full CATH classification ID"
-                },
-                "superfamily_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "CATH superfamily ID (C.A.T.H)"
-                },
-                "class": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "CATH Class number (1=Alpha, 2=Beta, 3=Alpha-Beta, 4=Few SS)"
-                },
-                "architecture": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "CATH Architecture (C.A)"
-                },
-                "topology": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "CATH Topology (C.A.T)"
-                },
-                "homologous_superfamily": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "CATH Superfamily (C.A.T.H)"
-                },
-                "class_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Human-readable class name"
-                },
-                "residue_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of residues in domain"
-                }
-              }
+            "domain_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Query domain ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                }
-              }
+            "cath_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Full CATH classification ID"
+            },
+            "superfamily_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "CATH superfamily ID (C.A.T.H)"
+            },
+            "class": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "CATH Class number (1=Alpha, 2=Beta, 3=Alpha-Beta, 4=Few SS)"
+            },
+            "architecture": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "CATH Architecture (C.A)"
+            },
+            "topology": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "CATH Topology (C.A.T)"
+            },
+            "homologous_superfamily": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "CATH Superfamily (C.A.T.H)"
+            },
+            "class_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Human-readable class name"
+            },
+            "residue_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of residues in domain"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -284,31 +246,68 @@
           "description": "Maximum number of FunFams to return (default: 25)."
         }
       },
-      "required": ["superfamily_id"]
+      "required": [
+        "superfamily_id"
+      ]
     },
     "fields": {
       "endpoint": "list_funfams"
     },
     "type": "CATHTool",
     "test_examples": [
-      {"superfamily_id": "1.10.510.10", "max_results": 5},
-      {"superfamily_id": "3.40.50.300", "max_results": 5}
+      {
+        "superfamily_id": "1.10.510.10",
+        "max_results": 5
+      },
+      {
+        "superfamily_id": "3.40.50.300",
+        "max_results": 5
+      }
     ],
     "return_schema": {
       "type": "object",
       "properties": {
-        "superfamily_id": {"type": "string"},
-        "total_funfams": {"type": "integer"},
+        "superfamily_id": {
+          "type": "string"
+        },
+        "total_funfams": {
+          "type": "integer"
+        },
         "funfams": {
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "funfam_number": {"type": ["string", "null"]},
-              "name": {"type": ["string", "null"]},
-              "num_members": {"type": ["string", "null"]},
-              "rep_id": {"type": ["string", "null"]},
-              "superfamily_id": {"type": ["string", "null"]}
+              "funfam_number": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "num_members": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "rep_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "superfamily_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
           }
         }
@@ -330,29 +329,91 @@
           "description": "FunFam number within the superfamily (e.g., '1', '83'). Get from CATH_list_funfams or CATH_get_domain_summary."
         }
       },
-      "required": ["superfamily_id", "funfam_number"]
+      "required": [
+        "superfamily_id",
+        "funfam_number"
+      ]
     },
     "fields": {
       "endpoint": "get_funfam"
     },
     "type": "CATHTool",
     "test_examples": [
-      {"superfamily_id": "1.10.510.10", "funfam_number": "1"},
-      {"superfamily_id": "2.40.50.140", "funfam_number": "83"}
+      {
+        "superfamily_id": "1.10.510.10",
+        "funfam_number": "1"
+      },
+      {
+        "superfamily_id": "2.40.50.140",
+        "funfam_number": "83"
+      }
     ],
     "return_schema": {
       "type": "object",
       "properties": {
-        "funfam_number": {"type": ["string", "null"]},
-        "superfamily_id": {"type": ["string", "null"]},
-        "name": {"type": ["string", "null"]},
-        "description": {"type": ["string", "null"]},
-        "num_members": {"type": ["string", "integer", "null"]},
-        "num_seed_members": {"type": ["string", "integer", "null"]},
-        "dops_score": {"type": ["string", "number", "null"]},
-        "rep_id": {"type": ["string", "null"]},
-        "ec_terms": {"type": "array", "items": {"type": "object"}},
-        "go_terms": {"type": "array", "items": {"type": "object"}}
+        "funfam_number": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "superfamily_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "num_members": {
+          "type": [
+            "string",
+            "integer",
+            "null"
+          ]
+        },
+        "num_seed_members": {
+          "type": [
+            "string",
+            "integer",
+            "null"
+          ]
+        },
+        "dops_score": {
+          "type": [
+            "string",
+            "number",
+            "null"
+          ]
+        },
+        "rep_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ec_terms": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "go_terms": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
       }
     }
   }

--- a/src/tooluniverse/data/cellpose_tools.json
+++ b/src/tooluniverse/data/cellpose_tools.json
@@ -71,96 +71,85 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Successful segmentation. Mirrors the content of the 'data' field returned by the tool.",
           "properties": {
-            "status": {
-              "const": "success"
+            "image_path": {
+              "type": "string",
+              "description": "The input image path that was segmented."
             },
-            "data": {
-              "type": "object",
-              "description": "Successful segmentation. Mirrors the content of the 'data' field returned by the tool.",
-              "properties": {
-                "image_path": {
-                  "type": "string",
-                  "description": "The input image path that was segmented."
-                },
-                "model_type_requested": {
-                  "type": "string",
-                  "description": "The model_type the caller asked for."
-                },
-                "model_used": {
-                  "type": "string",
-                  "description": "Identifier of the cellpose model that actually produced the segmentation."
-                },
-                "num_objects": {
-                  "type": "integer",
-                  "description": "Number of segmented cells/nuclei (distinct nonzero labels in the mask)."
-                },
-                "image_shape": {
-                  "type": "array",
-                  "items": {
-                    "type": "integer"
+            "model_type_requested": {
+              "type": "string",
+              "description": "The model_type the caller asked for."
+            },
+            "model_used": {
+              "type": "string",
+              "description": "Identifier of the cellpose model that actually produced the segmentation."
+            },
+            "num_objects": {
+              "type": "integer",
+              "description": "Number of segmented cells/nuclei (distinct nonzero labels in the mask)."
+            },
+            "image_shape": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "description": "Shape of the output label mask, e.g. [height, width]."
+            },
+            "objects": {
+              "type": "array",
+              "description": "One entry per segmented object.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "integer",
+                    "description": "Integer label of this object in the mask."
                   },
-                  "description": "Shape of the output label mask, e.g. [height, width]."
-                },
-                "objects": {
-                  "type": "array",
-                  "description": "One entry per segmented object.",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "label": {
-                        "type": "integer",
-                        "description": "Integer label of this object in the mask."
-                      },
-                      "area": {
-                        "type": "integer",
-                        "description": "Object area in pixels."
-                      },
-                      "centroid_y": {
-                        "type": "number",
-                        "description": "Centroid row (y) coordinate in pixels."
-                      },
-                      "centroid_x": {
-                        "type": "number",
-                        "description": "Centroid column (x) coordinate in pixels."
-                      }
-                    },
-                    "required": [
-                      "label",
-                      "area",
-                      "centroid_y",
-                      "centroid_x"
-                    ]
+                  "area": {
+                    "type": "integer",
+                    "description": "Object area in pixels."
+                  },
+                  "centroid_y": {
+                    "type": "number",
+                    "description": "Centroid row (y) coordinate in pixels."
+                  },
+                  "centroid_x": {
+                    "type": "number",
+                    "description": "Centroid column (x) coordinate in pixels."
                   }
                 },
-                "mask_path": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Path to the saved label-mask image, or null if save_mask was false."
-                },
-                "note": {
-                  "type": "string",
-                  "description": "Present when the cellpose build ignored model_type (unified-model builds)."
-                },
-                "mask_save_error": {
-                  "type": "string",
-                  "description": "Present only if saving the mask failed (segmentation still succeeded)."
-                }
-              },
-              "required": [
-                "image_path",
-                "model_type_requested",
-                "model_used",
-                "num_objects",
-                "image_shape",
-                "objects"
-              ]
+                "required": [
+                  "label",
+                  "area",
+                  "centroid_y",
+                  "centroid_x"
+                ]
+              }
+            },
+            "mask_path": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Path to the saved label-mask image, or null if save_mask was false."
+            },
+            "note": {
+              "type": "string",
+              "description": "Present when the cellpose build ignored model_type (unified-model builds)."
+            },
+            "mask_save_error": {
+              "type": "string",
+              "description": "Present only if saving the mask failed (segmentation still succeeded)."
             }
           },
           "required": [
-            "data"
+            "image_path",
+            "model_type_requested",
+            "model_used",
+            "num_objects",
+            "image_shape",
+            "objects"
           ]
         },
         {

--- a/src/tooluniverse/data/cellxgene_discovery_tools.json
+++ b/src/tooluniverse/data/cellxgene_discovery_tools.json
@@ -1,242 +1,312 @@
 [
-    {
-        "name": "CxGDisc_list_collections",
-        "description": "List curated single-cell RNA-seq collections from CZI CellxGene Discovery. Each collection is a published dataset group with DOI, typically corresponding to a paper. The platform hosts 350+ public collections spanning diverse tissues, diseases, and organisms with cell-type annotations. Returns collection name, DOI, dataset count, total cell count, and curator info.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum number of collections to return (1-100). Default: 20."
-                }
-            },
-            "required": []
-        },
-        "fields": {
-            "endpoint": "list_collections"
-        },
-        "type": "CellxGeneDiscoveryTool",
-        "test_examples": [
-            {
-                "limit": 5
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "total_collections": {
-                                    "type": "integer",
-                                    "description": "Total number of public collections"
-                                },
-                                "returned": {
-                                    "type": "integer",
-                                    "description": "Number returned in this response"
-                                },
-                                "collections": {
-                                    "type": "array",
-                                    "description": "Collection summaries with name, DOI, dataset count, cell count",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "collection_id": {"type": "string"},
-                                            "name": {"type": "string"},
-                                            "doi": {"type": ["string", "null"]},
-                                            "dataset_count": {"type": "integer"},
-                                            "total_cells": {"type": "integer"}
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
+  {
+    "name": "CxGDisc_list_collections",
+    "description": "List curated single-cell RNA-seq collections from CZI CellxGene Discovery. Each collection is a published dataset group with DOI, typically corresponding to a paper. The platform hosts 350+ public collections spanning diverse tissues, diseases, and organisms with cell-type annotations. Returns collection name, DOI, dataset count, total cell count, and curator info.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "limit": {
+          "type": "integer",
+          "description": "Maximum number of collections to return (1-100). Default: 20."
         }
+      },
+      "required": []
     },
-    {
-        "name": "CxGDisc_get_collection",
-        "description": "Get detailed information about a specific CellxGene Discovery collection, including all datasets with tissue, disease, organism, cell type, and assay details. Example: collection '48259aa8-f168-4bf5-b797-af8e88da6637' is the Human Breast Cell Atlas with 5 datasets (stroma, epithelial, integrated) totaling 2.8M cells. Each dataset includes cell count, tissue labels, disease status, and available assay types.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "collection_id": {
-                    "type": "string",
-                    "description": "Collection UUID from CellxGene Discovery (e.g., '48259aa8-f168-4bf5-b797-af8e88da6637' for Human Breast Cell Atlas)."
-                }
-            },
-            "required": ["collection_id"]
-        },
-        "fields": {
-            "endpoint": "get_collection"
-        },
-        "type": "CellxGeneDiscoveryTool",
-        "test_examples": [
-            {
-                "collection_id": "48259aa8-f168-4bf5-b797-af8e88da6637"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "collection_id": {"type": "string"},
-                                "name": {"type": "string"},
-                                "description": {"type": ["string", "null"]},
-                                "doi": {"type": ["string", "null"]},
-                                "dataset_count": {"type": "integer"},
-                                "datasets": {
-                                    "type": "array",
-                                    "description": "Datasets with cell count, tissues, diseases, organisms, cell types",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "dataset_id": {"type": "string"},
-                                            "name": {"type": ["string", "null"]},
-                                            "cell_count": {"type": "integer"},
-                                            "tissues": {"type": "array", "items": {"type": "string"}},
-                                            "diseases": {"type": "array", "items": {"type": "string"}},
-                                            "organisms": {"type": "array", "items": {"type": "string"}},
-                                            "cell_types": {"type": "array", "items": {"type": "string"}},
-                                            "assays": {"type": "array", "items": {"type": "string"}}
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
+    "fields": {
+      "endpoint": "list_collections"
     },
-    {
-        "name": "CxGDisc_search_datasets",
-        "description": "Search CellxGene Discovery single-cell RNA-seq datasets by tissue, disease, organism, or cell type. The platform hosts 2,000+ datasets with detailed cell-type annotations. Supports flexible text-based filtering: 'lung' returns 134 lung datasets, 'brain' returns 144, 'T cell' returns 667, 'cancer' returns 193. Results sorted by cell count (largest first).",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "tissue": {
-                    "type": "string",
-                    "description": "Filter by tissue name (e.g., 'lung', 'brain', 'heart', 'kidney', 'liver'). Case-insensitive partial match."
-                },
-                "disease": {
-                    "type": "string",
-                    "description": "Filter by disease (e.g., 'cancer', 'COVID', 'Alzheimer', 'normal'). Case-insensitive partial match."
-                },
-                "organism": {
-                    "type": "string",
-                    "description": "Filter by organism (e.g., 'Homo sapiens', 'Mus musculus'). Case-insensitive partial match."
-                },
-                "cell_type": {
-                    "type": "string",
-                    "description": "Filter by cell type (e.g., 'T cell', 'neuron', 'macrophage', 'epithelial'). Case-insensitive partial match."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum datasets to return (1-100). Default: 20."
+    "type": "CellxGeneDiscoveryTool",
+    "test_examples": [
+      {
+        "limit": 5
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "total_collections": {
+              "type": "integer",
+              "description": "Total number of public collections"
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number returned in this response"
+            },
+            "collections": {
+              "type": "array",
+              "description": "Collection summaries with name, DOI, dataset count, cell count",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "collection_id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "doi": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "dataset_count": {
+                    "type": "integer"
+                  },
+                  "total_cells": {
+                    "type": "integer"
+                  }
                 }
-            },
-            "required": []
-        },
-        "fields": {
-            "endpoint": "search_datasets"
-        },
-        "type": "CellxGeneDiscoveryTool",
-        "test_examples": [
-            {
-                "tissue": "lung",
-                "organism": "Homo sapiens",
-                "limit": 5
-            },
-            {
-                "disease": "cancer",
-                "limit": 5
+              }
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "total_matching": {
-                                    "type": "integer",
-                                    "description": "Total datasets matching filters"
-                                },
-                                "returned": {
-                                    "type": "integer",
-                                    "description": "Number returned in this response"
-                                },
-                                "datasets": {
-                                    "type": "array",
-                                    "description": "Matching datasets sorted by cell count",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "dataset_id": {"type": "string"},
-                                            "name": {"type": "string"},
-                                            "cell_count": {"type": "integer"},
-                                            "tissues": {"type": "array", "items": {"type": "string"}},
-                                            "diseases": {"type": "array", "items": {"type": "string"}},
-                                            "organisms": {"type": "array", "items": {"type": "string"}},
-                                            "explorer_url": {"type": ["string", "null"]}
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "CxGDisc_get_collection",
+    "description": "Get detailed information about a specific CellxGene Discovery collection, including all datasets with tissue, disease, organism, cell type, and assay details. Example: collection '48259aa8-f168-4bf5-b797-af8e88da6637' is the Human Breast Cell Atlas with 5 datasets (stroma, epithelial, integrated) totaling 2.8M cells. Each dataset includes cell count, tissue labels, disease status, and available assay types.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "collection_id": {
+          "type": "string",
+          "description": "Collection UUID from CellxGene Discovery (e.g., '48259aa8-f168-4bf5-b797-af8e88da6637' for Human Breast Cell Atlas)."
+        }
+      },
+      "required": [
+        "collection_id"
+      ]
+    },
+    "fields": {
+      "endpoint": "get_collection"
+    },
+    "type": "CellxGeneDiscoveryTool",
+    "test_examples": [
+      {
+        "collection_id": "48259aa8-f168-4bf5-b797-af8e88da6637"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "collection_id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "doi": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "dataset_count": {
+              "type": "integer"
+            },
+            "datasets": {
+              "type": "array",
+              "description": "Datasets with cell count, tissues, diseases, organisms, cell types",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "dataset_id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cell_count": {
+                    "type": "integer"
+                  },
+                  "tissues": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "diseases": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "organisms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "cell_types": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "assays": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "CxGDisc_search_datasets",
+    "description": "Search CellxGene Discovery single-cell RNA-seq datasets by tissue, disease, organism, or cell type. The platform hosts 2,000+ datasets with detailed cell-type annotations. Supports flexible text-based filtering: 'lung' returns 134 lung datasets, 'brain' returns 144, 'T cell' returns 667, 'cancer' returns 193. Results sorted by cell count (largest first).",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "tissue": {
+          "type": "string",
+          "description": "Filter by tissue name (e.g., 'lung', 'brain', 'heart', 'kidney', 'liver'). Case-insensitive partial match."
+        },
+        "disease": {
+          "type": "string",
+          "description": "Filter by disease (e.g., 'cancer', 'COVID', 'Alzheimer', 'normal'). Case-insensitive partial match."
+        },
+        "organism": {
+          "type": "string",
+          "description": "Filter by organism (e.g., 'Homo sapiens', 'Mus musculus'). Case-insensitive partial match."
+        },
+        "cell_type": {
+          "type": "string",
+          "description": "Filter by cell type (e.g., 'T cell', 'neuron', 'macrophage', 'epithelial'). Case-insensitive partial match."
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Maximum datasets to return (1-100). Default: 20."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "endpoint": "search_datasets"
+    },
+    "type": "CellxGeneDiscoveryTool",
+    "test_examples": [
+      {
+        "tissue": "lung",
+        "organism": "Homo sapiens",
+        "limit": 5
+      },
+      {
+        "disease": "cancer",
+        "limit": 5
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "total_matching": {
+              "type": "integer",
+              "description": "Total datasets matching filters"
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number returned in this response"
+            },
+            "datasets": {
+              "type": "array",
+              "description": "Matching datasets sorted by cell count",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "dataset_id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "cell_count": {
+                    "type": "integer"
+                  },
+                  "tissues": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "diseases": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "organisms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "explorer_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/chebi_tools.json
+++ b/src/tooluniverse/data/chebi_tools.json
@@ -34,89 +34,67 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "chebi_id": {
-                  "type": "integer"
-                },
-                "chebi_accession": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "definition": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "stars": {
-                  "type": "integer"
-                },
-                "formula": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "mass": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "monoisotopic_mass": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "charge": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "smiles": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "inchikey": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
+            "chebi_id": {
+              "type": "integer"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+            "chebi_accession": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "definition": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "stars": {
+              "type": "integer"
+            },
+            "formula": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "mass": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "monoisotopic_mass": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "charge": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "smiles": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "inchikey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -173,67 +151,45 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string"
-                },
-                "result_count": {
-                  "type": "integer"
-                },
-                "compounds": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "chebi_accession": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "formula": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "mass": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "stars": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+            "query": {
+              "type": "string"
+            },
+            "result_count": {
+              "type": "integer"
+            },
+            "compounds": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "chebi_accession": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "formula": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "mass": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "stars": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -284,61 +240,39 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "chebi_id": {
-                  "type": "integer"
-                },
-                "chebi_accession": {
-                  "type": "string"
-                },
-                "relation_count": {
-                  "type": "integer"
-                },
-                "relations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "child_id": {
-                        "type": "integer"
-                      },
-                      "child_name": {
-                        "type": "string"
-                      },
-                      "relation_type": {
-                        "type": "string"
-                      },
-                      "parent_id": {
-                        "type": "integer"
-                      },
-                      "parent_name": {
-                        "type": "string"
-                      }
-                    }
+            "chebi_id": {
+              "type": "integer"
+            },
+            "chebi_accession": {
+              "type": "string"
+            },
+            "relation_count": {
+              "type": "integer"
+            },
+            "relations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "child_id": {
+                    "type": "integer"
+                  },
+                  "child_name": {
+                    "type": "string"
+                  },
+                  "relation_type": {
+                    "type": "string"
+                  },
+                  "parent_id": {
+                    "type": "integer"
+                  },
+                  "parent_name": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -389,55 +323,33 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "chebi_id": {
-                  "type": "integer"
-                },
-                "chebi_accession": {
-                  "type": "string"
-                },
-                "relation_count": {
-                  "type": "integer"
-                },
-                "relations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "relation_type": {
-                        "type": "string"
-                      },
-                      "parent_id": {
-                        "type": "integer"
-                      },
-                      "parent_name": {
-                        "type": "string"
-                      }
-                    }
+            "chebi_id": {
+              "type": "integer"
+            },
+            "chebi_accession": {
+              "type": "string"
+            },
+            "relation_count": {
+              "type": "integer"
+            },
+            "relations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "relation_type": {
+                    "type": "string"
+                  },
+                  "parent_id": {
+                    "type": "integer"
+                  },
+                  "parent_name": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/clingen_ar_tools.json
+++ b/src/tooluniverse/data/clingen_ar_tools.json
@@ -31,66 +31,47 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "allele_id": {
-                  "type": "string",
-                  "description": "ClinGen canonical allele ID (e.g., CA000387)"
-                },
-                "allele_url": {
-                  "type": "string",
-                  "description": "Full URL to allele record"
-                },
-                "community_standard_title": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Standardized HGVS title"
-                },
-                "external_records": {
-                  "type": "object",
-                  "description": "Cross-references to external databases (dbSNP, ClinVar, COSMIC, gnomAD, ExAC)"
-                },
-                "genomic_alleles": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "hgvs": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "reference_genome": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  },
-                  "description": "Genomic coordinates in different assemblies"
-                }
-              }
+            "allele_id": {
+              "type": "string",
+              "description": "ClinGen canonical allele ID (e.g., CA000387)"
             },
-            "metadata": {
+            "allele_url": {
+              "type": "string",
+              "description": "Full URL to allele record"
+            },
+            "community_standard_title": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Standardized HGVS title"
+            },
+            "external_records": {
               "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_hgvs": {
-                  "type": "string"
+              "description": "Cross-references to external databases (dbSNP, ClinVar, COSMIC, gnomAD, ExAC)"
+            },
+            "genomic_alleles": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "hgvs": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "reference_genome": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
-              }
+              },
+              "description": "Genomic coordinates in different assemblies"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -135,45 +116,26 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "allele_id": {
-                  "type": "string",
-                  "description": "ClinGen canonical allele ID"
-                },
-                "community_standard_title": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Standardized variant title"
-                },
-                "databases": {
-                  "type": "object",
-                  "description": "External database records keyed by database name (ClinVarAlleles, ClinVarVariations, dbSNP, COSMIC, gnomAD_2, gnomAD_3, gnomAD_4, ExAC, MyVariantInfo_hg19, MyVariantInfo_hg38)"
-                },
-                "database_count": {
-                  "type": "integer",
-                  "description": "Number of external databases with records"
-                }
-              }
+            "allele_id": {
+              "type": "string",
+              "description": "ClinGen canonical allele ID"
             },
-            "metadata": {
+            "community_standard_title": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Standardized variant title"
+            },
+            "databases": {
               "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_allele_id": {
-                  "type": "string"
-                }
-              }
+              "description": "External database records keyed by database name (ClinVarAlleles, ClinVarVariations, dbSNP, COSMIC, gnomAD_2, gnomAD_3, gnomAD_4, ExAC, MyVariantInfo_hg19, MyVariantInfo_hg38)"
+            },
+            "database_count": {
+              "type": "integer",
+              "description": "Number of external databases with records"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -196,11 +158,19 @@
       "type": "object",
       "properties": {
         "dbsnp_rs": {
-          "type": ["string", "integer", "null"],
+          "type": [
+            "string",
+            "integer",
+            "null"
+          ],
           "description": "dbSNP rsID to resolve. The 'rs' prefix is optional (e.g. 113488022 or 'rs113488022'). Mutually exclusive with clinvar_variation_id."
         },
         "clinvar_variation_id": {
-          "type": ["string", "integer", "null"],
+          "type": [
+            "string",
+            "integer",
+            "null"
+          ],
           "description": "ClinVar VariationID to resolve (e.g. 13961). Mutually exclusive with dbsnp_rs."
         }
       },
@@ -223,64 +193,68 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string",
-                  "description": "The external-id query that was resolved (e.g. 'dbSNP.rs=113488022')"
-                },
-                "allele_count": {
-                  "type": "integer",
-                  "description": "Number of matching canonical alleles"
-                },
-                "alleles": {
-                  "type": "array",
-                  "description": "Matching canonical alleles, each with CA id and cross-references",
-                  "items": {
+            "query": {
+              "type": "string",
+              "description": "The external-id query that was resolved (e.g. 'dbSNP.rs=113488022')"
+            },
+            "allele_count": {
+              "type": "integer",
+              "description": "Number of matching canonical alleles"
+            },
+            "alleles": {
+              "type": "array",
+              "description": "Matching canonical alleles, each with CA id and cross-references",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "allele_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "ClinGen canonical allele ID (e.g. CA123643)"
+                  },
+                  "allele_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "community_standard_title": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Standardized HGVS title"
+                  },
+                  "external_records": {
                     "type": "object",
-                    "properties": {
-                      "allele_id": {
-                        "type": ["string", "null"],
-                        "description": "ClinGen canonical allele ID (e.g. CA123643)"
-                      },
-                      "allele_url": {
-                        "type": ["string", "null"]
-                      },
-                      "community_standard_title": {
-                        "type": ["string", "null"],
-                        "description": "Standardized HGVS title"
-                      },
-                      "external_records": {
-                        "type": "object",
-                        "description": "Cross-references (ClinVarAlleles, ClinVarVariations, dbSNP, COSMIC, gnomAD, MyVariantInfo)"
-                      },
-                      "genomic_alleles": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "hgvs": {"type": ["string", "null"]},
-                            "reference_genome": {"type": ["string", "null"]}
-                          }
+                    "description": "Cross-references (ClinVarAlleles, ClinVarVariations, dbSNP, COSMIC, gnomAD, MyVariantInfo)"
+                  },
+                  "genomic_alleles": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "hgvs": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "reference_genome": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
                         }
                       }
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "query": {"type": "string"}
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/clingen_tools.json
+++ b/src/tooluniverse/data/clingen_tools.json
@@ -155,14 +155,38 @@
       "timeout": 200
     },
     "return_schema": {
-      "type": "object",
-      "properties": {
-        "data": {
-          "type": ["array", "object"]
-        },
-        "total": {"type": "integer"},
-        "context": {"type": "string"},
-        "source": {"type": "string"}
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "docId": {"type": "string"},
+          "topicIri": {"type": "string"},
+          "curationType": {"type": "string"},
+          "latestSearchDate": {"type": "string"},
+          "lastUpdated": {"type": "string"},
+          "lastAuthor": {"type": "string"},
+          "context": {"type": "string"},
+          "contextIri": {"type": "string"},
+          "release": {"type": "string"},
+          "releaseDate": {"type": "string"},
+          "geneOrVariant": {"type": "string"},
+          "geneOmim": {"type": "string"},
+          "disease": {"type": "string"},
+          "omim": {"type": "string"},
+          "status-overall": {"type": "string"},
+          "status-stg1": {"type": "string"},
+          "status-stg2": {"type": "string"},
+          "status-scoring": {"type": "string"},
+          "outcome": {"type": ["string", "null"]},
+          "outcomeScoringGroup": {"type": "string"},
+          "intervention": {"type": ["string", "null"]},
+          "interventionScoringGroup": {"type": "string"},
+          "severity": {"type": ["string", "null"]},
+          "likelihood": {"type": ["string", "null"]},
+          "natureOfIntervention": {"type": ["string", "null"]},
+          "effectiveness": {"type": ["string", "null"]},
+          "overall": {"type": ["string", "null"]}
+        }
       }
     },
     "test_examples": [
@@ -189,14 +213,38 @@
       "timeout": 200
     },
     "return_schema": {
-      "type": "object",
-      "properties": {
-        "data": {
-          "type": ["array", "object"]
-        },
-        "total": {"type": "integer"},
-        "context": {"type": "string"},
-        "source": {"type": "string"}
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "docId": {"type": "string"},
+          "topicIri": {"type": "string"},
+          "curationType": {"type": "string"},
+          "latestSearchDate": {"type": "string"},
+          "lastUpdated": {"type": "string"},
+          "lastAuthor": {"type": "string"},
+          "context": {"type": "string"},
+          "contextIri": {"type": "string"},
+          "release": {"type": "string"},
+          "releaseDate": {"type": "string"},
+          "geneOrVariant": {"type": "string"},
+          "geneOmim": {"type": "string"},
+          "disease": {"type": "string"},
+          "omim": {"type": "string"},
+          "status-overall": {"type": "string"},
+          "status-stg1": {"type": "string"},
+          "status-stg2": {"type": "string"},
+          "status-scoring": {"type": "string"},
+          "outcome": {"type": ["string", "null"]},
+          "outcomeScoringGroup": {"type": "string"},
+          "intervention": {"type": ["string", "null"]},
+          "interventionScoringGroup": {"type": "string"},
+          "severity": {"type": ["string", "null"]},
+          "likelihood": {"type": ["string", "null"]},
+          "natureOfIntervention": {"type": ["string", "null"]},
+          "effectiveness": {"type": ["string", "null"]},
+          "overall": {"type": ["string", "null"]}
+        }
       }
     },
     "test_examples": [

--- a/src/tooluniverse/data/clinical_trial_stats_tools.json
+++ b/src/tooluniverse/data/clinical_trial_stats_tools.json
@@ -49,97 +49,82 @@
       ]
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "n_subjects": {
+              "type": "integer"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_subjects": {
-                  "type": "integer"
-                },
-                "group_col": {
-                  "type": "string"
-                },
-                "subgroup": {
-                  "type": "string"
-                },
-                "aesev_distribution": {
-                  "type": "object"
-                },
-                "test": {
-                  "type": "string"
-                },
-                "test_statistic": {
-                  "type": "number"
-                },
-                "p_value": {
-                  "type": "number"
-                },
-                "dof": {
-                  "type": "integer"
-                },
-                "contingency_table": {
-                  "type": "object"
-                },
-                "or": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "ci_lower": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "ci_upper": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "odds_ratios": {
-                  "type": "object"
-                },
-                "covariates": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "model_summary": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "n_subjects",
-                "group_col",
-                "aesev_distribution"
+            "group_col": {
+              "type": "string"
+            },
+            "subgroup": {
+              "type": "string"
+            },
+            "aesev_distribution": {
+              "type": "object"
+            },
+            "test": {
+              "type": "string"
+            },
+            "test_statistic": {
+              "type": "number"
+            },
+            "p_value": {
+              "type": "number"
+            },
+            "dof": {
+              "type": "integer"
+            },
+            "contingency_table": {
+              "type": "object"
+            },
+            "or": {
+              "type": [
+                "number",
+                "null"
               ]
+            },
+            "ci_lower": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "ci_upper": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "odds_ratios": {
+              "type": "object"
+            },
+            "covariates": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "model_summary": {
+              "type": "string"
             }
           },
           "required": [
-            "status",
-            "data"
+            "n_subjects",
+            "group_col",
+            "aesev_distribution"
           ]
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }

--- a/src/tooluniverse/data/clinicaltrials_gov_tools.json
+++ b/src/tooluniverse/data/clinicaltrials_gov_tools.json
@@ -1178,90 +1178,79 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "nct_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "brief_title": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "official_title": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "status": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "study_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "phases": {
-                  "type": "array"
-                },
-                "enrollment": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "brief_summary": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "conditions": {
-                  "type": "array"
-                },
-                "interventions": {
-                  "type": "array"
-                },
-                "primary_outcomes": {
-                  "type": "array"
-                },
-                "eligibility_criteria": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "sponsor": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "locations": {
-                  "type": "array"
-                },
-                "references": {
-                  "type": "array"
-                }
-              }
+            "nct_id": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "metadata": {
-              "type": "object"
+            "brief_title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "official_title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "study_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "phases": {
+              "type": "array"
+            },
+            "enrollment": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "brief_summary": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "conditions": {
+              "type": "array"
+            },
+            "interventions": {
+              "type": "array"
+            },
+            "primary_outcomes": {
+              "type": "array"
+            },
+            "eligibility_criteria": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sponsor": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "locations": {
+              "type": "array"
+            },
+            "references": {
+              "type": "array"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1349,33 +1338,22 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "studies": {
-                  "type": "array"
-                },
-                "total_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "next_page_token": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
+            "studies": {
+              "type": "array"
             },
-            "metadata": {
-              "type": "object"
+            "total_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "next_page_token": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1457,33 +1435,22 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "studies": {
-                  "type": "array"
-                },
-                "total_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "next_page_token": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
+            "studies": {
+              "type": "array"
             },
-            "metadata": {
-              "type": "object"
+            "total_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "next_page_token": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1611,47 +1578,36 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "field": {
-                  "type": "string"
-                },
-                "values": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "value": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "studies_count": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+            "field": {
+              "type": "string"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "studies_count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   }
-                },
-                "total_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "total_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/coexpression_module_tools.json
+++ b/src/tooluniverse/data/coexpression_module_tools.json
@@ -5,12 +5,35 @@
     "description": "Detect co-expression modules from a genes x samples expression matrix (WGCNA-style): builds a soft-thresholded correlation network and partitions it into modules of co-regulated genes by modularity, returning each module's genes and its module eigengene (first PC = per-sample summary profile). Pure-compute (NumPy + NetworkX). Simplified WGCNA (no TOM / dynamic tree cut).",
     "parameter": {
       "type": "object",
-      "required": ["expression"],
+      "required": [
+        "expression"
+      ],
       "properties": {
-        "expression": {"type": "object", "description": "{gene: [value_per_sample, ...]} — a genes x samples expression matrix (log-normalized)."},
-        "power": {"type": ["integer", "null"], "description": "Soft-threshold exponent on |correlation| (default 6, the WGCNA scale-free default)."},
-        "correlation_threshold": {"type": ["number", "null"], "description": "Minimum |correlation| to connect two genes (default 0.5)."},
-        "min_module_size": {"type": ["integer", "null"], "description": "Minimum genes for a module to be reported (default 5)."}
+        "expression": {
+          "type": "object",
+          "description": "{gene: [value_per_sample, ...]} \u2014 a genes x samples expression matrix (log-normalized)."
+        },
+        "power": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Soft-threshold exponent on |correlation| (default 6, the WGCNA scale-free default)."
+        },
+        "correlation_threshold": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Minimum |correlation| to connect two genes (default 0.5)."
+        },
+        "min_module_size": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Minimum genes for a module to be reported (default 5)."
+        }
       }
     },
     "return_schema": {
@@ -18,32 +41,109 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_genes": {"type": "integer"},
-                "n_samples": {"type": "integer"},
-                "n_modules": {"type": "integer"},
-                "n_unassigned": {"type": "integer"},
-                "modules": {"type": "array", "items": {"type": "object"}}
+            "n_genes": {
+              "type": "integer"
+            },
+            "n_samples": {
+              "type": "integer"
+            },
+            "n_modules": {
+              "type": "integer"
+            },
+            "n_unassigned": {
+              "type": "integer"
+            },
+            "modules": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "status": {
+              "const": "error"
+            },
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
         "expression": {
-          "G1": [6, 5, 4, 3, 2, 1], "G2": [6.1, 4.9, 4.0, 3.1, 1.9, 1.0], "G3": [5.9, 5.1, 3.9, 3.0, 2.1, 0.9], "G4": [6.0, 5.0, 4.1, 2.9, 2.0, 1.1],
-          "G5": [1, 2, 1, 2, 1, 2], "G6": [1.1, 1.9, 1.0, 2.1, 0.9, 2.0], "G7": [0.9, 2.1, 1.1, 1.9, 1.0, 2.1], "G8": [1.0, 2.0, 0.9, 2.0, 1.1, 1.9]
+          "G1": [
+            6,
+            5,
+            4,
+            3,
+            2,
+            1
+          ],
+          "G2": [
+            6.1,
+            4.9,
+            4.0,
+            3.1,
+            1.9,
+            1.0
+          ],
+          "G3": [
+            5.9,
+            5.1,
+            3.9,
+            3.0,
+            2.1,
+            0.9
+          ],
+          "G4": [
+            6.0,
+            5.0,
+            4.1,
+            2.9,
+            2.0,
+            1.1
+          ],
+          "G5": [
+            1,
+            2,
+            1,
+            2,
+            1,
+            2
+          ],
+          "G6": [
+            1.1,
+            1.9,
+            1.0,
+            2.1,
+            0.9,
+            2.0
+          ],
+          "G7": [
+            0.9,
+            2.1,
+            1.1,
+            1.9,
+            1.0,
+            2.1
+          ],
+          "G8": [
+            1.0,
+            2.0,
+            0.9,
+            2.0,
+            1.1,
+            1.9
+          ]
         },
         "min_module_size": 3
       }

--- a/src/tooluniverse/data/colocalization_tools.json
+++ b/src/tooluniverse/data/colocalization_tools.json
@@ -23,23 +23,16 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_snps": {"type": "integer"},
-                "posteriors": {"type": "object"},
-                "pp4_colocalization": {"type": "number"},
-                "best_causal_snp": {},
-                "interpretation": {"type": "string"}
-              }
-            }
-          },
-          "required": ["data"]
+            "n_snps": {"type": "integer"},
+            "posteriors": {"type": "object"},
+            "pp4_colocalization": {"type": "number"},
+            "best_causal_snp": {},
+            "interpretation": {"type": "string"}
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
+          "properties": {"error": {"type": "string"}},
           "required": ["error"]
         }
       ]

--- a/src/tooluniverse/data/compound_disease_tools.json
+++ b/src/tooluniverse/data/compound_disease_tools.json
@@ -17,50 +17,168 @@
     },
     "return_schema": {
       "type": "object",
-      "oneOf": [
-        {
+      "description": "Unwrapped payload (result['data']) of a successful call.",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "The disease name that was queried."
+        },
+        "sources_queried": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sources_failed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Human-readable error messages for sources that failed or returned no usable data."
+        },
+        "profile": {
+          "type": "object",
+          "description": "Unified profile built from all successfully-queried sources.",
           "properties": {
-            "status": {
-              "const": "success"
+            "disease": {
+              "type": "string"
             },
-            "data": {
+            "identifiers": {
               "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string"
-                },
-                "sources_queried": {
-                  "type": "array"
-                },
-                "sources_failed": {
-                  "type": "array"
-                },
-                "profile": {
-                  "type": "object"
-                },
-                "per_source": {
-                  "type": "object"
-                }
+              "description": "Cross-reference identifiers keyed by ontology/source name (e.g. orphanet, efo, mondo, doid, mesh, snomed, ncit, ordo, hp, omim); keys vary per disease."
+            },
+            "prevalence": {
+              "type": "string"
+            },
+            "inheritance": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "top_genes": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
           },
           "required": [
-            "data"
+            "disease",
+            "identifiers"
           ]
         },
-        {
+        "per_source": {
+          "type": "object",
+          "description": "Raw-ish per-source parsed results; sources that failed or returned nothing appear as {}.",
           "properties": {
-            "status": {
-              "const": "error"
+            "orphanet": {
+              "type": "object",
+              "properties": {
+                "orpha_code": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "prevalence": {
+                  "type": "string"
+                },
+                "inheritance": {
+                  "type": "string"
+                }
+              }
             },
-            "error": {
-              "type": "string"
+            "omim": {
+              "type": "object",
+              "properties": {
+                "entries": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "mim_number": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "disgenet": {
+              "type": "object",
+              "properties": {
+                "associated_genes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "gene": {
+                        "type": "string"
+                      },
+                      "score": {}
+                    }
+                  }
+                }
+              }
+            },
+            "opentargets": {
+              "type": "object",
+              "properties": {
+                "efo_id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "dbXRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "ols": {
+              "type": "object",
+              "properties": {
+                "terms": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "label": {
+                        "type": "string"
+                      },
+                      "ontology": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
             }
-          },
-          "required": [
-            "error"
-          ]
+          }
         }
+      },
+      "required": [
+        "query",
+        "sources_queried",
+        "sources_failed",
+        "profile",
+        "per_source"
       ]
     },
     "test_examples": [

--- a/src/tooluniverse/data/compound_gene_disease_tools.json
+++ b/src/tooluniverse/data/compound_gene_disease_tools.json
@@ -25,60 +25,122 @@
     },
     "return_schema": {
       "type": "object",
-      "oneOf": [
-        {
+      "description": "Unwrapped payload (result['data']) of a successful call.",
+      "properties": {
+        "query": {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "gene": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
+            "disease": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "sources_queried": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sources_failed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "num_associations": {
+          "type": "integer"
+        },
+        "associations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "concordance": {
+                "type": "integer"
+              },
+              "total_sources_queried": {
+                "type": "integer"
+              },
+              "scores": {
+                "type": "object",
+                "description": "Association score keyed by source name; sources without a numeric score are omitted."
+              }
+            },
+            "required": [
+              "name",
+              "sources",
+              "concordance",
+              "total_sources_queried",
+              "scores"
+            ]
+          }
+        },
+        "per_source_results": {
+          "type": "object",
+          "description": "Up to 10 raw extracted items per source, keyed by source name (DisGeNET, OMIM, OpenTargets, GenCC, ClinVar).",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
               "type": "object",
               "properties": {
-                "query": {
-                  "type": "object"
+                "name": {
+                  "type": "string"
                 },
-                "sources_queried": {
-                  "type": "array"
-                },
-                "sources_failed": {
-                  "type": "array"
-                },
-                "num_associations": {
-                  "type": "integer"
-                },
-                "associations": {
-                  "type": "array"
-                },
-                "per_source_results": {
-                  "type": "object"
-                },
-                "notes": {
+                "score": {
                   "type": [
-                    "array",
+                    "number",
                     "null"
-                  ],
-                  "description": "Present only when a source's contribution needs explanation beyond a plain empty result (e.g. it lacks the data shape this tool extracts from, distinct from genuinely having no data for the query)."
+                  ]
+                },
+                "source": {
+                  "type": "string"
+                },
+                "evidence": {
+                  "type": "string",
+                  "description": "Present only for GenCC entries (classification, e.g. Definitive, Strong, Moderate)."
                 }
-              }
+              },
+              "required": [
+                "name",
+                "score",
+                "source"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
-        {
-          "properties": {
-            "status": {
-              "const": "error"
-            },
-            "error": {
-              "type": "string"
-            }
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "required": [
-            "error"
-          ]
+          "description": "Present only when a source's contribution needs explanation beyond a plain empty result (e.g. it lacks the data shape this tool extracts from, distinct from genuinely having no data for the query)."
         }
+      },
+      "required": [
+        "query",
+        "sources_queried",
+        "sources_failed",
+        "num_associations",
+        "associations",
+        "per_source_results"
       ]
     },
     "test_examples": [

--- a/src/tooluniverse/data/compound_variant_tools.json
+++ b/src/tooluniverse/data/compound_variant_tools.json
@@ -32,50 +32,120 @@
     },
     "return_schema": {
       "type": "object",
-      "oneOf": [
-        {
+      "description": "Unwrapped payload (result['data']) of a successful call.",
+      "properties": {
+        "query": {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "variant": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "object"
-                },
-                "sources_queried": {
-                  "type": "array"
-                },
-                "sources_failed": {
-                  "type": "array"
-                },
-                "summary": {
-                  "type": "object"
-                },
-                "annotations": {
-                  "type": "object"
-                }
+            "gene": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "rsid": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        "sources_queried": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Subset of clinvar, gnomad, civic, uniprot that were actually queried (a source is skipped entirely if no gene could be resolved)."
+        },
+        "sources_failed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sources_with_data": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
+            },
+            "clinvar_classification": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Present when ClinVar returned gene-level variants; null when none matched the queried variant exactly."
+            },
+            "clinvar_classifications": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Present only when multiple distinct classifications matched (e.g. a multi-allelic rsid)."
+            },
+            "clinvar_note": {
+              "type": "string",
+              "description": "Present only to explain an ambiguous or missing exact ClinVar match."
+            },
+            "gnomad_gene_id": {
+              "type": "string",
+              "description": "Present only when gnomAD returned gene data."
+            },
+            "civic_variants_matched": {
+              "type": "integer",
+              "description": "Present only when CIViC matched at least one variant."
             }
           },
           "required": [
-            "data"
+            "query",
+            "sources_with_data"
           ]
         },
-        {
+        "annotations": {
+          "type": "object",
+          "description": "Per-source parsed results, keyed by source name (clinvar, gnomad, civic, uniprot); a source is present only if it was queried, and its inner shape differs per source (or may fall back to {\"raw\": \"<string>\"} on an unparseable response).",
           "properties": {
-            "status": {
-              "const": "error"
+            "clinvar": {
+              "type": "object",
+              "description": "Typically {total_gene_variants, matched, exact_match, variants: [{name, classification, review_status}]}."
             },
-            "error": {
-              "type": "string"
+            "gnomad": {
+              "type": "object",
+              "description": "Typically {gene_id, symbol, name, chromosome, canonical_transcript}, or {} if gnomAD had no record."
+            },
+            "civic": {
+              "type": "object",
+              "description": "Typically {total_gene_variants, matched, exact_match, variants: [{name, civic_id, feature}]}."
+            },
+            "uniprot": {
+              "type": "object",
+              "description": "Typically {accession, protein_name, gene_name, function}."
             }
-          },
-          "required": [
-            "error"
-          ]
+          }
         }
+      },
+      "required": [
+        "query",
+        "sources_queried",
+        "sources_failed",
+        "summary",
+        "annotations"
       ]
     },
     "test_examples": [

--- a/src/tooluniverse/data/cpic_tools.json
+++ b/src/tooluniverse/data/cpic_tools.json
@@ -1011,66 +1011,35 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "description": "Alleles in this page of results",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Star allele name (e.g. '*4')"
-                  },
-                  "functionalstatus": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "activityvalue": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  },
-                  "clinicalfunctionalstatus": {
-                    "type": [
-                      "null",
-                      "string"
-                    ]
-                  }
-                }
+          "type": "array",
+          "description": "Alleles in this page of results",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Star allele name (e.g. '*4')"
+              },
+              "functionalstatus": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "activityvalue": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "clinicalfunctionalstatus": {
+                "type": [
+                  "null",
+                  "string"
+                ]
               }
-            },
-            "url": {
-              "type": "string",
-              "description": "Resolved CPIC API request URL"
-            },
-            "count": {
-              "type": "integer",
-              "description": "Number of alleles in this page"
-            },
-            "total_count": {
-              "type": "integer",
-              "description": "Total alleles CPIC curates for this gene"
-            },
-            "offset": {
-              "type": "integer",
-              "description": "Zero-based index of the first allele returned"
-            },
-            "note": {
-              "type": "string",
-              "description": "Present when more alleles remain; explains how to page to them"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/crossref_tools.json
+++ b/src/tooluniverse/data/crossref_tools.json
@@ -394,19 +394,38 @@
       "method": "GET"
     },
     "return_schema": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "type": "string"
-        },
-        "data": {
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "error": {
-          "type": "string"
+      "type": "array",
+      "description": "List of Crossref member (publisher) records matching the search query, each with DOI-coverage analytics.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "primary-name": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "counts": {
+            "type": "object",
+            "description": "current-dois, backfile-dois, total-dois"
+          },
+          "breakdowns": {
+            "type": "object",
+            "description": "dois-by-issued-year"
+          },
+          "prefixes": {
+            "type": "array"
+          },
+          "flags": {
+            "type": "object"
+          },
+          "coverage": {
+            "type": "object"
+          }
         }
       }
     },

--- a/src/tooluniverse/data/dailymed_tools.json
+++ b/src/tooluniverse/data/dailymed_tools.json
@@ -61,58 +61,23 @@
       }
     ],
     "return_schema": {
-      "type": "object",
-      "properties": {
-        "data": {
-          "type": "array"
-        },
-        "metadata": {
-          "type": "object",
-          "properties": {
-            "db_published_date": {
-              "type": "string"
-            },
-            "elements_per_page": {
-              "type": "integer"
-            },
-            "current_url": {
-              "type": "string"
-            },
-            "next_page_url": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "total_elements": {
-              "type": "integer"
-            },
-            "total_pages": {
-              "type": "integer"
-            },
-            "current_page": {
-              "type": "integer"
-            },
-            "previous_page": {
-              "type": [
-                "string",
-                "integer",
-                "null"
-              ]
-            },
-            "previous_page_url": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "next_page": {
-              "type": [
-                "string",
-                "integer",
-                "null"
-              ]
-            }
+      "type": "array",
+      "description": "List of matching Structured Product Labeling (SPL) documents.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "spl_version": {
+            "type": "integer"
+          },
+          "published_date": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "setid": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       }

--- a/src/tooluniverse/data/dailymed_tools.json
+++ b/src/tooluniverse/data/dailymed_tools.json
@@ -37,7 +37,10 @@
           "default": 100
         },
         "limit": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Alias for pagesize."
         },
         "page": {
@@ -76,7 +79,10 @@
               "type": "string"
             },
             "next_page_url": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "total_elements": {
               "type": "integer"
@@ -88,13 +94,24 @@
               "type": "integer"
             },
             "previous_page": {
-              "type": ["string", "integer", "null"]
+              "type": [
+                "string",
+                "integer",
+                "null"
+              ]
             },
             "previous_page_url": {
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "next_page": {
-              "type": ["string", "integer", "null"]
+              "type": [
+                "string",
+                "integer",
+                "null"
+              ]
             }
           }
         }
@@ -395,50 +412,46 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "setid": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "setid": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": ["string", "null"]
-                },
-                "spl_version": {
-                  "type": ["integer", "null"]
-                },
-                "media": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "mime_type": {
-                        "type": "string",
-                        "description": "Image MIME type, e.g., image/jpeg"
-                      },
-                      "name": {
-                        "type": "string",
-                        "description": "Media file name"
-                      },
-                      "url": {
-                        "type": "string",
-                        "description": "Direct image URL"
-                      }
-                    }
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "spl_version": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "media": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "mime_type": {
+                    "type": "string",
+                    "description": "Image MIME type, e.g., image/jpeg"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Media file name"
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "Direct image URL"
                   }
                 }
-              },
-              "required": ["setid", "media"]
-            },
-            "metadata": {
-              "type": "object",
-              "additionalProperties": true
+              }
             }
           },
-          "required": ["data"]
+          "required": [
+            "setid",
+            "media"
+          ]
         },
         {
           "type": "object",
@@ -447,7 +460,9 @@
               "type": "string"
             }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -482,43 +497,36 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "setid": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "setid": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": ["string", "null"]
-                },
-                "history": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "spl_version": {
-                        "type": "integer",
-                        "description": "SPL version number"
-                      },
-                      "published_date": {
-                        "type": "string",
-                        "description": "Publication date, e.g., 'Jul 22, 2022'"
-                      }
-                    }
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "history": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "spl_version": {
+                    "type": "integer",
+                    "description": "SPL version number"
+                  },
+                  "published_date": {
+                    "type": "string",
+                    "description": "Publication date, e.g., 'Jul 22, 2022'"
                   }
                 }
-              },
-              "required": ["setid", "history"]
-            },
-            "metadata": {
-              "type": "object",
-              "additionalProperties": true
+              }
             }
           },
-          "required": ["data"]
+          "required": [
+            "setid",
+            "history"
+          ]
         },
         {
           "type": "object",
@@ -527,7 +535,9 @@
               "type": "string"
             }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/decoupler_ulm_tools.json
+++ b/src/tooluniverse/data/decoupler_ulm_tools.json
@@ -5,13 +5,51 @@
     "description": "Infer transcription-factor / pathway activities from a per-gene statistic (e.g. a DESeq2/edgeR t-stat or logFC) and a regulatory network (source=TF/pathway, target=gene, weight=mode of regulation), using decoupleR's univariate-linear-model (ULM) method. Returns per-source activity (slope t-value; +=active) and p-value. Pure-compute; pairs with the DoRothEA/PROGENy networks from OmniPath_get_dorothea_regulon.",
     "parameter": {
       "type": "object",
-      "required": ["network"],
+      "required": [
+        "network"
+      ],
       "properties": {
-        "gene_stats": {"type": ["object", "null"], "description": "{gene: statistic} mapping (e.g. DE t-statistic per gene). Alternative to genes+stats."},
-        "genes": {"type": ["array", "null"], "items": {"type": "string"}, "description": "Gene identifiers (use with `stats`, same order)."},
-        "stats": {"type": ["array", "null"], "items": {"type": "number"}, "description": "Per-gene statistic (same order as `genes`)."},
-        "network": {"type": "array", "items": {"type": "object"}, "description": "Regulatory edges: [{source, target, weight}] (weight defaults to 1; 'mor' accepted as an alias)."},
-        "min_targets": {"type": ["integer", "null"], "description": "Minimum targets present in the gene list for a source to be tested (default 5)."}
+        "gene_stats": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "description": "{gene: statistic} mapping (e.g. DE t-statistic per gene). Alternative to genes+stats."
+        },
+        "genes": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Gene identifiers (use with `stats`, same order)."
+        },
+        "stats": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-gene statistic (same order as `genes`)."
+        },
+        "network": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "Regulatory edges: [{source, target, weight}] (weight defaults to 1; 'mor' accepted as an alias)."
+        },
+        "min_targets": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Minimum targets present in the gene list for a source to be tested (default 5)."
+        }
       }
     },
     "return_schema": {
@@ -19,31 +57,121 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_genes": {"type": "integer"},
-                "n_sources_tested": {"type": "integer"},
-                "activities": {"type": "array", "items": {"type": "object"}}
+            "n_genes": {
+              "type": "integer"
+            },
+            "n_sources_tested": {
+              "type": "integer"
+            },
+            "activities": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "status": {
+              "const": "error"
+            },
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "gene_stats": {"G1": 4.0, "G2": 3.5, "G3": 3.0, "G4": 2.8, "G5": 2.5, "G6": 2.2, "G7": 2.0, "G8": 1.8, "G9": 0.2, "G10": 0.0, "G11": -0.1, "G12": 0.1, "G13": -1.8, "G14": -2.0, "G15": -2.4, "G16": -2.7, "G17": -3.0, "G18": -3.3, "G19": -3.6, "G20": -4.0},
+        "gene_stats": {
+          "G1": 4.0,
+          "G2": 3.5,
+          "G3": 3.0,
+          "G4": 2.8,
+          "G5": 2.5,
+          "G6": 2.2,
+          "G7": 2.0,
+          "G8": 1.8,
+          "G9": 0.2,
+          "G10": 0.0,
+          "G11": -0.1,
+          "G12": 0.1,
+          "G13": -1.8,
+          "G14": -2.0,
+          "G15": -2.4,
+          "G16": -2.7,
+          "G17": -3.0,
+          "G18": -3.3,
+          "G19": -3.6,
+          "G20": -4.0
+        },
         "network": [
-          {"source": "TF_A", "target": "G1", "weight": 1}, {"source": "TF_A", "target": "G2", "weight": 1}, {"source": "TF_A", "target": "G3", "weight": 1}, {"source": "TF_A", "target": "G4", "weight": 1}, {"source": "TF_A", "target": "G5", "weight": 1}, {"source": "TF_A", "target": "G6", "weight": 1},
-          {"source": "TF_B", "target": "G15", "weight": 1}, {"source": "TF_B", "target": "G16", "weight": 1}, {"source": "TF_B", "target": "G17", "weight": 1}, {"source": "TF_B", "target": "G18", "weight": 1}, {"source": "TF_B", "target": "G19", "weight": 1}, {"source": "TF_B", "target": "G20", "weight": 1}
+          {
+            "source": "TF_A",
+            "target": "G1",
+            "weight": 1
+          },
+          {
+            "source": "TF_A",
+            "target": "G2",
+            "weight": 1
+          },
+          {
+            "source": "TF_A",
+            "target": "G3",
+            "weight": 1
+          },
+          {
+            "source": "TF_A",
+            "target": "G4",
+            "weight": 1
+          },
+          {
+            "source": "TF_A",
+            "target": "G5",
+            "weight": 1
+          },
+          {
+            "source": "TF_A",
+            "target": "G6",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G15",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G16",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G17",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G18",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G19",
+            "weight": 1
+          },
+          {
+            "source": "TF_B",
+            "target": "G20",
+            "weight": 1
+          }
         ]
       }
     ]

--- a/src/tooluniverse/data/deseq2_tools.json
+++ b/src/tooluniverse/data/deseq2_tools.json
@@ -92,26 +92,13 @@
       ]
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "object"
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/disease_ontology_tools.json
+++ b/src/tooluniverse/data/disease_ontology_tools.json
@@ -31,81 +31,65 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "description": "Disease Ontology ID (DOID:XXXX)"
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Disease name"
-                },
-                "definition": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Disease definition"
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Disease synonyms with relationship type (EXACT, RELATED)"
-                },
-                "parents": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "relationship": {
-                        "type": "string",
-                        "description": "Relationship type (is_a)"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "id": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "description": "Parent terms in DO hierarchy"
-                },
-                "cross_references": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Cross-references to ICD10CM, ICD9CM, MeSH, NCI, SNOMEDCT, UMLS, OMIM, ICDO"
-                },
-                "subsets": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "DO subsets this disease belongs to (e.g. DO_cancer_slim, DO_AGR_slim)"
-                }
-              }
+            "id": {
+              "type": "string",
+              "description": "Disease Ontology ID (DOID:XXXX)"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Disease name"
+            },
+            "definition": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Disease definition"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Disease synonyms with relationship type (EXACT, RELATED)"
+            },
+            "parents": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "relationship": {
+                    "type": "string",
+                    "description": "Relationship type (is_a)"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  }
                 }
-              }
+              },
+              "description": "Parent terms in DO hierarchy"
+            },
+            "cross_references": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Cross-references to ICD10CM, ICD9CM, MeSH, NCI, SNOMEDCT, UMLS, OMIM, ICDO"
+            },
+            "subsets": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "DO subsets this disease belongs to (e.g. DO_cancer_slim, DO_AGR_slim)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -153,79 +137,63 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "description": "Queried Disease Ontology ID"
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Disease name"
-                },
-                "parents": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "description": "Parent DOID"
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Parent disease name"
-                      },
-                      "definition": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Parent disease definition"
-                      },
-                      "grandparents": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "name": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            }
-                          }
-                        },
-                        "description": "Parent's parent terms"
-                      }
-                    }
-                  },
-                  "description": "Direct parent disease terms with their parents"
-                }
-              }
+            "id": {
+              "type": "string",
+              "description": "Queried Disease Ontology ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Disease name"
+            },
+            "parents": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "Parent DOID"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Parent disease name"
+                  },
+                  "definition": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Parent disease definition"
+                  },
+                  "grandparents": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "description": "Parent's parent terms"
+                  }
                 }
-              }
+              },
+              "description": "Direct parent disease terms with their parents"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/disgenet_tools.json
+++ b/src/tooluniverse/data/disgenet_tools.json
@@ -69,7 +69,7 @@
   },
   {
     "name": "DisGeNET_search_disease",
-    "description": "Search DisGeNET for genes associated with a disease. Query by disease name or UMLS CUI (e.g., C0006142 for breast cancer). Returns associated genes with scores and evidence. Requires DISGENET_API_KEY.",
+    "description": "Search DisGeNET for genes associated with a disease. Requires a UMLS CUI, NOT a free-text disease name (e.g. 'C0006142' for breast cancer, not 'breast cancer') -- resolve a disease name to its CUI first via umls_search_concepts. Returns associated genes with scores and evidence. Requires DISGENET_API_KEY.",
     "type": "DisGeNETTool",
     "parameter": {
       "type": "object",
@@ -81,7 +81,7 @@
         },
         "disease": {
           "type": "string",
-          "description": "Disease name or UMLS CUI (e.g., C0006142, breast cancer)"
+          "description": "UMLS CUI for the disease, e.g. 'C0006142' (breast cancer). Free-text disease names are NOT accepted -- resolve one via umls_search_concepts first."
         },
         "limit": {
           "type": "integer",

--- a/src/tooluniverse/data/disprot_tools.json
+++ b/src/tooluniverse/data/disprot_tools.json
@@ -32,36 +32,22 @@
         "return_schema": {
             "oneOf": [
                 {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "disprot_id": {"type": "string", "description": "DisProt accession (e.g., DP00086)"},
-                                    "acc": {"type": "string", "description": "UniProt accession"},
-                                    "name": {"type": "string", "description": "Protein name"},
-                                    "gene": {"type": "string", "description": "Gene symbol"},
-                                    "organism": {"type": "string"},
-                                    "length": {"type": "integer"},
-                                    "disorder_content": {"type": ["number", "null"], "description": "Fraction of sequence that is disordered (0-1)"},
-                                    "regions_counter": {"type": ["integer", "null"], "description": "Number of annotated disorder regions"},
-                                    "dataset": {"type": "array", "items": {"type": "string"}, "description": "Dataset categories"}
-                                }
-                            },
-                            "description": "List of matching disordered proteins"
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "query": {"type": "string"},
-                                "returned": {"type": "integer"}
-                            }
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "disprot_id": {"type": "string", "description": "DisProt accession (e.g., DP00086)"},
+                            "acc": {"type": "string", "description": "UniProt accession"},
+                            "name": {"type": "string", "description": "Protein name"},
+                            "gene": {"type": "string", "description": "Gene symbol"},
+                            "organism": {"type": "string"},
+                            "length": {"type": "integer"},
+                            "disorder_content": {"type": ["number", "null"], "description": "Fraction of sequence that is disordered (0-1)"},
+                            "regions_counter": {"type": ["integer", "null"], "description": "Number of annotated disorder regions"},
+                            "dataset": {"type": "array", "items": {"type": "string"}, "description": "Dataset categories"}
                         }
                     },
-                    "required": ["data"]
+                    "description": "List of matching disordered proteins"
                 },
                 {
                     "type": "object",
@@ -103,55 +89,42 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "disprot_id": {"type": "string"},
-                                "acc": {"type": "string"},
-                                "name": {"type": "string"},
-                                "gene": {"type": "string"},
-                                "organism": {"type": "string"},
-                                "length": {"type": "integer"},
-                                "disorder_content": {"type": ["number", "null"]},
-                                "regions_counter": {"type": ["integer", "null"]},
-                                "dataset": {"type": "array", "items": {"type": "string"}},
-                                "regions": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "region_id": {"type": ["string", "null"]},
-                                            "start": {"type": ["integer", "null"]},
-                                            "end": {"type": ["integer", "null"]},
-                                            "term_name": {"type": ["string", "null"], "description": "Disorder classification term"},
-                                            "term_namespace": {"type": ["string", "null"]},
-                                            "evidence_code": {"type": ["string", "null"]},
-                                            "method": {"type": ["string", "null"]},
-                                            "cross_refs": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "db": {"type": "string"},
-                                                        "id": {"type": "string"}
-                                                    }
-                                                }
+                        "disprot_id": {"type": "string"},
+                        "acc": {"type": "string"},
+                        "name": {"type": "string"},
+                        "gene": {"type": "string"},
+                        "organism": {"type": "string"},
+                        "length": {"type": "integer"},
+                        "disorder_content": {"type": ["number", "null"]},
+                        "regions_counter": {"type": ["integer", "null"]},
+                        "dataset": {"type": "array", "items": {"type": "string"}},
+                        "regions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "region_id": {"type": ["string", "null"]},
+                                    "start": {"type": ["integer", "null"]},
+                                    "end": {"type": ["integer", "null"]},
+                                    "term_name": {"type": ["string", "null"], "description": "Disorder classification term"},
+                                    "term_namespace": {"type": ["string", "null"]},
+                                    "evidence_code": {"type": ["string", "null"]},
+                                    "method": {"type": ["string", "null"]},
+                                    "cross_refs": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "db": {"type": "string"},
+                                                "id": {"type": "string"}
                                             }
                                         }
-                                    },
-                                    "description": "Experimentally validated disorder regions"
+                                    }
                                 }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_regions": {"type": "integer"}
-                            }
+                            },
+                            "description": "Experimentally validated disorder regions"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",

--- a/src/tooluniverse/data/dn_ds_tools.json
+++ b/src/tooluniverse/data/dn_ds_tools.json
@@ -15,10 +15,21 @@
     },
     "return_schema": {
       "type": "object",
-      "oneOf": [
-        {"properties": {"status": {"const": "success"}, "data": {"type": "object"}}, "required": ["data"]},
-        {"properties": {"status": {"const": "error"}, "error": {"type": "string"}}, "required": ["error"]}
-      ]
+      "description": "Nei-Gojobori (1986) dN/dS estimate between two coding sequences.",
+      "properties": {
+        "dN_dS": {"type": "number", "description": "dN/dS (Ka/Ks) ratio."},
+        "dN": {"type": "number", "description": "Nonsynonymous substitution rate."},
+        "dS": {"type": "number", "description": "Synonymous substitution rate."},
+        "pN": {"type": "number", "description": "Proportion of nonsynonymous differences."},
+        "pS": {"type": "number", "description": "Proportion of synonymous differences."},
+        "N_sites": {"type": "number", "description": "Number of nonsynonymous sites."},
+        "S_sites": {"type": "number", "description": "Number of synonymous sites."},
+        "Nd": {"type": "number", "description": "Observed number of nonsynonymous differences."},
+        "Sd": {"type": "number", "description": "Observed number of synonymous differences."},
+        "codons_compared": {"type": "integer", "description": "Number of codons compared."},
+        "interpretation": {"type": "string", "description": "Human-readable interpretation of the selection signal."}
+      },
+      "required": ["dN_dS", "dN", "dS", "codons_compared"]
     },
     "test_examples": [
       {"seq1": "ATGGCCAAATTTGAAGATCTGAGCACCGTGCGTGGC", "seq2": "ATGGCCAAGTTCGAAAATCTGAGCACCGTACGTGGC"}

--- a/src/tooluniverse/data/drug_properties_tools.json
+++ b/src/tooluniverse/data/drug_properties_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "DrugProps_lipinski_filter",
-    "description": "Check drug-likeness of a compound using Lipinski Rule of Five (Ro5), Veber, Pfizer 3/75, Egan, and Ghose filters. Returns MW, cLogP, HBD, HBA, TPSA, RotBonds, Csp3 fraction, and pass/fail status for each filter. Essential first step in hit-to-lead optimization. Lipinski Ro5 (pass = drug-like): MW≤500, cLogP≤5, HBD≤5, HBA≤10 (max 1 violation). Veber (oral bioavailability): RotBonds≤10, TPSA≤140. Pfizer 3/75 (reduces promiscuity): cLogP≤3, TPSA≥75. Examples: aspirin ('CC(=O)Oc1ccccc1C(=O)O') passes all filters; venetoclax fails Ro5 due to MW>900 (beyond-Ro5 territory).",
+    "description": "Check drug-likeness of a compound using Lipinski Rule of Five (Ro5), Veber, Pfizer 3/75, Egan, and Ghose filters. Returns MW, cLogP, HBD, HBA, TPSA, RotBonds, Csp3 fraction, and pass/fail status for each filter. Essential first step in hit-to-lead optimization. Lipinski Ro5 (pass = drug-like): MW\u2264500, cLogP\u22645, HBD\u22645, HBA\u226410 (max 1 violation). Veber (oral bioavailability): RotBonds\u226410, TPSA\u2264140. Pfizer 3/75 (reduces promiscuity): cLogP\u22643, TPSA\u226575. Examples: aspirin ('CC(=O)Oc1ccccc1C(=O)O') passes all filters; venetoclax fails Ro5 due to MW>900 (beyond-Ro5 territory).",
     "parameter": {
       "type": "object",
       "properties": {
@@ -10,85 +10,124 @@
           "description": "SMILES string of the molecule. Examples: 'CC(=O)Oc1ccccc1C(=O)O' (aspirin), 'CC(C)Cc1ccc(cc1)C(C)C(=O)O' (ibuprofen), 'c1ccc2c(c1)cc1ccc3cccc4ccc2c1c34' (pyrene, non-drug-like)."
         }
       },
-      "required": ["smiles"]
+      "required": [
+        "smiles"
+      ]
     },
     "fields": {
       "endpoint": "lipinski_filter"
     },
     "type": "DrugPropertiesTool",
     "test_examples": [
-      {"smiles": "CC(=O)Oc1ccccc1C(=O)O"},
-      {"smiles": "CC(C)Cc1ccc(cc1)C(C)C(=O)O"},
-      {"smiles": "CN1CCC[C@H]1c2cccnc2"}
+      {
+        "smiles": "CC(=O)Oc1ccccc1C(=O)O"
+      },
+      {
+        "smiles": "CC(C)Cc1ccc(cc1)C(C)C(=O)O"
+      },
+      {
+        "smiles": "CN1CCC[C@H]1c2cccnc2"
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "data": {
+            "smiles": {
+              "type": "string"
+            },
+            "descriptors": {
               "type": "object",
               "properties": {
-                "smiles": {"type": "string"},
-                "descriptors": {
-                  "type": "object",
-                  "properties": {
-                    "molecular_weight_Da": {"type": "number"},
-                    "cLogP": {"type": "number"},
-                    "HBD": {"type": "integer"},
-                    "HBA": {"type": "integer"},
-                    "rotatable_bonds": {"type": "integer"},
-                    "TPSA_A2": {"type": "number"},
-                    "aromatic_rings": {"type": "integer"},
-                    "heavy_atoms": {"type": "integer"},
-                    "molar_refractivity": {"type": "number"},
-                    "Csp3_fraction": {"type": "number"}
-                  }
+                "molecular_weight_Da": {
+                  "type": "number"
                 },
-                "filters": {
-                  "type": "object",
-                  "properties": {
-                    "lipinski_ro5": {
-                      "type": "object",
-                      "properties": {
-                        "pass": {"type": "boolean"},
-                        "violations": {"type": "integer"},
-                        "rule": {"type": "string"}
-                      }
-                    },
-                    "veber": {"type": "object"},
-                    "pfizer_3_75": {"type": "object"},
-                    "egan": {"type": "object"},
-                    "ghose": {"type": "object"},
-                    "beyond_ro5_territory": {"type": "object"}
-                  }
+                "cLogP": {
+                  "type": "number"
                 },
-                "overall_drug_likeness": {"type": "string"}
+                "HBD": {
+                  "type": "integer"
+                },
+                "HBA": {
+                  "type": "integer"
+                },
+                "rotatable_bonds": {
+                  "type": "integer"
+                },
+                "TPSA_A2": {
+                  "type": "number"
+                },
+                "aromatic_rings": {
+                  "type": "integer"
+                },
+                "heavy_atoms": {
+                  "type": "integer"
+                },
+                "molar_refractivity": {
+                  "type": "number"
+                },
+                "Csp3_fraction": {
+                  "type": "number"
+                }
               }
             },
-            "metadata": {
+            "filters": {
               "type": "object",
               "properties": {
-                "source": {"type": "string"},
-                "filters_applied": {"type": "string"}
+                "lipinski_ro5": {
+                  "type": "object",
+                  "properties": {
+                    "pass": {
+                      "type": "boolean"
+                    },
+                    "violations": {
+                      "type": "integer"
+                    },
+                    "rule": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "veber": {
+                  "type": "object"
+                },
+                "pfizer_3_75": {
+                  "type": "object"
+                },
+                "egan": {
+                  "type": "object"
+                },
+                "ghose": {
+                  "type": "object"
+                },
+                "beyond_ro5_territory": {
+                  "type": "object"
+                }
               }
+            },
+            "overall_drug_likeness": {
+              "type": "string"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }
   },
   {
     "name": "DrugProps_calculate_qed",
-    "description": "Calculate Quantitative Estimate of Drug-likeness (QED) score for a compound using the Bickerton et al. (2012) method. QED integrates 8 molecular descriptors (MW, AlogP, HBA, HBD, PSA, rotatable bonds, aromatic rings, structural alerts) into a single score from 0 (non-drug-like) to 1 (most drug-like). Median QED of approved oral drugs is ~0.49. High QED (≥0.67) = drug-like; Medium (0.34–0.67) = borderline; Low (<0.34) = non-drug-like. Use after DrugProps_lipinski_filter for a more nuanced drug-likeness assessment.",
+    "description": "Calculate Quantitative Estimate of Drug-likeness (QED) score for a compound using the Bickerton et al. (2012) method. QED integrates 8 molecular descriptors (MW, AlogP, HBA, HBD, PSA, rotatable bonds, aromatic rings, structural alerts) into a single score from 0 (non-drug-like) to 1 (most drug-like). Median QED of approved oral drugs is ~0.49. High QED (\u22650.67) = drug-like; Medium (0.34\u20130.67) = borderline; Low (<0.34) = non-drug-like. Use after DrugProps_lipinski_filter for a more nuanced drug-likeness assessment.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -97,61 +136,87 @@
           "description": "SMILES string of the molecule. Examples: 'CC(=O)Oc1ccccc1C(=O)O' (aspirin, QED~0.55), 'c1ccc2c(c1)cc1ccc3cccc4ccc2c1c34' (pyrene, low QED)."
         }
       },
-      "required": ["smiles"]
+      "required": [
+        "smiles"
+      ]
     },
     "fields": {
       "endpoint": "calculate_qed"
     },
     "type": "DrugPropertiesTool",
     "test_examples": [
-      {"smiles": "CC(=O)Oc1ccccc1C(=O)O"},
-      {"smiles": "Clc1ccc2[nH]c(=O)/C(=C/c3ccco3)c2c1"},
-      {"smiles": "CN1CCC[C@H]1c2cccnc2"}
+      {
+        "smiles": "CC(=O)Oc1ccccc1C(=O)O"
+      },
+      {
+        "smiles": "Clc1ccc2[nH]c(=O)/C(=C/c3ccco3)c2c1"
+      },
+      {
+        "smiles": "CN1CCC[C@H]1c2cccnc2"
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "data": {
+            "smiles": {
+              "type": "string"
+            },
+            "qed_score": {
+              "type": "number",
+              "description": "QED score 0-1"
+            },
+            "qed_category": {
+              "type": "string"
+            },
+            "qed_components": {
               "type": "object",
               "properties": {
-                "smiles": {"type": "string"},
-                "qed_score": {"type": "number", "description": "QED score 0-1"},
-                "qed_category": {"type": "string"},
-                "qed_components": {
-                  "type": "object",
-                  "properties": {
-                    "MW": {"type": "number"},
-                    "ALOGP": {"type": "number"},
-                    "HBA": {"type": "integer"},
-                    "HBD": {"type": "integer"},
-                    "PSA": {"type": "number"},
-                    "ROTB": {"type": "integer"},
-                    "AROM": {"type": "integer"},
-                    "ALERTS": {"type": "integer"}
-                  }
+                "MW": {
+                  "type": "number"
                 },
-                "additional_descriptors": {"type": "object"},
-                "interpretation": {"type": "string"}
+                "ALOGP": {
+                  "type": "number"
+                },
+                "HBA": {
+                  "type": "integer"
+                },
+                "HBD": {
+                  "type": "integer"
+                },
+                "PSA": {
+                  "type": "number"
+                },
+                "ROTB": {
+                  "type": "integer"
+                },
+                "AROM": {
+                  "type": "integer"
+                },
+                "ALERTS": {
+                  "type": "integer"
+                }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "reference": {"type": "string"}
-              }
+            "additional_descriptors": {
+              "type": "object"
+            },
+            "interpretation": {
+              "type": "string"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -167,70 +232,103 @@
           "description": "SMILES string of the molecule to screen. Examples: 'O=C1CSC(=S)N1' (rhodanine PAINS), 'O=C1C=CC(=O)c2ccccc21' (quinone PAINS), 'CC(=O)Oc1ccccc1C(=O)O' (aspirin, clean)."
         }
       },
-      "required": ["smiles"]
+      "required": [
+        "smiles"
+      ]
     },
     "fields": {
       "endpoint": "pains_filter"
     },
     "type": "DrugPropertiesTool",
     "test_examples": [
-      {"smiles": "CC(=O)Oc1ccccc1C(=O)O"},
-      {"smiles": "O=C1CSC(=S)N1"},
-      {"smiles": "Oc1ccc(O)cc1"}
+      {
+        "smiles": "CC(=O)Oc1ccccc1C(=O)O"
+      },
+      {
+        "smiles": "O=C1CSC(=S)N1"
+      },
+      {
+        "smiles": "Oc1ccc(O)cc1"
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "data": {
+            "smiles": {
+              "type": "string"
+            },
+            "is_clean": {
+              "type": "boolean",
+              "description": "True if no PAINS or Brenk alerts"
+            },
+            "pains": {
               "type": "object",
               "properties": {
-                "smiles": {"type": "string"},
-                "is_clean": {"type": "boolean", "description": "True if no PAINS or Brenk alerts"},
-                "pains": {
-                  "type": "object",
-                  "properties": {
-                    "pass": {"type": "boolean"},
-                    "matches": {"type": "array", "items": {"type": "object"}},
-                    "count": {"type": "integer"}
+                "pass": {
+                  "type": "boolean"
+                },
+                "matches": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
                   }
                 },
-                "brenk": {
-                  "type": "object",
-                  "properties": {
-                    "pass": {"type": "boolean"},
-                    "matches": {"type": "array", "items": {"type": "string"}},
-                    "count": {"type": "integer"}
-                  }
-                },
-                "nih": {
-                  "type": "object",
-                  "properties": {
-                    "pass": {"type": "boolean"},
-                    "matches": {"type": "array", "items": {"type": "string"}},
-                    "count": {"type": "integer"}
-                  }
-                },
-                "recommendation": {"type": "string"}
+                "count": {
+                  "type": "integer"
+                }
               }
             },
-            "metadata": {
+            "brenk": {
               "type": "object",
               "properties": {
-                "source": {"type": "string"},
-                "filters": {"type": "string"}
+                "pass": {
+                  "type": "boolean"
+                },
+                "matches": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "count": {
+                  "type": "integer"
+                }
               }
+            },
+            "nih": {
+              "type": "object",
+              "properties": {
+                "pass": {
+                  "type": "boolean"
+                },
+                "matches": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "count": {
+                  "type": "integer"
+                }
+              }
+            },
+            "recommendation": {
+              "type": "string"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/drugcentral_tools.json
+++ b/src/tooluniverse/data/drugcentral_tools.json
@@ -32,78 +32,53 @@
       }
     ],
     "return_schema": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "description": "List of matching drugs with DrugCentral data",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "inchikey": {
-                    "type": ["string", "null"],
-                    "description": "InChIKey identifier"
-                  },
-                  "name": {
-                    "type": ["string", "null"],
-                    "description": "International Nonproprietary Name (INN)"
-                  },
-                  "cas_rn": {
-                    "type": ["string", "null"],
-                    "description": "CAS Registry Number"
-                  },
-                  "smiles": {
-                    "type": ["string", "null"],
-                    "description": "SMILES chemical structure"
-                  },
-                  "approval": {
-                    "type": ["array", "null"],
-                    "description": "Regulatory approval records",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "agency": {"type": ["string", "null"]},
-                        "company": {"type": ["string", "null"]},
-                        "date": {"type": ["string", "null"]}
-                      }
-                    }
-                  },
-                  "drugbank_id": {
-                    "type": ["string", "null"],
-                    "description": "DrugBank identifier"
-                  },
-                  "chembl_id": {
-                    "type": ["string", "array", "null"],
-                    "description": "ChEMBL identifier(s)"
-                  },
-                  "pubchem_cid": {
-                    "type": ["string", "integer", "null"],
-                    "description": "PubChem Compound ID"
-                  }
-                }
-              }
-            },
-            "metadata": {
+      "type": "array",
+      "description": "List of matching drugs with DrugCentral data",
+      "items": {
+        "type": "object",
+        "properties": {
+          "inchikey": {
+            "type": ["string", "null"],
+            "description": "InChIKey identifier"
+          },
+          "name": {
+            "type": ["string", "null"],
+            "description": "International Nonproprietary Name (INN)"
+          },
+          "cas_rn": {
+            "type": ["string", "null"],
+            "description": "CAS Registry Number"
+          },
+          "smiles": {
+            "type": ["string", "null"],
+            "description": "SMILES chemical structure"
+          },
+          "approval": {
+            "type": ["array", "null"],
+            "description": "Regulatory approval records",
+            "items": {
               "type": "object",
               "properties": {
-                "total_hits": {"type": "integer"},
-                "returned": {"type": "integer"},
-                "query": {"type": "string"},
-                "source": {"type": "string"}
+                "agency": {"type": ["string", "null"]},
+                "company": {"type": ["string", "null"]},
+                "date": {"type": ["string", "null"]}
               }
             }
-          }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "error": {"type": "string"}
           },
-          "required": ["error"]
+          "drugbank_id": {
+            "type": ["string", "null"],
+            "description": "DrugBank identifier"
+          },
+          "chembl_id": {
+            "type": ["string", "array", "null"],
+            "description": "ChEMBL identifier(s)"
+          },
+          "pubchem_cid": {
+            "type": ["string", "integer", "null"],
+            "description": "PubChem Compound ID"
+          }
         }
-      ]
+      }
     }
   },
   {

--- a/src/tooluniverse/data/ebi_proteins_coordinates_tools.json
+++ b/src/tooluniverse/data/ebi_proteins_coordinates_tools.json
@@ -29,61 +29,48 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "accession": {"type": "string"},
-                                "protein_name": {"type": ["string", "null"]},
-                                "taxid": {"type": "integer"},
-                                "gene": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "value": {"type": "string"},
-                                            "type": {"type": "string"}
-                                        }
-                                    }
-                                },
-                                "coordinate_mappings": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "ensembl_gene_id": {"type": ["string", "null"]},
-                                            "ensembl_transcript_id": {"type": ["string", "null"]},
-                                            "chromosome": {"type": ["string", "null"]},
-                                            "start": {"type": ["integer", "null"]},
-                                            "end": {"type": ["integer", "null"]},
-                                            "reverse_strand": {"type": ["boolean", "null"]},
-                                            "num_exons": {"type": "integer"},
-                                            "exons": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "exon_id": {"type": ["string", "null"]},
-                                                        "protein_start": {"type": ["integer", "null"]},
-                                                        "protein_end": {"type": ["integer", "null"]},
-                                                        "genome_start": {"type": ["integer", "null"]},
-                                                        "genome_end": {"type": ["integer", "null"]}
-                                                    }
-                                                }
+                        "accession": {"type": "string"},
+                        "protein_name": {"type": ["string", "null"]},
+                        "taxid": {"type": "integer"},
+                        "gene": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "value": {"type": "string"},
+                                    "type": {"type": "string"}
+                                }
+                            }
+                        },
+                        "coordinate_mappings": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "ensembl_gene_id": {"type": ["string", "null"]},
+                                    "ensembl_transcript_id": {"type": ["string", "null"]},
+                                    "chromosome": {"type": ["string", "null"]},
+                                    "start": {"type": ["integer", "null"]},
+                                    "end": {"type": ["integer", "null"]},
+                                    "reverse_strand": {"type": ["boolean", "null"]},
+                                    "num_exons": {"type": "integer"},
+                                    "exons": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "exon_id": {"type": ["string", "null"]},
+                                                "protein_start": {"type": ["integer", "null"]},
+                                                "protein_end": {"type": ["integer", "null"]},
+                                                "genome_start": {"type": ["integer", "null"]},
+                                                "genome_end": {"type": ["integer", "null"]}
                                             }
                                         }
                                     }
                                 }
                             }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_transcript_mappings": {"type": "integer"}
-                            }
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",

--- a/src/tooluniverse/data/ebi_proteins_epitope_tools.json
+++ b/src/tooluniverse/data/ebi_proteins_epitope_tools.json
@@ -29,107 +29,96 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "UniProt accession"
-                },
-                "entry_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "UniProt entry name"
-                },
-                "taxid": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "NCBI taxonomy ID"
-                },
-                "total_epitopes": {
-                  "type": "integer",
-                  "description": "Total number of epitope regions"
-                },
-                "epitopes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Feature type (EPITOPE)"
-                      },
-                      "begin": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ],
-                        "description": "Start position on protein sequence"
-                      },
-                      "end": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ],
-                        "description": "End position on protein sequence"
-                      },
-                      "sequence": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Epitope amino acid sequence"
-                      },
-                      "match_score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "description": "Epitope match score"
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Additional description"
-                      },
-                      "pmids": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "description": "PubMed IDs of supporting publications"
-                      },
-                      "iedb_ids": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "description": "IEDB epitope identifiers"
-                      }
-                    }
+            "accession": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "UniProt accession"
+            },
+            "entry_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "UniProt entry name"
+            },
+            "taxid": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "NCBI taxonomy ID"
+            },
+            "total_epitopes": {
+              "type": "integer",
+              "description": "Total number of epitope regions"
+            },
+            "epitopes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Feature type (EPITOPE)"
+                  },
+                  "begin": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "description": "Start position on protein sequence"
+                  },
+                  "end": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "description": "End position on protein sequence"
+                  },
+                  "sequence": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Epitope amino acid sequence"
+                  },
+                  "match_score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Epitope match score"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Additional description"
+                  },
+                  "pmids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "PubMed IDs of supporting publications"
+                  },
+                  "iedb_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "IEDB epitope identifiers"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ebi_proteins_features_tools.json
+++ b/src/tooluniverse/data/ebi_proteins_features_tools.json
@@ -31,99 +31,77 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "UniProt accession"
-                },
-                "entry_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "UniProt entry name"
-                },
-                "sequence_length": {
-                  "type": "integer",
-                  "description": "Protein sequence length"
-                },
-                "features": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Feature type (DNA_BIND, BINDING, REGION, MOTIF, SITE, etc.)"
-                      },
-                      "position_start": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Start residue position"
-                      },
-                      "position_end": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "End residue position"
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Feature description (interaction partner, binding specificity, etc.)"
-                      },
-                      "evidences": {
-                        "type": "array",
-                        "items": {
-                          "type": "object"
-                        },
-                        "description": "Literature evidence"
-                      }
-                    }
-                  },
-                  "description": "Domain/site features (max 100)"
-                },
-                "total_features": {
-                  "type": "integer",
-                  "description": "Total feature count"
-                },
-                "feature_type_counts": {
-                  "type": "object",
-                  "description": "Count of each feature type (DNA_BIND, BINDING, REGION, MOTIF, SITE)"
-                }
-              }
+            "accession": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "UniProt accession"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "accession": {
-                  "type": "string"
-                },
-                "category": {
-                  "type": "string"
+            "entry_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "UniProt entry name"
+            },
+            "sequence_length": {
+              "type": "integer",
+              "description": "Protein sequence length"
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Feature type (DNA_BIND, BINDING, REGION, MOTIF, SITE, etc.)"
+                  },
+                  "position_start": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Start residue position"
+                  },
+                  "position_end": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "End residue position"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Feature description (interaction partner, binding specificity, etc.)"
+                  },
+                  "evidences": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    },
+                    "description": "Literature evidence"
+                  }
                 }
-              }
+              },
+              "description": "Domain/site features (max 100)"
+            },
+            "total_features": {
+              "type": "integer",
+              "description": "Total feature count"
+            },
+            "feature_type_counts": {
+              "type": "object",
+              "description": "Count of each feature type (DNA_BIND, BINDING, REGION, MOTIF, SITE)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -171,99 +149,77 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "UniProt accession"
-                },
-                "entry_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "UniProt entry name"
-                },
-                "sequence_length": {
-                  "type": "integer",
-                  "description": "Full precursor sequence length"
-                },
-                "features": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Feature type (SIGNAL, TRANSIT, CHAIN, PEPTIDE, PROPEP, INIT_MET)"
-                      },
-                      "position_start": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Start residue position"
-                      },
-                      "position_end": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "End residue position"
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Chain/peptide name or processing description"
-                      },
-                      "evidences": {
-                        "type": "array",
-                        "items": {
-                          "type": "object"
-                        },
-                        "description": "Evidence references"
-                      }
-                    }
-                  },
-                  "description": "Molecule processing features"
-                },
-                "total_features": {
-                  "type": "integer",
-                  "description": "Total feature count"
-                },
-                "feature_type_counts": {
-                  "type": "object",
-                  "description": "Count of each processing type (SIGNAL, CHAIN, PEPTIDE, PROPEP, etc.)"
-                }
-              }
+            "accession": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "UniProt accession"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "accession": {
-                  "type": "string"
-                },
-                "category": {
-                  "type": "string"
+            "entry_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "UniProt entry name"
+            },
+            "sequence_length": {
+              "type": "integer",
+              "description": "Full precursor sequence length"
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Feature type (SIGNAL, TRANSIT, CHAIN, PEPTIDE, PROPEP, INIT_MET)"
+                  },
+                  "position_start": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Start residue position"
+                  },
+                  "position_end": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "End residue position"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Chain/peptide name or processing description"
+                  },
+                  "evidences": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    },
+                    "description": "Evidence references"
+                  }
                 }
-              }
+              },
+              "description": "Molecule processing features"
+            },
+            "total_features": {
+              "type": "integer",
+              "description": "Total feature count"
+            },
+            "feature_type_counts": {
+              "type": "object",
+              "description": "Count of each processing type (SIGNAL, CHAIN, PEPTIDE, PROPEP, etc.)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -311,92 +267,70 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "UniProt accession"
-                },
-                "entry_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "UniProt entry name"
-                },
-                "sequence_length": {
-                  "type": "integer",
-                  "description": "Protein sequence length"
-                },
-                "features": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Secondary structure type (HELIX, STRAND, TURN)"
-                      },
-                      "position_start": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Start residue position"
-                      },
-                      "position_end": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "End residue position"
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Additional description"
-                      }
-                    }
-                  },
-                  "description": "Secondary structure elements (max 100)"
-                },
-                "total_features": {
-                  "type": "integer",
-                  "description": "Total secondary structure element count"
-                },
-                "feature_type_counts": {
-                  "type": "object",
-                  "description": "Count of each type (HELIX, STRAND, TURN)"
-                }
-              }
+            "accession": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "UniProt accession"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "accession": {
-                  "type": "string"
-                },
-                "category": {
-                  "type": "string"
+            "entry_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "UniProt entry name"
+            },
+            "sequence_length": {
+              "type": "integer",
+              "description": "Protein sequence length"
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Secondary structure type (HELIX, STRAND, TURN)"
+                  },
+                  "position_start": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Start residue position"
+                  },
+                  "position_end": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "End residue position"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Additional description"
+                  }
                 }
-              }
+              },
+              "description": "Secondary structure elements (max 100)"
+            },
+            "total_features": {
+              "type": "integer",
+              "description": "Total secondary structure element count"
+            },
+            "feature_type_counts": {
+              "type": "object",
+              "description": "Count of each type (HELIX, STRAND, TURN)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ebi_proteins_interactions_tools.json
+++ b/src/tooluniverse/data/ebi_proteins_interactions_tools.json
@@ -1,158 +1,205 @@
 [
-    {
-        "name": "EBIProteins_get_interactions",
-        "description": "Get protein-protein interaction partners for a protein from the EBI Proteins API (sourced from IntAct). Returns experimentally validated binary interactions with partner accessions, gene names, number of supporting experiments, and whether the interacting proteins are from different organisms. Example: P04637 (TP53) returns 198 interaction partners including ABL1 (2 experiments), AIMP2 (6 experiments), EP300 (8 experiments). Useful for building interaction networks and identifying key binding partners.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "accession": {
-                    "type": "string",
-                    "description": "UniProt accession of the query protein. Examples: 'P04637' (TP53), 'P00533' (EGFR), 'P38398' (BRCA1), 'P01308' (insulin)."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum number of interaction partners to return (default: 50, sorted by experiment count descending).",
-                    "default": 50
-                }
-            },
-            "required": ["accession"]
+  {
+    "name": "EBIProteins_get_interactions",
+    "description": "Get protein-protein interaction partners for a protein from the EBI Proteins API (sourced from IntAct). Returns experimentally validated binary interactions with partner accessions, gene names, number of supporting experiments, and whether the interacting proteins are from different organisms. Example: P04637 (TP53) returns 198 interaction partners including ABL1 (2 experiments), AIMP2 (6 experiments), EP300 (8 experiments). Useful for building interaction networks and identifying key binding partners.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "UniProt accession of the query protein. Examples: 'P04637' (TP53), 'P00533' (EGFR), 'P38398' (BRCA1), 'P01308' (insulin)."
         },
-        "fields": {
-            "endpoint": "interactions"
-        },
-        "type": "EBIProteinsInteractionsTool",
-        "test_examples": [
-            {
-                "accession": "P04637"
-            },
-            {
-                "accession": "P00533"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "query_accession": {"type": "string"},
-                                "interactions": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "partner_accession": {"type": "string", "description": "UniProt accession of the interaction partner"},
-                                            "gene_name": {"type": ["string", "null"], "description": "Gene name of the interaction partner"},
-                                            "experiments": {"type": "integer", "description": "Number of supporting experiments"},
-                                            "organism_differ": {"type": "boolean", "description": "Whether the partner is from a different organism"},
-                                            "intact_id_a": {"type": ["string", "null"]},
-                                            "intact_id_b": {"type": ["string", "null"]}
-                                        }
-                                    },
-                                    "description": "Binary protein-protein interactions"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_interactions": {"type": "integer"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+        "limit": {
+          "type": "integer",
+          "description": "Maximum number of interaction partners to return (default: 50, sorted by experiment count descending).",
+          "default": 50
         }
+      },
+      "required": [
+        "accession"
+      ]
     },
-    {
-        "name": "EBIProteins_get_interaction_details",
-        "description": "Get detailed protein information along with its interaction partners, disease associations, and subcellular localizations from the EBI Proteins API. Returns the full protein record including name, existence evidence, taxonomy, plus all binary interactions with partner details. Example: P04637 (TP53) returns 97 protein entries with interactions, diseases like Li-Fraumeni syndrome, and subcellular locations.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "accession": {
-                    "type": "string",
-                    "description": "UniProt accession of the query protein. Examples: 'P04637' (TP53), 'P00533' (EGFR)."
-                }
+    "fields": {
+      "endpoint": "interactions"
+    },
+    "type": "EBIProteinsInteractionsTool",
+    "test_examples": [
+      {
+        "accession": "P04637"
+      },
+      {
+        "accession": "P00533"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "query_accession": {
+              "type": "string"
             },
-            "required": ["accession"]
-        },
-        "fields": {
-            "endpoint": "interaction_details"
-        },
-        "type": "EBIProteinsInteractionsTool",
-        "test_examples": [
-            {
-                "accession": "P04637"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "query_accession": {"type": "string"},
-                                "protein_name": {"type": ["string", "null"]},
-                                "protein_existence": {"type": ["string", "null"]},
-                                "organism": {"type": ["string", "null"]},
-                                "total_interaction_entries": {"type": "integer"},
-                                "top_interactions": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "partner_accession": {"type": "string"},
-                                            "gene_name": {"type": ["string", "null"]},
-                                            "experiments": {"type": "integer"},
-                                            "organism_differ": {"type": "boolean"}
-                                        }
-                                    },
-                                    "description": "Top interaction partners sorted by experiment count"
-                                },
-                                "diseases": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "Associated disease names"
-                                },
-                                "subcellular_locations": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "Subcellular location terms"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_interactions": {"type": "integer"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
+            "interactions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "partner_accession": {
+                    "type": "string",
+                    "description": "UniProt accession of the interaction partner"
+                  },
+                  "gene_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Gene name of the interaction partner"
+                  },
+                  "experiments": {
+                    "type": "integer",
+                    "description": "Number of supporting experiments"
+                  },
+                  "organism_differ": {
+                    "type": "boolean",
+                    "description": "Whether the partner is from a different organism"
+                  },
+                  "intact_id_a": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "intact_id_b": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
-            ]
+              },
+              "description": "Binary protein-protein interactions"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "EBIProteins_get_interaction_details",
+    "description": "Get detailed protein information along with its interaction partners, disease associations, and subcellular localizations from the EBI Proteins API. Returns the full protein record including name, existence evidence, taxonomy, plus all binary interactions with partner details. Example: P04637 (TP53) returns 97 protein entries with interactions, diseases like Li-Fraumeni syndrome, and subcellular locations.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "UniProt accession of the query protein. Examples: 'P04637' (TP53), 'P00533' (EGFR)."
+        }
+      },
+      "required": [
+        "accession"
+      ]
+    },
+    "fields": {
+      "endpoint": "interaction_details"
+    },
+    "type": "EBIProteinsInteractionsTool",
+    "test_examples": [
+      {
+        "accession": "P04637"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "query_accession": {
+              "type": "string"
+            },
+            "protein_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "protein_existence": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organism": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "total_interaction_entries": {
+              "type": "integer"
+            },
+            "top_interactions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "partner_accession": {
+                    "type": "string"
+                  },
+                  "gene_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "experiments": {
+                    "type": "integer"
+                  },
+                  "organism_differ": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "description": "Top interaction partners sorted by experiment count"
+            },
+            "diseases": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Associated disease names"
+            },
+            "subcellular_locations": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Subcellular location terms"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/ebi_taxonomy_tools.json
+++ b/src/tooluniverse/data/ebi_taxonomy_tools.json
@@ -31,104 +31,85 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "tax_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "scientific_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "common_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "rank": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "division": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "lineage": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "genetic_code": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "mitochondrial_genetic_code": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "authority": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "other_names": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "submittable": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "binomial": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "formal_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
+            "tax_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "scientific_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "common_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "rank": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "division": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "lineage": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "genetic_code": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "mitochondrial_genetic_code": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "authority": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "other_names": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_tax_id": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
-              }
+            "submittable": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "binomial": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "formal_name": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -174,82 +155,60 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tax_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "scientific_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "common_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "rank": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "division": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "lineage": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "genetic_code": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "authority": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "query_name": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tax_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "scientific_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "common_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "rank": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "division": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "lineage": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "genetic_code": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "authority": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -295,76 +254,54 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tax_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "scientific_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "common_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "rank": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "division": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "lineage": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "authority": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "query_name": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tax_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "scientific_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "common_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "rank": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "division": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "lineage": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "authority": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -410,64 +347,42 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tax_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "scientific_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "common_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "rank": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "display_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tax_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "scientific_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "common_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "rank": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "display_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/edger_limma_tools.json
+++ b/src/tooluniverse/data/edger_limma_tools.json
@@ -21,10 +21,9 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
-        {"properties": {"status": {"const": "success"}, "data": {"type": "object"}}, "required": ["data"]},
-        {"properties": {"status": {"const": "error"}, "error": {"type": "string"}}, "required": ["error"]}
+        {"type": "object"},
+        {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
       ]
     },
     "test_examples": [

--- a/src/tooluniverse/data/ena_portal_tools.json
+++ b/src/tooluniverse/data/ena_portal_tools.json
@@ -45,52 +45,27 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "study_accession": {
-                    "type": "string"
-                  },
-                  "study_title": {
-                    "type": "string"
-                  },
-                  "center_name": {
-                    "type": "string"
-                  },
-                  "first_public": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "study_accession": {
+                "type": "string"
+              },
+              "study_title": {
+                "type": "string"
+              },
+              "center_name": {
+                "type": "string"
+              },
+              "first_public": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -155,55 +130,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "sample_accession": {
-                    "type": "string"
-                  },
-                  "sample_alias": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "tax_id": {
-                    "type": "string"
-                  },
-                  "scientific_name": {
-                    "type": "string"
-                  },
-                  "first_public": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "sample_accession": {
+                "type": "string"
+              },
+              "sample_alias": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "tax_id": {
+                "type": "string"
+              },
+              "scientific_name": {
+                "type": "string"
+              },
+              "first_public": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -259,36 +209,17 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "count": {
-                  "type": "integer",
-                  "description": "Number of matching records"
-                },
-                "result_type": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                }
-              }
+            "count": {
+              "type": "integer",
+              "description": "Number of matching records"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "result_type": {
+              "type": "string"
+            },
+            "query": {
+              "type": "string"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -350,55 +281,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "run_accession": {
-                    "type": "string"
-                  },
-                  "fastq_ftp": {
-                    "type": "string"
-                  },
-                  "submitted_ftp": {
-                    "type": "string"
-                  },
-                  "sra_ftp": {
-                    "type": "string"
-                  },
-                  "library_strategy": {
-                    "type": "string"
-                  },
-                  "instrument_platform": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "run_accession": {
+                "type": "string"
+              },
+              "fastq_ftp": {
+                "type": "string"
+              },
+              "submitted_ftp": {
+                "type": "string"
+              },
+              "sra_ftp": {
+                "type": "string"
+              },
+              "library_strategy": {
+                "type": "string"
+              },
+              "instrument_platform": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/encori_tools.json
+++ b/src/tooluniverse/data/encori_tools.json
@@ -41,25 +41,18 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "mirna": {"type": "string"},
-                  "gene": {"type": "string"},
-                  "gene_id": {"type": "string"},
-                  "clip_experiments": {"type": "integer"},
-                  "predicted_by": {"type": "array", "items": {"type": "string"}},
-                  "n_programs": {"type": "integer"}
-                }
-              }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["data"]
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mirna": {"type": "string"},
+              "gene": {"type": "string"},
+              "gene_id": {"type": "string"},
+              "clip_experiments": {"type": "integer"},
+              "predicted_by": {"type": "array", "items": {"type": "string"}},
+              "n_programs": {"type": "integer"}
+            }
+          }
         },
         {
           "type": "object",
@@ -119,27 +112,20 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "rbp": {"type": "string"},
-                  "gene": {"type": "string"},
-                  "gene_id": {"type": "string"},
-                  "cluster_num": {"type": "integer"},
-                  "total_clip_experiments": {"type": "integer"},
-                  "total_clip_sites": {"type": "integer"},
-                  "chromosome": {"type": "string"},
-                  "strand": {"type": "string"}
-                }
-              }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["data"]
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rbp": {"type": "string"},
+              "gene": {"type": "string"},
+              "gene_id": {"type": "string"},
+              "cluster_num": {"type": "integer"},
+              "total_clip_experiments": {"type": "integer"},
+              "total_clip_sites": {"type": "integer"},
+              "chromosome": {"type": "string"},
+              "strand": {"type": "string"}
+            }
+          }
         },
         {
           "type": "object",
@@ -194,25 +180,18 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene": {"type": "string"},
-                  "partner": {"type": "string"},
-                  "partner_id": {"type": "string"},
-                  "shared_mirna_families": {"type": "integer"},
-                  "pval": {"type": ["number", "string", "null"]},
-                  "fdr": {"type": ["number", "string", "null"]}
-                }
-              }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["data"]
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene": {"type": "string"},
+              "partner": {"type": "string"},
+              "partner_id": {"type": "string"},
+              "shared_mirna_families": {"type": "integer"},
+              "pval": {"type": ["number", "string", "null"]},
+              "fdr": {"type": ["number", "string", "null"]}
+            }
+          }
         },
         {
           "type": "object",
@@ -267,25 +246,18 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "rna": {"type": "string"},
-                  "partner": {"type": "string"},
-                  "interaction_num": {"type": "integer"},
-                  "total_experiments": {"type": "integer"},
-                  "total_reads": {"type": "integer"},
-                  "free_energy": {"type": ["number", "string", "null"]}
-                }
-              }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["data"]
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rna": {"type": "string"},
+              "partner": {"type": "string"},
+              "interaction_num": {"type": "integer"},
+              "total_experiments": {"type": "integer"},
+              "total_reads": {"type": "integer"},
+              "free_energy": {"type": ["number", "string", "null"]}
+            }
+          }
         },
         {
           "type": "object",
@@ -344,25 +316,18 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "mirna": {"type": "string"},
-                  "gene": {"type": "string"},
-                  "cleave_event_num": {"type": "integer"},
-                  "degradome_experiments": {"type": "integer"},
-                  "total_reads": {"type": "integer"},
-                  "category": {"type": "string"}
-                }
-              }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["data"]
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mirna": {"type": "string"},
+              "gene": {"type": "string"},
+              "cleave_event_num": {"type": "integer"},
+              "degradome_experiments": {"type": "integer"},
+              "total_reads": {"type": "integer"},
+              "category": {"type": "string"}
+            }
+          }
         },
         {
           "type": "object",
@@ -413,26 +378,19 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "rbp": {"type": "string"},
-                  "gene": {"type": "string"},
-                  "tissue": {"type": "string"},
-                  "diseases": {"type": "string"},
-                  "disease_cosmic_id": {"type": "string"},
-                  "cosmic_num": {"type": "integer"},
-                  "sample_num": {"type": "integer"}
-                }
-              }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["data"]
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rbp": {"type": "string"},
+              "gene": {"type": "string"},
+              "tissue": {"type": "string"},
+              "diseases": {"type": "string"},
+              "disease_cosmic_id": {"type": "string"},
+              "cosmic_num": {"type": "integer"},
+              "sample_num": {"type": "integer"}
+            }
+          }
         },
         {
           "type": "object",
@@ -483,26 +441,19 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "rbp": {"type": "string"},
-                  "dataset_id": {"type": "string"},
-                  "motif_rank": {"type": "integer"},
-                  "identified_motif": {"type": "string"},
-                  "query_motif": {"type": "string"},
-                  "target_peak_num": {"type": "integer"},
-                  "pvalue": {"type": ["number", "string", "null"]}
-                }
-              }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["data"]
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rbp": {"type": "string"},
+              "dataset_id": {"type": "string"},
+              "motif_rank": {"type": "integer"},
+              "identified_motif": {"type": "string"},
+              "query_motif": {"type": "string"},
+              "target_peak_num": {"type": "integer"},
+              "pvalue": {"type": ["number", "string", "null"]}
+            }
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ensembl_archive_tools.json
+++ b/src/tooluniverse/data/ensembl_archive_tools.json
@@ -10,7 +10,9 @@
                     "description": "Ensembl stable ID to look up (gene: ENSG*, transcript: ENST*, protein: ENSP*, e.g., 'ENSG00000141510' for TP53)."
                 }
             },
-            "required": ["ensembl_id"]
+            "required": [
+                "ensembl_id"
+            ]
         },
         "fields": {
             "endpoint": "get_id_history"
@@ -29,44 +31,41 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "string",
-                                    "description": "Ensembl stable ID"
-                                },
-                                "latest_version": {
-                                    "type": "string",
-                                    "description": "Full versioned ID (e.g., ENSG00000141510.20)"
-                                },
-                                "current_release": {
-                                    "type": "integer",
-                                    "description": "Ensembl release number (e.g., 115)"
-                                },
-                                "assembly": {
-                                    "type": "string",
-                                    "description": "Genome assembly (e.g., GRCh38)"
-                                },
-                                "is_current": {
-                                    "type": "boolean",
-                                    "description": "Whether this ID is still active"
-                                },
-                                "type": {
-                                    "type": ["string", "null"],
-                                    "description": "Feature type (Gene, Transcript, Translation)"
-                                },
-                                "possible_replacement": {
-                                    "type": ["array", "null"],
-                                    "description": "Replacement IDs if this ID was retired"
-                                }
-                            }
+                        "id": {
+                            "type": "string",
+                            "description": "Ensembl stable ID"
                         },
-                        "metadata": {
-                            "type": "object"
+                        "latest_version": {
+                            "type": "string",
+                            "description": "Full versioned ID (e.g., ENSG00000141510.20)"
+                        },
+                        "current_release": {
+                            "type": "integer",
+                            "description": "Ensembl release number (e.g., 115)"
+                        },
+                        "assembly": {
+                            "type": "string",
+                            "description": "Genome assembly (e.g., GRCh38)"
+                        },
+                        "is_current": {
+                            "type": "boolean",
+                            "description": "Whether this ID is still active"
+                        },
+                        "type": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "Feature type (Gene, Transcript, Translation)"
+                        },
+                        "possible_replacement": {
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "description": "Replacement IDs if this ID was retired"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -75,7 +74,9 @@
                             "type": "string"
                         }
                     },
-                    "required": ["error"]
+                    "required": [
+                        "error"
+                    ]
                 }
             ]
         }
@@ -91,7 +92,9 @@
                     "description": "Comma-separated Ensembl stable IDs (max 50). Example: 'ENSG00000141510,ENSG00000012048' for TP53 and BRCA1."
                 }
             },
-            "required": ["ensembl_ids"]
+            "required": [
+                "ensembl_ids"
+            ]
         },
         "fields": {
             "endpoint": "batch_lookup"
@@ -107,39 +110,45 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "queried_ids": {
-                                    "type": "integer",
-                                    "description": "Number of IDs queried"
-                                },
-                                "found": {
-                                    "type": "integer",
-                                    "description": "Number of IDs found"
-                                },
-                                "entries": {
-                                    "type": "array",
-                                    "description": "Archive entries for each ID",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {"type": "string"},
-                                            "latest_version": {"type": "string"},
-                                            "current_release": {"type": "integer"},
-                                            "assembly": {"type": "string"},
-                                            "is_current": {"type": "boolean"},
-                                            "type": {"type": ["string", "null"]}
-                                        }
+                        "queried_ids": {
+                            "type": "integer",
+                            "description": "Number of IDs queried"
+                        },
+                        "found": {
+                            "type": "integer",
+                            "description": "Number of IDs found"
+                        },
+                        "entries": {
+                            "type": "array",
+                            "description": "Archive entries for each ID",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "latest_version": {
+                                        "type": "string"
+                                    },
+                                    "current_release": {
+                                        "type": "integer"
+                                    },
+                                    "assembly": {
+                                        "type": "string"
+                                    },
+                                    "is_current": {
+                                        "type": "boolean"
+                                    },
+                                    "type": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
                                     }
                                 }
                             }
-                        },
-                        "metadata": {
-                            "type": "object"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -148,7 +157,9 @@
                             "type": "string"
                         }
                     },
-                    "required": ["error"]
+                    "required": [
+                        "error"
+                    ]
                 }
             ]
         }

--- a/src/tooluniverse/data/ensembl_compara_tools.json
+++ b/src/tooluniverse/data/ensembl_compara_tools.json
@@ -44,86 +44,61 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "source_gene": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Source Ensembl gene ID"
-                  },
-                  "target_gene": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Target orthologue Ensembl gene ID"
-                  },
-                  "target_protein": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Target orthologue Ensembl protein ID"
-                  },
-                  "target_species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Target species name"
-                  },
-                  "homology_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Type: ortholog_one2one, ortholog_one2many, ortholog_many2many"
-                  },
-                  "taxonomy_level": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Taxonomic level of divergence (e.g., Euarchontoglires, Mammalia)"
-                  },
-                  "method": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Method used (ENSEMBL_ORTHOLOGUES)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_gene": {
-                  "type": "string"
-                },
-                "query_species": {
-                  "type": "string"
-                },
-                "total_orthologues": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source_gene": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Source Ensembl gene ID"
+              },
+              "target_gene": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Target orthologue Ensembl gene ID"
+              },
+              "target_protein": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Target orthologue Ensembl protein ID"
+              },
+              "target_species": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Target species name"
+              },
+              "homology_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Type: ortholog_one2one, ortholog_one2many, ortholog_many2many"
+              },
+              "taxonomy_level": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Taxonomic level of divergence (e.g., Euarchontoglires, Mammalia)"
+              },
+              "method": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Method used (ENSEMBL_ORTHOLOGUES)"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -174,79 +149,54 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "source_gene": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Source Ensembl gene ID"
-                  },
-                  "paralogue_gene": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Paralogue Ensembl gene ID"
-                  },
-                  "paralogue_protein": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Paralogue Ensembl protein ID"
-                  },
-                  "species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Species name"
-                  },
-                  "paralogy_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Type of paralogy (within_species_paralog, etc.)"
-                  },
-                  "taxonomy_level": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Level of gene duplication event"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_gene": {
-                  "type": "string"
-                },
-                "query_species": {
-                  "type": "string"
-                },
-                "total_paralogues": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source_gene": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Source Ensembl gene ID"
+              },
+              "paralogue_gene": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Paralogue Ensembl gene ID"
+              },
+              "paralogue_protein": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Paralogue Ensembl protein ID"
+              },
+              "species": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Species name"
+              },
+              "paralogy_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Type of paralogy (within_species_paralog, etc.)"
+              },
+              "taxonomy_level": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Level of gene duplication event"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -296,59 +246,40 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "tree_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Gene tree stable ID"
-                },
-                "newick": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Tree in Newick format (if available)"
-                },
-                "rooted": {
-                  "type": [
-                    "boolean",
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Whether tree is rooted (may be 0/1 integer or boolean)"
-                },
-                "members": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  },
-                  "description": "Gene tree members (gene_id, species) - max 50 shown"
-                },
-                "total_members": {
-                  "type": "integer",
-                  "description": "Total members in the gene tree"
-                }
-              }
+            "tree_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Gene tree stable ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_gene": {
-                  "type": "string"
-                }
-              }
+            "newick": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Tree in Newick format (if available)"
+            },
+            "rooted": {
+              "type": [
+                "boolean",
+                "integer",
+                "null"
+              ],
+              "description": "Whether tree is rooted (may be 0/1 integer or boolean)"
+            },
+            "members": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "description": "Gene tree members (gene_id, species) - max 50 shown"
+            },
+            "total_members": {
+              "type": "integer",
+              "description": "Total members in the gene tree"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ensembl_info_tools.json
+++ b/src/tooluniverse/data/ensembl_info_tools.json
@@ -31,107 +31,88 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "species": {
-                  "type": "string",
-                  "description": "Species name queried"
-                },
-                "assembly_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Assembly name (e.g., GRCh38.p14)"
-                },
-                "assembly_accession": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "GenBank/RefSeq assembly accession (e.g., GCA_000001405.29)"
-                },
-                "assembly_date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Assembly release date"
-                },
-                "genebuild_method": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Method used for gene annotation"
-                },
-                "genebuild_last_update": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Date of last genebuild update"
-                },
-                "golden_path_length": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Total genome length in base pairs"
-                },
-                "karyotype": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Ordered list of chromosome names"
-                },
-                "coordinate_system_versions": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Available coordinate system versions (e.g., GRCh38, GRCh37)"
-                },
-                "total_regions": {
-                  "type": "integer",
-                  "description": "Total number of top-level regions"
-                },
-                "chromosomes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "Chromosome name"
-                      },
-                      "length": {
-                        "type": "integer",
-                        "description": "Chromosome length in bp"
-                      }
-                    }
-                  },
-                  "description": "Chromosomes with lengths (max 30)"
-                }
-              }
+            "species": {
+              "type": "string",
+              "description": "Species name queried"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
+            "assembly_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Assembly name (e.g., GRCh38.p14)"
+            },
+            "assembly_accession": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "GenBank/RefSeq assembly accession (e.g., GCA_000001405.29)"
+            },
+            "assembly_date": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Assembly release date"
+            },
+            "genebuild_method": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Method used for gene annotation"
+            },
+            "genebuild_last_update": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Date of last genebuild update"
+            },
+            "golden_path_length": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Total genome length in base pairs"
+            },
+            "karyotype": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Ordered list of chromosome names"
+            },
+            "coordinate_system_versions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Available coordinate system versions (e.g., GRCh38, GRCh37)"
+            },
+            "total_regions": {
+              "type": "integer",
+              "description": "Total number of top-level regions"
+            },
+            "chromosomes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Chromosome name"
+                  },
+                  "length": {
+                    "type": "integer",
+                    "description": "Chromosome length in bp"
+                  }
                 }
-              }
+              },
+              "description": "Chromosomes with lengths (max 30)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -177,113 +158,94 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_species": {
-                  "type": "integer",
-                  "description": "Total species in Ensembl"
-                },
-                "matched_species": {
-                  "type": "integer",
-                  "description": "Number of species matching search"
-                },
-                "search_term": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Search term used (null if listing all)"
-                },
-                "species": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Ensembl species name (e.g., homo_sapiens)"
-                      },
-                      "display_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Display name (e.g., Human)"
-                      },
-                      "common_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Common name"
-                      },
-                      "taxon_id": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ],
-                        "description": "NCBI taxonomy ID"
-                      },
-                      "assembly": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Current assembly name"
-                      },
-                      "accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Assembly accession"
-                      },
-                      "division": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Ensembl division (EnsemblVertebrates, EnsemblPlants, etc.)"
-                      },
-                      "strain": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Strain name if applicable"
-                      },
-                      "strain_collection": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Strain collection name"
-                      }
-                    }
-                  },
-                  "description": "Matched species (max 50)"
-                }
-              }
+            "total_species": {
+              "type": "integer",
+              "description": "Total species in Ensembl"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "search": {
-                  "type": "string"
+            "matched_species": {
+              "type": "integer",
+              "description": "Number of species matching search"
+            },
+            "search_term": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Search term used (null if listing all)"
+            },
+            "species": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Ensembl species name (e.g., homo_sapiens)"
+                  },
+                  "display_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Display name (e.g., Human)"
+                  },
+                  "common_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Common name"
+                  },
+                  "taxon_id": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "description": "NCBI taxonomy ID"
+                  },
+                  "assembly": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Current assembly name"
+                  },
+                  "accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Assembly accession"
+                  },
+                  "division": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Ensembl division (EnsemblVertebrates, EnsemblPlants, etc.)"
+                  },
+                  "strain": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Strain name if applicable"
+                  },
+                  "strain_collection": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Strain collection name"
+                  }
                 }
-              }
+              },
+              "description": "Matched species (max 50)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ensembl_ld_tools.json
+++ b/src/tooluniverse/data/ensembl_ld_tools.json
@@ -61,70 +61,48 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "query_variant": {
-                  "type": "string"
-                },
-                "population": {
-                  "type": "string"
-                },
-                "total_ld_count": {
-                  "type": "integer",
-                  "description": "Total LD partners passing the thresholds, before truncation"
-                },
-                "ld_count": {
-                  "type": "integer",
-                  "description": "Number of LD partners actually returned in ld_variants"
-                },
-                "truncated": {
-                  "type": "boolean",
-                  "description": "True when total_ld_count exceeds ld_count; raise `limit` to retrieve the rest"
-                },
-                "ld_variants": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "variant1": {
-                        "type": "string"
-                      },
-                      "variant2": {
-                        "type": "string"
-                      },
-                      "r2": {
-                        "type": "number"
-                      },
-                      "d_prime": {
-                        "type": "number"
-                      },
-                      "population_name": {
-                        "type": "string"
-                      }
-                    }
+            "query_variant": {
+              "type": "string"
+            },
+            "population": {
+              "type": "string"
+            },
+            "total_ld_count": {
+              "type": "integer",
+              "description": "Total LD partners passing the thresholds, before truncation"
+            },
+            "ld_count": {
+              "type": "integer",
+              "description": "Number of LD partners actually returned in ld_variants"
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True when total_ld_count exceeds ld_count; raise `limit` to retrieve the rest"
+            },
+            "ld_variants": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "variant1": {
+                    "type": "string"
+                  },
+                  "variant2": {
+                    "type": "string"
+                  },
+                  "r2": {
+                    "type": "number"
+                  },
+                  "d_prime": {
+                    "type": "number"
+                  },
+                  "population_name": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -179,55 +157,33 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "variant1": {
-                  "type": "string"
-                },
-                "variant2": {
-                  "type": "string"
-                },
-                "population_count": {
-                  "type": "integer"
-                },
-                "ld_by_population": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "population_name": {
-                        "type": "string"
-                      },
-                      "r2": {
-                        "type": "number"
-                      },
-                      "d_prime": {
-                        "type": "number"
-                      }
-                    }
+            "variant1": {
+              "type": "string"
+            },
+            "variant2": {
+              "type": "string"
+            },
+            "population_count": {
+              "type": "integer"
+            },
+            "ld_by_population": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "population_name": {
+                    "type": "string"
+                  },
+                  "r2": {
+                    "type": "number"
+                  },
+                  "d_prime": {
+                    "type": "number"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -292,61 +248,39 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "region": {
-                  "type": "string"
-                },
-                "population": {
-                  "type": "string"
-                },
-                "ld_count": {
-                  "type": "integer"
-                },
-                "ld_pairs": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "variant1": {
-                        "type": "string"
-                      },
-                      "variant2": {
-                        "type": "string"
-                      },
-                      "r2": {
-                        "type": "number"
-                      },
-                      "d_prime": {
-                        "type": "number"
-                      },
-                      "population_name": {
-                        "type": "string"
-                      }
-                    }
+            "region": {
+              "type": "string"
+            },
+            "population": {
+              "type": "string"
+            },
+            "ld_count": {
+              "type": "integer"
+            },
+            "ld_pairs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "variant1": {
+                    "type": "string"
+                  },
+                  "variant2": {
+                    "type": "string"
+                  },
+                  "r2": {
+                    "type": "number"
+                  },
+                  "d_prime": {
+                    "type": "number"
+                  },
+                  "population_name": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ensembl_map_tools.json
+++ b/src/tooluniverse/data/ensembl_map_tools.json
@@ -59,51 +59,38 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "mappings": {
-                                    "type": "array",
-                                    "items": {
+                        "mappings": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "original": {
                                         "type": "object",
                                         "properties": {
-                                            "original": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "assembly": {"type": "string"},
-                                                    "seq_region_name": {"type": "string"},
-                                                    "start": {"type": "integer"},
-                                                    "end": {"type": "integer"},
-                                                    "strand": {"type": "integer"},
-                                                    "coord_system": {"type": "string"}
-                                                }
-                                            },
-                                            "mapped": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "assembly": {"type": "string"},
-                                                    "seq_region_name": {"type": "string"},
-                                                    "start": {"type": "integer"},
-                                                    "end": {"type": "integer"},
-                                                    "strand": {"type": "integer"},
-                                                    "coord_system": {"type": "string"}
-                                                }
-                                            }
+                                            "assembly": {"type": "string"},
+                                            "seq_region_name": {"type": "string"},
+                                            "start": {"type": "integer"},
+                                            "end": {"type": "integer"},
+                                            "strand": {"type": "integer"},
+                                            "coord_system": {"type": "string"}
                                         }
                                     },
-                                    "description": "List of coordinate mappings between assemblies"
+                                    "mapped": {
+                                        "type": "object",
+                                        "properties": {
+                                            "assembly": {"type": "string"},
+                                            "seq_region_name": {"type": "string"},
+                                            "start": {"type": "integer"},
+                                            "end": {"type": "integer"},
+                                            "strand": {"type": "integer"},
+                                            "coord_system": {"type": "string"}
+                                        }
+                                    }
                                 }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_mappings": {"type": "integer"}
-                            }
+                            },
+                            "description": "List of coordinate mappings between assemblies"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -160,36 +147,21 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "mappings": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "seq_region_name": {"type": "string", "description": "Chromosome"},
-                                            "start": {"type": "integer", "description": "Genomic start"},
-                                            "end": {"type": "integer", "description": "Genomic end"},
-                                            "strand": {"type": "integer", "description": "Strand (1 or -1)"},
-                                            "coord_system": {"type": "string"}
-                                        }
-                                    },
-                                    "description": "Genomic coordinates corresponding to the protein/cDNA positions"
+                        "mappings": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "seq_region_name": {"type": "string", "description": "Chromosome"},
+                                    "start": {"type": "integer", "description": "Genomic start"},
+                                    "end": {"type": "integer", "description": "Genomic end"},
+                                    "strand": {"type": "integer", "description": "Strand (1 or -1)"},
+                                    "coord_system": {"type": "string"}
                                 }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "query_id": {"type": "string"},
-                                "coordinate_type": {"type": "string"},
-                                "total_mappings": {"type": "integer"}
-                            }
+                            },
+                            "description": "Genomic coordinates corresponding to the protein/cDNA positions"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",

--- a/src/tooluniverse/data/ensembl_overlap_tools.json
+++ b/src/tooluniverse/data/ensembl_overlap_tools.json
@@ -1,169 +1,217 @@
 [
-    {
-        "name": "Ensembl_get_region_features",
-        "description": "Get all genomic features overlapping a specified chromosomal region. Returns genes, transcripts, regulatory elements, constrained elements, and other features within the coordinates. Essential for understanding the functional landscape of a genomic region, finding genes near a variant, or identifying regulatory elements in a locus. Supports multiple feature types in one query. Example: region '7:140424943-140524564' (BRAF locus) returns 5 genes, 20 regulatory elements, and 82 constrained elements; region '17:7661779-7687546' (TP53 locus) returns genes, enhancers, CTCF binding sites, and promoters.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "species": {
-                    "type": "string",
-                    "description": "Species name. Default: 'human'. Examples: 'human', 'mouse', 'rat', 'zebrafish'."
-                },
-                "region": {
-                    "type": "string",
-                    "description": "Genomic region in format 'chr:start-end'. Examples: '17:7661779-7687546' (TP53), '7:140424943-140524564' (BRAF), '13:32315086-32400266' (BRCA2). Max region size ~5Mb."
-                },
-                "feature_types": {
-                    "type": "string",
-                    "description": "Comma-separated feature types to retrieve. Options: 'gene', 'transcript', 'regulatory', 'constrained', 'variation', 'repeat', 'motif'. Default: 'gene'. Example: 'gene,regulatory,constrained'."
-                }
-            },
-            "required": ["region"]
+  {
+    "name": "Ensembl_get_region_features",
+    "description": "Get all genomic features overlapping a specified chromosomal region. Returns genes, transcripts, regulatory elements, constrained elements, and other features within the coordinates. Essential for understanding the functional landscape of a genomic region, finding genes near a variant, or identifying regulatory elements in a locus. Supports multiple feature types in one query. Example: region '7:140424943-140524564' (BRAF locus) returns 5 genes, 20 regulatory elements, and 82 constrained elements; region '17:7661779-7687546' (TP53 locus) returns genes, enhancers, CTCF binding sites, and promoters.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "species": {
+          "type": "string",
+          "description": "Species name. Default: 'human'. Examples: 'human', 'mouse', 'rat', 'zebrafish'."
         },
-        "fields": {
-            "endpoint": "region"
+        "region": {
+          "type": "string",
+          "description": "Genomic region in format 'chr:start-end'. Examples: '17:7661779-7687546' (TP53), '7:140424943-140524564' (BRAF), '13:32315086-32400266' (BRCA2). Max region size ~5Mb."
         },
-        "type": "EnsemblOverlapTool",
-        "test_examples": [
-            {
-                "species": "human",
-                "region": "7:140424943-140524564",
-                "feature_types": "gene,regulatory,constrained"
-            },
-            {
-                "species": "human",
-                "region": "17:7661779-7687546",
-                "feature_types": "gene,regulatory"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "region": {"type": "string"},
-                                "species": {"type": "string"},
-                                "features": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "feature_type": {"type": "string"},
-                                            "id": {"type": ["string", "null"]},
-                                            "start": {"type": "integer"},
-                                            "end": {"type": "integer"},
-                                            "strand": {"type": "integer"},
-                                            "biotype": {"type": ["string", "null"]},
-                                            "external_name": {"type": ["string", "null"]},
-                                            "description": {"type": ["string", "null"]}
-                                        }
-                                    }
-                                },
-                                "type_summary": {
-                                    "type": "object",
-                                    "description": "Count of features by type"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_features": {"type": "integer"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+        "feature_types": {
+          "type": "string",
+          "description": "Comma-separated feature types to retrieve. Options: 'gene', 'transcript', 'regulatory', 'constrained', 'variation', 'repeat', 'motif'. Default: 'gene'. Example: 'gene,regulatory,constrained'."
         }
+      },
+      "required": [
+        "region"
+      ]
     },
-    {
-        "name": "Ensembl_get_gene_overlapping_features",
-        "description": "Get features overlapping an Ensembl gene by gene ID. Returns all genomic features co-located with the gene, including neighboring genes, overlapping transcripts, regulatory elements, and antisense transcripts. Useful for finding overlapping genes, identifying all transcript isoforms in a locus, or discovering regulatory features at a gene. Example: 'ENSG00000141510' (TP53) returns 2 overlapping genes (TP53 and WRAP53), 42 transcripts across 4 biotypes (protein_coding, nonsense_mediated_decay, retained_intron, protein_coding_CDS_not_defined), and 9 regulatory features.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "gene_id": {
-                    "type": "string",
-                    "description": "Ensembl gene ID. Examples: 'ENSG00000141510' (TP53), 'ENSG00000012048' (BRCA1), 'ENSG00000157764' (BRAF)."
-                },
-                "feature_types": {
-                    "type": "string",
-                    "description": "Comma-separated feature types. Options: 'gene', 'transcript', 'regulatory', 'constrained', 'variation', 'repeat'. Default: 'gene'."
+    "fields": {
+      "endpoint": "region"
+    },
+    "type": "EnsemblOverlapTool",
+    "test_examples": [
+      {
+        "species": "human",
+        "region": "7:140424943-140524564",
+        "feature_types": "gene,regulatory,constrained"
+      },
+      {
+        "species": "human",
+        "region": "17:7661779-7687546",
+        "feature_types": "gene,regulatory"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "region": {
+              "type": "string"
+            },
+            "species": {
+              "type": "string"
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "feature_type": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "start": {
+                    "type": "integer"
+                  },
+                  "end": {
+                    "type": "integer"
+                  },
+                  "strand": {
+                    "type": "integer"
+                  },
+                  "biotype": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "external_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
+              }
             },
-            "required": ["gene_id"]
-        },
-        "fields": {
-            "endpoint": "gene_id"
-        },
-        "type": "EnsemblOverlapTool",
-        "test_examples": [
-            {
-                "gene_id": "ENSG00000141510",
-                "feature_types": "gene"
-            },
-            {
-                "gene_id": "ENSG00000141510",
-                "feature_types": "transcript"
+            "type_summary": {
+              "type": "object",
+              "description": "Count of features by type"
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "gene_id": {"type": "string"},
-                                "features": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "feature_type": {"type": "string"},
-                                            "id": {"type": ["string", "null"]},
-                                            "start": {"type": "integer"},
-                                            "end": {"type": "integer"},
-                                            "biotype": {"type": ["string", "null"]},
-                                            "external_name": {"type": ["string", "null"]},
-                                            "transcript_id": {"type": ["string", "null"]}
-                                        }
-                                    }
-                                },
-                                "type_summary": {"type": "object"}
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_features": {"type": "integer"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "Ensembl_get_gene_overlapping_features",
+    "description": "Get features overlapping an Ensembl gene by gene ID. Returns all genomic features co-located with the gene, including neighboring genes, overlapping transcripts, regulatory elements, and antisense transcripts. Useful for finding overlapping genes, identifying all transcript isoforms in a locus, or discovering regulatory features at a gene. Example: 'ENSG00000141510' (TP53) returns 2 overlapping genes (TP53 and WRAP53), 42 transcripts across 4 biotypes (protein_coding, nonsense_mediated_decay, retained_intron, protein_coding_CDS_not_defined), and 9 regulatory features.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "gene_id": {
+          "type": "string",
+          "description": "Ensembl gene ID. Examples: 'ENSG00000141510' (TP53), 'ENSG00000012048' (BRCA1), 'ENSG00000157764' (BRAF)."
+        },
+        "feature_types": {
+          "type": "string",
+          "description": "Comma-separated feature types. Options: 'gene', 'transcript', 'regulatory', 'constrained', 'variation', 'repeat'. Default: 'gene'."
+        }
+      },
+      "required": [
+        "gene_id"
+      ]
+    },
+    "fields": {
+      "endpoint": "gene_id"
+    },
+    "type": "EnsemblOverlapTool",
+    "test_examples": [
+      {
+        "gene_id": "ENSG00000141510",
+        "feature_types": "gene"
+      },
+      {
+        "gene_id": "ENSG00000141510",
+        "feature_types": "transcript"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "gene_id": {
+              "type": "string"
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "feature_type": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "start": {
+                    "type": "integer"
+                  },
+                  "end": {
+                    "type": "integer"
+                  },
+                  "biotype": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "external_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "transcript_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "type_summary": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/ensembl_phenotype_tools.json
+++ b/src/tooluniverse/data/ensembl_phenotype_tools.json
@@ -37,73 +37,54 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "phenotype_count": {
-                  "type": "integer"
-                },
-                "phenotypes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "description": {
-                        "type": "string"
-                      },
-                      "source": {
-                        "type": "string"
-                      },
-                      "location": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "gene_ensembl_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "ontology_accessions": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "external_references": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
+            "gene": {
+              "type": "string"
+            },
+            "species": {
+              "type": "string"
+            },
+            "phenotype_count": {
+              "type": "integer"
+            },
+            "phenotypes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "gene_ensembl_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ontology_accessions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "external_references": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -164,70 +145,51 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "region": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "phenotype_count": {
-                  "type": "integer"
-                },
-                "phenotypes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "description": {
-                        "type": "string"
-                      },
-                      "source": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "location": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "ontology_accessions": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
+            "region": {
+              "type": "string"
+            },
+            "species": {
+              "type": "string"
+            },
+            "phenotype_count": {
+              "type": "integer"
+            },
+            "phenotypes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ontology_accessions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -288,115 +250,93 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string"
-                },
-                "query_kind": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "association_count": {
-                  "type": "integer"
-                },
-                "associations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "description": {
-                        "type": "string"
-                      },
-                      "variant": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "gene": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "risk_allele": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "p_value": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "beta": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "odds_ratio": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "clinical_significance": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "source": {
-                        "type": "string"
-                      },
-                      "location": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "mapped_to_accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "external_reference": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "query": {
+              "type": "string"
+            },
+            "query_kind": {
+              "type": "string"
+            },
+            "species": {
+              "type": "string"
+            },
+            "association_count": {
+              "type": "integer"
+            },
+            "associations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "variant": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "gene": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "risk_allele": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "p_value": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "beta": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "odds_ratio": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "clinical_significance": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "mapped_to_accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "external_reference": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                },
-                "total_returned": {
-                  "type": "integer"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -450,85 +390,66 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "variant_id": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "phenotype_count": {
-                  "type": "integer"
-                },
-                "phenotypes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "trait": {
-                        "type": "string"
-                      },
-                      "source": {
-                        "type": "string"
-                      },
-                      "risk_allele": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "pvalue": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "beta_coefficient": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "study": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "genes": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "ontology_accessions": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
+            "variant_id": {
+              "type": "string"
+            },
+            "species": {
+              "type": "string"
+            },
+            "phenotype_count": {
+              "type": "integer"
+            },
+            "phenotypes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "trait": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "risk_allele": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "pvalue": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "beta_coefficient": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "study": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "genes": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ontology_accessions": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ensembl_regulation_tools.json
+++ b/src/tooluniverse/data/ensembl_regulation_tools.json
@@ -37,76 +37,57 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "region": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "motif_count": {
-                  "type": "integer"
-                },
-                "motif_features": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "stable_id": {
-                        "type": "string"
-                      },
-                      "transcription_factor_complex": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "binding_matrix_stable_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "start": {
-                        "type": "integer"
-                      },
-                      "end": {
-                        "type": "integer"
-                      },
-                      "strand": {
-                        "type": "integer"
-                      },
-                      "seq_region_name": {
-                        "type": "string"
-                      }
-                    }
+            "region": {
+              "type": "string"
+            },
+            "species": {
+              "type": "string"
+            },
+            "motif_count": {
+              "type": "integer"
+            },
+            "motif_features": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "stable_id": {
+                    "type": "string"
+                  },
+                  "transcription_factor_complex": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "binding_matrix_stable_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "start": {
+                    "type": "integer"
+                  },
+                  "end": {
+                    "type": "integer"
+                  },
+                  "strand": {
+                    "type": "integer"
+                  },
+                  "seq_region_name": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -160,64 +141,45 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "region": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "element_count": {
-                  "type": "integer"
-                },
-                "constrained_elements": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "start": {
-                        "type": "integer"
-                      },
-                      "end": {
-                        "type": "integer"
-                      },
-                      "score": {
-                        "type": "number"
-                      },
-                      "strand": {
-                        "type": "integer"
-                      },
-                      "seq_region_name": {
-                        "type": "string"
-                      }
-                    }
+            "region": {
+              "type": "string"
+            },
+            "species": {
+              "type": "string"
+            },
+            "element_count": {
+              "type": "integer"
+            },
+            "constrained_elements": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "start": {
+                    "type": "integer"
+                  },
+                  "end": {
+                    "type": "integer"
+                  },
+                  "score": {
+                    "type": "number"
+                  },
+                  "strand": {
+                    "type": "integer"
+                  },
+                  "seq_region_name": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -271,78 +233,59 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "stable_id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "source": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "length": {
-                  "type": "integer"
-                },
-                "threshold": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "unit": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "max_position_sum": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "elements_string": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "associated_tfs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "matrix": {
-                  "type": "object",
-                  "description": "Position weight matrix: position -> {A, C, G, T} counts"
-                }
+            "stable_id": {
+              "type": "string"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "length": {
+              "type": "integer"
+            },
+            "threshold": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "unit": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "max_position_sum": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "elements_string": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "associated_tfs": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
-            "metadata": {
+            "matrix": {
               "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+              "description": "Position weight matrix: position -> {A, C, G, T} counts"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ensembl_sequence_tools.json
+++ b/src/tooluniverse/data/ensembl_sequence_tools.json
@@ -37,40 +37,31 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "species": {
-                                    "type": "string",
-                                    "description": "Species name"
-                                },
-                                "region": {
-                                    "type": "string",
-                                    "description": "Genomic region queried"
-                                },
-                                "molecule": {
-                                    "type": "string",
-                                    "description": "Molecule type (dna)"
-                                },
-                                "description": {
-                                    "type": ["string", "null"],
-                                    "description": "Region description from Ensembl"
-                                },
-                                "sequence_length": {
-                                    "type": "integer",
-                                    "description": "Length of returned sequence in bp"
-                                },
-                                "sequence": {
-                                    "type": "string",
-                                    "description": "DNA sequence (truncated to 10kb if longer)"
-                                }
-                            }
+                        "species": {
+                            "type": "string",
+                            "description": "Species name"
                         },
-                        "metadata": {
-                            "type": "object"
+                        "region": {
+                            "type": "string",
+                            "description": "Genomic region queried"
+                        },
+                        "molecule": {
+                            "type": "string",
+                            "description": "Molecule type (dna)"
+                        },
+                        "description": {
+                            "type": ["string", "null"],
+                            "description": "Region description from Ensembl"
+                        },
+                        "sequence_length": {
+                            "type": "integer",
+                            "description": "Length of returned sequence in bp"
+                        },
+                        "sequence": {
+                            "type": "string",
+                            "description": "DNA sequence (truncated to 10kb if longer)"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -122,36 +113,27 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "ensembl_id": {
-                                    "type": "string",
-                                    "description": "Ensembl stable ID"
-                                },
-                                "molecule": {
-                                    "type": ["string", "null"],
-                                    "description": "Molecule type (protein or dna)"
-                                },
-                                "description": {
-                                    "type": ["string", "null"],
-                                    "description": "Sequence description"
-                                },
-                                "sequence_length": {
-                                    "type": "integer",
-                                    "description": "Sequence length (aa for protein, bp for DNA)"
-                                },
-                                "sequence": {
-                                    "type": "string",
-                                    "description": "Amino acid or nucleotide sequence (truncated to 10kb)"
-                                }
-                            }
+                        "ensembl_id": {
+                            "type": "string",
+                            "description": "Ensembl stable ID"
                         },
-                        "metadata": {
-                            "type": "object"
+                        "molecule": {
+                            "type": ["string", "null"],
+                            "description": "Molecule type (protein or dna)"
+                        },
+                        "description": {
+                            "type": ["string", "null"],
+                            "description": "Sequence description"
+                        },
+                        "sequence_length": {
+                            "type": "integer",
+                            "description": "Sequence length (aa for protein, bp for DNA)"
+                        },
+                        "sequence": {
+                            "type": "string",
+                            "description": "Amino acid or nucleotide sequence (truncated to 10kb)"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",

--- a/src/tooluniverse/data/ensembl_tools.json
+++ b/src/tooluniverse/data/ensembl_tools.json
@@ -27,63 +27,49 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "transcript_id": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "transcript_id": {
-                  "type": "string"
-                },
-                "total_haplotype_count": {
-                  "type": "integer"
-                },
-                "protein_haplotypes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "count": {
-                        "type": "integer"
-                      },
-                      "frequency": {
-                        "type": "number"
-                      },
-                      "has_indel": {},
-                      "population_frequencies": {
-                        "type": "object"
-                      },
-                      "population_counts": {
-                        "type": "object"
-                      },
-                      "contributing_variants": {
-                        "type": "array"
-                      }
-                    }
-                  }
-                },
-                "cds_haplotypes": {
-                  "type": "array",
-                  "items": {
+            "total_haplotype_count": {
+              "type": "integer"
+            },
+            "protein_haplotypes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "count": {
+                    "type": "integer"
+                  },
+                  "frequency": {
+                    "type": "number"
+                  },
+                  "has_indel": {},
+                  "population_frequencies": {
                     "type": "object"
+                  },
+                  "population_counts": {
+                    "type": "object"
+                  },
+                  "contributing_variants": {
+                    "type": "array"
                   }
-                },
-                "total_population_counts": {
-                  "type": "object"
                 }
               }
             },
-            "url": {
-              "type": "string"
+            "cds_haplotypes": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "total_population_counts": {
+              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ensembl_variation_ext_tools.json
+++ b/src/tooluniverse/data/ensembl_variation_ext_tools.json
@@ -1,184 +1,252 @@
 [
-    {
-        "name": "EnsemblVar_get_population_frequencies",
-        "description": "Get allele frequency data for a variant (SNP/indel) across global populations from gnomAD and 1000 Genomes via Ensembl. Returns allele frequencies broken down by population (e.g., gnomADe:ALL, gnomADe:nfe, 1000GENOMES:phase_3:CEU, etc.). Essential for assessing variant rarity in different ethnic groups, interpreting clinical significance, and population genetics studies. Example: rs429358 (APOE epsilon-4 allele) shows C allele frequency of 14.8% globally (gnomAD), 22.7% in African populations, 9.8% in East Asian populations.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "variant_id": {
-                    "type": "string",
-                    "description": "dbSNP rsID of the variant. Examples: 'rs429358' (APOE), 'rs7903146' (TCF7L2), 'rs1042779'."
-                },
-                "species": {
-                    "type": "string",
-                    "description": "Species name. Default 'human'. Examples: 'human', 'homo_sapiens'."
-                }
-            },
-            "required": ["variant_id"]
+  {
+    "name": "EnsemblVar_get_population_frequencies",
+    "description": "Get allele frequency data for a variant (SNP/indel) across global populations from gnomAD and 1000 Genomes via Ensembl. Returns allele frequencies broken down by population (e.g., gnomADe:ALL, gnomADe:nfe, 1000GENOMES:phase_3:CEU, etc.). Essential for assessing variant rarity in different ethnic groups, interpreting clinical significance, and population genetics studies. Example: rs429358 (APOE epsilon-4 allele) shows C allele frequency of 14.8% globally (gnomAD), 22.7% in African populations, 9.8% in East Asian populations.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "variant_id": {
+          "type": "string",
+          "description": "dbSNP rsID of the variant. Examples: 'rs429358' (APOE), 'rs7903146' (TCF7L2), 'rs1042779'."
         },
-        "fields": {
-            "endpoint": "population_frequencies"
-        },
-        "type": "EnsemblVariationExtTool",
-        "test_examples": [
-            {
-                "variant_id": "rs429358"
-            },
-            {
-                "variant_id": "rs7903146",
-                "species": "human"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "variant_id": {"type": "string"},
-                                "most_severe_consequence": {"type": ["string", "null"]},
-                                "source": {"type": ["string", "null"]},
-                                "location": {
-                                    "type": "object",
-                                    "properties": {
-                                        "chromosome": {"type": "string"},
-                                        "start": {"type": "integer"},
-                                        "allele_string": {"type": "string"},
-                                        "assembly": {"type": "string"}
-                                    }
-                                },
-                                "populations": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "population": {"type": "string", "description": "Population name (e.g., gnomADe:ALL, 1000GENOMES:phase_3:CEU)"},
-                                            "allele": {"type": "string", "description": "Allele base(s)"},
-                                            "frequency": {"type": "number", "description": "Allele frequency (0-1)"},
-                                            "allele_count": {"type": ["integer", "null"]},
-                                            "count": {"type": ["integer", "null"]}
-                                        }
-                                    },
-                                    "description": "Allele frequency data across global populations"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_population_entries": {"type": "integer"},
-                                "unique_populations": {"type": "integer"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+        "species": {
+          "type": "string",
+          "description": "Species name. Default 'human'. Examples: 'human', 'homo_sapiens'."
         }
+      },
+      "required": [
+        "variant_id"
+      ]
     },
-    {
-        "name": "EnsemblVar_get_variant_consequences",
-        "description": "Get detailed variant information including consequence type, clinical significance, synonyms, evidence attributes, and allele mappings from Ensembl. More comprehensive than VEP - returns the full variant record with all known synonyms, mapped positions, ancestral allele, and minor allele data. Example: rs429358 returns most_severe_consequence='missense_variant', 27 synonyms, mapped to chr19:44908684 (GRCh38), and is classified as a missense_variant affecting APOE.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "variant_id": {
-                    "type": "string",
-                    "description": "dbSNP rsID of the variant. Examples: 'rs429358' (APOE), 'rs7903146' (TCF7L2), 'rs1042779'."
+    "fields": {
+      "endpoint": "population_frequencies"
+    },
+    "type": "EnsemblVariationExtTool",
+    "test_examples": [
+      {
+        "variant_id": "rs429358"
+      },
+      {
+        "variant_id": "rs7903146",
+        "species": "human"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "variant_id": {
+              "type": "string"
+            },
+            "most_severe_consequence": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "location": {
+              "type": "object",
+              "properties": {
+                "chromosome": {
+                  "type": "string"
                 },
-                "species": {
-                    "type": "string",
-                    "description": "Species name. Default 'human'. Examples: 'human', 'homo_sapiens'."
+                "start": {
+                  "type": "integer"
+                },
+                "allele_string": {
+                  "type": "string"
+                },
+                "assembly": {
+                  "type": "string"
                 }
+              }
             },
-            "required": ["variant_id"]
-        },
-        "fields": {
-            "endpoint": "variant_detail"
-        },
-        "type": "EnsemblVariationExtTool",
-        "test_examples": [
-            {
-                "variant_id": "rs429358"
-            },
-            {
-                "variant_id": "rs7903146"
+            "populations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "population": {
+                    "type": "string",
+                    "description": "Population name (e.g., gnomADe:ALL, 1000GENOMES:phase_3:CEU)"
+                  },
+                  "allele": {
+                    "type": "string",
+                    "description": "Allele base(s)"
+                  },
+                  "frequency": {
+                    "type": "number",
+                    "description": "Allele frequency (0-1)"
+                  },
+                  "allele_count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "description": "Allele frequency data across global populations"
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                                "source": {"type": ["string", "null"]},
-                                "most_severe_consequence": {"type": ["string", "null"]},
-                                "ancestral_allele": {"type": ["string", "null"]},
-                                "minor_allele": {"type": ["string", "null"]},
-                                "MAF": {"type": ["number", "null"]},
-                                "synonyms": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "Alternative variant identifiers"
-                                },
-                                "mappings": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "seq_region_name": {"type": "string"},
-                                            "start": {"type": "integer"},
-                                            "end": {"type": "integer"},
-                                            "allele_string": {"type": "string"},
-                                            "strand": {"type": "integer"},
-                                            "assembly_name": {"type": "string"}
-                                        }
-                                    }
-                                },
-                                "evidence": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "Evidence tags (e.g., 1000Genomes, gnomAD, Cited)"
-                                },
-                                "clinical_significance": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "Clinical significance annotations"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_synonyms": {"type": "integer"},
-                                "total_mappings": {"type": "integer"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "EnsemblVar_get_variant_consequences",
+    "description": "Get detailed variant information including consequence type, clinical significance, synonyms, evidence attributes, and allele mappings from Ensembl. More comprehensive than VEP - returns the full variant record with all known synonyms, mapped positions, ancestral allele, and minor allele data. Example: rs429358 returns most_severe_consequence='missense_variant', 27 synonyms, mapped to chr19:44908684 (GRCh38), and is classified as a missense_variant affecting APOE.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "variant_id": {
+          "type": "string",
+          "description": "dbSNP rsID of the variant. Examples: 'rs429358' (APOE), 'rs7903146' (TCF7L2), 'rs1042779'."
+        },
+        "species": {
+          "type": "string",
+          "description": "Species name. Default 'human'. Examples: 'human', 'homo_sapiens'."
+        }
+      },
+      "required": [
+        "variant_id"
+      ]
+    },
+    "fields": {
+      "endpoint": "variant_detail"
+    },
+    "type": "EnsemblVariationExtTool",
+    "test_examples": [
+      {
+        "variant_id": "rs429358"
+      },
+      {
+        "variant_id": "rs7903146"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "most_severe_consequence": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ancestral_allele": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "minor_allele": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "MAF": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Alternative variant identifiers"
+            },
+            "mappings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "seq_region_name": {
+                    "type": "string"
+                  },
+                  "start": {
+                    "type": "integer"
+                  },
+                  "end": {
+                    "type": "integer"
+                  },
+                  "allele_string": {
+                    "type": "string"
+                  },
+                  "strand": {
+                    "type": "integer"
+                  },
+                  "assembly_name": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "evidence": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Evidence tags (e.g., 1000Genomes, gnomAD, Cited)"
+            },
+            "clinical_significance": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Clinical significance annotations"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/ensembl_vep_tools.json
+++ b/src/tooluniverse/data/ensembl_vep_tools.json
@@ -37,185 +37,163 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "input": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Input variant identifier"
-                },
-                "assembly_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Reference genome assembly"
-                },
-                "seq_region_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Chromosome or contig"
-                },
-                "start": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Genomic start position"
-                },
-                "end": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Genomic end position"
-                },
-                "strand": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Strand (1 or -1)"
-                },
-                "allele_string": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Allele string (ref/alt)"
-                },
-                "most_severe_consequence": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Most severe consequence (e.g., missense_variant)"
-                },
-                "transcript_consequences": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "gene_symbol": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "gene_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "transcript_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "biotype": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "consequence_terms": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "impact": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "amino_acids": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "codons": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "sift_prediction": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "sift_score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "polyphen_prediction": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "polyphen_score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
+            "input": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Input variant identifier"
+            },
+            "assembly_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Reference genome assembly"
+            },
+            "seq_region_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Chromosome or contig"
+            },
+            "start": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Genomic start position"
+            },
+            "end": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Genomic end position"
+            },
+            "strand": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Strand (1 or -1)"
+            },
+            "allele_string": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Allele string (ref/alt)"
+            },
+            "most_severe_consequence": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Most severe consequence (e.g., missense_variant)"
+            },
+            "transcript_consequences": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "gene_symbol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "gene_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "transcript_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "biotype": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "consequence_terms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
-                  }
-                },
-                "colocated_variants": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "allele_string": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+                  },
+                  "impact": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "amino_acids": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "codons": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "sift_prediction": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "sift_score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "polyphen_prediction": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "polyphen_score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "input": {
-                  "type": "string"
+            "colocated_variants": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "allele_string": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -274,118 +252,96 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "input": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "assembly_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "seq_region_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "start": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "end": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "allele_string": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "most_severe_consequence": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "transcript_consequences": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "gene_symbol": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "consequence_terms": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "impact": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "amino_acids": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "sift_prediction": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "polyphen_prediction": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
+            "input": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "assembly_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "seq_region_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "start": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "end": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "allele_string": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "most_severe_consequence": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "transcript_consequences": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "gene_symbol": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "consequence_terms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "impact": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "amino_acids": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "sift_prediction": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "polyphen_prediction": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
-                },
-                "colocated_variants": {
-                  "type": "array"
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "input": {
-                  "type": "string"
-                }
-              }
+            "colocated_variants": {
+              "type": "array"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -436,80 +392,55 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "allele": {
-                    "type": "string",
-                    "description": "Alternative allele"
-                  },
-                  "input": {
-                    "type": "string",
-                    "description": "Original input variant ID"
-                  },
-                  "id": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Known variant IDs (rsIDs, COSMIC, etc.)"
-                  },
-                  "hgvsg": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "HGVS genomic notation(s)"
-                  },
-                  "hgvsc": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "HGVS coding notation(s) for each transcript"
-                  },
-                  "hgvsp": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "HGVS protein notation(s)"
-                  },
-                  "spdi": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "SPDI notation(s)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "allele": {
+                "type": "string",
+                "description": "Alternative allele"
+              },
+              "input": {
+                "type": "string",
+                "description": "Original input variant ID"
+              },
+              "id": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 },
-                "species": {
+                "description": "Known variant IDs (rsIDs, COSMIC, etc.)"
+              },
+              "hgvsg": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 },
-                "input": {
+                "description": "HGVS genomic notation(s)"
+              },
+              "hgvsc": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 },
-                "num_alleles": {
-                  "type": "integer"
-                }
+                "description": "HGVS coding notation(s) for each transcript"
+              },
+              "hgvsp": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "HGVS protein notation(s)"
+              },
+              "spdi": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "SPDI notation(s)"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ensembl_xrefs_tools.json
+++ b/src/tooluniverse/data/ensembl_xrefs_tools.json
@@ -1,160 +1,187 @@
 [
-    {
-        "name": "Ensembl_get_cross_references",
-        "description": "Get all external database cross-references for an Ensembl stable identifier. Returns linked records from HGNC, EntrezGene, UniProt, GeneCards, Reactome, MIM/OMIM, ArrayExpress, and other databases. Essential for mapping between Ensembl and other identifier systems, discovering related database entries, or building cross-database links for a gene. Can filter by specific external database. Example: 'ENSG00000141510' (TP53) returns 157 cross-references across 11 databases including HGNC:11998, EntrezGene:7157, GeneCards:TP53, MIM_GENE:191170, and Reactome pathways.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "ensembl_id": {
-                    "type": "string",
-                    "description": "Ensembl stable identifier. Can be gene (ENSG*), transcript (ENST*), or translation (ENSP*). Examples: 'ENSG00000141510' (TP53 gene), 'ENST00000269305' (TP53 canonical transcript)."
-                },
-                "external_db": {
-                    "type": ["string", "null"],
-                    "description": "Optional: filter by external database name. Examples: 'HGNC', 'EntrezGene', 'Uniprot_gn', 'MIM_GENE', 'Reactome_gene', 'GeneCards'. If not specified, returns all cross-references."
-                }
-            },
-            "required": ["ensembl_id"]
+  {
+    "name": "Ensembl_get_cross_references",
+    "description": "Get all external database cross-references for an Ensembl stable identifier. Returns linked records from HGNC, EntrezGene, UniProt, GeneCards, Reactome, MIM/OMIM, ArrayExpress, and other databases. Essential for mapping between Ensembl and other identifier systems, discovering related database entries, or building cross-database links for a gene. Can filter by specific external database. Example: 'ENSG00000141510' (TP53) returns 157 cross-references across 11 databases including HGNC:11998, EntrezGene:7157, GeneCards:TP53, MIM_GENE:191170, and Reactome pathways.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "ensembl_id": {
+          "type": "string",
+          "description": "Ensembl stable identifier. Can be gene (ENSG*), transcript (ENST*), or translation (ENSP*). Examples: 'ENSG00000141510' (TP53 gene), 'ENST00000269305' (TP53 canonical transcript)."
         },
-        "fields": {
-            "endpoint": "xrefs_by_id"
-        },
-        "type": "EnsemblXrefsTool",
-        "test_examples": [
-            {
-                "ensembl_id": "ENSG00000141510"
-            },
-            {
-                "ensembl_id": "ENSG00000141510",
-                "external_db": "HGNC"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "ensembl_id": {"type": "string"},
-                                "xrefs": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "dbname": {"type": "string"},
-                                            "db_display_name": {"type": ["string", "null"]},
-                                            "primary_id": {"type": "string"},
-                                            "display_id": {"type": "string"},
-                                            "description": {"type": ["string", "null"]},
-                                            "info_type": {"type": ["string", "null"]},
-                                            "synonyms": {"type": "array", "items": {"type": "string"}}
-                                        }
-                                    }
-                                },
-                                "database_summary": {
-                                    "type": "object",
-                                    "description": "Count of xrefs per database"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_xrefs": {"type": "integer"},
-                                "databases_found": {"type": "integer"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+        "external_db": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional: filter by external database name. Examples: 'HGNC', 'EntrezGene', 'Uniprot_gn', 'MIM_GENE', 'Reactome_gene', 'GeneCards'. If not specified, returns all cross-references."
         }
+      },
+      "required": [
+        "ensembl_id"
+      ]
     },
-    {
-        "name": "Ensembl_lookup_gene_by_symbol",
-        "description": "Look up Ensembl gene IDs for a gene symbol across external databases. Given a gene symbol (e.g., 'TP53'), returns all matching Ensembl gene and transcript IDs. Useful for converting gene symbols to Ensembl stable identifiers for use with other Ensembl APIs. Example: symbol 'TP53' in human returns ENSG00000141510 (gene) and related transcript/translation IDs; 'BRCA1' returns ENSG00000012048.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "symbol": {
-                    "type": "string",
-                    "description": "Gene symbol to look up. Examples: 'TP53', 'BRCA1', 'EGFR', 'BRAF', 'KRAS'."
-                },
-                "species": {
-                    "type": "string",
-                    "description": "Species name. Default: 'human'. Examples: 'human', 'mouse', 'rat', 'zebrafish'."
-                },
-                "external_db": {
-                    "type": ["string", "null"],
-                    "description": "Optional: filter by external database. Examples: 'HGNC', 'EntrezGene'."
+    "fields": {
+      "endpoint": "xrefs_by_id"
+    },
+    "type": "EnsemblXrefsTool",
+    "test_examples": [
+      {
+        "ensembl_id": "ENSG00000141510"
+      },
+      {
+        "ensembl_id": "ENSG00000141510",
+        "external_db": "HGNC"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ensembl_id": {
+              "type": "string"
+            },
+            "xrefs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "dbname": {
+                    "type": "string"
+                  },
+                  "db_display_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "primary_id": {
+                    "type": "string"
+                  },
+                  "display_id": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "info_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "synonyms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
                 }
+              }
             },
-            "required": ["symbol"]
-        },
-        "fields": {
-            "endpoint": "xrefs_by_symbol"
-        },
-        "type": "EnsemblXrefsTool",
-        "test_examples": [
-            {
-                "symbol": "TP53",
-                "species": "human"
-            },
-            {
-                "symbol": "BRCA1",
-                "species": "human"
+            "database_summary": {
+              "type": "object",
+              "description": "Count of xrefs per database"
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "symbol": {"type": "string"},
-                                "species": {"type": "string"},
-                                "ensembl_ids": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {"type": "string"},
-                                            "type": {"type": "string"}
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_results": {"type": "integer"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "Ensembl_lookup_gene_by_symbol",
+    "description": "Look up Ensembl gene IDs for a gene symbol across external databases. Given a gene symbol (e.g., 'TP53'), returns all matching Ensembl gene and transcript IDs. Useful for converting gene symbols to Ensembl stable identifiers for use with other Ensembl APIs. Example: symbol 'TP53' in human returns ENSG00000141510 (gene) and related transcript/translation IDs; 'BRCA1' returns ENSG00000012048.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "description": "Gene symbol to look up. Examples: 'TP53', 'BRCA1', 'EGFR', 'BRAF', 'KRAS'."
+        },
+        "species": {
+          "type": "string",
+          "description": "Species name. Default: 'human'. Examples: 'human', 'mouse', 'rat', 'zebrafish'."
+        },
+        "external_db": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional: filter by external database. Examples: 'HGNC', 'EntrezGene'."
+        }
+      },
+      "required": [
+        "symbol"
+      ]
+    },
+    "fields": {
+      "endpoint": "xrefs_by_symbol"
+    },
+    "type": "EnsemblXrefsTool",
+    "test_examples": [
+      {
+        "symbol": "TP53",
+        "species": "human"
+      },
+      {
+        "symbol": "BRCA1",
+        "species": "human"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "symbol": {
+              "type": "string"
+            },
+            "species": {
+              "type": "string"
+            },
+            "ensembl_ids": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/eol_tools.json
+++ b/src/tooluniverse/data/eol_tools.json
@@ -44,59 +44,31 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "page_id": {
-                    "type": "integer",
-                    "description": "EOL page ID for detailed lookup"
-                  },
-                  "title": {
-                    "type": "string",
-                    "description": "Scientific name of the taxon"
-                  },
-                  "link": {
-                    "type": "string",
-                    "description": "URL to the EOL page"
-                  },
-                  "content": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Name variants and synonyms"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "start_index": {
-                  "type": "integer"
-                },
-                "items_per_page": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "page_id": {
+                "type": "integer",
+                "description": "EOL page ID for detailed lookup"
+              },
+              "title": {
+                "type": "string",
+                "description": "Scientific name of the taxon"
+              },
+              "link": {
+                "type": "string",
+                "description": "URL to the EOL page"
+              },
+              "content": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Name variants and synonyms"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -195,163 +167,138 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "page_id": {
-                  "type": "integer",
-                  "description": "EOL page identifier"
-                },
-                "scientific_name": {
-                  "type": "string",
-                  "description": "Full scientific name with authority"
-                },
-                "richness_score": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "description": "Data richness score"
-                },
-                "common_names": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "language": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  },
-                  "description": "Vernacular names in various languages"
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
+            "page_id": {
+              "type": "integer",
+              "description": "EOL page identifier"
+            },
+            "scientific_name": {
+              "type": "string",
+              "description": "Full scientific name with authority"
+            },
+            "richness_score": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Data richness score"
+            },
+            "common_names": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
                     "type": "string"
                   },
-                  "description": "Taxonomic synonyms"
-                },
-                "images": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "media_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "thumbnail_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "rights_holder": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "license": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  },
-                  "description": "Image data objects with URLs"
-                },
-                "descriptions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "text": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "source": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "license": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  },
-                  "description": "Text descriptions from various sources"
-                },
-                "classifications": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "hierarchy_entry_id": {
-                        "type": "integer",
-                        "description": "ID for EOL_get_hierarchy_entry"
-                      },
-                      "source": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "rank": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  },
-                  "description": "Available taxonomy classifications (NCBI, GBIF, etc.)"
+                  "language": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
-              }
+              },
+              "description": "Vernacular names in various languages"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "num_common_names": {
-                  "type": "integer"
-                },
-                "num_synonyms": {
-                  "type": "integer"
-                },
-                "num_classifications": {
-                  "type": "integer"
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Taxonomic synonyms"
+            },
+            "images": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "media_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "thumbnail_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rights_holder": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "license": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
-              }
+              },
+              "description": "Image data objects with URLs"
+            },
+            "descriptions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "license": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "description": "Text descriptions from various sources"
+            },
+            "classifications": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "hierarchy_entry_id": {
+                    "type": "integer",
+                    "description": "ID for EOL_get_hierarchy_entry"
+                  },
+                  "source": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rank": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "description": "Available taxonomy classifications (NCBI, GBIF, etc.)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -415,159 +362,137 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "taxon_id": {
-                  "type": "integer",
-                  "description": "Hierarchy entry taxon ID"
-                },
-                "scientific_name": {
-                  "type": "string",
-                  "description": "Scientific name"
-                },
-                "rank": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Taxonomic rank (species, genus, etc.)"
-                },
-                "page_id": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Corresponding EOL page ID"
-                },
-                "source": {
-                  "type": "array",
-                  "items": {
+            "taxon_id": {
+              "type": "integer",
+              "description": "Hierarchy entry taxon ID"
+            },
+            "scientific_name": {
+              "type": "string",
+              "description": "Scientific name"
+            },
+            "rank": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Taxonomic rank (species, genus, etc.)"
+            },
+            "page_id": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Corresponding EOL page ID"
+            },
+            "source": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Classification source (NCBI, GBIF, etc.)"
+            },
+            "source_identifier": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Original identifier in source database"
+            },
+            "ancestors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "taxon_id": {
+                    "type": "integer"
+                  },
+                  "scientific_name": {
                     "type": "string"
                   },
-                  "description": "Classification source (NCBI, GBIF, etc.)"
-                },
-                "source_identifier": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Original identifier in source database"
-                },
-                "ancestors": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "taxon_id": {
-                        "type": "integer"
-                      },
-                      "scientific_name": {
-                        "type": "string"
-                      },
-                      "rank": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "page_id": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "source_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+                  "rank": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
-                  "description": "Full taxonomic lineage from root to parent"
-                },
-                "children": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "taxon_id": {
-                        "type": "integer"
-                      },
-                      "scientific_name": {
-                        "type": "string"
-                      },
-                      "rank": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "page_id": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+                  "page_id": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   },
-                  "description": "Direct child taxa"
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "scientific_name": {
-                        "type": "string"
-                      },
-                      "taxonomic_status": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+                  "source_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
-                },
-                "vernacular_names": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "vernacularName": {
-                        "type": "string"
-                      },
-                      "language": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+                }
+              },
+              "description": "Full taxonomic lineage from root to parent"
+            },
+            "children": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "taxon_id": {
+                    "type": "integer"
+                  },
+                  "scientific_name": {
+                    "type": "string"
+                  },
+                  "rank": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "page_id": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "description": "Direct child taxa"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "scientific_name": {
+                    "type": "string"
+                  },
+                  "taxonomic_status": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "num_ancestors": {
-                  "type": "integer"
-                },
-                "num_children": {
-                  "type": "integer"
+            "vernacular_names": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "vernacularName": {
+                    "type": "string"
+                  },
+                  "language": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -649,95 +574,73 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "description": "Collection name"
-                },
-                "description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Collection description"
-                },
-                "total_items": {
-                  "type": "integer",
-                  "description": "Total number of items in collection"
-                },
-                "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "object_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "object_id": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "title": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "annotation": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  },
-                  "description": "Collection member items"
-                },
-                "created": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "modified": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
+            "name": {
+              "type": "string",
+              "description": "Collection name"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "collection_id": {
-                  "type": "integer"
-                },
-                "page": {
-                  "type": "integer"
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Collection description"
+            },
+            "total_items": {
+              "type": "integer",
+              "description": "Total number of items in collection"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "object_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "object_id": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "title": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "annotation": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
-              }
+              },
+              "description": "Collection member items"
+            },
+            "created": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "modified": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/epigenomics_tools.json
+++ b/src/tooluniverse/data/epigenomics_tools.json
@@ -199,44 +199,33 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total": {
-                  "type": "integer"
-                },
-                "experiments": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "assay_title": {
-                        "type": "string"
-                      },
-                      "biosample_summary": {
-                        "type": "string"
-                      },
-                      "status": {
-                        "type": "string"
-                      },
-                      "lab": {
-                        "type": "string"
-                      }
-                    }
+            "total": {
+              "type": "integer"
+            },
+            "experiments": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "assay_title": {
+                    "type": "string"
+                  },
+                  "biosample_summary": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "lab": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -322,44 +311,33 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total": {
-                  "type": "integer"
-                },
-                "experiments": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "assay_title": {
-                        "type": "string"
-                      },
-                      "biosample_summary": {
-                        "type": "string"
-                      },
-                      "status": {
-                        "type": "string"
-                      },
-                      "lab": {
-                        "type": "string"
-                      }
-                    }
+            "total": {
+              "type": "integer"
+            },
+            "experiments": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "assay_title": {
+                    "type": "string"
+                  },
+                  "biosample_summary": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "lab": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -452,50 +430,39 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total": {
-                  "type": "integer"
-                },
-                "annotations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "annotation_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "biosample_summary": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "status": {
-                        "type": "string"
-                      }
-                    }
+            "total": {
+              "type": "integer"
+            },
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "annotation_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "biosample_summary": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "status": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -580,65 +547,54 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "genome": {
-                  "type": "string"
-                },
-                "region": {
-                  "type": "string"
-                },
-                "cpg_island_count": {
-                  "type": "integer"
-                },
-                "cpg_islands": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "chrom": {
-                        "type": "string"
-                      },
-                      "chromStart": {
-                        "type": "integer"
-                      },
-                      "chromEnd": {
-                        "type": "integer"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "length": {
-                        "type": "integer"
-                      },
-                      "cpgNum": {
-                        "type": "integer"
-                      },
-                      "gcNum": {
-                        "type": "integer"
-                      },
-                      "perCpg": {
-                        "type": "number"
-                      },
-                      "perGc": {
-                        "type": "number"
-                      },
-                      "obsExp": {
-                        "type": "number"
-                      }
-                    }
+            "genome": {
+              "type": "string"
+            },
+            "region": {
+              "type": "string"
+            },
+            "cpg_island_count": {
+              "type": "integer"
+            },
+            "cpg_islands": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "chrom": {
+                    "type": "string"
+                  },
+                  "chromStart": {
+                    "type": "integer"
+                  },
+                  "chromEnd": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "length": {
+                    "type": "integer"
+                  },
+                  "cpgNum": {
+                    "type": "integer"
+                  },
+                  "gcNum": {
+                    "type": "integer"
+                  },
+                  "perCpg": {
+                    "type": "number"
+                  },
+                  "perGc": {
+                    "type": "number"
+                  },
+                  "obsExp": {
+                    "type": "number"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -725,62 +681,51 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "genome": {
-                  "type": "string"
-                },
-                "region": {
-                  "type": "string"
-                },
-                "ccre_count": {
-                  "type": "integer"
-                },
-                "ccres": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "chrom": {
-                        "type": "string"
-                      },
-                      "chromStart": {
-                        "type": "integer"
-                      },
-                      "chromEnd": {
-                        "type": "integer"
-                      },
-                      "cCRE_class": {
-                        "type": "string"
-                      },
-                      "DNase_maxZ": {
-                        "type": "number"
-                      },
-                      "H3K4me3_maxZ": {
-                        "type": "number"
-                      },
-                      "H3K27ac_maxZ": {
-                        "type": "number"
-                      },
-                      "CTCF_maxZ": {
-                        "type": "number"
-                      }
-                    }
+            "genome": {
+              "type": "string"
+            },
+            "region": {
+              "type": "string"
+            },
+            "ccre_count": {
+              "type": "integer"
+            },
+            "ccres": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "chrom": {
+                    "type": "string"
+                  },
+                  "chromStart": {
+                    "type": "integer"
+                  },
+                  "chromEnd": {
+                    "type": "integer"
+                  },
+                  "cCRE_class": {
+                    "type": "string"
+                  },
+                  "DNase_maxZ": {
+                    "type": "number"
+                  },
+                  "H3K4me3_maxZ": {
+                    "type": "number"
+                  },
+                  "H3K27ac_maxZ": {
+                    "type": "number"
+                  },
+                  "CTCF_maxZ": {
+                    "type": "number"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -870,53 +815,42 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "genome": {
-                  "type": "string"
-                },
-                "region": {
-                  "type": "string"
-                },
-                "tf_cluster_count": {
-                  "type": "integer"
-                },
-                "tf_clusters": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "chrom": {
-                        "type": "string"
-                      },
-                      "chromStart": {
-                        "type": "integer"
-                      },
-                      "chromEnd": {
-                        "type": "integer"
-                      },
-                      "score": {
-                        "type": "integer"
-                      },
-                      "sourceCount": {
-                        "type": "integer"
-                      }
-                    }
+            "genome": {
+              "type": "string"
+            },
+            "region": {
+              "type": "string"
+            },
+            "tf_cluster_count": {
+              "type": "integer"
+            },
+            "tf_clusters": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "chrom": {
+                    "type": "string"
+                  },
+                  "chromStart": {
+                    "type": "integer"
+                  },
+                  "chromEnd": {
+                    "type": "integer"
+                  },
+                  "score": {
+                    "type": "integer"
+                  },
+                  "sourceCount": {
+                    "type": "integer"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1001,56 +935,45 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total": {
-                  "type": "integer"
-                },
-                "datasets": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "summary": {
-                        "type": "string"
-                      },
-                      "platform": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "organism": {
-                        "type": "string"
-                      },
-                      "n_samples": {
-                        "type": "integer"
-                      },
-                      "date_published": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "total": {
+              "type": "integer"
+            },
+            "datasets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "summary": {
+                    "type": "string"
+                  },
+                  "platform": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "organism": {
+                    "type": "string"
+                  },
+                  "n_samples": {
+                    "type": "integer"
+                  },
+                  "date_published": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1132,50 +1055,39 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total": {
-                  "type": "integer"
-                },
-                "datasets": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "title": {
-                        "type": "string"
-                      },
-                      "summary": {
-                        "type": "string"
-                      },
-                      "organism": {
-                        "type": "string"
-                      },
-                      "n_samples": {
-                        "type": "integer"
-                      },
-                      "date_published": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "total": {
+              "type": "integer"
+            },
+            "datasets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "summary": {
+                    "type": "string"
+                  },
+                  "organism": {
+                    "type": "string"
+                  },
+                  "n_samples": {
+                    "type": "integer"
+                  },
+                  "date_published": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1243,57 +1155,46 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": "string"
-                },
-                "summary": {
-                  "type": "string"
-                },
-                "experiment_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "platform": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "organism": {
-                  "type": "string"
-                },
-                "n_samples": {
-                  "type": "integer"
-                },
-                "date_published": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "supplementary_data": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                }
-              }
+            "accession": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object"
+            "title": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "experiment_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "platform": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organism": {
+              "type": "string"
+            },
+            "n_samples": {
+              "type": "integer"
+            },
+            "date_published": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "supplementary_data": {
+              "type": [
+                "array",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1373,56 +1274,45 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "species": {
-                  "type": "string"
-                },
-                "region": {
-                  "type": "string"
-                },
-                "feature_count": {
-                  "type": "integer"
-                },
-                "regulatory_features": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "feature_type": {
-                        "type": "string"
-                      },
-                      "start": {
-                        "type": "integer"
-                      },
-                      "end": {
-                        "type": "integer"
-                      },
-                      "strand": {
-                        "type": "integer"
-                      },
-                      "seq_region_name": {
-                        "type": "string"
-                      }
-                    }
+            "species": {
+              "type": "string"
+            },
+            "region": {
+              "type": "string"
+            },
+            "feature_count": {
+              "type": "integer"
+            },
+            "regulatory_features": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "feature_type": {
+                    "type": "string"
+                  },
+                  "start": {
+                    "type": "integer"
+                  },
+                  "end": {
+                    "type": "integer"
+                  },
+                  "strand": {
+                    "type": "integer"
+                  },
+                  "seq_region_name": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1508,50 +1398,39 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total": {
-                  "type": "integer"
-                },
-                "annotations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": "string"
-                      },
-                      "annotation_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "biosample_summary": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "status": {
-                        "type": "string"
-                      }
-                    }
+            "total": {
+              "type": "integer"
+            },
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "annotation_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "biosample_summary": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "status": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/esm2_variant_effect_tools.json
+++ b/src/tooluniverse/data/esm2_variant_effect_tools.json
@@ -5,7 +5,11 @@
     "description": "Score a missense protein variant with ESM-2 masked-marginal log-likelihood ratio (Meier 2021) over HuggingFace's keyless hf-inference. Input wild-type 1-letter sequence + 1-based position + mutant residue; returns LLR = logP(mut) - logP(wt). Negative => mutant disfavored (candidate deleterious). No API key. For ESMC/SAE scoring with a key use ESM_score_sequence.",
     "parameter": {
       "type": "object",
-      "required": ["sequence", "position", "mutant"],
+      "required": [
+        "sequence",
+        "position",
+        "mutant"
+      ],
       "properties": {
         "sequence": {
           "type": "string",
@@ -20,15 +24,24 @@
           "description": "Mutant amino acid (single 1-letter code, one of the 20 standard residues)."
         },
         "wild_type": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional wild-type residue (1-letter). If given, it is validated against the residue at `position` to catch coordinate/sequence mismatches."
         },
         "model_id": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "ESM-2 model to use. Default 'facebook/esm2_t33_650M_UR50D'. Other sizes: esm2_t30_150M_UR50D, esm2_t12_35M_UR50D, esm2_t6_8M_UR50D."
         },
         "wait_for_model": {
-          "type": ["boolean", "null"],
+          "type": [
+            "boolean",
+            "null"
+          ],
           "description": "If true, block until the model finishes loading on the HF servers instead of returning a retryable 'loading' status."
         }
       }
@@ -38,29 +51,42 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "variant": {"type": "string"},
-                "wild_type": {"type": "string"},
-                "mutant": {"type": "string"},
-                "p_wild_type": {"type": "number"},
-                "p_mutant": {"type": "number"},
-                "log_likelihood_ratio": {"type": "number"},
-                "direction": {"type": "string"}
-              }
+            "variant": {
+              "type": "string"
+            },
+            "wild_type": {
+              "type": "string"
+            },
+            "mutant": {
+              "type": "string"
+            },
+            "p_wild_type": {
+              "type": "number"
+            },
+            "p_mutant": {
+              "type": "number"
+            },
+            "log_likelihood_ratio": {
+              "type": "number"
+            },
+            "direction": {
+              "type": "string"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"const": "error"},
-            "error": {"type": "string"}
+            "status": {
+              "const": "error"
+            },
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },

--- a/src/tooluniverse/data/evo2_variant_effect_tools.json
+++ b/src/tooluniverse/data/evo2_variant_effect_tools.json
@@ -31,22 +31,15 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "delta_loglik": {"type": "number"},
-                "ref_loglik": {"type": "number"},
-                "alt_loglik": {"type": "number"},
-                "direction": {"type": "string"}
-              }
-            }
-          },
-          "required": ["data"]
+            "delta_loglik": {"type": "number"},
+            "ref_loglik": {"type": "number"},
+            "alt_loglik": {"type": "number"},
+            "direction": {"type": "string"}
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
+          "properties": {"error": {"type": "string"}},
           "required": ["error"]
         }
       ]

--- a/src/tooluniverse/data/executed_notebook_tools.json
+++ b/src/tooluniverse/data/executed_notebook_tools.json
@@ -39,75 +39,60 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "notebook_path": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "notebook_path": {
-                  "type": "string"
-                },
-                "total_cells": {
-                  "type": "integer"
-                },
-                "cells": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "idx": {
-                        "type": "integer"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "source": {
-                        "type": "string"
-                      },
-                      "output": {
-                        "type": "string"
-                      }
-                    }
+            "total_cells": {
+              "type": "integer"
+            },
+            "cells": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "idx": {
+                    "type": "integer"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "output": {
+                    "type": "string"
                   }
-                },
-                "search": {
-                  "type": "string"
-                },
-                "matching_cells": {
-                  "type": "array"
-                },
-                "n_matches": {
-                  "type": "integer"
                 }
-              },
-              "required": [
-                "notebook_path",
-                "total_cells",
-                "cells"
-              ]
+              }
+            },
+            "search": {
+              "type": "string"
+            },
+            "matching_cells": {
+              "type": "array"
+            },
+            "n_matches": {
+              "type": "integer"
             }
           },
           "required": [
-            "status",
-            "data"
+            "notebook_path",
+            "total_cells",
+            "cells"
           ]
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }

--- a/src/tooluniverse/data/finemap_abf_tools.json
+++ b/src/tooluniverse/data/finemap_abf_tools.json
@@ -5,13 +5,49 @@
     "description": "Single-causal-variant fine-mapping from GWAS/QTL summary statistics (per-SNP effect size + SE over a region). Computes each SNP's posterior inclusion probability (PIP) via Wakefield approximate Bayes factors and the 95% credible set (smallest SNP set capturing the causal variant). LD-free (assumes one causal signal); pure-compute, no R. For multi-signal loci use SuSiE/FINEMAP with LD.",
     "parameter": {
       "type": "object",
-      "required": ["beta", "se"],
+      "required": [
+        "beta",
+        "se"
+      ],
       "properties": {
-        "beta": {"type": "array", "items": {"type": "number"}, "description": "Per-SNP effect sizes over the region."},
-        "se": {"type": "array", "items": {"type": "number"}, "description": "Standard errors of beta (positive)."},
-        "snp": {"type": ["array", "null"], "items": {"type": "string"}, "description": "Optional SNP identifiers (same order) to label PIPs and the credible set."},
-        "coverage": {"type": ["number", "null"], "description": "Credible-set coverage in (0,1] (default 0.95)."},
-        "sd_prior": {"type": ["number", "null"], "description": "Prior SD of the effect size (default 0.15)."}
+        "beta": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-SNP effect sizes over the region."
+        },
+        "se": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Standard errors of beta (positive)."
+        },
+        "snp": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional SNP identifiers (same order) to label PIPs and the credible set."
+        },
+        "coverage": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Credible-set coverage in (0,1] (default 0.95)."
+        },
+        "sd_prior": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Prior SD of the effect size (default 0.15)."
+        }
       }
     },
     "return_schema": {
@@ -19,34 +55,74 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_snps": {"type": "integer"},
-                "top_snp": {"type": "string"},
-                "top_pip": {"type": "number"},
-                "credible_set": {"type": "array", "items": {"type": "object"}},
-                "credible_set_size": {"type": "integer"},
-                "credible_set_coverage": {"type": "number"},
-                "pip": {"type": "object"}
+            "n_snps": {
+              "type": "integer"
+            },
+            "top_snp": {
+              "type": "string"
+            },
+            "top_pip": {
+              "type": "number"
+            },
+            "credible_set": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
+            },
+            "credible_set_size": {
+              "type": "integer"
+            },
+            "credible_set_coverage": {
+              "type": "number"
+            },
+            "pip": {
+              "type": "object"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "status": {
+              "const": "error"
+            },
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "beta": [0.02, 0.03, 0.25, 0.04, 0.02, 0.05],
-        "se": [0.02, 0.02, 0.02, 0.02, 0.02, 0.02],
-        "snp": ["rs1", "rs2", "rs3", "rs4", "rs5", "rs6"]
+        "beta": [
+          0.02,
+          0.03,
+          0.25,
+          0.04,
+          0.02,
+          0.05
+        ],
+        "se": [
+          0.02,
+          0.02,
+          0.02,
+          0.02,
+          0.02,
+          0.02
+        ],
+        "snp": [
+          "rs1",
+          "rs2",
+          "rs3",
+          "rs4",
+          "rs5",
+          "rs6"
+        ]
       }
     ]
   }

--- a/src/tooluniverse/data/flybase_tools.json
+++ b/src/tooluniverse/data/flybase_tools.json
@@ -31,158 +31,133 @@
         {
           "type": "object",
           "properties": {
-            "data": {
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "symbol": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "species": {
               "type": "object",
               "properties": {
-                "id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "symbol": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
                 "name": {
                   "type": [
                     "string",
                     "null"
                   ]
                 },
-                "species": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "short_name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "taxon_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "data_provider": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
-                },
-                "gene_synopsis": {
+                "short_name": {
                   "type": [
                     "string",
                     "null"
                   ]
                 },
-                "automated_gene_synopsis": {
+                "taxon_id": {
                   "type": [
                     "string",
                     "null"
                   ]
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "so_term": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "genomic_location": {
-                  "type": "object",
-                  "properties": {
-                    "chromosome": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "start": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "end": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "assembly": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "strand": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
-                },
-                "cross_references": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_gene_id": {
-                  "type": "string"
                 },
                 "data_provider": {
                   "type": [
                     "string",
                     "null"
                   ]
+                }
+              }
+            },
+            "gene_synopsis": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "automated_gene_synopsis": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "so_term": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "genomic_location": {
+              "type": "object",
+              "properties": {
+                "chromosome": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "source": {
-                  "type": "string"
+                "start": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "end": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "assembly": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "strand": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "cross_references": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -242,100 +217,69 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "subject_gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "subject_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "subject_species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ortholog_gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ortholog_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ortholog_species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "is_best_score": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "is_best_score_reverse": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "methods": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "method_count": {
-                    "type": "integer"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "stringency": {
-                  "type": "string"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "source": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "subject_gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subject_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subject_species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ortholog_gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ortholog_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ortholog_species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_best_score": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_best_score_reverse": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "methods": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 }
+              },
+              "method_count": {
+                "type": "integer"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -391,108 +335,80 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "symbol_text": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "category": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "has_disease": {
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "has_phenotype": {
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "variants": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "name": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "type": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "location": {
-                          "type": [
-                            "object",
-                            "null"
-                          ]
-                        }
-                      }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "symbol_text": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "category": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "has_disease": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "has_phenotype": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "variants": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "location": {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "source": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -543,67 +459,45 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
+            "total_annotations": {
+              "type": "integer"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_annotations": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "annotations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "stage": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "location": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "data_provider": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "reference": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "returned": {
+              "type": "integer"
+            },
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "stage": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "data_provider": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "reference": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -668,79 +562,48 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "subject_gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "subject_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "interactor_gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "interactor_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "interactor_species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "interaction_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "interaction_type": {
-                  "type": "string"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "source": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "subject_gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subject_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interactor_gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interactor_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interactor_species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interaction_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -796,96 +659,68 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "model_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "model_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "data_provider": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "diseases": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "disease_name": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "disease_id": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "association_type": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        }
-                      }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "model_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "model_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "data_provider": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "diseases": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "disease_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "disease_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "association_type": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "source": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/genome_nexus_tools.json
+++ b/src/tooluniverse/data/genome_nexus_tools.json
@@ -29,87 +29,75 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
+                        "variant": {"type": "string", "description": "HGVS genomic notation"},
+                        "hgvsg": {"type": "string", "description": "Standardized HGVS genomic notation"},
+                        "assembly_name": {"type": "string", "description": "Genome assembly (GRCh37)"},
+                        "most_severe_consequence": {"type": "string", "description": "Most severe consequence type (e.g., missense_variant)"},
+                        "annotation_summary": {
                             "type": "object",
                             "properties": {
-                                "variant": {"type": "string", "description": "HGVS genomic notation"},
-                                "hgvsg": {"type": "string", "description": "Standardized HGVS genomic notation"},
-                                "assembly_name": {"type": "string", "description": "Genome assembly (GRCh37)"},
-                                "most_severe_consequence": {"type": "string", "description": "Most severe consequence type (e.g., missense_variant)"},
-                                "annotation_summary": {
-                                    "type": "object",
-                                    "properties": {
-                                        "variantType": {"type": "string"},
-                                        "canonicalTranscriptId": {"type": "string"},
-                                        "transcriptConsequences": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "transcriptId": {"type": "string"},
-                                                    "hugoGeneSymbol": {"type": "string"},
-                                                    "hgvspShort": {"type": ["string", "null"]},
-                                                    "codonChange": {"type": ["string", "null"]},
-                                                    "consequenceTerms": {"type": "string"},
-                                                    "entrezGeneId": {"type": ["string", "null"]}
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "transcript_consequences": {
+                                "variantType": {"type": "string"},
+                                "canonicalTranscriptId": {"type": "string"},
+                                "transcriptConsequences": {
                                     "type": "array",
                                     "items": {
                                         "type": "object",
                                         "properties": {
-                                            "gene_symbol": {"type": "string"},
-                                            "transcript_id": {"type": "string"},
-                                            "consequence_terms": {"type": "array", "items": {"type": "string"}},
-                                            "hgvsp": {"type": ["string", "null"]},
-                                            "hgvsc": {"type": ["string", "null"]},
-                                            "amino_acids": {"type": ["string", "null"]},
-                                            "polyphen_prediction": {"type": ["string", "null"]},
-                                            "polyphen_score": {"type": ["number", "null"]},
-                                            "sift_prediction": {"type": ["string", "null"]},
-                                            "sift_score": {"type": ["number", "null"]},
-                                            "alphaMissense": {
-                                                "type": ["object", "null"],
-                                                "properties": {
-                                                    "score": {"type": "number"},
-                                                    "pathogenicity": {"type": "string"}
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "hotspots": {
-                                    "type": ["object", "null"],
-                                    "properties": {
-                                        "annotation": {
-                                            "type": "array",
-                                            "description": "Cancer mutation hotspot data"
-                                        }
-                                    }
-                                },
-                                "colocated_variants": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "dbSnpId": {"type": "string"}
+                                            "transcriptId": {"type": "string"},
+                                            "hugoGeneSymbol": {"type": "string"},
+                                            "hgvspShort": {"type": ["string", "null"]},
+                                            "codonChange": {"type": ["string", "null"]},
+                                            "consequenceTerms": {"type": "string"},
+                                            "entrezGeneId": {"type": ["string", "null"]}
                                         }
                                     }
                                 }
                             }
                         },
-                        "metadata": {
-                            "type": "object",
+                        "transcript_consequences": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "gene_symbol": {"type": "string"},
+                                    "transcript_id": {"type": "string"},
+                                    "consequence_terms": {"type": "array", "items": {"type": "string"}},
+                                    "hgvsp": {"type": ["string", "null"]},
+                                    "hgvsc": {"type": ["string", "null"]},
+                                    "amino_acids": {"type": ["string", "null"]},
+                                    "polyphen_prediction": {"type": ["string", "null"]},
+                                    "polyphen_score": {"type": ["number", "null"]},
+                                    "sift_prediction": {"type": ["string", "null"]},
+                                    "sift_score": {"type": ["number", "null"]},
+                                    "alphaMissense": {
+                                        "type": ["object", "null"],
+                                        "properties": {
+                                            "score": {"type": "number"},
+                                            "pathogenicity": {"type": "string"}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "hotspots": {
+                            "type": ["object", "null"],
                             "properties": {
-                                "source": {"type": "string"}
+                                "annotation": {
+                                    "type": "array",
+                                    "description": "Cancer mutation hotspot data"
+                                }
+                            }
+                        },
+                        "colocated_variants": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "dbSnpId": {"type": "string"}
+                                }
                             }
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -151,34 +139,22 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "variant": {"type": "string"},
-                                "gene_symbol": {"type": ["string", "null"]},
-                                "is_hotspot": {"type": "boolean"},
-                                "hotspots": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "hugoSymbol": {"type": "string"},
-                                            "residue": {"type": "string"},
-                                            "tumorCount": {"type": "integer"},
-                                            "type": {"type": "string", "description": "single residue or 3d"}
-                                        }
-                                    }
+                        "variant": {"type": "string"},
+                        "gene_symbol": {"type": ["string", "null"]},
+                        "is_hotspot": {"type": "boolean"},
+                        "hotspots": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "hugoSymbol": {"type": "string"},
+                                    "residue": {"type": "string"},
+                                    "tumorCount": {"type": "integer"},
+                                    "type": {"type": "string", "description": "single residue or 3d"}
                                 }
                             }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"}
-                            }
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -220,38 +196,26 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "transcriptId": {"type": "string", "description": "Ensembl transcript ID"},
-                                "geneId": {"type": "string", "description": "Ensembl gene ID"},
-                                "proteinId": {"type": "string", "description": "Ensembl protein ID"},
-                                "proteinLength": {"type": "integer"},
-                                "hugoSymbols": {"type": "array", "items": {"type": "string"}},
-                                "refseqMrnaId": {"type": ["string", "null"]},
-                                "ccdsId": {"type": ["string", "null"]},
-                                "pfamDomains": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "pfamDomainId": {"type": "string"},
-                                            "pfamDomainStart": {"type": "integer"},
-                                            "pfamDomainEnd": {"type": "integer"},
-                                            "pfamDomainDescription": {"type": ["string", "null"]}
-                                        }
-                                    }
+                        "transcriptId": {"type": "string", "description": "Ensembl transcript ID"},
+                        "geneId": {"type": "string", "description": "Ensembl gene ID"},
+                        "proteinId": {"type": "string", "description": "Ensembl protein ID"},
+                        "proteinLength": {"type": "integer"},
+                        "hugoSymbols": {"type": "array", "items": {"type": "string"}},
+                        "refseqMrnaId": {"type": ["string", "null"]},
+                        "ccdsId": {"type": ["string", "null"]},
+                        "pfamDomains": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "pfamDomainId": {"type": "string"},
+                                    "pfamDomainStart": {"type": "integer"},
+                                    "pfamDomainEnd": {"type": "integer"},
+                                    "pfamDomainDescription": {"type": ["string", "null"]}
                                 }
                             }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"}
-                            }
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -317,33 +281,21 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "variant": {"type": "string"},
-                                "hgvsg": {"type": "string"},
-                                "assembly_name": {"type": "string"},
-                                "most_severe_consequence": {"type": "string"},
-                                "annotation_summary": {"type": "object"},
-                                "transcript_consequences": {
-                                    "type": "array",
-                                    "items": {"type": "object"}
-                                },
-                                "hotspots": {"type": ["object", "null"]},
-                                "colocated_variants": {
-                                    "type": "array",
-                                    "items": {"type": "object"}
-                                }
-                            }
+                        "variant": {"type": "string"},
+                        "hgvsg": {"type": "string"},
+                        "assembly_name": {"type": "string"},
+                        "most_severe_consequence": {"type": "string"},
+                        "annotation_summary": {"type": "object"},
+                        "transcript_consequences": {
+                            "type": "array",
+                            "items": {"type": "object"}
                         },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"}
-                            }
+                        "hotspots": {"type": ["object", "null"]},
+                        "colocated_variants": {
+                            "type": "array",
+                            "items": {"type": "object"}
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -385,54 +337,42 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "variant": {"type": "string", "description": "dbSNP rsID that was queried"},
-                                "hgvsg": {"type": ["string", "null"]},
-                                "assembly_name": {"type": ["string", "null"]},
-                                "most_severe_consequence": {"type": ["string", "null"]},
-                                "annotation_summary": {"type": ["object", "null"]},
-                                "transcript_consequences": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
+                        "variant": {"type": "string", "description": "dbSNP rsID that was queried"},
+                        "hgvsg": {"type": ["string", "null"]},
+                        "assembly_name": {"type": ["string", "null"]},
+                        "most_severe_consequence": {"type": ["string", "null"]},
+                        "annotation_summary": {"type": ["object", "null"]},
+                        "transcript_consequences": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "gene_symbol": {"type": ["string", "null"]},
+                                    "transcript_id": {"type": ["string", "null"]},
+                                    "consequence_terms": {"type": "array", "items": {"type": "string"}},
+                                    "hgvsp": {"type": ["string", "null"]},
+                                    "hgvsc": {"type": ["string", "null"]},
+                                    "amino_acids": {"type": ["string", "null"]},
+                                    "polyphen_prediction": {"type": ["string", "null"]},
+                                    "polyphen_score": {"type": ["number", "null"]},
+                                    "sift_prediction": {"type": ["string", "null"]},
+                                    "sift_score": {"type": ["number", "null"]},
+                                    "alphaMissense": {
+                                        "type": ["object", "null"],
                                         "properties": {
-                                            "gene_symbol": {"type": ["string", "null"]},
-                                            "transcript_id": {"type": ["string", "null"]},
-                                            "consequence_terms": {"type": "array", "items": {"type": "string"}},
-                                            "hgvsp": {"type": ["string", "null"]},
-                                            "hgvsc": {"type": ["string", "null"]},
-                                            "amino_acids": {"type": ["string", "null"]},
-                                            "polyphen_prediction": {"type": ["string", "null"]},
-                                            "polyphen_score": {"type": ["number", "null"]},
-                                            "sift_prediction": {"type": ["string", "null"]},
-                                            "sift_score": {"type": ["number", "null"]},
-                                            "alphaMissense": {
-                                                "type": ["object", "null"],
-                                                "properties": {
-                                                    "score": {"type": "number"},
-                                                    "pathogenicity": {"type": "string"}
-                                                }
-                                            }
+                                            "score": {"type": "number"},
+                                            "pathogenicity": {"type": "string"}
                                         }
                                     }
-                                },
-                                "hotspots": {"type": ["object", "null"]},
-                                "colocated_variants": {
-                                    "type": "array",
-                                    "items": {"type": "object"}
                                 }
                             }
                         },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"}
-                            }
+                        "hotspots": {"type": ["object", "null"]},
+                        "colocated_variants": {
+                            "type": "array",
+                            "items": {"type": "object"}
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",

--- a/src/tooluniverse/data/geo_tools.json
+++ b/src/tooluniverse/data/geo_tools.json
@@ -83,7 +83,11 @@
       "Search"
     ],
     "metadata": {
-      "tags": ["expression", "microarray", "search"],
+      "tags": [
+        "expression",
+        "microarray",
+        "search"
+      ],
       "difficulty_level": "easy",
       "estimated_execution_time": "< 3 seconds"
     }
@@ -100,7 +104,9 @@
           "description": "GEO dataset ID (e.g., 'GDS1234', 'GSE12345')"
         }
       },
-      "required": ["dataset_id"]
+      "required": [
+        "dataset_id"
+      ]
     },
     "fields": {
       "endpoint": "/esummary.fcgi",
@@ -156,7 +162,11 @@
       "Information"
     ],
     "metadata": {
-      "tags": ["dataset", "metadata", "expression"],
+      "tags": [
+        "dataset",
+        "metadata",
+        "expression"
+      ],
       "difficulty_level": "easy",
       "estimated_execution_time": "< 3 seconds"
     }
@@ -173,7 +183,9 @@
           "description": "GEO dataset ID (e.g., 'GDS1234', 'GSE12345')"
         }
       },
-      "required": ["dataset_id"]
+      "required": [
+        "dataset_id"
+      ]
     },
     "fields": {
       "endpoint": "/esummary.fcgi",
@@ -221,7 +233,11 @@
       "Information"
     ],
     "metadata": {
-      "tags": ["sample", "characteristics", "expression"],
+      "tags": [
+        "sample",
+        "characteristics",
+        "expression"
+      ],
       "difficulty_level": "easy",
       "estimated_execution_time": "< 3 seconds"
     }
@@ -238,7 +254,9 @@
           "description": "GEO Series (GSE...) or Sample (GSM...) accession. Examples: 'GSE42657', 'GSE1000', 'GSM1045442'."
         }
       },
-      "required": ["accession"]
+      "required": [
+        "accession"
+      ]
     },
     "fields": {
       "mode": "supplementary_files"
@@ -261,54 +279,45 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "accession": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": "string"
-                },
-                "suppl_url": {
-                  "type": "string"
-                },
-                "files": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "kind": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "modified": {
-                        "type": "string"
-                      },
-                      "size": {
-                        "type": ["integer", "string"]
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "download_url": {
-                        "type": "string"
-                      }
-                    }
+            "suppl_url": {
+              "type": "string"
+            },
+            "files": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "modified": {
+                    "type": "string"
+                  },
+                  "size": {
+                    "type": [
+                      "integer",
+                      "string"
+                    ]
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "download_url": {
+                    "type": "string"
                   }
-                },
-                "file_count": {
-                  "type": "integer"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "file_count": {
+              "type": "integer"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
@@ -320,12 +329,19 @@
               "type": "string"
             }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "metadata": {
-      "tags": ["geo", "supplementary", "download", "raw-files"],
+      "tags": [
+        "geo",
+        "supplementary",
+        "download",
+        "raw-files"
+      ],
       "difficulty_level": "easy",
       "estimated_execution_time": "< 3 seconds"
     }

--- a/src/tooluniverse/data/glygen_tools.json
+++ b/src/tooluniverse/data/glygen_tools.json
@@ -32,74 +32,52 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "glytoucan_ac": {
-                  "type": "string",
-                  "description": "GlyTouCan accession ID"
-                },
-                "mass": {
-                  "type": "number",
-                  "description": "Molecular mass in Daltons"
-                },
-                "number_monosaccharides": {
-                  "type": "integer",
-                  "description": "Number of monosaccharide residues"
-                },
-                "glycan_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Glycan classification type"
-                },
-                "iupac": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "IUPAC condensed notation"
-                },
-                "wurcs": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "WURCS linear notation"
-                },
-                "species": {
-                  "type": "array",
-                  "description": "Species where glycan is found"
-                },
-                "glycoprotein_count": {
-                  "type": "integer",
-                  "description": "Number of associated glycoproteins"
-                },
-                "publication_count": {
-                  "type": "integer",
-                  "description": "Number of associated publications"
-                }
-              }
+            "glytoucan_ac": {
+              "type": "string",
+              "description": "GlyTouCan accession ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "mass": {
+              "type": "number",
+              "description": "Molecular mass in Daltons"
+            },
+            "number_monosaccharides": {
+              "type": "integer",
+              "description": "Number of monosaccharide residues"
+            },
+            "glycan_type": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Glycan classification type"
+            },
+            "iupac": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "IUPAC condensed notation"
+            },
+            "wurcs": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "WURCS linear notation"
+            },
+            "species": {
+              "type": "array",
+              "description": "Species where glycan is found"
+            },
+            "glycoprotein_count": {
+              "type": "integer",
+              "description": "Number of associated glycoproteins"
+            },
+            "publication_count": {
+              "type": "integer",
+              "description": "Number of associated publications"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -175,52 +153,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "glytoucan_ac": {
-                    "type": "string"
-                  },
-                  "mass": {
-                    "type": "number"
-                  },
-                  "number_proteins": {
-                    "type": "integer"
-                  },
-                  "number_enzymes": {
-                    "type": "integer"
-                  },
-                  "number_species": {
-                    "type": "integer"
-                  },
-                  "hit_score": {
-                    "type": "number"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "list_id": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "object"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "glytoucan_ac": {
+                "type": "string"
+              },
+              "mass": {
+                "type": "number"
+              },
+              "number_proteins": {
+                "type": "integer"
+              },
+              "number_enzymes": {
+                "type": "integer"
+              },
+              "number_species": {
+                "type": "integer"
+              },
+              "hit_score": {
+                "type": "number"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -269,55 +225,33 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "protein_name": {
-                  "type": "string"
-                },
-                "gene_names": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "species": {
-                  "type": "string"
-                },
-                "glycosylation_count": {
-                  "type": "integer",
-                  "description": "Total number of glycosylation annotations"
-                },
-                "glycosylation_sites": {
-                  "type": "array",
-                  "description": "Glycosylation site details with positions, types, and attached glycans"
-                },
-                "disease_count": {
-                  "type": "integer"
-                },
-                "pathway_count": {
-                  "type": "integer"
-                }
+            "protein_name": {
+              "type": "string"
+            },
+            "gene_names": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "species": {
+              "type": "string"
+            },
+            "glycosylation_count": {
+              "type": "integer",
+              "description": "Total number of glycosylation annotations"
+            },
+            "glycosylation_sites": {
+              "type": "array",
+              "description": "Glycosylation site details with positions, types, and attached glycans"
+            },
+            "disease_count": {
+              "type": "integer"
+            },
+            "pathway_count": {
+              "type": "integer"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -388,52 +322,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "uniprot_canonical_ac": {
-                    "type": "string"
-                  },
-                  "protein_name": {
-                    "type": "string"
-                  },
-                  "gene_name": {
-                    "type": "string"
-                  },
-                  "organism": {
-                    "type": "string"
-                  },
-                  "glycosylation_count": {
-                    "type": "integer"
-                  },
-                  "hit_score": {
-                    "type": "number"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "list_id": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "object"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "uniprot_canonical_ac": {
+                "type": "string"
+              },
+              "protein_name": {
+                "type": "string"
+              },
+              "gene_name": {
+                "type": "string"
+              },
+              "organism": {
+                "type": "string"
+              },
+              "glycosylation_count": {
+                "type": "integer"
+              },
+              "hit_score": {
+                "type": "number"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -482,61 +394,39 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "site_id": {
-                  "type": "string"
-                },
-                "uniprot_ac": {
-                  "type": "string"
-                },
-                "start_pos": {
-                  "type": "integer"
-                },
-                "end_pos": {
-                  "type": "integer"
-                },
-                "site_seq": {
-                  "type": "string",
-                  "description": "Amino acid at the glycosylation site"
-                },
-                "upstream_seq": {
-                  "type": "string",
-                  "description": "Upstream flanking sequence"
-                },
-                "downstream_seq": {
-                  "type": "string",
-                  "description": "Downstream flanking sequence"
-                },
-                "glycosylation": {
-                  "type": "array",
-                  "description": "Glycosylation annotations at this site"
-                },
-                "snv": {
-                  "type": "array",
-                  "description": "SNVs at this position"
-                }
-              }
+            "site_id": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "uniprot_ac": {
+              "type": "string"
+            },
+            "start_pos": {
+              "type": "integer"
+            },
+            "end_pos": {
+              "type": "integer"
+            },
+            "site_seq": {
+              "type": "string",
+              "description": "Amino acid at the glycosylation site"
+            },
+            "upstream_seq": {
+              "type": "string",
+              "description": "Upstream flanking sequence"
+            },
+            "downstream_seq": {
+              "type": "string",
+              "description": "Downstream flanking sequence"
+            },
+            "glycosylation": {
+              "type": "array",
+              "description": "Glycosylation annotations at this site"
+            },
+            "snv": {
+              "type": "array",
+              "description": "SNVs at this position"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/gnps_tools.json
+++ b/src/tooluniverse/data/gnps_tools.json
@@ -31,79 +31,57 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "usi": {
-                  "type": "string"
-                },
-                "precursor_mz": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "precursor_charge": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "n_peaks": {
-                  "type": "integer"
-                },
-                "mz_range": {
-                  "type": "array",
-                  "items": {
+            "usi": {
+              "type": "string"
+            },
+            "precursor_mz": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "precursor_charge": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "n_peaks": {
+              "type": "integer"
+            },
+            "mz_range": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "top_20_peaks": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "mz": {
+                    "type": "number"
+                  },
+                  "intensity": {
                     "type": "number"
                   }
-                },
-                "top_20_peaks": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "mz": {
-                        "type": "number"
-                      },
-                      "intensity": {
-                        "type": "number"
-                      }
-                    }
-                  }
-                },
-                "spectrum_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "splash": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "spectrum_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "splash": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -154,69 +132,50 @@
         {
           "type": "object",
           "properties": {
-            "data": {
+            "spectrum_1": {
               "type": "object",
               "properties": {
-                "spectrum_1": {
-                  "type": "object",
-                  "properties": {
-                    "usi": {
-                      "type": "string"
-                    },
-                    "precursor_mz": {
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "n_peaks": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    }
-                  }
-                },
-                "spectrum_2": {
-                  "type": "object",
-                  "properties": {
-                    "usi": {
-                      "type": "string"
-                    },
-                    "precursor_mz": {
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "n_peaks": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    }
-                  }
-                },
-                "mirror_plot_url": {
+                "usi": {
                   "type": "string"
+                },
+                "precursor_mz": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "n_peaks": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 }
               }
             },
-            "metadata": {
+            "spectrum_2": {
               "type": "object",
               "properties": {
-                "source": {
+                "usi": {
                   "type": "string"
                 },
-                "endpoint": {
-                  "type": "string"
+                "precursor_mz": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "n_peaks": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 }
               }
+            },
+            "mirror_plot_url": {
+              "type": "string"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/go_api_tools.json
+++ b/src/tooluniverse/data/go_api_tools.json
@@ -31,72 +31,56 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "go_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "GO term identifier"
-                },
-                "label": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Term name/label"
-                },
-                "definition": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Full text definition"
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Exact synonyms"
-                },
-                "related_synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Related synonyms"
-                },
-                "xrefs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Cross-references (Reactome, Wikipedia, etc.)"
-                },
-                "alternative_ids": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Alternative/obsolete GO IDs"
-                }
-              }
+            "go_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "GO term identifier"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                }
-              }
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Term name/label"
+            },
+            "definition": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Full text definition"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Exact synonyms"
+            },
+            "related_synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Related synonyms"
+            },
+            "xrefs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Cross-references (Reactome, Wikipedia, etc.)"
+            },
+            "alternative_ids": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Alternative/obsolete GO IDs"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -151,83 +135,61 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "go_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "GO term ID"
-                  },
-                  "go_label": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "GO term name"
-                  },
-                  "category": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "GO domain (biological_process, molecular_function, cellular_component)"
-                  },
-                  "evidence_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Evidence code (IDA, IMP, ISS, IEA, etc.)"
-                  },
-                  "evidence_label": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Full evidence description"
-                  },
-                  "provided_by": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Annotation providers"
-                  },
-                  "references": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Literature references (PMID, UniProtKB)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "go_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "GO term ID"
+              },
+              "go_label": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "GO term name"
+              },
+              "category": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "GO domain (biological_process, molecular_function, cellular_component)"
+              },
+              "evidence_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Evidence code (IDA, IMP, ISS, IEA, etc.)"
+              },
+              "evidence_label": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Full evidence description"
+              },
+              "provided_by": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 },
-                "gene_id": {
+                "description": "Annotation providers"
+              },
+              "references": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 },
-                "total_results": {
-                  "type": "integer"
-                }
+                "description": "Literature references (PMID, UniProtKB)"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -284,76 +246,54 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene/protein identifier (UniProtKB, HGNC, etc.)"
-                  },
-                  "gene_label": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene symbol or name"
-                  },
-                  "taxon_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Taxon identifier"
-                  },
-                  "taxon_label": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Species name"
-                  },
-                  "evidence_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Evidence code"
-                  },
-                  "references": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Literature references"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene/protein identifier (UniProtKB, HGNC, etc.)"
+              },
+              "gene_label": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene symbol or name"
+              },
+              "taxon_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Taxon identifier"
+              },
+              "taxon_label": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Species name"
+              },
+              "evidence_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Evidence code"
+              },
+              "references": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 },
-                "go_id": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+                "description": "Literature references"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/gprofiler_tools.json
+++ b/src/tooluniverse/data/gprofiler_tools.json
@@ -1,310 +1,381 @@
 [
-    {
-        "name": "gProfiler_enrichment",
-        "description": "Perform functional enrichment analysis on a gene list using g:Profiler (g:GOSt) from the University of Tartu. Identifies statistically overrepresented biological functions, pathways, and phenotypes in your gene list. Supports multiple data sources: Gene Ontology (GO:BP, GO:MF, GO:CC), KEGG pathways, Reactome, WikiPathways, Human Phenotype Ontology (HP), miRNA targets (MIRNA), CORUM protein complexes, and Transcription Factor targets (TF). Returns enriched terms with p-values (g:SCS multiple testing correction), term sizes, intersection genes, precision, and recall. Input is a comma-separated string of gene symbols (e.g., 'TP53,BRCA1,EGFR,KRAS,PTEN') -- a JSON array is not accepted. Supports 500+ organisms (use NCBI taxonomy prefix, e.g., 'hsapiens', 'mmusculus', 'dmelanogaster').",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "gene_list": {
-                    "type": "string",
-                    "description": "Comma-separated list of gene symbols. Examples: 'TP53,BRCA1,EGFR,KRAS,PTEN' or 'Trp53,Brca1,Egfr' (mouse)."
-                },
-                "organism": {
-                    "type": "string",
-                    "description": "Organism identifier. Default: 'hsapiens'. Examples: 'hsapiens' (human), 'mmusculus' (mouse), 'dmelanogaster' (fly), 'scerevisiae' (yeast), 'drerio' (zebrafish)."
-                },
-                "sources": {
-                    "type": "string",
-                    "description": "Comma-separated data sources to query. Default: 'GO:BP,GO:MF,GO:CC,KEGG,REAC,WP,HP'. Options: GO:BP, GO:MF, GO:CC, KEGG, REAC, WP, MIRNA, HPA, CORUM, HP, TF."
-                }
-            },
-            "required": ["gene_list"]
+  {
+    "name": "gProfiler_enrichment",
+    "description": "Perform functional enrichment analysis on a gene list using g:Profiler (g:GOSt) from the University of Tartu. Identifies statistically overrepresented biological functions, pathways, and phenotypes in your gene list. Supports multiple data sources: Gene Ontology (GO:BP, GO:MF, GO:CC), KEGG pathways, Reactome, WikiPathways, Human Phenotype Ontology (HP), miRNA targets (MIRNA), CORUM protein complexes, and Transcription Factor targets (TF). Returns enriched terms with p-values (g:SCS multiple testing correction), term sizes, intersection genes, precision, and recall. Input is a comma-separated string of gene symbols (e.g., 'TP53,BRCA1,EGFR,KRAS,PTEN') -- a JSON array is not accepted. Supports 500+ organisms (use NCBI taxonomy prefix, e.g., 'hsapiens', 'mmusculus', 'dmelanogaster').",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "gene_list": {
+          "type": "string",
+          "description": "Comma-separated list of gene symbols. Examples: 'TP53,BRCA1,EGFR,KRAS,PTEN' or 'Trp53,Brca1,Egfr' (mouse)."
         },
-        "fields": {
-            "endpoint": "enrichment"
+        "organism": {
+          "type": "string",
+          "description": "Organism identifier. Default: 'hsapiens'. Examples: 'hsapiens' (human), 'mmusculus' (mouse), 'dmelanogaster' (fly), 'scerevisiae' (yeast), 'drerio' (zebrafish)."
         },
-        "type": "GProfilerTool",
-        "test_examples": [
-            {
-                "gene_list": "TP53,BRCA1,EGFR,KRAS,PTEN"
-            },
-            {
-                "gene_list": "TP53,BRCA1,EGFR,KRAS,PTEN",
-                "sources": "KEGG,REAC,WP"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "source": {"type": "string", "description": "Data source (GO:BP, KEGG, REAC, etc.)"},
-                                    "native": {"type": "string", "description": "Native term ID (e.g., GO:0006915, KEGG:04115)"},
-                                    "name": {"type": "string", "description": "Term name"},
-                                    "p_value": {"type": "number", "description": "Corrected p-value (g:SCS method)"},
-                                    "significant": {"type": "boolean"},
-                                    "term_size": {"type": "integer", "description": "Total genes annotated to this term"},
-                                    "query_size": {"type": "integer", "description": "Number of input genes recognized"},
-                                    "intersection_size": {"type": "integer", "description": "Number of input genes in this term"},
-                                    "precision": {"type": "number", "description": "intersection_size / query_size"},
-                                    "recall": {"type": "number", "description": "intersection_size / term_size"}
-                                }
-                            },
-                            "description": "Enriched terms sorted by p-value"
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "organism": {"type": "string"},
-                                "total_results": {"type": "integer"},
-                                "query_genes": {"type": "array", "items": {"type": "string"}}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+        "sources": {
+          "type": "string",
+          "description": "Comma-separated data sources to query. Default: 'GO:BP,GO:MF,GO:CC,KEGG,REAC,WP,HP'. Options: GO:BP, GO:MF, GO:CC, KEGG, REAC, WP, MIRNA, HPA, CORUM, HP, TF."
         }
+      },
+      "required": [
+        "gene_list"
+      ]
     },
-    {
-        "name": "gProfiler_convert_ids",
-        "description": "Convert gene identifiers between different namespaces using g:Profiler (g:Convert) from the University of Tartu. Supports conversion between gene symbols, Ensembl IDs, Entrez IDs, UniProt accessions, RefSeq IDs, and many other identifiers. Input is a list of gene identifiers and a target namespace. Supports 500+ organisms. Example: convert 'TP53,BRCA1,EGFR' to Ensembl gene IDs (ENSG). Available target namespaces: ENSG (Ensembl Gene), ENST (Ensembl Transcript), ENSP (Ensembl Protein), UNIPROTSWISSPROT (UniProt reviewed), ENTREZGENE_ACC (Entrez Gene), WIKIGENE_ACC (WikiGene).",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "gene_list": {
-                    "type": "string",
-                    "description": "Comma-separated list of gene identifiers to convert. Examples: 'TP53,BRCA1,EGFR' (symbols), 'ENSG00000141510,ENSG00000012048' (Ensembl IDs)."
-                },
-                "target_namespace": {
-                    "type": "string",
-                    "description": "Target namespace for conversion. Default: 'ENSG'. Options: ENSG (Ensembl Gene), ENST (Ensembl Transcript), ENSP (Ensembl Protein), UNIPROTSWISSPROT (UniProt), ENTREZGENE_ACC (Entrez), WIKIGENE_ACC (WikiGene), REFSEQ_MRNA_ACC, REFSEQ_PEPTIDE_ACC."
-                },
-                "organism": {
-                    "type": "string",
-                    "description": "Organism identifier. Default: 'hsapiens'. Examples: 'hsapiens', 'mmusculus'."
-                }
-            },
-            "required": ["gene_list"]
-        },
-        "fields": {
-            "endpoint": "convert_ids"
-        },
-        "type": "GProfilerTool",
-        "test_examples": [
-            {
-                "gene_list": "TP53,BRCA1,EGFR",
-                "target_namespace": "ENSG"
-            },
-            {
-                "gene_list": "ENSG00000141510,ENSG00000012048",
-                "target_namespace": "UNIPROTSWISSPROT"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "incoming": {"type": "string", "description": "Original input identifier"},
-                                    "converted": {"type": "string", "description": "Converted identifier in target namespace"},
-                                    "name": {"type": ["string", "null"], "description": "Gene name/description"},
-                                    "description": {"type": ["string", "null"], "description": "Full description"},
-                                    "namespaces": {"type": ["string", "null"]}
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "organism": {"type": "string"},
-                                "target_namespace": {"type": "string"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
+    "fields": {
+      "endpoint": "enrichment"
     },
-    {
-        "name": "gProfiler_find_orthologs",
-        "description": "Find orthologous genes across species using g:Profiler (g:Orth) from the University of Tartu. Maps genes from a source organism to their orthologs in a target organism using Ensembl orthology data. Useful for translating gene lists between model organisms. Example: find mouse orthologs of human TP53 and BRCA1. Supports 500+ organisms in the Ensembl database. Input is a list of gene identifiers from the source organism, and the target organism to map to.",
-        "parameter": {
+    "type": "GProfilerTool",
+    "test_examples": [
+      {
+        "gene_list": "TP53,BRCA1,EGFR,KRAS,PTEN"
+      },
+      {
+        "gene_list": "TP53,BRCA1,EGFR,KRAS,PTEN",
+        "sources": "KEGG,REAC,WP"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
             "type": "object",
             "properties": {
-                "gene_list": {
-                    "type": "string",
-                    "description": "Comma-separated list of gene identifiers from the source organism. Examples: 'TP53,BRCA1,EGFR' (human genes to find mouse orthologs)."
-                },
-                "source_organism": {
-                    "type": "string",
-                    "description": "Source organism. Default: 'hsapiens'. Examples: 'hsapiens' (human), 'mmusculus' (mouse)."
-                },
-                "target_organism": {
-                    "type": "string",
-                    "description": "Target organism to find orthologs in. Default: 'mmusculus'. Examples: 'mmusculus' (mouse), 'rnorvegicus' (rat), 'drerio' (zebrafish), 'dmelanogaster' (fly), 'celegans' (worm)."
-                }
-            },
-            "required": ["gene_list"]
-        },
-        "fields": {
-            "endpoint": "find_orthologs"
-        },
-        "type": "GProfilerTool",
-        "test_examples": [
-            {
-                "gene_list": "TP53,BRCA1,EGFR",
-                "target_organism": "mmusculus"
-            },
-            {
-                "gene_list": "TP53,BRCA1",
-                "target_organism": "drerio"
+              "source": {
+                "type": "string",
+                "description": "Data source (GO:BP, KEGG, REAC, etc.)"
+              },
+              "native": {
+                "type": "string",
+                "description": "Native term ID (e.g., GO:0006915, KEGG:04115)"
+              },
+              "name": {
+                "type": "string",
+                "description": "Term name"
+              },
+              "p_value": {
+                "type": "number",
+                "description": "Corrected p-value (g:SCS method)"
+              },
+              "significant": {
+                "type": "boolean"
+              },
+              "term_size": {
+                "type": "integer",
+                "description": "Total genes annotated to this term"
+              },
+              "query_size": {
+                "type": "integer",
+                "description": "Number of input genes recognized"
+              },
+              "intersection_size": {
+                "type": "integer",
+                "description": "Number of input genes in this term"
+              },
+              "precision": {
+                "type": "number",
+                "description": "intersection_size / query_size"
+              },
+              "recall": {
+                "type": "number",
+                "description": "intersection_size / term_size"
+              }
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "incoming": {"type": "string", "description": "Input gene identifier"},
-                                    "name": {"type": ["string", "null"], "description": "Ortholog gene name in target organism"},
-                                    "ortholog_ensg": {"type": ["string", "null"], "description": "Ensembl gene ID of ortholog"},
-                                    "description": {"type": ["string", "null"], "description": "Gene description in target organism"}
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "source_organism": {"type": "string"},
-                                "target_organism": {"type": "string"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
-    },
-    {
-        "name": "gProfiler_annotate_snps",
-        "description": "Map SNP rsIDs to genes and annotate their functional consequences using g:Profiler (g:SNPense) from the University of Tartu. Given a list of SNP rsIDs, returns the chromosome, position, strand, associated Ensembl gene IDs, gene names, and predicted variant consequences (missense_variant, synonymous_variant, intron_variant, etc.) with counts. Useful for annotating GWAS hits, linking variants to genes, or understanding the functional impact of SNPs. Example: 'rs11540652' maps to chromosome 17 position 7674220, gene TP53 (ENSG00000141510), with 18 missense variant consequences; 'rs429358' maps to APOE on chromosome 19.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "snp_list": {
-                    "type": "string",
-                    "description": "Comma-separated list of SNP rsIDs. Examples: 'rs11540652,rs429358,rs7903146' or 'rs1042779,rs6792369'. Maximum ~200 SNPs per query."
-                },
-                "organism": {
-                    "type": "string",
-                    "description": "Organism identifier. Default: 'hsapiens'. Examples: 'hsapiens' (human), 'mmusculus' (mouse)."
-                }
-            },
-            "required": ["snp_list"]
+          },
+          "description": "Enriched terms sorted by p-value"
         },
-        "fields": {
-            "endpoint": "snpense"
-        },
-        "type": "GProfilerTool",
-        "test_examples": [
-            {
-                "snp_list": "rs11540652,rs429358"
-            },
-            {
-                "snp_list": "rs7903146,rs1042779"
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "rs_id": {"type": "string", "description": "SNP rsID"},
-                                    "chromosome": {"type": "string", "description": "Chromosome number"},
-                                    "start": {"type": "integer", "description": "Genomic start position"},
-                                    "end": {"type": "integer", "description": "Genomic end position"},
-                                    "strand": {"type": "string"},
-                                    "ensembl_gene_ids": {"type": "array", "items": {"type": "string"}, "description": "Ensembl gene IDs overlapping this SNP"},
-                                    "gene_names": {"type": "array", "items": {"type": "string"}, "description": "Gene symbols"},
-                                    "variant_consequences": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "consequence": {"type": "string", "description": "Variant consequence type (e.g., missense_variant)"},
-                                                "count": {"type": "integer", "description": "Number of transcripts with this consequence"}
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "organism": {"type": "string"},
-                                "total_snps_queried": {"type": "integer"},
-                                "total_results": {"type": "integer"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "gProfiler_convert_ids",
+    "description": "Convert gene identifiers between different namespaces using g:Profiler (g:Convert) from the University of Tartu. Supports conversion between gene symbols, Ensembl IDs, Entrez IDs, UniProt accessions, RefSeq IDs, and many other identifiers. Input is a list of gene identifiers and a target namespace. Supports 500+ organisms. Example: convert 'TP53,BRCA1,EGFR' to Ensembl gene IDs (ENSG). Available target namespaces: ENSG (Ensembl Gene), ENST (Ensembl Transcript), ENSP (Ensembl Protein), UNIPROTSWISSPROT (UniProt reviewed), ENTREZGENE_ACC (Entrez Gene), WIKIGENE_ACC (WikiGene).",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "gene_list": {
+          "type": "string",
+          "description": "Comma-separated list of gene identifiers to convert. Examples: 'TP53,BRCA1,EGFR' (symbols), 'ENSG00000141510,ENSG00000012048' (Ensembl IDs)."
+        },
+        "target_namespace": {
+          "type": "string",
+          "description": "Target namespace for conversion. Default: 'ENSG'. Options: ENSG (Ensembl Gene), ENST (Ensembl Transcript), ENSP (Ensembl Protein), UNIPROTSWISSPROT (UniProt), ENTREZGENE_ACC (Entrez), WIKIGENE_ACC (WikiGene), REFSEQ_MRNA_ACC, REFSEQ_PEPTIDE_ACC."
+        },
+        "organism": {
+          "type": "string",
+          "description": "Organism identifier. Default: 'hsapiens'. Examples: 'hsapiens', 'mmusculus'."
+        }
+      },
+      "required": [
+        "gene_list"
+      ]
+    },
+    "fields": {
+      "endpoint": "convert_ids"
+    },
+    "type": "GProfilerTool",
+    "test_examples": [
+      {
+        "gene_list": "TP53,BRCA1,EGFR",
+        "target_namespace": "ENSG"
+      },
+      {
+        "gene_list": "ENSG00000141510,ENSG00000012048",
+        "target_namespace": "UNIPROTSWISSPROT"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "incoming": {
+                "type": "string",
+                "description": "Original input identifier"
+              },
+              "converted": {
+                "type": "string",
+                "description": "Converted identifier in target namespace"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene name/description"
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Full description"
+              },
+              "namespaces": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "gProfiler_find_orthologs",
+    "description": "Find orthologous genes across species using g:Profiler (g:Orth) from the University of Tartu. Maps genes from a source organism to their orthologs in a target organism using Ensembl orthology data. Useful for translating gene lists between model organisms. Example: find mouse orthologs of human TP53 and BRCA1. Supports 500+ organisms in the Ensembl database. Input is a list of gene identifiers from the source organism, and the target organism to map to.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "gene_list": {
+          "type": "string",
+          "description": "Comma-separated list of gene identifiers from the source organism. Examples: 'TP53,BRCA1,EGFR' (human genes to find mouse orthologs)."
+        },
+        "source_organism": {
+          "type": "string",
+          "description": "Source organism. Default: 'hsapiens'. Examples: 'hsapiens' (human), 'mmusculus' (mouse)."
+        },
+        "target_organism": {
+          "type": "string",
+          "description": "Target organism to find orthologs in. Default: 'mmusculus'. Examples: 'mmusculus' (mouse), 'rnorvegicus' (rat), 'drerio' (zebrafish), 'dmelanogaster' (fly), 'celegans' (worm)."
+        }
+      },
+      "required": [
+        "gene_list"
+      ]
+    },
+    "fields": {
+      "endpoint": "find_orthologs"
+    },
+    "type": "GProfilerTool",
+    "test_examples": [
+      {
+        "gene_list": "TP53,BRCA1,EGFR",
+        "target_organism": "mmusculus"
+      },
+      {
+        "gene_list": "TP53,BRCA1",
+        "target_organism": "drerio"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "incoming": {
+                "type": "string",
+                "description": "Input gene identifier"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Ortholog gene name in target organism"
+              },
+              "ortholog_ensg": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Ensembl gene ID of ortholog"
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene description in target organism"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "gProfiler_annotate_snps",
+    "description": "Map SNP rsIDs to genes and annotate their functional consequences using g:Profiler (g:SNPense) from the University of Tartu. Given a list of SNP rsIDs, returns the chromosome, position, strand, associated Ensembl gene IDs, gene names, and predicted variant consequences (missense_variant, synonymous_variant, intron_variant, etc.) with counts. Useful for annotating GWAS hits, linking variants to genes, or understanding the functional impact of SNPs. Example: 'rs11540652' maps to chromosome 17 position 7674220, gene TP53 (ENSG00000141510), with 18 missense variant consequences; 'rs429358' maps to APOE on chromosome 19.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "snp_list": {
+          "type": "string",
+          "description": "Comma-separated list of SNP rsIDs. Examples: 'rs11540652,rs429358,rs7903146' or 'rs1042779,rs6792369'. Maximum ~200 SNPs per query."
+        },
+        "organism": {
+          "type": "string",
+          "description": "Organism identifier. Default: 'hsapiens'. Examples: 'hsapiens' (human), 'mmusculus' (mouse)."
+        }
+      },
+      "required": [
+        "snp_list"
+      ]
+    },
+    "fields": {
+      "endpoint": "snpense"
+    },
+    "type": "GProfilerTool",
+    "test_examples": [
+      {
+        "snp_list": "rs11540652,rs429358"
+      },
+      {
+        "snp_list": "rs7903146,rs1042779"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rs_id": {
+                "type": "string",
+                "description": "SNP rsID"
+              },
+              "chromosome": {
+                "type": "string",
+                "description": "Chromosome number"
+              },
+              "start": {
+                "type": "integer",
+                "description": "Genomic start position"
+              },
+              "end": {
+                "type": "integer",
+                "description": "Genomic end position"
+              },
+              "strand": {
+                "type": "string"
+              },
+              "ensembl_gene_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Ensembl gene IDs overlapping this SNP"
+              },
+              "gene_names": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Gene symbols"
+              },
+              "variant_consequences": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "consequence": {
+                      "type": "string",
+                      "description": "Variant consequence type (e.g., missense_variant)"
+                    },
+                    "count": {
+                      "type": "integer",
+                      "description": "Number of transcripts with this consequence"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/gsea_prerank_tools.json
+++ b/src/tooluniverse/data/gsea_prerank_tools.json
@@ -6,13 +6,64 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "ranked_genes": {"type": ["object", "null"], "description": "{gene: score} mapping (score = DE statistic / fold change). Genes are ranked by score descending. Alternative to genes+scores."},
-        "genes": {"type": ["array", "null"], "items": {"type": "string"}, "description": "Gene identifiers (use with `scores`, same order)."},
-        "scores": {"type": ["array", "null"], "items": {"type": "number"}, "description": "Per-gene ranking metric (same order as `genes`)."},
-        "gene_sets": {"type": ["object", "null"], "description": "{set_name: [gene, ...]} collection to test. Alternative to gene_set."},
-        "gene_set": {"type": ["array", "null"], "items": {"type": "string"}, "description": "A single gene set (list of gene symbols)."},
-        "weight": {"type": ["number", "null"], "description": "Score weighting exponent for the running sum (default 1.0; classic GSEA)."},
-        "n_permutations": {"type": ["integer", "null"], "description": "Gene-label permutations for the p-value (default 1000)."}
+        "ranked_genes": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "description": "{gene: score} mapping (score = DE statistic / fold change). Genes are ranked by score descending. Alternative to genes+scores."
+        },
+        "genes": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Gene identifiers (use with `scores`, same order)."
+        },
+        "scores": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-gene ranking metric (same order as `genes`)."
+        },
+        "gene_sets": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "description": "{set_name: [gene, ...]} collection to test. Alternative to gene_set."
+        },
+        "gene_set": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "A single gene set (list of gene symbols)."
+        },
+        "weight": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Score weighting exponent for the running sum (default 1.0; classic GSEA)."
+        },
+        "n_permutations": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Gene-label permutations for the p-value (default 1000)."
+        }
       }
     },
     "return_schema": {
@@ -20,29 +71,69 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_genes_ranked": {"type": "integer"},
-                "n_gene_sets": {"type": "integer"},
-                "results": {"type": "array", "items": {"type": "object"}}
+            "n_genes_ranked": {
+              "type": "integer"
+            },
+            "n_gene_sets": {
+              "type": "integer"
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "status": {
+              "const": "error"
+            },
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "ranked_genes": {"G1": 5.0, "G2": 4.5, "G3": 4.0, "G4": 3.5, "G5": 3.0, "G6": 1.0, "G7": 0.5, "G8": 0.0, "G9": -0.5, "G10": -1.0, "G11": -1.5, "G12": -2.0, "G13": -2.5, "G14": -3.0, "G15": -3.5},
-        "gene_sets": {"TOP_SET": ["G1", "G2", "G3", "G4"], "BOTTOM_SET": ["G12", "G13", "G14", "G15"]}
+        "ranked_genes": {
+          "G1": 5.0,
+          "G2": 4.5,
+          "G3": 4.0,
+          "G4": 3.5,
+          "G5": 3.0,
+          "G6": 1.0,
+          "G7": 0.5,
+          "G8": 0.0,
+          "G9": -0.5,
+          "G10": -1.0,
+          "G11": -1.5,
+          "G12": -2.0,
+          "G13": -2.5,
+          "G14": -3.0,
+          "G15": -3.5
+        },
+        "gene_sets": {
+          "TOP_SET": [
+            "G1",
+            "G2",
+            "G3",
+            "G4"
+          ],
+          "BOTTOM_SET": [
+            "G12",
+            "G13",
+            "G14",
+            "G15"
+          ]
+        }
       }
     ]
   }

--- a/src/tooluniverse/data/gsva_tools.json
+++ b/src/tooluniverse/data/gsva_tools.json
@@ -2,17 +2,58 @@
   {
     "name": "GSVA_score",
     "type": "GSVATool",
-    "description": "Gene Set Variation Analysis (Hänzelmann 2013): turn an expression matrix (genes x samples) into a label-free gene_set x sample pathway-activity matrix. Unlike ssGSEA, GSVA first converts each gene to a kernel-CDF quantile across samples, then runs a symmetric KS walk with a max-deviation difference score (mx_diff), giving signed scores centered near zero (positive = set up-regulated in that sample vs the cohort). Pure-compute (no R); supply log-scale expression + gene sets from MSigDB/Enrichr.",
+    "description": "Gene Set Variation Analysis (H\u00e4nzelmann 2013): turn an expression matrix (genes x samples) into a label-free gene_set x sample pathway-activity matrix. Unlike ssGSEA, GSVA first converts each gene to a kernel-CDF quantile across samples, then runs a symmetric KS walk with a max-deviation difference score (mx_diff), giving signed scores centered near zero (positive = set up-regulated in that sample vs the cohort). Pure-compute (no R); supply log-scale expression + gene sets from MSigDB/Enrichr.",
     "parameter": {
       "type": "object",
-      "required": ["expression"],
+      "required": [
+        "expression"
+      ],
       "properties": {
-        "expression": {"type": "object", "description": "{gene: [value_per_sample, ...]} — a genes x samples expression matrix on a continuous (e.g. log-normalized) scale."},
-        "samples": {"type": ["array", "null"], "items": {"type": "string"}, "description": "Sample names (same order as the per-gene value lists); defaults to sample_1.."},
-        "gene_sets": {"type": ["object", "null"], "description": "{set_name: [gene, ...]} collection to score. Alternative to gene_set."},
-        "gene_set": {"type": ["array", "null"], "items": {"type": "string"}, "description": "A single gene set (list of gene symbols)."},
-        "tau": {"type": ["number", "null"], "description": "Rank-weighting exponent in the random walk (default 1.0, the GSVA standard)."},
-        "mx_diff": {"type": ["boolean", "null"], "description": "True (default) = ES_pos+ES_neg difference score (signed, bimodal, GSVA default); False = classic single max-deviation KS statistic."}
+        "expression": {
+          "type": "object",
+          "description": "{gene: [value_per_sample, ...]} \u2014 a genes x samples expression matrix on a continuous (e.g. log-normalized) scale."
+        },
+        "samples": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Sample names (same order as the per-gene value lists); defaults to sample_1.."
+        },
+        "gene_sets": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "description": "{set_name: [gene, ...]} collection to score. Alternative to gene_set."
+        },
+        "gene_set": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "A single gene set (list of gene symbols)."
+        },
+        "tau": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Rank-weighting exponent in the random walk (default 1.0, the GSVA standard)."
+        },
+        "mx_diff": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "True (default) = ES_pos+ES_neg difference score (signed, bimodal, GSVA default); False = classic single max-deviation KS statistic."
+        }
       }
     },
     "return_schema": {
@@ -20,32 +61,106 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_genes": {"type": "integer"},
-                "n_samples": {"type": "integer"},
-                "samples": {"type": "array", "items": {"type": "string"}},
-                "enrichment_scores": {"type": "object"},
-                "skipped_sets": {"type": "array"}
+            "n_genes": {
+              "type": "integer"
+            },
+            "n_samples": {
+              "type": "integer"
+            },
+            "samples": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
+            },
+            "enrichment_scores": {
+              "type": "object"
+            },
+            "skipped_sets": {
+              "type": "array"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "status": {
+              "const": "error"
+            },
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "expression": {"G1": [12, 1], "G2": [11, 2], "G3": [10, 3], "G4": [9, 4], "G5": [8, 5], "G6": [7, 6], "G7": [6, 7], "G8": [5, 8], "G9": [4, 9], "G10": [3, 10], "G11": [2, 11], "G12": [1, 12]},
-        "samples": ["tumor", "normal"],
-        "gene_sets": {"TOP_SIG": ["G1", "G2", "G3", "G4"]}
+        "expression": {
+          "G1": [
+            12,
+            1
+          ],
+          "G2": [
+            11,
+            2
+          ],
+          "G3": [
+            10,
+            3
+          ],
+          "G4": [
+            9,
+            4
+          ],
+          "G5": [
+            8,
+            5
+          ],
+          "G6": [
+            7,
+            6
+          ],
+          "G7": [
+            6,
+            7
+          ],
+          "G8": [
+            5,
+            8
+          ],
+          "G9": [
+            4,
+            9
+          ],
+          "G10": [
+            3,
+            10
+          ],
+          "G11": [
+            2,
+            11
+          ],
+          "G12": [
+            1,
+            12
+          ]
+        },
+        "samples": [
+          "tumor",
+          "normal"
+        ],
+        "gene_sets": {
+          "TOP_SIG": [
+            "G1",
+            "G2",
+            "G3",
+            "G4"
+          ]
+        }
       }
     ]
   }

--- a/src/tooluniverse/data/gtopdb_tools.json
+++ b/src/tooluniverse/data/gtopdb_tools.json
@@ -265,331 +265,323 @@
       ]
     }
   },
- {
-  "name": "GtoPdb_search_diseases",
-  "description": "Search the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) for diseases by name, and retrieve their curated disease IDs, names, synonyms, and cross-references to external databases (OMIM, Orphanet, Disease Ontology). GtoPdb links diseases to the drug targets and approved/experimental ligands relevant to them. Example: 'epilepsy' returns disease entries such as 'Epilepsy and Intellectual Disability'. No authentication required.",
-  "parameter": {
-   "type": "object",
-   "properties": {
-    "name": {
-     "type": [
-      "string",
-      "null"
-     ],
-     "description": "Disease name to search. Examples: 'epilepsy', 'asthma', 'hypertension', 'breast cancer'."
+  {
+    "name": "GtoPdb_search_diseases",
+    "description": "Search the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) for diseases by name, and retrieve their curated disease IDs, names, synonyms, and cross-references to external databases (OMIM, Orphanet, Disease Ontology). GtoPdb links diseases to the drug targets and approved/experimental ligands relevant to them. Example: 'epilepsy' returns disease entries such as 'Epilepsy and Intellectual Disability'. No authentication required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Disease name to search. Examples: 'epilepsy', 'asthma', 'hypertension', 'breast cancer'."
+        },
+        "query": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Name/keyword to search for. Alias for the \"name\" parameter."
+        }
+      },
+      "required": [],
+      "additionalProperties": false
     },
-    "query": {
-     "type": [
-      "string",
-      "null"
-     ],
-     "description": "Name/keyword to search for. Alias for the \"name\" parameter."
-    }
-   },
-   "required": [],
-   "additionalProperties": false
-  },
-  "fields": {
-   "endpoint": "https://www.guidetopharmacology.org/services/diseases",
-   "params": {}
-  },
-  "type": "GtoPdbRESTTool",
-  "test_examples": [
-   {
-    "name": "epilepsy"
-   },
-   {
-    "query": "asthma"
-   }
-  ],
-  "return_schema": {
-   "oneOf": [
-    {
-     "type": "object",
-     "properties": {
-      "data": {
-       "type": "array",
-       "items": {
-        "type": "object",
-        "properties": {
-         "diseaseId": {
-          "type": [
-           "integer",
-           "null"
-          ],
-          "description": "GtoPdb disease ID"
-         },
-         "name": {
-          "type": [
-           "string",
-           "null"
-          ],
-          "description": "Disease name"
-         },
-         "description": {
-          "type": [
-           "string",
-           "null"
-          ]
-         },
-         "synonyms": {
+    "fields": {
+      "endpoint": "https://www.guidetopharmacology.org/services/diseases",
+      "params": {}
+    },
+    "type": "GtoPdbRESTTool",
+    "test_examples": [
+      {
+        "name": "epilepsy"
+      },
+      {
+        "query": "asthma"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
           "type": "array",
           "items": {
-           "type": [
-            "object",
-            "string"
-           ],
-           "description": "GtoPdb returns synonyms as objects like {\"name\": \"...\"}; a plain string is also accepted."
-          }
-         },
-         "databaseLinks": {
-          "type": "array"
-         }
-        }
-       }
-      }
-     },
-     "required": [
-      "data"
-     ]
-    },
-    {
-     "type": "object",
-     "properties": {
-      "error": {
-       "type": "string"
-      }
-     },
-     "required": [
-      "error"
-     ]
-    }
-   ]
-  }
- },
- {
-  "name": "GtoPdb_get_ligand_properties",
-  "description": "Get the chemical structure and computed molecular properties of a ligand from the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) by its ligand ID. Merges two keyless endpoints into one record: structure (canonical SMILES, InChI, InChIKey, IUPAC name) and molecularProperties (molecular weight, logP, hydrogen-bond donors/acceptors, rotatable bonds, topological polar surface area, Lipinski rule-of-five violation count). Use GtoPdb_search_ligands first to find a ligand_id (e.g., aspirin = 4139). No authentication required.",
-  "parameter": {
-   "type": "object",
-   "properties": {
-    "ligand_id": {
-     "type": [
-      "integer",
-      "null"
-     ],
-     "description": "GtoPdb ligand ID. Get from GtoPdb_search_ligands. Examples: 4139 (aspirin), 1 (a-bungarotoxin). Alias: ligandId also accepted."
-    },
-    "ligandId": {
-     "type": [
-      "integer",
-      "null"
-     ],
-     "description": "Alias for ligand_id. GtoPdb ligand ID."
-    }
-   },
-   "required": []
-  },
-  "fields": {
-   "endpoint": "https://www.guidetopharmacology.org/services/ligands/ligandProperties",
-   "params": {}
-  },
-  "type": "GtoPdbRESTTool",
-  "test_examples": [
-   {
-    "ligand_id": 4139
-   },
-   {
-    "ligandId": 4139
-   }
-  ],
-  "return_schema": {
-    "oneOf": [
-      {
-        "type": "object",
-        "properties": {
-          "ligandId": {
-            "type": [
-              "integer",
-              "null"
-            ]
-          },
-          "ligandName": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "iupacName": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "smiles": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "inchi": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "inchiKey": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "molecularProperties": {
-            "type": [
-              "object",
-              "null"
-            ],
+            "type": "object",
             "properties": {
-              "molecularWeight": {
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "logP": {
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "hydrogenBondDonors": {
+              "diseaseId": {
                 "type": [
                   "integer",
                   "null"
-                ]
+                ],
+                "description": "GtoPdb disease ID"
               },
-              "hydrogenBondAcceptors": {
+              "name": {
                 "type": [
-                  "integer",
+                  "string",
+                  "null"
+                ],
+                "description": "Disease name"
+              },
+              "description": {
+                "type": [
+                  "string",
                   "null"
                 ]
               },
-              "rotatableBonds": {
-                "type": [
-                  "integer",
-                  "null"
-                ]
+              "synonyms": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "object",
+                    "string"
+                  ],
+                  "description": "GtoPdb returns synonyms as objects like {\"name\": \"...\"}; a plain string is also accepted."
+                }
               },
-              "topologicalPolarSurfaceArea": {
-                "type": [
-                  "number",
-                  "null"
-                ]
-              },
-              "lipinskisRuleOfFive": {
-                "type": [
-                  "integer",
-                  "null"
-                ]
+              "databaseLinks": {
+                "type": "array"
               }
             }
           }
         },
-        "required": [
-          "ligandId"
-        ]
-      },
-      {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "error"
-        ]
-      }
-    ]
-  }
- },
- {
-  "name": "GtoPdb_get_disease_associations",
-  "description": "Get curated disease-to-target and disease-to-ligand associations from the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) for a given disease ID. Merges two keyless endpoints into one record: diseaseTargets (drug targets linked to the disease, with roles, references, and ligand-target interactions) and diseaseLigands (approved/experimental ligands linked to the disease, with approval status and clinical-use notes). An empty list is a valid result (some diseases have targets but no curated ligands). Use GtoPdb_search_diseases first to find a disease_id (e.g., non-allergic asthma = 1161). No authentication required.",
-  "parameter": {
-   "type": "object",
-   "properties": {
-    "disease_id": {
-     "type": [
-      "integer",
-      "null"
-     ],
-     "description": "GtoPdb disease ID. Get from GtoPdb_search_diseases. Examples: 1161 (non-allergic asthma), 34 (acute myeloid leukemia). Alias: diseaseId also accepted."
-    },
-    "diseaseId": {
-     "type": [
-      "integer",
-      "null"
-     ],
-     "description": "Alias for disease_id. GtoPdb disease ID."
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
     }
-   },
-   "required": []
   },
-  "fields": {
-   "endpoint": "https://www.guidetopharmacology.org/services/diseases/diseaseAssociations",
-   "params": {}
-  },
-  "type": "GtoPdbRESTTool",
-  "test_examples": [
-   {
-    "disease_id": 1161
-   },
-   {
-    "disease_id": 34
-   }
-  ],
-  "return_schema": {
-    "oneOf": [
-      {
-        "type": "object",
-        "properties": {
-          "diseaseId": {
-            "type": [
-              "integer",
-              "null"
-            ]
-          },
-          "diseaseTargets": {
-            "type": "array",
-            "items": {
-              "type": "object"
-            }
-          },
-          "diseaseLigands": {
-            "type": "array",
-            "items": {
-              "type": "object"
-            }
-          }
+  {
+    "name": "GtoPdb_get_ligand_properties",
+    "description": "Get the chemical structure and computed molecular properties of a ligand from the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) by its ligand ID. Merges two keyless endpoints into one record: structure (canonical SMILES, InChI, InChIKey, IUPAC name) and molecularProperties (molecular weight, logP, hydrogen-bond donors/acceptors, rotatable bonds, topological polar surface area, Lipinski rule-of-five violation count). Use GtoPdb_search_ligands first to find a ligand_id (e.g., aspirin = 4139). No authentication required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "ligand_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "GtoPdb ligand ID. Get from GtoPdb_search_ligands. Examples: 4139 (aspirin), 1 (a-bungarotoxin). Alias: ligandId also accepted."
         },
-        "required": [
-          "diseaseTargets",
-          "diseaseLigands"
-        ]
+        "ligandId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Alias for ligand_id. GtoPdb ligand ID."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "endpoint": "https://www.guidetopharmacology.org/services/ligands/ligandProperties",
+      "params": {}
+    },
+    "type": "GtoPdbRESTTool",
+    "test_examples": [
+      {
+        "ligand_id": 4139
       },
       {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "error"
-        ]
+        "ligandId": 4139
       }
-    ]
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ligandId": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "ligandName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "iupacName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "smiles": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "inchi": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "inchiKey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "molecularProperties": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "molecularWeight": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "logP": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "hydrogenBondDonors": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "hydrogenBondAcceptors": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "rotatableBonds": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "topologicalPolarSurfaceArea": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "lipinskisRuleOfFive": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              }
+            }
+          },
+          "required": [
+            "ligandId"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "GtoPdb_get_disease_associations",
+    "description": "Get curated disease-to-target and disease-to-ligand associations from the Guide to Pharmacology (GtoPdb / IUPHAR-BPS) for a given disease ID. Merges two keyless endpoints into one record: diseaseTargets (drug targets linked to the disease, with roles, references, and ligand-target interactions) and diseaseLigands (approved/experimental ligands linked to the disease, with approval status and clinical-use notes). An empty list is a valid result (some diseases have targets but no curated ligands). Use GtoPdb_search_diseases first to find a disease_id (e.g., non-allergic asthma = 1161). No authentication required.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "disease_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "GtoPdb disease ID. Get from GtoPdb_search_diseases. Examples: 1161 (non-allergic asthma), 34 (acute myeloid leukemia). Alias: diseaseId also accepted."
+        },
+        "diseaseId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Alias for disease_id. GtoPdb disease ID."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "endpoint": "https://www.guidetopharmacology.org/services/diseases/diseaseAssociations",
+      "params": {}
+    },
+    "type": "GtoPdbRESTTool",
+    "test_examples": [
+      {
+        "disease_id": 1161
+      },
+      {
+        "disease_id": 34
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "diseaseId": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "diseaseTargets": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "diseaseLigands": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          },
+          "required": [
+            "diseaseTargets",
+            "diseaseLigands"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
   }
- }
 ]

--- a/src/tooluniverse/data/gwas_tools.json
+++ b/src/tooluniverse/data/gwas_tools.json
@@ -8,7 +8,7 @@
       "properties": {
         "disease_trait": {
           "type": "string",
-          "description": "Disease or trait name for text-based search (e.g., 'diabetes', 'coronary artery disease', 'breast cancer'). NOTE: GWAS associations are indexed by trait/disease, not by gene or drug name — passing a gene symbol or drug name here will fail. Use efo_id for precise filtering."
+          "description": "Disease or trait name for text-based search (e.g., 'diabetes', 'coronary artery disease', 'breast cancer'). NOTE: GWAS associations are indexed by trait/disease, not by gene or drug name \u2014 passing a gene symbol or drug name here will fail. Use efo_id for precise filtering."
         },
         "query": {
           "type": "string",
@@ -250,10 +250,8 @@
       "Search"
     ],
     "return_schema": {
-      "type": "object",
-      "description": "GWAS studies search results with pagination metadata",
-      "properties": {
-        "data": {
+      "oneOf": [
+        {
           "type": "array",
           "description": "Array of GWAS study objects",
           "items": {
@@ -369,34 +367,18 @@
             }
           }
         },
-        "metadata": {
+        {
           "type": "object",
-          "description": "Pagination and navigation metadata",
           "properties": {
-            "pagination": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "integer"
-                },
-                "totalElements": {
-                  "type": "integer"
-                },
-                "totalPages": {
-                  "type": "integer"
-                },
-                "number": {
-                  "type": "integer"
-                }
-              }
-            },
-            "links": {
-              "type": "object",
-              "description": "Navigation links"
+            "error": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     },
     "test_examples": [
       {
@@ -438,10 +420,8 @@
       "Search"
     ],
     "return_schema": {
-      "type": "object",
-      "description": "GWAS SNPs search results with pagination metadata",
-      "properties": {
-        "data": {
+      "oneOf": [
+        {
           "type": "array",
           "description": "Array of SNP objects",
           "items": {
@@ -514,34 +494,18 @@
             }
           }
         },
-        "metadata": {
+        {
           "type": "object",
-          "description": "Pagination and navigation metadata",
           "properties": {
-            "pagination": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "integer"
-                },
-                "totalElements": {
-                  "type": "integer"
-                },
-                "totalPages": {
-                  "type": "integer"
-                },
-                "number": {
-                  "type": "integer"
-                }
-              }
-            },
-            "links": {
-              "type": "object",
-              "description": "Navigation links"
+            "error": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     },
     "test_examples": [
       {
@@ -1002,10 +966,8 @@
       "Genetics"
     ],
     "return_schema": {
-      "type": "object",
-      "description": "GWAS variants for trait results with pagination metadata",
-      "properties": {
-        "data": {
+      "oneOf": [
+        {
           "type": "array",
           "description": "Array of variant objects",
           "items": {
@@ -1078,34 +1040,18 @@
             }
           }
         },
-        "metadata": {
+        {
           "type": "object",
-          "description": "Pagination and navigation metadata",
           "properties": {
-            "pagination": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "integer"
-                },
-                "totalElements": {
-                  "type": "integer"
-                },
-                "totalPages": {
-                  "type": "integer"
-                },
-                "number": {
-                  "type": "integer"
-                }
-              }
-            },
-            "links": {
-              "type": "object",
-              "description": "Navigation links"
+            "error": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     },
     "test_examples": [
       {
@@ -1176,10 +1122,8 @@
       "Significance"
     ],
     "return_schema": {
-      "type": "object",
-      "description": "GWAS associations for trait results with pagination metadata",
-      "properties": {
-        "data": {
+      "oneOf": [
+        {
           "type": "array",
           "description": "Array of GWAS association objects",
           "items": {
@@ -1287,34 +1231,18 @@
             }
           }
         },
-        "metadata": {
+        {
           "type": "object",
-          "description": "Pagination and navigation metadata",
           "properties": {
-            "pagination": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "integer"
-                },
-                "totalElements": {
-                  "type": "integer"
-                },
-                "totalPages": {
-                  "type": "integer"
-                },
-                "number": {
-                  "type": "integer"
-                }
-              }
-            },
-            "links": {
-              "type": "object",
-              "description": "Navigation links"
+            "error": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     },
     "test_examples": [
       {
@@ -1362,10 +1290,8 @@
       "Traits"
     ],
     "return_schema": {
-      "type": "object",
-      "description": "GWAS associations for SNP results with pagination metadata",
-      "properties": {
-        "data": {
+      "oneOf": [
+        {
           "type": "array",
           "description": "Array of GWAS association objects",
           "items": {
@@ -1473,34 +1399,18 @@
             }
           }
         },
-        "metadata": {
+        {
           "type": "object",
-          "description": "Pagination and navigation metadata",
           "properties": {
-            "pagination": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "integer"
-                },
-                "totalElements": {
-                  "type": "integer"
-                },
-                "totalPages": {
-                  "type": "integer"
-                },
-                "number": {
-                  "type": "integer"
-                }
-              }
-            },
-            "links": {
-              "type": "object",
-              "description": "Navigation links"
+            "error": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     },
     "test_examples": [
       {
@@ -1585,10 +1495,8 @@
       "Research"
     ],
     "return_schema": {
-      "type": "object",
-      "description": "GWAS studies for trait results with pagination metadata",
-      "properties": {
-        "data": {
+      "oneOf": [
+        {
           "type": "array",
           "description": "Array of GWAS study objects",
           "items": {
@@ -1704,34 +1612,18 @@
             }
           }
         },
-        "metadata": {
+        {
           "type": "object",
-          "description": "Pagination and navigation metadata",
           "properties": {
-            "pagination": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "integer"
-                },
-                "totalElements": {
-                  "type": "integer"
-                },
-                "totalPages": {
-                  "type": "integer"
-                },
-                "number": {
-                  "type": "integer"
-                }
-              }
-            },
-            "links": {
-              "type": "object",
-              "description": "Navigation links"
+            "error": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     },
     "test_examples": [
       {
@@ -1777,10 +1669,8 @@
       "Mapping"
     ],
     "return_schema": {
-      "type": "object",
-      "description": "GWAS SNPs for gene results with pagination metadata",
-      "properties": {
-        "data": {
+      "oneOf": [
+        {
           "type": "array",
           "description": "Array of SNP objects",
           "items": {
@@ -1853,34 +1743,18 @@
             }
           }
         },
-        "metadata": {
+        {
           "type": "object",
-          "description": "Pagination and navigation metadata",
           "properties": {
-            "pagination": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "integer"
-                },
-                "totalElements": {
-                  "type": "integer"
-                },
-                "totalPages": {
-                  "type": "integer"
-                },
-                "number": {
-                  "type": "integer"
-                }
-              }
-            },
-            "links": {
-              "type": "object",
-              "description": "Navigation links"
+            "error": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     },
     "test_examples": [
       {
@@ -1921,10 +1795,8 @@
       "Results"
     ],
     "return_schema": {
-      "type": "object",
-      "description": "GWAS associations for study results with pagination metadata",
-      "properties": {
-        "data": {
+      "oneOf": [
+        {
           "type": "array",
           "description": "Array of GWAS association objects",
           "items": {
@@ -2032,34 +1904,18 @@
             }
           }
         },
-        "metadata": {
+        {
           "type": "object",
-          "description": "Pagination and navigation metadata",
           "properties": {
-            "pagination": {
-              "type": "object",
-              "properties": {
-                "size": {
-                  "type": "integer"
-                },
-                "totalElements": {
-                  "type": "integer"
-                },
-                "totalPages": {
-                  "type": "integer"
-                },
-                "number": {
-                  "type": "integer"
-                }
-              }
-            },
-            "links": {
-              "type": "object",
-              "description": "Navigation links"
+            "error": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     },
     "test_examples": [
       {

--- a/src/tooluniverse/data/gxa_tools.json
+++ b/src/tooluniverse/data/gxa_tools.json
@@ -1,248 +1,281 @@
 [
-    {
-        "name": "GxA_list_experiments",
-        "description": "List gene expression experiments from EBI Gene Expression Atlas. Can filter by species (e.g., 'Homo sapiens') and experiment type ('baseline' for tissue expression, 'differential' for condition comparisons). The Atlas contains 4,500+ experiments across hundreds of species. Example: filtering by 'Homo sapiens' and 'baseline' returns 123 human tissue-level expression experiments including E-MTAB-2836 (122 human tissues), E-MTAB-2706 (675 cancer cell lines), and E-GEOD-46817 (melanoma).",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "species": {
-                    "type": "string",
-                    "description": "Species name to filter experiments (e.g., 'Homo sapiens', 'Mus musculus', 'Arabidopsis thaliana'). Leave empty for all species."
-                },
-                "experiment_type": {
-                    "type": "string",
-                    "description": "Filter by experiment type: 'baseline' (tissue/cell type expression), 'differential' (condition comparisons), 'proteomics', or 'rnaseq'. Leave empty for all types."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum number of experiments to return (1-100). Default: 20."
-                }
-            },
-            "required": []
+  {
+    "name": "GxA_list_experiments",
+    "description": "List gene expression experiments from EBI Gene Expression Atlas. Can filter by species (e.g., 'Homo sapiens') and experiment type ('baseline' for tissue expression, 'differential' for condition comparisons). The Atlas contains 4,500+ experiments across hundreds of species. Example: filtering by 'Homo sapiens' and 'baseline' returns 123 human tissue-level expression experiments including E-MTAB-2836 (122 human tissues), E-MTAB-2706 (675 cancer cell lines), and E-GEOD-46817 (melanoma).",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "species": {
+          "type": "string",
+          "description": "Species name to filter experiments (e.g., 'Homo sapiens', 'Mus musculus', 'Arabidopsis thaliana'). Leave empty for all species."
         },
-        "fields": {
-            "endpoint": "list_experiments"
+        "experiment_type": {
+          "type": "string",
+          "description": "Filter by experiment type: 'baseline' (tissue/cell type expression), 'differential' (condition comparisons), 'proteomics', or 'rnaseq'. Leave empty for all types."
         },
-        "type": "GxATool",
-        "test_examples": [
-            {
-                "species": "Homo sapiens",
-                "experiment_type": "baseline",
-                "limit": 5
-            },
-            {
-                "species": "Mus musculus",
-                "limit": 5
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "total_experiments": {
-                                    "type": "integer",
-                                    "description": "Total number of matching experiments"
-                                },
-                                "returned": {
-                                    "type": "integer",
-                                    "description": "Number of experiments in this response"
-                                },
-                                "experiments": {
-                                    "type": "array",
-                                    "description": "List of experiments with accession, description, species, type, and assay count",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "accession": {"type": "string"},
-                                            "description": {"type": "string"},
-                                            "species": {"type": "string"},
-                                            "experiment_type": {"type": "string"},
-                                            "number_of_assays": {"type": "integer"}
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
+        "limit": {
+          "type": "integer",
+          "description": "Maximum number of experiments to return (1-100). Default: 20."
         }
+      },
+      "required": []
     },
-    {
-        "name": "GxA_get_experiment_expression",
-        "description": "Get gene expression data from a specific Expression Atlas experiment. Returns expression levels across tissues or conditions, with optional filtering by gene ID. Experiment E-MTAB-2836 contains RNA-seq of 122 human tissues, E-MTAB-2706 covers 675 cancer cell lines. For each gene, expression values are provided across all assayed conditions (tissues, cell types, developmental stages, etc.).",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "experiment_accession": {
-                    "type": "string",
-                    "description": "Expression Atlas experiment accession (e.g., 'E-MTAB-2836' for human tissues RNA-seq, 'E-MTAB-2706' for cancer cell lines)."
-                },
-                "gene_id": {
-                    "type": "string",
-                    "description": "Optional Ensembl gene ID to filter expression data for a specific gene (e.g., 'ENSG00000141510' for TP53). Leave empty for all genes in the experiment."
-                }
-            },
-            "required": ["experiment_accession"]
-        },
-        "fields": {
-            "endpoint": "get_experiment_expression"
-        },
-        "type": "GxATool",
-        "test_examples": [
-            {
-                "experiment_accession": "E-MTAB-2836"
-            },
-            {
-                "experiment_accession": "E-MTAB-2836",
-                "gene_id": "ENSG00000141510"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "experiment_accession": {
-                                    "type": "string",
-                                    "description": "Experiment accession ID"
-                                },
-                                "experiment_description": {
-                                    "type": "string",
-                                    "description": "Experiment description"
-                                },
-                                "columns": {
-                                    "type": "array",
-                                    "description": "Assay conditions (tissues/cell types/treatments)",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "factor_value": {"type": "string"},
-                                            "ontology_term_id": {"type": ["string", "null"]},
-                                            "replicates": {"type": ["integer", "null"]}
-                                        }
-                                    }
-                                },
-                                "total_gene_profiles": {
-                                    "type": "integer",
-                                    "description": "Total genes with expression data"
-                                },
-                                "gene_profiles": {
-                                    "type": "array",
-                                    "description": "Gene expression profiles with tissue/condition values",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "gene_id": {"type": "string"},
-                                            "gene_name": {"type": "string"},
-                                            "expressions": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "tissue": {"type": "string"},
-                                                        "value": {"type": "number"}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
+    "fields": {
+      "endpoint": "list_experiments"
     },
-    {
-        "name": "GxA_get_experiment_info",
-        "description": "Get metadata about a Gene Expression Atlas experiment including species, number of genes and conditions, and experimental design. Useful for understanding what data is available before querying specific gene expression. Example: E-MTAB-2836 has 29 conditions (tissues) and profiles for thousands of genes in Homo sapiens.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "experiment_accession": {
-                    "type": "string",
-                    "description": "Expression Atlas experiment accession (e.g., 'E-MTAB-2836', 'E-MTAB-2706', 'E-GEOD-46817')."
-                }
+    "type": "GxATool",
+    "test_examples": [
+      {
+        "species": "Homo sapiens",
+        "experiment_type": "baseline",
+        "limit": 5
+      },
+      {
+        "species": "Mus musculus",
+        "limit": 5
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "total_experiments": {
+              "type": "integer",
+              "description": "Total number of matching experiments"
             },
-            "required": ["experiment_accession"]
-        },
-        "fields": {
-            "endpoint": "get_experiment_info"
-        },
-        "type": "GxATool",
-        "test_examples": [
-            {
-                "experiment_accession": "E-MTAB-2836"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "accession": {"type": "string"},
-                                "description": {"type": ["string", "null"]},
-                                "species": {"type": ["string", "null"]},
-                                "total_genes": {"type": "integer"},
-                                "total_conditions": {"type": "integer"},
-                                "column_groupings": {"type": "array"},
-                                "config": {"type": "object"}
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
+            "returned": {
+              "type": "integer",
+              "description": "Number of experiments in this response"
+            },
+            "experiments": {
+              "type": "array",
+              "description": "List of experiments with accession, description, species, type, and assay count",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "species": {
+                    "type": "string"
+                  },
+                  "experiment_type": {
+                    "type": "string"
+                  },
+                  "number_of_assays": {
+                    "type": "integer"
+                  }
                 }
-            ]
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "GxA_get_experiment_expression",
+    "description": "Get gene expression data from a specific Expression Atlas experiment. Returns expression levels across tissues or conditions, with optional filtering by gene ID. Experiment E-MTAB-2836 contains RNA-seq of 122 human tissues, E-MTAB-2706 covers 675 cancer cell lines. For each gene, expression values are provided across all assayed conditions (tissues, cell types, developmental stages, etc.).",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "experiment_accession": {
+          "type": "string",
+          "description": "Expression Atlas experiment accession (e.g., 'E-MTAB-2836' for human tissues RNA-seq, 'E-MTAB-2706' for cancer cell lines)."
+        },
+        "gene_id": {
+          "type": "string",
+          "description": "Optional Ensembl gene ID to filter expression data for a specific gene (e.g., 'ENSG00000141510' for TP53). Leave empty for all genes in the experiment."
+        }
+      },
+      "required": [
+        "experiment_accession"
+      ]
+    },
+    "fields": {
+      "endpoint": "get_experiment_expression"
+    },
+    "type": "GxATool",
+    "test_examples": [
+      {
+        "experiment_accession": "E-MTAB-2836"
+      },
+      {
+        "experiment_accession": "E-MTAB-2836",
+        "gene_id": "ENSG00000141510"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "experiment_accession": {
+              "type": "string",
+              "description": "Experiment accession ID"
+            },
+            "experiment_description": {
+              "type": "string",
+              "description": "Experiment description"
+            },
+            "columns": {
+              "type": "array",
+              "description": "Assay conditions (tissues/cell types/treatments)",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "factor_value": {
+                    "type": "string"
+                  },
+                  "ontology_term_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "replicates": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "total_gene_profiles": {
+              "type": "integer",
+              "description": "Total genes with expression data"
+            },
+            "gene_profiles": {
+              "type": "array",
+              "description": "Gene expression profiles with tissue/condition values",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "gene_id": {
+                    "type": "string"
+                  },
+                  "gene_name": {
+                    "type": "string"
+                  },
+                  "expressions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "tissue": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "GxA_get_experiment_info",
+    "description": "Get metadata about a Gene Expression Atlas experiment including species, number of genes and conditions, and experimental design. Useful for understanding what data is available before querying specific gene expression. Example: E-MTAB-2836 has 29 conditions (tissues) and profiles for thousands of genes in Homo sapiens.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "experiment_accession": {
+          "type": "string",
+          "description": "Expression Atlas experiment accession (e.g., 'E-MTAB-2836', 'E-MTAB-2706', 'E-GEOD-46817')."
+        }
+      },
+      "required": [
+        "experiment_accession"
+      ]
+    },
+    "fields": {
+      "endpoint": "get_experiment_info"
+    },
+    "type": "GxATool",
+    "test_examples": [
+      {
+        "experiment_accession": "E-MTAB-2836"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "accession": {
+              "type": "string"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "species": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "total_genes": {
+              "type": "integer"
+            },
+            "total_conditions": {
+              "type": "integer"
+            },
+            "column_groupings": {
+              "type": "array"
+            },
+            "config": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/hgnc_tools.json
+++ b/src/tooluniverse/data/hgnc_tools.json
@@ -32,133 +32,108 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "hgnc_id": {
-                  "type": "string",
-                  "description": "HGNC identifier (e.g., HGNC:11998)"
-                },
-                "symbol": {
-                  "type": "string",
-                  "description": "Approved gene symbol"
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Approved gene name"
-                },
-                "locus_type": {
-                  "type": "string",
-                  "description": "Type of locus (e.g., gene with protein product)"
-                },
-                "locus_group": {
-                  "type": "string",
-                  "description": "Locus group classification"
-                },
-                "status": {
-                  "type": "string",
-                  "description": "Symbol status (Approved, etc.)"
-                },
-                "location": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Chromosomal location"
-                },
-                "entrez_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "NCBI Entrez Gene ID"
-                },
-                "ensembl_gene_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Ensembl Gene ID"
-                },
-                "uniprot_ids": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "UniProt accession(s)"
-                },
-                "refseq_accession": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "RefSeq accession(s)"
-                },
-                "omim_id": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "OMIM ID(s)"
-                },
-                "ccds_id": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "CCDS ID(s)"
-                },
-                "prev_symbol": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "Previous gene symbols"
-                },
-                "prev_name": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "Previous gene names"
-                },
-                "alias_symbol": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "Alias symbols"
-                },
-                "gene_group": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "Gene group memberships"
-                }
-              }
+            "hgnc_id": {
+              "type": "string",
+              "description": "HGNC identifier (e.g., HGNC:11998)"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_field": {
-                  "type": "string"
-                },
-                "query_value": {
-                  "type": "string"
-                },
-                "num_found": {
-                  "type": "integer"
-                }
-              }
+            "symbol": {
+              "type": "string",
+              "description": "Approved gene symbol"
+            },
+            "name": {
+              "type": "string",
+              "description": "Approved gene name"
+            },
+            "locus_type": {
+              "type": "string",
+              "description": "Type of locus (e.g., gene with protein product)"
+            },
+            "locus_group": {
+              "type": "string",
+              "description": "Locus group classification"
+            },
+            "status": {
+              "type": "string",
+              "description": "Symbol status (Approved, etc.)"
+            },
+            "location": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Chromosomal location"
+            },
+            "entrez_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "NCBI Entrez Gene ID"
+            },
+            "ensembl_gene_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Ensembl Gene ID"
+            },
+            "uniprot_ids": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "UniProt accession(s)"
+            },
+            "refseq_accession": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "RefSeq accession(s)"
+            },
+            "omim_id": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "OMIM ID(s)"
+            },
+            "ccds_id": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "CCDS ID(s)"
+            },
+            "prev_symbol": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "Previous gene symbols"
+            },
+            "prev_name": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "Previous gene names"
+            },
+            "alias_symbol": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "Alias symbols"
+            },
+            "gene_group": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "Gene group memberships"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -207,77 +182,52 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "hgnc_id": {
-                  "type": "string"
-                },
-                "symbol": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "locus_type": {
-                  "type": "string"
-                },
-                "status": {
-                  "type": "string"
-                },
-                "location": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "entrez_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "ensembl_gene_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "uniprot_ids": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "refseq_accession": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                }
-              }
+            "hgnc_id": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_field": {
-                  "type": "string"
-                },
-                "query_value": {
-                  "type": "string"
-                },
-                "num_found": {
-                  "type": "integer"
-                }
-              }
+            "symbol": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "locus_type": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "location": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "entrez_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ensembl_gene_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "uniprot_ids": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "refseq_accession": {
+              "type": [
+                "array",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -332,55 +282,33 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "hgnc_id": {
-                    "type": "string"
-                  },
-                  "symbol": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "status": {
-                    "type": "string"
-                  },
-                  "location": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hgnc_id": {
+                "type": "string"
+              },
+              "symbol": {
+                "type": "string"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "location": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -427,61 +355,39 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "hgnc_id": {
-                    "type": "string"
-                  },
-                  "symbol": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "status": {
-                    "type": "string"
-                  },
-                  "location": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "locus_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query_location": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hgnc_id": {
+                "type": "string"
+              },
+              "symbol": {
+                "type": "string"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "location": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "locus_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -528,92 +434,64 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "description": "Full HGNC record for every member gene of the family",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "hgnc_id": {
-                    "type": "string"
-                  },
-                  "symbol": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "locus_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "location": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_group": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "gene_group_id": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "ensembl_gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "entrez_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "uniprot_ids": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_field": {
-                  "type": "string"
-                },
-                "query_value": {
-                  "type": "string"
-                },
-                "num_found": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "description": "Full HGNC record for every member gene of the family",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hgnc_id": {
+                "type": "string"
+              },
+              "symbol": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "locus_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "location": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_group": {
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "gene_group_id": {
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
+              "ensembl_gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "entrez_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uniprot_ids": {
+                "type": [
+                  "array",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/hpo_tools.json
+++ b/src/tooluniverse/data/hpo_tools.json
@@ -31,82 +31,63 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "HPO term ID (e.g., HP:0001250)"
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Term name"
-                },
-                "definition": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Full term definition"
-                },
-                "comment": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Additional comments or notes"
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Alternative names for the term"
-                },
-                "descendant_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of more specific child terms"
-                },
-                "xrefs": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Cross-references (UMLS, SNOMED-CT, etc.)"
-                },
-                "translations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  },
-                  "description": "Translations in other languages"
-                }
-              }
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "HPO term ID (e.g., HP:0001250)"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "term_id": {
-                  "type": "string"
-                }
-              }
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Term name"
+            },
+            "definition": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Full term definition"
+            },
+            "comment": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Additional comments or notes"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Alternative names for the term"
+            },
+            "descendant_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of more specific child terms"
+            },
+            "xrefs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Cross-references (UMLS, SNOMED-CT, etc.)"
+            },
+            "translations": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "description": "Translations in other languages"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -160,69 +141,47 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "HPO term ID"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Term name"
-                  },
-                  "definition": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Term definition"
-                  },
-                  "descendant_count": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of child terms"
-                  },
-                  "synonyms": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "First 5 synonyms"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "HPO term ID"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Term name"
+              },
+              "definition": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Term definition"
+              },
+              "descendant_count": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of child terms"
+              },
+              "synonyms": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 },
-                "query": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+                "description": "First 5 synonyms"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -277,51 +236,26 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "HPO term ID"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Term name"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "term_id": {
-                  "type": "string"
-                },
-                "direction": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "HPO term ID"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Term name"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -374,54 +308,29 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "genes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Identifier (e.g. 'NCBIGene:5649' for genes, 'ORPHA:..'/'OMIM:..' for diseases)"
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Name"
-                      }
-                    }
+            "genes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Identifier (e.g. 'NCBIGene:5649' for genes, 'ORPHA:..'/'OMIM:..' for diseases)"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Name"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "term_id": {
-                  "type": "string"
-                },
-                "total": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -474,61 +383,36 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "diseases": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Identifier (e.g. 'NCBIGene:5649' for genes, 'ORPHA:..'/'OMIM:..' for diseases)"
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Name"
-                      },
-                      "mondo_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Cross-referenced MONDO disease ID"
-                      }
-                    }
+            "diseases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Identifier (e.g. 'NCBIGene:5649' for genes, 'ORPHA:..'/'OMIM:..' for diseases)"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Name"
+                  },
+                  "mondo_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Cross-referenced MONDO disease ID"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "term_id": {
-                  "type": "string"
-                },
-                "total": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -573,185 +457,154 @@
         {
           "type": "object",
           "properties": {
-            "data": {
+            "disease": {
               "type": "object",
               "properties": {
-                "disease": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "mondo_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "description": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
+                "id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "medical_actions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "MAxO action CURIE (e.g., 'MAXO:0000653')."
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "relations": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "description": "Action relations, e.g. ['PREVENTS', 'TREATS']."
-                      },
-                      "targets": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "name": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            }
-                          }
-                        },
-                        "description": "Targeted HPO phenotypes."
-                      }
-                    }
-                  }
+                "name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "categories": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "body_system": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "phenotype_count": {
-                        "type": "integer"
-                      },
-                      "phenotypes": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "name": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "frequency": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "onset": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            }
-                          }
+                "mondo_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "description": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "medical_actions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "MAxO action CURIE (e.g., 'MAXO:0000653')."
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "relations": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Action relations, e.g. ['PREVENTS', 'TREATS']."
+                  },
+                  "targets": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
                         }
                       }
-                    }
+                    },
+                    "description": "Targeted HPO phenotypes."
                   }
-                },
-                "genes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
+                }
+              }
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "body_system": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "phenotype_count": {
+                    "type": "integer"
+                  },
+                  "phenotypes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "frequency": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "onset": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
                       }
                     }
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "disease_id": {
-                  "type": "string"
-                },
-                "total_medical_actions": {
-                  "type": "integer"
-                },
-                "total_body_systems": {
-                  "type": "integer"
-                },
-                "total_phenotypes": {
-                  "type": "integer"
-                },
-                "total_genes": {
-                  "type": "integer"
+            "genes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/huggingface_inference_tools.json
+++ b/src/tooluniverse/data/huggingface_inference_tools.json
@@ -33,52 +33,40 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "top_label": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "labels": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "top_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -143,41 +131,29 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "dimension": {
-                  "type": "integer"
-                },
-                "embedding": {
-                  "type": "array",
-                  "items": {
-                    "type": "number"
-                  }
-                },
-                "preview": {
-                  "type": "array",
-                  "items": {
-                    "type": "number"
-                  }
-                }
+            "dimension": {
+              "type": "integer"
+            },
+            "embedding": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "preview": {
+              "type": "array",
+              "items": {
+                "type": "number"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -249,58 +225,46 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "top_token": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "predictions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "token_str": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "sequence": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "top_token": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "predictions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "token_str": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "sequence": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -380,29 +344,17 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "summary_text": {
-                  "type": "string"
-                }
-              }
+            "summary_text": {
+              "type": "string"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -479,52 +431,40 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "top_label": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "labels": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "top_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -590,67 +530,55 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "entity_count": {
-                  "type": "integer"
-                },
-                "entities": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "entity_group": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "word": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "start": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "end": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+            "entity_count": {
+              "type": "integer"
+            },
+            "entities": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "entity_group": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "word": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "start": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "end": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -715,50 +643,38 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "answer": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "score": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "start": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "end": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                }
-              }
+            "answer": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "score": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "start": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "end": {
+              "type": [
+                "integer",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -819,29 +735,17 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "translation_text": {
-                  "type": "string"
-                }
-              }
+            "translation_text": {
+              "type": "string"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -910,52 +814,40 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "top_label": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "labels": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "top_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -1024,78 +916,66 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "model_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "model_id": {
-                  "type": "string"
-                },
-                "object_count": {
-                  "type": "integer"
-                },
-                "objects": {
-                  "type": "array",
-                  "items": {
+            "object_count": {
+              "type": "integer"
+            },
+            "objects": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "box": {
                     "type": "object",
                     "properties": {
-                      "label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
+                      "xmin": {
                         "type": [
                           "number",
                           "null"
                         ]
                       },
-                      "box": {
-                        "type": "object",
-                        "properties": {
-                          "xmin": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "ymin": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "xmax": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "ymax": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          }
-                        }
+                      "ymin": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      },
+                      "xmax": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      },
+                      "ymax": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
                       }
                     }
                   }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/humanmine_tools.json
+++ b/src/tooluniverse/data/humanmine_tools.json
@@ -407,40 +407,54 @@
           "type": "object",
           "description": "InterMine PathQuery JSON result",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "views": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Column paths in result order"
-                },
-                "results": {
-                  "type": "array",
-                  "items": {
-                    "type": "array"
-                  },
-                  "description": "Result rows; each row is a list of cell values matching 'views'"
-                },
-                "rootClass": {
-                  "type": "string"
-                },
-                "wasSuccessful": {
-                  "type": "boolean"
-                },
-                "executionTime": {
-                  "type": "string"
-                }
+            "views": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Column paths in result order"
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "array"
+              },
+              "description": "Result rows; each row is a list of cell values matching 'views'"
+            },
+            "modelName": {
+              "type": "string"
+            },
+            "columnHeaders": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
+            },
+            "rootClass": {
+              "type": "string"
+            },
+            "start": {
+              "type": "integer"
+            },
+            "wasSuccessful": {
+              "type": "boolean"
+            },
+            "executionTime": {
+              "type": "string"
+            },
+            "error": {
+              "type": ["string", "null"]
+            },
+            "statusCode": {
+              "type": "integer"
             },
             "url": {
               "type": "string"
             }
           },
           "required": [
-            "data"
+            "views",
+            "results"
           ]
         },
         {

--- a/src/tooluniverse/data/icite_tools.json
+++ b/src/tooluniverse/data/icite_tools.json
@@ -30,261 +30,139 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "_id": {
-                    "type": "string"
-                  },
-                  "authors": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "lastName": {
-                          "type": "string"
-                        },
-                        "fullName": {
-                          "type": "string"
-                        },
-                        "firstName": {
-                          "type": "string"
-                        }
-                      }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "_id": {
+                "type": "string"
+              },
+              "authors": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "lastName": {
+                      "type": "string"
+                    },
+                    "fullName": {
+                      "type": "string"
+                    },
+                    "firstName": {
+                      "type": "string"
                     }
-                  },
-                  "doi": {
-                    "type": "string"
-                  },
-                  "pmid": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "title": {
-                    "type": "string"
-                  },
-                  "animal": {
-                    "type": "number"
-                  },
-                  "human": {
-                    "type": "number"
-                  },
-                  "apt": {
-                    "type": "number"
-                  },
-                  "citedByClinicalArticle": {
-                    "type": "boolean"
-                  },
-                  "citedByPmidsByYear": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "36244096": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "39507426": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "34717201": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "39359723": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "35359543": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "24939975": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "31555204": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "35359563": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "31518578": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "32679995": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "38359253": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "41414399": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "35209409": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "36236933": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "35473031": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "38394080": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "33804690": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "36010775": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "37420482": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        },
-                        "37361425": {
-                          "type": [
-                            "integer",
-                            "number"
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "year": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "journal": {
-                    "type": "string"
-                  },
-                  "is_research_article": {
-                    "type": "boolean"
-                  },
-                  "citation_count": {
-                    "type": [
-                      "integer",
-                      "number"
-                    ]
-                  },
-                  "field_citation_rate": {
-                    "type": "number"
-                  },
-                  "expected_citations_per_year": {
-                    "type": "number"
-                  },
-                  "citations_per_year": {
-                    "type": "number"
-                  },
-                  "relative_citation_ratio": {
-                    "type": "number"
-                  },
-                  "nih_percentile": {
-                    "type": "number"
-                  },
-                  "molecular_cellular": {
-                    "type": "number"
-                  },
-                  "x_coord": {
-                    "type": "number"
-                  },
-                  "y_coord": {
-                    "type": "number"
-                  },
-                  "is_clinical": {
-                    "type": "boolean"
-                  },
-                  "cited_by_clin": {
-                    "type": "null"
-                  },
-                  "cited_by": {
-                    "type": "array",
-                    "items": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
-                  },
-                  "references": {
-                    "type": "array",
-                    "items": {
-                      "type": [
-                        "integer",
-                        "number"
-                      ]
-                    }
-                  },
-                  "provisional": {
-                    "type": "boolean"
                   }
                 }
+              },
+              "doi": {
+                "type": "string"
+              },
+              "pmid": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "title": {
+                "type": "string"
+              },
+              "animal": {
+                "type": "number"
+              },
+              "human": {
+                "type": "number"
+              },
+              "apt": {
+                "type": "number"
+              },
+              "citedByClinicalArticle": {
+                "type": "boolean"
+              },
+              "citedByPmidsByYear": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^[0-9]+$": {
+                      "type": [
+                        "integer",
+                        "number"
+                      ]
+                    }
+                  }
+                }
+              },
+              "year": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "journal": {
+                "type": "string"
+              },
+              "is_research_article": {
+                "type": "boolean"
+              },
+              "citation_count": {
+                "type": [
+                  "integer",
+                  "number"
+                ]
+              },
+              "field_citation_rate": {
+                "type": "number"
+              },
+              "expected_citations_per_year": {
+                "type": "number"
+              },
+              "citations_per_year": {
+                "type": "number"
+              },
+              "relative_citation_ratio": {
+                "type": "number"
+              },
+              "nih_percentile": {
+                "type": "number"
+              },
+              "molecular_cellular": {
+                "type": "number"
+              },
+              "x_coord": {
+                "type": "number"
+              },
+              "y_coord": {
+                "type": "number"
+              },
+              "is_clinical": {
+                "type": "boolean"
+              },
+              "cited_by_clin": {
+                "type": ["null", "array"]
+              },
+              "cited_by": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
+              },
+              "references": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "integer",
+                    "number"
+                  ]
+                }
+              },
+              "provisional": {
+                "type": "boolean"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/iedb_prediction_tools.json
+++ b/src/tooluniverse/data/iedb_prediction_tools.json
@@ -48,18 +48,7 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array"
-            },
-            "metadata": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "array"
         },
         {
           "type": "object",
@@ -117,18 +106,7 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array"
-            },
-            "metadata": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "array"
         },
         {
           "type": "object",
@@ -181,52 +159,41 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "epitope_regions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "start": {
-                        "type": [
-                          "string",
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "end": {
-                        "type": [
-                          "string",
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "peptide": {
-                        "type": "string"
-                      },
-                      "mean_score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "epitope_regions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "start": {
+                    "type": [
+                      "string",
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "end": {
+                    "type": [
+                      "string",
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "peptide": {
+                    "type": "string"
+                  },
+                  "mean_score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
-                },
-                "per_residue": {
-                  "type": "array"
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "per_residue": {
+              "type": "array"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -290,56 +257,37 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "peptide": {
-                    "type": "string"
-                  },
-                  "proteasome_score": {
-                    "type": ["number", "string"]
-                  },
-                  "tap_score": {
-                    "type": ["number", "string"]
-                  },
-                  "mhc_score": {
-                    "type": ["number", "string"]
-                  },
-                  "processing_score": {
-                    "type": ["number", "string"]
-                  },
-                  "total_score": {
-                    "type": ["number", "string"]
-                  },
-                  "ic50_score": {
-                    "type": ["number", "string"]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "peptide": {
+                "type": "string"
+              },
+              "proteasome_score": {
+                "type": ["number", "string"]
+              },
+              "tap_score": {
+                "type": ["number", "string"]
+              },
+              "mhc_score": {
+                "type": ["number", "string"]
+              },
+              "processing_score": {
+                "type": ["number", "string"]
+              },
+              "total_score": {
+                "type": ["number", "string"]
+              },
+              "ic50_score": {
+                "type": ["number", "string"]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string",
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/inaturalist_tools.json
+++ b/src/tooluniverse/data/inaturalist_tools.json
@@ -37,78 +37,56 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "integer",
-                    "description": "iNaturalist taxon ID"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Scientific name"
-                  },
-                  "common_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Preferred common name"
-                  },
-                  "rank": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Taxonomic rank (species, genus, family, etc.)"
-                  },
-                  "observations_count": {
-                    "type": "integer",
-                    "description": "Total research-grade observations"
-                  },
-                  "is_active": {
-                    "type": "boolean",
-                    "description": "Whether taxon is currently accepted"
-                  },
-                  "conservation_status": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "IUCN conservation status if available"
-                  },
-                  "wikipedia_url": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Link to Wikipedia article"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "iNaturalist taxon ID"
+              },
+              "name": {
+                "type": "string",
+                "description": "Scientific name"
+              },
+              "common_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Preferred common name"
+              },
+              "rank": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Taxonomic rank (species, genus, family, etc.)"
+              },
+              "observations_count": {
+                "type": "integer",
+                "description": "Total research-grade observations"
+              },
+              "is_active": {
+                "type": "boolean",
+                "description": "Whether taxon is currently accepted"
+              },
+              "conservation_status": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "IUCN conservation status if available"
+              },
+              "wikipedia_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Link to Wikipedia article"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -315,101 +293,79 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "integer",
-                    "description": "Observation ID"
-                  },
-                  "species_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Scientific name of observed species"
-                  },
-                  "common_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Common name"
-                  },
-                  "observed_on": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Date of observation (YYYY-MM-DD)"
-                  },
-                  "place_guess": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Location description"
-                  },
-                  "latitude": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "GPS latitude"
-                  },
-                  "longitude": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "GPS longitude"
-                  },
-                  "quality_grade": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Observation quality grade"
-                  },
-                  "user": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Observer username"
-                  },
-                  "photo_url": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "URL of observation photo"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "per_page": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "Observation ID"
+              },
+              "species_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Scientific name of observed species"
+              },
+              "common_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Common name"
+              },
+              "observed_on": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Date of observation (YYYY-MM-DD)"
+              },
+              "place_guess": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Location description"
+              },
+              "latitude": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "GPS latitude"
+              },
+              "longitude": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "GPS longitude"
+              },
+              "quality_grade": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Observation quality grade"
+              },
+              "user": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Observer username"
+              },
+              "photo_url": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "URL of observation photo"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -480,57 +436,38 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "taxon_id": {
-                    "type": "integer",
-                    "description": "iNaturalist taxon ID"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Scientific name"
-                  },
-                  "common_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Common name"
-                  },
-                  "rank": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Taxonomic rank"
-                  },
-                  "count": {
-                    "type": "integer",
-                    "description": "Number of observations"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_species": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "taxon_id": {
+                "type": "integer",
+                "description": "iNaturalist taxon ID"
+              },
+              "name": {
+                "type": "string",
+                "description": "Scientific name"
+              },
+              "common_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Common name"
+              },
+              "rank": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Taxonomic rank"
+              },
+              "count": {
+                "type": "integer",
+                "description": "Number of observations"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/intact_tools.json
+++ b/src/tooluniverse/data/intact_tools.json
@@ -261,33 +261,7 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array"
-            },
-            "count": {
-              "type": "integer"
-            },
-            "hitCount": {
-              "type": "integer"
-            },
-            "interaction_ids": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "array"
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/interpro_member_db_tools.json
+++ b/src/tooluniverse/data/interpro_member_db_tools.json
@@ -28,108 +28,97 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Member-database signature detail.",
           "properties": {
-            "status": {
-              "const": "success"
+            "accession": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "description": "Member-database signature detail.",
-              "properties": {
-                "accession": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "source_database": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "integrated_interpro": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "go_terms": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "identifier": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "category": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "counters": {
-                  "type": "object",
-                  "properties": {
-                    "proteins": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "structures": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "taxa": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    }
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source_database": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "integrated_interpro": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "go_terms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "identifier": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "category": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": [
-                "accession",
-                "source_database"
-              ]
+              }
+            },
+            "counters": {
+              "type": "object",
+              "properties": {
+                "proteins": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "structures": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "taxa": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              }
             }
           },
           "required": [
-            "data"
+            "accession",
+            "source_database"
           ]
         },
         {
@@ -193,67 +182,56 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "A page of member-database signatures.",
           "properties": {
-            "status": {
-              "const": "success"
+            "member_database": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "description": "A page of member-database signatures.",
-              "properties": {
-                "member_database": {
-                  "type": "string"
-                },
-                "total_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "entries": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "integrated_interpro": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "total_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "returned": {
+              "type": "integer"
+            },
+            "entries": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "integrated_interpro": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": [
-                "member_database",
-                "entries"
-              ]
+              }
             }
           },
           "required": [
-            "data"
+            "member_database",
+            "entries"
           ]
         },
         {
@@ -314,67 +292,56 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "PDB structures containing the InterPro domain.",
           "properties": {
-            "status": {
-              "const": "success"
+            "interpro_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "description": "PDB structures containing the InterPro domain.",
-              "properties": {
-                "interpro_id": {
-                  "type": "string"
-                },
-                "total_structures": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "structures": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pdb_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "title": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "experiment_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "resolution": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "total_structures": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "returned": {
+              "type": "integer"
+            },
+            "structures": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pdb_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "title": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "experiment_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "resolution": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": [
-                "interpro_id",
-                "structures"
-              ]
+              }
             }
           },
           "required": [
-            "data"
+            "interpro_id",
+            "structures"
           ]
         },
         {
@@ -419,63 +386,52 @@
       "oneOf": [
         {
           "type": "object",
+          "description": "Member-database catalog with counts.",
           "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "object",
-              "description": "Member-database catalog with counts.",
-              "properties": {
-                "databases": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "member_database": {
-                        "type": "string"
-                      },
-                      "entry_count": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+            "databases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "member_database": {
+                    "type": "string"
+                  },
+                  "entry_count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   }
-                },
-                "integrated_total": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "unintegrated_total": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "interpro_total": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "all_total": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
                 }
-              },
-              "required": [
-                "databases"
+              }
+            },
+            "integrated_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "unintegrated_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "interpro_total": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "all_total": {
+              "type": [
+                "integer",
+                "null"
               ]
             }
           },
           "required": [
-            "data"
+            "databases"
           ]
         },
         {

--- a/src/tooluniverse/data/itis_tools.json
+++ b/src/tooluniverse/data/itis_tools.json
@@ -29,59 +29,37 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tsn": {
-                    "type": "string",
-                    "description": "Taxonomic Serial Number (unique ITIS identifier)"
-                  },
-                  "combined_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Full scientific name"
-                  },
-                  "author": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Taxonomic authority (author, year)"
-                  },
-                  "kingdom": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Kingdom classification"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tsn": {
+                "type": "string",
+                "description": "Taxonomic Serial Number (unique ITIS identifier)"
+              },
+              "combined_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Full scientific name"
+              },
+              "author": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Taxonomic authority (author, year)"
+              },
+              "kingdom": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Kingdom classification"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -127,52 +105,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tsn": {
-                    "type": "string",
-                    "description": "Taxonomic Serial Number"
-                  },
-                  "common_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Common name found"
-                  },
-                  "language": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Language of the common name"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tsn": {
+                "type": "string",
+                "description": "Taxonomic Serial Number"
+              },
+              "common_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Common name found"
+              },
+              "language": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Language of the common name"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -218,62 +174,40 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tsn": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "TSN of this rank"
-                  },
-                  "taxon_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Taxon name at this rank"
-                  },
-                  "rank_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Taxonomic rank (Kingdom, Phylum, Class, etc.)"
-                  },
-                  "parent_tsn": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Parent TSN"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_tsn": {
-                  "type": "string"
-                },
-                "hierarchy_depth": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tsn": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "TSN of this rank"
+              },
+              "taxon_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Taxon name at this rank"
+              },
+              "rank_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Taxonomic rank (Kingdom, Phylum, Class, etc.)"
+              },
+              "parent_tsn": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Parent TSN"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -321,93 +255,74 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "tsn": {
-                  "type": "string",
-                  "description": "Taxonomic Serial Number"
-                },
-                "scientific_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Full scientific name"
-                },
-                "kingdom": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Kingdom"
-                },
-                "author": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Taxonomic authority"
-                },
-                "usage_rating": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Usage status (valid/invalid/accepted)"
-                },
-                "common_names": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "language": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  },
-                  "description": "Common names in various languages"
-                },
-                "parent_tsn": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Parent taxon TSN"
-                },
-                "rank": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Taxonomic rank"
-                }
-              }
+            "tsn": {
+              "type": "string",
+              "description": "Taxonomic Serial Number"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_tsn": {
-                  "type": "string"
+            "scientific_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Full scientific name"
+            },
+            "kingdom": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Kingdom"
+            },
+            "author": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Taxonomic authority"
+            },
+            "usage_rating": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Usage status (valid/invalid/accepted)"
+            },
+            "common_names": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "language": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
-              }
+              },
+              "description": "Common names in various languages"
+            },
+            "parent_tsn": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Parent taxon TSN"
+            },
+            "rank": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Taxonomic rank"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/iucn_tools.json
+++ b/src/tooluniverse/data/iucn_tools.json
@@ -26,7 +26,7 @@
     },
     "return_schema": {
       "oneOf": [
-        {"type": "object", "properties": {"data": {"type": ["object", "null"], "properties": {"scientific_name": {"type": "string"}, "red_list_category_code": {"type": ["string", "null"]}, "red_list_category": {"type": ["string", "null"]}, "year_published": {"type": ["string", "integer", "null"]}}}, "metadata": {"type": "object"}}, "required": ["data"]},
+        {"type": ["object", "null"], "properties": {"scientific_name": {"type": "string"}, "red_list_category_code": {"type": ["string", "null"]}, "red_list_category": {"type": ["string", "null"]}, "year_published": {"type": ["string", "integer", "null"]}}},
         {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
       ]
     }

--- a/src/tooluniverse/data/iupred3_tools.json
+++ b/src/tooluniverse/data/iupred3_tools.json
@@ -27,121 +27,109 @@
       ]
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
+          "description": "Successful disorder prediction (content of the data field).",
           "properties": {
-            "status": {
-              "const": "success"
+            "accession": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "description": "Successful disorder prediction (content of the data field).",
-              "properties": {
-                "accession": {
-                  "type": "string"
-                },
-                "iupred_type": {
-                  "type": "string"
-                },
-                "sequence_length": {
-                  "type": "integer"
-                },
-                "mean_disorder_score": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "description": "Mean per-residue disorder score (0-1)"
-                },
-                "disordered_residues": {
-                  "type": "integer",
-                  "description": "Count of residues with disorder score >= 0.5"
-                },
-                "disordered_fraction": {
-                  "type": "number",
-                  "description": "Fraction of the sequence predicted disordered"
-                },
-                "disordered_regions": {
-                  "type": "array",
-                  "description": "Contiguous disordered segments (score >= 0.5), 1-based inclusive positions.",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "start": {
-                        "type": "integer"
-                      },
-                      "end": {
-                        "type": "integer"
-                      },
-                      "length": {
-                        "type": "integer"
-                      }
-                    }
+            "iupred_type": {
+              "type": "string"
+            },
+            "sequence_length": {
+              "type": "integer"
+            },
+            "mean_disorder_score": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Mean per-residue disorder score (0-1)"
+            },
+            "disordered_residues": {
+              "type": "integer",
+              "description": "Count of residues with disorder score >= 0.5"
+            },
+            "disordered_fraction": {
+              "type": "number",
+              "description": "Fraction of the sequence predicted disordered"
+            },
+            "disordered_regions": {
+              "type": "array",
+              "description": "Contiguous disordered segments (score >= 0.5), 1-based inclusive positions.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "start": {
+                    "type": "integer"
+                  },
+                  "end": {
+                    "type": "integer"
+                  },
+                  "length": {
+                    "type": "integer"
                   }
-                },
-                "anchor_binding_regions": {
-                  "type": "array",
-                  "description": "ANCHOR2 protein-binding regions (only present when iupred_type='anchor').",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "start": {
-                        "type": "integer"
-                      },
-                      "end": {
-                        "type": "integer"
-                      },
-                      "length": {
-                        "type": "integer"
-                      }
-                    }
-                  }
-                },
-                "redox_sensitive_regions": {
-                  "type": "array",
-                  "description": "Redox-sensitive regions (only present when iupred_type='redox')."
-                },
-                "per_residue": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "position": {
-                        "type": "integer"
-                      },
-                      "residue": {
-                        "type": "string"
-                      },
-                      "disorder_score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "anchor_score": {
-                        "type": "number"
-                      }
-                    }
-                  }
-                },
-                "sequence": {
-                  "type": "string",
-                  "description": "The amino acid sequence used for prediction"
                 }
-              },
-              "required": [
-                "accession",
-                "iupred_type",
-                "sequence_length",
-                "disordered_regions",
-                "per_residue"
-              ]
+              }
+            },
+            "anchor_binding_regions": {
+              "type": "array",
+              "description": "ANCHOR2 protein-binding regions (only present when iupred_type='anchor').",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "start": {
+                    "type": "integer"
+                  },
+                  "end": {
+                    "type": "integer"
+                  },
+                  "length": {
+                    "type": "integer"
+                  }
+                }
+              }
+            },
+            "redox_sensitive_regions": {
+              "type": "array",
+              "description": "Redox-sensitive regions (only present when iupred_type='redox')."
+            },
+            "per_residue": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "position": {
+                    "type": "integer"
+                  },
+                  "residue": {
+                    "type": "string"
+                  },
+                  "disorder_score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "anchor_score": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            "sequence": {
+              "type": "string",
+              "description": "The amino acid sequence used for prediction"
             }
           },
           "required": [
-            "data"
+            "accession",
+            "iupred_type",
+            "sequence_length",
+            "disordered_regions",
+            "per_residue"
           ]
         },
         {

--- a/src/tooluniverse/data/kegg_ext_tools.json
+++ b/src/tooluniverse/data/kegg_ext_tools.json
@@ -42,35 +42,26 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "gene_id": {
-                                    "type": "string",
-                                    "description": "Queried KEGG gene ID"
-                                },
-                                "pathway_count": {
-                                    "type": "integer",
-                                    "description": "Number of pathways the gene participates in"
-                                },
-                                "pathways": {
-                                    "type": "array",
-                                    "description": "List of KEGG pathways with IDs and names",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "pathway_id": {"type": "string"},
-                                            "pathway_name": {"type": "string"}
-                                        }
-                                    }
+                        "gene_id": {
+                            "type": "string",
+                            "description": "Queried KEGG gene ID"
+                        },
+                        "pathway_count": {
+                            "type": "integer",
+                            "description": "Number of pathways the gene participates in"
+                        },
+                        "pathways": {
+                            "type": "array",
+                            "description": "List of KEGG pathways with IDs and names",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "pathway_id": {"type": "string"},
+                                    "pathway_name": {"type": "string"}
                                 }
                             }
-                        },
-                        "metadata": {
-                            "type": "object"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -114,33 +105,24 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "pathway_id": {
-                                    "type": "string",
-                                    "description": "KEGG pathway ID"
-                                },
-                                "pathway_name": {
-                                    "type": "string",
-                                    "description": "Pathway name and species"
-                                },
-                                "gene_count": {
-                                    "type": "integer",
-                                    "description": "Number of genes in the pathway"
-                                },
-                                "genes": {
-                                    "type": "array",
-                                    "description": "List of KEGG gene IDs in the pathway",
-                                    "items": {"type": "string"}
-                                }
-                            }
+                        "pathway_id": {
+                            "type": "string",
+                            "description": "KEGG pathway ID"
                         },
-                        "metadata": {
-                            "type": "object"
+                        "pathway_name": {
+                            "type": "string",
+                            "description": "Pathway name and species"
+                        },
+                        "gene_count": {
+                            "type": "integer",
+                            "description": "Number of genes in the pathway"
+                        },
+                        "genes": {
+                            "type": "array",
+                            "description": "List of KEGG gene IDs in the pathway",
+                            "items": {"type": "string"}
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -184,50 +166,41 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "compound_id": {
-                                    "type": "string",
-                                    "description": "KEGG compound ID"
-                                },
-                                "names": {
-                                    "type": "array",
-                                    "description": "Compound names (common and systematic)",
-                                    "items": {"type": "string"}
-                                },
-                                "formula": {
-                                    "type": ["string", "null"],
-                                    "description": "Chemical formula"
-                                },
-                                "exact_mass": {
-                                    "type": ["number", "null"],
-                                    "description": "Exact mass in Da"
-                                },
-                                "mol_weight": {
-                                    "type": ["number", "null"],
-                                    "description": "Molecular weight in Da"
-                                },
-                                "pathways": {
-                                    "type": "object",
-                                    "description": "Map of pathway IDs to names"
-                                },
-                                "enzymes": {
-                                    "type": "array",
-                                    "description": "EC numbers of enzymes using this compound",
-                                    "items": {"type": "string"}
-                                },
-                                "dblinks": {
-                                    "type": "object",
-                                    "description": "Cross-references to other databases (PubChem, ChEBI, DrugBank, etc.)"
-                                }
-                            }
+                        "compound_id": {
+                            "type": "string",
+                            "description": "KEGG compound ID"
                         },
-                        "metadata": {
-                            "type": "object"
+                        "names": {
+                            "type": "array",
+                            "description": "Compound names (common and systematic)",
+                            "items": {"type": "string"}
+                        },
+                        "formula": {
+                            "type": ["string", "null"],
+                            "description": "Chemical formula"
+                        },
+                        "exact_mass": {
+                            "type": ["number", "null"],
+                            "description": "Exact mass in Da"
+                        },
+                        "mol_weight": {
+                            "type": ["number", "null"],
+                            "description": "Molecular weight in Da"
+                        },
+                        "pathways": {
+                            "type": "object",
+                            "description": "Map of pathway IDs to names"
+                        },
+                        "enzymes": {
+                            "type": "array",
+                            "description": "EC numbers of enzymes using this compound",
+                            "items": {"type": "string"}
+                        },
+                        "dblinks": {
+                            "type": "object",
+                            "description": "Cross-references to other databases (PubChem, ChEBI, DrugBank, etc.)"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -294,39 +267,30 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "search_field": {
-                                    "type": "string",
-                                    "description": "Which field was searched: exact_mass, mol_weight, formula, or name"
-                                },
-                                "query": {
-                                    "type": "string",
-                                    "description": "The submitted query value"
-                                },
-                                "count": {
-                                    "type": "integer",
-                                    "description": "Number of candidate compounds returned"
-                                },
-                                "compounds": {
-                                    "type": "array",
-                                    "description": "Candidate KEGG compounds",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "compound_id": {"type": "string"},
-                                            "description": {"type": "string"}
-                                        }
-                                    }
+                        "search_field": {
+                            "type": "string",
+                            "description": "Which field was searched: exact_mass, mol_weight, formula, or name"
+                        },
+                        "query": {
+                            "type": "string",
+                            "description": "The submitted query value"
+                        },
+                        "count": {
+                            "type": "integer",
+                            "description": "Number of candidate compounds returned"
+                        },
+                        "compounds": {
+                            "type": "array",
+                            "description": "Candidate KEGG compounds",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "compound_id": {"type": "string"},
+                                    "description": {"type": "string"}
                                 }
                             }
-                        },
-                        "metadata": {
-                            "type": "object"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -374,48 +338,41 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "module_id": {"type": "string"},
-                                "name": {"type": "string", "description": "Module name"},
-                                "definition": {"type": "string", "description": "Boolean K-number reaction-step expression"},
-                                "class": {"type": "string", "description": "CLASS hierarchy string"},
-                                "reactions": {
-                                    "type": "array",
-                                    "description": "Member reactions with their definitions",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "reaction_id": {"type": "string"},
-                                            "definition": {"type": "string"}
-                                        }
-                                    }
-                                },
-                                "compounds": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "compound_id": {"type": "string"},
-                                            "name": {"type": "string"}
-                                        }
-                                    }
-                                },
-                                "orthology": {
-                                    "type": "array",
-                                    "description": "ORTHOLOGY lines (KO groups with EC/RN annotations)",
-                                    "items": {"type": "string"}
-                                },
-                                "pathways": {
-                                    "type": "object",
-                                    "description": "Parent pathway IDs to names"
+                        "module_id": {"type": "string"},
+                        "name": {"type": "string", "description": "Module name"},
+                        "definition": {"type": "string", "description": "Boolean K-number reaction-step expression"},
+                        "class": {"type": "string", "description": "CLASS hierarchy string"},
+                        "reactions": {
+                            "type": "array",
+                            "description": "Member reactions with their definitions",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "reaction_id": {"type": "string"},
+                                    "definition": {"type": "string"}
                                 }
                             }
                         },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
+                        "compounds": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "compound_id": {"type": "string"},
+                                    "name": {"type": "string"}
+                                }
+                            }
+                        },
+                        "orthology": {
+                            "type": "array",
+                            "description": "ORTHOLOGY lines (KO groups with EC/RN annotations)",
+                            "items": {"type": "string"}
+                        },
+                        "pathways": {
+                            "type": "object",
+                            "description": "Parent pathway IDs to names"
+                        }
+                    }
                 },
                 {
                     "type": "object",
@@ -461,36 +418,29 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "reaction_id": {"type": "string"},
-                                "name": {"type": "string"},
-                                "definition": {"type": "string", "description": "Human-readable reaction equation"},
-                                "equation": {"type": "string", "description": "Balanced equation with KEGG C-number stoichiometry"},
-                                "enzymes": {
-                                    "type": "array",
-                                    "description": "Catalyzing EC numbers",
-                                    "items": {"type": "string"}
-                                },
-                                "rclass": {
-                                    "type": "array",
-                                    "description": "Reaction class (RCLASS) codes",
-                                    "items": {"type": "string"}
-                                },
-                                "pathways": {
-                                    "type": "object",
-                                    "description": "Parent pathway IDs to names"
-                                },
-                                "modules": {
-                                    "type": "object",
-                                    "description": "Parent module IDs to names"
-                                }
-                            }
+                        "reaction_id": {"type": "string"},
+                        "name": {"type": "string"},
+                        "definition": {"type": "string", "description": "Human-readable reaction equation"},
+                        "equation": {"type": "string", "description": "Balanced equation with KEGG C-number stoichiometry"},
+                        "enzymes": {
+                            "type": "array",
+                            "description": "Catalyzing EC numbers",
+                            "items": {"type": "string"}
                         },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
+                        "rclass": {
+                            "type": "array",
+                            "description": "Reaction class (RCLASS) codes",
+                            "items": {"type": "string"}
+                        },
+                        "pathways": {
+                            "type": "object",
+                            "description": "Parent pathway IDs to names"
+                        },
+                        "modules": {
+                            "type": "object",
+                            "description": "Parent module IDs to names"
+                        }
+                    }
                 },
                 {
                     "type": "object",
@@ -540,39 +490,32 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "ec_number": {"type": "string"},
-                                "names": {
-                                    "type": "array",
-                                    "description": "Accepted name and synonyms",
-                                    "items": {"type": "string"}
-                                },
-                                "class": {
-                                    "type": "array",
-                                    "description": "3-level EC CLASS hierarchy lines",
-                                    "items": {"type": "string"}
-                                },
-                                "sysname": {"type": "string", "description": "Systematic name"},
-                                "reaction": {"type": "string", "description": "Catalyzed reaction"},
-                                "substrates": {
-                                    "type": "array",
-                                    "items": {"type": "string"}
-                                },
-                                "products": {
-                                    "type": "array",
-                                    "items": {"type": "string"}
-                                },
-                                "orthology": {
-                                    "type": "object",
-                                    "description": "KO ortholog IDs to descriptions"
-                                }
-                            }
+                        "ec_number": {"type": "string"},
+                        "names": {
+                            "type": "array",
+                            "description": "Accepted name and synonyms",
+                            "items": {"type": "string"}
                         },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
+                        "class": {
+                            "type": "array",
+                            "description": "3-level EC CLASS hierarchy lines",
+                            "items": {"type": "string"}
+                        },
+                        "sysname": {"type": "string", "description": "Systematic name"},
+                        "reaction": {"type": "string", "description": "Catalyzed reaction"},
+                        "substrates": {
+                            "type": "array",
+                            "items": {"type": "string"}
+                        },
+                        "products": {
+                            "type": "array",
+                            "items": {"type": "string"}
+                        },
+                        "orthology": {
+                            "type": "object",
+                            "description": "KO ortholog IDs to descriptions"
+                        }
+                    }
                 },
                 {
                     "type": "object",

--- a/src/tooluniverse/data/ldlink_tools.json
+++ b/src/tooluniverse/data/ldlink_tools.json
@@ -5,18 +5,54 @@
     "parameter": {
       "type": "object",
       "properties": {
-        "variant": {"type": "string", "description": "Query SNP rsID, e.g. 'rs7903146'."},
-        "population": {"type": ["string", "null"], "description": "1000 Genomes population code (default 'CEU'). Examples: 'CEU' (European), 'YRI' (African), 'CHB' (East Asian), or super-populations 'EUR'/'AFR'/'EAS'/'SAS'/'AMR'."},
-        "r2_threshold": {"type": ["number", "null"], "description": "Minimum R2 to report (default 0.8; high LD)."},
-        "genome_build": {"type": ["string", "null"], "description": "'grch38' (default) or 'grch37'."},
-        "limit": {"type": ["integer", "null"], "description": "Max proxies to return (1-500, default 50)."}
+        "variant": {
+          "type": "string",
+          "description": "Query SNP rsID, e.g. 'rs7903146'."
+        },
+        "population": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "1000 Genomes population code (default 'CEU'). Examples: 'CEU' (European), 'YRI' (African), 'CHB' (East Asian), or super-populations 'EUR'/'AFR'/'EAS'/'SAS'/'AMR'."
+        },
+        "r2_threshold": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Minimum R2 to report (default 0.8; high LD)."
+        },
+        "genome_build": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "'grch38' (default) or 'grch37'."
+        },
+        "limit": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Max proxies to return (1-500, default 50)."
+        }
       },
-      "required": ["variant"]
+      "required": [
+        "variant"
+      ]
     },
     "fields": {},
     "type": "LDlinkTool",
-    "test_examples": [{"variant": "rs7903146", "population": "CEU"}],
-    "optional_api_keys": ["LDLINK_TOKEN"],
+    "test_examples": [
+      {
+        "variant": "rs7903146",
+        "population": "CEU"
+      }
+    ],
+    "optional_api_keys": [
+      "LDLINK_TOKEN"
+    ],
     "api_key_info": {
       "LDLINK_TOKEN": {
         "domain": "Genomics & Variants",
@@ -28,8 +64,58 @@
     },
     "return_schema": {
       "oneOf": [
-        {"type": "object", "properties": {"data": {"type": "array", "items": {"type": "object", "properties": {"rsid": {"type": "string"}, "r2": {"type": ["number", "null"]}, "coord": {"type": ["string", "null"]}, "alleles": {"type": ["string", "null"]}, "maf": {"type": ["string", "null"]}, "distance": {"type": ["string", "null"]}}}}, "metadata": {"type": "object"}}, "required": ["data"]},
-        {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rsid": {
+                "type": "string"
+              },
+              "r2": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "coord": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "alleles": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "maf": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "distance": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
       ]
     }
   }

--- a/src/tooluniverse/data/lipidmaps_gene_tools.json
+++ b/src/tooluniverse/data/lipidmaps_gene_tools.json
@@ -50,98 +50,86 @@
       }
     ],
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "lmp_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_synonyms": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "alt_names": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "chromosome": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "map_location": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "summary": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "taxid": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species_long": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "lmp_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_synonyms": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "alt_names": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "chromosome": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "map_location": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "summary": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "taxid": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "species_long": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -220,116 +208,104 @@
       }
     ],
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "lmp_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "uniprot_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "protein_entry": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "protein_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "refseq_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "mrna_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "protein_gi": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "seqlength": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "seq": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "taxid": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species_long": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "lmp_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uniprot_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "protein_entry": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "protein_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "refseq_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "mrna_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "protein_gi": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "seqlength": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "seq": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "taxid": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "species_long": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/lncrna_tools.json
+++ b/src/tooluniverse/data/lncrna_tools.json
@@ -46,59 +46,48 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_hits": {
-                  "type": "integer",
-                  "description": "Total number of matching lncRNA entries"
-                },
-                "returned": {
-                  "type": "integer",
-                  "description": "Number of entries returned in this response"
-                },
-                "entries": {
-                  "type": "array",
-                  "description": "List of lncRNA entries with IDs, descriptions, and metadata",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "rnacentral_id": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "rna_type": {
-                        "type": "string"
-                      },
-                      "length": {
-                        "type": "integer"
-                      },
-                      "expert_databases": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "has_secondary_structure": {
-                        "type": "boolean"
-                      },
-                      "has_genomic_coordinates": {
-                        "type": "boolean"
-                      }
+            "total_hits": {
+              "type": "integer",
+              "description": "Total number of matching lncRNA entries"
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number of entries returned in this response"
+            },
+            "entries": {
+              "type": "array",
+              "description": "List of lncRNA entries with IDs, descriptions, and metadata",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "rnacentral_id": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "rna_type": {
+                    "type": "string"
+                  },
+                  "length": {
+                    "type": "integer"
+                  },
+                  "expert_databases": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "has_secondary_structure": {
+                    "type": "boolean"
+                  },
+                  "has_genomic_coordinates": {
+                    "type": "boolean"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -170,64 +159,53 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "rnacentral_id": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "short_description": {
-                  "type": "string"
-                },
-                "sequence": {
-                  "type": "string"
-                },
-                "length": {
-                  "type": "integer"
-                },
-                "rna_type": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "taxid": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "genes": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "publications_count": {
-                  "type": "integer"
-                },
-                "is_active": {
-                  "type": "boolean"
-                },
-                "distinct_databases": {
-                  "type": [
-                    "string",
-                    "array",
-                    "null"
-                  ]
-                }
+            "rnacentral_id": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "short_description": {
+              "type": "string"
+            },
+            "sequence": {
+              "type": "string"
+            },
+            "length": {
+              "type": "integer"
+            },
+            "rna_type": {
+              "type": "string"
+            },
+            "species": {
+              "type": "string"
+            },
+            "taxid": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "genes": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
-            "metadata": {
-              "type": "object"
+            "publications_count": {
+              "type": "integer"
+            },
+            "is_active": {
+              "type": "boolean"
+            },
+            "distinct_databases": {
+              "type": [
+                "string",
+                "array",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -299,58 +277,47 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_publications": {
-                  "type": "integer",
-                  "description": "Total number of publications for this lncRNA"
-                },
-                "returned": {
-                  "type": "integer",
-                  "description": "Number returned in this page"
-                },
-                "publications": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "title": {
-                        "type": "string"
-                      },
-                      "authors": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "publication": {
-                        "type": "string"
-                      },
-                      "pubmed_id": {
-                        "type": "string"
-                      },
-                      "doi": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "expert_db": {
-                        "type": "boolean"
-                      }
+            "total_publications": {
+              "type": "integer",
+              "description": "Total number of publications for this lncRNA"
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number returned in this page"
+            },
+            "publications": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "authors": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "publication": {
+                    "type": "string"
+                  },
+                  "pubmed_id": {
+                    "type": "string"
+                  },
+                  "doi": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expert_db": {
+                    "type": "boolean"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -421,82 +388,71 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_xrefs": {
-                  "type": "integer",
-                  "description": "Total number of cross-references"
-                },
-                "returned": {
-                  "type": "integer",
-                  "description": "Number returned in this page"
-                },
-                "cross_references": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "database": {
-                        "type": "string"
-                      },
-                      "accession_id": {
-                        "type": "string"
-                      },
-                      "external_id": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "species": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "rna_type": {
-                        "type": "string"
-                      },
-                      "gene": {
-                        "type": "string"
-                      },
-                      "taxid": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "is_active": {
-                        "type": "boolean"
-                      },
-                      "expert_db_url": {
-                        "type": "string"
-                      },
-                      "mirbase_mature_products": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "mirbase_precursor": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "total_xrefs": {
+              "type": "integer",
+              "description": "Total number of cross-references"
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number returned in this page"
+            },
+            "cross_references": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "database": {
+                    "type": "string"
+                  },
+                  "accession_id": {
+                    "type": "string"
+                  },
+                  "external_id": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "species": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rna_type": {
+                    "type": "string"
+                  },
+                  "gene": {
+                    "type": "string"
+                  },
+                  "taxid": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "is_active": {
+                    "type": "boolean"
+                  },
+                  "expert_db_url": {
+                    "type": ["string", "null"]
+                  },
+                  "mirbase_mature_products": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "mirbase_precursor": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -578,59 +534,48 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_hits": {
-                  "type": "integer",
-                  "description": "Total number of matching ncRNA entries"
-                },
-                "returned": {
-                  "type": "integer",
-                  "description": "Number of entries returned in this response"
-                },
-                "entries": {
-                  "type": "array",
-                  "description": "List of ncRNA entries",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "rnacentral_id": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "rna_type": {
-                        "type": "string"
-                      },
-                      "length": {
-                        "type": "integer"
-                      },
-                      "expert_databases": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "has_secondary_structure": {
-                        "type": "boolean"
-                      },
-                      "has_genomic_coordinates": {
-                        "type": "boolean"
-                      }
+            "total_hits": {
+              "type": "integer",
+              "description": "Total number of matching ncRNA entries"
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number of entries returned in this response"
+            },
+            "entries": {
+              "type": "array",
+              "description": "List of ncRNA entries",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "rnacentral_id": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "rna_type": {
+                    "type": "string"
+                  },
+                  "length": {
+                    "type": "integer"
+                  },
+                  "expert_databases": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "has_secondary_structure": {
+                    "type": "boolean"
+                  },
+                  "has_genomic_coordinates": {
+                    "type": "boolean"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/mendelian_randomization_tools.json
+++ b/src/tooluniverse/data/mendelian_randomization_tools.json
@@ -5,12 +5,41 @@
     "description": "Two-sample Mendelian randomization causal estimate from harmonized instrument summary statistics (SNP-exposure + SNP-outcome betas and SEs, e.g. from OpenGWAS_get_mr_instruments). Returns IVW (primary), MR-Egger (with directional-pleiotropy intercept), weighted-median estimates, and Cochran's Q / I^2 heterogeneity. Pure-compute (no R, no API key); reimplements TwoSampleMR's core estimators.",
     "parameter": {
       "type": "object",
-      "required": ["beta_exposure", "se_exposure", "beta_outcome", "se_outcome"],
+      "required": [
+        "beta_exposure",
+        "se_exposure",
+        "beta_outcome",
+        "se_outcome"
+      ],
       "properties": {
-        "beta_exposure": {"type": "array", "items": {"type": "number"}, "description": "Per-instrument SNP-exposure effect sizes (harmonized to the same effect allele; non-zero)."},
-        "se_exposure": {"type": "array", "items": {"type": "number"}, "description": "Standard errors of beta_exposure (positive)."},
-        "beta_outcome": {"type": "array", "items": {"type": "number"}, "description": "Per-instrument SNP-outcome effect sizes (same SNP order / effect allele)."},
-        "se_outcome": {"type": "array", "items": {"type": "number"}, "description": "Standard errors of beta_outcome (positive)."}
+        "beta_exposure": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-instrument SNP-exposure effect sizes (harmonized to the same effect allele; non-zero)."
+        },
+        "se_exposure": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Standard errors of beta_exposure (positive)."
+        },
+        "beta_outcome": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-instrument SNP-outcome effect sizes (same SNP order / effect allele)."
+        },
+        "se_outcome": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Standard errors of beta_outcome (positive)."
+        }
       }
     },
     "return_schema": {
@@ -18,39 +47,81 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
+            "n_instruments": {
+              "type": "integer"
+            },
+            "estimates": {
               "type": "object",
               "properties": {
-                "n_instruments": {"type": "integer"},
-                "estimates": {
-                  "type": "object",
-                  "properties": {
-                    "ivw": {"type": "object"},
-                    "mr_egger": {"type": "object"},
-                    "weighted_median": {"type": "object"}
-                  }
+                "ivw": {
+                  "type": "object"
                 },
-                "egger_intercept": {"type": "object"},
-                "heterogeneity": {"type": "object"}
+                "mr_egger": {
+                  "type": "object"
+                },
+                "weighted_median": {
+                  "type": "object"
+                }
               }
+            },
+            "egger_intercept": {
+              "type": "object"
+            },
+            "heterogeneity": {
+              "type": "object"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "status": {
+              "const": "error"
+            },
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "beta_exposure": [0.10, 0.15, 0.08, 0.20, 0.12, 0.18],
-        "se_exposure": [0.02, 0.03, 0.02, 0.03, 0.02, 0.03],
-        "beta_outcome": [0.05, 0.08, 0.03, 0.11, 0.07, 0.09],
-        "se_outcome": [0.02, 0.02, 0.02, 0.03, 0.02, 0.02]
+        "beta_exposure": [
+          0.1,
+          0.15,
+          0.08,
+          0.2,
+          0.12,
+          0.18
+        ],
+        "se_exposure": [
+          0.02,
+          0.03,
+          0.02,
+          0.03,
+          0.02,
+          0.03
+        ],
+        "beta_outcome": [
+          0.05,
+          0.08,
+          0.03,
+          0.11,
+          0.07,
+          0.09
+        ],
+        "se_outcome": [
+          0.02,
+          0.02,
+          0.02,
+          0.03,
+          0.02,
+          0.02
+        ]
       }
     ]
   }

--- a/src/tooluniverse/data/mesh_tools.json
+++ b/src/tooluniverse/data/mesh_tools.json
@@ -46,58 +46,33 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "descriptor_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "MeSH descriptor ID (e.g., D009369)"
-                  },
-                  "label": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Descriptor label/name"
-                  },
-                  "resource_uri": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Full MeSH URI"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "match_type": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "descriptor_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "MeSH descriptor ID (e.g., D009369)"
+              },
+              "label": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Descriptor label/name"
+              },
+              "resource_uri": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Full MeSH URI"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -145,89 +120,70 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "descriptor_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "MeSH descriptor ID"
-                },
-                "label": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Descriptor name"
-                },
-                "type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Entry type (TopicalDescriptor, etc.)"
-                },
-                "annotation": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Usage annotation/notes"
-                },
-                "tree_numbers": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "MeSH tree numbers for hierarchy"
-                },
-                "consider_also": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Related terms to consider"
-                },
-                "date_introduced": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Year descriptor was introduced"
-                },
-                "last_updated": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Last update date"
-                },
-                "active": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "description": "Whether descriptor is active"
-                }
-              }
+            "descriptor_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "MeSH descriptor ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                }
-              }
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Descriptor name"
+            },
+            "type": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Entry type (TopicalDescriptor, etc.)"
+            },
+            "annotation": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Usage annotation/notes"
+            },
+            "tree_numbers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "MeSH tree numbers for hierarchy"
+            },
+            "consider_also": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Related terms to consider"
+            },
+            "date_introduced": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Year descriptor was introduced"
+            },
+            "last_updated": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Last update date"
+            },
+            "active": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Whether descriptor is active"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -290,58 +246,33 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "term_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "MeSH term ID (e.g., T027926)"
-                  },
-                  "label": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Term label/name"
-                  },
-                  "resource_uri": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Full MeSH URI"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "match_type": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "term_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "MeSH term ID (e.g., T027926)"
+              },
+              "label": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Term label/name"
+              },
+              "resource_uri": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Full MeSH URI"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/mgi_tools.json
+++ b/src/tooluniverse/data/mgi_tools.json
@@ -36,53 +36,29 @@
       }
     ],
     "return_schema": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "description": "List of matching mouse genes",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "symbol": {
-                    "type": ["string", "null"],
-                    "description": "Official gene symbol (e.g., 'Trp53')"
-                  },
-                  "name": {
-                    "type": ["string", "null"],
-                    "description": "Gene name"
-                  },
-                  "gene_id": {
-                    "type": ["string", "null"],
-                    "description": "MGI identifier (e.g., 'MGI:98834')"
-                  },
-                  "category": {
-                    "type": ["string", "null"],
-                    "description": "Entity category (always 'gene')"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {"type": "integer"},
-                "query": {"type": "string"},
-                "source": {"type": "string"}
-              }
-            }
-          }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "error": {"type": "string"}
+      "type": "array",
+      "description": "List of matching mouse genes",
+      "items": {
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "type": ["string", "null"],
+            "description": "Official gene symbol (e.g., 'Trp53')"
           },
-          "required": ["error"]
+          "name": {
+            "type": ["string", "null"],
+            "description": "Gene name"
+          },
+          "gene_id": {
+            "type": ["string", "null"],
+            "description": "MGI identifier (e.g., 'MGI:98834')"
+          },
+          "category": {
+            "type": ["string", "null"],
+            "description": "Entity category (always 'gene')"
+          }
         }
-      ]
+      }
     }
   },
   {
@@ -111,91 +87,67 @@
       }
     ],
     "return_schema": {
-      "oneOf": [
-        {
+      "type": "object",
+      "description": "Mouse gene details from MGI",
+      "properties": {
+        "id": {
+          "type": ["string", "null"],
+          "description": "MGI identifier (e.g., 'MGI:98834')"
+        },
+        "symbol": {
+          "type": ["string", "null"],
+          "description": "Official gene symbol (e.g., 'Trp53')"
+        },
+        "name": {
+          "type": ["string", "null"],
+          "description": "Full gene name (e.g., 'transformation related protein 53')"
+        },
+        "species": {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "description": "Mouse gene details from MGI",
-              "properties": {
-                "id": {
-                  "type": ["string", "null"],
-                  "description": "MGI identifier (e.g., 'MGI:98834')"
-                },
-                "symbol": {
-                  "type": ["string", "null"],
-                  "description": "Official gene symbol (e.g., 'Trp53')"
-                },
-                "name": {
-                  "type": ["string", "null"],
-                  "description": "Full gene name (e.g., 'transformation related protein 53')"
-                },
-                "species": {
-                  "type": "object",
-                  "properties": {
-                    "name": {"type": ["string", "null"]},
-                    "short_name": {"type": ["string", "null"]},
-                    "taxon_id": {"type": ["string", "null"]},
-                    "data_provider": {"type": ["string", "null"]}
-                  }
-                },
-                "gene_synopsis": {
-                  "type": ["string", "null"],
-                  "description": "Curated gene synopsis from MGI"
-                },
-                "automated_gene_synopsis": {
-                  "type": ["string", "null"],
-                  "description": "Automatically generated gene synopsis"
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {"type": "string"}
-                },
-                "so_term": {
-                  "type": ["string", "null"],
-                  "description": "Sequence Ontology term (e.g., 'protein_coding_gene')"
-                },
-                "genomic_location": {
-                  "type": "object",
-                  "properties": {
-                    "chromosome": {"type": ["string", "null"]},
-                    "start": {"type": ["integer", "null"]},
-                    "end": {"type": ["integer", "null"]},
-                    "assembly": {"type": ["string", "null"]},
-                    "strand": {"type": ["string", "null"]}
-                  }
-                },
-                "cross_references": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {"type": ["string", "null"]},
-                      "url": {"type": ["string", "null"]}
-                    }
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_gene_id": {"type": "string"},
-                "data_provider": {"type": ["string", "null"]},
-                "source": {"type": "string"}
-              }
-            }
+            "name": {"type": ["string", "null"]},
+            "short_name": {"type": ["string", "null"]},
+            "taxon_id": {"type": ["string", "null"]},
+            "data_provider": {"type": ["string", "null"]}
           }
         },
-        {
+        "gene_synopsis": {
+          "type": ["string", "null"],
+          "description": "Curated gene synopsis from MGI"
+        },
+        "automated_gene_synopsis": {
+          "type": ["string", "null"],
+          "description": "Automatically generated gene synopsis"
+        },
+        "synonyms": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "so_term": {
+          "type": ["string", "null"],
+          "description": "Sequence Ontology term (e.g., 'protein_coding_gene')"
+        },
+        "genomic_location": {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
-          },
-          "required": ["error"]
+            "chromosome": {"type": ["string", "null"]},
+            "start": {"type": ["integer", "null"]},
+            "end": {"type": ["integer", "null"]},
+            "assembly": {"type": ["string", "null"]},
+            "strand": {"type": ["string", "null"]}
+          }
+        },
+        "cross_references": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {"type": ["string", "null"]},
+              "url": {"type": ["string", "null"]}
+            }
+          }
         }
-      ]
+      }
     }
   },
   {
@@ -236,51 +188,25 @@
       }
     ],
     "return_schema": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "description": "List of phenotype annotations for the mouse gene",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_symbol": {
-                    "type": ["string", "null"],
-                    "description": "Gene symbol"
-                  },
-                  "gene_id": {
-                    "type": ["string", "null"],
-                    "description": "MGI gene ID"
-                  },
-                  "phenotype_statement": {
-                    "type": ["string", "null"],
-                    "description": "Phenotype description from MP ontology annotation"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {"type": "integer"},
-                "returned": {"type": "integer"},
-                "query_gene_id": {"type": "string"},
-                "page": {"type": "integer"},
-                "source": {"type": "string"}
-              }
-            }
-          }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "error": {"type": "string"}
+      "type": "array",
+      "description": "List of phenotype annotations for the mouse gene",
+      "items": {
+        "type": "object",
+        "properties": {
+          "gene_symbol": {
+            "type": ["string", "null"],
+            "description": "Gene symbol"
           },
-          "required": ["error"]
+          "gene_id": {
+            "type": ["string", "null"],
+            "description": "MGI gene ID"
+          },
+          "phenotype_statement": {
+            "type": ["string", "null"],
+            "description": "Phenotype description from MP ontology annotation"
+          }
         }
-      ]
+      }
     }
   }
 ]

--- a/src/tooluniverse/data/mgnify_expanded_tools.json
+++ b/src/tooluniverse/data/mgnify_expanded_tools.json
@@ -32,61 +32,39 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "genome_id": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string",
-                  "description": "Isolate or MAG"
-                },
-                "taxonomy": {
-                  "type": "string",
-                  "description": "Full taxonomic lineage"
-                },
-                "completeness": {
-                  "type": "number"
-                },
-                "contamination": {
-                  "type": "number"
-                },
-                "length": {
-                  "type": "integer"
-                },
-                "num_proteins": {
-                  "type": "integer"
-                },
-                "gc_content": {
-                  "type": "number"
-                },
-                "n50": {
-                  "type": "integer"
-                },
-                "geographic_origin": {
-                  "type": "string"
-                }
-              }
+            "genome_id": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "type": {
+              "type": "string",
+              "description": "Isolate or MAG"
+            },
+            "taxonomy": {
+              "type": "string",
+              "description": "Full taxonomic lineage"
+            },
+            "completeness": {
+              "type": "number"
+            },
+            "contamination": {
+              "type": "number"
+            },
+            "length": {
+              "type": "integer"
+            },
+            "num_proteins": {
+              "type": "integer"
+            },
+            "gc_content": {
+              "type": "number"
+            },
+            "n50": {
+              "type": "integer"
+            },
+            "geographic_origin": {
+              "type": "string"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -140,55 +118,33 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "genome_id": {
-                    "type": "string"
-                  },
-                  "type": {
-                    "type": "string"
-                  },
-                  "taxonomy": {
-                    "type": "string"
-                  },
-                  "completeness": {
-                    "type": "number"
-                  },
-                  "contamination": {
-                    "type": "number"
-                  },
-                  "length": {
-                    "type": "integer"
-                  },
-                  "num_proteins": {
-                    "type": "integer"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "pages": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "genome_id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "taxonomy": {
+                "type": "string"
+              },
+              "completeness": {
+                "type": "number"
+              },
+              "contamination": {
+                "type": "number"
+              },
+              "length": {
+                "type": "integer"
+              },
+              "num_proteins": {
+                "type": "integer"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -241,43 +197,21 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "biome_id": {
-                    "type": "string"
-                  },
-                  "biome_name": {
-                    "type": "string"
-                  },
-                  "samples_count": {
-                    "type": "integer"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "pages": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "biome_id": {
+                "type": "string"
+              },
+              "biome_name": {
+                "type": "string"
+              },
+              "samples_count": {
+                "type": "integer"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -326,56 +260,34 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "study_id": {
-                  "type": "string"
-                },
-                "study_name": {
-                  "type": "string"
-                },
-                "study_abstract": {
-                  "type": "string"
-                },
-                "bioproject": {
-                  "type": "string"
-                },
-                "centre_name": {
-                  "type": "string"
-                },
-                "biomes": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "analyses_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                }
+            "study_id": {
+              "type": "string"
+            },
+            "study_name": {
+              "type": "string"
+            },
+            "study_abstract": {
+              "type": "string"
+            },
+            "bioproject": {
+              "type": "string"
+            },
+            "centre_name": {
+              "type": "string"
+            },
+            "biomes": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "analyses_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -412,7 +324,9 @@
           "default": 25
         }
       },
-      "required": ["analysis_id"]
+      "required": [
+        "analysis_id"
+      ]
     },
     "fields": {
       "endpoint_type": "analysis",
@@ -435,18 +349,44 @@
       "items": {
         "type": "object",
         "properties": {
-          "organism_id": {"type": "string"},
-          "name": {"type": "string"},
-          "rank": {"type": "string"},
-          "domain": {"type": ["string", "null"]},
-          "count": {"type": "integer"},
-          "lineage": {"type": "string"}
+          "organism_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "rank": {
+            "type": "string"
+          },
+          "domain": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "count": {
+            "type": "integer"
+          },
+          "lineage": {
+            "type": "string"
+          }
         }
       }
     },
-    "label": ["MGnify", "Microbiome", "Taxonomy", "Metagenomics"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "Taxonomy",
+      "Metagenomics"
+    ],
     "metadata": {
-      "tags": ["taxonomy", "microbiome", "16S", "metagenomics", "community_composition"],
+      "tags": [
+        "taxonomy",
+        "microbiome",
+        "16S",
+        "metagenomics",
+        "community_composition"
+      ],
       "estimated_execution_time": "< 5 seconds"
     }
   },
@@ -466,7 +406,9 @@
           "default": 25
         }
       },
-      "required": ["analysis_id"]
+      "required": [
+        "analysis_id"
+      ]
     },
     "fields": {
       "endpoint_type": "analysis",
@@ -488,16 +430,34 @@
       "items": {
         "type": "object",
         "properties": {
-          "go_id": {"type": "string"},
-          "description": {"type": "string"},
-          "count": {"type": "integer"},
-          "category": {"type": "string"}
+          "go_id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "category": {
+            "type": "string"
+          }
         }
       }
     },
-    "label": ["MGnify", "Microbiome", "GO Terms", "Functional Annotation"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "GO Terms",
+      "Functional Annotation"
+    ],
     "metadata": {
-      "tags": ["go_terms", "functional_annotation", "microbiome", "metagenomics"],
+      "tags": [
+        "go_terms",
+        "functional_annotation",
+        "microbiome",
+        "metagenomics"
+      ],
       "estimated_execution_time": "< 5 seconds"
     }
   },
@@ -517,7 +477,9 @@
           "default": 25
         }
       },
-      "required": ["analysis_id"]
+      "required": [
+        "analysis_id"
+      ]
     },
     "fields": {
       "endpoint_type": "analysis",
@@ -539,15 +501,32 @@
       "items": {
         "type": "object",
         "properties": {
-          "interpro_id": {"type": "string"},
-          "description": {"type": "string"},
-          "count": {"type": "integer"}
+          "interpro_id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          }
         }
       }
     },
-    "label": ["MGnify", "Microbiome", "InterPro", "Protein Domains"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "InterPro",
+      "Protein Domains"
+    ],
     "metadata": {
-      "tags": ["interpro", "protein_domains", "functional_annotation", "microbiome", "metagenomics"],
+      "tags": [
+        "interpro",
+        "protein_domains",
+        "functional_annotation",
+        "microbiome",
+        "metagenomics"
+      ],
       "estimated_execution_time": "< 5 seconds"
     }
   },
@@ -558,23 +537,38 @@
       "type": "object",
       "properties": {
         "sample_accession": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Fetch a single sample by its MGnify/ENA accession (e.g., 'SRS10016989'). If provided, study_accession/biome/page are ignored."
         },
         "study_accession": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Filter samples belonging to a study (e.g., 'MGYS00002008')."
         },
         "biome": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Filter by biome name lineage (e.g., 'root:Host-associated:Human:Digestive system')."
         },
         "page": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Page number (default 1)."
         },
         "page_size": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Samples per page (default 25, max 100)."
         }
       },
@@ -676,9 +670,22 @@
         }
       ]
     },
-    "label": ["MGnify", "Microbiome", "Samples", "Metadata"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "Samples",
+      "Metadata"
+    ],
     "metadata": {
-      "tags": ["samples", "sample_metadata", "geography", "host", "environment", "microbiome", "metagenomics"],
+      "tags": [
+        "samples",
+        "sample_metadata",
+        "geography",
+        "host",
+        "environment",
+        "microbiome",
+        "metagenomics"
+      ],
       "estimated_execution_time": "< 5 seconds"
     }
   },
@@ -693,11 +700,16 @@
           "description": "MGnify analysis accession (e.g., 'MGYA00585482'). Find IDs via MGnify_list_analyses."
         },
         "page_size": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Number of download entries to return (default 100, max 100)."
         }
       },
-      "required": ["analysis_id"]
+      "required": [
+        "analysis_id"
+      ]
     },
     "fields": {
       "endpoint_type": "analysis",
@@ -776,9 +788,23 @@
         }
       ]
     },
-    "label": ["MGnify", "Microbiome", "Downloads", "Files"],
+    "label": [
+      "MGnify",
+      "Microbiome",
+      "Downloads",
+      "Files"
+    ],
     "metadata": {
-      "tags": ["downloads", "files", "predicted_cds", "eggnog", "interpro", "diamond", "microbiome", "metagenomics"],
+      "tags": [
+        "downloads",
+        "files",
+        "predicted_cds",
+        "eggnog",
+        "interpro",
+        "diamond",
+        "microbiome",
+        "metagenomics"
+      ],
       "estimated_execution_time": "< 5 seconds"
     }
   }

--- a/src/tooluniverse/data/mirna_tools.json
+++ b/src/tooluniverse/data/mirna_tools.json
@@ -46,59 +46,48 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_hits": {
-                  "type": "integer",
-                  "description": "Total number of matching miRNA entries"
-                },
-                "returned": {
-                  "type": "integer",
-                  "description": "Number of entries returned in this response"
-                },
-                "entries": {
-                  "type": "array",
-                  "description": "List of miRNA entries with IDs, descriptions, and metadata",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "rnacentral_id": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "rna_type": {
-                        "type": "string"
-                      },
-                      "length": {
-                        "type": "integer"
-                      },
-                      "expert_databases": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "has_secondary_structure": {
-                        "type": "boolean"
-                      },
-                      "has_genomic_coordinates": {
-                        "type": "boolean"
-                      }
+            "total_hits": {
+              "type": "integer",
+              "description": "Total number of matching miRNA entries"
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number of entries returned in this response"
+            },
+            "entries": {
+              "type": "array",
+              "description": "List of miRNA entries with IDs, descriptions, and metadata",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "rnacentral_id": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "rna_type": {
+                    "type": "string"
+                  },
+                  "length": {
+                    "type": "integer"
+                  },
+                  "expert_databases": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "has_secondary_structure": {
+                    "type": "boolean"
+                  },
+                  "has_genomic_coordinates": {
+                    "type": "boolean"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -170,64 +159,53 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "rnacentral_id": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "short_description": {
-                  "type": "string"
-                },
-                "sequence": {
-                  "type": "string"
-                },
-                "length": {
-                  "type": "integer"
-                },
-                "rna_type": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "taxid": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "genes": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "publications_count": {
-                  "type": "integer"
-                },
-                "is_active": {
-                  "type": "boolean"
-                },
-                "distinct_databases": {
-                  "type": [
-                    "string",
-                    "array",
-                    "null"
-                  ]
-                }
+            "rnacentral_id": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "short_description": {
+              "type": "string"
+            },
+            "sequence": {
+              "type": "string"
+            },
+            "length": {
+              "type": "integer"
+            },
+            "rna_type": {
+              "type": "string"
+            },
+            "species": {
+              "type": "string"
+            },
+            "taxid": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "genes": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
-            "metadata": {
-              "type": "object"
+            "publications_count": {
+              "type": "integer"
+            },
+            "is_active": {
+              "type": "boolean"
+            },
+            "distinct_databases": {
+              "type": [
+                "string",
+                "array",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -299,58 +277,47 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_publications": {
-                  "type": "integer",
-                  "description": "Total number of publications for this RNA"
-                },
-                "returned": {
-                  "type": "integer",
-                  "description": "Number returned in this page"
-                },
-                "publications": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "title": {
-                        "type": "string"
-                      },
-                      "authors": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "publication": {
-                        "type": "string"
-                      },
-                      "pubmed_id": {
-                        "type": "string"
-                      },
-                      "doi": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "expert_db": {
-                        "type": "boolean"
-                      }
+            "total_publications": {
+              "type": "integer",
+              "description": "Total number of publications for this RNA"
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number returned in this page"
+            },
+            "publications": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "authors": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "publication": {
+                    "type": "string"
+                  },
+                  "pubmed_id": {
+                    "type": "string"
+                  },
+                  "doi": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expert_db": {
+                    "type": "boolean"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -421,82 +388,71 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_xrefs": {
-                  "type": "integer",
-                  "description": "Total number of cross-references"
-                },
-                "returned": {
-                  "type": "integer",
-                  "description": "Number returned in this page"
-                },
-                "cross_references": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "database": {
-                        "type": "string"
-                      },
-                      "accession_id": {
-                        "type": "string"
-                      },
-                      "external_id": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "species": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "rna_type": {
-                        "type": "string"
-                      },
-                      "gene": {
-                        "type": "string"
-                      },
-                      "taxid": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "is_active": {
-                        "type": "boolean"
-                      },
-                      "expert_db_url": {
-                        "type": "string"
-                      },
-                      "mirbase_mature_products": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "mirbase_precursor": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "total_xrefs": {
+              "type": "integer",
+              "description": "Total number of cross-references"
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number returned in this page"
+            },
+            "cross_references": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "database": {
+                    "type": "string"
+                  },
+                  "accession_id": {
+                    "type": "string"
+                  },
+                  "external_id": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "species": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rna_type": {
+                    "type": "string"
+                  },
+                  "gene": {
+                    "type": "string"
+                  },
+                  "taxid": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "is_active": {
+                    "type": "boolean"
+                  },
+                  "expert_db_url": {
+                    "type": ["string", "null"]
+                  },
+                  "mirbase_mature_products": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "mirbase_precursor": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/mobidb_tools.json
+++ b/src/tooluniverse/data/mobidb_tools.json
@@ -1,181 +1,265 @@
 [
-    {
-        "name": "MobiDB_get_protein",
-        "description": "Get comprehensive protein disorder data from MobiDB for a UniProt accession. MobiDB integrates curated disorder from DisProt, predicted disorder from MobiDB-lite, structural data from PDB, PTM annotations, and binding mode information to provide a complete picture of protein intrinsic disorder. Returns predicted disordered regions with residue-level scores, curated disorder regions, linear interacting peptides (LIPs), PTM summary, and subcellular localization. Example: P04637 (TP53) shows predicted disorder at N-terminus (1-90) and C-terminus (360-393), curated disorder from DisProt, 28+ PTM types including phosphoserine and acetyllysine, localized to cytoplasm/nucleus/mitochondria.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "accession": {
-                    "type": "string",
-                    "description": "UniProt accession (e.g., 'P04637' for TP53, 'P00533' for EGFR, 'P38398' for BRCA1)."
-                }
-            },
-            "required": ["accession"]
-        },
-        "fields": {
-            "endpoint": "get_protein"
-        },
-        "type": "MobiDBTool",
-        "test_examples": [
-            {
-                "accession": "P04637"
-            },
-            {
-                "accession": "P00533"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "accession": {"type": "string"},
-                                "gene": {"type": ["string", "null"]},
-                                "name": {"type": ["string", "null"]},
-                                "organism": {"type": ["string", "null"]},
-                                "length": {"type": "integer"},
-                                "sequence": {"type": ["string", "null"]},
-                                "prediction_disorder": {
-                                    "type": "object",
-                                    "properties": {
-                                        "regions": {"type": "array", "items": {"type": "array"}, "description": "Predicted disordered regions as [start, end] pairs"},
-                                        "content_fraction": {"type": ["number", "null"], "description": "Fraction of sequence predicted disordered (0-1)"},
-                                        "content_count": {"type": ["integer", "null"]}
-                                    },
-                                    "description": "MobiDB-lite disorder prediction"
-                                },
-                                "curated_disorder": {
-                                    "type": "object",
-                                    "properties": {
-                                        "regions": {"type": "array"},
-                                        "content_count": {"type": ["integer", "null"]}
-                                    },
-                                    "description": "Curated disorder from DisProt"
-                                },
-                                "curated_lip": {
-                                    "type": "object",
-                                    "properties": {
-                                        "regions": {"type": "array"},
-                                        "content_count": {"type": ["integer", "null"]}
-                                    },
-                                    "description": "Linear interacting peptides"
-                                },
-                                "ptm_summary": {
-                                    "type": "object",
-                                    "properties": {
-                                        "count": {"type": "integer"},
-                                        "types": {"type": "array", "items": {"type": "string"}}
-                                    },
-                                    "description": "Post-translational modification summary"
-                                },
-                                "localization": {"type": "array", "items": {"type": "string"}}
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "reviewed": {"type": ["boolean", "null"]}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+  {
+    "name": "MobiDB_get_protein",
+    "description": "Get comprehensive protein disorder data from MobiDB for a UniProt accession. MobiDB integrates curated disorder from DisProt, predicted disorder from MobiDB-lite, structural data from PDB, PTM annotations, and binding mode information to provide a complete picture of protein intrinsic disorder. Returns predicted disordered regions with residue-level scores, curated disorder regions, linear interacting peptides (LIPs), PTM summary, and subcellular localization. Example: P04637 (TP53) shows predicted disorder at N-terminus (1-90) and C-terminus (360-393), curated disorder from DisProt, 28+ PTM types including phosphoserine and acetyllysine, localized to cytoplasm/nucleus/mitochondria.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "UniProt accession (e.g., 'P04637' for TP53, 'P00533' for EGFR, 'P38398' for BRCA1)."
         }
+      },
+      "required": [
+        "accession"
+      ]
     },
-    {
-        "name": "MobiDB_get_consensus",
-        "description": "Get consensus disorder analysis for a protein from MobiDB, focusing on merged/consensus predictions, phase separation data, and binding mode transitions. Returns predicted disorder regions from MobiDB-lite, curated disorder regions merged across all evidence sources, phase separation propensity, and disorder-to-order/disorder-to-disorder binding mode transitions. Useful for understanding how a protein's disordered regions function in signaling, condensate formation, and protein-protein interactions. Example: P04637 (TP53) shows phase separation regions and binding mode transitions in the transactivation domain.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "accession": {
-                    "type": "string",
-                    "description": "UniProt accession (e.g., 'P04637' for TP53, 'P00533' for EGFR)."
-                }
+    "fields": {
+      "endpoint": "get_protein"
+    },
+    "type": "MobiDBTool",
+    "test_examples": [
+      {
+        "accession": "P04637"
+      },
+      {
+        "accession": "P00533"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "accession": {
+              "type": "string"
             },
-            "required": ["accession"]
-        },
-        "fields": {
-            "endpoint": "get_consensus"
-        },
-        "type": "MobiDBTool",
-        "test_examples": [
-            {
-                "accession": "P04637"
+            "gene": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            {
-                "accession": "P38398"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "accession": {"type": "string"},
-                                "gene": {"type": ["string", "null"]},
-                                "name": {"type": ["string", "null"]},
-                                "organism": {"type": ["string", "null"]},
-                                "length": {"type": "integer"},
-                                "predicted_disorder": {
-                                    "type": "object",
-                                    "properties": {
-                                        "regions": {"type": "array"},
-                                        "content_fraction": {"type": ["number", "null"]}
-                                    }
-                                },
-                                "curated_disorder_merged": {
-                                    "type": "object",
-                                    "properties": {
-                                        "regions": {"type": "array"}
-                                    },
-                                    "description": "Merged curated disorder from all evidence sources"
-                                },
-                                "phase_separation": {
-                                    "type": "object",
-                                    "properties": {
-                                        "regions": {"type": "array"}
-                                    },
-                                    "description": "Phase separation propensity data"
-                                },
-                                "binding_modes": {
-                                    "type": "object",
-                                    "description": "Disorder-to-order and disorder-to-disorder binding transitions"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organism": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "length": {
+              "type": "integer"
+            },
+            "sequence": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "prediction_disorder": {
+              "type": "object",
+              "properties": {
+                "regions": {
+                  "type": "array",
+                  "items": {
+                    "type": "array"
+                  },
+                  "description": "Predicted disordered regions as [start, end] pairs"
                 },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
+                "content_fraction": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "description": "Fraction of sequence predicted disordered (0-1)"
+                },
+                "content_count": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 }
-            ]
+              },
+              "description": "MobiDB-lite disorder prediction"
+            },
+            "curated_disorder": {
+              "type": "object",
+              "properties": {
+                "regions": {
+                  "type": "array"
+                },
+                "content_count": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "description": "Curated disorder from DisProt"
+            },
+            "curated_lip": {
+              "type": "object",
+              "properties": {
+                "regions": {
+                  "type": "array"
+                },
+                "content_count": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                }
+              },
+              "description": "Linear interacting peptides"
+            },
+            "ptm_summary": {
+              "type": "object",
+              "properties": {
+                "count": {
+                  "type": "integer"
+                },
+                "types": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "Post-translational modification summary"
+            },
+            "localization": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "MobiDB_get_consensus",
+    "description": "Get consensus disorder analysis for a protein from MobiDB, focusing on merged/consensus predictions, phase separation data, and binding mode transitions. Returns predicted disorder regions from MobiDB-lite, curated disorder regions merged across all evidence sources, phase separation propensity, and disorder-to-order/disorder-to-disorder binding mode transitions. Useful for understanding how a protein's disordered regions function in signaling, condensate formation, and protein-protein interactions. Example: P04637 (TP53) shows phase separation regions and binding mode transitions in the transactivation domain.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "accession": {
+          "type": "string",
+          "description": "UniProt accession (e.g., 'P04637' for TP53, 'P00533' for EGFR)."
+        }
+      },
+      "required": [
+        "accession"
+      ]
+    },
+    "fields": {
+      "endpoint": "get_consensus"
+    },
+    "type": "MobiDBTool",
+    "test_examples": [
+      {
+        "accession": "P04637"
+      },
+      {
+        "accession": "P38398"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "accession": {
+              "type": "string"
+            },
+            "gene": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organism": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "length": {
+              "type": "integer"
+            },
+            "predicted_disorder": {
+              "type": "object",
+              "properties": {
+                "regions": {
+                  "type": "array"
+                },
+                "content_fraction": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "curated_disorder_merged": {
+              "type": "object",
+              "properties": {
+                "regions": {
+                  "type": "array"
+                }
+              },
+              "description": "Merged curated disorder from all evidence sources"
+            },
+            "phase_separation": {
+              "type": "object",
+              "properties": {
+                "regions": {
+                  "type": "array"
+                }
+              },
+              "description": "Phase separation propensity data"
+            },
+            "binding_modes": {
+              "type": "object",
+              "description": "Disorder-to-order and disorder-to-disorder binding transitions"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/monarch_v3_tools.json
+++ b/src/tooluniverse/data/monarch_v3_tools.json
@@ -285,177 +285,149 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "average_score": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "best_score": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "metric": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "subject_best_matches": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "query_phenotype": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "query_label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "matched_phenotype": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "matched_label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "ancestor_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "ancestor_label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "jaccard_similarity": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "phenodigm_score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "object_best_matches": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "query_phenotype": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "query_label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "matched_phenotype": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "matched_label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "ancestor_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "ancestor_label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "jaccard_similarity": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "phenodigm_score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "average_score": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "best_score": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "metric": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "subject_best_matches": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "query_phenotype": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "query_label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "matched_phenotype": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "matched_label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "ancestor_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ancestor_label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "jaccard_similarity": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "phenodigm_score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "subjects": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "objects": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
+            "object_best_matches": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "query_phenotype": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "query_label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "matched_phenotype": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "matched_label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "ancestor_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ancestor_label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "jaccard_similarity": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "phenodigm_score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/mondo_tools.json
+++ b/src/tooluniverse/data/mondo_tools.json
@@ -14,68 +14,82 @@
           "description": "Maximum number of results to return (default: 10, max: 50)."
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "fields": {
       "endpoint": "mondo_search"
     },
     "type": "MonarchV3Tool",
     "test_examples": [
-      {"query": "Alzheimer disease", "limit": 5},
-      {"query": "breast cancer", "limit": 5},
-      {"query": "type 2 diabetes"}
+      {
+        "query": "Alzheimer disease",
+        "limit": 5
+      },
+      {
+        "query": "breast cancer",
+        "limit": 5
+      },
+      {
+        "query": "type 2 diabetes"
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": ["string", "null"],
-                    "description": "Mondo disease identifier (e.g., MONDO:0004975)"
-                  },
-                  "name": {
-                    "type": ["string", "null"],
-                    "description": "Disease name"
-                  },
-                  "category": {
-                    "type": ["string", "null"],
-                    "description": "Biolink category (biolink:Disease)"
-                  },
-                  "description": {
-                    "type": ["string", "null"],
-                    "description": "Disease description"
-                  },
-                  "xref": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Cross-references to other ontologies (OMIM, Orphanet, DOID, MeSH, etc.)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "query": {"type": "string"},
-                "total_results": {"type": "integer"}
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Mondo disease identifier (e.g., MONDO:0004975)"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Disease name"
+              },
+              "category": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Biolink category (biolink:Disease)"
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Disease description"
+              },
+              "xref": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Cross-references to other ontologies (OMIM, Orphanet, DOID, MeSH, etc.)"
               }
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -91,114 +105,176 @@
           "description": "Mondo disease identifier. Examples: 'MONDO:0004975' (Alzheimer disease), 'MONDO:0005148' (type 2 diabetes mellitus), 'MONDO:0007254' (breast cancer), 'MONDO:0018076' (Huntington disease), 'MONDO:0009061' (cystic fibrosis)."
         }
       },
-      "required": ["disease_id"]
+      "required": [
+        "disease_id"
+      ]
     },
     "fields": {
       "endpoint": "mondo_disease"
     },
     "type": "MonarchV3Tool",
     "test_examples": [
-      {"disease_id": "MONDO:0004975"},
-      {"disease_id": "MONDO:0005148"},
-      {"disease_id": "MONDO:0009061"}
+      {
+        "disease_id": "MONDO:0004975"
+      },
+      {
+        "disease_id": "MONDO:0005148"
+      },
+      {
+        "disease_id": "MONDO:0009061"
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Mondo disease identifier"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Disease name"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Disease description"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Known disease synonyms"
+            },
+            "xrefs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Cross-references (OMIM, Orphanet, DOID, MeSH, ICD-10, NCIT, UMLS, etc.)"
+            },
+            "mappings": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "description": "Mappings to external ontologies with URLs"
+            },
+            "parent_diseases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "description": "Parent disease categories in Mondo hierarchy"
+            },
+            "subtypes_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of disease subtypes (descendants)"
+            },
+            "causal_genes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Gene CURIE (e.g., HGNC:1884)"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Gene name"
+                  }
+                }
+              },
+              "description": "Known causal genes"
+            },
+            "inheritance": {
+              "type": [
+                "object",
+                "null"
+              ],
               "properties": {
                 "id": {
-                  "type": ["string", "null"],
-                  "description": "Mondo disease identifier"
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "HPO inheritance ID (e.g., HP:0000006)"
                 },
                 "name": {
-                  "type": ["string", "null"],
-                  "description": "Disease name"
-                },
-                "description": {
-                  "type": ["string", "null"],
-                  "description": "Disease description"
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {"type": "string"},
-                  "description": "Known disease synonyms"
-                },
-                "xrefs": {
-                  "type": "array",
-                  "items": {"type": "string"},
-                  "description": "Cross-references (OMIM, Orphanet, DOID, MeSH, ICD-10, NCIT, UMLS, etc.)"
-                },
-                "mappings": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {"type": ["string", "null"]},
-                      "url": {"type": ["string", "null"]}
-                    }
-                  },
-                  "description": "Mappings to external ontologies with URLs"
-                },
-                "parent_diseases": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {"type": ["string", "null"]},
-                      "name": {"type": ["string", "null"]}
-                    }
-                  },
-                  "description": "Parent disease categories in Mondo hierarchy"
-                },
-                "subtypes_count": {
-                  "type": ["integer", "null"],
-                  "description": "Number of disease subtypes (descendants)"
-                },
-                "causal_genes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {"type": ["string", "null"], "description": "Gene CURIE (e.g., HGNC:1884)"},
-                      "name": {"type": ["string", "null"], "description": "Gene name"}
-                    }
-                  },
-                  "description": "Known causal genes"
-                },
-                "inheritance": {
-                  "type": ["object", "null"],
-                  "properties": {
-                    "id": {"type": ["string", "null"], "description": "HPO inheritance ID (e.g., HP:0000006)"},
-                    "name": {"type": ["string", "null"], "description": "Inheritance pattern name (e.g., Autosomal dominant)"}
-                  },
-                  "description": "Inheritance pattern if known"
-                },
-                "association_counts": {
-                  "type": "object",
-                  "description": "Counts of different association types (phenotypes, genes, etc.)"
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "description": "Inheritance pattern name (e.g., Autosomal dominant)"
                 }
-              }
+              },
+              "description": "Inheritance pattern if known"
             },
-            "metadata": {
+            "association_counts": {
               "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "disease_id": {"type": "string"}
-              }
+              "description": "Counts of different association types (phenotypes, genes, etc.)"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }
@@ -218,75 +294,97 @@
           "description": "Maximum number of phenotypes to return (default: 20, max: 200)."
         }
       },
-      "required": ["disease_id"]
+      "required": [
+        "disease_id"
+      ]
     },
     "fields": {
       "endpoint": "mondo_phenotypes"
     },
     "type": "MonarchV3Tool",
     "test_examples": [
-      {"disease_id": "MONDO:0004975", "limit": 10},
-      {"disease_id": "MONDO:0005148", "limit": 10},
-      {"disease_id": "MONDO:0009061", "limit": 10}
+      {
+        "disease_id": "MONDO:0004975",
+        "limit": 10
+      },
+      {
+        "disease_id": "MONDO:0005148",
+        "limit": 10
+      },
+      {
+        "disease_id": "MONDO:0009061",
+        "limit": 10
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "phenotype_id": {
-                    "type": ["string", "null"],
-                    "description": "HPO phenotype identifier (e.g., HP:0000726)"
-                  },
-                  "phenotype_name": {
-                    "type": ["string", "null"],
-                    "description": "Phenotype name (e.g., 'Dementia')"
-                  },
-                  "disease_subtype": {
-                    "type": ["string", "null"],
-                    "description": "Specific disease subtype contributing this phenotype"
-                  },
-                  "disease_subtype_id": {
-                    "type": ["string", "null"],
-                    "description": "MONDO ID of the contributing disease subtype"
-                  },
-                  "predicate": {
-                    "type": ["string", "null"],
-                    "description": "Relationship predicate"
-                  },
-                  "negated": {
-                    "type": ["boolean", "null"],
-                    "description": "Whether the phenotype association is negated"
-                  },
-                  "primary_knowledge_source": {
-                    "type": ["string", "null"],
-                    "description": "Primary data source for this association"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "disease_id": {"type": "string"},
-                "total_phenotypes": {"type": "integer"}
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "phenotype_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "HPO phenotype identifier (e.g., HP:0000726)"
+              },
+              "phenotype_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Phenotype name (e.g., 'Dementia')"
+              },
+              "disease_subtype": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Specific disease subtype contributing this phenotype"
+              },
+              "disease_subtype_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "MONDO ID of the contributing disease subtype"
+              },
+              "predicate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Relationship predicate"
+              },
+              "negated": {
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Whether the phenotype association is negated"
+              },
+              "primary_knowledge_source": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Primary data source for this association"
               }
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/msigdb_tools.json
+++ b/src/tooluniverse/data/msigdb_tools.json
@@ -207,30 +207,19 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_set_name": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_set_name": {
-                  "type": "string"
-                },
-                "gene": {
-                  "type": "string"
-                },
-                "is_member": {
-                  "type": "boolean"
-                },
-                "total_genes_in_set": {
-                  "type": "integer"
-                }
-              }
+            "gene": {
+              "type": "string"
+            },
+            "is_member": {
+              "type": "boolean"
+            },
+            "total_genes_in_set": {
+              "type": "integer"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -290,30 +279,19 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_set_name": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_set_name": {
-                  "type": "string"
-                },
-                "num_genes": {
-                  "type": "integer"
-                },
-                "genes": {
-                  "type": "array"
-                },
-                "collection": {
-                  "type": "string"
-                }
-              }
+            "num_genes": {
+              "type": "integer"
+            },
+            "genes": {
+              "type": "array"
+            },
+            "collection": {
+              "type": "string"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/mydisease_tools.json
+++ b/src/tooluniverse/data/mydisease_tools.json
@@ -1,167 +1,168 @@
 [
-    {
-        "name": "MyDisease_get_disease",
-        "description": "Get comprehensive disease annotations from MyDisease.info, a BioThings disease aggregator that integrates data from MONDO, Disease Ontology, CTD (chemicals and pathways related to disease), HPO (phenotypes), and DisGeNET (gene-disease associations). Returns standardized disease identifiers, definitions, cross-references, associated chemicals, pathways, and phenotypes. Example: MONDO:0005148 (type 2 diabetes) returns 160 CTD chemicals, 984 related pathways, and 3 HPO phenotypes including late onset and autosomal dominant inheritance.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "disease_id": {
-                    "type": "string",
-                    "description": "Disease identifier. Supports MONDO IDs (e.g., 'MONDO:0005148' for T2DM), DOID IDs (e.g., 'DOID:9352'), OMIM IDs (e.g., 'OMIM:125853'), or MESH IDs (e.g., 'MESH:D003924'). MONDO IDs provide the most comprehensive results."
-                },
-                "fields": {
-                    "type": "string",
-                    "description": "Comma-separated list of data fields to return. Options: 'mondo', 'disease_ontology', 'ctd', 'hpo', 'disgenet', 'all'. Default: 'mondo,disease_ontology,ctd,hpo'. Use 'all' for complete data."
-                }
-            },
-            "required": [
-                "disease_id"
-            ]
+  {
+    "name": "MyDisease_get_disease",
+    "description": "Get comprehensive disease annotations from MyDisease.info, a BioThings disease aggregator that integrates data from MONDO, Disease Ontology, CTD (chemicals and pathways related to disease), HPO (phenotypes), and DisGeNET (gene-disease associations). Returns standardized disease identifiers, definitions, cross-references, associated chemicals, pathways, and phenotypes. Example: MONDO:0005148 (type 2 diabetes) returns 160 CTD chemicals, 984 related pathways, and 3 HPO phenotypes including late onset and autosomal dominant inheritance.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "disease_id": {
+          "type": "string",
+          "description": "Disease identifier. Supports MONDO IDs (e.g., 'MONDO:0005148' for T2DM), DOID IDs (e.g., 'DOID:9352'), OMIM IDs (e.g., 'OMIM:125853'), or MESH IDs (e.g., 'MESH:D003924'). MONDO IDs provide the most comprehensive results."
         },
         "fields": {
-            "endpoint": "get_disease"
-        },
-        "type": "MyDiseaseTool",
-        "test_examples": [
-            {
-                "disease_id": "MONDO:0005148"
-            },
-            {
-                "disease_id": "DOID:9352",
-                "fields": "disease_ontology,hpo"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "disease_id": {
-                                    "type": "string",
-                                    "description": "Queried disease identifier"
-                                },
-                                "mondo": {
-                                    "type": ["object", "null"],
-                                    "description": "MONDO ontology data: label, definition, ancestors, children, xrefs"
-                                },
-                                "disease_ontology": {
-                                    "type": ["object", "null"],
-                                    "description": "Disease Ontology data: name, definition, DOID, ancestors, xrefs"
-                                },
-                                "ctd": {
-                                    "type": ["object", "null"],
-                                    "description": "CTD data: chemicals and pathways related to disease"
-                                },
-                                "hpo": {
-                                    "type": ["object", "null"],
-                                    "description": "HPO data: phenotypes related to disease, inheritance, clinical course"
-                                },
-                                "disgenet": {
-                                    "type": ["object", "null"],
-                                    "description": "DisGeNET gene-disease associations"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
+          "type": "string",
+          "description": "Comma-separated list of data fields to return. Options: 'mondo', 'disease_ontology', 'ctd', 'hpo', 'disgenet', 'all'. Default: 'mondo,disease_ontology,ctd,hpo'. Use 'all' for complete data."
         }
+      },
+      "required": [
+        "disease_id"
+      ]
     },
-    {
-        "name": "MyDisease_search_diseases",
-        "description": "Search for diseases by keyword in MyDisease.info, a BioThings aggregator combining data from MONDO, Disease Ontology, CTD, HPO, and DisGeNET. Returns matching disease identifiers with names and basic annotations. Useful for finding disease IDs from free-text names. Example: searching 'breast cancer' returns 45 hits including MONDO:0004438 (sporadic breast cancer), MONDO:0006512 (ER+ breast cancer), MONDO:0006513 (ER- breast cancer). Searching 'melanoma' returns 104 hits.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Search query. Can be disease name (e.g., 'breast cancer', 'melanoma', 'diabetes'), gene symbol (e.g., 'BRCA1'), or ontology term. Supports boolean operators: AND, OR, NOT."
-                },
-                "size": {
-                    "type": "integer",
-                    "description": "Maximum number of results to return (default 10, max 100).",
-                    "default": 10
-                },
-                "fields": {
-                    "type": "string",
-                    "description": "Comma-separated list of fields to include in results. Default: 'mondo.label,disease_ontology.name,disease_ontology.doid,hpo.disease_name'. Use 'all' for everything."
-                }
+    "fields": {
+      "endpoint": "get_disease"
+    },
+    "type": "MyDiseaseTool",
+    "test_examples": [
+      {
+        "disease_id": "MONDO:0005148"
+      },
+      {
+        "disease_id": "DOID:9352",
+        "fields": "disease_ontology,hpo"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "disease_id": {
+              "type": "string",
+              "description": "Queried disease identifier"
             },
-            "required": [
-                "query"
-            ]
+            "mondo": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "MONDO ontology data: label, definition, ancestors, children, xrefs"
+            },
+            "disease_ontology": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "Disease Ontology data: name, definition, DOID, ancestors, xrefs"
+            },
+            "ctd": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "CTD data: chemicals and pathways related to disease"
+            },
+            "hpo": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "HPO data: phenotypes related to disease, inheritance, clinical course"
+            },
+            "disgenet": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "DisGeNET gene-disease associations"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "MyDisease_search_diseases",
+    "description": "Search for diseases by keyword in MyDisease.info, a BioThings aggregator combining data from MONDO, Disease Ontology, CTD, HPO, and DisGeNET. Returns matching disease identifiers with names and basic annotations. Useful for finding disease IDs from free-text names. Example: searching 'breast cancer' returns 45 hits including MONDO:0004438 (sporadic breast cancer), MONDO:0006512 (ER+ breast cancer), MONDO:0006513 (ER- breast cancer). Searching 'melanoma' returns 104 hits.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Search query. Can be disease name (e.g., 'breast cancer', 'melanoma', 'diabetes'), gene symbol (e.g., 'BRCA1'), or ontology term. Supports boolean operators: AND, OR, NOT."
+        },
+        "size": {
+          "type": "integer",
+          "description": "Maximum number of results to return (default 10, max 100).",
+          "default": 10
         },
         "fields": {
-            "endpoint": "search_diseases"
-        },
-        "type": "MyDiseaseTool",
-        "test_examples": [
-            {
-                "query": "breast cancer",
-                "size": 5
-            },
-            {
-                "query": "melanoma",
-                "size": 3
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "total_hits": {
-                                    "type": "integer",
-                                    "description": "Total number of matching diseases"
-                                },
-                                "returned": {
-                                    "type": "integer",
-                                    "description": "Number of results returned"
-                                },
-                                "diseases": {
-                                    "type": "array",
-                                    "description": "List of matching diseases with IDs, names, and requested fields",
-                                    "items": {
-                                        "type": "object"
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
+          "type": "string",
+          "description": "Comma-separated list of fields to include in results. Default: 'mondo.label,disease_ontology.name,disease_ontology.doid,hpo.disease_name'. Use 'all' for everything."
         }
+      },
+      "required": [
+        "query"
+      ]
+    },
+    "fields": {
+      "endpoint": "search_diseases"
+    },
+    "type": "MyDiseaseTool",
+    "test_examples": [
+      {
+        "query": "breast cancer",
+        "size": 5
+      },
+      {
+        "query": "melanoma",
+        "size": 3
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "total_hits": {
+              "type": "integer",
+              "description": "Total number of matching diseases"
+            },
+            "returned": {
+              "type": "integer",
+              "description": "Number of results returned"
+            },
+            "diseases": {
+              "type": "array",
+              "description": "List of matching diseases with IDs, names, and requested fields",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
     }
+  }
 ]

--- a/src/tooluniverse/data/nca_tools.json
+++ b/src/tooluniverse/data/nca_tools.json
@@ -64,36 +64,21 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "Cmax": {"type": "number", "description": "Maximum concentration"},
-                "Tmax": {"type": "number", "description": "Time of maximum concentration"},
-                "Clast": {"type": "number", "description": "Last measured positive concentration"},
-                "Tlast": {"type": "number", "description": "Time of last measured positive concentration"},
-                "lambda_z": {"type": ["number", "null"], "description": "Terminal elimination rate constant (1/time_unit)"},
-                "t_half": {"type": ["number", "null"], "description": "Terminal half-life in time_unit"},
-                "r_squared_terminal_fit": {"type": ["number", "null"], "description": "R² of terminal log-linear regression"},
-                "AUC0-inf": {"type": ["number", "null"], "description": "AUC extrapolated to infinity"},
-                "AUC_extrapolation_pct": {"type": ["number", "null"], "description": "Percent of AUC from extrapolation (should be <20%)"},
-                "clearance_CL": {"type": ["number", "null"], "description": "Systemic clearance (dose/AUC)"},
-                "volume_distribution_Vd": {"type": ["number", "null"], "description": "Volume of distribution"},
-                "method": {"type": "string"},
-                "note": {"type": "string"},
-                "units": {"type": "object"}
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "n_timepoints": {"type": "integer"},
-                "route_of_administration": {"type": "string"},
-                "reference": {"type": "string"}
-              }
-            }
-          },
-          "required": ["data"]
+            "Cmax": {"type": "number", "description": "Maximum concentration"},
+            "Tmax": {"type": "number", "description": "Time of maximum concentration"},
+            "Clast": {"type": "number", "description": "Last measured positive concentration"},
+            "Tlast": {"type": "number", "description": "Time of last measured positive concentration"},
+            "lambda_z": {"type": ["number", "null"], "description": "Terminal elimination rate constant (1/time_unit)"},
+            "t_half": {"type": ["number", "null"], "description": "Terminal half-life in time_unit"},
+            "r_squared_terminal_fit": {"type": ["number", "null"], "description": "R² of terminal log-linear regression"},
+            "AUC0-inf": {"type": ["number", "null"], "description": "AUC extrapolated to infinity"},
+            "AUC_extrapolation_pct": {"type": ["number", "null"], "description": "Percent of AUC from extrapolation (should be <20%)"},
+            "clearance_CL": {"type": ["number", "null"], "description": "Systemic clearance (dose/AUC)"},
+            "volume_distribution_Vd": {"type": ["number", "null"], "description": "Volume of distribution"},
+            "method": {"type": "string"},
+            "note": {"type": "string"},
+            "units": {"type": "object"}
+          }
         },
         {
           "type": "object",
@@ -164,32 +149,19 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "model": {"type": "string"},
-                "equation": {"type": "string"},
-                "C0_initial_concentration": {"type": "number"},
-                "k_el_elimination_rate": {"type": "number"},
-                "t_half": {"type": "number"},
-                "r_squared": {"type": "number"},
-                "goodness_of_fit": {"type": "string"},
-                "standard_errors": {"type": "object"},
-                "volume_distribution_Vd": {"type": ["number", "null"]},
-                "clearance_CL": {"type": ["number", "null"]},
-                "AUC0_inf_model": {"type": ["number", "null"]},
-                "units": {"type": "object"}
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "n_timepoints_fitted": {"type": "integer"}
-              }
-            }
-          },
-          "required": ["data"]
+            "model": {"type": "string"},
+            "equation": {"type": "string"},
+            "C0_initial_concentration": {"type": "number"},
+            "k_el_elimination_rate": {"type": "number"},
+            "t_half": {"type": "number"},
+            "r_squared": {"type": "number"},
+            "goodness_of_fit": {"type": "string"},
+            "standard_errors": {"type": "object"},
+            "volume_distribution_Vd": {"type": ["number", "null"]},
+            "clearance_CL": {"type": ["number", "null"]},
+            "AUC0_inf_model": {"type": ["number", "null"]},
+            "units": {"type": "object"}
+          }
         },
         {
           "type": "object",
@@ -240,27 +212,14 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "bioavailability_F": {"type": "number", "description": "Absolute bioavailability as fraction (0-1)"},
-                "bioavailability_pct": {"type": "number", "description": "Bioavailability as percentage"},
-                "category": {"type": "string"},
-                "clinical_note": {"type": "string"},
-                "formula": {"type": "string"},
-                "inputs": {"type": "object"},
-                "general_note": {"type": "string"}
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "method": {"type": "string"}
-              }
-            }
-          },
-          "required": ["data"]
+            "bioavailability_F": {"type": "number", "description": "Absolute bioavailability as fraction (0-1)"},
+            "bioavailability_pct": {"type": "number", "description": "Bioavailability as percentage"},
+            "category": {"type": "string"},
+            "clinical_note": {"type": "string"},
+            "formula": {"type": "string"},
+            "inputs": {"type": "object"},
+            "general_note": {"type": "string"}
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ncbi_sra_tools.json
+++ b/src/tooluniverse/data/ncbi_sra_tools.json
@@ -473,47 +473,39 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "accession": {"type": "string"},
-                  "file_count": {"type": "integer"},
-                  "files": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {"type": "string"},
-                        "type": {"type": "string"},
-                        "size": {"type": ["integer", "null"]},
-                        "md5": {"type": ["string", "null"]},
-                        "modification_date": {"type": ["string", "null"]},
-                        "locations": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "service": {"type": "string"},
-                              "region": {"type": ["string", "null"]},
-                              "link": {"type": "string"}
-                            }
-                          }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession": {"type": "string"},
+              "file_count": {"type": "integer"},
+              "files": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {"type": "string"},
+                    "type": {"type": "string"},
+                    "size": {"type": ["integer", "null"]},
+                    "md5": {"type": ["string", "null"]},
+                    "modification_date": {"type": ["string", "null"]},
+                    "locations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "service": {"type": "string"},
+                          "region": {"type": ["string", "null"]},
+                          "link": {"type": "string"}
                         }
                       }
                     }
-                  },
-                  "error": {"type": "string"}
+                  }
                 }
-              }
-            },
-            "count": {"type": "integer"}
-          },
-          "required": ["data"]
+              },
+              "error": {"type": "string"}
+            }
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/nci_thesaurus_tools.json
+++ b/src/tooluniverse/data/nci_thesaurus_tools.json
@@ -37,56 +37,34 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "code": {
-                    "type": "string",
-                    "description": "NCI Thesaurus concept code (e.g., C3224)"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Preferred concept name"
-                  },
-                  "terminology": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Source terminology (ncit)"
-                  },
-                  "leaf": {
-                    "type": [
-                      "boolean",
-                      "null"
-                    ],
-                    "description": "Whether concept is a leaf node"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "NCI Thesaurus concept code (e.g., C3224)"
+              },
+              "name": {
+                "type": "string",
+                "description": "Preferred concept name"
+              },
+              "terminology": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Source terminology (ncit)"
+              },
+              "leaf": {
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Whether concept is a leaf node"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -134,82 +112,63 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "code": {
-                  "type": "string",
-                  "description": "NCI concept code"
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Preferred name"
-                },
-                "definition": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Full text definition"
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Synonym type (FULL_SYN, etc.)"
-                      },
-                      "source": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Source database"
-                      }
-                    }
-                  },
-                  "description": "Synonyms from various sources"
-                },
-                "properties": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string"
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "description": "Additional properties (semantic type, etc.)"
-                }
-              }
+            "code": {
+              "type": "string",
+              "description": "NCI concept code"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "terminology": {
-                  "type": "string"
+            "name": {
+              "type": "string",
+              "description": "Preferred name"
+            },
+            "definition": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Full text definition"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Synonym type (FULL_SYN, etc.)"
+                  },
+                  "source": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Source database"
+                  }
                 }
-              }
+              },
+              "description": "Synonyms from various sources"
+            },
+            "properties": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "Additional properties (semantic type, etc.)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -255,49 +214,27 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "code": {
-                    "type": "string",
-                    "description": "Child concept code"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Child concept name"
-                  },
-                  "leaf": {
-                    "type": [
-                      "boolean",
-                      "null"
-                    ],
-                    "description": "Whether this is a leaf node (no children)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "parent_code": {
-                  "type": "string"
-                },
-                "total_children": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Child concept code"
+              },
+              "name": {
+                "type": "string",
+                "description": "Child concept name"
+              },
+              "leaf": {
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Whether this is a leaf node (no children)"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -343,49 +280,27 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "code": {
-                    "type": "string",
-                    "description": "Parent concept code"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Parent concept name (broader category)"
-                  },
-                  "leaf": {
-                    "type": [
-                      "boolean",
-                      "null"
-                    ],
-                    "description": "Whether the parent is a leaf node"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "child_code": {
-                  "type": "string"
-                },
-                "total_parents": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Parent concept code"
+              },
+              "name": {
+                "type": "string",
+                "description": "Parent concept name (broader category)"
+              },
+              "leaf": {
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "description": "Whether the parent is a leaf node"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -433,90 +348,65 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "code": {
-                  "type": "string",
-                  "description": "NCI concept code"
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Concept preferred name"
-                },
-                "maps": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Map relationship type (e.g., 'Has Synonym')"
-                      },
-                      "target_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Name of the mapped target term"
-                      },
-                      "target_code": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Code in the target terminology (e.g., MedDRA 10006187)"
-                      },
-                      "target_term_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Target term type (e.g., LLT, PT)"
-                      },
-                      "target_terminology": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Target terminology name (MedDRA, SNOMED, GDC, ICD)"
-                      },
-                      "target_terminology_version": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Version of the target terminology"
-                      }
-                    }
-                  }
-                }
-              }
+            "code": {
+              "type": "string",
+              "description": "NCI concept code"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_maps": {
-                  "type": "integer"
-                },
-                "target_terminologies": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
+            "name": {
+              "type": "string",
+              "description": "Concept preferred name"
+            },
+            "maps": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Map relationship type (e.g., 'Has Synonym')"
+                  },
+                  "target_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Name of the mapped target term"
+                  },
+                  "target_code": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Code in the target terminology (e.g., MedDRA 10006187)"
+                  },
+                  "target_term_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Target term type (e.g., LLT, PT)"
+                  },
+                  "target_terminology": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Target terminology name (MedDRA, SNOMED, GDC, ICD)"
+                  },
+                  "target_terminology_version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Version of the target terminology"
                   }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ndex_tools.json
+++ b/src/tooluniverse/data/ndex_tools.json
@@ -38,100 +38,75 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "uuid": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Network UUID (use with NDEx_get_network_summary or NDEx_get_network)"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Network name"
-                  },
-                  "description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Network description (truncated)"
-                  },
-                  "owner": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Network owner/contributor"
-                  },
-                  "node_count": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of nodes in the network"
-                  },
-                  "edge_count": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of edges in the network"
-                  },
-                  "visibility": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Network visibility (PUBLIC/PRIVATE)"
-                  },
-                  "doi": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "DOI if published"
-                  },
-                  "version": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Network version"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "start": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "uuid": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Network UUID (use with NDEx_get_network_summary or NDEx_get_network)"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Network name"
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Network description (truncated)"
+              },
+              "owner": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Network owner/contributor"
+              },
+              "node_count": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of nodes in the network"
+              },
+              "edge_count": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of edges in the network"
+              },
+              "visibility": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Network visibility (PUBLIC/PRIVATE)"
+              },
+              "doi": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "DOI if published"
+              },
+              "version": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Network version"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -179,104 +154,88 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "uuid": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Network UUID"
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Network name"
-                },
-                "description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Full description"
-                },
-                "owner": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Owner username"
-                },
-                "node_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of nodes"
-                },
-                "edge_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of edges"
-                },
-                "visibility": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "PUBLIC or PRIVATE"
-                },
-                "doi": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Digital Object Identifier"
-                },
-                "version": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Network version"
-                },
-                "creation_time": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Creation timestamp (ms)"
-                },
-                "modification_time": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Last modification timestamp (ms)"
-                },
-                "properties": {
-                  "type": "object",
-                  "description": "Custom network properties (key-value pairs)"
-                }
-              }
+            "uuid": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Network UUID"
             },
-            "metadata": {
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Network name"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Full description"
+            },
+            "owner": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Owner username"
+            },
+            "node_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of nodes"
+            },
+            "edge_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of edges"
+            },
+            "visibility": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "PUBLIC or PRIVATE"
+            },
+            "doi": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Digital Object Identifier"
+            },
+            "version": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Network version"
+            },
+            "creation_time": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Creation timestamp (ms)"
+            },
+            "modification_time": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Last modification timestamp (ms)"
+            },
+            "properties": {
               "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                }
-              }
+              "description": "Custom network properties (key-value pairs)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -321,63 +280,41 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "network_name": {
-                  "type": "string",
-                  "description": "Network name"
-                },
-                "nodes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  },
-                  "description": "Network nodes (id, name, represents)"
-                },
-                "edges": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  },
-                  "description": "Network edges (source, target, interaction)"
-                },
-                "total_nodes": {
-                  "type": "integer",
-                  "description": "Total nodes in network"
-                },
-                "total_edges": {
-                  "type": "integer",
-                  "description": "Total edges in network"
-                },
-                "truncated_nodes": {
-                  "type": "boolean",
-                  "description": "Whether node list was truncated"
-                },
-                "truncated_edges": {
-                  "type": "boolean",
-                  "description": "Whether edge list was truncated"
-                }
-              }
+            "network_name": {
+              "type": "string",
+              "description": "Network name"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "uuid": {
-                  "type": "string"
-                },
-                "format": {
-                  "type": "string"
-                }
-              }
+            "nodes": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "description": "Network nodes (id, name, represents)"
+            },
+            "edges": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "description": "Network edges (source, target, interaction)"
+            },
+            "total_nodes": {
+              "type": "integer",
+              "description": "Total nodes in network"
+            },
+            "total_edges": {
+              "type": "integer",
+              "description": "Total edges in network"
+            },
+            "truncated_nodes": {
+              "type": "boolean",
+              "description": "Whether node list was truncated"
+            },
+            "truncated_edges": {
+              "type": "boolean",
+              "description": "Whether edge list was truncated"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/network_proximity_tools.json
+++ b/src/tooluniverse/data/network_proximity_tools.json
@@ -20,10 +20,22 @@
     },
     "return_schema": {
       "type": "object",
-      "oneOf": [
-        {"properties": {"status": {"const": "success"}, "data": {"type": "object"}}, "required": ["data"]},
-        {"properties": {"status": {"const": "error"}, "error": {"type": "string"}}, "required": ["error"]}
-      ]
+      "description": "Network proximity (Guney/Barabasi 'closest'/'shortest' or Menche 'separation') between two node sets, with a degree-matched random Z-score and empirical p-value.",
+      "properties": {
+        "measure": {"type": "string", "description": "Distance measure used: 'closest', 'shortest', or 'separation'."},
+        "value": {"type": "number", "description": "Observed distance/separation value."},
+        "n_set_a_in_network": {"type": "integer", "description": "Number of set_a nodes found in the network."},
+        "n_set_b_in_network": {"type": "integer", "description": "Number of set_b nodes found in the network."},
+        "nodes_in_network": {"type": "integer", "description": "Total number of nodes in the network."},
+        "missing_set_a": {"type": ["array", "null"], "items": {"type": "string"}, "description": "set_a nodes not found in the network."},
+        "missing_set_b": {"type": ["array", "null"], "items": {"type": "string"}, "description": "set_b nodes not found in the network."},
+        "z_score": {"type": "number", "description": "Z-score of the observed value against the degree-matched random null."},
+        "p_value": {"type": "number", "description": "Empirical p-value from the randomizations."},
+        "random_mean": {"type": "number", "description": "Mean of the degree-matched random null distribution."},
+        "random_std": {"type": "number", "description": "Standard deviation of the degree-matched random null distribution."},
+        "n_randomizations": {"type": "integer", "description": "Number of randomizations performed."}
+      },
+      "required": ["measure", "value", "z_score", "p_value"]
     },
     "test_examples": [
       {"edges": [["A", "B"], ["B", "C"], ["C", "D"], ["D", "E"], ["A", "C"], ["B", "D"], ["E", "F"], ["F", "G"], ["A", "F"], ["C", "G"]], "set_a": ["A", "B"], "set_b": ["D", "E"], "measure": "closest", "n_rand": 200, "seed": 1}

--- a/src/tooluniverse/data/neuromorpho_tools.json
+++ b/src/tooluniverse/data/neuromorpho_tools.json
@@ -39,83 +39,67 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "neuron_id": {
-                  "type": "integer"
-                },
-                "neuron_name": {
-                  "type": "string"
-                },
-                "archive": {
-                  "type": "string",
-                  "description": "Contributing lab/archive name"
-                },
-                "species": {
-                  "type": "string"
-                },
-                "strain": {
-                  "type": "string"
-                },
-                "scientific_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "brain_region": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "cell_type": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "gender": {
-                  "type": "string"
-                },
-                "age_classification": {
-                  "type": "string"
-                },
-                "stain": {
-                  "type": "string"
-                },
-                "protocol": {
-                  "type": "string"
-                },
-                "domain": {
-                  "type": "string",
-                  "description": "Neuronal compartments reconstructed (Dendrites, Axon, Soma)"
-                },
-                "reference_pmid": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "png_url": {
-                  "type": "string",
-                  "description": "URL to neuron image"
-                }
+            "neuron_id": {
+              "type": "integer"
+            },
+            "neuron_name": {
+              "type": "string"
+            },
+            "archive": {
+              "type": "string",
+              "description": "Contributing lab/archive name"
+            },
+            "species": {
+              "type": "string"
+            },
+            "strain": {
+              "type": "string"
+            },
+            "scientific_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "brain_region": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                }
+            "cell_type": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
+            },
+            "gender": {
+              "type": "string"
+            },
+            "age_classification": {
+              "type": "string"
+            },
+            "stain": {
+              "type": "string"
+            },
+            "protocol": {
+              "type": "string"
+            },
+            "domain": {
+              "type": "string",
+              "description": "Neuronal compartments reconstructed (Dendrites, Axon, Soma)"
+            },
+            "reference_pmid": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "png_url": {
+              "type": "string",
+              "description": "URL to neuron image"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -197,61 +181,36 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "neuron_id": {
-                    "type": "integer"
-                  },
-                  "neuron_name": {
-                    "type": "string"
-                  },
-                  "species": {
-                    "type": "string"
-                  },
-                  "brain_region": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "cell_type": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "archive": {
-                    "type": "string"
-                  }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "neuron_id": {
+                "type": "integer"
+              },
+              "neuron_name": {
+                "type": "string"
+              },
+              "species": {
+                "type": "string"
+              },
+              "brain_region": {
+                "type": "array",
+                "items": {
+                  "type": "string"
                 }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "total_pages": {
-                  "type": "integer"
-                },
-                "current_page": {
-                  "type": "integer"
-                },
-                "page_size": {
-                  "type": "integer"
+              },
+              "cell_type": {
+                "type": "array",
+                "items": {
+                  "type": "string"
                 }
+              },
+              "archive": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -307,97 +266,81 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "neuron_name": {
-                  "type": "string"
-                },
-                "neuron_id": {
-                  "type": "integer"
-                },
-                "surface": {
-                  "type": "number",
-                  "description": "Total surface area (um^2)"
-                },
-                "volume": {
-                  "type": "number",
-                  "description": "Total volume (um^3)"
-                },
-                "n_stems": {
-                  "type": "number",
-                  "description": "Number of stems"
-                },
-                "n_bifs": {
-                  "type": "number",
-                  "description": "Number of bifurcations"
-                },
-                "n_branch": {
-                  "type": "number",
-                  "description": "Number of branches"
-                },
-                "width": {
-                  "type": "number",
-                  "description": "Width (um)"
-                },
-                "height": {
-                  "type": "number",
-                  "description": "Height (um)"
-                },
-                "depth": {
-                  "type": "number",
-                  "description": "Depth (um)"
-                },
-                "diameter": {
-                  "type": "number",
-                  "description": "Average diameter (um)"
-                },
-                "eucDistance": {
-                  "type": "number",
-                  "description": "Max Euclidean distance (um)"
-                },
-                "pathDistance": {
-                  "type": "number",
-                  "description": "Max path distance (um)"
-                },
-                "branch_Order": {
-                  "type": "number"
-                },
-                "contraction": {
-                  "type": "number"
-                },
-                "fragmentation": {
-                  "type": "number"
-                },
-                "partition_asymmetry": {
-                  "type": "number"
-                },
-                "fractal_Dim": {
-                  "type": "number",
-                  "description": "Fractal dimension"
-                },
-                "soma_Surface": {
-                  "type": "number",
-                  "description": "Soma surface area (um^2)"
-                },
-                "length": {
-                  "type": "number",
-                  "description": "Total length (um)"
-                }
-              }
+            "neuron_name": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                }
-              }
+            "neuron_id": {
+              "type": "integer"
+            },
+            "surface": {
+              "type": "number",
+              "description": "Total surface area (um^2)"
+            },
+            "volume": {
+              "type": "number",
+              "description": "Total volume (um^3)"
+            },
+            "n_stems": {
+              "type": "number",
+              "description": "Number of stems"
+            },
+            "n_bifs": {
+              "type": "number",
+              "description": "Number of bifurcations"
+            },
+            "n_branch": {
+              "type": "number",
+              "description": "Number of branches"
+            },
+            "width": {
+              "type": "number",
+              "description": "Width (um)"
+            },
+            "height": {
+              "type": "number",
+              "description": "Height (um)"
+            },
+            "depth": {
+              "type": "number",
+              "description": "Depth (um)"
+            },
+            "diameter": {
+              "type": "number",
+              "description": "Average diameter (um)"
+            },
+            "eucDistance": {
+              "type": "number",
+              "description": "Max Euclidean distance (um)"
+            },
+            "pathDistance": {
+              "type": "number",
+              "description": "Max path distance (um)"
+            },
+            "branch_Order": {
+              "type": "number"
+            },
+            "contraction": {
+              "type": "number"
+            },
+            "fragmentation": {
+              "type": "number"
+            },
+            "partition_asymmetry": {
+              "type": "number"
+            },
+            "fractal_Dim": {
+              "type": "number",
+              "description": "Fractal dimension"
+            },
+            "soma_Surface": {
+              "type": "number",
+              "description": "Soma surface area (um^2)"
+            },
+            "length": {
+              "type": "number",
+              "description": "Total length (um)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -453,36 +396,11 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "List of available values for the specified field"
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "field_name": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "total_pages": {
-                  "type": "integer"
-                },
-                "current_page": {
-                  "type": "integer"
-                }
-              }
-            }
+          "type": "array",
+          "items": {
+            "type": "string"
           },
-          "required": [
-            "data"
-          ]
+          "description": "List of available values for the specified field"
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/neuromorpho_tools.json
+++ b/src/tooluniverse/data/neuromorpho_tools.json
@@ -468,109 +468,136 @@
       }
     ],
     "return_schema": {
-      "oneOf": [
-        {
-          "type": "object",
-          "description": "Paginated list of source-publication records",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "article_id": {
-                    "type": "string",
-                    "description": "NeuroMorpho internal article ID (use with NeuroMorpho_get_literature)"
-                  },
-                  "doi": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "pmid": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "journal": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "title": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "authors": {
-                    "type": [
-                      "array",
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "brainRegion": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "cellType": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "tracingSystem": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
+      "type": "array",
+      "description": "List of matching source-publication records",
+      "items": {
+        "type": "object",
+        "properties": {
+          "article_id": {
+            "type": "string",
+            "description": "NeuroMorpho internal article ID (use with NeuroMorpho_get_literature)"
+          },
+          "doi": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pmid": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "journal": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "authors": {
+            "type": [
+              "array",
+              "string",
+              "null"
+            ]
+          },
+          "species": {
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "brainRegion": {
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "cellType": {
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "tracingSystem": {
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "evaluatedDate": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Evaluation timestamp (epoch milliseconds)"
+          },
+          "publishedDate": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Publication timestamp (epoch milliseconds)"
+          },
+          "dataUsage": {
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "sharedReconstructions": {
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "status": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
               "type": "object",
               "properties": {
-                "total_results": {
-                  "type": "integer"
+                "specificDetails": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "total_pages": {
-                  "type": "integer"
+                "nReconstructions": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "_links": {
+                  "type": "object"
                 }
               }
             }
-          }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "error": {
-              "type": "string"
-            }
           },
-          "required": [
-            "error"
-          ]
+          "globalStatus": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "collection": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
-      ]
+      }
     }
   },
   {
@@ -599,95 +626,130 @@
       }
     ],
     "return_schema": {
-      "oneOf": [
-        {
-          "type": "object",
-          "description": "A single source-publication record",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "article_id": {
-                  "type": "string"
-                },
-                "doi": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "pmid": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "journal": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "title": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "species": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "brainRegion": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "cellType": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "tracingSystem": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                }
+      "type": "object",
+      "description": "A single source-publication record",
+      "properties": {
+        "article_id": {
+          "type": "string"
+        },
+        "doi": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pmid": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "journal": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "authors": {
+          "type": [
+            "array",
+            "string",
+            "null"
+          ]
+        },
+        "species": {
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "brainRegion": {
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "cellType": {
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "tracingSystem": {
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "evaluatedDate": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "publishedDate": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "dataUsage": {
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "sharedReconstructions": {
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "status": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "specificDetails": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "nReconstructions": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "_links": {
+                "type": "object"
               }
             }
           }
         },
-        {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "error": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "error"
+        "globalStatus": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "collection": {
+          "type": [
+            "string",
+            "null"
           ]
         }
-      ]
+      }
     }
   },
   {
@@ -716,70 +778,33 @@
       }
     ],
     "return_schema": {
-      "oneOf": [
-        {
-          "type": "object",
-          "description": "Persistence vector (TMD shape signature) for the neuron",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "neuron_id": {
-                  "type": "integer"
-                },
-                "scaling_factor": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "description": "Scaling factor applied to the persistence diagram"
-                },
-                "distance": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "coefficients": {
-                  "type": "array",
-                  "description": "100-element persistence vector (TMD shape signature)",
-                  "items": {
-                    "type": "number"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "num_coefficients": {
-                  "type": "integer"
-                }
-              }
-            }
-          }
+      "type": "object",
+      "description": "Persistence vector (TMD shape signature) for the neuron",
+      "properties": {
+        "neuron_id": {
+          "type": "integer"
         },
-        {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "error": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "error"
+        "scaling_factor": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Scaling factor applied to the persistence diagram"
+        },
+        "distance": {
+          "type": [
+            "number",
+            "null"
           ]
+        },
+        "coefficients": {
+          "type": "array",
+          "description": "100-element persistence vector (TMD shape signature)",
+          "items": {
+            "type": "number"
+          }
         }
-      ]
+      }
     }
   }
 ]

--- a/src/tooluniverse/data/nextstrain_tools.json
+++ b/src/tooluniverse/data/nextstrain_tools.json
@@ -30,52 +30,24 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "pathogen": {
-                    "type": "string"
-                  },
-                  "dataset_count": {
-                    "type": "integer"
-                  },
-                  "datasets": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_pathogens": {
-                  "type": "integer"
-                },
-                "total_datasets": {
-                  "type": "integer"
-                },
-                "filter": {
-                  "type": "string"
-                },
-                "endpoint": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pathogen": {
+                "type": "string"
+              },
+              "dataset_count": {
+                "type": "integer"
+              },
+              "datasets": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -123,77 +95,52 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "dataset": {
-                  "type": "string"
-                },
-                "title": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "updated": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "build_url": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "num_sequences": {
-                  "type": "integer"
-                },
-                "data_provenance": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "maintainers": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "root_attributes": {
-                  "type": "object"
-                },
-                "available_colorings": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
+            "dataset": {
+              "type": "string"
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "updated": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "build_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "num_sequences": {
+              "type": "integer"
+            },
+            "data_provenance": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "version": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+            "maintainers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "root_attributes": {
+              "type": "object"
+            },
+            "available_colorings": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/nhanes_tools.json
+++ b/src/tooluniverse/data/nhanes_tools.json
@@ -46,62 +46,48 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "datasets": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "description": "Dataset name"
-                      },
-                      "year": {
-                        "type": "string",
-                        "description": "NHANES cycle"
-                      },
-                      "component": {
-                        "type": "string"
-                      },
-                      "download_url": {
-                        "type": "string",
-                        "description": "CDC listing page for this component and cycle"
-                      },
-                      "description": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                },
-                "count": {
-                  "type": "integer",
-                  "description": "Number of component/cycle entries returned"
-                },
-                "cycles_covered": {
-                  "type": "array",
-                  "items": {
+            "datasets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Dataset name"
+                  },
+                  "year": {
+                    "type": "string",
+                    "description": "NHANES cycle"
+                  },
+                  "component": {
                     "type": "string"
                   },
-                  "description": "The NHANES cycles these entries describe"
-                },
-                "note": {
-                  "type": "string",
-                  "description": "Information about data format and access"
+                  "download_url": {
+                    "type": "string",
+                    "description": "CDC listing page for this component and cycle"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
                 }
               }
             },
-            "metadata": {
-              "type": "object"
+            "count": {
+              "type": "integer",
+              "description": "Number of component/cycle entries returned"
+            },
+            "cycles_covered": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "The NHANES cycles these entries describe"
+            },
+            "note": {
+              "type": "string",
+              "description": "Information about data format and access"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/omnipath_tools.json
+++ b/src/tooluniverse/data/omnipath_tools.json
@@ -68,84 +68,73 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "source_uniprot": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Source protein UniProt accession"
-                  },
-                  "target_uniprot": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Target protein UniProt accession"
-                  },
-                  "source_genesymbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Source protein gene symbol"
-                  },
-                  "target_genesymbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Target protein gene symbol"
-                  },
-                  "is_directed": {
-                    "type": "boolean",
-                    "description": "Whether the interaction has a known direction"
-                  },
-                  "is_stimulation": {
-                    "type": "boolean",
-                    "description": "Whether the interaction is stimulatory/activating"
-                  },
-                  "is_inhibition": {
-                    "type": "boolean",
-                    "description": "Whether the interaction is inhibitory"
-                  },
-                  "sources": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "List of supporting databases/resources"
-                  },
-                  "curation_effort": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of curated references supporting this interaction"
-                  },
-                  "type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Interaction type: post_translational, transcriptional, etc."
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source_uniprot": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Source protein UniProt accession"
+              },
+              "target_uniprot": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Target protein UniProt accession"
+              },
+              "source_genesymbol": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Source protein gene symbol"
+              },
+              "target_genesymbol": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Target protein gene symbol"
+              },
+              "is_directed": {
+                "type": "boolean",
+                "description": "Whether the interaction has a known direction"
+              },
+              "is_stimulation": {
+                "type": "boolean",
+                "description": "Whether the interaction is stimulatory/activating"
+              },
+              "is_inhibition": {
+                "type": "boolean",
+                "description": "Whether the interaction is inhibitory"
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "List of supporting databases/resources"
+              },
+              "curation_effort": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of curated references supporting this interaction"
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Interaction type: post_translational, transcriptional, etc."
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -240,95 +229,84 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "uniprot": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "UniProt accession"
-                  },
-                  "genesymbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene symbol"
-                  },
-                  "category": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Intercellular role category (ligand, receptor, adhesion, etc.)"
-                  },
-                  "parent": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Parent category"
-                  },
-                  "database": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Source database for this annotation"
-                  },
-                  "scope": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "generic or specific"
-                  },
-                  "aspect": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "functional or locational"
-                  },
-                  "consensus_score": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Consensus score across databases (higher = more confident)"
-                  },
-                  "transmitter": {
-                    "type": "boolean",
-                    "description": "Whether protein acts as signal transmitter/sender"
-                  },
-                  "receiver": {
-                    "type": "boolean",
-                    "description": "Whether protein acts as signal receiver"
-                  },
-                  "secreted": {
-                    "type": "boolean",
-                    "description": "Whether protein is secreted"
-                  },
-                  "plasma_membrane_transmembrane": {
-                    "type": "boolean",
-                    "description": "Whether protein is plasma membrane transmembrane"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "uniprot": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "UniProt accession"
+              },
+              "genesymbol": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene symbol"
+              },
+              "category": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Intercellular role category (ligand, receptor, adhesion, etc.)"
+              },
+              "parent": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Parent category"
+              },
+              "database": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Source database for this annotation"
+              },
+              "scope": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "generic or specific"
+              },
+              "aspect": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "functional or locational"
+              },
+              "consensus_score": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Consensus score across databases (higher = more confident)"
+              },
+              "transmitter": {
+                "type": "boolean",
+                "description": "Whether protein acts as signal transmitter/sender"
+              },
+              "receiver": {
+                "type": "boolean",
+                "description": "Whether protein acts as signal receiver"
+              },
+              "secreted": {
+                "type": "boolean",
+                "description": "Whether protein is secreted"
+              },
+              "plasma_membrane_transmembrane": {
+                "type": "boolean",
+                "description": "Whether protein is plasma membrane transmembrane"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -431,96 +409,85 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "source_uniprot": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Source protein UniProt accession"
-                  },
-                  "target_uniprot": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Target protein UniProt accession"
-                  },
-                  "source_genesymbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Source protein gene symbol"
-                  },
-                  "target_genesymbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Target protein gene symbol"
-                  },
-                  "is_directed": {
-                    "type": "boolean",
-                    "description": "Whether the interaction direction is known"
-                  },
-                  "is_stimulation": {
-                    "type": "boolean",
-                    "description": "Whether the interaction is stimulatory"
-                  },
-                  "is_inhibition": {
-                    "type": "boolean",
-                    "description": "Whether the interaction is inhibitory"
-                  },
-                  "consensus_direction": {
-                    "type": "boolean",
-                    "description": "Whether multiple databases agree on direction"
-                  },
-                  "consensus_stimulation": {
-                    "type": "boolean",
-                    "description": "Whether multiple databases agree on stimulation"
-                  },
-                  "consensus_inhibition": {
-                    "type": "boolean",
-                    "description": "Whether multiple databases agree on inhibition"
-                  },
-                  "sources": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "List of supporting databases"
-                  },
-                  "curation_effort": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of curated references"
-                  },
-                  "type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Interaction type"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source_uniprot": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Source protein UniProt accession"
+              },
+              "target_uniprot": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Target protein UniProt accession"
+              },
+              "source_genesymbol": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Source protein gene symbol"
+              },
+              "target_genesymbol": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Target protein gene symbol"
+              },
+              "is_directed": {
+                "type": "boolean",
+                "description": "Whether the interaction direction is known"
+              },
+              "is_stimulation": {
+                "type": "boolean",
+                "description": "Whether the interaction is stimulatory"
+              },
+              "is_inhibition": {
+                "type": "boolean",
+                "description": "Whether the interaction is inhibitory"
+              },
+              "consensus_direction": {
+                "type": "boolean",
+                "description": "Whether multiple databases agree on direction"
+              },
+              "consensus_stimulation": {
+                "type": "boolean",
+                "description": "Whether multiple databases agree on stimulation"
+              },
+              "consensus_inhibition": {
+                "type": "boolean",
+                "description": "Whether multiple databases agree on inhibition"
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "List of supporting databases"
+              },
+              "curation_effort": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of curated references"
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Interaction type"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -577,80 +544,69 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Complex name"
-                  },
-                  "components": {
-                    "type": [
-                      "array",
-                      "string",
-                      "null"
-                    ],
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "UniProt accessions of complex components"
-                  },
-                  "components_genesymbols": {
-                    "type": [
-                      "array",
-                      "string",
-                      "null"
-                    ],
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Gene symbols of complex components"
-                  },
-                  "stoichiometry": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Component stoichiometry (e.g., '1:1:1')"
-                  },
-                  "sources": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Source databases for this complex"
-                  },
-                  "references": {
-                    "type": [
-                      "array",
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "identifiers": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Database-specific complex IDs (e.g., CORUM:2342)"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Complex name"
+              },
+              "components": {
+                "type": [
+                  "array",
+                  "string",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "description": "UniProt accessions of complex components"
+              },
+              "components_genesymbols": {
+                "type": [
+                  "array",
+                  "string",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "description": "Gene symbols of complex components"
+              },
+              "stoichiometry": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Component stoichiometry (e.g., '1:1:1')"
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Source databases for this complex"
+              },
+              "references": {
+                "type": [
+                  "array",
+                  "string",
+                  "null"
+                ]
+              },
+              "identifiers": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Database-specific complex IDs (e.g., CORUM:2342)"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -715,72 +671,61 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "uniprot": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "UniProt accession"
-                  },
-                  "genesymbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene symbol"
-                  },
-                  "entity_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Entity type (protein, complex, etc.)"
-                  },
-                  "source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Source database name"
-                  },
-                  "label": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Annotation label/key (role, pathway, category, etc.)"
-                  },
-                  "value": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Annotation value (ligand, receptor, TGFb, Secreted Signaling, etc.)"
-                  },
-                  "record_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Record identifier within the source database"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "uniprot": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "UniProt accession"
+              },
+              "genesymbol": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene symbol"
+              },
+              "entity_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Entity type (protein, complex, etc.)"
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Source database name"
+              },
+              "label": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Annotation label/key (role, pathway, category, etc.)"
+              },
+              "value": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Annotation value (ligand, receptor, TGFb, Secreted Signaling, etc.)"
+              },
+              "record_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Record identifier within the source database"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -862,79 +807,68 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "enzyme_uniprot": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Enzyme UniProt accession"
-                  },
-                  "substrate_uniprot": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Substrate UniProt accession"
-                  },
-                  "enzyme_genesymbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Enzyme gene symbol"
-                  },
-                  "substrate_genesymbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Substrate gene symbol"
-                  },
-                  "residue_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Modified residue type (Y, S, T, K, etc.)"
-                  },
-                  "residue_offset": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Position of modified residue in substrate sequence"
-                  },
-                  "modification": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Type of modification (phosphorylation, ubiquitination, etc.)"
-                  },
-                  "sources": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Supporting databases"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "enzyme_uniprot": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Enzyme UniProt accession"
+              },
+              "substrate_uniprot": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Substrate UniProt accession"
+              },
+              "enzyme_genesymbol": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Enzyme gene symbol"
+              },
+              "substrate_genesymbol": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Substrate gene symbol"
+              },
+              "residue_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Modified residue type (Y, S, T, K, etc.)"
+              },
+              "residue_offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Position of modified residue in substrate sequence"
+              },
+              "modification": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Type of modification (phosphorylation, ubiquitination, etc.)"
+              },
+              "sources": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Supporting databases"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -995,43 +929,31 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "data",
-            "metadata"
-          ],
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tf_genesymbol": {
-                    "type": "string"
-                  },
-                  "target_genesymbol": {
-                    "type": "string"
-                  },
-                  "is_stimulation": {
-                    "type": "boolean"
-                  },
-                  "is_inhibition": {
-                    "type": "boolean"
-                  },
-                  "dorothea_level": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "curation_effort": {
-                    "type": "integer"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tf_genesymbol": {
+                "type": "string"
+              },
+              "target_genesymbol": {
+                "type": "string"
+              },
+              "is_stimulation": {
+                "type": "boolean"
+              },
+              "is_inhibition": {
+                "type": "boolean"
+              },
+              "dorothea_level": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "curation_effort": {
+                "type": "integer"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
@@ -1084,40 +1006,28 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "data",
-            "metadata"
-          ],
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tf_genesymbol": {
-                    "type": "string"
-                  },
-                  "target_genesymbol": {
-                    "type": "string"
-                  },
-                  "mor": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "dorothea_level": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tf_genesymbol": {
+                "type": "string"
+              },
+              "target_genesymbol": {
+                "type": "string"
+              },
+              "mor": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "dorothea_level": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },
@@ -1181,47 +1091,35 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": [
-            "data",
-            "metadata"
-          ],
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "uniprot": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "UniProt accession of the resource member"
+              },
+              "genesymbol": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene symbol of the resource member"
+              },
+              "entity_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Entity type (protein, complex, mirna)"
+              },
+              "annotations": {
                 "type": "object",
-                "properties": {
-                  "uniprot": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "UniProt accession of the resource member"
-                  },
-                  "genesymbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene symbol of the resource member"
-                  },
-                  "entity_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Entity type (protein, complex, mirna)"
-                  },
-                  "annotations": {
-                    "type": "object",
-                    "description": "Label/value annotation pairs for this member from the resource (e.g., {\"tier\": \"1\", \"hallmark\": \"True\"} for CancerGeneCensus; {\"mainclass\": \"Transporters\"} for Surfaceome; {\"group\": \"AGC\"} for kinase.com)."
-                  }
-                }
+                "description": "Label/value annotation pairs for this member from the resource (e.g., {\"tier\": \"1\", \"hallmark\": \"True\"} for CancerGeneCensus; {\"mainclass\": \"Transporters\"} for Surfaceome; {\"group\": \"AGC\"} for kinase.com)."
               }
-            },
-            "metadata": {
-              "type": "object"
             }
           }
         },

--- a/src/tooluniverse/data/opentarget_genetics_tools.json
+++ b/src/tooluniverse/data/opentarget_genetics_tools.json
@@ -35,79 +35,71 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
+                        "variant": {
                             "type": "object",
                             "properties": {
-                                "variant": {
+                                "id": {
+                                    "type": "string",
+                                    "description": "Variant identifier in chr_pos_ref_alt format"
+                                },
+                                "rsIds": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "description": "dbSNP rs identifiers"
+                                },
+                                "chromosome": {
+                                    "type": "string"
+                                },
+                                "position": {
+                                    "type": "integer"
+                                },
+                                "referenceAllele": {
+                                    "type": "string"
+                                },
+                                "alternateAllele": {
+                                    "type": "string"
+                                },
+                                "hgvsId": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "description": "HGVS notation"
+                                },
+                                "variantDescription": {
+                                    "type": "string",
+                                    "description": "Human-readable variant description"
+                                },
+                                "mostSevereConsequence": {
                                     "type": "object",
                                     "properties": {
                                         "id": {
-                                            "type": "string",
-                                            "description": "Variant identifier in chr_pos_ref_alt format"
+                                            "type": "string"
                                         },
-                                        "rsIds": {
-                                            "type": "array",
-                                            "items": {
+                                        "label": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "alleleFrequencies": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "populationName": {
                                                 "type": "string"
                                             },
-                                            "description": "dbSNP rs identifiers"
-                                        },
-                                        "chromosome": {
-                                            "type": "string"
-                                        },
-                                        "position": {
-                                            "type": "integer"
-                                        },
-                                        "referenceAllele": {
-                                            "type": "string"
-                                        },
-                                        "alternateAllele": {
-                                            "type": "string"
-                                        },
-                                        "hgvsId": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ],
-                                            "description": "HGVS notation"
-                                        },
-                                        "variantDescription": {
-                                            "type": "string",
-                                            "description": "Human-readable variant description"
-                                        },
-                                        "mostSevereConsequence": {
-                                            "type": "object",
-                                            "properties": {
-                                                "id": {
-                                                    "type": "string"
-                                                },
-                                                "label": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        },
-                                        "alleleFrequencies": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "populationName": {
-                                                        "type": "string"
-                                                    },
-                                                    "alleleFrequency": {
-                                                        "type": "number"
-                                                    }
-                                                }
+                                            "alleleFrequency": {
+                                                "type": "number"
                                             }
                                         }
                                     }
                                 }
                             }
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "object",
@@ -163,137 +155,132 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
+                        "variant": {
                             "type": "object",
                             "properties": {
-                                "variant": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "rsIds": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "credibleSets": {
                                     "type": "object",
                                     "properties": {
-                                        "id": {
-                                            "type": "string"
+                                        "count": {
+                                            "type": "integer"
                                         },
-                                        "rsIds": {
+                                        "rows": {
                                             "type": "array",
                                             "items": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "credibleSets": {
-                                            "type": "object",
-                                            "properties": {
-                                                "count": {
-                                                    "type": "integer"
-                                                },
-                                                "rows": {
-                                                    "type": "array",
-                                                    "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "studyLocusId": {
+                                                        "type": "string"
+                                                    },
+                                                    "studyId": {
+                                                        "type": "string"
+                                                    },
+                                                    "region": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "finemappingMethod": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "pValueMantissa": {
+                                                        "type": [
+                                                            "number",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "pValueExponent": {
+                                                        "type": [
+                                                            "integer",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "beta": {
+                                                        "type": [
+                                                            "number",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "confidence": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "study": {
                                                         "type": "object",
                                                         "properties": {
-                                                            "studyLocusId": {
+                                                            "id": {
                                                                 "type": "string"
                                                             },
-                                                            "studyId": {
-                                                                "type": "string"
-                                                            },
-                                                            "region": {
+                                                            "traitFromSource": {
                                                                 "type": [
                                                                     "string",
                                                                     "null"
                                                                 ]
                                                             },
-                                                            "finemappingMethod": {
+                                                            "publicationFirstAuthor": {
                                                                 "type": [
                                                                     "string",
                                                                     "null"
                                                                 ]
                                                             },
-                                                            "pValueMantissa": {
-                                                                "type": [
-                                                                    "number",
-                                                                    "null"
-                                                                ]
-                                                            },
-                                                            "pValueExponent": {
-                                                                "type": [
-                                                                    "integer",
-                                                                    "null"
-                                                                ]
-                                                            },
-                                                            "beta": {
-                                                                "type": [
-                                                                    "number",
-                                                                    "null"
-                                                                ]
-                                                            },
-                                                            "confidence": {
+                                                            "pubmedId": {
                                                                 "type": [
                                                                     "string",
                                                                     "null"
                                                                 ]
                                                             },
-                                                            "study": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "id": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "traitFromSource": {
-                                                                        "type": [
-                                                                            "string",
-                                                                            "null"
-                                                                        ]
-                                                                    },
-                                                                    "publicationFirstAuthor": {
-                                                                        "type": [
-                                                                            "string",
-                                                                            "null"
-                                                                        ]
-                                                                    },
-                                                                    "pubmedId": {
-                                                                        "type": [
-                                                                            "string",
-                                                                            "null"
-                                                                        ]
-                                                                    },
-                                                                    "diseases": {
-                                                                        "type": "array",
-                                                                        "items": {
+                                                            "diseases": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "id": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "l2GPredictions": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "rows": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                        "target": {
                                                                             "type": "object",
                                                                             "properties": {
                                                                                 "id": {
                                                                                     "type": "string"
                                                                                 },
-                                                                                "name": {
+                                                                                "approvedSymbol": {
                                                                                     "type": "string"
                                                                                 }
                                                                             }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            },
-                                                            "l2GPredictions": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "rows": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "target": {
-                                                                                    "type": "object",
-                                                                                    "properties": {
-                                                                                        "id": {
-                                                                                            "type": "string"
-                                                                                        },
-                                                                                        "approvedSymbol": {
-                                                                                            "type": "string"
-                                                                                        }
-                                                                                    }
-                                                                                },
-                                                                                "score": {
-                                                                                    "type": "number"
-                                                                                }
-                                                                            }
+                                                                        },
+                                                                        "score": {
+                                                                            "type": "number"
                                                                         }
                                                                     }
                                                                 }
@@ -307,10 +294,7 @@
                                 }
                             }
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "object",
@@ -362,141 +346,133 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
+                        "study": {
                             "type": "object",
                             "properties": {
-                                "study": {
-                                    "type": "object",
-                                    "properties": {
-                                        "id": {
-                                            "type": "string"
-                                        },
-                                        "studyType": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "traitFromSource": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "publicationFirstAuthor": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "publicationTitle": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "publicationDate": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "publicationJournal": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "pubmedId": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "nSamples": {
-                                            "type": [
-                                                "integer",
-                                                "null"
-                                            ]
-                                        },
-                                        "nCases": {
-                                            "type": [
-                                                "integer",
-                                                "null"
-                                            ]
-                                        },
-                                        "nControls": {
-                                            "type": [
-                                                "integer",
-                                                "null"
-                                            ]
-                                        },
-                                        "initialSampleSize": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "hasSumstats": {
-                                            "type": [
-                                                "boolean",
-                                                "null"
-                                            ]
-                                        },
-                                        "summarystatsLocation": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "cohorts": {
-                                            "type": [
-                                                "array",
-                                                "null"
-                                            ],
-                                            "items": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "studyType": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "traitFromSource": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "publicationFirstAuthor": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "publicationTitle": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "publicationDate": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "publicationJournal": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "pubmedId": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "nSamples": {
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ]
+                                },
+                                "nCases": {
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ]
+                                },
+                                "nControls": {
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ]
+                                },
+                                "initialSampleSize": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "hasSumstats": {
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ]
+                                },
+                                "summarystatsLocation": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "cohorts": {
+                                    "type": [
+                                        "array",
+                                        "null"
+                                    ],
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "diseases": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "name": {
                                                 "type": "string"
                                             }
-                                        },
-                                        "diseases": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string"
-                                                    },
-                                                    "name": {
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ldPopulationStructure": {
-                                            "type": [
-                                                "array",
-                                                "null"
-                                            ],
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "ldPopulation": {
-                                                        "type": "string"
-                                                    },
-                                                    "relativeSampleSize": {
-                                                        "type": "number"
-                                                    }
-                                                }
+                                        }
+                                    }
+                                },
+                                "ldPopulationStructure": {
+                                    "type": [
+                                        "array",
+                                        "null"
+                                    ],
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "ldPopulation": {
+                                                "type": "string"
+                                            },
+                                            "relativeSampleSize": {
+                                                "type": "number"
                                             }
                                         }
                                     }
                                 }
                             }
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "object",
@@ -574,95 +550,90 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
+                        "studies": {
                             "type": "object",
                             "properties": {
-                                "studies": {
-                                    "type": "object",
-                                    "properties": {
-                                        "count": {
-                                            "type": "integer"
-                                        },
-                                        "rows": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string"
-                                                    },
-                                                    "studyType": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "traitFromSource": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "publicationFirstAuthor": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "publicationTitle": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "publicationDate": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "pubmedId": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "nSamples": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "nCases": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "nControls": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "hasSumstats": {
-                                                        "type": [
-                                                            "boolean",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "diseases": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "id": {
-                                                                    "type": "string"
-                                                                },
-                                                                "name": {
-                                                                    "type": "string"
-                                                                }
-                                                            }
+                                "count": {
+                                    "type": "integer"
+                                },
+                                "rows": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "studyType": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "traitFromSource": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "publicationFirstAuthor": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "publicationTitle": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "publicationDate": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "pubmedId": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "nSamples": {
+                                                "type": [
+                                                    "integer",
+                                                    "null"
+                                                ]
+                                            },
+                                            "nCases": {
+                                                "type": [
+                                                    "integer",
+                                                    "null"
+                                                ]
+                                            },
+                                            "nControls": {
+                                                "type": [
+                                                    "integer",
+                                                    "null"
+                                                ]
+                                            },
+                                            "hasSumstats": {
+                                                "type": [
+                                                    "boolean",
+                                                    "null"
+                                                ]
+                                            },
+                                            "diseases": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
                                                         }
                                                     }
                                                 }
@@ -672,10 +643,7 @@
                                 }
                             }
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "object",
@@ -725,199 +693,194 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
+                        "credibleSet": {
                             "type": "object",
                             "properties": {
-                                "credibleSet": {
+                                "studyLocusId": {
+                                    "type": "string"
+                                },
+                                "studyId": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "region": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "chromosome": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "position": {
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ]
+                                },
+                                "finemappingMethod": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "pValueMantissa": {
+                                    "type": [
+                                        "number",
+                                        "null"
+                                    ]
+                                },
+                                "pValueExponent": {
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ]
+                                },
+                                "beta": {
+                                    "type": [
+                                        "number",
+                                        "null"
+                                    ]
+                                },
+                                "standardError": {
+                                    "type": [
+                                        "number",
+                                        "null"
+                                    ]
+                                },
+                                "confidence": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "credibleSetlog10BF": {
+                                    "type": [
+                                        "number",
+                                        "null"
+                                    ]
+                                },
+                                "sampleSize": {
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ]
+                                },
+                                "variant": {
                                     "type": "object",
                                     "properties": {
-                                        "studyLocusId": {
+                                        "id": {
                                             "type": "string"
                                         },
-                                        "studyId": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "region": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
+                                        "rsIds": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
                                         },
                                         "chromosome": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
+                                            "type": "string"
                                         },
                                         "position": {
-                                            "type": [
-                                                "integer",
-                                                "null"
-                                            ]
+                                            "type": "integer"
                                         },
-                                        "finemappingMethod": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
+                                        "referenceAllele": {
+                                            "type": "string"
                                         },
-                                        "pValueMantissa": {
-                                            "type": [
-                                                "number",
-                                                "null"
-                                            ]
+                                        "alternateAllele": {
+                                            "type": "string"
                                         },
-                                        "pValueExponent": {
-                                            "type": [
-                                                "integer",
-                                                "null"
-                                            ]
-                                        },
-                                        "beta": {
-                                            "type": [
-                                                "number",
-                                                "null"
-                                            ]
-                                        },
-                                        "standardError": {
-                                            "type": [
-                                                "number",
-                                                "null"
-                                            ]
-                                        },
-                                        "confidence": {
-                                            "type": [
-                                                "string",
-                                                "null"
-                                            ]
-                                        },
-                                        "credibleSetlog10BF": {
-                                            "type": [
-                                                "number",
-                                                "null"
-                                            ]
-                                        },
-                                        "sampleSize": {
-                                            "type": [
-                                                "integer",
-                                                "null"
-                                            ]
-                                        },
-                                        "variant": {
+                                        "mostSevereConsequence": {
                                             "type": "object",
                                             "properties": {
                                                 "id": {
                                                     "type": "string"
                                                 },
-                                                "rsIds": {
-                                                    "type": "array",
-                                                    "items": {
+                                                "label": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "study": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string"
+                                        },
+                                        "traitFromSource": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        },
+                                        "publicationFirstAuthor": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        },
+                                        "publicationTitle": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        },
+                                        "pubmedId": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        },
+                                        "nSamples": {
+                                            "type": [
+                                                "integer",
+                                                "null"
+                                            ]
+                                        },
+                                        "diseases": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
                                                         "type": "string"
-                                                    }
-                                                },
-                                                "chromosome": {
-                                                    "type": "string"
-                                                },
-                                                "position": {
-                                                    "type": "integer"
-                                                },
-                                                "referenceAllele": {
-                                                    "type": "string"
-                                                },
-                                                "alternateAllele": {
-                                                    "type": "string"
-                                                },
-                                                "mostSevereConsequence": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "id": {
-                                                            "type": "string"
-                                                        },
-                                                        "label": {
-                                                            "type": "string"
-                                                        }
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
                                                     }
                                                 }
                                             }
-                                        },
-                                        "study": {
-                                            "type": "object",
-                                            "properties": {
-                                                "id": {
-                                                    "type": "string"
-                                                },
-                                                "traitFromSource": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "publicationFirstAuthor": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "publicationTitle": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "pubmedId": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "nSamples": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "diseases": {
-                                                    "type": "array",
-                                                    "items": {
+                                        }
+                                    }
+                                },
+                                "l2GPredictions": {
+                                    "type": "object",
+                                    "properties": {
+                                        "rows": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "target": {
                                                         "type": "object",
                                                         "properties": {
                                                             "id": {
                                                                 "type": "string"
                                                             },
-                                                            "name": {
+                                                            "approvedSymbol": {
                                                                 "type": "string"
                                                             }
                                                         }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "l2GPredictions": {
-                                            "type": "object",
-                                            "properties": {
-                                                "rows": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "target": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "id": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "approvedSymbol": {
-                                                                        "type": "string"
-                                                                    }
-                                                                }
-                                                            },
-                                                            "score": {
-                                                                "type": "number"
-                                                            }
-                                                        }
+                                                    },
+                                                    "score": {
+                                                        "type": "number"
                                                     }
                                                 }
                                             }
@@ -926,10 +889,7 @@
                                 }
                             }
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "object",
@@ -995,136 +955,131 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
+                        "credibleSets": {
                             "type": "object",
                             "properties": {
-                                "credibleSets": {
-                                    "type": "object",
-                                    "properties": {
-                                        "count": {
-                                            "type": "integer"
-                                        },
-                                        "rows": {
-                                            "type": "array",
-                                            "items": {
+                                "count": {
+                                    "type": "integer"
+                                },
+                                "rows": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "studyLocusId": {
+                                                "type": "string"
+                                            },
+                                            "studyId": {
+                                                "type": "string"
+                                            },
+                                            "region": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "chromosome": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "position": {
+                                                "type": [
+                                                    "integer",
+                                                    "null"
+                                                ]
+                                            },
+                                            "finemappingMethod": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "pValueMantissa": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            },
+                                            "pValueExponent": {
+                                                "type": [
+                                                    "integer",
+                                                    "null"
+                                                ]
+                                            },
+                                            "beta": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            },
+                                            "confidence": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "variant": {
                                                 "type": "object",
                                                 "properties": {
-                                                    "studyLocusId": {
+                                                    "id": {
                                                         "type": "string"
                                                     },
-                                                    "studyId": {
-                                                        "type": "string"
-                                                    },
-                                                    "region": {
+                                                    "rsIds": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "study": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "traitFromSource": {
                                                         "type": [
                                                             "string",
                                                             "null"
                                                         ]
                                                     },
-                                                    "chromosome": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "position": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "finemappingMethod": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "pValueMantissa": {
-                                                        "type": [
-                                                            "number",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "pValueExponent": {
-                                                        "type": [
-                                                            "integer",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "beta": {
-                                                        "type": [
-                                                            "number",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "confidence": {
-                                                        "type": [
-                                                            "string",
-                                                            "null"
-                                                        ]
-                                                    },
-                                                    "variant": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "id": {
-                                                                "type": "string"
-                                                            },
-                                                            "rsIds": {
-                                                                "type": "array",
-                                                                "items": {
+                                                    "diseases": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "id": {
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
                                                                     "type": "string"
                                                                 }
                                                             }
                                                         }
-                                                    },
-                                                    "study": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "traitFromSource": {
-                                                                "type": [
-                                                                    "string",
-                                                                    "null"
-                                                                ]
-                                                            },
-                                                            "diseases": {
-                                                                "type": "array",
-                                                                "items": {
+                                                    }
+                                                }
+                                            },
+                                            "l2GPredictions": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "rows": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "target": {
                                                                     "type": "object",
                                                                     "properties": {
                                                                         "id": {
                                                                             "type": "string"
                                                                         },
-                                                                        "name": {
+                                                                        "approvedSymbol": {
                                                                             "type": "string"
                                                                         }
                                                                     }
-                                                                }
-                                                            }
-                                                        }
-                                                    },
-                                                    "l2GPredictions": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "rows": {
-                                                                "type": "array",
-                                                                "items": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "target": {
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "id": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "approvedSymbol": {
-                                                                                    "type": "string"
-                                                                                }
-                                                                            }
-                                                                        },
-                                                                        "score": {
-                                                                            "type": "number"
-                                                                        }
-                                                                    }
+                                                                },
+                                                                "score": {
+                                                                    "type": "number"
                                                                 }
                                                             }
                                                         }
@@ -1136,10 +1091,7 @@
                                 }
                             }
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "object",
@@ -1185,64 +1137,64 @@
             }
         ],
         "return_schema": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "variant": {
-                  "type": [
-                    "object",
-                    "null"
-                  ],
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "rsIds": {
-                      "type": "array"
-                    },
-                    "variantEffect": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "method": {
-                            "type": "string"
-                          },
-                          "assessment": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "variant": {
                             "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "score": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          }
+                                "object",
+                                "null"
+                            ],
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "rsIds": {
+                                    "type": "array"
+                                },
+                                "variantEffect": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "method": {
+                                                "type": "string"
+                                            },
+                                            "assessment": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "score": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                      }
-                    }
-                  }
+                    },
+                    "required": [
+                        "variant"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "error"
+                    ]
                 }
-              },
-              "required": [
-                "variant"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "error"
-              ]
-            }
-          ]
+            ]
         }
     },
     {
@@ -1274,70 +1226,70 @@
             }
         ],
         "return_schema": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "variant": {
-                  "type": [
-                    "object",
-                    "null"
-                  ],
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "rsIds": {
-                      "type": "array"
-                    },
-                    "transcriptConsequences": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "transcriptId": {
-                            "type": "string"
-                          },
-                          "aminoAcidChange": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "variant": {
                             "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "consequenceScore": {
-                            "type": [
-                              "number",
-                              "null"
-                            ]
-                          },
-                          "impact": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          }
+                                "object",
+                                "null"
+                            ],
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "rsIds": {
+                                    "type": "array"
+                                },
+                                "transcriptConsequences": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "transcriptId": {
+                                                "type": "string"
+                                            },
+                                            "aminoAcidChange": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "consequenceScore": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            },
+                                            "impact": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                      }
-                    }
-                  }
+                    },
+                    "required": [
+                        "variant"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "error"
+                    ]
                 }
-              },
-              "required": [
-                "variant"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "error"
-              ]
-            }
-          ]
+            ]
         }
     },
     {
@@ -1370,70 +1322,70 @@
             }
         ],
         "return_schema": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "variant": {
-                  "type": [
-                    "object",
-                    "null"
-                  ],
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "rsIds": {
-                      "type": "array"
-                    },
-                    "pharmacogenomics": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "drugs": {
-                            "type": "array"
-                          },
-                          "phenotypeText": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "variant": {
                             "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "evidenceLevel": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
-                          "genotypeAnnotationText": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          }
+                                "object",
+                                "null"
+                            ],
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "rsIds": {
+                                    "type": "array"
+                                },
+                                "pharmacogenomics": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "drugs": {
+                                                "type": "array"
+                                            },
+                                            "phenotypeText": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "evidenceLevel": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            },
+                                            "genotypeAnnotationText": {
+                                                "type": [
+                                                    "string",
+                                                    "null"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                      }
-                    }
-                  }
+                    },
+                    "required": [
+                        "variant"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "error"
+                    ]
                 }
-              },
-              "required": [
-                "variant"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "error"
-              ]
-            }
-          ]
+            ]
         }
     },
     {
@@ -1473,87 +1425,87 @@
             }
         ],
         "return_schema": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "credibleSet": {
-                  "type": [
-                    "object",
-                    "null"
-                  ],
-                  "properties": {
-                    "studyLocusId": {
-                      "type": "string"
-                    },
-                    "colocalisation": {
-                      "type": [
-                        "object",
-                        "null"
-                      ],
-                      "properties": {
-                        "count": {
-                          "type": "integer"
-                        },
-                        "rows": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "credibleSet": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
                             "properties": {
-                              "colocalisationMethod": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "h4": {
-                                "type": [
-                                  "number",
-                                  "null"
-                                ]
-                              },
-                              "clpp": {
-                                "type": [
-                                  "number",
-                                  "null"
-                                ]
-                              },
-                              "numberColocalisingVariants": {
-                                "type": [
-                                  "number",
-                                  "null"
-                                ]
-                              },
-                              "otherStudyLocus": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              }
+                                "studyLocusId": {
+                                    "type": "string"
+                                },
+                                "colocalisation": {
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "properties": {
+                                        "count": {
+                                            "type": "integer"
+                                        },
+                                        "rows": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "colocalisationMethod": {
+                                                        "type": [
+                                                            "string",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "h4": {
+                                                        "type": [
+                                                            "number",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "clpp": {
+                                                        "type": [
+                                                            "number",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "numberColocalisingVariants": {
+                                                        "type": [
+                                                            "number",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "otherStudyLocus": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
-                          }
                         }
-                      }
-                    }
-                  }
+                    },
+                    "required": [
+                        "credibleSet"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "error"
+                    ]
                 }
-              },
-              "required": [
-                "credibleSet"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "error"
-              ]
-            }
-          ]
+            ]
         }
     }
 ]

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -3679,60 +3679,51 @@
             "oneOf": [
                 {
                     "type": "object",
-                    "description": "GraphQL response with drug pharmacogenomics data",
                     "properties": {
-                        "data": {
+                        "drug": {
                             "type": "object",
                             "properties": {
-                                "drug": {
-                                    "type": "object",
-                                    "properties": {
-                                        "id": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "pharmacogenomics": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "datasourceId": {
-                                                        "type": "string"
-                                                    },
-                                                    "evidenceLevel": {
-                                                        "type": "string"
-                                                    },
-                                                    "genotype": {
-                                                        "type": "string"
-                                                    },
-                                                    "genotypeAnnotationText": {
-                                                        "type": "string"
-                                                    },
-                                                    "pgxCategory": {
-                                                        "type": "string"
-                                                    },
-                                                    "phenotypeText": {
-                                                        "type": "string"
-                                                    },
-                                                    "variantRsId": {
-                                                        "type": "string"
-                                                    },
-                                                    "isDirectTarget": {
-                                                        "type": "boolean"
-                                                    }
-                                                }
+                                "id": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "pharmacogenomics": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "datasourceId": {
+                                                "type": "string"
+                                            },
+                                            "evidenceLevel": {
+                                                "type": "string"
+                                            },
+                                            "genotype": {
+                                                "type": "string"
+                                            },
+                                            "genotypeAnnotationText": {
+                                                "type": "string"
+                                            },
+                                            "pgxCategory": {
+                                                "type": "string"
+                                            },
+                                            "phenotypeText": {
+                                                "type": "string"
+                                            },
+                                            "variantRsId": {
+                                                "type": "string"
+                                            },
+                                            "isDirectTarget": {
+                                                "type": "boolean"
                                             }
                                         }
                                     }
                                 }
                             }
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "null",
@@ -5075,96 +5066,88 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
+                        "target": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
                             "properties": {
-                                "target": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "approvedSymbol": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "approvedName": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "biotype": {
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ]
+                                },
+                                "functionDescriptions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "proteinIds": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "source": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "genomicLocation": {
                                     "type": [
                                         "object",
                                         "null"
                                     ],
                                     "properties": {
-                                        "id": {
-                                            "type": "string"
-                                        },
-                                        "approvedSymbol": {
+                                        "chromosome": {
                                             "type": [
                                                 "string",
                                                 "null"
                                             ]
                                         },
-                                        "approvedName": {
+                                        "start": {
                                             "type": [
-                                                "string",
+                                                "integer",
                                                 "null"
                                             ]
                                         },
-                                        "biotype": {
+                                        "end": {
                                             "type": [
-                                                "string",
+                                                "integer",
                                                 "null"
                                             ]
                                         },
-                                        "functionDescriptions": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "proteinIds": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "id": {
-                                                        "type": "string"
-                                                    },
-                                                    "source": {
-                                                        "type": "string"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "genomicLocation": {
+                                        "strand": {
                                             "type": [
-                                                "object",
+                                                "integer",
                                                 "null"
-                                            ],
-                                            "properties": {
-                                                "chromosome": {
-                                                    "type": [
-                                                        "string",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "start": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "end": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ]
-                                                },
-                                                "strand": {
-                                                    "type": [
-                                                        "integer",
-                                                        "null"
-                                                    ]
-                                                }
-                                            }
+                                            ]
                                         }
                                     }
                                 }
                             }
                         }
-                    },
-                    "required": [
-                        "data"
-                    ]
+                    }
                 },
                 {
                     "type": "object",
@@ -5211,96 +5194,96 @@
             }
         ],
         "return_schema": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "target": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "approvedSymbol": {
-                      "type": "string"
-                    },
-                    "baselineExpression": {
-                      "type": "object",
-                      "properties": {
-                        "count": {
-                          "type": "integer"
-                        },
-                        "rows": {
-                          "type": "array",
-                          "items": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "target": {
                             "type": "object",
                             "properties": {
-                              "datasourceId": {
-                                "type": "string"
-                              },
-                              "datatypeId": {
-                                "type": "string"
-                              },
-                              "unit": {
-                                "type": "string"
-                              },
-                              "min": {
-                                "type": "number"
-                              },
-                              "q1": {
-                                "type": "number"
-                              },
-                              "median": {
-                                "type": "number"
-                              },
-                              "q3": {
-                                "type": "number"
-                              },
-                              "max": {
-                                "type": "number"
-                              },
-                              "specificity_score": {
-                                "type": "number"
-                              },
-                              "distribution_score": {
-                                "type": "number"
-                              },
-                              "tissueBiosample": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              },
-                              "celltypeBiosample": {
-                                "type": [
-                                  "object",
-                                  "null"
-                                ]
-                              }
+                                "id": {
+                                    "type": "string"
+                                },
+                                "approvedSymbol": {
+                                    "type": "string"
+                                },
+                                "baselineExpression": {
+                                    "type": "object",
+                                    "properties": {
+                                        "count": {
+                                            "type": "integer"
+                                        },
+                                        "rows": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "datasourceId": {
+                                                        "type": "string"
+                                                    },
+                                                    "datatypeId": {
+                                                        "type": "string"
+                                                    },
+                                                    "unit": {
+                                                        "type": "string"
+                                                    },
+                                                    "min": {
+                                                        "type": "number"
+                                                    },
+                                                    "q1": {
+                                                        "type": "number"
+                                                    },
+                                                    "median": {
+                                                        "type": "number"
+                                                    },
+                                                    "q3": {
+                                                        "type": "number"
+                                                    },
+                                                    "max": {
+                                                        "type": "number"
+                                                    },
+                                                    "specificity_score": {
+                                                        "type": "number"
+                                                    },
+                                                    "distribution_score": {
+                                                        "type": "number"
+                                                    },
+                                                    "tissueBiosample": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    },
+                                                    "celltypeBiosample": {
+                                                        "type": [
+                                                            "object",
+                                                            "null"
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
-                          }
                         }
-                      }
-                    }
-                  }
+                    },
+                    "required": [
+                        "target"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "error"
+                    ]
                 }
-              },
-              "required": [
-                "target"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "error"
-              ]
-            }
-          ]
+            ]
         }
     },
     {
@@ -5333,55 +5316,55 @@
             }
         ],
         "return_schema": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "target": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "approvedSymbol": {
-                      "type": "string"
-                    },
-                    "pathways": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "pathwayId": {
-                            "type": "string"
-                          },
-                          "pathway": {
-                            "type": "string"
-                          },
-                          "topLevelTerm": {
-                            "type": "string"
-                          }
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "approvedSymbol": {
+                                    "type": "string"
+                                },
+                                "pathways": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "pathwayId": {
+                                                "type": "string"
+                                            },
+                                            "pathway": {
+                                                "type": "string"
+                                            },
+                                            "topLevelTerm": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                      }
-                    }
-                  }
+                    },
+                    "required": [
+                        "target"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "error"
+                    ]
                 }
-              },
-              "required": [
-                "target"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "error"
-              ]
-            }
-          ]
+            ]
         }
     },
     {
@@ -5415,58 +5398,58 @@
             }
         ],
         "return_schema": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "target": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "approvedSymbol": {
-                      "type": "string"
-                    },
-                    "isEssential": {
-                      "type": [
-                        "boolean",
-                        "null"
-                      ]
-                    },
-                    "depMapEssentiality": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "tissueName": {
-                            "type": "string"
-                          },
-                          "screens": {
-                            "type": "array"
-                          }
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "approvedSymbol": {
+                                    "type": "string"
+                                },
+                                "isEssential": {
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ]
+                                },
+                                "depMapEssentiality": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "tissueName": {
+                                                "type": "string"
+                                            },
+                                            "screens": {
+                                                "type": "array"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
-                      }
-                    }
-                  }
+                    },
+                    "required": [
+                        "target"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "error"
+                    ]
                 }
-              },
-              "required": [
-                "target"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "error"
-              ]
-            }
-          ]
+            ]
         }
     },
     {
@@ -5499,60 +5482,60 @@
             }
         ],
         "return_schema": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "target": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "approvedSymbol": {
-                      "type": "string"
-                    },
-                    "prioritisation": {
-                      "type": [
-                        "object",
-                        "null"
-                      ],
-                      "properties": {
-                        "items": {
-                          "type": "array",
-                          "items": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "target": {
                             "type": "object",
                             "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "value": {
-                                "type": "string"
-                              }
+                                "id": {
+                                    "type": "string"
+                                },
+                                "approvedSymbol": {
+                                    "type": "string"
+                                },
+                                "prioritisation": {
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "properties": {
+                                        "items": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "key": {
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
-                          }
                         }
-                      }
-                    }
-                  }
+                    },
+                    "required": [
+                        "target"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "error"
+                    ]
                 }
-              },
-              "required": [
-                "target"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "error"
-              ]
-            }
-          ]
+            ]
         }
     },
     {
@@ -5585,52 +5568,52 @@
             }
         ],
         "return_schema": {
-          "oneOf": [
-            {
-              "type": "object",
-              "properties": {
-                "target": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "approvedSymbol": {
-                      "type": "string"
-                    },
-                    "hallmarks": {
-                      "type": [
-                        "object",
-                        "null"
-                      ],
-                      "properties": {
-                        "cancerHallmarks": {
-                          "type": "array"
-                        },
-                        "attributes": {
-                          "type": "array"
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "approvedSymbol": {
+                                    "type": "string"
+                                },
+                                "hallmarks": {
+                                    "type": [
+                                        "object",
+                                        "null"
+                                    ],
+                                    "properties": {
+                                        "cancerHallmarks": {
+                                            "type": "array"
+                                        },
+                                        "attributes": {
+                                            "type": "array"
+                                        }
+                                    }
+                                }
+                            }
                         }
-                      }
-                    }
-                  }
+                    },
+                    "required": [
+                        "target"
+                    ]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "error"
+                    ]
                 }
-              },
-              "required": [
-                "target"
-              ]
-            },
-            {
-              "type": "object",
-              "properties": {
-                "error": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "error"
-              ]
-            }
-          ]
+            ]
         }
     }
 ]

--- a/src/tooluniverse/data/opentree_tools.json
+++ b/src/tooluniverse/data/opentree_tools.json
@@ -29,71 +29,45 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "query_name": {
-                    "type": "string",
-                    "description": "Original query name"
-                  },
-                  "matched_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Name matched in taxonomy"
-                  },
-                  "ott_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Open Tree Taxonomy identifier"
-                  },
-                  "is_synonym": {
-                    "type": "boolean",
-                    "description": "Whether matched name is a synonym"
-                  },
-                  "score": {
-                    "type": "number",
-                    "description": "Match confidence score (0-1)"
-                  },
-                  "nomenclature_code": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Nomenclature code (ICZN, ICN, etc.)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "context": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Taxonomic context used for matching"
-                },
-                "total_results": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "query_name": {
+                "type": "string",
+                "description": "Original query name"
+              },
+              "matched_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Name matched in taxonomy"
+              },
+              "ott_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Open Tree Taxonomy identifier"
+              },
+              "is_synonym": {
+                "type": "boolean",
+                "description": "Whether matched name is a synonym"
+              },
+              "score": {
+                "type": "number",
+                "description": "Match confidence score (0-1)"
+              },
+              "nomenclature_code": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Nomenclature code (ICZN, ICN, etc.)"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -141,69 +115,47 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "ott_id": {
-                  "type": "integer",
-                  "description": "Open Tree Taxonomy ID"
-                },
-                "name": {
-                  "type": "string",
-                  "description": "Taxon name"
-                },
-                "rank": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Taxonomic rank (species, genus, family, etc.)"
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Known synonyms"
-                },
-                "tax_sources": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Source databases (e.g., ncbi:9606, gbif:2436436)"
-                },
-                "flags": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Taxonomic flags (extinct, incertae_sedis, etc.)"
-                },
-                "is_suppressed": {
-                  "type": "boolean",
-                  "description": "Whether taxon is suppressed from synthesis"
-                }
-              }
+            "ott_id": {
+              "type": "integer",
+              "description": "Open Tree Taxonomy ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "taxonomy_version": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
+            "name": {
+              "type": "string",
+              "description": "Taxon name"
+            },
+            "rank": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Taxonomic rank (species, genus, family, etc.)"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Known synonyms"
+            },
+            "tax_sources": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Source databases (e.g., ncbi:9606, gbif:2436436)"
+            },
+            "flags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Taxonomic flags (extinct, incertae_sedis, etc.)"
+            },
+            "is_suppressed": {
+              "type": "boolean",
+              "description": "Whether taxon is suppressed from synthesis"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -251,64 +203,42 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "mrca_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Name of the MRCA taxon"
-                },
-                "mrca_ott_id": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "OTT ID of the MRCA taxon"
-                },
-                "mrca_rank": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Taxonomic rank of the MRCA"
-                },
-                "mrca_node_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Node ID in the synthetic tree"
-                },
-                "num_tips": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of descendant tips in the synthetic tree"
-                }
-              }
+            "mrca_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Name of the MRCA taxon"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "input_ott_ids": {
-                  "type": "array",
-                  "items": {
-                    "type": "integer"
-                  }
-                }
-              }
+            "mrca_ott_id": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "OTT ID of the MRCA taxon"
+            },
+            "mrca_rank": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Taxonomic rank of the MRCA"
+            },
+            "mrca_node_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Node ID in the synthetic tree"
+            },
+            "num_tips": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of descendant tips in the synthetic tree"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -353,43 +283,18 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "newick": {
-                  "type": "string",
-                  "description": "Phylogenetic tree in Newick format"
-                },
-                "supporting_studies": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Study IDs supporting the topology"
-                }
-              }
+            "newick": {
+              "type": "string",
+              "description": "Phylogenetic tree in Newick format"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "input_ott_ids": {
-                  "type": "array",
-                  "items": {
-                    "type": "integer"
-                  }
-                },
-                "num_taxa": {
-                  "type": "integer"
-                }
-              }
+            "supporting_studies": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Study IDs supporting the topology"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/orthodb_tools.json
+++ b/src/tooluniverse/data/orthodb_tools.json
@@ -53,61 +53,42 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string",
-                  "description": "Search query used"
-                },
-                "groups": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "group_id": {
-                        "type": "string",
-                        "description": "OrthoDB group ID (e.g., '727649at7742')"
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Group name (for first result)"
-                      },
-                      "level_taxid": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Taxonomic level ID"
-                      }
-                    }
-                  },
-                  "description": "Orthologous groups matching query"
-                },
-                "total_groups": {
-                  "type": "integer",
-                  "description": "Total groups found"
-                }
-              }
+            "query": {
+              "type": "string",
+              "description": "Search query used"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
+            "groups": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "group_id": {
+                    "type": "string",
+                    "description": "OrthoDB group ID (e.g., '727649at7742')"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Group name (for first result)"
+                  },
+                  "level_taxid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Taxonomic level ID"
+                  }
                 }
-              }
+              },
+              "description": "Orthologous groups matching query"
+            },
+            "total_groups": {
+              "type": "integer",
+              "description": "Total groups found"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -155,150 +136,131 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "group_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "OrthoDB group ID"
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Group consensus name"
-                },
-                "level_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Taxonomic level name (Vertebrata, Metazoa, etc.)"
-                },
-                "tax_id": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Taxonomic level ID"
-                },
-                "go_terms": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "category": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "count": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
-                  },
-                  "description": "GO term annotations"
-                },
-                "kegg_pathways": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "count": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
-                  },
-                  "description": "KEGG pathway associations"
-                },
-                "interpro_domains": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "count": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
-                  },
-                  "description": "InterPro domain annotations"
-                }
-              }
+            "group_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "OrthoDB group ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "group_id": {
-                  "type": "string"
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Group consensus name"
+            },
+            "level_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Taxonomic level name (Vertebrata, Metazoa, etc.)"
+            },
+            "tax_id": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Taxonomic level ID"
+            },
+            "go_terms": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "category": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
                 }
-              }
+              },
+              "description": "GO term annotations"
+            },
+            "kegg_pathways": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "description": "KEGG pathway associations"
+            },
+            "interpro_domains": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
+                }
+              },
+              "description": "InterPro domain annotations"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -354,96 +316,77 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "group_id": {
-                  "type": "string",
-                  "description": "OrthoDB group ID"
-                },
-                "orthologs": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "group_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Ortholog group ID"
-                      },
-                      "group_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Group name"
-                      },
-                      "level_taxid": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Taxonomic level"
-                      },
-                      "organism_taxid": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Organism taxonomy ID"
-                      },
-                      "organism_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Organism scientific name"
-                      },
-                      "gene_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Gene identifier"
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Gene/protein description"
-                      }
-                    }
-                  },
-                  "description": "Orthologous genes (max 100)"
-                },
-                "total_orthologs": {
-                  "type": "integer",
-                  "description": "Total orthologs returned"
-                },
-                "organisms_summary": {
-                  "type": "object",
-                  "description": "Count of genes per organism"
-                }
-              }
+            "group_id": {
+              "type": "string",
+              "description": "OrthoDB group ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "group_id": {
-                  "type": "string"
+            "orthologs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "group_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Ortholog group ID"
+                  },
+                  "group_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Group name"
+                  },
+                  "level_taxid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Taxonomic level"
+                  },
+                  "organism_taxid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Organism taxonomy ID"
+                  },
+                  "organism_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Organism scientific name"
+                  },
+                  "gene_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Gene identifier"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Gene/protein description"
+                  }
                 }
-              }
+              },
+              "description": "Orthologous genes (max 100)"
+            },
+            "total_orthologs": {
+              "type": "integer",
+              "description": "Total orthologs returned"
+            },
+            "organisms_summary": {
+              "type": "object",
+              "description": "Count of genes per organism"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/panglaodb_tools.json
+++ b/src/tooluniverse/data/panglaodb_tools.json
@@ -47,101 +47,89 @@
       "operation": "markers_for_cell_type"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_symbol": {
-                    "type": "string"
-                  },
-                  "cell_type": {
-                    "type": "string"
-                  },
-                  "organ": {
-                    "type": "string"
-                  },
-                  "germ_layer": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species": {
-                    "type": "string"
-                  },
-                  "canonical_marker": {
-                    "type": "boolean"
-                  },
-                  "nicknames": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "product_description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ubiquitousness_index": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "sensitivity_human": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "sensitivity_mouse": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "specificity_human": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "specificity_mouse": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "gene_symbol",
-                  "cell_type",
-                  "organ",
-                  "canonical_marker"
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene_symbol": {
+                "type": "string"
+              },
+              "cell_type": {
+                "type": "string"
+              },
+              "organ": {
+                "type": "string"
+              },
+              "germ_layer": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "species": {
+                "type": "string"
+              },
+              "canonical_marker": {
+                "type": "boolean"
+              },
+              "nicknames": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "product_description": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ubiquitousness_index": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "sensitivity_human": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "sensitivity_mouse": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "specificity_human": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "specificity_mouse": {
+                "type": [
+                  "number",
+                  "null"
                 ]
               }
-            }
-          },
-          "required": [
-            "data"
-          ]
+            },
+            "required": [
+              "gene_symbol",
+              "cell_type",
+              "organ",
+              "canonical_marker"
+            ]
+          }
         },
         {
           "type": "object",
@@ -211,101 +199,89 @@
       "operation": "cell_types_for_gene"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_symbol": {
-                    "type": "string"
-                  },
-                  "cell_type": {
-                    "type": "string"
-                  },
-                  "organ": {
-                    "type": "string"
-                  },
-                  "germ_layer": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "species": {
-                    "type": "string"
-                  },
-                  "canonical_marker": {
-                    "type": "boolean"
-                  },
-                  "nicknames": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "product_description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ubiquitousness_index": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "sensitivity_human": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "sensitivity_mouse": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "specificity_human": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "specificity_mouse": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  }
-                },
-                "required": [
-                  "gene_symbol",
-                  "cell_type",
-                  "organ",
-                  "canonical_marker"
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene_symbol": {
+                "type": "string"
+              },
+              "cell_type": {
+                "type": "string"
+              },
+              "organ": {
+                "type": "string"
+              },
+              "germ_layer": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "species": {
+                "type": "string"
+              },
+              "canonical_marker": {
+                "type": "boolean"
+              },
+              "nicknames": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "product_description": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ubiquitousness_index": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "sensitivity_human": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "sensitivity_mouse": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "specificity_human": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "specificity_mouse": {
+                "type": [
+                  "number",
+                  "null"
                 ]
               }
-            }
-          },
-          "required": [
-            "data"
-          ]
+            },
+            "required": [
+              "gene_symbol",
+              "cell_type",
+              "organ",
+              "canonical_marker"
+            ]
+          }
         },
         {
           "type": "object",
@@ -358,42 +334,30 @@
       "operation": "list_cell_types"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "cell_type": {
-                    "type": "string"
-                  },
-                  "organs": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "marker_count": {
-                    "type": "integer"
-                  }
-                },
-                "required": [
-                  "cell_type",
-                  "marker_count"
-                ]
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "cell_type": {
+                "type": "string"
+              },
+              "organs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "marker_count": {
+                "type": "integer"
               }
-            }
-          },
-          "required": [
-            "data"
-          ]
+            },
+            "required": [
+              "cell_type",
+              "marker_count"
+            ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/panther_tools.json
+++ b/src/tooluniverse/data/panther_tools.json
@@ -40,72 +40,50 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_id": {
-                  "type": "string"
-                },
-                "organism": {
-                  "type": "integer"
-                },
-                "family_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "subfamily_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "annotations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "category": {
-                        "type": "string"
-                      },
-                      "terms": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "name": {
-                              "type": "string"
-                            }
-                          }
+            "gene_id": {
+              "type": "string"
+            },
+            "organism": {
+              "type": "integer"
+            },
+            "family_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "subfamily_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "category": {
+                    "type": "string"
+                  },
+                  "terms": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
                         }
                       }
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -171,76 +149,54 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_list": {
-                  "type": "string"
-                },
-                "organism": {
-                  "type": "integer"
-                },
-                "annotation_dataset": {
-                  "type": "string"
-                },
-                "result_count": {
-                  "type": "integer"
-                },
-                "enriched_terms": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "term_id": {
-                        "type": "string"
-                      },
-                      "term_label": {
-                        "type": "string"
-                      },
-                      "number_in_list": {
-                        "type": "integer"
-                      },
-                      "number_in_reference": {
-                        "type": "integer"
-                      },
-                      "expected": {
-                        "type": "number"
-                      },
-                      "fold_enrichment": {
-                        "type": "number"
-                      },
-                      "pvalue": {
-                        "type": "number"
-                      },
-                      "fdr": {
-                        "type": "number"
-                      },
-                      "direction": {
-                        "type": "string"
-                      }
-                    }
+            "gene_list": {
+              "type": "string"
+            },
+            "organism": {
+              "type": "integer"
+            },
+            "annotation_dataset": {
+              "type": "string"
+            },
+            "result_count": {
+              "type": "integer"
+            },
+            "enriched_terms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term_id": {
+                    "type": "string"
+                  },
+                  "term_label": {
+                    "type": "string"
+                  },
+                  "number_in_list": {
+                    "type": "integer"
+                  },
+                  "number_in_reference": {
+                    "type": "integer"
+                  },
+                  "expected": {
+                    "type": "number"
+                  },
+                  "fold_enrichment": {
+                    "type": "number"
+                  },
+                  "pvalue": {
+                    "type": "number"
+                  },
+                  "fdr": {
+                    "type": "number"
+                  },
+                  "direction": {
+                    "type": "string"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -315,76 +271,54 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
+            "gene_id": {
+              "type": "string"
+            },
+            "source_organism": {
+              "type": "integer"
+            },
+            "target_organism": {
+              "type": "integer"
+            },
+            "ortholog_type": {
+              "type": "string"
+            },
+            "mapping": {
+              "type": [
+                "object",
+                "null"
+              ],
               "properties": {
-                "gene_id": {
+                "source_gene": {
                   "type": "string"
                 },
-                "source_organism": {
-                  "type": "integer"
+                "target_gene": {
+                  "type": "string"
                 },
-                "target_organism": {
-                  "type": "integer"
+                "target_gene_symbol": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
                 "ortholog_type": {
                   "type": "string"
                 },
-                "mapping": {
+                "persistent_id": {
                   "type": [
-                    "object",
+                    "string",
                     "null"
-                  ],
-                  "properties": {
-                    "source_gene": {
-                      "type": "string"
-                    },
-                    "target_gene": {
-                      "type": "string"
-                    },
-                    "target_gene_symbol": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "ortholog_type": {
-                      "type": "string"
-                    },
-                    "persistent_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "target_persistent_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
+                  ]
                 },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
+                "target_persistent_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/pdbe_compound_tools.json
+++ b/src/tooluniverse/data/pdbe_compound_tools.json
@@ -1,164 +1,218 @@
 [
-    {
-        "name": "PDBe_get_compound_summary",
-        "description": "Get detailed chemical compound information from PDBe by PDB chemical component ID (3-letter code). Returns molecular formula, weight, formal charge, compound type, InChI identifier, InChI key, SMILES representations, systematic IUPAC names, and cross-references to PubChem, DrugBank, EPA CompTox, ClinicalTrials, and other chemical databases. Essential for studying protein-ligand interactions, drug binding, or identifying compounds in crystal structures. Example: 'ATP' returns adenosine-5'-triphosphate (C10H16N5O13P3, 507.18 Da, linked to DrugBank DB00171 and PubChem 5957); 'HEM' returns protoporphyrin IX containing Fe (616.49 Da); 'CFF' returns caffeine (194.19 Da).",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "comp_id": {
-                    "type": "string",
-                    "description": "PDB chemical component ID (3-letter code). Examples: 'ATP', 'HEM' (heme), 'NAG' (N-acetylglucosamine), 'CFF' (caffeine), 'GOL' (glycerol), 'ZN' (zinc ion), 'FAD', 'NAD'. Case-insensitive."
-                }
-            },
-            "required": ["comp_id"]
-        },
-        "fields": {
-            "endpoint": "get_summary"
-        },
-        "type": "PDBECompoundTool",
-        "test_examples": [
-            {
-                "comp_id": "ATP"
-            },
-            {
-                "comp_id": "HEM"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "comp_id": {"type": "string"},
-                                "name": {"type": "string", "description": "Chemical compound name"},
-                                "formula": {"type": "string", "description": "Molecular formula"},
-                                "weight": {"type": "number", "description": "Molecular weight in Daltons"},
-                                "formal_charge": {"type": "integer"},
-                                "compound_type": {"type": "string", "description": "Type (NON-POLYMER, D-saccharide, etc.)"},
-                                "inchi": {"type": ["string", "null"], "description": "InChI identifier"},
-                                "inchi_key": {"type": ["string", "null"], "description": "InChI key for database lookup"},
-                                "smiles": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "program": {"type": "string"},
-                                            "value": {"type": "string"}
-                                        }
-                                    },
-                                    "description": "SMILES representations"
-                                },
-                                "systematic_names": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "program": {"type": "string"},
-                                            "name": {"type": "string"}
-                                        }
-                                    }
-                                },
-                                "cross_references": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "resource": {"type": "string"},
-                                            "resource_id": {"type": "string"}
-                                        }
-                                    },
-                                    "description": "Links to PubChem, DrugBank, EPA, ClinicalTrials, etc."
-                                },
-                                "first_observed_in": {"type": "array", "items": {"type": "string"}},
-                                "release_status": {"type": "string"},
-                                "creation_date": {"type": ["string", "null"]}
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+  {
+    "name": "PDBe_get_compound_summary",
+    "description": "Get detailed chemical compound information from PDBe by PDB chemical component ID (3-letter code). Returns molecular formula, weight, formal charge, compound type, InChI identifier, InChI key, SMILES representations, systematic IUPAC names, and cross-references to PubChem, DrugBank, EPA CompTox, ClinicalTrials, and other chemical databases. Essential for studying protein-ligand interactions, drug binding, or identifying compounds in crystal structures. Example: 'ATP' returns adenosine-5'-triphosphate (C10H16N5O13P3, 507.18 Da, linked to DrugBank DB00171 and PubChem 5957); 'HEM' returns protoporphyrin IX containing Fe (616.49 Da); 'CFF' returns caffeine (194.19 Da).",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "comp_id": {
+          "type": "string",
+          "description": "PDB chemical component ID (3-letter code). Examples: 'ATP', 'HEM' (heme), 'NAG' (N-acetylglucosamine), 'CFF' (caffeine), 'GOL' (glycerol), 'ZN' (zinc ion), 'FAD', 'NAD'. Case-insensitive."
         }
+      },
+      "required": [
+        "comp_id"
+      ]
     },
-    {
-        "name": "PDBe_get_compound_structures",
-        "description": "Get PDB structures containing a specific chemical compound (ligand/cofactor/ion). Returns compound details and a list of PDB entry IDs where the compound appears. Useful for finding all crystal structures with a drug or cofactor bound, studying binding site diversity, or identifying protein targets of a compound. Example: 'ATP' appears in thousands of PDB structures (kinases, ATPases, motor proteins); 'HEM' appears in hemoglobins, cytochromes, peroxidases; 'NAG' (N-acetylglucosamine) appears in glycoproteins.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "comp_id": {
-                    "type": "string",
-                    "description": "PDB chemical component ID (3-letter code). Examples: 'ATP', 'HEM', 'NAG', 'FAD', 'NAD', 'ZN', 'GOL'. Case-insensitive."
+    "fields": {
+      "endpoint": "get_summary"
+    },
+    "type": "PDBECompoundTool",
+    "test_examples": [
+      {
+        "comp_id": "ATP"
+      },
+      {
+        "comp_id": "HEM"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "comp_id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string",
+              "description": "Chemical compound name"
+            },
+            "formula": {
+              "type": "string",
+              "description": "Molecular formula"
+            },
+            "weight": {
+              "type": "number",
+              "description": "Molecular weight in Daltons"
+            },
+            "formal_charge": {
+              "type": "integer"
+            },
+            "compound_type": {
+              "type": "string",
+              "description": "Type (NON-POLYMER, D-saccharide, etc.)"
+            },
+            "inchi": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "InChI identifier"
+            },
+            "inchi_key": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "InChI key for database lookup"
+            },
+            "smiles": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "program": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
                 }
+              },
+              "description": "SMILES representations"
             },
-            "required": ["comp_id"]
-        },
-        "fields": {
-            "endpoint": "get_structures"
-        },
-        "type": "PDBECompoundTool",
-        "test_examples": [
-            {
-                "comp_id": "CFF"
+            "systematic_names": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "program": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
             },
-            {
-                "comp_id": "NAG"
+            "cross_references": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "resource": {
+                    "type": "string"
+                  },
+                  "resource_id": {
+                    "type": "string"
+                  }
+                }
+              },
+              "description": "Links to PubChem, DrugBank, EPA, ClinicalTrials, etc."
+            },
+            "first_observed_in": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "release_status": {
+              "type": "string"
+            },
+            "creation_date": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "comp_id": {"type": "string"},
-                                "name": {"type": "string"},
-                                "formula": {"type": "string"},
-                                "weight": {"type": "number"},
-                                "first_observed_in": {"type": "array", "items": {"type": "string"}},
-                                "pdb_entries": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "PDB entry IDs containing this compound"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_structures": {"type": "integer"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "PDBe_get_compound_structures",
+    "description": "Get PDB structures containing a specific chemical compound (ligand/cofactor/ion). Returns compound details and a list of PDB entry IDs where the compound appears. Useful for finding all crystal structures with a drug or cofactor bound, studying binding site diversity, or identifying protein targets of a compound. Example: 'ATP' appears in thousands of PDB structures (kinases, ATPases, motor proteins); 'HEM' appears in hemoglobins, cytochromes, peroxidases; 'NAG' (N-acetylglucosamine) appears in glycoproteins.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "comp_id": {
+          "type": "string",
+          "description": "PDB chemical component ID (3-letter code). Examples: 'ATP', 'HEM', 'NAG', 'FAD', 'NAD', 'ZN', 'GOL'. Case-insensitive."
+        }
+      },
+      "required": [
+        "comp_id"
+      ]
+    },
+    "fields": {
+      "endpoint": "get_structures"
+    },
+    "type": "PDBECompoundTool",
+    "test_examples": [
+      {
+        "comp_id": "CFF"
+      },
+      {
+        "comp_id": "NAG"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "comp_id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "formula": {
+              "type": "string"
+            },
+            "weight": {
+              "type": "number"
+            },
+            "first_observed_in": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "pdb_entries": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "PDB entry IDs containing this compound"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/pdbe_kb_tools.json
+++ b/src/tooluniverse/data/pdbe_kb_tools.json
@@ -31,62 +31,46 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "uniprot_accession": {
-                  "type": "string",
-                  "description": "UniProt accession queried"
-                },
-                "pdbs": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of PDB structures available"
-                },
-                "ligands": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of unique ligands bound"
-                },
-                "interaction_partners": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of protein interaction partners with structural evidence"
-                },
-                "annotations": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of functional annotations"
-                },
-                "similar_proteins": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of similar proteins in PDB"
-                }
-              }
+            "uniprot_accession": {
+              "type": "string",
+              "description": "UniProt accession queried"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                }
-              }
+            "pdbs": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of PDB structures available"
+            },
+            "ligands": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of unique ligands bound"
+            },
+            "interaction_partners": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of protein interaction partners with structural evidence"
+            },
+            "annotations": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of functional annotations"
+            },
+            "similar_proteins": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of similar proteins in PDB"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -134,119 +118,103 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "uniprot_accession": {
-                  "type": "string",
-                  "description": "UniProt accession queried"
-                },
-                "protein_length": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Protein sequence length"
-                },
-                "ligands": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Ligand full name"
-                      },
-                      "accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Ligand chemical component ID (e.g. ATP, NAD, ZN)"
-                      },
-                      "binding_residues": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "start": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ],
-                              "description": "Start residue position (UniProt numbering)"
-                            },
-                            "end": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ],
-                              "description": "End residue position"
-                            },
-                            "pdb_entries": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              },
-                              "description": "PDB IDs where this binding observed"
-                            }
-                          }
-                        },
-                        "description": "Residues involved in ligand binding"
-                      },
-                      "is_cofactor": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ],
-                        "description": "Whether ligand is a cofactor"
-                      },
-                      "is_solvent": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ],
-                        "description": "Whether ligand is a solvent molecule"
-                      },
-                      "chembl_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "ChEMBL compound ID if drug-like"
-                      },
-                      "drugbank_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "DrugBank ID if applicable"
-                      }
-                    }
-                  },
-                  "description": "Ligands with binding site details"
-                },
-                "total_ligands": {
-                  "type": "integer",
-                  "description": "Total number of unique ligands"
-                }
-              }
+            "uniprot_accession": {
+              "type": "string",
+              "description": "UniProt accession queried"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
+            "protein_length": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Protein sequence length"
+            },
+            "ligands": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Ligand full name"
+                  },
+                  "accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Ligand chemical component ID (e.g. ATP, NAD, ZN)"
+                  },
+                  "binding_residues": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "start": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "Start residue position (UniProt numbering)"
+                        },
+                        "end": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "End residue position"
+                        },
+                        "pdb_entries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "PDB IDs where this binding observed"
+                        }
+                      }
+                    },
+                    "description": "Residues involved in ligand binding"
+                  },
+                  "is_cofactor": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Whether ligand is a cofactor"
+                  },
+                  "is_solvent": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ],
+                    "description": "Whether ligand is a solvent molecule"
+                  },
+                  "chembl_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "ChEMBL compound ID if drug-like"
+                  },
+                  "drugbank_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "DrugBank ID if applicable"
+                  }
                 }
-              }
+              },
+              "description": "Ligands with binding site details"
+            },
+            "total_ligands": {
+              "type": "integer",
+              "description": "Total number of unique ligands"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -294,91 +262,75 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "uniprot_accession": {
-                  "type": "string",
-                  "description": "UniProt accession queried"
-                },
-                "protein_length": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Protein sequence length"
-                },
-                "interaction_partners": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "partner_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Name of the interaction partner protein"
-                      },
-                      "partner_accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "UniProt accession of interaction partner"
-                      },
-                      "interface_residues": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "start": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ],
-                              "description": "Start residue position (UniProt numbering)"
-                            },
-                            "end": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ],
-                              "description": "End residue position"
-                            },
-                            "pdb_entries": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              },
-                              "description": "PDB IDs with this interface"
-                            }
-                          }
-                        },
-                        "description": "Residues at the interaction interface"
-                      }
-                    }
-                  },
-                  "description": "Interaction partners with interface details"
-                },
-                "total_partners": {
-                  "type": "integer",
-                  "description": "Total number of interaction partners"
-                }
-              }
+            "uniprot_accession": {
+              "type": "string",
+              "description": "UniProt accession queried"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
+            "protein_length": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Protein sequence length"
+            },
+            "interaction_partners": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "partner_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Name of the interaction partner protein"
+                  },
+                  "partner_accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "UniProt accession of interaction partner"
+                  },
+                  "interface_residues": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "start": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "Start residue position (UniProt numbering)"
+                        },
+                        "end": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "End residue position"
+                        },
+                        "pdb_entries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "PDB IDs with this interface"
+                        }
+                      }
+                    },
+                    "description": "Residues at the interaction interface"
+                  }
                 }
-              }
+              },
+              "description": "Interaction partners with interface details"
+            },
+            "total_partners": {
+              "type": "integer",
+              "description": "Total number of interaction partners"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -426,73 +378,68 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "uniprot_accession": {
-                  "type": "string"
-                },
-                "segments": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "segment_start": {
-                        "type": "integer",
-                        "description": "Start residue position (UniProt numbering)"
-                      },
-                      "segment_end": {
-                        "type": "integer",
-                        "description": "End residue position"
-                      },
-                      "num_clusters": {
-                        "type": "integer",
-                        "description": "Number of structural clusters"
-                      },
-                      "clusters": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
+            "uniprot_accession": {
+              "type": "string"
+            },
+            "segments": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "segment_start": {
+                    "type": "integer",
+                    "description": "Start residue position (UniProt numbering)"
+                  },
+                  "segment_end": {
+                    "type": "integer",
+                    "description": "End residue position"
+                  },
+                  "num_clusters": {
+                    "type": "integer",
+                    "description": "Number of structural clusters"
+                  },
+                  "clusters": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "representative": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
                           "properties": {
-                            "representative": {
-                              "type": [
-                                "object",
-                                "null"
-                              ],
-                              "properties": {
-                                "pdb_id": {
-                                  "type": "string"
-                                },
-                                "auth_asym_id": {
-                                  "type": "string"
-                                },
-                                "is_representative": {
-                                  "type": "boolean"
-                                }
+                            "pdb_id": {
+                              "type": "string"
+                            },
+                            "auth_asym_id": {
+                              "type": "string"
+                            },
+                            "is_representative": {
+                              "type": "boolean"
+                            }
+                          },
+                          "description": "Representative structure for this cluster"
+                        },
+                        "total_members": {
+                          "type": "integer"
+                        },
+                        "members": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "pdb_id": {
+                                "type": "string"
                               },
-                              "description": "Representative structure for this cluster"
-                            },
-                            "total_members": {
-                              "type": "integer"
-                            },
-                            "members": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "pdb_id": {
-                                    "type": "string"
-                                  },
-                                  "auth_asym_id": {
-                                    "type": "string"
-                                  },
-                                  "entity_id": {
-                                    "type": "integer"
-                                  },
-                                  "is_representative": {
-                                    "type": "boolean"
-                                  }
-                                }
+                              "auth_asym_id": {
+                                "type": "string"
+                              },
+                              "entity_id": {
+                                "type": "integer"
+                              },
+                              "is_representative": {
+                                "type": "boolean"
                               }
                             }
                           }
@@ -500,24 +447,13 @@
                       }
                     }
                   }
-                },
-                "total_segments": {
-                  "type": "integer"
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                }
-              }
+            "total_segments": {
+              "type": "integer"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/pdbe_kb_tools.json
+++ b/src/tooluniverse/data/pdbe_kb_tools.json
@@ -88,13 +88,17 @@
   },
   {
     "name": "PDBe_KB_get_ligand_sites",
-    "description": "Get ligand binding site residues for a UniProt protein from PDBe-KB. Returns all known ligands that bind the protein, with the specific residue positions (UniProt numbering) involved in binding, the PDB structures where binding was observed, and ligand metadata (scaffold, cofactor status, drug associations). Essential for understanding protein function, drug binding, and designing mutagenesis experiments. Example: P04637 (TP53) shows NAD binding at residue 382, zinc coordination at the DNA-binding domain.",
+    "description": "Get ligand binding site residues for a UniProt protein from PDBe-KB. Returns all known ligands that bind the protein, with the specific residue positions (UniProt numbering) involved in binding, the PDB structures where binding was observed, and ligand metadata (scaffold, cofactor status, drug associations). Essential for understanding protein function, drug binding, and designing mutagenesis experiments. Example: P04637 (TP53) shows NAD binding at residue 382, zinc coordination at the DNA-binding domain. Proteins with many known ligands (e.g. well-studied drug targets) are truncated to `max_ligands` entries by default -- check the response's `truncated` flag and raise `max_ligands` if a specific ligand of interest is missing.",
     "parameter": {
       "type": "object",
       "properties": {
         "uniprot_accession": {
           "type": "string",
           "description": "UniProt accession ID for the protein. Examples: 'P04637' (TP53), 'P00533' (EGFR), 'P38398' (BRCA1)."
+        },
+        "max_ligands": {
+          "type": "integer",
+          "description": "Maximum number of ligands to return (default 100). The underlying API does not guarantee ordering by clinical relevance, so pass a value >= total_ligands (from a prior call, or from the response's truncation_note) to guarantee a specific ligand isn't cut off."
         }
       },
       "required": [
@@ -213,6 +217,14 @@
             "total_ligands": {
               "type": "integer",
               "description": "Total number of unique ligands"
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True if fewer ligands were returned than total_ligands"
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Explains the truncation and how to raise max_ligands to see all results"
             }
           }
         },
@@ -232,13 +244,17 @@
   },
   {
     "name": "PDBe_KB_get_interface_residues",
-    "description": "Get protein-protein interaction interface residues for a UniProt protein from PDBe-KB. Returns residue positions (UniProt numbering) at interaction interfaces with other proteins, the identity of interaction partners, and PDB structures where each interface was observed. Essential for understanding protein complex formation, designing interface-disrupting mutations, and identifying functional hotspots. Example: P04637 (TP53) shows interaction interfaces with MDM2, p53BP2, and DNA.",
+    "description": "Get protein-protein interaction interface residues for a UniProt protein from PDBe-KB. Returns residue positions (UniProt numbering) at interaction interfaces with other proteins, the identity of interaction partners, and PDB structures where each interface was observed. Essential for understanding protein complex formation, designing interface-disrupting mutations, and identifying functional hotspots. Example: P04637 (TP53) shows interaction interfaces with MDM2, p53BP2, and DNA. Proteins with many known partners are truncated to `max_partners` entries by default -- check the response's `truncated` flag if a specific partner of interest is missing.",
     "parameter": {
       "type": "object",
       "properties": {
         "uniprot_accession": {
           "type": "string",
           "description": "UniProt accession ID for the protein. Examples: 'P04637' (TP53), 'P00533' (EGFR), 'P38398' (BRCA1)."
+        },
+        "max_partners": {
+          "type": "integer",
+          "description": "Maximum number of interaction partners to return (default 60). Pass a value >= total_partners (from a prior call) to guarantee a specific partner isn't cut off."
         }
       },
       "required": [
@@ -329,6 +345,14 @@
             "total_partners": {
               "type": "integer",
               "description": "Total number of interaction partners"
+            },
+            "truncated": {
+              "type": "boolean",
+              "description": "True if fewer partners were returned than total_partners"
+            },
+            "truncation_note": {
+              "type": "string",
+              "description": "Explains the truncation and how to raise max_partners to see all results"
             }
           }
         },

--- a/src/tooluniverse/data/pdbe_ligands_tools.json
+++ b/src/tooluniverse/data/pdbe_ligands_tools.json
@@ -29,47 +29,35 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "pdb_id": {"type": "string"},
-                                "ligands": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "chem_comp_id": {"type": "string", "description": "3-letter chemical component code"},
-                                            "chem_comp_name": {"type": "string", "description": "Full chemical name"},
-                                            "weight": {"type": "number", "description": "Molecular weight in Da"},
-                                            "chain_id": {"type": "string"},
-                                            "entity_id": {"type": "integer"},
-                                            "author_residue_number": {"type": "integer"},
-                                            "carbohydrate_polymer": {"type": "boolean"},
-                                            "annotations": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "type": {"type": ["string", "null"]},
-                                                        "interacting_chain": {"type": ["string", "null"]},
-                                                        "interacting_uniprot": {"type": ["string", "null"]}
-                                                    }
-                                                }
+                        "pdb_id": {"type": "string"},
+                        "ligands": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "chem_comp_id": {"type": "string", "description": "3-letter chemical component code"},
+                                    "chem_comp_name": {"type": "string", "description": "Full chemical name"},
+                                    "weight": {"type": "number", "description": "Molecular weight in Da"},
+                                    "chain_id": {"type": "string"},
+                                    "entity_id": {"type": "integer"},
+                                    "author_residue_number": {"type": "integer"},
+                                    "carbohydrate_polymer": {"type": "boolean"},
+                                    "annotations": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {"type": ["string", "null"]},
+                                                "interacting_chain": {"type": ["string", "null"]},
+                                                "interacting_uniprot": {"type": ["string", "null"]}
                                             }
                                         }
                                     }
-                                },
-                                "total_ligands": {"type": "integer"}
+                                }
                             }
                         },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
+                        "total_ligands": {"type": "integer"}
+                    }
                 },
                 {
                     "type": "object",
@@ -116,52 +104,40 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "pdb_id": {"type": "string"},
-                                "molecules": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "entity_id": {"type": "integer"},
-                                            "chains": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "chain_id": {"type": "string"},
-                                                        "total_residues": {"type": "integer"},
-                                                        "residues": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "residue_number": {"type": "integer"},
-                                                                    "residue_name": {"type": "string"},
-                                                                    "author_residue_number": {"type": "integer"},
-                                                                    "observed_ratio": {"type": "number"}
-                                                                }
-                                                            }
+                        "pdb_id": {"type": "string"},
+                        "molecules": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "entity_id": {"type": "integer"},
+                                    "chains": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "chain_id": {"type": "string"},
+                                                "total_residues": {"type": "integer"},
+                                                "residues": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "residue_number": {"type": "integer"},
+                                                            "residue_name": {"type": "string"},
+                                                            "author_residue_number": {"type": "integer"},
+                                                            "observed_ratio": {"type": "number"}
                                                         }
                                                     }
                                                 }
                                             }
                                         }
                                     }
-                                },
-                                "total_molecules": {"type": "integer"}
+                                }
                             }
                         },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
+                        "total_molecules": {"type": "integer"}
+                    }
                 },
                 {
                     "type": "object",

--- a/src/tooluniverse/data/pdbe_search_tools.json
+++ b/src/tooluniverse/data/pdbe_search_tools.json
@@ -38,79 +38,51 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "pdb_id": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "resolution": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "experimental_method": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "deposition_date": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "number_of_entities": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "organism": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pdb_id": {
+                "type": "string"
+              },
+              "title": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "resolution": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "experimental_method": {
+                "type": "array",
+                "items": {
+                  "type": "string"
                 }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_found": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
+              },
+              "deposition_date": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "number_of_entities": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "organism": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -158,80 +130,58 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "compound_id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "formula": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "weight": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "compound_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "inchi": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "inchi_key": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "smiles": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "systematic_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
+            "compound_id": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "formula": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "weight": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "compound_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "inchi": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "inchi_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "smiles": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "systematic_name": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -294,76 +244,45 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "pdb_id": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "resolution": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "experimental_method": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "deposition_date": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "organism": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pdb_id": {
+                "type": "string"
+              },
+              "title": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "resolution": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "experimental_method": {
+                "type": "array",
+                "items": {
+                  "type": "string"
                 }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_found": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "organism_filter": {
-                  "type": "string"
-                },
-                "endpoint": {
+              },
+              "deposition_date": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "organism": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/pdbe_sifts_tools.json
+++ b/src/tooluniverse/data/pdbe_sifts_tools.json
@@ -47,111 +47,92 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "uniprot_accession": {
-                  "type": "string",
-                  "description": "UniProt accession queried"
-                },
-                "structures": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pdb_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "PDB entry ID (4 characters)"
-                      },
-                      "chain_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Chain ID in PDB entry"
-                      },
-                      "uniprot_start": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ],
-                        "description": "UniProt sequence start covered"
-                      },
-                      "uniprot_end": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ],
-                        "description": "UniProt sequence end covered"
-                      },
-                      "resolution": {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "description": "Structure resolution in Angstroms"
-                      },
-                      "experimental_method": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Method (X-ray diffraction, Electron Microscopy, NMR)"
-                      },
-                      "coverage": {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "description": "Fraction of UniProt sequence covered"
-                      },
-                      "tax_id": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ],
-                        "description": "Taxonomy ID of source organism"
-                      }
-                    }
-                  },
-                  "description": "Ranked PDB structures (this page)"
-                },
-                "total_structures": {
-                  "type": "integer",
-                  "description": "Total available structure-chain entries"
-                },
-                "returned_structures": {
-                  "type": "integer",
-                  "description": "Number of entries in this page of results"
-                },
-                "offset": {
-                  "type": "integer",
-                  "description": "Zero-based index of the first entry returned"
-                },
-                "note": {
-                  "type": "string",
-                  "description": "Present when more entries remain; explains how to page to them"
-                }
-              }
+            "uniprot_accession": {
+              "type": "string",
+              "description": "UniProt accession queried"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "accession": {
-                  "type": "string"
+            "structures": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pdb_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "PDB entry ID (4 characters)"
+                  },
+                  "chain_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Chain ID in PDB entry"
+                  },
+                  "uniprot_start": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "description": "UniProt sequence start covered"
+                  },
+                  "uniprot_end": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "description": "UniProt sequence end covered"
+                  },
+                  "resolution": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Structure resolution in Angstroms"
+                  },
+                  "experimental_method": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Method (X-ray diffraction, Electron Microscopy, NMR)"
+                  },
+                  "coverage": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Fraction of UniProt sequence covered"
+                  },
+                  "tax_id": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "description": "Taxonomy ID of source organism"
+                  }
                 }
-              }
+              },
+              "description": "Ranked PDB structures (this page)"
+            },
+            "total_structures": {
+              "type": "integer",
+              "description": "Total available structure-chain entries"
+            },
+            "returned_structures": {
+              "type": "integer",
+              "description": "Number of entries in this page of results"
+            },
+            "offset": {
+              "type": "integer",
+              "description": "Zero-based index of the first entry returned"
+            },
+            "note": {
+              "type": "string",
+              "description": "Present when more entries remain; explains how to page to them"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -199,109 +180,90 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "pdb_id": {
-                  "type": "string",
-                  "description": "PDB entry ID"
-                },
-                "proteins": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "uniprot_accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "UniProt accession"
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Protein identifier"
-                      },
-                      "chain_mappings": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "chain_id": {
-                              "type": [
-                                "string",
-                                "null"
-                              ],
-                              "description": "Chain ID"
-                            },
-                            "pdb_start": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ],
-                              "description": "PDB residue start"
-                            },
-                            "pdb_end": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ],
-                              "description": "PDB residue end"
-                            },
-                            "uniprot_start": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ],
-                              "description": "UniProt residue start"
-                            },
-                            "uniprot_end": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ],
-                              "description": "UniProt residue end"
-                            }
-                          }
-                        },
-                        "description": "Chain-to-UniProt residue mappings"
-                      },
-                      "total_chain_mappings": {
-                        "type": "integer",
-                        "description": "Total chain mappings for this accession (chain_mappings shows at most the first 20)"
-                      },
-                      "chain_mappings_truncated": {
-                        "type": "boolean",
-                        "description": "True when total_chain_mappings exceeds the 20 returned in chain_mappings"
-                      }
-                    }
-                  },
-                  "description": "UniProt proteins found in PDB entry"
-                },
-                "total_proteins": {
-                  "type": "integer",
-                  "description": "Number of distinct UniProt proteins"
-                }
-              }
+            "pdb_id": {
+              "type": "string",
+              "description": "PDB entry ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "pdb_id": {
-                  "type": "string"
+            "proteins": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "uniprot_accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "UniProt accession"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Protein identifier"
+                  },
+                  "chain_mappings": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "chain_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Chain ID"
+                        },
+                        "pdb_start": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "PDB residue start"
+                        },
+                        "pdb_end": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "PDB residue end"
+                        },
+                        "uniprot_start": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "UniProt residue start"
+                        },
+                        "uniprot_end": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ],
+                          "description": "UniProt residue end"
+                        }
+                      }
+                    },
+                    "description": "Chain-to-UniProt residue mappings"
+                  },
+                  "total_chain_mappings": {
+                    "type": "integer",
+                    "description": "Total chain mappings for this accession (chain_mappings shows at most the first 20)"
+                  },
+                  "chain_mappings_truncated": {
+                    "type": "boolean",
+                    "description": "True when total_chain_mappings exceeds the 20 returned in chain_mappings"
+                  }
                 }
-              }
+              },
+              "description": "UniProt proteins found in PDB entry"
+            },
+            "total_proteins": {
+              "type": "integer",
+              "description": "Number of distinct UniProt proteins"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -365,113 +327,94 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "uniprot_accession": {
-                  "type": "string",
-                  "description": "UniProt accession queried"
-                },
-                "pdb_entries": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pdb_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "PDB entry ID"
-                      },
-                      "resolution": {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "description": "Resolution in Angstroms"
-                      },
-                      "experimental_method": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Experimental method"
-                      },
-                      "chains": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "chain_id": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "uniprot_start": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ]
-                            },
-                            "uniprot_end": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ]
-                            },
-                            "coverage": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            }
-                          }
-                        },
-                        "description": "Chains in this PDB entry"
-                      }
-                    }
-                  },
-                  "description": "PDB entries sorted by resolution (this page)"
-                },
-                "total_pdb_entries": {
-                  "type": "integer",
-                  "description": "Total unique PDB entries"
-                },
-                "total_chain_mappings": {
-                  "type": "integer",
-                  "description": "Total chain-level mappings"
-                },
-                "returned_pdb_entries": {
-                  "type": "integer",
-                  "description": "Number of entries in this page of results"
-                },
-                "offset": {
-                  "type": "integer",
-                  "description": "Zero-based index of the first entry returned"
-                },
-                "note": {
-                  "type": "string",
-                  "description": "Present when more entries remain; explains how to page to them"
-                }
-              }
+            "uniprot_accession": {
+              "type": "string",
+              "description": "UniProt accession queried"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "accession": {
-                  "type": "string"
+            "pdb_entries": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pdb_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "PDB entry ID"
+                  },
+                  "resolution": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Resolution in Angstroms"
+                  },
+                  "experimental_method": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Experimental method"
+                  },
+                  "chains": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "chain_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "uniprot_start": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "uniprot_end": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "coverage": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        }
+                      }
+                    },
+                    "description": "Chains in this PDB entry"
+                  }
                 }
-              }
+              },
+              "description": "PDB entries sorted by resolution (this page)"
+            },
+            "total_pdb_entries": {
+              "type": "integer",
+              "description": "Total unique PDB entries"
+            },
+            "total_chain_mappings": {
+              "type": "integer",
+              "description": "Total chain-level mappings"
+            },
+            "returned_pdb_entries": {
+              "type": "integer",
+              "description": "Number of entries in this page of results"
+            },
+            "offset": {
+              "type": "integer",
+              "description": "Zero-based index of the first entry returned"
+            },
+            "note": {
+              "type": "string",
+              "description": "Present when more entries remain; explains how to page to them"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -516,165 +459,143 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "pdb_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "pdb_id": {
-                  "type": "string"
-                },
-                "scop_domains": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "scop_sunid": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "SCOP sunid (stable unique identifier) for the domain"
-                      },
-                      "sccs": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "SCOP Concise Classification String (e.g., 'b.60.1.2')"
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "identifier": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "class": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "SCOP class (e.g., 'All beta proteins')"
-                      },
-                      "class_sunid": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "fold": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "SCOP fold (e.g., 'Lipocalins')"
-                      },
-                      "fold_sunid": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "superfamily": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "SCOP superfamily"
-                      },
-                      "superfamily_sunid": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "mappings": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "chain_id": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "struct_asym_id": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "entity_id": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ]
-                            },
-                            "scop_id": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "start_residue": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ]
-                            },
-                            "end_residue": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ]
-                            },
-                            "start_author_residue": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ]
-                            },
-                            "end_author_residue": {
-                              "type": [
-                                "integer",
-                                "null"
-                              ]
-                            }
-                          }
+            "scop_domains": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "scop_sunid": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "SCOP sunid (stable unique identifier) for the domain"
+                  },
+                  "sccs": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "SCOP Concise Classification String (e.g., 'b.60.1.2')"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "identifier": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "class": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "SCOP class (e.g., 'All beta proteins')"
+                  },
+                  "class_sunid": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "fold": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "SCOP fold (e.g., 'Lipocalins')"
+                  },
+                  "fold_sunid": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "superfamily": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "SCOP superfamily"
+                  },
+                  "superfamily_sunid": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "mappings": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "chain_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
                         },
-                        "description": "Per-chain residue-range mappings for this SCOP domain"
+                        "struct_asym_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "entity_id": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "scop_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "start_residue": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "end_residue": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "start_author_residue": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "end_author_residue": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        }
                       }
-                    }
+                    },
+                    "description": "Per-chain residue-range mappings for this SCOP domain"
                   }
-                },
-                "total_domains": {
-                  "type": "integer"
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "pdb_id": {
-                  "type": "string"
-                }
-              }
+            "total_domains": {
+              "type": "integer"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/pdbe_validation_tools.json
+++ b/src/tooluniverse/data/pdbe_validation_tools.json
@@ -1,178 +1,207 @@
 [
-    {
-        "name": "PDBeValidation_get_quality_scores",
-        "description": "Get global quality validation scores for a PDB structure from PDBe. Returns percentile rankings for Ramachandran outliers, rotamer outliers, and clashscore. Each metric has a raw value, an absolute percentile (compared to all structures), and a relative percentile (compared to structures at similar resolution). Higher percentile = better quality. Essential for assessing whether a structure is reliable enough for downstream analysis. Example: 4HHB (hemoglobin) has clashscore raw=141.11 (absolute: 0.0%, relative: 0.0% - very poor by modern standards); 1TUP (p53-DNA complex) has similar vintage quality issues.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "pdb_id": {
-                    "type": "string",
-                    "description": "PDB identifier (4-character code). Case-insensitive. Examples: '4hhb' (hemoglobin), '1tup' (p53-DNA), '6lu7' (SARS-CoV-2 main protease)."
-                }
-            },
-            "required": ["pdb_id"]
-        },
-        "fields": {
-            "endpoint": "quality_scores"
-        },
-        "type": "PDBeValidationTool",
-        "test_examples": [
-            {
-                "pdb_id": "4hhb"
-            },
-            {
-                "pdb_id": "1tup"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "pdb_id": {"type": "string"},
-                                "quality_metrics": {
-                                    "type": "object",
-                                    "properties": {
-                                        "ramachandran_outliers": {
-                                            "type": "object",
-                                            "properties": {
-                                                "raw_value": {"type": "number", "description": "Percentage of Ramachandran outliers"},
-                                                "absolute_percentile": {"type": "number", "description": "Percentile vs all structures (0-100)"},
-                                                "relative_percentile": {"type": "number", "description": "Percentile vs similar resolution structures (0-100)"}
-                                            }
-                                        },
-                                        "rotamer_outliers": {
-                                            "type": "object",
-                                            "properties": {
-                                                "raw_value": {"type": "number"},
-                                                "absolute_percentile": {"type": "number"},
-                                                "relative_percentile": {"type": "number"}
-                                            }
-                                        },
-                                        "clashscore": {
-                                            "type": "object",
-                                            "properties": {
-                                                "raw_value": {"type": "number", "description": "Number of clashes per 1000 atoms"},
-                                                "absolute_percentile": {"type": "number"},
-                                                "relative_percentile": {"type": "number"}
-                                            }
-                                        }
-                                    },
-                                    "description": "Structure quality validation metrics with percentile scores"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "description": {"type": "string"}
-                            }
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+  {
+    "name": "PDBeValidation_get_quality_scores",
+    "description": "Get global quality validation scores for a PDB structure from PDBe. Returns percentile rankings for Ramachandran outliers, rotamer outliers, and clashscore. Each metric has a raw value, an absolute percentile (compared to all structures), and a relative percentile (compared to structures at similar resolution). Higher percentile = better quality. Essential for assessing whether a structure is reliable enough for downstream analysis. Example: 4HHB (hemoglobin) has clashscore raw=141.11 (absolute: 0.0%, relative: 0.0% - very poor by modern standards); 1TUP (p53-DNA complex) has similar vintage quality issues.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "pdb_id": {
+          "type": "string",
+          "description": "PDB identifier (4-character code). Case-insensitive. Examples: '4hhb' (hemoglobin), '1tup' (p53-DNA), '6lu7' (SARS-CoV-2 main protease)."
         }
+      },
+      "required": [
+        "pdb_id"
+      ]
     },
-    {
-        "name": "PDBeValidation_get_outlier_residues",
-        "description": "Get residue-level validation outliers for a PDB structure from PDBe. Identifies specific residues with geometry problems (Ramachandran outliers, sidechain rotamer outliers, bond angle/length deviations). Returns problematic residues organized by molecule/chain. Essential for identifying unreliable regions before using structure data for molecular docking, mutation analysis, or protein engineering. Example: 4HHB has residue-level outliers in chains A-D with rotamer and Ramachandran deviations.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "pdb_id": {
-                    "type": "string",
-                    "description": "PDB identifier (4-character code). Case-insensitive. Examples: '4hhb', '1tup', '6lu7'."
-                }
+    "fields": {
+      "endpoint": "quality_scores"
+    },
+    "type": "PDBeValidationTool",
+    "test_examples": [
+      {
+        "pdb_id": "4hhb"
+      },
+      {
+        "pdb_id": "1tup"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "pdb_id": {
+              "type": "string"
             },
-            "required": ["pdb_id"]
-        },
-        "fields": {
-            "endpoint": "outlier_residues"
-        },
-        "type": "PDBeValidationTool",
-        "test_examples": [
-            {
-                "pdb_id": "4hhb"
-            },
-            {
-                "pdb_id": "6lu7"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "pdb_id": {"type": "string"},
-                                "molecules": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "entity_id": {"type": "integer"},
-                                            "chains": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "chain_id": {"type": "string"},
-                                                        "outlier_residues": {
-                                                            "type": "array",
-                                                            "items": {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "residue_number": {"type": ["integer", "null"]},
-                                                                    "residue_name": {"type": ["integer", "string", "null"]},
-                                                                    "outlier_types": {
-                                                                        "type": "array",
-                                                                        "items": {"type": "string"},
-                                                                        "description": "Types of outliers (e.g., RAMACHANDRAN, SIDECHAIN, BOND_ANGLES)"
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "description": "Molecules with outlier residues"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_outlier_residues": {"type": "integer"}
-                            }
-                        }
+            "quality_metrics": {
+              "type": "object",
+              "properties": {
+                "ramachandran_outliers": {
+                  "type": "object",
+                  "properties": {
+                    "raw_value": {
+                      "type": "number",
+                      "description": "Percentage of Ramachandran outliers"
                     },
-                    "required": ["data"]
+                    "absolute_percentile": {
+                      "type": "number",
+                      "description": "Percentile vs all structures (0-100)"
+                    },
+                    "relative_percentile": {
+                      "type": "number",
+                      "description": "Percentile vs similar resolution structures (0-100)"
+                    }
+                  }
                 },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
+                "rotamer_outliers": {
+                  "type": "object",
+                  "properties": {
+                    "raw_value": {
+                      "type": "number"
                     },
-                    "required": ["error"]
+                    "absolute_percentile": {
+                      "type": "number"
+                    },
+                    "relative_percentile": {
+                      "type": "number"
+                    }
+                  }
+                },
+                "clashscore": {
+                  "type": "object",
+                  "properties": {
+                    "raw_value": {
+                      "type": "number",
+                      "description": "Number of clashes per 1000 atoms"
+                    },
+                    "absolute_percentile": {
+                      "type": "number"
+                    },
+                    "relative_percentile": {
+                      "type": "number"
+                    }
+                  }
                 }
-            ]
+              },
+              "description": "Structure quality validation metrics with percentile scores"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "PDBeValidation_get_outlier_residues",
+    "description": "Get residue-level validation outliers for a PDB structure from PDBe. Identifies specific residues with geometry problems (Ramachandran outliers, sidechain rotamer outliers, bond angle/length deviations). Returns problematic residues organized by molecule/chain. Essential for identifying unreliable regions before using structure data for molecular docking, mutation analysis, or protein engineering. Example: 4HHB has residue-level outliers in chains A-D with rotamer and Ramachandran deviations.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "pdb_id": {
+          "type": "string",
+          "description": "PDB identifier (4-character code). Case-insensitive. Examples: '4hhb', '1tup', '6lu7'."
+        }
+      },
+      "required": [
+        "pdb_id"
+      ]
+    },
+    "fields": {
+      "endpoint": "outlier_residues"
+    },
+    "type": "PDBeValidationTool",
+    "test_examples": [
+      {
+        "pdb_id": "4hhb"
+      },
+      {
+        "pdb_id": "6lu7"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "pdb_id": {
+              "type": "string"
+            },
+            "molecules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "entity_id": {
+                    "type": "integer"
+                  },
+                  "chains": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "chain_id": {
+                          "type": "string"
+                        },
+                        "outlier_residues": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "residue_number": {
+                                "type": [
+                                  "integer",
+                                  "null"
+                                ]
+                              },
+                              "residue_name": {
+                                "type": [
+                                  "integer",
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "outlier_types": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Types of outliers (e.g., RAMACHANDRAN, SIDECHAIN, BOND_ANGLES)"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "description": "Molecules with outlier residues"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/pfam_tools.json
+++ b/src/tooluniverse/data/pfam_tools.json
@@ -15,7 +15,9 @@
                     "default": 20
                 }
             },
-            "required": ["query"]
+            "required": [
+                "query"
+            ]
         },
         "fields": {
             "endpoint": "search_families"
@@ -35,37 +37,58 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "query": {"type": "string", "description": "Search query used"},
-                                "total_results": {"type": "integer", "description": "Total matching Pfam families"},
-                                "returned": {"type": "integer", "description": "Number of results returned"},
-                                "families": {
-                                    "type": "array",
-                                    "description": "Matching Pfam families",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "accession": {"type": "string", "description": "Pfam accession (e.g., PF00069)"},
-                                            "name": {"type": "string", "description": "Full family name"},
-                                            "type": {"type": "string", "description": "Entry type: domain, family, repeat, etc."},
-                                            "integrated_interpro": {"type": ["string", "null"], "description": "Integrated InterPro accession"}
-                                        }
+                        "query": {
+                            "type": "string",
+                            "description": "Search query used"
+                        },
+                        "total_results": {
+                            "type": "integer",
+                            "description": "Total matching Pfam families"
+                        },
+                        "returned": {
+                            "type": "integer",
+                            "description": "Number of results returned"
+                        },
+                        "families": {
+                            "type": "array",
+                            "description": "Matching Pfam families",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "accession": {
+                                        "type": "string",
+                                        "description": "Pfam accession (e.g., PF00069)"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Full family name"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "description": "Entry type: domain, family, repeat, etc."
+                                    },
+                                    "integrated_interpro": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ],
+                                        "description": "Integrated InterPro accession"
                                     }
                                 }
                             }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
+                        }
+                    }
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "error": {"type": "string"}
+                        "error": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["error"]
+                    "required": [
+                        "error"
+                    ]
                 }
             ]
         }
@@ -81,7 +104,9 @@
                     "description": "Pfam family accession. Examples: 'PF00001' (7tm_1, GPCR rhodopsin family), 'PF00076' (RRM_1, RNA recognition motif), 'PF00069' (Pkinase), 'PF00096' (zf-C2H2, zinc finger)."
                 }
             },
-            "required": ["pfam_accession"]
+            "required": [
+                "pfam_accession"
+            ]
         },
         "fields": {
             "endpoint": "get_family_detail"
@@ -100,49 +125,108 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
+                        "accession": {
+                            "type": "string",
+                            "description": "Pfam accession"
+                        },
+                        "name": {
+                            "type": "string",
+                            "description": "Full family name"
+                        },
+                        "short_name": {
+                            "type": "string",
+                            "description": "Short name (e.g., 7tm_1)"
+                        },
+                        "type": {
+                            "type": "string",
+                            "description": "Entry type: domain, family, repeat, motif, etc."
+                        },
+                        "source_database": {
+                            "type": "string"
+                        },
+                        "integrated_interpro": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "InterPro accession this family is integrated into"
+                        },
+                        "description": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "Detailed description of the family"
+                        },
+                        "clan_accession": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "Pfam clan/superfamily accession (e.g., CL0221)"
+                        },
+                        "clan_name": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "description": "Pfam clan name"
+                        },
+                        "counters": {
                             "type": "object",
+                            "description": "Database statistics",
                             "properties": {
-                                "accession": {"type": "string", "description": "Pfam accession"},
-                                "name": {"type": "string", "description": "Full family name"},
-                                "short_name": {"type": "string", "description": "Short name (e.g., 7tm_1)"},
-                                "type": {"type": "string", "description": "Entry type: domain, family, repeat, motif, etc."},
-                                "source_database": {"type": "string"},
-                                "integrated_interpro": {"type": ["string", "null"], "description": "InterPro accession this family is integrated into"},
-                                "description": {"type": ["string", "null"], "description": "Detailed description of the family"},
-                                "clan_accession": {"type": ["string", "null"], "description": "Pfam clan/superfamily accession (e.g., CL0221)"},
-                                "clan_name": {"type": ["string", "null"], "description": "Pfam clan name"},
-                                "counters": {
-                                    "type": "object",
-                                    "description": "Database statistics",
-                                    "properties": {
-                                        "proteins": {"type": "integer"},
-                                        "structures": {"type": "integer"},
-                                        "taxa": {"type": "integer"},
-                                        "proteomes": {"type": "integer"},
-                                        "domain_architectures": {"type": "integer"},
-                                        "matches": {"type": "integer"}
-                                    }
+                                "proteins": {
+                                    "type": "integer"
                                 },
-                                "representative_structure": {
-                                    "type": ["object", "null"],
-                                    "description": "Representative PDB structure"
+                                "structures": {
+                                    "type": "integer"
                                 },
-                                "wikipedia_title": {"type": ["string", "null"]},
-                                "literature_count": {"type": "integer"},
-                                "go_terms": {"type": "array"}
+                                "taxa": {
+                                    "type": "integer"
+                                },
+                                "proteomes": {
+                                    "type": "integer"
+                                },
+                                "domain_architectures": {
+                                    "type": "integer"
+                                },
+                                "matches": {
+                                    "type": "integer"
+                                }
                             }
                         },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
+                        "representative_structure": {
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "description": "Representative PDB structure"
+                        },
+                        "wikipedia_title": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "literature_count": {
+                            "type": "integer"
+                        },
+                        "go_terms": {
+                            "type": "array"
+                        }
+                    }
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "error": {"type": "string"}
+                        "error": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["error"]
+                    "required": [
+                        "error"
+                    ]
                 }
             ]
         }
@@ -168,11 +252,16 @@
                     "default": true
                 },
                 "tax_id": {
-                    "type": ["string", "null"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "description": "NCBI taxonomy ID to filter by species. Examples: '9606' (human), '10090' (mouse), '7227' (Drosophila), '559292' (S. cerevisiae)."
                 }
             },
-            "required": ["pfam_accession"]
+            "required": [
+                "pfam_accession"
+            ]
         },
         "fields": {
             "endpoint": "get_family_proteins"
@@ -195,51 +284,93 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "pfam_accession": {"type": "string"},
-                                "total_proteins": {"type": "integer", "description": "Total proteins matching the query"},
-                                "returned": {"type": "integer"},
-                                "reviewed_only": {"type": "boolean"},
-                                "tax_id_filter": {"type": ["string", "null"]},
-                                "proteins": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "accession": {"type": "string", "description": "UniProt accession"},
-                                            "name": {"type": "string"},
-                                            "gene": {"type": ["string", "null"]},
-                                            "length": {"type": ["integer", "null"]},
-                                            "organism": {"type": ["string", "null"]},
-                                            "tax_id": {"type": ["string", "null"]},
-                                            "domain_positions": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "start": {"type": "integer"},
-                                                        "end": {"type": "integer"}
-                                                    }
+                        "pfam_accession": {
+                            "type": "string"
+                        },
+                        "total_proteins": {
+                            "type": "integer",
+                            "description": "Total proteins matching the query"
+                        },
+                        "returned": {
+                            "type": "integer"
+                        },
+                        "reviewed_only": {
+                            "type": "boolean"
+                        },
+                        "tax_id_filter": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "proteins": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "accession": {
+                                        "type": "string",
+                                        "description": "UniProt accession"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "gene": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "length": {
+                                        "type": [
+                                            "integer",
+                                            "null"
+                                        ]
+                                    },
+                                    "organism": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "tax_id": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "domain_positions": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "start": {
+                                                    "type": "integer"
+                                                },
+                                                "end": {
+                                                    "type": "integer"
                                                 }
-                                            },
-                                            "in_alphafold": {"type": "boolean"}
+                                            }
                                         }
+                                    },
+                                    "in_alphafold": {
+                                        "type": "boolean"
                                     }
                                 }
                             }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
+                        }
+                    }
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "error": {"type": "string"}
+                        "error": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["error"]
+                    "required": [
+                        "error"
+                    ]
                 }
             ]
         }
@@ -255,7 +386,9 @@
                     "description": "UniProt protein accession. Examples: 'P04637' (TP53, 4 domains), 'P00533' (EGFR), 'P68431' (Histone H3.1), 'P38398' (BRCA1), 'P01308' (Insulin)."
                 }
             },
-            "required": ["accession"]
+            "required": [
+                "accession"
+            ]
         },
         "fields": {
             "endpoint": "get_protein_pfam"
@@ -274,41 +407,72 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "accession": {"type": "string", "description": "UniProt accession queried"},
-                                "protein_length": {"type": ["integer", "null"], "description": "Total protein length"},
-                                "domain_count": {"type": "integer", "description": "Number of Pfam domains found"},
-                                "domains": {
-                                    "type": "array",
-                                    "description": "Pfam domains with positions, sorted by start position",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "pfam_accession": {"type": "string"},
-                                            "name": {"type": "string"},
-                                            "short_name": {"type": "string"},
-                                            "type": {"type": "string"},
-                                            "integrated_interpro": {"type": ["string", "null"]},
-                                            "start": {"type": "integer"},
-                                            "end": {"type": "integer"},
-                                            "score": {"type": ["number", "null"]}
-                                        }
+                        "accession": {
+                            "type": "string",
+                            "description": "UniProt accession queried"
+                        },
+                        "protein_length": {
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "description": "Total protein length"
+                        },
+                        "domain_count": {
+                            "type": "integer",
+                            "description": "Number of Pfam domains found"
+                        },
+                        "domains": {
+                            "type": "array",
+                            "description": "Pfam domains with positions, sorted by start position",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "pfam_accession": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "short_name": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string"
+                                    },
+                                    "integrated_interpro": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "start": {
+                                        "type": "integer"
+                                    },
+                                    "end": {
+                                        "type": "integer"
+                                    },
+                                    "score": {
+                                        "type": [
+                                            "number",
+                                            "null"
+                                        ]
                                     }
                                 }
                             }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
+                        }
+                    }
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "error": {"type": "string"}
+                        "error": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["error"]
+                    "required": [
+                        "error"
+                    ]
                 }
             ]
         }
@@ -349,35 +513,48 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "query": {"type": "string", "description": "Search query used"},
-                                "total_results": {"type": "integer", "description": "Total matching clans"},
-                                "returned": {"type": "integer"},
-                                "clans": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "accession": {"type": "string", "description": "Clan accession (e.g., CL0016)"},
-                                            "name": {"type": "string", "description": "Clan name"},
-                                            "source_database": {"type": "string"}
-                                        }
+                        "query": {
+                            "type": "string",
+                            "description": "Search query used"
+                        },
+                        "total_results": {
+                            "type": "integer",
+                            "description": "Total matching clans"
+                        },
+                        "returned": {
+                            "type": "integer"
+                        },
+                        "clans": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "accession": {
+                                        "type": "string",
+                                        "description": "Clan accession (e.g., CL0016)"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Clan name"
+                                    },
+                                    "source_database": {
+                                        "type": "string"
                                     }
                                 }
                             }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
+                        }
+                    }
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "error": {"type": "string"}
+                        "error": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["error"]
+                    "required": [
+                        "error"
+                    ]
                 }
             ]
         }
@@ -398,7 +575,9 @@
                     "default": 20
                 }
             },
-            "required": ["pfam_accession"]
+            "required": [
+                "pfam_accession"
+            ]
         },
         "fields": {
             "endpoint": "get_family_proteomes"
@@ -419,36 +598,52 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "pfam_accession": {"type": "string"},
-                                "total_proteomes": {"type": "integer", "description": "Total number of proteomes containing this domain"},
-                                "returned": {"type": "integer"},
-                                "proteomes": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "proteome_accession": {"type": "string", "description": "UniProt proteome accession"},
-                                            "organism_name": {"type": "string"},
-                                            "taxonomy_id": {"type": ["string", "null"]},
-                                            "is_reference": {"type": "boolean"}
-                                        }
+                        "pfam_accession": {
+                            "type": "string"
+                        },
+                        "total_proteomes": {
+                            "type": "integer",
+                            "description": "Total number of proteomes containing this domain"
+                        },
+                        "returned": {
+                            "type": "integer"
+                        },
+                        "proteomes": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "proteome_accession": {
+                                        "type": "string",
+                                        "description": "UniProt proteome accession"
+                                    },
+                                    "organism_name": {
+                                        "type": "string"
+                                    },
+                                    "taxonomy_id": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "is_reference": {
+                                        "type": "boolean"
                                     }
                                 }
                             }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
+                        }
+                    }
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "error": {"type": "string"}
+                        "error": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["error"]
+                    "required": [
+                        "error"
+                    ]
                 }
             ]
         }

--- a/src/tooluniverse/data/pharmgkb_tools.json
+++ b/src/tooluniverse/data/pharmgkb_tools.json
@@ -152,12 +152,8 @@
       }
     ],
     "return_schema": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "type": "string"
-        },
-        "data": {
+      "oneOf": [
+        {
           "type": "array",
           "items": {
             "type": "object",
@@ -181,8 +177,19 @@
             },
             "additionalProperties": true
           }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
-      }
+      ]
     }
   },
   {

--- a/src/tooluniverse/data/pharmgkb_tools.json
+++ b/src/tooluniverse/data/pharmgkb_tools.json
@@ -345,35 +345,58 @@
       }
     ],
     "return_schema": {
-      "type": "object",
-      "properties": {
-        "status": {
-          "type": "string"
-        },
-        "data": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "objCls": {
-                "type": "string"
-              },
-              "id": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "location": {
-                "type": "object"
-              },
-              "gene": {
-                "type": "object"
-              }
-            },
-            "additionalProperties": true
+      "type": "array",
+      "description": "List of matching PharmGKB genetic variants.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "objCls": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "changeClassification": {
+            "type": "string"
+          },
+          "clinicalSignificance": {
+            "type": "string"
+          },
+          "history": {
+            "type": "array"
+          },
+          "lastUpdatedFromDbsnp": {
+            "type": "string"
+          },
+          "obsolete": {
+            "type": "boolean"
+          },
+          "rare": {
+            "type": "boolean"
+          },
+          "raritySource": {
+            "type": "string"
+          },
+          "terms": {
+            "type": "array"
+          },
+          "type": {
+            "type": "string"
+          },
+          "location": {
+            "type": "object"
+          },
+          "gene": {
+            "type": "object"
           }
-        }
+        },
+        "additionalProperties": true
       }
     }
   },

--- a/src/tooluniverse/data/phykit_tools.json
+++ b/src/tooluniverse/data/phykit_tools.json
@@ -70,46 +70,33 @@
       ]
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "function": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "function": {
-                  "type": "string"
-                },
-                "n_files": {
-                  "type": "integer"
-                },
-                "mean": {
-                  "type": "number"
-                },
-                "median": {
-                  "type": "number"
-                },
-                "min": {
-                  "type": "number"
-                },
-                "max": {
-                  "type": "number"
-                }
-              }
+            "n_files": {
+              "type": "integer"
+            },
+            "mean": {
+              "type": "number"
+            },
+            "median": {
+              "type": "number"
+            },
+            "min": {
+              "type": "number"
+            },
+            "max": {
+              "type": "number"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }

--- a/src/tooluniverse/data/plant_reactome_tools.json
+++ b/src/tooluniverse/data/plant_reactome_tools.json
@@ -37,64 +37,39 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "stId": {
-                    "type": "string",
-                    "description": "Stable identifier (e.g., R-OSA-1119312)"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "species": {
-                    "type": [
-                      "string",
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "exact_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Entity type (Pathway, Reaction, etc.)"
-                  },
-                  "compartment_names": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "total_groups": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "stId": {
+                "type": "string",
+                "description": "Stable identifier (e.g., R-OSA-1119312)"
+              },
+              "name": {
+                "type": "string"
+              },
+              "species": {
+                "type": [
+                  "string",
+                  "array",
+                  "null"
+                ]
+              },
+              "exact_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Entity type (Pathway, Reaction, etc.)"
+              },
+              "compartment_names": {
+                "type": [
+                  "array",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -142,75 +117,56 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "stId": {
-                  "type": "string"
-                },
-                "displayName": {
-                  "type": "string"
-                },
-                "speciesName": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "isInDisease": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                },
-                "isInferred": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                },
-                "hasEvent": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "description": "Sub-events (reactions and sub-pathways)"
-                },
-                "compartment": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                },
-                "goBiologicalProcess": {
-                  "type": [
-                    "object",
-                    "null"
-                  ]
-                },
-                "crossReference": {
-                  "type": [
-                    "array",
-                    "null"
-                  ]
-                }
-              }
+            "stId": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "pathway_id": {
-                  "type": "string"
-                }
-              }
+            "displayName": {
+              "type": "string"
+            },
+            "speciesName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "isInDisease": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "isInferred": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "hasEvent": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "Sub-events (reactions and sub-pathways)"
+            },
+            "compartment": {
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "goBiologicalProcess": {
+              "type": [
+                "object",
+                "null"
+              ]
+            },
+            "crossReference": {
+              "type": [
+                "array",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -244,50 +200,31 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "dbId": {
-                    "type": "integer"
-                  },
-                  "displayName": {
-                    "type": "string",
-                    "description": "Species name"
-                  },
-                  "taxId": {
-                    "type": [
-                      "string",
-                      "integer"
-                    ]
-                  },
-                  "abbreviation": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_species": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "dbId": {
+                "type": "integer"
+              },
+              "displayName": {
+                "type": "string",
+                "description": "Species name"
+              },
+              "taxId": {
+                "type": [
+                  "string",
+                  "integer"
+                ]
+              },
+              "abbreviation": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -330,80 +267,69 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "pe_db_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "display_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "schema_class": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ref_entities": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "identifier": {
-                          "type": [
-                            "string",
-                            "null"
-                          ],
-                          "description": "UniProt accession (e.g. Q10MK5)"
-                        },
-                        "display_name": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "gene_names": {
-                          "type": [
-                            "array",
-                            "null"
-                          ]
-                        },
-                        "schema_class": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "url": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        }
-                      }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pe_db_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "display_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "schema_class": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ref_entities": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "identifier": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "UniProt accession (e.g. Q10MK5)"
+                    },
+                    "display_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "gene_names": {
+                      "type": [
+                        "array",
+                        "null"
+                      ]
+                    },
+                    "schema_class": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "url": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -449,47 +375,36 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "stId": {
-                    "type": "string"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "children": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "stId": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "children": {
+                "type": [
+                  "array",
+                  "null"
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/pombase_tools.json
+++ b/src/tooluniverse/data/pombase_tools.json
@@ -31,103 +31,81 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "systematic_id": {
-                  "type": "string"
-                },
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "product": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "taxon_id": {
-                  "type": "integer"
-                },
-                "uniprot_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "deletion_viability": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "biogrid_id": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "interpro_domains": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "db": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "interpro_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "start": {
-                        "type": "integer"
-                      },
-                      "end": {
-                        "type": "integer"
-                      }
-                    }
+            "systematic_id": {
+              "type": "string"
+            },
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "product": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "taxon_id": {
+              "type": "integer"
+            },
+            "uniprot_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "deletion_viability": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "biogrid_id": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "interpro_domains": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "db": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "interpro_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "start": {
+                    "type": "integer"
+                  },
+                  "end": {
+                    "type": "integer"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -182,61 +160,33 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "systematic_id": {
-                    "type": "string"
-                  },
-                  "gene_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "product": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "uniprot_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_genes": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "systematic_id": {
+                "type": "string"
+              },
+              "gene_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "product": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "uniprot_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -284,79 +234,57 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "systematic_id": {
-                  "type": "string"
-                },
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "deletion_viability": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "phenotype_count": {
-                  "type": "integer"
-                },
-                "phenotypes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "term_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "term_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "evidence": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "cv_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "systematic_id": {
+              "type": "string"
+            },
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "deletion_viability": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "phenotype_count": {
+              "type": "integer"
+            },
+            "phenotypes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "term_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "evidence": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cv_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -402,70 +330,48 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "systematic_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "ortholog_count": {
-                  "type": "integer"
-                },
-                "orthologs": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "ortholog_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "ortholog_taxon_id": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "ortholog_species": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "systematic_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ortholog_count": {
+              "type": "integer"
+            },
+            "orthologs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ortholog_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ortholog_taxon_id": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "ortholog_species": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -511,135 +417,113 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "systematic_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "physical_interaction_count": {
-                  "type": "integer"
-                },
-                "physical_interactions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "interactor_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "interactor_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "evidence": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "reference": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "throughput": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "source_database": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "genetic_interaction_count": {
-                  "type": "integer"
-                },
-                "genetic_interactions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "interactor_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "interactor_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "interaction_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "reference": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "throughput": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "source_database": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "systematic_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "physical_interaction_count": {
+              "type": "integer"
+            },
+            "physical_interactions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "interactor_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "interactor_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "evidence": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "reference": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "throughput": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_database": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
+            "genetic_interaction_count": {
+              "type": "integer"
+            },
+            "genetic_interactions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "interactor_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "interactor_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "interaction_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "reference": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "throughput": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source_database": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -685,82 +569,60 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "systematic_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "aspect_counts": {
-                  "type": "object"
-                },
-                "go_term_count": {
-                  "type": "integer"
-                },
-                "go_terms": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "term_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "term_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "aspect": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "aspect_code": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "is_not": {
-                        "type": "boolean"
-                      }
-                    }
+            "systematic_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "aspect_counts": {
+              "type": "object"
+            },
+            "go_term_count": {
+              "type": "integer"
+            },
+            "go_terms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "term_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "aspect": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "aspect_code": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "is_not": {
+                    "type": "boolean"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/ppi_tools.json
+++ b/src/tooluniverse/data/ppi_tools.json
@@ -53,23 +53,52 @@
       "return_format": "TSV"
     },
     "return_schema": {
-      "type": "object",
-      "properties": {
-        "data": {
-          "type": "array",
-          "description": "Array of interaction records parsed from TSV"
-        },
-        "header": {
-          "type": "array",
-          "items": {
+      "type": "array",
+      "description": "Array of interaction records parsed from the STRING TSV network response.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "stringId_A": {
             "type": "string"
           },
-          "description": "Column headers from the TSV response"
+          "stringId_B": {
+            "type": "string"
+          },
+          "preferredName_A": {
+            "type": "string"
+          },
+          "preferredName_B": {
+            "type": "string"
+          },
+          "ncbiTaxonId": {
+            "type": "string"
+          },
+          "score": {
+            "type": "string"
+          },
+          "nscore": {
+            "type": "string"
+          },
+          "fscore": {
+            "type": "string"
+          },
+          "pscore": {
+            "type": "string"
+          },
+          "ascore": {
+            "type": "string"
+          },
+          "escore": {
+            "type": "string"
+          },
+          "dscore": {
+            "type": "string"
+          },
+          "tscore": {
+            "type": "string"
+          }
         },
-        "error": {
-          "type": "string",
-          "description": "Error message if request failed"
-        }
+        "additionalProperties": true
       }
     },
     "implementation": {

--- a/src/tooluniverse/data/prosite_tools.json
+++ b/src/tooluniverse/data/prosite_tools.json
@@ -26,71 +26,57 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": ["string", "null"],
-                  "description": "PROSITE accession (e.g., PS00001)"
-                },
-                "entry_name": {
-                  "type": ["string", "null"],
-                  "description": "Entry name (e.g., ASN_GLYCOSYLATION)"
-                },
-                "entry_type": {
-                  "type": ["string", "null"],
-                  "description": "Entry type: PATTERN or MATRIX (profile)"
-                },
-                "description": {
-                  "type": ["string", "null"],
-                  "description": "Human-readable description of the motif/domain"
-                },
-                "pattern": {
-                  "type": ["string", "null"],
-                  "description": "Consensus pattern in PROSITE syntax (e.g., N-{P}-[ST]-{P} for glycosylation)"
-                },
-                "dates": {
-                  "type": ["string", "null"],
-                  "description": "Creation and update dates"
-                },
-                "comments": {
-                  "type": ["string", "null"],
-                  "description": "Additional annotations and site information"
-                },
-                "functional_sites": {
-                  "type": "array",
-                  "items": {"type": "string"},
-                  "description": "Functional site positions annotated in the pattern"
-                },
-                "skip_flag": {
-                  "type": ["boolean", "null"],
-                  "description": "If true, pattern matches frequent sites (may produce many hits)"
-                },
-                "prorule": {
-                  "type": ["string", "null"],
-                  "description": "ProRule reference ID"
-                },
-                "documentation": {
-                  "type": ["string", "null"],
-                  "description": "PDOC documentation reference"
-                },
-                "cross_references": {
-                  "type": "array",
-                  "items": {"type": "string"},
-                  "description": "UniProt protein cross-references (first 20)"
-                }
-              }
+            "accession": {
+              "type": ["string", "null"],
+              "description": "PROSITE accession (e.g., PS00001)"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "accession": {"type": "string"},
-                "url": {"type": "string"}
-              }
+            "entry_name": {
+              "type": ["string", "null"],
+              "description": "Entry name (e.g., ASN_GLYCOSYLATION)"
+            },
+            "entry_type": {
+              "type": ["string", "null"],
+              "description": "Entry type: PATTERN or MATRIX (profile)"
+            },
+            "description": {
+              "type": ["string", "null"],
+              "description": "Human-readable description of the motif/domain"
+            },
+            "pattern": {
+              "type": ["string", "null"],
+              "description": "Consensus pattern in PROSITE syntax (e.g., N-{P}-[ST]-{P} for glycosylation)"
+            },
+            "dates": {
+              "type": ["string", "null"],
+              "description": "Creation and update dates"
+            },
+            "comments": {
+              "type": ["string", "null"],
+              "description": "Additional annotations and site information"
+            },
+            "functional_sites": {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "Functional site positions annotated in the pattern"
+            },
+            "skip_flag": {
+              "type": ["boolean", "null"],
+              "description": "If true, pattern matches frequent sites (may produce many hits)"
+            },
+            "prorule": {
+              "type": ["string", "null"],
+              "description": "ProRule reference ID"
+            },
+            "documentation": {
+              "type": ["string", "null"],
+              "description": "PDOC documentation reference"
+            },
+            "cross_references": {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "UniProt protein cross-references (first 20)"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
@@ -131,50 +117,37 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "accession": {
-                    "type": ["string", "null"],
-                    "description": "PROSITE accession (e.g., PS00028)"
-                  },
-                  "name": {
-                    "type": ["string", "null"],
-                    "description": "Full entry name"
-                  },
-                  "short_name": {
-                    "type": ["string", "null"],
-                    "description": "Short entry name identifier"
-                  },
-                  "type": {
-                    "type": ["string", "null"],
-                    "description": "Entry type (conserved_site, domain, active_site, etc.)"
-                  },
-                  "source_database": {
-                    "type": ["string", "null"],
-                    "description": "Source database (prosite)"
-                  },
-                  "integrated_into": {
-                    "type": ["string", "null"],
-                    "description": "InterPro entry this PROSITE pattern is integrated into"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "query": {"type": "string"},
-                "total_results": {"type": "integer"}
+          "type": "array",
+          "description": "Array of PROSITE entries matching the search query",
+          "items": {
+            "type": "object",
+            "properties": {
+              "accession": {
+                "type": ["string", "null"],
+                "description": "PROSITE accession (e.g., PS00028)"
+              },
+              "name": {
+                "type": ["string", "null"],
+                "description": "Full entry name"
+              },
+              "short_name": {
+                "type": ["string", "null"],
+                "description": "Short entry name identifier"
+              },
+              "type": {
+                "type": ["string", "null"],
+                "description": "Entry type (conserved_site, domain, active_site, etc.)"
+              },
+              "source_database": {
+                "type": ["string", "null"],
+                "description": "Source database (prosite)"
+              },
+              "integrated_into": {
+                "type": ["string", "null"],
+                "description": "InterPro entry this PROSITE pattern is integrated into"
               }
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
@@ -220,51 +193,37 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "signature_accession": {
-                    "type": ["string", "null"],
-                    "description": "PROSITE accession of the matched pattern (e.g., PS50862)"
-                  },
-                  "signature_name": {
-                    "type": ["string", "null"],
-                    "description": "PROSITE entry name of the matched pattern"
-                  },
-                  "start": {
-                    "type": ["integer", "null"],
-                    "description": "Start position of the match in the sequence"
-                  },
-                  "end": {
-                    "type": ["integer", "null"],
-                    "description": "End position of the match"
-                  },
-                  "score": {
-                    "type": ["number", "null"],
-                    "description": "Match score (for profiles; null for patterns)"
-                  },
-                  "level": {
-                    "type": ["integer", "null"],
-                    "description": "Confidence level (0 = strong match)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "sequence_length": {"type": "integer"},
-                "total_matches": {"type": "integer"},
-                "skip_frequent_patterns": {"type": "boolean"}
+          "type": "array",
+          "description": "Array of PROSITE signature matches found in the scanned sequence",
+          "items": {
+            "type": "object",
+            "properties": {
+              "signature_accession": {
+                "type": ["string", "null"],
+                "description": "PROSITE accession of the matched pattern (e.g., PS50862)"
+              },
+              "signature_name": {
+                "type": ["string", "null"],
+                "description": "PROSITE entry name of the matched pattern"
+              },
+              "start": {
+                "type": ["integer", "null"],
+                "description": "Start position of the match in the sequence"
+              },
+              "end": {
+                "type": ["integer", "null"],
+                "description": "End position of the match"
+              },
+              "score": {
+                "type": ["number", "null"],
+                "description": "Match score (for profiles; null for patterns)"
+              },
+              "level": {
+                "type": ["integer", "null"],
+                "description": "Confidence level (0 = strong match)"
               }
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/proteinsplus_tools.json
+++ b/src/tooluniverse/data/proteinsplus_tools.json
@@ -36,32 +36,21 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "pockets": {
-                  "type": "array",
-                  "description": "Array of predicted binding pockets (URLs or objects)",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "object"
-                      }
-                    ]
+            "pockets": {
+              "type": "array",
+              "description": "Array of predicted binding pockets (URLs or objects)",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
                   }
-                }
+                ]
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -148,61 +137,50 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "result_table": {
-                  "type": "string",
-                  "description": "CSV formatted table with pocket predictions"
-                },
-                "pockets": {
-                  "type": "array",
-                  "description": "Array of predicted pockets with subpocket information",
-                  "items": {
-                    "oneOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "object"
-                      }
-                    ]
+            "result_table": {
+              "type": "string",
+              "description": "CSV formatted table with pocket predictions"
+            },
+            "pockets": {
+              "type": "array",
+              "description": "Array of predicted pockets with subpocket information",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object"
                   }
-                },
-                "residues": {
-                  "oneOf": [
-                    {
-                      "type": "object"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  ],
-                  "description": "Mapping of pockets to constituent residues, or array of URL strings"
-                },
-                "descriptor_explanation": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "URL or explanations of calculated descriptors"
-                },
-                "parameters": {
-                  "type": "object",
-                  "description": "Parameters used for the analysis"
-                }
+                ]
               }
             },
-            "metadata": {
-              "type": "object"
+            "residues": {
+              "oneOf": [
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "description": "Mapping of pockets to constituent residues, or array of URL strings"
+            },
+            "descriptor_explanation": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "URL or explanations of calculated descriptors"
+            },
+            "parameters": {
+              "type": "object",
+              "description": "Parameters used for the analysis"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -270,30 +248,19 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "result_png_picture": {
-                  "type": "string",
-                  "description": "URL or base64-encoded PNG interaction diagram"
-                },
-                "result_pdf_picture": {
-                  "type": "string",
-                  "description": "URL or base64-encoded PDF interaction diagram"
-                },
-                "result_svg_picture": {
-                  "type": "string",
-                  "description": "URL or base64-encoded SVG interaction diagram"
-                }
-              }
+            "result_png_picture": {
+              "type": "string",
+              "description": "URL or base64-encoded PNG interaction diagram"
             },
-            "metadata": {
-              "type": "object"
+            "result_pdf_picture": {
+              "type": "string",
+              "description": "URL or base64-encoded PDF interaction diagram"
+            },
+            "result_svg_picture": {
+              "type": "string",
+              "description": "URL or base64-encoded SVG interaction diagram"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -409,51 +376,40 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "result_table": {
-                  "type": "string",
-                  "description": "CSV table with binding site similarity analysis results"
+            "result_table": {
+              "type": "string",
+              "description": "CSV table with binding site similarity analysis results"
+            },
+            "pdb_files": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Aligned PDB structures in the ensemble"
+            },
+            "ligands": {
+              "oneOf": [
+                {
+                  "type": "string"
                 },
-                "pdb_files": {
+                {
                   "type": "array",
                   "items": {
                     "type": "string"
-                  },
-                  "description": "Aligned PDB structures in the ensemble"
-                },
-                "ligands": {
-                  "oneOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  ],
-                  "description": "SDF file URL(s) with aligned ligands"
-                },
-                "alignment": {
-                  "type": "string",
-                  "description": "Text file with sequence alignment"
-                },
-                "parameters": {
-                  "type": "object",
-                  "description": "Parameters used for the analysis"
+                  }
                 }
-              }
+              ],
+              "description": "SDF file URL(s) with aligned ligands"
             },
-            "metadata": {
-              "type": "object"
+            "alignment": {
+              "type": "string",
+              "description": "Text file with sequence alignment"
+            },
+            "parameters": {
+              "type": "object",
+              "description": "Parameters used for the analysis"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -524,42 +480,31 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "complex": {
-                  "type": "string",
-                  "description": "URL to overall protein-ligand complex quality metrics"
-                },
-                "activesite": {
-                  "type": "string",
-                  "description": "URL to active site geometry and quality assessment"
-                },
-                "ligands": {
-                  "type": "string",
-                  "description": "URL to individual ligand quality assessments"
-                },
-                "smarts": {
-                  "type": "string",
-                  "description": "URL to SMARTS patterns for chemical validation"
-                },
-                "hetcode": {
-                  "type": "string",
-                  "description": "Heteroatom residue codes found"
-                },
-                "config": {
-                  "type": "string",
-                  "description": "URL to configuration and parameters used"
-                }
-              }
+            "complex": {
+              "type": "string",
+              "description": "URL to overall protein-ligand complex quality metrics"
             },
-            "metadata": {
-              "type": "object"
+            "activesite": {
+              "type": "string",
+              "description": "URL to active site geometry and quality assessment"
+            },
+            "ligands": {
+              "type": "string",
+              "description": "URL to individual ligand quality assessments"
+            },
+            "smarts": {
+              "type": "string",
+              "description": "URL to SMARTS patterns for chemical validation"
+            },
+            "hetcode": {
+              "type": "string",
+              "description": "Heteroatom residue codes found"
+            },
+            "config": {
+              "type": "string",
+              "description": "URL to configuration and parameters used"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -626,30 +571,19 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "protein": {
-                  "type": "string",
-                  "description": "URL to the protonated protein structure (PDB format)"
-                },
-                "ligands": {
-                  "type": "string",
-                  "description": "URL to the protonated ligand(s) (SDF format)"
-                },
-                "log": {
-                  "type": "string",
-                  "description": "URL to the ProtoSS log file"
-                }
-              }
+            "protein": {
+              "type": "string",
+              "description": "URL to the protonated protein structure (PDB format)"
             },
-            "metadata": {
-              "type": "object"
+            "ligands": {
+              "type": "string",
+              "description": "URL to the protonated ligand(s) (SDF format)"
+            },
+            "log": {
+              "type": "string",
+              "description": "URL to the ProtoSS log file"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/pubchem_bioassay_tools.json
+++ b/src/tooluniverse/data/pubchem_bioassay_tools.json
@@ -31,95 +31,76 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "aid": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Assay ID"
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Assay name"
-                },
-                "source_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Data source organization"
-                },
-                "description": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Assay description paragraphs"
-                },
-                "protocol": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Experimental protocol"
-                },
-                "comment": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Additional comments"
-                },
-                "targets": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "molecule_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "gi": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
-                  },
-                  "description": "Molecular targets of the assay"
-                }
-              }
+            "aid": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Assay ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "aid": {
-                  "type": "string"
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Assay name"
+            },
+            "source_name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Data source organization"
+            },
+            "description": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Assay description paragraphs"
+            },
+            "protocol": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Experimental protocol"
+            },
+            "comment": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Additional comments"
+            },
+            "targets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "molecule_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "gi": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
                 }
-              }
+              },
+              "description": "Molecular targets of the assay"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -167,80 +148,55 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_assays": {
-                  "type": "integer",
-                  "description": "Total number of assays targeting this gene"
-                },
-                "assays": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "aid": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "source": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "method": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "targets": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "has_score": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      }
+            "total_assays": {
+              "type": "integer",
+              "description": "Total number of assays targeting this gene"
+            },
+            "assays": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "aid": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "method": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "targets": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "has_score": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "gene_symbol": {
-                  "type": "string"
-                },
-                "total_assays": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -288,120 +244,101 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "aid": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "source": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "source_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "method": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "has_score": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                },
-                "number_of_tids": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "targets": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "gene_targets": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "gene_symbols": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "gene_ids": {
-                        "type": "array",
-                        "items": {
-                          "type": "integer"
-                        }
-                      },
-                      "protein_names": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                },
-                "description": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
+            "aid": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "method": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "has_score": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "number_of_tids": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "targets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "aid": {
-                  "type": "string"
+            "gene_targets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "gene_symbols": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "gene_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "protein_names": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
+            },
+            "description": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -428,7 +365,10 @@
           "description": "PubChem BioAssay ID (AID). Examples: 504832 (malaria qHTS, 305803 rows), 1259393 (TSHR counter screen)."
         },
         "max_rows": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Maximum number of compound rows to return in the payload (default 1000, max 100000). total_rows always reports the true full count regardless of this cap."
         }
       },
@@ -455,61 +395,36 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "aid": {
-                  "type": ["integer", "string"],
-                  "description": "Assay ID"
-                },
-                "columns": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Column headers (AID, SID, CID, Activity Outcome, Target Accession, Target GeneID, Activity Value [uM], Activity Name, ...)"
-                },
-                "total_rows": {
-                  "type": "integer",
-                  "description": "Total number of compound rows in the assay (full count, not capped)"
-                },
-                "returned_rows": {
-                  "type": "integer",
-                  "description": "Number of rows actually returned in this payload"
-                },
-                "rows": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  },
-                  "description": "Per-compound rows keyed by column header. Each row maps each column name to its cell value (SID, CID, Activity Outcome, Activity Value [uM], etc.)."
-                }
-              }
+            "aid": {
+              "type": [
+                "integer",
+                "string"
+              ],
+              "description": "Assay ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "aid": {
-                  "type": "string"
-                },
-                "total_rows": {
-                  "type": "integer"
-                },
-                "returned_rows": {
-                  "type": "integer"
-                },
-                "truncated": {
-                  "type": "boolean"
-                }
-              }
+            "columns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Column headers (AID, SID, CID, Activity Outcome, Target Accession, Target GeneID, Activity Value [uM], Activity Name, ...)"
+            },
+            "total_rows": {
+              "type": "integer",
+              "description": "Total number of compound rows in the assay (full count, not capped)"
+            },
+            "returned_rows": {
+              "type": "integer",
+              "description": "Number of rows actually returned in this payload"
+            },
+            "rows": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "description": "Per-compound rows keyed by column header. Each row maps each column name to its cell value (SID, CID, Activity Outcome, Activity Value [uM], etc.)."
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/pubchem_tox_tools.json
+++ b/src/tooluniverse/data/pubchem_tox_tools.json
@@ -1,527 +1,648 @@
 [
-    {
-        "name": "PubChemTox_get_ghs_classification",
-        "description": "Get GHS (Globally Harmonized System) hazard classification for a chemical compound from PubChem. Returns hazard pictograms, signal words (Danger/Warning), GHS hazard statements (e.g., H301 'Toxic if swallowed'), and precautionary statements. GHS is the UN system for identifying hazardous chemicals. Can look up by PubChem CID or compound name. For example, arsenic (CID 5359596) has pictograms for Acute Toxic and Environmental Hazard with signal word 'Danger', while aspirin (CID 2244) has signal word 'Warning' with H302 'Harmful if swallowed'. Use this to assess chemical hazards and safety requirements.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "cid": {
-                    "type": ["integer", "null"],
-                    "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 2244 (aspirin), 702 (ethanol), 5462309 (cadmium), 24524 (formaldehyde)."
-                },
-                "compound_name": {
-                    "type": ["string", "null"],
-                    "description": "Compound name (used if cid is not provided). Examples: 'arsenic', 'aspirin', 'formaldehyde', 'benzene', 'mercury'."
-                }
-            },
-            "required": []
+  {
+    "name": "PubChemTox_get_ghs_classification",
+    "description": "Get GHS (Globally Harmonized System) hazard classification for a chemical compound from PubChem. Returns hazard pictograms, signal words (Danger/Warning), GHS hazard statements (e.g., H301 'Toxic if swallowed'), and precautionary statements. GHS is the UN system for identifying hazardous chemicals. Can look up by PubChem CID or compound name. For example, arsenic (CID 5359596) has pictograms for Acute Toxic and Environmental Hazard with signal word 'Danger', while aspirin (CID 2244) has signal word 'Warning' with H302 'Harmful if swallowed'. Use this to assess chemical hazards and safety requirements.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "cid": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 2244 (aspirin), 702 (ethanol), 5462309 (cadmium), 24524 (formaldehyde)."
         },
-        "fields": {
-            "endpoint": "ghs_classification"
-        },
-        "type": "PubChemToxTool",
-        "test_examples": [
-            {
-                "cid": 2244
-            },
-            {
-                "compound_name": "arsenic"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "cid": {"type": "integer", "description": "PubChem Compound ID"},
-                                "compound_name": {"type": "string", "description": "Compound name from PubChem record"},
-                                "ghs_classification": {
-                                    "type": "array",
-                                    "description": "GHS hazard classification entries",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {"type": "string", "description": "Classification field name (Pictogram, Signal, GHS Hazard Statements, etc.)"},
-                                            "value": {"type": "string", "description": "Classification value"},
-                                            "pictogram_labels": {
-                                                "type": "array",
-                                                "description": "Pictogram labels if applicable",
-                                                "items": {"type": "string"}
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+        "compound_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Compound name (used if cid is not provided). Examples: 'arsenic', 'aspirin', 'formaldehyde', 'benzene', 'mercury'."
         }
+      },
+      "required": []
     },
-    {
-        "name": "PubChemTox_get_toxicity_values",
-        "description": "Get non-human toxicity values (LD50, LC50, etc.) for a chemical compound from PubChem. Returns lethal dose/concentration data from animal studies, typically including LD50 (dose lethal to 50% of test animals) values for different species and routes of exposure. Data sourced from HSDB (Hazardous Substances Data Bank) and other toxicological databases. For example, aspirin (CID 2244) has LD50 values of 1800 mg/kg (rabbit, oral) and 1500 mg/kg (rat, oral). Arsenic (CID 5359596) has much lower LD50 values indicating higher toxicity. Use this to assess acute toxicity and compare chemical hazard levels.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "cid": {
-                    "type": ["integer", "null"],
-                    "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 2244 (aspirin), 702 (ethanol), 887 (methanol)."
-                },
-                "compound_name": {
-                    "type": ["string", "null"],
-                    "description": "Compound name (used if cid is not provided). Examples: 'aspirin', 'methanol', 'caffeine', 'lead'."
-                }
-            },
-            "required": []
-        },
-        "fields": {
-            "endpoint": "toxicity_values"
-        },
-        "type": "PubChemToxTool",
-        "test_examples": [
-            {
-                "cid": 2244
-            },
-            {
-                "compound_name": "caffeine"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "cid": {"type": "integer"},
-                                "compound_name": {"type": "string"},
-                                "toxicity_values_count": {"type": "integer", "description": "Number of toxicity values found"},
-                                "toxicity_values": {
-                                    "type": "array",
-                                    "description": "LD50/LC50 values and other toxicity measurements",
-                                    "items": {"type": "string"}
-                                }
-                            }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
+    "fields": {
+      "endpoint": "ghs_classification"
     },
-    {
-        "name": "PubChemTox_get_ecotoxicity_values",
-        "description": "Get aquatic/environmental ecotoxicity values for a chemical compound from PubChem (PUG View 'Ecotoxicity Values' heading under Ecological Information). Returns LC50/EC50 lethal- and effect-concentration data for aquatic and environmental organisms such as fish, crustaceans (shrimp, crabs), and protozoa, sourced largely from HSDB. Use this to assess environmental/aquatic hazard, distinct from PubChemTox_get_toxicity_values which returns mammalian LD50/LC50 lab-animal data. Example: benzene (CID 241) returns entries like 'LC50; Species: Palaemonetes pugio (grass shrimp); Concentration: 27 ppm for 96 hr' and 'LC50; Cancer magister (crab larvae) 108 ppm 96 hr'.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "cid": {
-                    "type": ["integer", "null"],
-                    "description": "PubChem Compound ID. Examples: 241 (benzene), 887 (methanol), 6228 (atrazine), 2244 (aspirin)."
-                },
-                "compound_name": {
-                    "type": ["string", "null"],
-                    "description": "Compound name (used if cid is not provided). Examples: 'benzene', 'toluene', 'atrazine', 'chlorpyrifos'."
+    "type": "PubChemToxTool",
+    "test_examples": [
+      {
+        "cid": 2244
+      },
+      {
+        "compound_name": "arsenic"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cid": {
+              "type": "integer",
+              "description": "PubChem Compound ID"
+            },
+            "compound_name": {
+              "type": "string",
+              "description": "Compound name from PubChem record"
+            },
+            "ghs_classification": {
+              "type": "array",
+              "description": "GHS hazard classification entries",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Classification field name (Pictogram, Signal, GHS Hazard Statements, etc.)"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "Classification value"
+                  },
+                  "pictogram_labels": {
+                    "type": "array",
+                    "description": "Pictogram labels if applicable",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
                 }
-            },
-            "required": []
-        },
-        "fields": {
-            "endpoint": "ecotoxicity_values"
-        },
-        "type": "PubChemToxTool",
-        "test_examples": [
-            {
-                "cid": 241
-            },
-            {
-                "compound_name": "toluene"
+              }
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "cid": {"type": "integer"},
-                                "compound_name": {"type": "string"},
-                                "ecotoxicity_values_count": {"type": "integer", "description": "Number of ecotoxicity value entries found"},
-                                "ecotoxicity_values": {
-                                    "type": "array",
-                                    "description": "Aquatic/environmental LC50/EC50 value strings (species, concentration, duration)",
-                                    "items": {"type": "string"}
-                                }
-                            }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
-    },
-    {
-        "name": "PubChemTox_get_human_toxicity_values",
-        "description": "Get human toxicity values for a chemical compound from PubChem (PUG View 'Human Toxicity Values' heading under Toxicological Information). Returns human-specific lethality and exposure data such as estimated fatal oral doses, fatal air concentrations, and IDLH ('Immediately Dangerous to Life and Health') thresholds, sourced largely from HSDB. Use this for human exposure / occupational-safety endpoints, distinct from PubChemTox_get_toxicity_values which returns animal LD50/LC50 data. Example: benzene (CID 241) returns 'Estimated oral doses from 9-30 g have proved fatal.', a fatal air concentration of '66,000 mg/cu m (20,000 ppm) ... fatal in man within 5-10 minutes', and 'Immediately dangerous to life and health = 500 ppm'.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "cid": {
-                    "type": ["integer", "null"],
-                    "description": "PubChem Compound ID. Examples: 241 (benzene), 887 (methanol), 702 (ethanol), 6326 (hydrogen cyanide)."
-                },
-                "compound_name": {
-                    "type": ["string", "null"],
-                    "description": "Compound name (used if cid is not provided). Examples: 'benzene', 'methanol', 'carbon monoxide', 'hydrogen sulfide'."
-                }
-            },
-            "required": []
+          }
         },
-        "fields": {
-            "endpoint": "human_toxicity_values"
-        },
-        "type": "PubChemToxTool",
-        "test_examples": [
-            {
-                "cid": 241
-            },
-            {
-                "compound_name": "methanol"
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "cid": {"type": "integer"},
-                                "compound_name": {"type": "string"},
-                                "human_toxicity_values_count": {"type": "integer", "description": "Number of human toxicity value entries found"},
-                                "human_toxicity_values": {
-                                    "type": "array",
-                                    "description": "Human lethal dose / IDLH / fatal exposure threshold strings",
-                                    "items": {"type": "string"}
-                                }
-                            }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
+          },
+          "required": [
+            "error"
+          ]
         }
-    },
-    {
-        "name": "PubChemTox_get_carcinogen_classification",
-        "description": "Get carcinogen classification data for a chemical compound from PubChem. Returns classifications from authoritative bodies including IARC (International Agency for Research on Cancer), NTP (National Toxicology Program), EPA, and others. IARC groups: Group 1 (Carcinogenic to humans), Group 2A (Probably carcinogenic), Group 2B (Possibly carcinogenic), Group 3 (Not classifiable). For example, arsenic (CID 5359596) is IARC Group 1 (Carcinogenic to humans), benzene (CID 241) is also Group 1, while caffeine (CID 2519) is Group 3. Use this to assess cancer risk associated with chemical exposure.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "cid": {
-                    "type": ["integer", "null"],
-                    "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 241 (benzene), 24524 (formaldehyde), 5462309 (cadmium)."
-                },
-                "compound_name": {
-                    "type": ["string", "null"],
-                    "description": "Compound name (used if cid is not provided). Examples: 'arsenic', 'benzene', 'formaldehyde', 'vinyl chloride'."
-                }
-            },
-            "required": []
-        },
-        "fields": {
-            "endpoint": "carcinogen_classification"
-        },
-        "type": "PubChemToxTool",
-        "test_examples": [
-            {
-                "cid": 5359596
-            },
-            {
-                "compound_name": "benzene"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "cid": {"type": "integer"},
-                                "compound_name": {"type": "string"},
-                                "classification_count": {"type": "integer", "description": "Number of classification entries"},
-                                "classifications": {
-                                    "type": "array",
-                                    "description": "Carcinogen classification entries from various sources",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "source": {"type": ["string", "null"], "description": "Source organization (e.g., IARC, NTP)"},
-                                            "classification": {"type": "string", "description": "Classification text"}
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
-    },
-    {
-        "name": "PubChemTox_get_target_organs",
-        "description": "Get the target organs affected by a toxic chemical compound from PubChem. Returns the organs and body systems known to be damaged by exposure to the chemical, based on toxicological studies and clinical evidence. For example, arsenic (CID 5359596) targets cardiovascular, dermal, endocrine, gastrointestinal, hematological, neurological, and renal systems, as well as liver, kidneys, skin, lungs, and lymphatic system. Lead (CID 5352425) primarily targets the nervous system, kidneys, and hematological system. Use this to understand which body systems are at risk from chemical exposure.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "cid": {
-                    "type": ["integer", "null"],
-                    "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 5352425 (lead), 23978 (mercury), 5462309 (cadmium)."
-                },
-                "compound_name": {
-                    "type": ["string", "null"],
-                    "description": "Compound name (used if cid is not provided). Examples: 'arsenic', 'lead', 'mercury', 'cadmium', 'chromium'."
-                }
-            },
-            "required": []
-        },
-        "fields": {
-            "endpoint": "target_organs"
-        },
-        "type": "PubChemToxTool",
-        "test_examples": [
-            {
-                "cid": 5359596
-            },
-            {
-                "compound_name": "lead"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "cid": {"type": "integer"},
-                                "compound_name": {"type": "string"},
-                                "target_organs_count": {"type": "integer"},
-                                "target_organs": {
-                                    "type": "array",
-                                    "description": "Affected organs and body systems",
-                                    "items": {"type": "string"}
-                                }
-                            }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
-    },
-    {
-        "name": "PubChemTox_get_acute_effects",
-        "description": "Get acute toxicity effects for a chemical compound from PubChem. Returns documented acute (short-term) health effects from exposure, including symptoms, clinical observations, and effects from different exposure routes (oral, inhalation, dermal). Data comes from toxicological databases and clinical case reports. For example, arsenic acute effects include severe gastrointestinal damage, cardiovascular collapse, and multi-organ failure. Methanol (CID 887) causes visual disturbances, metabolic acidosis, and CNS depression. Use this to understand immediate health risks from chemical exposure.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "cid": {
-                    "type": ["integer", "null"],
-                    "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 887 (methanol), 702 (ethanol), 241 (benzene)."
-                },
-                "compound_name": {
-                    "type": ["string", "null"],
-                    "description": "Compound name (used if cid is not provided). Examples: 'arsenic', 'methanol', 'cyanide', 'chlorine'."
-                }
-            },
-            "required": []
-        },
-        "fields": {
-            "endpoint": "acute_effects"
-        },
-        "type": "PubChemToxTool",
-        "test_examples": [
-            {
-                "cid": 5359596
-            },
-            {
-                "compound_name": "methanol"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "cid": {"type": "integer"},
-                                "compound_name": {"type": "string"},
-                                "effects_count": {"type": "integer"},
-                                "acute_effects": {
-                                    "type": "array",
-                                    "description": "Acute toxicity effects",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "source": {"type": ["string", "null"]},
-                                            "effect": {"type": "string", "description": "Description of the acute effect"}
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
-    },
-    {
-        "name": "PubChemTox_get_toxicity_summary",
-        "description": "Get a comprehensive toxicity data summary for a chemical compound from PubChem. Returns an overview of all available toxicity data sections and subsections, including previews of each data type. This acts as a table of contents for all toxicological data available in PubChem for a compound. Sections include: Toxicological Information (EPA IRIS, hepatotoxicity, carcinogen classification, exposure routes, target organs, LD50 values, human/non-human toxicity excerpts), and Ecological Information (environmental screening levels, environmental fate, exposure routes). Use this as a first step to understand what toxicity data is available before querying specific sections.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "cid": {
-                    "type": ["integer", "null"],
-                    "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 2244 (aspirin), 241 (benzene), 702 (ethanol)."
-                },
-                "compound_name": {
-                    "type": ["string", "null"],
-                    "description": "Compound name (used if cid is not provided). Examples: 'arsenic', 'benzene', 'formaldehyde', 'acetaminophen'."
-                }
-            },
-            "required": []
-        },
-        "fields": {
-            "endpoint": "toxicity_summary"
-        },
-        "type": "PubChemToxTool",
-        "test_examples": [
-            {
-                "cid": 5359596
-            },
-            {
-                "compound_name": "benzene"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "cid": {"type": "integer"},
-                                "compound_name": {"type": "string"},
-                                "toxicity_sections": {
-                                    "type": "array",
-                                    "description": "Toxicity data sections with subsection details",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "section": {"type": "string", "description": "Main section name"},
-                                            "topics": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "heading": {"type": "string"},
-                                                        "info_count": {"type": "integer", "description": "Number of data entries in this topic"},
-                                                        "preview": {"type": ["string", "null"], "description": "Preview of first data entry"}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {"type": "object"}
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {"type": "string"}
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
+      ]
     }
+  },
+  {
+    "name": "PubChemTox_get_toxicity_values",
+    "description": "Get non-human toxicity values (LD50, LC50, etc.) for a chemical compound from PubChem. Returns lethal dose/concentration data from animal studies, typically including LD50 (dose lethal to 50% of test animals) values for different species and routes of exposure. Data sourced from HSDB (Hazardous Substances Data Bank) and other toxicological databases. For example, aspirin (CID 2244) has LD50 values of 1800 mg/kg (rabbit, oral) and 1500 mg/kg (rat, oral). Arsenic (CID 5359596) has much lower LD50 values indicating higher toxicity. Use this to assess acute toxicity and compare chemical hazard levels.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "cid": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 2244 (aspirin), 702 (ethanol), 887 (methanol)."
+        },
+        "compound_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Compound name (used if cid is not provided). Examples: 'aspirin', 'methanol', 'caffeine', 'lead'."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "endpoint": "toxicity_values"
+    },
+    "type": "PubChemToxTool",
+    "test_examples": [
+      {
+        "cid": 2244
+      },
+      {
+        "compound_name": "caffeine"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cid": {
+              "type": "integer"
+            },
+            "compound_name": {
+              "type": "string"
+            },
+            "toxicity_values_count": {
+              "type": "integer",
+              "description": "Number of toxicity values found"
+            },
+            "toxicity_values": {
+              "type": "array",
+              "description": "LD50/LC50 values and other toxicity measurements",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "PubChemTox_get_ecotoxicity_values",
+    "description": "Get aquatic/environmental ecotoxicity values for a chemical compound from PubChem (PUG View 'Ecotoxicity Values' heading under Ecological Information). Returns LC50/EC50 lethal- and effect-concentration data for aquatic and environmental organisms such as fish, crustaceans (shrimp, crabs), and protozoa, sourced largely from HSDB. Use this to assess environmental/aquatic hazard, distinct from PubChemTox_get_toxicity_values which returns mammalian LD50/LC50 lab-animal data. Example: benzene (CID 241) returns entries like 'LC50; Species: Palaemonetes pugio (grass shrimp); Concentration: 27 ppm for 96 hr' and 'LC50; Cancer magister (crab larvae) 108 ppm 96 hr'.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "cid": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "PubChem Compound ID. Examples: 241 (benzene), 887 (methanol), 6228 (atrazine), 2244 (aspirin)."
+        },
+        "compound_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Compound name (used if cid is not provided). Examples: 'benzene', 'toluene', 'atrazine', 'chlorpyrifos'."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "endpoint": "ecotoxicity_values"
+    },
+    "type": "PubChemToxTool",
+    "test_examples": [
+      {
+        "cid": 241
+      },
+      {
+        "compound_name": "toluene"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cid": {
+              "type": "integer"
+            },
+            "compound_name": {
+              "type": "string"
+            },
+            "ecotoxicity_values_count": {
+              "type": "integer",
+              "description": "Number of ecotoxicity value entries found"
+            },
+            "ecotoxicity_values": {
+              "type": "array",
+              "description": "Aquatic/environmental LC50/EC50 value strings (species, concentration, duration)",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "PubChemTox_get_human_toxicity_values",
+    "description": "Get human toxicity values for a chemical compound from PubChem (PUG View 'Human Toxicity Values' heading under Toxicological Information). Returns human-specific lethality and exposure data such as estimated fatal oral doses, fatal air concentrations, and IDLH ('Immediately Dangerous to Life and Health') thresholds, sourced largely from HSDB. Use this for human exposure / occupational-safety endpoints, distinct from PubChemTox_get_toxicity_values which returns animal LD50/LC50 data. Example: benzene (CID 241) returns 'Estimated oral doses from 9-30 g have proved fatal.', a fatal air concentration of '66,000 mg/cu m (20,000 ppm) ... fatal in man within 5-10 minutes', and 'Immediately dangerous to life and health = 500 ppm'.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "cid": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "PubChem Compound ID. Examples: 241 (benzene), 887 (methanol), 702 (ethanol), 6326 (hydrogen cyanide)."
+        },
+        "compound_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Compound name (used if cid is not provided). Examples: 'benzene', 'methanol', 'carbon monoxide', 'hydrogen sulfide'."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "endpoint": "human_toxicity_values"
+    },
+    "type": "PubChemToxTool",
+    "test_examples": [
+      {
+        "cid": 241
+      },
+      {
+        "compound_name": "methanol"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cid": {
+              "type": "integer"
+            },
+            "compound_name": {
+              "type": "string"
+            },
+            "human_toxicity_values_count": {
+              "type": "integer",
+              "description": "Number of human toxicity value entries found"
+            },
+            "human_toxicity_values": {
+              "type": "array",
+              "description": "Human lethal dose / IDLH / fatal exposure threshold strings",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "PubChemTox_get_carcinogen_classification",
+    "description": "Get carcinogen classification data for a chemical compound from PubChem. Returns classifications from authoritative bodies including IARC (International Agency for Research on Cancer), NTP (National Toxicology Program), EPA, and others. IARC groups: Group 1 (Carcinogenic to humans), Group 2A (Probably carcinogenic), Group 2B (Possibly carcinogenic), Group 3 (Not classifiable). For example, arsenic (CID 5359596) is IARC Group 1 (Carcinogenic to humans), benzene (CID 241) is also Group 1, while caffeine (CID 2519) is Group 3. Use this to assess cancer risk associated with chemical exposure.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "cid": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 241 (benzene), 24524 (formaldehyde), 5462309 (cadmium)."
+        },
+        "compound_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Compound name (used if cid is not provided). Examples: 'arsenic', 'benzene', 'formaldehyde', 'vinyl chloride'."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "endpoint": "carcinogen_classification"
+    },
+    "type": "PubChemToxTool",
+    "test_examples": [
+      {
+        "cid": 5359596
+      },
+      {
+        "compound_name": "benzene"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cid": {
+              "type": "integer"
+            },
+            "compound_name": {
+              "type": "string"
+            },
+            "classification_count": {
+              "type": "integer",
+              "description": "Number of classification entries"
+            },
+            "classifications": {
+              "type": "array",
+              "description": "Carcinogen classification entries from various sources",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Source organization (e.g., IARC, NTP)"
+                  },
+                  "classification": {
+                    "type": "string",
+                    "description": "Classification text"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "PubChemTox_get_target_organs",
+    "description": "Get the target organs affected by a toxic chemical compound from PubChem. Returns the organs and body systems known to be damaged by exposure to the chemical, based on toxicological studies and clinical evidence. For example, arsenic (CID 5359596) targets cardiovascular, dermal, endocrine, gastrointestinal, hematological, neurological, and renal systems, as well as liver, kidneys, skin, lungs, and lymphatic system. Lead (CID 5352425) primarily targets the nervous system, kidneys, and hematological system. Use this to understand which body systems are at risk from chemical exposure.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "cid": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 5352425 (lead), 23978 (mercury), 5462309 (cadmium)."
+        },
+        "compound_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Compound name (used if cid is not provided). Examples: 'arsenic', 'lead', 'mercury', 'cadmium', 'chromium'."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "endpoint": "target_organs"
+    },
+    "type": "PubChemToxTool",
+    "test_examples": [
+      {
+        "cid": 5359596
+      },
+      {
+        "compound_name": "lead"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cid": {
+              "type": "integer"
+            },
+            "compound_name": {
+              "type": "string"
+            },
+            "target_organs_count": {
+              "type": "integer"
+            },
+            "target_organs": {
+              "type": "array",
+              "description": "Affected organs and body systems",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "PubChemTox_get_acute_effects",
+    "description": "Get acute toxicity effects for a chemical compound from PubChem. Returns documented acute (short-term) health effects from exposure, including symptoms, clinical observations, and effects from different exposure routes (oral, inhalation, dermal). Data comes from toxicological databases and clinical case reports. For example, arsenic acute effects include severe gastrointestinal damage, cardiovascular collapse, and multi-organ failure. Methanol (CID 887) causes visual disturbances, metabolic acidosis, and CNS depression. Use this to understand immediate health risks from chemical exposure.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "cid": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 887 (methanol), 702 (ethanol), 241 (benzene)."
+        },
+        "compound_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Compound name (used if cid is not provided). Examples: 'arsenic', 'methanol', 'cyanide', 'chlorine'."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "endpoint": "acute_effects"
+    },
+    "type": "PubChemToxTool",
+    "test_examples": [
+      {
+        "cid": 5359596
+      },
+      {
+        "compound_name": "methanol"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cid": {
+              "type": "integer"
+            },
+            "compound_name": {
+              "type": "string"
+            },
+            "effects_count": {
+              "type": "integer"
+            },
+            "acute_effects": {
+              "type": "array",
+              "description": "Acute toxicity effects",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "effect": {
+                    "type": "string",
+                    "description": "Description of the acute effect"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "PubChemTox_get_toxicity_summary",
+    "description": "Get a comprehensive toxicity data summary for a chemical compound from PubChem. Returns an overview of all available toxicity data sections and subsections, including previews of each data type. This acts as a table of contents for all toxicological data available in PubChem for a compound. Sections include: Toxicological Information (EPA IRIS, hepatotoxicity, carcinogen classification, exposure routes, target organs, LD50 values, human/non-human toxicity excerpts), and Ecological Information (environmental screening levels, environmental fate, exposure routes). Use this as a first step to understand what toxicity data is available before querying specific sections.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "cid": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "PubChem Compound ID. Examples: 5359596 (arsenic), 2244 (aspirin), 241 (benzene), 702 (ethanol)."
+        },
+        "compound_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Compound name (used if cid is not provided). Examples: 'arsenic', 'benzene', 'formaldehyde', 'acetaminophen'."
+        }
+      },
+      "required": []
+    },
+    "fields": {
+      "endpoint": "toxicity_summary"
+    },
+    "type": "PubChemToxTool",
+    "test_examples": [
+      {
+        "cid": 5359596
+      },
+      {
+        "compound_name": "benzene"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cid": {
+              "type": "integer"
+            },
+            "compound_name": {
+              "type": "string"
+            },
+            "toxicity_sections": {
+              "type": "array",
+              "description": "Toxicity data sections with subsection details",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "section": {
+                    "type": "string",
+                    "description": "Main section name"
+                  },
+                  "topics": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "heading": {
+                          "type": "string"
+                        },
+                        "info_count": {
+                          "type": "integer",
+                          "description": "Number of data entries in this topic"
+                        },
+                        "preview": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "description": "Preview of first data entry"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/quickgo_tools.json
+++ b/src/tooluniverse/data/quickgo_tools.json
@@ -51,100 +51,75 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "go_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "GO term accession"
-                  },
-                  "go_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "GO term name"
-                  },
-                  "go_aspect": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "GO aspect (biological_process, etc.)"
-                  },
-                  "gene_product_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene product accession"
-                  },
-                  "symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene symbol"
-                  },
-                  "qualifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Annotation qualifier"
-                  },
-                  "go_evidence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Evidence code (IDA, IMP, ISS, etc.)"
-                  },
-                  "assigned_by": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Database that made the annotation"
-                  },
-                  "reference": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Literature reference"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "total_annotations": {
-                  "type": "integer"
-                },
-                "page_size": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "go_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "GO term accession"
+              },
+              "go_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "GO term name"
+              },
+              "go_aspect": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "GO aspect (biological_process, etc.)"
+              },
+              "gene_product_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene product accession"
+              },
+              "symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene symbol"
+              },
+              "qualifier": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Annotation qualifier"
+              },
+              "go_evidence": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Evidence code (IDA, IMP, ISS, etc.)"
+              },
+              "assigned_by": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Database that made the annotation"
+              },
+              "reference": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Literature reference"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -206,100 +181,75 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_product_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene product accession"
-                  },
-                  "symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Gene symbol"
-                  },
-                  "go_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "GO term accession"
-                  },
-                  "go_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "GO term name"
-                  },
-                  "go_aspect": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "GO aspect"
-                  },
-                  "qualifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Annotation qualifier"
-                  },
-                  "go_evidence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Evidence code"
-                  },
-                  "taxon_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "NCBI taxonomy ID"
-                  },
-                  "assigned_by": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Annotating database"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query_go_id": {
-                  "type": "string"
-                },
-                "total_annotations": {
-                  "type": "integer"
-                },
-                "page_size": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene_product_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene product accession"
+              },
+              "symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Gene symbol"
+              },
+              "go_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "GO term accession"
+              },
+              "go_name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "GO term name"
+              },
+              "go_aspect": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "GO aspect"
+              },
+              "qualifier": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Annotation qualifier"
+              },
+              "go_evidence": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Evidence code"
+              },
+              "taxon_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "NCBI taxonomy ID"
+              },
+              "assigned_by": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Annotating database"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -347,109 +297,87 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "description": "GO term accession"
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "GO term name"
-                },
-                "definition": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "GO term definition text"
-                },
-                "aspect": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "GO aspect (biological_process, etc.)"
-                },
-                "is_obsolete": {
-                  "type": "boolean",
-                  "description": "Whether the term is obsolete"
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "id": {
+              "type": "string",
+              "description": "GO term accession"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "GO term name"
+            },
+            "definition": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "GO term definition text"
+            },
+            "aspect": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "GO aspect (biological_process, etc.)"
+            },
+            "is_obsolete": {
+              "type": "boolean",
+              "description": "Whether the term is obsolete"
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
-                },
-                "xrefs": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "db_code": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "db_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "usage": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Usage constraints"
-                },
-                "num_children": {
-                  "type": "integer",
-                  "description": "Number of child terms"
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "found": {
-                  "type": "boolean"
+            "xrefs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "db_code": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "db_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
               }
+            },
+            "usage": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Usage constraints"
+            },
+            "num_children": {
+              "type": "integer",
+              "description": "Number of child terms"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -495,56 +423,34 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "Child GO term accession"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Child term name"
-                  },
-                  "relation": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Relationship type (is_a, part_of, regulates, etc.)"
-                  },
-                  "has_children": {
-                    "type": "boolean",
-                    "description": "Whether this child has further children"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "parent_go_id": {
-                  "type": "string"
-                },
-                "num_children": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Child GO term accession"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Child term name"
+              },
+              "relation": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Relationship type (is_a, part_of, regulates, etc.)"
+              },
+              "has_children": {
+                "type": "boolean",
+                "description": "Whether this child has further children"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/rcsb_advanced_search_tools.json
+++ b/src/tooluniverse/data/rcsb_advanced_search_tools.json
@@ -86,65 +86,26 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "pdb_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "4-character PDB identifier"
-                  },
-                  "score": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Search relevance score"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_count": {
-                  "type": "integer",
-                  "description": "Total matching structures in PDB"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "start": {
-                  "type": "integer",
-                  "description": "Zero-based index of the first returned result"
-                },
-                "rows": {
-                  "type": "integer",
-                  "description": "Effective page size after clamping to max_rows_per_page"
-                },
-                "max_rows_per_page": {
-                  "type": "integer",
-                  "description": "Maximum results returnable in one call"
-                },
-                "note": {
-                  "type": "string",
-                  "description": "Present when the result set was clamped or more pages remain; explains how to reach the rest"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pdb_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "4-character PDB identifier"
+              },
+              "score": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Search relevance score"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -159,7 +120,9 @@
         }
       ]
     },
-    "aliases": ["RCSB_search"]
+    "aliases": [
+      "RCSB_search"
+    ]
   },
   {
     "name": "RCSBAdvSearch_search_by_motif",
@@ -211,84 +174,40 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "pdb_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "4-character PDB identifier"
-                  },
-                  "entity_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Polymer entity number within the PDB entry"
-                  },
-                  "identifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Full identifier (PDB_ID + entity, e.g., '1A1F_3')"
-                  },
-                  "score": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Match score"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_count": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "start": {
-                  "type": "integer",
-                  "description": "Zero-based index of the first returned result"
-                },
-                "rows": {
-                  "type": "integer",
-                  "description": "Effective page size after clamping to max_rows_per_page"
-                },
-                "max_rows_per_page": {
-                  "type": "integer",
-                  "description": "Maximum results returnable in one call"
-                },
-                "note": {
-                  "type": "string",
-                  "description": "Present when the result set was clamped or more pages remain; explains how to reach the rest"
-                },
-                "pattern": {
-                  "type": "string"
-                },
-                "pattern_type": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pdb_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "4-character PDB identifier"
+              },
+              "entity_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Polymer entity number within the PDB entry"
+              },
+              "identifier": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Full identifier (PDB_ID + entity, e.g., '1A1F_3')"
+              },
+              "score": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Match score"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/rcsb_data_tools.json
+++ b/src/tooluniverse/data/rcsb_data_tools.json
@@ -206,106 +206,84 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "pdb_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "PDB entry ID"
-                },
-                "assembly_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Assembly identifier"
-                },
-                "oligomeric_details": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Oligomeric state description (e.g., 'tetrameric', 'dimeric')"
-                },
-                "oligomeric_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Number of polymer chains in assembly"
-                },
-                "method_details": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Method used to determine assembly (PISA, author, etc.)"
-                },
-                "polymer_entity_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Unique polymer entity types in assembly"
-                },
-                "nonpolymer_entity_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Unique non-polymer entity types in assembly"
-                },
-                "polymer_entity_instance_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Total polymer chain instances in assembly"
-                },
-                "total_polymer_monomer_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Total residues across all polymer chains"
-                },
-                "operations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  },
-                  "description": "Symmetry operations defining the assembly"
-                },
-                "evidence": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  },
-                  "description": "Evidence for biological relevance"
-                }
-              }
+            "pdb_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "PDB entry ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "pdb_id": {
-                  "type": "string"
-                },
-                "assembly_id": {
-                  "type": "string"
-                }
-              }
+            "assembly_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Assembly identifier"
+            },
+            "oligomeric_details": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Oligomeric state description (e.g., 'tetrameric', 'dimeric')"
+            },
+            "oligomeric_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of polymer chains in assembly"
+            },
+            "method_details": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Method used to determine assembly (PISA, author, etc.)"
+            },
+            "polymer_entity_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Unique polymer entity types in assembly"
+            },
+            "nonpolymer_entity_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Unique non-polymer entity types in assembly"
+            },
+            "polymer_entity_instance_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Total polymer chain instances in assembly"
+            },
+            "total_polymer_monomer_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Total residues across all polymer chains"
+            },
+            "operations": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "description": "Symmetry operations defining the assembly"
+            },
+            "evidence": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "description": "Evidence for biological relevance"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -360,85 +338,63 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "pdb_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "PDB entry ID"
-                },
-                "entity_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Entity identifier"
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Chemical name of the non-polymer entity"
-                },
-                "comp_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Chemical component ID (e.g., HEM, ATP, ZN)"
-                },
-                "formula_weight": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "description": "Formula weight in kDa"
-                },
-                "details": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Additional details"
-                },
-                "auth_asym_ids": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Chain IDs where this entity is found"
-                },
-                "annotations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  },
-                  "description": "Database annotations (DrugBank, etc.)"
-                }
-              }
+            "pdb_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "PDB entry ID"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "pdb_id": {
-                  "type": "string"
-                },
-                "entity_id": {
-                  "type": "string"
-                }
-              }
+            "entity_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Entity identifier"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Chemical name of the non-polymer entity"
+            },
+            "comp_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Chemical component ID (e.g., HEM, ATP, ZN)"
+            },
+            "formula_weight": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Formula weight in kDa"
+            },
+            "details": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Additional details"
+            },
+            "auth_asym_ids": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Chain IDs where this entity is found"
+            },
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              },
+              "description": "Database annotations (DrugBank, etc.)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/rcsb_graphql_tools.json
+++ b/src/tooluniverse/data/rcsb_graphql_tools.json
@@ -37,156 +37,131 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "pdb_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "PDB identifier"
-                  },
-                  "title": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Structure title"
-                  },
-                  "resolution": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Resolution in Angstroms"
-                  },
-                  "molecular_weight_kda": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Molecular weight in kDa"
-                  },
-                  "atom_count": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of deposited atoms"
-                  },
-                  "polymer_entity_count": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of polymer entities"
-                  },
-                  "nonpolymer_entity_count": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of non-polymer entities (ligands)"
-                  },
-                  "experimental_method": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Experimental method"
-                  },
-                  "deposit_date": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Deposition date"
-                  },
-                  "release_date": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Initial release date"
-                  },
-                  "citation_pubmed_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "PubMed ID of primary citation"
-                  },
-                  "citation_title": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Title of primary citation"
-                  },
-                  "citation_journal": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Journal abbreviation"
-                  },
-                  "citation_year": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Publication year"
-                  },
-                  "unit_cell_a": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Unit cell dimension a"
-                  },
-                  "unit_cell_b": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Unit cell dimension b"
-                  },
-                  "unit_cell_c": {
-                    "type": [
-                      "number",
-                      "null"
-                    ],
-                    "description": "Unit cell dimension c"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "requested_ids": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "returned": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pdb_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "PDB identifier"
+              },
+              "title": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Structure title"
+              },
+              "resolution": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Resolution in Angstroms"
+              },
+              "molecular_weight_kda": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Molecular weight in kDa"
+              },
+              "atom_count": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of deposited atoms"
+              },
+              "polymer_entity_count": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of polymer entities"
+              },
+              "nonpolymer_entity_count": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of non-polymer entities (ligands)"
+              },
+              "experimental_method": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Experimental method"
+              },
+              "deposit_date": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Deposition date"
+              },
+              "release_date": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Initial release date"
+              },
+              "citation_pubmed_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "PubMed ID of primary citation"
+              },
+              "citation_title": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Title of primary citation"
+              },
+              "citation_journal": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Journal abbreviation"
+              },
+              "citation_year": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Publication year"
+              },
+              "unit_cell_a": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Unit cell dimension a"
+              },
+              "unit_cell_b": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Unit cell dimension b"
+              },
+              "unit_cell_c": {
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "description": "Unit cell dimension c"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -234,136 +209,114 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "comp_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Chemical component identifier"
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Chemical name"
-                },
-                "formula": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Molecular formula"
-                },
-                "formula_weight": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "description": "Molecular weight in Da"
-                },
-                "type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Component type (non-polymer, peptide-like, etc.)"
-                },
-                "parent_comp_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Parent component if modified residue"
-                },
-                "inchikey": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "InChIKey structural identifier"
-                },
-                "smiles": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "SMILES chemical notation"
-                },
-                "initial_release_date": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Date first released in PDB"
-                },
-                "targets": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Target protein name"
-                      },
-                      "actions": {
-                        "type": [
-                          "array",
-                          "null"
-                        ],
-                        "description": "Target actions (inhibitor, substrate, etc.)"
-                      },
-                      "provenance": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Data source (e.g., DrugBank)"
-                      },
-                      "accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Target accession (e.g., UniProt ID)"
-                      },
-                      "database": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Reference database name"
-                      }
-                    }
-                  },
-                  "description": "Known drug targets for this compound"
-                }
-              }
+            "comp_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Chemical component identifier"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "comp_id": {
-                  "type": "string"
-                },
-                "target_count": {
-                  "type": "integer"
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Chemical name"
+            },
+            "formula": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Molecular formula"
+            },
+            "formula_weight": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Molecular weight in Da"
+            },
+            "type": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Component type (non-polymer, peptide-like, etc.)"
+            },
+            "parent_comp_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Parent component if modified residue"
+            },
+            "inchikey": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "InChIKey structural identifier"
+            },
+            "smiles": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "SMILES chemical notation"
+            },
+            "initial_release_date": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Date first released in PDB"
+            },
+            "targets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Target protein name"
+                  },
+                  "actions": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "description": "Target actions (inhibitor, substrate, etc.)"
+                  },
+                  "provenance": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Data source (e.g., DrugBank)"
+                  },
+                  "accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Target accession (e.g., UniProt ID)"
+                  },
+                  "database": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Reference database name"
+                  }
                 }
-              }
+              },
+              "description": "Known drug targets for this compound"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -425,134 +378,109 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "entity_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Entity identifier (e.g., '4HHB_1')"
-                  },
-                  "description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Polymer description"
-                  },
-                  "chain_ids": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Comma-separated chain IDs"
-                  },
-                  "polymer_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Polymer type (Protein, DNA, RNA, etc.)"
-                  },
-                  "entity_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Entity type (polypeptide(L), polyribonucleotide, etc.)"
-                  },
-                  "sequence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "One-letter amino acid sequence"
-                  },
-                  "sequence_length": {
-                    "type": "integer",
-                    "description": "Length of the sequence"
-                  },
-                  "annotations": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": [
-                            "string",
-                            "null"
-                          ],
-                          "description": "Annotation ID (Pfam, GO, etc.)"
-                        },
-                        "type": {
-                          "type": [
-                            "string",
-                            "null"
-                          ],
-                          "description": "Annotation type (Pfam, GO, etc.)"
-                        },
-                        "description": {
-                          "type": [
-                            "string",
-                            "null"
-                          ],
-                          "description": "Annotation description"
-                        }
-                      }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "entity_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Entity identifier (e.g., '4HHB_1')"
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Polymer description"
+              },
+              "chain_ids": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Comma-separated chain IDs"
+              },
+              "polymer_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Polymer type (Protein, DNA, RNA, etc.)"
+              },
+              "entity_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Entity type (polypeptide(L), polyribonucleotide, etc.)"
+              },
+              "sequence": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "One-letter amino acid sequence"
+              },
+              "sequence_length": {
+                "type": "integer",
+                "description": "Length of the sequence"
+              },
+              "annotations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Annotation ID (Pfam, GO, etc.)"
                     },
-                    "description": "Domain/family/GO annotations"
-                  },
-                  "source_organisms": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "scientific_name": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "ncbi_taxonomy_id": {
-                          "type": [
-                            "integer",
-                            "null"
-                          ]
-                        }
-                      }
+                    "type": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Annotation type (Pfam, GO, etc.)"
                     },
-                    "description": "Source organism(s)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "requested_ids": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
+                    "description": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Annotation description"
+                    }
                   }
                 },
-                "returned": {
-                  "type": "integer"
-                }
+                "description": "Domain/family/GO annotations"
+              },
+              "source_organisms": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "scientific_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "ncbi_taxonomy_id": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "description": "Source organism(s)"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/rdkit_cheminfo_tools.json
+++ b/src/tooluniverse/data/rdkit_cheminfo_tools.json
@@ -10,82 +10,111 @@
           "description": "SMILES string of the molecule. Examples: 'CC(=O)Oc1ccccc1C(=O)O' (aspirin), 'c1ccc(cc1)C(=N)N' (benzamidine, has PosIonizable + HBD)."
         },
         "include_features": {
-          "type": ["array", "null"],
-          "items": {"type": "string"},
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
           "description": "List of feature types to extract (default: all). Options: 'HBD', 'HBA', 'Aromatic', 'Hydrophobic', 'PosIonizable', 'NegIonizable'."
         }
       },
-      "required": ["smiles"]
+      "required": [
+        "smiles"
+      ]
     },
     "fields": {
       "endpoint": "pharmacophore_features"
     },
     "type": "RDKitCheminfoTool",
     "test_examples": [
-      {"smiles": "CC(=O)Oc1ccccc1C(=O)O"},
-      {"smiles": "c1ccc(cc1)C(=N)N"},
-      {"smiles": "CC(=O)Oc1ccccc1C(=O)O", "include_features": ["HBD", "HBA", "Aromatic"]}
+      {
+        "smiles": "CC(=O)Oc1ccccc1C(=O)O"
+      },
+      {
+        "smiles": "c1ccc(cc1)C(=N)N"
+      },
+      {
+        "smiles": "CC(=O)Oc1ccccc1C(=O)O",
+        "include_features": [
+          "HBD",
+          "HBA",
+          "Aromatic"
+        ]
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "data": {
+            "smiles": {
+              "type": "string"
+            },
+            "pharmacophore_features": {
+              "type": "object",
+              "description": "Feature name \u2192 {count, atom_indices} mapping"
+            },
+            "feature_counts": {
+              "type": "object",
+              "description": "Feature name \u2192 integer count"
+            },
+            "feature_centers_3d": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "Feature name \u2192 [x, y, z] center coordinates (from MMFF conformer)"
+            },
+            "interpretation": {
               "type": "object",
               "properties": {
-                "smiles": {"type": "string"},
-                "pharmacophore_features": {
-                  "type": "object",
-                  "description": "Feature name → {count, atom_indices} mapping"
+                "HBD_count": {
+                  "type": "integer"
                 },
-                "feature_counts": {
-                  "type": "object",
-                  "description": "Feature name → integer count"
+                "HBA_count": {
+                  "type": "integer"
                 },
-                "feature_centers_3d": {
-                  "type": ["object", "null"],
-                  "description": "Feature name → [x, y, z] center coordinates (from MMFF conformer)"
+                "aromatic_atom_count": {
+                  "type": "integer"
                 },
-                "interpretation": {
-                  "type": "object",
-                  "properties": {
-                    "HBD_count": {"type": "integer"},
-                    "HBA_count": {"type": "integer"},
-                    "aromatic_atom_count": {"type": "integer"},
-                    "hydrophobic_atom_count": {"type": "integer"},
-                    "hbd_hba_ratio": {"type": ["number", "null"]},
-                    "3d_available": {"type": "boolean"},
-                    "note": {"type": "string"}
-                  }
+                "hydrophobic_atom_count": {
+                  "type": "integer"
+                },
+                "hbd_hba_ratio": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "3d_available": {
+                  "type": "boolean"
+                },
+                "note": {
+                  "type": "string"
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {"type": "string"},
-                "method": {"type": "string"},
-                "3d_method": {"type": ["string", "null"]},
-                "reference": {"type": "string"}
-              }
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }
   },
   {
     "name": "RDKit_matched_molecular_pair",
-    "description": "Find the Matched Molecular Pair (MMP) transformation between two SMILES compounds using the Hussain-Rea single-cut fragmentation algorithm (rdMMPA). Identifies the maximal common core scaffold and the side-chain substituents that differ between compound A and compound B. Returns: common core SMILES, side-chain A, side-chain B, transformation string (sidechain_A → sidechain_B), Tanimoto similarity (Morgan r=2), and property deltas (ΔMW, ΔcLogP, ΔHBD, ΔHBA, ΔTPSA). Essential for SAR analysis: understand what structural change caused a property improvement or potency shift.",
+    "description": "Find the Matched Molecular Pair (MMP) transformation between two SMILES compounds using the Hussain-Rea single-cut fragmentation algorithm (rdMMPA). Identifies the maximal common core scaffold and the side-chain substituents that differ between compound A and compound B. Returns: common core SMILES, side-chain A, side-chain B, transformation string (sidechain_A \u2192 sidechain_B), Tanimoto similarity (Morgan r=2), and property deltas (\u0394MW, \u0394cLogP, \u0394HBD, \u0394HBA, \u0394TPSA). Essential for SAR analysis: understand what structural change caused a property improvement or potency shift.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -98,7 +127,10 @@
           "description": "SMILES of compound B (analog/modified compound). Example: 'CC(=O)Nc1ccc(F)cc1' (fluorine analog of paracetamol)."
         }
       },
-      "required": ["smiles_a", "smiles_b"]
+      "required": [
+        "smiles_a",
+        "smiles_b"
+      ]
     },
     "fields": {
       "endpoint": "matched_molecular_pair"
@@ -123,59 +155,110 @@
         {
           "type": "object",
           "properties": {
-            "data": {
+            "smiles_a": {
+              "type": "string",
+              "description": "Canonical SMILES of compound A"
+            },
+            "smiles_b": {
+              "type": "string",
+              "description": "Canonical SMILES of compound B"
+            },
+            "tanimoto_similarity": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "similarity_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "mmp_analysis": {
               "type": "object",
               "properties": {
-                "smiles_a": {"type": "string", "description": "Canonical SMILES of compound A"},
-                "smiles_b": {"type": "string", "description": "Canonical SMILES of compound B"},
-                "tanimoto_similarity": {"type": ["number", "null"]},
-                "similarity_label": {"type": ["string", "null"]},
-                "mmp_analysis": {
-                  "type": "object",
-                  "properties": {
-                    "is_mmp": {"type": ["boolean", "null"]},
-                    "common_core_smiles": {"type": ["string", "null"]},
-                    "side_chain_a": {"type": ["string", "null"]},
-                    "side_chain_b": {"type": ["string", "null"]},
-                    "transformation": {"type": ["string", "null"]},
-                    "n_common_cores_found": {"type": ["integer", "null"]},
-                    "note": {"type": ["string", "null"]}
-                  }
+                "is_mmp": {
+                  "type": [
+                    "boolean",
+                    "null"
+                  ]
                 },
-                "property_deltas": {
-                  "type": "object",
-                  "properties": {
-                    "description": {"type": "string"},
-                    "deltas": {"type": "object"},
-                    "formatted": {"type": "object"}
-                  }
+                "common_core_smiles": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "descriptors": {
-                  "type": "object",
-                  "properties": {
-                    "compound_a": {"type": "object"},
-                    "compound_b": {"type": "object"}
-                  }
+                "side_chain_a": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "side_chain_b": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "transformation": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "n_common_cores_found": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "note": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               }
             },
-            "metadata": {
+            "property_deltas": {
               "type": "object",
               "properties": {
-                "source": {"type": "string"},
-                "method": {"type": "string"},
-                "reference": {"type": "string"}
+                "description": {
+                  "type": "string"
+                },
+                "deltas": {
+                  "type": "object"
+                },
+                "formatted": {
+                  "type": "object"
+                }
+              }
+            },
+            "descriptors": {
+              "type": "object",
+              "properties": {
+                "compound_a": {
+                  "type": "object"
+                },
+                "compound_b": {
+                  "type": "object"
+                }
               }
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/rdkit_cheminfo_tools.json
+++ b/src/tooluniverse/data/rdkit_cheminfo_tools.json
@@ -71,16 +71,16 @@
               "type": "object",
               "properties": {
                 "HBD_count": {
-                  "type": "integer"
+                  "type": ["integer", "null"]
                 },
                 "HBA_count": {
-                  "type": "integer"
+                  "type": ["integer", "null"]
                 },
                 "aromatic_atom_count": {
-                  "type": "integer"
+                  "type": ["integer", "null"]
                 },
                 "hydrophobic_atom_count": {
-                  "type": "integer"
+                  "type": ["integer", "null"]
                 },
                 "hbd_hba_ratio": {
                   "type": [

--- a/src/tooluniverse/data/reactome_analysis_tools.json
+++ b/src/tooluniverse/data/reactome_analysis_tools.json
@@ -53,138 +53,116 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "token": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Analysis token for retrieving results later"
-                },
-                "analysis_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "OVERREPRESENTATION or EXPRESSION"
-                },
-                "projection": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ],
-                  "description": "Whether projection was applied"
-                },
-                "identifiers_not_found": {
-                  "type": "integer",
-                  "description": "Count of unmatched identifiers"
-                },
-                "pathways_found": {
-                  "type": "integer",
-                  "description": "Total enriched pathways"
-                },
-                "pathways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pathway_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "species": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "is_disease": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      },
-                      "is_lowest_level": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      },
-                      "entities_found": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "entities_total": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "entities_ratio": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "p_value": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "fdr": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "reactions_found": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "reactions_total": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+            "token": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Analysis token for retrieving results later"
+            },
+            "analysis_type": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "OVERREPRESENTATION or EXPRESSION"
+            },
+            "projection": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Whether projection was applied"
+            },
+            "identifiers_not_found": {
+              "type": "integer",
+              "description": "Count of unmatched identifiers"
+            },
+            "pathways_found": {
+              "type": "integer",
+              "description": "Total enriched pathways"
+            },
+            "pathways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pathway_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "species": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "is_disease": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "is_lowest_level": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "entities_found": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "entities_total": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "entities_ratio": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "p_value": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "fdr": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "reactions_found": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "reactions_total": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_pathways": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -247,121 +225,99 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "token": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "analysis_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "projection": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                },
-                "identifiers_not_found": {
-                  "type": "integer"
-                },
-                "pathways_found": {
-                  "type": "integer"
-                },
-                "pathways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pathway_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "species": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "is_disease": {
-                        "type": [
-                          "boolean",
-                          "null"
-                        ]
-                      },
-                      "entities_found": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "entities_total": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "p_value": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "fdr": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "reactions_found": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "reactions_total": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+            "token": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "analysis_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "projection": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "identifiers_not_found": {
+              "type": "integer"
+            },
+            "pathways_found": {
+              "type": "integer"
+            },
+            "pathways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pathway_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "species": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "is_disease": {
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "entities_found": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "entities_total": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "p_value": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "fdr": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "reactions_found": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "reactions_total": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_pathways": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -432,104 +388,93 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "token": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "analysis_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Expected to be EXPRESSION"
-                },
-                "expression_column_names": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
+            "token": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "analysis_type": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Expected to be EXPRESSION"
+            },
+            "expression_column_names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Names of the submitted expression value columns"
+            },
+            "expression_min": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "expression_max": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "identifiers_not_found": {
+              "type": "integer"
+            },
+            "pathways_found": {
+              "type": "integer"
+            },
+            "pathways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pathway_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
-                  "description": "Names of the submitted expression value columns"
-                },
-                "expression_min": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "expression_max": {
-                  "type": [
-                    "number",
-                    "null"
-                  ]
-                },
-                "identifiers_not_found": {
-                  "type": "integer"
-                },
-                "pathways_found": {
-                  "type": "integer"
-                },
-                "pathways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pathway_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "entities_found": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "entities_exp": {
-                        "type": [
-                          "array",
-                          "null"
-                        ],
-                        "items": {
-                          "type": "number"
-                        },
-                        "description": "Matched expression values overlaid on this pathway"
-                      },
-                      "p_value": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "fdr": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "entities_found": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "entities_exp": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "type": "number"
+                    },
+                    "description": "Matched expression values overlaid on this pathway"
+                  },
+                  "p_value": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "fdr": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -594,75 +539,64 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "token": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "analysis_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Expected to be SPECIES_COMPARISON"
-                },
-                "identifiers_not_found": {
-                  "type": "integer"
-                },
-                "pathways_found": {
-                  "type": "integer"
-                },
-                "pathways": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "pathway_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "entities_found": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "p_value": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "fdr": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "token": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "analysis_type": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Expected to be SPECIES_COMPARISON"
+            },
+            "identifiers_not_found": {
+              "type": "integer"
+            },
+            "pathways_found": {
+              "type": "integer"
+            },
+            "pathways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "pathway_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "entities_found": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "p_value": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "fdr": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -715,58 +649,53 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "pathway": {
-                  "type": "string"
-                },
-                "found": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "total_entities_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "resources": {
-                  "type": "array"
-                },
-                "identifiers": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "exp": {
-                        "type": "array"
-                      },
-                      "mapsTo": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "resource": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "ids": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              }
-                            }
+            "pathway": {
+              "type": "string"
+            },
+            "found": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "total_entities_count": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "resources": {
+              "type": "array"
+            },
+            "identifiers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "exp": {
+                    "type": "array"
+                  },
+                  "mapsTo": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "resource": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "ids": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
                           }
                         }
                       }
@@ -774,14 +703,8 @@
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -822,33 +745,22 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "token": {
-                  "type": "string"
-                },
-                "not_found_count": {
-                  "type": "integer"
-                },
-                "not_found": {
-                  "type": "array",
-                  "items": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
+            "token": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object"
+            "not_found_count": {
+              "type": "integer"
+            },
+            "not_found": {
+              "type": "array",
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -896,45 +808,34 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "token": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "analysis_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "projection": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                },
-                "identifiers_not_found": {
-                  "type": "integer"
-                },
-                "pathways_found": {
-                  "type": "integer"
-                },
-                "pathways": {
-                  "type": "array"
-                }
-              }
+            "token": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "metadata": {
-              "type": "object"
+            "analysis_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "projection": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "identifiers_not_found": {
+              "type": "integer"
+            },
+            "pathways_found": {
+              "type": "integer"
+            },
+            "pathways": {
+              "type": "array"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/reactome_content_tools.json
+++ b/src/tooluniverse/data/reactome_content_tools.json
@@ -1,306 +1,327 @@
 [
-    {
-        "name": "ReactomeContent_search",
-        "description": "Search Reactome for pathways, reactions, and biological entities by keyword. Performs free-text search across Reactome's knowledge base of biological pathways. Supports filtering by species and entity type. Example: searching 'apoptosis' in Homo sapiens returns pathways like R-HSA-109581 (Apoptosis), R-HSA-169911 (Regulation of Apoptosis), R-HSA-9635465 (Suppression of apoptosis). Use this to discover relevant pathways before querying their details.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Search query. Examples: 'apoptosis', 'TP53', 'cell cycle', 'DNA repair', 'insulin signaling'."
-                },
-                "species": {
-                    "type": "string",
-                    "description": "Species name for filtering results. Default: 'Homo sapiens'. Other options: 'Mus musculus', 'Rattus norvegicus', 'Danio rerio', 'Drosophila melanogaster'.",
-                    "default": "Homo sapiens"
-                },
-                "types": {
-                    "type": "string",
-                    "description": "Entity type to search. Options: 'Pathway', 'Reaction', 'Complex', 'Protein', 'SmallMolecule'. Default: 'Pathway'.",
-                    "default": "Pathway"
-                }
-            },
-            "required": [
-                "query"
-            ]
+  {
+    "name": "ReactomeContent_search",
+    "description": "Search Reactome for pathways, reactions, and biological entities by keyword. Performs free-text search across Reactome's knowledge base of biological pathways. Supports filtering by species and entity type. Example: searching 'apoptosis' in Homo sapiens returns pathways like R-HSA-109581 (Apoptosis), R-HSA-169911 (Regulation of Apoptosis), R-HSA-9635465 (Suppression of apoptosis). Use this to discover relevant pathways before querying their details.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Search query. Examples: 'apoptosis', 'TP53', 'cell cycle', 'DNA repair', 'insulin signaling'."
         },
-        "fields": {
-            "endpoint": "search"
+        "species": {
+          "type": "string",
+          "description": "Species name for filtering results. Default: 'Homo sapiens'. Other options: 'Mus musculus', 'Rattus norvegicus', 'Danio rerio', 'Drosophila melanogaster'.",
+          "default": "Homo sapiens"
         },
-        "type": "ReactomeContentTool",
-        "test_examples": [
-            {
-                "query": "apoptosis"
-            },
-            {
-                "query": "DNA repair",
-                "types": "Pathway"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "query": {
-                                    "type": "string",
-                                    "description": "Search query used"
-                                },
-                                "species": {
-                                    "type": "string",
-                                    "description": "Species filter applied"
-                                },
-                                "total_results": {
-                                    "type": "integer",
-                                    "description": "Total number of results"
-                                },
-                                "results": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "type": {
-                                                "type": "string",
-                                                "description": "Entity type (Pathway, Reaction, etc.)"
-                                            },
-                                            "stId": {
-                                                "type": ["string", "null"],
-                                                "description": "Reactome stable identifier"
-                                            },
-                                            "name": {
-                                                "type": ["string", "null"],
-                                                "description": "Entity name"
-                                            },
-                                            "species": {
-                                                "type": "array",
-                                                "description": "Species list"
-                                            },
-                                            "is_disease": {
-                                                "type": "boolean",
-                                                "description": "Whether this is a disease-related pathway"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
+        "types": {
+          "type": "string",
+          "description": "Entity type to search. Options: 'Pathway', 'Reaction', 'Complex', 'Protein', 'SmallMolecule'. Default: 'Pathway'.",
+          "default": "Pathway"
         }
+      },
+      "required": [
+        "query"
+      ]
     },
-    {
-        "name": "ReactomeContent_get_contained_events",
-        "description": "Get all events (sub-pathways and reactions) contained within a Reactome pathway. Decomposes a top-level pathway into its complete hierarchy of sub-pathways and individual biochemical reactions. Returns counts and lists of both pathways and reactions. Example: R-HSA-109581 (Apoptosis) contains 177 events total: 4 major sub-pathways (extrinsic, intrinsic, execution, regulation) plus 173 individual reactions.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "identifier": {
-                    "type": "string",
-                    "description": "Reactome pathway stable identifier. Examples: 'R-HSA-109581' (Apoptosis, 177 events), 'R-HSA-69278' (Cell Cycle), 'R-HSA-73857' (RNA Polymerase II Transcription), 'R-HSA-1640170' (Cell Cycle Checkpoints)."
-                }
-            },
-            "required": [
-                "identifier"
-            ]
-        },
-        "fields": {
-            "endpoint": "contained_events"
-        },
-        "type": "ReactomeContentTool",
-        "test_examples": [
-            {
-                "identifier": "R-HSA-109581"
-            },
-            {
-                "identifier": "R-HSA-6804757"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "identifier": {
-                                    "type": "string",
-                                    "description": "Pathway identifier queried"
-                                },
-                                "total_events": {
-                                    "type": "integer",
-                                    "description": "Total number of contained events"
-                                },
-                                "pathway_count": {
-                                    "type": "integer",
-                                    "description": "Number of sub-pathways"
-                                },
-                                "reaction_count": {
-                                    "type": "integer",
-                                    "description": "Number of individual reactions"
-                                },
-                                "pathways": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "stId": {
-                                                "type": ["string", "null"],
-                                                "description": "Sub-pathway stable ID"
-                                            },
-                                            "name": {
-                                                "type": ["string", "null"],
-                                                "description": "Sub-pathway name"
-                                            },
-                                            "schemaClass": {
-                                                "type": ["string", "null"],
-                                                "description": "Schema class (Pathway)"
-                                            }
-                                        }
-                                    }
-                                },
-                                "reactions": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "stId": {
-                                                "type": ["string", "null"],
-                                                "description": "Reaction stable ID"
-                                            },
-                                            "name": {
-                                                "type": ["string", "null"],
-                                                "description": "Reaction name"
-                                            },
-                                            "schemaClass": {
-                                                "type": ["string", "null"],
-                                                "description": "Schema class (Reaction, BlackBoxEvent, etc.)"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
+    "fields": {
+      "endpoint": "search"
     },
-    {
-        "name": "ReactomeContent_get_enhanced_pathway",
-        "description": "Get enhanced pathway details from Reactome including description, literature references, GO biological process terms, and direct sub-events. Provides richer information than basic pathway lookup by including curated summaries, PubMed references, and Gene Ontology annotations. Example: R-HSA-109581 (Apoptosis) returns a detailed summation, GO:0006915 annotation, 4 sub-pathways (extrinsic, intrinsic, execution, regulation), and key literature references.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "identifier": {
+    "type": "ReactomeContentTool",
+    "test_examples": [
+      {
+        "query": "apoptosis"
+      },
+      {
+        "query": "DNA repair",
+        "types": "Pathway"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "Search query used"
+            },
+            "species": {
+              "type": "string",
+              "description": "Species filter applied"
+            },
+            "total_results": {
+              "type": "integer",
+              "description": "Total number of results"
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
                     "type": "string",
-                    "description": "Reactome pathway stable identifier. Examples: 'R-HSA-109581' (Apoptosis), 'R-HSA-6804757' (Regulation of TP53 Degradation), 'R-HSA-69278' (Cell Cycle), 'R-HSA-168256' (Immune System)."
+                    "description": "Entity type (Pathway, Reaction, etc.)"
+                  },
+                  "stId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Reactome stable identifier"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Entity name"
+                  },
+                  "species": {
+                    "type": "array",
+                    "description": "Species list"
+                  },
+                  "is_disease": {
+                    "type": "boolean",
+                    "description": "Whether this is a disease-related pathway"
+                  }
                 }
-            },
-            "required": [
-                "identifier"
-            ]
-        },
-        "fields": {
-            "endpoint": "enhanced_pathway"
-        },
-        "type": "ReactomeContentTool",
-        "test_examples": [
-            {
-                "identifier": "R-HSA-109581"
-            },
-            {
-                "identifier": "R-HSA-6804757"
+              }
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "identifier": {
-                                    "type": ["string", "null"],
-                                    "description": "Pathway stable ID"
-                                },
-                                "name": {
-                                    "type": ["string", "null"],
-                                    "description": "Pathway display name"
-                                },
-                                "species": {
-                                    "type": ["string", "null"],
-                                    "description": "Species name"
-                                },
-                                "schemaClass": {
-                                    "type": ["string", "null"],
-                                    "description": "Schema class (Pathway)"
-                                },
-                                "summation": {
-                                    "type": ["string", "null"],
-                                    "description": "Curated pathway description/summary"
-                                },
-                                "go_biological_process": {
-                                    "type": ["array", "null"],
-                                    "description": "Associated GO biological process terms"
-                                },
-                                "sub_events": {
-                                    "type": "array",
-                                    "description": "Direct sub-pathways and reactions"
-                                },
-                                "literature": {
-                                    "type": "array",
-                                    "description": "Key literature references with PubMed IDs"
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "ReactomeContent_get_contained_events",
+    "description": "Get all events (sub-pathways and reactions) contained within a Reactome pathway. Decomposes a top-level pathway into its complete hierarchy of sub-pathways and individual biochemical reactions. Returns counts and lists of both pathways and reactions. Example: R-HSA-109581 (Apoptosis) contains 177 events total: 4 major sub-pathways (extrinsic, intrinsic, execution, regulation) plus 173 individual reactions.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "identifier": {
+          "type": "string",
+          "description": "Reactome pathway stable identifier. Examples: 'R-HSA-109581' (Apoptosis, 177 events), 'R-HSA-69278' (Cell Cycle), 'R-HSA-73857' (RNA Polymerase II Transcription), 'R-HSA-1640170' (Cell Cycle Checkpoints)."
+        }
+      },
+      "required": [
+        "identifier"
+      ]
+    },
+    "fields": {
+      "endpoint": "contained_events"
+    },
+    "type": "ReactomeContentTool",
+    "test_examples": [
+      {
+        "identifier": "R-HSA-109581"
+      },
+      {
+        "identifier": "R-HSA-6804757"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "identifier": {
+              "type": "string",
+              "description": "Pathway identifier queried"
+            },
+            "total_events": {
+              "type": "integer",
+              "description": "Total number of contained events"
+            },
+            "pathway_count": {
+              "type": "integer",
+              "description": "Number of sub-pathways"
+            },
+            "reaction_count": {
+              "type": "integer",
+              "description": "Number of individual reactions"
+            },
+            "pathways": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "stId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Sub-pathway stable ID"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Sub-pathway name"
+                  },
+                  "schemaClass": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Schema class (Pathway)"
+                  }
+                }
+              }
+            },
+            "reactions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "stId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Reaction stable ID"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Reaction name"
+                  },
+                  "schemaClass": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Schema class (Reaction, BlackBoxEvent, etc.)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "ReactomeContent_get_enhanced_pathway",
+    "description": "Get enhanced pathway details from Reactome including description, literature references, GO biological process terms, and direct sub-events. Provides richer information than basic pathway lookup by including curated summaries, PubMed references, and Gene Ontology annotations. Example: R-HSA-109581 (Apoptosis) returns a detailed summation, GO:0006915 annotation, 4 sub-pathways (extrinsic, intrinsic, execution, regulation), and key literature references.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "identifier": {
+          "type": "string",
+          "description": "Reactome pathway stable identifier. Examples: 'R-HSA-109581' (Apoptosis), 'R-HSA-6804757' (Regulation of TP53 Degradation), 'R-HSA-69278' (Cell Cycle), 'R-HSA-168256' (Immune System)."
+        }
+      },
+      "required": [
+        "identifier"
+      ]
+    },
+    "fields": {
+      "endpoint": "enhanced_pathway"
+    },
+    "type": "ReactomeContentTool",
+    "test_examples": [
+      {
+        "identifier": "R-HSA-109581"
+      },
+      {
+        "identifier": "R-HSA-6804757"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "identifier": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Pathway stable ID"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Pathway display name"
+            },
+            "species": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Species name"
+            },
+            "schemaClass": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Schema class (Pathway)"
+            },
+            "summation": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Curated pathway description/summary"
+            },
+            "go_biological_process": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "Associated GO biological process terms"
+            },
+            "sub_events": {
+              "type": "array",
+              "description": "Direct sub-pathways and reactions"
+            },
+            "literature": {
+              "type": "array",
+              "description": "Key literature references with PubMed IDs"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/reactome_interactors_tools.json
+++ b/src/tooluniverse/data/reactome_interactors_tools.json
@@ -40,68 +40,57 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "accession": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Query protein UniProt accession"
-                },
-                "total_interactors": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Total number of known interactors"
-                },
-                "interactors": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Interactor UniProt accession"
-                      },
-                      "alias": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Gene name/alias of interactor"
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "description": "Interaction confidence score (0-1, higher = more confident)"
-                      },
-                      "evidences": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ],
-                        "description": "Number of experimental evidences supporting this interaction"
-                      }
-                    }
+            "accession": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Query protein UniProt accession"
+            },
+            "total_interactors": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Total number of known interactors"
+            },
+            "interactors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Interactor UniProt accession"
+                  },
+                  "alias": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Gene name/alias of interactor"
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Interaction confidence score (0-1, higher = more confident)"
+                  },
+                  "evidences": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "description": "Number of experimental evidences supporting this interaction"
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -154,52 +143,41 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "stable_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Reactome pathway stable identifier"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Pathway name"
-                  },
-                  "species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Species name"
-                  },
-                  "is_disease": {
-                    "type": "boolean",
-                    "description": "Whether pathway is disease-associated"
-                  },
-                  "has_diagram": {
-                    "type": "boolean",
-                    "description": "Whether pathway has a diagram available"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "stable_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Reactome pathway stable identifier"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Pathway name"
+              },
+              "species": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Species name"
+              },
+              "is_disease": {
+                "type": "boolean",
+                "description": "Whether pathway is disease-associated"
+              },
+              "has_diagram": {
+                "type": "boolean",
+                "description": "Whether pathway has a diagram available"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -260,71 +238,60 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "stable_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Reactome stable identifier (e.g., R-HSA-69488)"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Entity name"
-                  },
-                  "type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Entity type: Protein, Complex, Reaction, Pathway, etc."
-                  },
-                  "species": {
-                    "type": [
-                      "array",
-                      "null"
-                    ],
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Species list"
-                  },
-                  "exact_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Exact Reactome entity type"
-                  },
-                  "compartment_names": {
-                    "type": [
-                      "array",
-                      "null"
-                    ],
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Cellular compartment locations"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "stable_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Reactome stable identifier (e.g., R-HSA-69488)"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Entity name"
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Entity type: Protein, Complex, Reaction, Pathway, etc."
+              },
+              "species": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "description": "Species list"
+              },
+              "exact_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Exact Reactome entity type"
+              },
+              "compartment_names": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "description": "Cellular compartment locations"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/rgd_strain_tools.json
+++ b/src/tooluniverse/data/rgd_strain_tools.json
@@ -34,98 +34,86 @@
       "operation": "search_strains"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "rgd_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "full_strain_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "substrain": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "strain_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "genetics": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "origin": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "background_strain_rgd_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "research_use": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rgd_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "full_strain_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "substrain": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "strain_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "genetics": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "origin": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "background_strain_rgd_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "research_use": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -175,95 +163,83 @@
       "operation": "get_strain"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "rgd_id": {
+              "type": [
+                "integer",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "rgd_id": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "symbol": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "full_strain_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "substrain": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "strain_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "genetics": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "origin": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "source": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "background_strain_rgd_id": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "research_use": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
+            "symbol": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "full_strain_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "substrain": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "strain_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "genetics": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "origin": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "background_strain_rgd_id": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "research_use": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -317,74 +293,62 @@
       "operation": "get_strain_annotations"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "term": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "term_acc": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "category": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "aspect": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "qualifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "evidence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "data_source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ref_rgd_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "term": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "term_acc": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "category": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "aspect": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "qualifier": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "evidence": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "data_source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ref_rgd_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/rgd_tools.json
+++ b/src/tooluniverse/data/rgd_tools.json
@@ -29,18 +29,7 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "object"
-            },
-            "metadata": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "object"
         },
         {
           "type": "object",
@@ -92,18 +81,7 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array"
-            },
-            "metadata": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "array"
         },
         {
           "type": "object",
@@ -155,18 +133,7 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array"
-            },
-            "metadata": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "array"
         },
         {
           "type": "object",
@@ -209,18 +176,7 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array"
-            },
-            "metadata": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "array"
         },
         {
           "type": "object",
@@ -282,97 +238,60 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "rgd_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "chromosome": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "lod": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "p_value": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "variance": {
-                    "type": [
-                      "number",
-                      "null"
-                    ]
-                  },
-                  "inheritance_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "chromosome": {
-                  "type": "string"
-                },
-                "start": {
-                  "type": "integer"
-                },
-                "stop": {
-                  "type": "integer"
-                },
-                "map_key": {
-                  "type": "integer"
-                },
-                "assembly": {
-                  "type": "string"
-                },
-                "total_qtls": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "source": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rgd_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "chromosome": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "lod": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "p_value": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "variance": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "inheritance_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -458,26 +377,7 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "description": "Gene record (symbol mode) or list of genes in region (region mode)."
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "mode": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "description": "Gene record (symbol mode) or list of genes in region (region mode)."
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/rhea_tools.json
+++ b/src/tooluniverse/data/rhea_tools.json
@@ -44,75 +44,33 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "rhea_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Rhea reaction identifier (e.g., RHEA:14293)"
-                  },
-                  "equation": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Chemical equation with compound names"
-                  },
-                  "ec_numbers": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Enzyme Commission numbers (semicolon-separated)"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Total number of matching Rhea reactions, independent of `limit`. Null if the count query failed."
-                },
-                "returned": {
-                  "type": "integer",
-                  "description": "Number of reactions in this response (at most `limit`)."
-                },
-                "offset": {
-                  "type": "integer"
-                },
-                "limit": {
-                  "type": "integer"
-                },
-                "has_more": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rhea_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Rhea reaction identifier (e.g., RHEA:14293)"
+              },
+              "equation": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Chemical equation with compound names"
+              },
+              "ec_numbers": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Enzyme Commission numbers (semicolon-separated)"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -173,72 +131,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "rhea_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "equation": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ec_numbers": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "ec_number": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Total number of matching Rhea reactions, independent of `limit`. Null if the count query failed."
-                },
-                "returned": {
-                  "type": "integer",
-                  "description": "Number of reactions in this response (at most `limit`)."
-                },
-                "offset": {
-                  "type": "integer"
-                },
-                "limit": {
-                  "type": "integer"
-                },
-                "has_more": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rhea_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "equation": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ec_numbers": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -299,78 +215,36 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "rhea_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "equation": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "chebi_ids": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ec_numbers": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "chebi_id": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Total number of matching Rhea reactions, independent of `limit`. Null if the count query failed."
-                },
-                "returned": {
-                  "type": "integer",
-                  "description": "Number of reactions in this response (at most `limit`)."
-                },
-                "offset": {
-                  "type": "integer"
-                },
-                "limit": {
-                  "type": "integer"
-                },
-                "has_more": {
-                  "type": [
-                    "boolean",
-                    "null"
-                  ]
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "rhea_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "equation": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "chebi_ids": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ec_numbers": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/rnacentral_tools.json
+++ b/src/tooluniverse/data/rnacentral_tools.json
@@ -15,10 +15,12 @@
           "default": 10,
           "minimum": 1,
           "maximum": 100,
-          "description": "Number of records per page (1–100)."
+          "description": "Number of records per page (1\u2013100)."
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     },
     "fields": {
       "endpoint": "https://rnacentral.org/api/v1/rna/",
@@ -28,35 +30,72 @@
       "type": "object",
       "description": "RNAcentral rna list response",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "data": {
           "type": "object",
           "properties": {
-            "count": {"type": "integer"},
+            "count": {
+              "type": "integer"
+            },
             "results": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "rnacentral_id": {"type": "string"},
-                  "description": {"type": "string"},
-                  "rna_type": {"type": "string"},
-                  "taxon": {"type": "object", "properties": {"scientific_name": {"type": "string"}, "taxid": {"type": "integer"}}}
+                  "rnacentral_id": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "rna_type": {
+                    "type": "string"
+                  },
+                  "taxon": {
+                    "type": "object",
+                    "properties": {
+                      "scientific_name": {
+                        "type": "string"
+                      },
+                      "taxid": {
+                        "type": "integer"
+                      }
+                    }
+                  }
                 }
               }
             }
           }
         },
-        "url": {"type": "string"}
+        "url": {
+          "type": "string"
+        }
       }
     },
     "test_examples": [
-      {"query": "let-7", "page_size": 1},
-      {"query": "U6", "page_size": 1}
+      {
+        "query": "let-7",
+        "page_size": 1
+      },
+      {
+        "query": "U6",
+        "page_size": 1
+      }
     ],
-    "label": ["RNAcentral", "ncRNA", "Search"],
+    "label": [
+      "RNAcentral",
+      "ncRNA",
+      "Search"
+    ],
     "metadata": {
-      "tags": ["rna", "mirna", "lncrna", "annotation"],
+      "tags": [
+        "rna",
+        "mirna",
+        "lncrna",
+        "annotation"
+      ],
       "estimated_execution_time": "< 2 seconds"
     }
   },
@@ -72,7 +111,9 @@
           "description": "RNAcentral accession (e.g., 'URS000075C808')."
         }
       },
-      "required": ["accession"]
+      "required": [
+        "accession"
+      ]
     },
     "fields": {
       "endpoint": "https://rnacentral.org/api/v1/rna/{accession}",
@@ -82,17 +123,33 @@
       "type": "object",
       "description": "RNAcentral accession response",
       "properties": {
-        "status": {"type": "string"},
-        "data": {"type": "object"},
-        "url": {"type": "string"}
+        "status": {
+          "type": "string"
+        },
+        "data": {
+          "type": "object"
+        },
+        "url": {
+          "type": "string"
+        }
       }
     },
     "test_examples": [
-      {"accession": "URS000075C808"}
+      {
+        "accession": "URS000075C808"
+      }
     ],
-    "label": ["RNAcentral", "ncRNA", "Record"],
+    "label": [
+      "RNAcentral",
+      "ncRNA",
+      "Record"
+    ],
     "metadata": {
-      "tags": ["rna", "accession", "annotation"],
+      "tags": [
+        "rna",
+        "accession",
+        "annotation"
+      ],
       "estimated_execution_time": "< 2 seconds"
     }
   },
@@ -108,11 +165,16 @@
           "description": "RNAcentral URS identifier (e.g., 'URS000063A371', 'URS000075C808')."
         }
       },
-      "required": ["accession"]
+      "required": [
+        "accession"
+      ]
     },
     "fields": {
       "endpoint": "https://rnacentral.org/api/v1/rna/{accession}/[xrefs,publications]",
-      "sub_resources": ["xrefs", "publications"],
+      "sub_resources": [
+        "xrefs",
+        "publications"
+      ],
       "format": "json"
     },
     "return_schema": {
@@ -120,46 +182,69 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "accession": {"type": "string"},
-            "data": {
+            "xrefs": {
               "type": "object",
               "properties": {
-                "xrefs": {
-                  "type": "object",
-                  "properties": {
-                    "count": {"type": "integer"},
-                    "results": {"type": "array", "items": {"type": "object"}}
-                  }
+                "count": {
+                  "type": "integer"
                 },
-                "publications": {
-                  "type": "object",
-                  "properties": {
-                    "count": {"type": "integer"},
-                    "results": {"type": "array", "items": {"type": "object"}}
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                }
+              }
+            },
+            "publications": {
+              "type": "object",
+              "properties": {
+                "count": {
+                  "type": "integer"
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
                   }
                 }
               }
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "error": {"type": "string"}
+            "status": {
+              "type": "string"
+            },
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"accession": "URS000063A371"}
+      {
+        "accession": "URS000063A371"
+      }
     ],
-    "label": ["RNAcentral", "ncRNA", "CrossReference"],
+    "label": [
+      "RNAcentral",
+      "ncRNA",
+      "CrossReference"
+    ],
     "metadata": {
-      "tags": ["rna", "xrefs", "publications", "annotation"],
+      "tags": [
+        "rna",
+        "xrefs",
+        "publications",
+        "annotation"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   },
@@ -171,23 +256,38 @@
       "type": "object",
       "properties": {
         "region": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Locus as 'chr:start-end' (1-based), e.g. '2:39745816-39826679'. Omit if giving chromosome/start/end."
         },
         "species": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Ensembl species slug (default 'homo_sapiens'). E.g. 'mus_musculus', 'danio_rerio'."
         },
         "chromosome": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Chromosome name without 'chr' prefix, e.g. '2'. Used with start/end when 'region' is omitted."
         },
         "start": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Region start (1-based). Used with chromosome/end when 'region' is omitted."
         },
         "end": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Region end (1-based). Used with chromosome/start when 'region' is omitted."
         }
       },
@@ -203,38 +303,67 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "species": {"type": "string"},
-            "region": {"type": "string"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "features": {"type": "array", "items": {"type": "object"}},
-                "transcripts": {"type": "array", "items": {"type": "object"}},
-                "exons": {"type": "array", "items": {"type": "object"}},
-                "transcript_count": {"type": "integer"},
-                "exon_count": {"type": "integer"}
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
+            },
+            "transcripts": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "exons": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "transcript_count": {
+              "type": "integer"
+            },
+            "exon_count": {
+              "type": "integer"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "error": {"type": "string"}
+            "status": {
+              "type": "string"
+            },
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"region": "2:39745816-39826679", "species": "homo_sapiens"}
+      {
+        "region": "2:39745816-39826679",
+        "species": "homo_sapiens"
+      }
     ],
-    "label": ["RNAcentral", "ncRNA", "GenomeRegion"],
+    "label": [
+      "RNAcentral",
+      "ncRNA",
+      "GenomeRegion"
+    ],
     "metadata": {
-      "tags": ["rna", "ncrna", "genome", "region", "annotation"],
+      "tags": [
+        "rna",
+        "ncrna",
+        "genome",
+        "region",
+        "annotation"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   }

--- a/src/tooluniverse/data/roc_analysis_tools.json
+++ b/src/tooluniverse/data/roc_analysis_tools.json
@@ -70,33 +70,91 @@
     },
     "return_schema": {
       "type": "object",
-      "oneOf": [
-        {
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+      "description": "ROC/AUC diagnostic-accuracy analysis results.",
+      "properties": {
+        "auc": {
+          "type": "number",
+          "description": "Area under the ROC curve."
         },
-        {
-          "properties": {
-            "status": {
-              "const": "error"
-            },
-            "error": {
-              "type": "string"
-            }
+        "auc_ci95": {
+          "type": "array",
+          "items": {
+            "type": "number"
           },
-          "required": [
-            "error"
-          ]
+          "description": "Bootstrap 95% confidence interval for AUC as [low, high]."
+        },
+        "n": {
+          "type": "integer",
+          "description": "Total number of samples."
+        },
+        "n_positive": {
+          "type": "integer",
+          "description": "Number of positive-class samples."
+        },
+        "n_negative": {
+          "type": "integer",
+          "description": "Number of negative-class samples."
+        },
+        "youden_optimal": {
+          "type": "object",
+          "description": "Cutoff maximizing Youden's J statistic (sensitivity + specificity - 1).",
+          "properties": {
+            "cutoff": {
+              "type": "number"
+            },
+            "sensitivity": {
+              "type": "number"
+            },
+            "specificity": {
+              "type": "number"
+            }
+          }
+        },
+        "roc_curve": {
+          "type": "object",
+          "description": "Downsampled ROC curve points.",
+          "properties": {
+            "fpr": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "tpr": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "thresholds": {
+              "type": "array",
+              "items": {
+                "type": ["number", "null"]
+              }
+            }
+          }
+        },
+        "at_cutoff": {
+          "type": "object",
+          "description": "Sensitivity/specificity at the user-specified fixed cutoff (present only when 'cutoff' parameter is given).",
+          "properties": {
+            "cutoff": {
+              "type": "number"
+            },
+            "sensitivity": {
+              "type": "number"
+            },
+            "specificity": {
+              "type": "number"
+            }
+          }
         }
+      },
+      "required": [
+        "auc",
+        "n",
+        "youden_optimal",
+        "roc_curve"
       ]
     },
     "test_examples": [

--- a/src/tooluniverse/data/rxnorm_extended_tools.json
+++ b/src/tooluniverse/data/rxnorm_extended_tools.json
@@ -11,7 +11,9 @@
           "description": "Drug name to look up (generic, brand, or synonym). Examples: 'metformin', 'Lipitor', 'acetaminophen', 'warfarin sodium'."
         }
       },
-      "required": ["drug_name"]
+      "required": [
+        "drug_name"
+      ]
     },
     "fields": {
       "operation": "find_rxcui",
@@ -20,27 +22,63 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "data": {
           "type": "object",
           "properties": {
-            "drug_name": {"type": "string"},
-            "rxcuis": {"type": "array", "items": {"type": "string"}},
-            "primary_rxcui": {"type": ["string", "null"]},
-            "found": {"type": "boolean"}
+            "drug_name": {
+              "type": "string"
+            },
+            "rxcuis": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "primary_rxcui": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "found": {
+              "type": "boolean"
+            }
           }
         },
-        "metadata": {"type": "object", "additionalProperties": true}
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
       }
     },
     "test_examples": [
-      {"drug_name": "metformin"},
-      {"drug_name": "warfarin"},
-      {"drug_name": "atorvastatin"}
+      {
+        "drug_name": "metformin"
+      },
+      {
+        "drug_name": "warfarin"
+      },
+      {
+        "drug_name": "atorvastatin"
+      }
     ],
-    "label": ["RxNorm", "RXCUI", "drug", "NLM", "standardization"],
+    "label": [
+      "RxNorm",
+      "RXCUI",
+      "drug",
+      "NLM",
+      "standardization"
+    ],
     "metadata": {
-      "tags": ["drug_standardization", "drug_identifier", "NLM", "rxnorm"],
+      "tags": [
+        "drug_standardization",
+        "drug_identifier",
+        "NLM",
+        "rxnorm"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   },
@@ -68,29 +106,78 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "data": {
           "type": "object",
           "properties": {
-            "rxcui": {"type": "string"},
-            "name": {"type": ["string", "null"]},
-            "synonym": {"type": ["string", "null"]},
-            "term_type": {"type": ["string", "null"]},
-            "term_type_label": {"type": ["string", "null"]},
-            "language": {"type": ["string", "null"]}
+            "rxcui": {
+              "type": "string"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "synonym": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "term_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "term_type_label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "language": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           }
         },
-        "metadata": {"type": "object", "additionalProperties": true}
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
       }
     },
     "test_examples": [
-      {"rxcui": "6809"},
-      {"drug_name": "warfarin"},
-      {"rxcui": "860975"}
+      {
+        "rxcui": "6809"
+      },
+      {
+        "drug_name": "warfarin"
+      },
+      {
+        "rxcui": "860975"
+      }
     ],
-    "label": ["RxNorm", "drug", "properties", "NLM", "terminology"],
+    "label": [
+      "RxNorm",
+      "drug",
+      "properties",
+      "NLM",
+      "terminology"
+    ],
     "metadata": {
-      "tags": ["drug_information", "drug_properties", "NLM", "rxnorm"],
+      "tags": [
+        "drug_information",
+        "drug_properties",
+        "NLM",
+        "rxnorm"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   },
@@ -123,11 +210,15 @@
     "return_schema": {
       "type": "object",
       "properties": {
-        "status": {"type": "string"},
+        "status": {
+          "type": "string"
+        },
         "data": {
           "type": "object",
           "properties": {
-            "rxcui": {"type": "string"},
+            "rxcui": {
+              "type": "string"
+            },
             "related_drugs": {
               "type": "object",
               "description": "Grouped by term-type label. Keys are human-readable type labels.",
@@ -136,27 +227,67 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "rxcui": {"type": ["string", "null"]},
-                    "name": {"type": ["string", "null"]},
-                    "synonym": {"type": ["string", "null"]}
+                    "rxcui": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "synonym": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
                   }
                 }
               }
             },
-            "total_related": {"type": "integer"}
+            "total_related": {
+              "type": "integer"
+            }
           }
         },
-        "metadata": {"type": "object", "additionalProperties": true}
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
       }
     },
     "test_examples": [
-      {"rxcui": "6809"},
-      {"drug_name": "atorvastatin"},
-      {"rxcui": "11289", "tty": "BN+SBD"}
+      {
+        "rxcui": "6809"
+      },
+      {
+        "drug_name": "atorvastatin"
+      },
+      {
+        "rxcui": "11289",
+        "tty": "BN+SBD"
+      }
     ],
-    "label": ["RxNorm", "drug", "brand", "generic", "related", "NLM"],
+    "label": [
+      "RxNorm",
+      "drug",
+      "brand",
+      "generic",
+      "related",
+      "NLM"
+    ],
     "metadata": {
-      "tags": ["drug_products", "brand_generic", "drug_lookup", "NLM", "rxnorm"],
+      "tags": [
+        "drug_products",
+        "brand_generic",
+        "drug_lookup",
+        "NLM",
+        "rxnorm"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   },
@@ -172,7 +303,9 @@
           "description": "National Drug Code, 11-digit. Accepts hyphenated (e.g., '00093-0058-01') or plain digits (e.g., '00093005801')."
         }
       },
-      "required": ["ndc"]
+      "required": [
+        "ndc"
+      ]
     },
     "fields": {
       "operation": "get_ndc_status_history",
@@ -183,52 +316,129 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "ndc": {"type": "string"},
-                "found": {"type": "boolean"},
-                "ndc11": {"type": ["string", "null"]},
-                "status": {"type": ["string", "null"]},
-                "active": {"type": ["string", "null"]},
-                "rxcui": {"type": ["string", "null"]},
-                "concept_name": {"type": ["string", "null"]},
-                "concept_status": {"type": ["string", "null"]},
-                "sources": {"type": "array", "items": {"type": "string"}},
-                "ndc_history": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "active_rxcui": {"type": ["string", "null"]},
-                      "original_rxcui": {"type": ["string", "null"]},
-                      "start_date": {"type": ["string", "null"]},
-                      "end_date": {"type": ["string", "null"]}
-                    }
+            "ndc": {
+              "type": "string"
+            },
+            "found": {
+              "type": "boolean"
+            },
+            "ndc11": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "active": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "rxcui": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "concept_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "concept_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sources": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ndc_history": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "active_rxcui": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "original_rxcui": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "start_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "end_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": ["ndc", "found"]
-            },
-            "metadata": {"type": "object", "additionalProperties": true}
+              }
+            }
           },
-          "required": ["data"]
+          "required": [
+            "ndc",
+            "found"
+          ]
         },
         {
           "type": "object",
-          "properties": {"error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"ndc": "00093-0058-01"},
-      {"ndc": "00093005801"}
+      {
+        "ndc": "00093-0058-01"
+      },
+      {
+        "ndc": "00093005801"
+      }
     ],
-    "label": ["RxNorm", "NDC", "status", "history", "drug_safety", "NLM"],
+    "label": [
+      "RxNorm",
+      "NDC",
+      "status",
+      "history",
+      "drug_safety",
+      "NLM"
+    ],
     "metadata": {
-      "tags": ["ndc", "drug_status", "remapping", "NLM", "rxnorm"],
+      "tags": [
+        "ndc",
+        "drug_status",
+        "remapping",
+        "NLM",
+        "rxnorm"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   },
@@ -244,7 +454,9 @@
           "description": "National Drug Code. Accepts hyphenated (e.g., '0781-1506-10') or plain-digit form."
         }
       },
-      "required": ["ndc"]
+      "required": [
+        "ndc"
+      ]
     },
     "fields": {
       "operation": "get_ndc_properties",
@@ -255,54 +467,142 @@
         {
           "type": "object",
           "properties": {
-            "status": {"type": "string"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "ndc": {"type": "string"},
-                "found": {"type": "boolean"},
-                "products": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "ndc_item": {"type": ["string", "null"]},
-                      "ndc10": {"type": ["string", "null"]},
-                      "ndc9": {"type": ["string", "null"]},
-                      "rxcui": {"type": ["string", "null"]},
-                      "spl_set_id": {"type": ["string", "null"]},
-                      "imprint_code": {"type": ["string", "null"]},
-                      "color": {"type": ["string", "null"]},
-                      "shape": {"type": ["string", "null"]},
-                      "labeler": {"type": ["string", "null"]},
-                      "marketing_category": {"type": ["string", "null"]},
-                      "anda": {"type": ["string", "null"]},
-                      "nda": {"type": ["string", "null"]},
-                      "packaging": {"type": "array", "items": {"type": "string"}},
-                      "properties": {"type": "object", "additionalProperties": true}
+            "ndc": {
+              "type": "string"
+            },
+            "found": {
+              "type": "boolean"
+            },
+            "products": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ndc_item": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ndc10": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ndc9": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "rxcui": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "spl_set_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "imprint_code": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "color": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "shape": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "labeler": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "marketing_category": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "anda": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "nda": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "packaging": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
+                  },
+                  "properties": {
+                    "type": "object",
+                    "additionalProperties": true
                   }
                 }
-              },
-              "required": ["ndc", "found"]
-            },
-            "metadata": {"type": "object", "additionalProperties": true}
+              }
+            }
           },
-          "required": ["data"]
+          "required": [
+            "ndc",
+            "found"
+          ]
         },
         {
           "type": "object",
-          "properties": {"error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
-      {"ndc": "0781-1506-10"}
+      {
+        "ndc": "0781-1506-10"
+      }
     ],
-    "label": ["RxNorm", "NDC", "pill_id", "imprint", "packaging", "NLM"],
+    "label": [
+      "RxNorm",
+      "NDC",
+      "pill_id",
+      "imprint",
+      "packaging",
+      "NLM"
+    ],
     "metadata": {
-      "tags": ["ndc", "pill_identification", "imprint", "NLM", "rxnorm"],
+      "tags": [
+        "ndc",
+        "pill_identification",
+        "imprint",
+        "NLM",
+        "rxnorm"
+      ],
       "estimated_execution_time": "< 3 seconds"
     }
   }

--- a/src/tooluniverse/data/sgd_protein_tools.json
+++ b/src/tooluniverse/data/sgd_protein_tools.json
@@ -25,86 +25,75 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "systematic_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "sgd_link": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "domain_count": {
-                  "type": "integer"
-                },
-                "domains": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "accession": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "source": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "start": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "end": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "domain_link": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "systematic_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sgd_link": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "domain_count": {
+              "type": "integer"
+            },
+            "domains": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "accession": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "source": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "start": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "end": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "domain_link": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": [
-                "domain_count",
-                "domains"
-              ]
+              }
             }
           },
           "required": [
-            "data"
+            "domain_count",
+            "domains"
           ]
         },
         {
@@ -158,80 +147,69 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "systematic_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "sgd_link": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "site_count": {
-                  "type": "integer"
-                },
-                "sites": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "modification": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "residue": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "position": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "reference": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "pubmed_id": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      }
-                    }
+            "systematic_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sgd_link": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "site_count": {
+              "type": "integer"
+            },
+            "sites": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "modification": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "residue": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "position": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "reference": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "pubmed_id": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
                   }
                 }
-              },
-              "required": [
-                "site_count",
-                "sites"
-              ]
+              }
             }
           },
           "required": [
-            "data"
+            "site_count",
+            "sites"
           ]
         },
         {
@@ -285,72 +263,61 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "query": {
+              "type": "string"
             },
-            "data": {
+            "total_references": {
+              "type": "integer"
+            },
+            "counts_by_category": {
               "type": "object",
-              "properties": {
-                "query": {
-                  "type": "string"
-                },
-                "total_references": {
-                  "type": "integer"
-                },
-                "counts_by_category": {
+              "additionalProperties": {
+                "type": "integer"
+              }
+            },
+            "references": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
                   "type": "object",
-                  "additionalProperties": {
-                    "type": "integer"
-                  }
-                },
-                "references": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "citation": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "pubmed_id": {
-                          "type": [
-                            "integer",
-                            "null"
-                          ]
-                        },
-                        "year": {
-                          "type": [
-                            "integer",
-                            "null"
-                          ]
-                        },
-                        "reference_link": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        }
-                      }
+                  "properties": {
+                    "citation": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "pubmed_id": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "year": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "reference_link": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   }
-                },
-                "truncated_per_category": {
-                  "type": "integer"
                 }
-              },
-              "required": [
-                "total_references",
-                "counts_by_category",
-                "references"
-              ]
+              }
+            },
+            "truncated_per_category": {
+              "type": "integer"
             }
           },
           "required": [
-            "data"
+            "total_references",
+            "counts_by_category",
+            "references"
           ]
         },
         {

--- a/src/tooluniverse/data/sgd_tools.json
+++ b/src/tooluniverse/data/sgd_tools.json
@@ -32,60 +32,38 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "sgd_id": {
-                  "type": "string",
-                  "description": "SGD identifier"
-                },
-                "display_name": {
-                  "type": "string",
-                  "description": "Gene name (e.g., GAL4)"
-                },
-                "gene_name": {
-                  "type": "string"
-                },
-                "systematic_name": {
-                  "type": "string",
-                  "description": "Systematic ORF name (e.g., YPL248C)"
-                },
-                "locus_type": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string",
-                  "description": "Curated functional description"
-                },
-                "uniprot_id": {
-                  "type": "string"
-                },
-                "aliases": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
+            "sgd_id": {
+              "type": "string",
+              "description": "SGD identifier"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+            "display_name": {
+              "type": "string",
+              "description": "Gene name (e.g., GAL4)"
+            },
+            "gene_name": {
+              "type": "string"
+            },
+            "systematic_name": {
+              "type": "string",
+              "description": "Systematic ORF name (e.g., YPL248C)"
+            },
+            "locus_type": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string",
+              "description": "Curated functional description"
+            },
+            "uniprot_id": {
+              "type": "string"
+            },
+            "aliases": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -132,77 +110,52 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "phenotype": {
-                    "type": "string",
-                    "description": "Phenotype name with qualifier (e.g., 'competitive fitness: decreased')"
-                  },
-                  "mutant_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "experiment_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "strain_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "allele": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "chemical": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "reference": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "phenotype": {
+                "type": "string",
+                "description": "Phenotype name with qualifier (e.g., 'competitive fitness: decreased')"
+              },
+              "mutant_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "experiment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "strain_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "allele": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "chemical": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -249,77 +202,52 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "go_id": {
-                    "type": "string",
-                    "description": "GO term identifier (e.g., GO:0007131)"
-                  },
-                  "go_term": {
-                    "type": "string",
-                    "description": "GO term name"
-                  },
-                  "go_aspect": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "GO namespace: biological_process, molecular_function, or cellular_component"
-                  },
-                  "evidence_code": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Evidence code (IDA, IMP, IGI, etc.)"
-                  },
-                  "qualifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "annotation_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "reference": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "go_id": {
+                "type": "string",
+                "description": "GO term identifier (e.g., GO:0007131)"
+              },
+              "go_term": {
+                "type": "string",
+                "description": "GO term name"
+              },
+              "go_aspect": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "GO namespace: biological_process, molecular_function, or cellular_component"
+              },
+              "evidence_code": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Evidence code (IDA, IMP, IGI, etc.)"
+              },
+              "qualifier": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "annotation_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -366,72 +294,47 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "interaction_type": {
-                    "type": "string",
-                    "description": "Physical or Genetic"
-                  },
-                  "experiment_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Experimental method (Two-hybrid, Affinity Capture-MS, Synthetic Lethality, etc.)"
-                  },
-                  "bait_gene": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "hit_gene": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "annotation_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "reference": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "interaction_type": {
+                "type": "string",
+                "description": "Physical or Genetic"
+              },
+              "experiment_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Experimental method (Two-hybrid, Affinity Capture-MS, Synthetic Lethality, etc.)"
+              },
+              "bait_gene": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "hit_gene": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "annotation_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -493,53 +396,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "category": {
-                    "type": "string"
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "href": {
-                    "type": "string"
-                  },
-                  "aliases": {
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "categories": {
-                  "type": "object",
-                  "description": "Count of results per category"
-                },
-                "query": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "category": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "href": {
+                "type": "string"
+              },
+              "aliases": {
+                "type": [
+                  "array",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -587,106 +467,81 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "regulator": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Regulator gene name"
-                  },
-                  "regulator_sgdid": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "target": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Target gene name"
-                  },
-                  "target_sgdid": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "regulation_of": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "What is regulated (e.g., transcription)"
-                  },
-                  "direction": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "happens_during": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "evidence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "annotation_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "reference": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "pubmed_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "regulator": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Regulator gene name"
+              },
+              "regulator_sgdid": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "target": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Target gene name"
+              },
+              "target_sgdid": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "regulation_of": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "What is regulated (e.g., transcription)"
+              },
+              "direction": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "happens_during": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "evidence": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "annotation_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pubmed_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -736,92 +591,70 @@
         {
           "type": "object",
           "properties": {
-            "data": {
+            "sgd_id": {
+              "type": "string"
+            },
+            "genomic_dna": {
               "type": "object",
               "properties": {
-                "sgd_id": {
-                  "type": "string"
+                "start": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 },
-                "genomic_dna": {
-                  "type": "object",
-                  "properties": {
-                    "start": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "end": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "strand": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "length": {
-                      "type": "integer"
-                    },
-                    "residues": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
+                "end": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 },
-                "coding_dna": {
-                  "type": "object",
-                  "properties": {
-                    "length": {
-                      "type": "integer"
-                    },
-                    "residues": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
+                "strand": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "protein": {
-                  "type": "object",
-                  "properties": {
-                    "length": {
-                      "type": "integer"
-                    },
-                    "residues": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
+                "length": {
+                  "type": "integer"
+                },
+                "residues": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               }
             },
-            "metadata": {
+            "coding_dna": {
               "type": "object",
               "properties": {
-                "source": {
-                  "type": "string"
+                "length": {
+                  "type": "integer"
                 },
-                "query": {
-                  "type": "string"
+                "residues": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "protein": {
+              "type": "object",
+              "properties": {
+                "length": {
+                  "type": "integer"
                 },
-                "endpoint": {
-                  "type": "string"
+                "residues": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -866,92 +699,67 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "disease_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "disease_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Disease Ontology ID (e.g., DOID:162)"
-                  },
-                  "annotation_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "qualifier": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "locus": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "locus_sgdid": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "reference": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "pubmed_id": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "total_results": {
-                  "type": "integer"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "disease_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "disease_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Disease Ontology ID (e.g., DOID:162)"
+              },
+              "annotation_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "qualifier": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "locus": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "locus_sgdid": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "pubmed_id": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/spredixcan_tools.json
+++ b/src/tooluniverse/data/spredixcan_tools.json
@@ -5,13 +5,58 @@
     "description": "Summary-based transcriptome-wide association (S-PrediXcan, Barbeira 2018): test a gene for trait association by combining its eQTL prediction weights with GWAS per-SNP z-scores. Returns the gene TWAS z-score and p-value. Pure-compute (no individual-level data, no LD panel needed when SNPs are independent/LD-pruned; optionally supply a SNP covariance matrix). Pairs with eQTL_get_associations + GWAS summary tools.",
     "parameter": {
       "type": "object",
-      "required": ["weight", "gwas_z"],
+      "required": [
+        "weight",
+        "gwas_z"
+      ],
       "properties": {
-        "weight": {"type": "array", "items": {"type": "number"}, "description": "Per-SNP eQTL prediction weights for the gene (same SNP order as gwas_z)."},
-        "gwas_z": {"type": "array", "items": {"type": "number"}, "description": "Per-SNP GWAS z-scores (beta/se), same SNP order."},
-        "snp_sd": {"type": ["array", "null"], "items": {"type": "number"}, "description": "Per-SNP standard deviation (~sqrt(2*MAF*(1-MAF))); default 1.0 (standardized)."},
-        "covariance": {"type": ["array", "null"], "items": {"type": "array", "items": {"type": "number"}}, "description": "Optional SNP covariance matrix (n x n, same SNP order). If omitted, SNPs are assumed independent."},
-        "snp": {"type": ["array", "null"], "items": {"type": "string"}, "description": "Optional SNP identifiers (same order), for reference."}
+        "weight": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-SNP eQTL prediction weights for the gene (same SNP order as gwas_z)."
+        },
+        "gwas_z": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-SNP GWAS z-scores (beta/se), same SNP order."
+        },
+        "snp_sd": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "number"
+          },
+          "description": "Per-SNP standard deviation (~sqrt(2*MAF*(1-MAF))); default 1.0 (standardized)."
+        },
+        "covariance": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          "description": "Optional SNP covariance matrix (n x n, same SNP order). If omitted, SNPs are assumed independent."
+        },
+        "snp": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional SNP identifiers (same order), for reference."
+        }
       }
     },
     "return_schema": {
@@ -19,31 +64,59 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_snps": {"type": "integer"},
-                "twas_zscore": {"type": "number"},
-                "p_value": {"type": "number"},
-                "direction": {"type": "string"}
-              }
+            "n_snps": {
+              "type": "integer"
+            },
+            "twas_zscore": {
+              "type": "number"
+            },
+            "p_value": {
+              "type": "number"
+            },
+            "direction": {
+              "type": "string"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "status": {
+              "const": "error"
+            },
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "weight": [0.5, 0.3, 0.2, 0.4, 0.25],
-        "gwas_z": [3.0, 2.0, 1.0, 2.5, 1.5],
-        "snp": ["rs1", "rs2", "rs3", "rs4", "rs5"]
+        "weight": [
+          0.5,
+          0.3,
+          0.2,
+          0.4,
+          0.25
+        ],
+        "gwas_z": [
+          3.0,
+          2.0,
+          1.0,
+          2.5,
+          1.5
+        ],
+        "snp": [
+          "rs1",
+          "rs2",
+          "rs3",
+          "rs4",
+          "rs5"
+        ]
       }
     ]
   }

--- a/src/tooluniverse/data/ssgsea_tools.json
+++ b/src/tooluniverse/data/ssgsea_tools.json
@@ -5,13 +5,48 @@
     "description": "Single-sample GSEA (Barbie 2009): score each sample for each gene set from an expression matrix (genes x samples), producing a gene_set x sample signature-score matrix. Positive = the set's genes are among that sample's highly-expressed genes. Basis for per-sample signature scoring (immune infiltration, pathway activity). Pure-compute (no R); supply gene sets from MSigDB/Enrichr.",
     "parameter": {
       "type": "object",
-      "required": ["expression"],
+      "required": [
+        "expression"
+      ],
       "properties": {
-        "expression": {"type": "object", "description": "{gene: [value_per_sample, ...]} — a genes x samples expression matrix (e.g. log-normalized)."},
-        "samples": {"type": ["array", "null"], "items": {"type": "string"}, "description": "Sample names (same order as the per-gene value lists); defaults to sample_1.."},
-        "gene_sets": {"type": ["object", "null"], "description": "{set_name: [gene, ...]} collection to score. Alternative to gene_set."},
-        "gene_set": {"type": ["array", "null"], "items": {"type": "string"}, "description": "A single gene set (list of gene symbols)."},
-        "alpha": {"type": ["number", "null"], "description": "Rank-weighting exponent (default 0.25, the ssGSEA standard)."}
+        "expression": {
+          "type": "object",
+          "description": "{gene: [value_per_sample, ...]} \u2014 a genes x samples expression matrix (e.g. log-normalized)."
+        },
+        "samples": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "Sample names (same order as the per-gene value lists); defaults to sample_1.."
+        },
+        "gene_sets": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "description": "{set_name: [gene, ...]} collection to score. Alternative to gene_set."
+        },
+        "gene_set": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "description": "A single gene set (list of gene symbols)."
+        },
+        "alpha": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "Rank-weighting exponent (default 0.25, the ssGSEA standard)."
+        }
       }
     },
     "return_schema": {
@@ -19,32 +54,106 @@
         {
           "type": "object",
           "properties": {
-            "status": {"const": "success"},
-            "data": {
-              "type": "object",
-              "properties": {
-                "n_genes": {"type": "integer"},
-                "n_samples": {"type": "integer"},
-                "samples": {"type": "array", "items": {"type": "string"}},
-                "enrichment_scores": {"type": "object"},
-                "skipped_sets": {"type": "array"}
+            "n_genes": {
+              "type": "integer"
+            },
+            "n_samples": {
+              "type": "integer"
+            },
+            "samples": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
+            },
+            "enrichment_scores": {
+              "type": "object"
+            },
+            "skipped_sets": {
+              "type": "array"
             }
-          },
-          "required": ["data"]
+          }
         },
         {
           "type": "object",
-          "properties": {"status": {"const": "error"}, "error": {"type": "string"}},
-          "required": ["error"]
+          "properties": {
+            "status": {
+              "const": "error"
+            },
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
-        "expression": {"G1": [12, 1], "G2": [11, 2], "G3": [10, 3], "G4": [9, 4], "G5": [8, 5], "G6": [7, 6], "G7": [6, 7], "G8": [5, 8], "G9": [4, 9], "G10": [3, 10], "G11": [2, 11], "G12": [1, 12]},
-        "samples": ["tumor", "normal"],
-        "gene_sets": {"TOP_SIG": ["G1", "G2", "G3", "G4"]}
+        "expression": {
+          "G1": [
+            12,
+            1
+          ],
+          "G2": [
+            11,
+            2
+          ],
+          "G3": [
+            10,
+            3
+          ],
+          "G4": [
+            9,
+            4
+          ],
+          "G5": [
+            8,
+            5
+          ],
+          "G6": [
+            7,
+            6
+          ],
+          "G7": [
+            6,
+            7
+          ],
+          "G8": [
+            5,
+            8
+          ],
+          "G9": [
+            4,
+            9
+          ],
+          "G10": [
+            3,
+            10
+          ],
+          "G11": [
+            2,
+            11
+          ],
+          "G12": [
+            1,
+            12
+          ]
+        },
+        "samples": [
+          "tumor",
+          "normal"
+        ],
+        "gene_sets": {
+          "TOP_SIG": [
+            "G1",
+            "G2",
+            "G3",
+            "G4"
+          ]
+        }
       }
     ]
   }

--- a/src/tooluniverse/data/stitch_tools.json
+++ b/src/tooluniverse/data/stitch_tools.json
@@ -54,44 +54,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "stringId_A": {
-                    "type": "string",
-                    "description": "STITCH ID of first entity"
-                  },
-                  "stringId_B": {
-                    "type": "string",
-                    "description": "STITCH ID of second entity"
-                  },
-                  "preferredName_A": {
-                    "type": "string"
-                  },
-                  "preferredName_B": {
-                    "type": "string"
-                  },
-                  "score": {
-                    "type": "number",
-                    "description": "Combined confidence score (0-1)"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "stringId_A": {
+                "type": "string",
+                "description": "STITCH ID of first entity"
+              },
+              "stringId_B": {
+                "type": "string",
+                "description": "STITCH ID of second entity"
+              },
+              "preferredName_A": {
+                "type": "string"
+              },
+              "preferredName_B": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number",
+                "description": "Combined confidence score (0-1)"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -161,35 +147,21 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "stringId": {
-                    "type": "string"
-                  },
-                  "preferredName": {
-                    "type": "string"
-                  },
-                  "annotation": {
-                    "type": "string"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "stringId": {
+                "type": "string"
+              },
+              "preferredName": {
+                "type": "string"
+              },
+              "annotation": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -246,39 +218,25 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string",
-              "enum": [
-                "success"
-              ]
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "stringId": {
-                    "type": "string",
-                    "description": "STITCH identifier"
-                  },
-                  "preferredName": {
-                    "type": "string"
-                  },
-                  "taxonId": {
-                    "type": "integer"
-                  },
-                  "annotation": {
-                    "type": "string"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "stringId": {
+                "type": "string",
+                "description": "STITCH identifier"
+              },
+              "preferredName": {
+                "type": "string"
+              },
+              "taxonId": {
+                "type": "integer"
+              },
+              "annotation": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/string_ext_tools.json
+++ b/src/tooluniverse/data/string_ext_tools.json
@@ -43,49 +43,27 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "identifiers": {
-                  "type": "string",
-                  "description": "Queried protein identifier"
-                },
-                "species": {
-                  "type": "integer",
-                  "description": "NCBI taxonomy ID"
-                },
-                "total_annotations": {
-                  "type": "integer",
-                  "description": "Total number of annotations across all categories"
-                },
-                "category_summary": {
-                  "type": "object",
-                  "description": "Number of annotations per category"
-                },
-                "annotations": {
-                  "type": "object",
-                  "description": "Annotations grouped by category, each with term, description, number_of_genes, input_genes (max 15 per category)"
-                }
-              }
+            "identifiers": {
+              "type": "string",
+              "description": "Queried protein identifier"
             },
-            "metadata": {
+            "species": {
+              "type": "integer",
+              "description": "NCBI taxonomy ID"
+            },
+            "total_annotations": {
+              "type": "integer",
+              "description": "Total number of annotations across all categories"
+            },
+            "category_summary": {
               "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "identifiers": {
-                  "type": "string"
-                },
-                "species": {
-                  "type": "integer"
-                }
-              }
+              "description": "Number of annotations per category"
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Annotations grouped by category, each with term, description, number_of_genes, input_genes (max 15 per category)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -117,61 +95,105 @@
           "default": 9606
         },
         "background_string_identifiers": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional newline-separated background gene set. If not provided, the entire genome proteome is used as background."
         }
       },
-      "required": ["identifiers"]
+      "required": [
+        "identifiers"
+      ]
     },
     "fields": {
       "endpoint": "enrichment"
     },
     "type": "STRINGExtTool",
     "test_examples": [
-      {"identifiers": "BRCA1\nBRCA2\nTP53\nATM\nPALB2", "species": 9606},
-      {"identifiers": "EGFR\nERBB2\nKRAS\nBRAF\nPIK3CA", "species": 9606}
+      {
+        "identifiers": "BRCA1\nBRCA2\nTP53\nATM\nPALB2",
+        "species": 9606
+      },
+      {
+        "identifiers": "EGFR\nERBB2\nKRAS\nBRAF\nPIK3CA",
+        "species": 9606
+      }
     ],
     "return_schema": {
       "oneOf": [
         {
           "type": "object",
+          "description": "Enrichment analysis results",
           "properties": {
-            "data": {
-              "type": "object",
-              "description": "Enrichment analysis results",
-              "properties": {
-                "identifiers": {"type": "string"},
-                "species": {"type": "integer"},
-                "enrichments": {
-                  "type": "array",
-                  "description": "List of enriched functional terms sorted by FDR",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "category": {"type": "string", "description": "Annotation category: Process (GO BP), Function (GO MF), Component (GO CC), KEGG, RCTM, WikiPathways, InterPro, Pfam, HPO, DISEASES, TISSUES, COMPARTMENTS"},
-                      "term": {"type": "string", "description": "Term identifier"},
-                      "description": {"type": "string", "description": "Term description"},
-                      "number_of_genes": {"type": "integer", "description": "Number of input genes with this annotation"},
-                      "number_of_genes_in_background": {"type": "integer", "description": "Total genes with this annotation in background"},
-                      "p_value": {"type": "number", "description": "Raw p-value"},
-                      "fdr": {"type": "number", "description": "FDR-corrected q-value"},
-                      "inputGenes": {"type": "array", "description": "Input genes matching this term", "items": {"type": "string"}},
-                      "preferredNames": {"type": "array", "items": {"type": "string"}}
+            "identifiers": {
+              "type": "string"
+            },
+            "species": {
+              "type": "integer"
+            },
+            "enrichments": {
+              "type": "array",
+              "description": "List of enriched functional terms sorted by FDR",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "category": {
+                    "type": "string",
+                    "description": "Annotation category: Process (GO BP), Function (GO MF), Component (GO CC), KEGG, RCTM, WikiPathways, InterPro, Pfam, HPO, DISEASES, TISSUES, COMPARTMENTS"
+                  },
+                  "term": {
+                    "type": "string",
+                    "description": "Term identifier"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Term description"
+                  },
+                  "number_of_genes": {
+                    "type": "integer",
+                    "description": "Number of input genes with this annotation"
+                  },
+                  "number_of_genes_in_background": {
+                    "type": "integer",
+                    "description": "Total genes with this annotation in background"
+                  },
+                  "p_value": {
+                    "type": "number",
+                    "description": "Raw p-value"
+                  },
+                  "fdr": {
+                    "type": "number",
+                    "description": "FDR-corrected q-value"
+                  },
+                  "inputGenes": {
+                    "type": "array",
+                    "description": "Input genes matching this term",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "preferredNames": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
                   }
                 }
               }
-            },
-            "metadata": {"type": "object"}
-          },
-          "required": ["data"]
+            }
+          }
         },
         {
           "type": "object",
           "properties": {
-            "error": {"type": "string"}
+            "error": {
+              "type": "string"
+            }
           },
-          "required": ["error"]
+          "required": [
+            "error"
+          ]
         }
       ]
     }

--- a/src/tooluniverse/data/swissdock_tools.json
+++ b/src/tooluniverse/data/swissdock_tools.json
@@ -55,38 +55,27 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "session_id": {
-                  "type": "string",
-                  "description": "Unique session identifier for this docking job"
-                },
-                "download_url": {
-                  "type": "string",
-                  "description": "URL to download complete docking results (tar.gz archive)"
-                },
-                "result_size_bytes": {
-                  "type": "integer",
-                  "description": "Size of result archive in bytes"
-                },
-                "content_type": {
-                  "type": "string",
-                  "description": "MIME type of result file"
-                },
-                "message": {
-                  "type": "string",
-                  "description": "Human-readable status message"
-                }
-              }
+            "session_id": {
+              "type": "string",
+              "description": "Unique session identifier for this docking job"
             },
-            "metadata": {
-              "type": "object"
+            "download_url": {
+              "type": "string",
+              "description": "URL to download complete docking results (tar.gz archive)"
+            },
+            "result_size_bytes": {
+              "type": "integer",
+              "description": "Size of result archive in bytes"
+            },
+            "content_type": {
+              "type": "string",
+              "description": "MIME type of result file"
+            },
+            "message": {
+              "type": "string",
+              "description": "Human-readable status message"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -133,34 +122,23 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "session_id": {
-                  "type": "string",
-                  "description": "Session identifier"
-                },
-                "job_status": {
-                  "type": "string",
-                  "description": "Current job status: RUNNING, FINISHED, ERROR, NOT_FOUND"
-                },
-                "is_finished": {
-                  "type": "boolean",
-                  "description": "True if job has completed successfully"
-                },
-                "has_error": {
-                  "type": "boolean",
-                  "description": "True if job encountered an error"
-                }
-              }
+            "session_id": {
+              "type": "string",
+              "description": "Session identifier"
             },
-            "metadata": {
-              "type": "object"
+            "job_status": {
+              "type": "string",
+              "description": "Current job status: RUNNING, FINISHED, ERROR, NOT_FOUND"
+            },
+            "is_finished": {
+              "type": "boolean",
+              "description": "True if job has completed successfully"
+            },
+            "has_error": {
+              "type": "boolean",
+              "description": "True if job encountered an error"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -211,42 +189,31 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "session_id": {
-                  "type": "string",
-                  "description": "Session identifier"
-                },
-                "download_url": {
-                  "type": "string",
-                  "description": "URL to download complete docking results"
-                },
-                "result_size_bytes": {
-                  "type": "integer",
-                  "description": "Size of result archive"
-                },
-                "content_type": {
-                  "type": "string",
-                  "description": "MIME type of result file"
-                },
-                "message": {
-                  "type": "string",
-                  "description": "Status message"
-                },
-                "job_status": {
-                  "type": "string",
-                  "description": "Job status if not FINISHED yet"
-                }
-              }
+            "session_id": {
+              "type": "string",
+              "description": "Session identifier"
             },
-            "metadata": {
-              "type": "object"
+            "download_url": {
+              "type": "string",
+              "description": "URL to download complete docking results"
+            },
+            "result_size_bytes": {
+              "type": "integer",
+              "description": "Size of result archive"
+            },
+            "content_type": {
+              "type": "string",
+              "description": "MIME type of result file"
+            },
+            "message": {
+              "type": "string",
+              "description": "Status message"
+            },
+            "job_status": {
+              "type": "string",
+              "description": "Job status if not FINISHED yet"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/swissmodel_tools.json
+++ b/src/tooluniverse/data/swissmodel_tools.json
@@ -62,124 +62,96 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "uniprot_id": {
-                  "type": "string"
-                },
-                "sequence_length": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "crc64": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "model_count": {
-                  "type": "integer"
-                },
-                "filters_applied": {
-                  "type": "object"
-                },
-                "models": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "template": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "method": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "coverage": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "from_residue": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "to_residue": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "created_date": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "provider": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "coordinates_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "qmean_global": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "qmean_z_score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ]
-                      }
-                    }
+            "uniprot_id": {
+              "type": "string"
+            },
+            "sequence_length": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "crc64": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "model_count": {
+              "type": "integer"
+            },
+            "filters_applied": {
+              "type": "object"
+            },
+            "models": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "template": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "method": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "coverage": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "from_residue": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "to_residue": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "created_date": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "provider": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "coordinates_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "qmean_global": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "qmean_z_score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "api_version": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": [
-                    "string",
-                    "object"
-                  ]
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -227,88 +199,66 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
+            "uniprot_id": {
+              "type": "string"
+            },
+            "sequence_length": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "total_models": {
+              "type": "integer"
+            },
+            "best_model": {
+              "type": [
+                "object",
+                "null"
+              ],
               "properties": {
-                "uniprot_id": {
+                "template": {
                   "type": "string"
                 },
-                "sequence_length": {
+                "method": {
+                  "type": "string"
+                },
+                "coverage": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "from_residue": {
                   "type": [
                     "integer",
                     "null"
                   ]
                 },
-                "total_models": {
-                  "type": "integer"
-                },
-                "best_model": {
+                "to_residue": {
                   "type": [
-                    "object",
+                    "integer",
                     "null"
-                  ],
-                  "properties": {
-                    "template": {
-                      "type": "string"
-                    },
-                    "method": {
-                      "type": "string"
-                    },
-                    "coverage": {
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    },
-                    "from_residue": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "to_residue": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "created_date": {
-                      "type": "string"
-                    },
-                    "coordinates_url": {
-                      "type": "string"
-                    },
-                    "qmean_global": {
-                      "type": [
-                        "number",
-                        "null"
-                      ]
-                    }
-                  }
+                  ]
                 },
-                "methods_distribution": {
-                  "type": "object"
+                "created_date": {
+                  "type": "string"
+                },
+                "coordinates_url": {
+                  "type": "string"
+                },
+                "qmean_global": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "methods_distribution": {
+              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -396,50 +346,25 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "uniprot_id": {
-                  "type": "string"
-                },
-                "format": {
-                  "type": "string"
-                },
-                "pdb_content": {
-                  "type": "string"
-                },
-                "atom_count": {
-                  "type": "integer"
-                },
-                "size_bytes": {
-                  "type": "integer"
-                },
-                "filters_applied": {
-                  "type": "object"
-                }
-              }
+            "uniprot_id": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                },
-                "content_type": {
-                  "type": "string"
-                }
-              }
+            "format": {
+              "type": "string"
+            },
+            "pdb_content": {
+              "type": "string"
+            },
+            "atom_count": {
+              "type": "integer"
+            },
+            "size_bytes": {
+              "type": "integer"
+            },
+            "filters_applied": {
+              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -491,73 +416,48 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "requested_count": {
-                  "type": "integer"
-                },
-                "returned_count": {
-                  "type": "integer"
-                },
-                "results": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "uniprot_ids": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "sequence_length": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "crc64": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "model_count": {
-                        "type": "integer"
-                      },
-                      "models": {
-                        "type": "array",
-                        "items": {
-                          "type": "object"
-                        }
-                      }
+            "requested_count": {
+              "type": "integer"
+            },
+            "returned_count": {
+              "type": "integer"
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "uniprot_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "sequence_length": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "crc64": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "model_count": {
+                    "type": "integer"
+                  },
+                  "models": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "api_version": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/synbiohub_tools.json
+++ b/src/tooluniverse/data/synbiohub_tools.json
@@ -36,72 +36,61 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "display_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Part identifier (e.g., BBa_E0040)"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Human-readable part name"
-                  },
-                  "description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Part description"
-                  },
-                  "uri": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "SynBioHub URI for the part (use with SynBioHub_get_part)"
-                  },
-                  "version": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Part version number"
-                  },
-                  "sbol_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "SBOL type: ComponentDefinition, Sequence, etc."
-                  },
-                  "role": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Functional role: promoter, CDS, terminator, RBS, etc."
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "display_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Part identifier (e.g., BBa_E0040)"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable part name"
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Part description"
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "SynBioHub URI for the part (use with SynBioHub_get_part)"
+              },
+              "version": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Part version number"
+              },
+              "sbol_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "SBOL type: ComponentDefinition, Sequence, etc."
+              },
+              "role": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Functional role: promoter, CDS, terminator, RBS, etc."
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -133,65 +122,54 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Collection name"
-                  },
-                  "description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Collection description"
-                  },
-                  "display_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Collection identifier"
-                  },
-                  "uri": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Collection URI"
-                  },
-                  "version": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Collection version"
-                  },
-                  "member_count": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of parts in collection"
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Collection name"
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Collection description"
+              },
+              "display_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Collection identifier"
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Collection URI"
+              },
+              "version": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Collection version"
+              },
+              "member_count": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of parts in collection"
               }
-            },
-            "metadata": {
-              "type": "object"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -240,91 +218,80 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "display_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Part display identifier"
-                },
-                "title": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Human-readable part title"
-                },
-                "description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Part description"
-                },
-                "type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "SBOL biological type (e.g., DnaRegion)"
-                },
-                "role": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Functional roles (SO terms and iGEM part types)"
-                },
-                "sequence": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "DNA sequence (first 500 characters)"
-                },
-                "sequence_length": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ],
-                  "description": "Full sequence length in base pairs"
-                },
-                "created": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Creation date"
-                },
-                "modified": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Last modification date"
-                },
-                "derived_from": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Original source URI (e.g., iGEM registry URL)"
-                }
-              }
+            "display_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Part display identifier"
             },
-            "metadata": {
-              "type": "object"
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Human-readable part title"
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Part description"
+            },
+            "type": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "SBOL biological type (e.g., DnaRegion)"
+            },
+            "role": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "description": "Functional roles (SO terms and iGEM part types)"
+            },
+            "sequence": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "DNA sequence (first 500 characters)"
+            },
+            "sequence_length": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Full sequence length in base pairs"
+            },
+            "created": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Creation date"
+            },
+            "modified": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Last modification date"
+            },
+            "derived_from": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Original source URI (e.g., iGEM registry URL)"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/t3db_tools.json
+++ b/src/tooluniverse/data/t3db_tools.json
@@ -22,18 +22,7 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "object"
-            },
-            "metadata": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "object"
         },
         {
           "type": "object",
@@ -72,18 +61,7 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array"
-            },
-            "metadata": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "array"
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/tdc_dataset_tools.json
+++ b/src/tooluniverse/data/tdc_dataset_tools.json
@@ -43,107 +43,94 @@
       }
     ],
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "problem": {
+              "type": "string",
+              "description": "Canonical TDC problem name used."
             },
-            "data": {
-              "type": "object",
-              "description": "Successful dataset load. Mirrors the 'data' field returned by the tool.",
+            "name": {
+              "type": "string",
+              "description": "Dataset name that was loaded."
+            },
+            "n_rows": {
+              "type": "integer",
+              "description": "Total number of rows in the dataset."
+            },
+            "columns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Column names of the dataset DataFrame (e.g. Drug_ID, Drug, Y)."
+            },
+            "label_summary": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "Summary of the 'Y' label column, or null if there is no 'Y' column.",
               "properties": {
-                "problem": {
+                "label_type": {
                   "type": "string",
-                  "description": "Canonical TDC problem name used."
+                  "description": "One of 'categorical', 'continuous', or 'other'."
                 },
-                "name": {
-                  "type": "string",
-                  "description": "Dataset name that was loaded."
+                "n_unique": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "description": "Number of distinct label values."
                 },
-                "n_rows": {
-                  "type": "integer",
-                  "description": "Total number of rows in the dataset."
-                },
-                "columns": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Column names of the dataset DataFrame (e.g. Drug_ID, Drug, Y)."
-                },
-                "label_summary": {
+                "distribution": {
                   "type": [
                     "object",
                     "null"
                   ],
-                  "description": "Summary of the 'Y' label column, or null if there is no 'Y' column.",
-                  "properties": {
-                    "label_type": {
-                      "type": "string",
-                      "description": "One of 'categorical', 'continuous', or 'other'."
-                    },
-                    "n_unique": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ],
-                      "description": "Number of distinct label values."
-                    },
-                    "distribution": {
-                      "type": [
-                        "object",
-                        "null"
-                      ],
-                      "description": "Value-count distribution for categorical labels, otherwise null."
-                    },
-                    "statistics": {
-                      "type": [
-                        "object",
-                        "null"
-                      ],
-                      "description": "Summary statistics (count, mean, std, min, quartiles, max) for continuous labels, otherwise null."
-                    }
-                  },
-                  "required": [
-                    "label_type"
-                  ]
+                  "description": "Value-count distribution for categorical labels, otherwise null."
                 },
-                "split_sizes": {
+                "statistics": {
                   "type": [
                     "object",
                     "null"
                   ],
-                  "description": "Row counts per split (train/valid/test), or null if the split could not be computed.",
-                  "additionalProperties": {
-                    "type": "integer"
-                  }
-                },
-                "sample_rows": {
-                  "type": "integer",
-                  "description": "Number of rows included in the sample."
-                },
-                "sample": {
-                  "type": "array",
-                  "description": "A small head() sample of rows as JSON objects keyed by column name.",
-                  "items": {
-                    "type": "object"
-                  }
+                  "description": "Summary statistics (count, mean, std, min, quartiles, max) for continuous labels, otherwise null."
                 }
               },
               "required": [
-                "problem",
-                "name",
-                "n_rows",
-                "columns",
-                "sample"
+                "label_type"
               ]
+            },
+            "split_sizes": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "description": "Row counts per split (train/valid/test), or null if the split could not be computed.",
+              "additionalProperties": {
+                "type": "integer"
+              }
+            },
+            "sample_rows": {
+              "type": "integer",
+              "description": "Number of rows included in the sample."
+            },
+            "sample": {
+              "type": "array",
+              "description": "A small head() sample of rows as JSON objects keyed by column name.",
+              "items": {
+                "type": "object"
+              }
             }
           },
           "required": [
-            "data"
+            "problem",
+            "name",
+            "n_rows",
+            "columns",
+            "sample"
           ]
         },
         {
@@ -192,43 +179,30 @@
       }
     ],
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "problem": {
+              "type": "string",
+              "description": "Canonical TDC problem name used."
             },
-            "data": {
-              "type": "object",
-              "description": "Successful listing. Mirrors the 'data' field returned by the tool.",
-              "properties": {
-                "problem": {
-                  "type": "string",
-                  "description": "Canonical TDC problem name used."
-                },
-                "n_datasets": {
-                  "type": "integer",
-                  "description": "Number of available datasets for this problem."
-                },
-                "dataset_names": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Normalized (lowercase) dataset names accepted case-insensitively by TDC_load_dataset."
-                }
+            "n_datasets": {
+              "type": "integer",
+              "description": "Number of available datasets for this problem."
+            },
+            "dataset_names": {
+              "type": "array",
+              "items": {
+                "type": "string"
               },
-              "required": [
-                "problem",
-                "n_datasets",
-                "dataset_names"
-              ]
+              "description": "Normalized (lowercase) dataset names accepted case-insensitively by TDC_load_dataset."
             }
           },
           "required": [
-            "data"
+            "problem",
+            "n_datasets",
+            "dataset_names"
           ]
         },
         {

--- a/src/tooluniverse/data/tdc_oracle_tools.json
+++ b/src/tooluniverse/data/tdc_oracle_tools.json
@@ -59,70 +59,58 @@
       }
     ],
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
+          "description": "Successful oracle scoring. Mirrors the content of the 'data' field returned by the tool.",
           "properties": {
-            "status": {
-              "const": "success"
+            "oracle": {
+              "type": "string",
+              "description": "Canonical oracle name that was used."
             },
-            "data": {
-              "type": "object",
-              "description": "Successful oracle scoring. Mirrors the content of the 'data' field returned by the tool.",
-              "properties": {
-                "oracle": {
-                  "type": "string",
-                  "description": "Canonical oracle name that was used."
-                },
-                "oracle_description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Human-readable description of the oracle."
-                },
-                "results": {
-                  "type": "array",
-                  "description": "One entry per input SMILES, in input order.",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "smiles": {
-                        "type": "string",
-                        "description": "The input SMILES string."
-                      },
-                      "score": {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "description": "The oracle score for this molecule, or null if scoring failed."
-                      },
-                      "error": {
-                        "type": [
-                          "string",
-                          "null"
-                        ],
-                        "description": "Error message if scoring this molecule failed, otherwise null."
-                      }
-                    },
-                    "required": [
-                      "smiles",
-                      "score",
-                      "error"
-                    ]
+            "oracle_description": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Human-readable description of the oracle."
+            },
+            "results": {
+              "type": "array",
+              "description": "One entry per input SMILES, in input order.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "smiles": {
+                    "type": "string",
+                    "description": "The input SMILES string."
+                  },
+                  "score": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "The oracle score for this molecule, or null if scoring failed."
+                  },
+                  "error": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "description": "Error message if scoring this molecule failed, otherwise null."
                   }
-                }
-              },
-              "required": [
-                "oracle",
-                "results"
-              ]
+                },
+                "required": [
+                  "smiles",
+                  "score",
+                  "error"
+                ]
+              }
             }
           },
           "required": [
-            "data"
+            "oracle",
+            "results"
           ]
         },
         {

--- a/src/tooluniverse/data/three_d_beacons_tools.json
+++ b/src/tooluniverse/data/three_d_beacons_tools.json
@@ -31,36 +31,27 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "accession": {
-                                    "type": "string",
-                                    "description": "UniProt accession queried"
-                                },
-                                "sequence_length": {
-                                    "type": ["integer", "null"],
-                                    "description": "Full protein sequence length"
-                                },
-                                "total_structures": {
-                                    "type": "integer",
-                                    "description": "Total number of 3D structures/models available"
-                                },
-                                "by_provider": {
-                                    "type": "object",
-                                    "description": "Structure counts by data provider (PDBe, AlphaFold DB, SWISS-MODEL, PED, AlphaFill, isoform.io)"
-                                },
-                                "by_category": {
-                                    "type": "object",
-                                    "description": "Structure counts by model category (EXPERIMENTALLY DETERMINED, TEMPLATE-BASED, AB-INITIO, CONFORMATIONAL ENSEMBLE)"
-                                }
-                            }
+                        "accession": {
+                            "type": "string",
+                            "description": "UniProt accession queried"
                         },
-                        "metadata": {
-                            "type": "object"
+                        "sequence_length": {
+                            "type": ["integer", "null"],
+                            "description": "Full protein sequence length"
+                        },
+                        "total_structures": {
+                            "type": "integer",
+                            "description": "Total number of 3D structures/models available"
+                        },
+                        "by_provider": {
+                            "type": "object",
+                            "description": "Structure counts by data provider (PDBe, AlphaFold DB, SWISS-MODEL, PED, AlphaFill, isoform.io)"
+                        },
+                        "by_category": {
+                            "type": "object",
+                            "description": "Structure counts by model category (EXPERIMENTALLY DETERMINED, TEMPLATE-BASED, AB-INITIO, CONFORMATIONAL ENSEMBLE)"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -121,68 +112,59 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "accession": {
-                                    "type": "string",
-                                    "description": "UniProt accession queried"
-                                },
-                                "sequence_length": {
-                                    "type": ["integer", "null"],
-                                    "description": "Full protein sequence length"
-                                },
-                                "total_matched": {
-                                    "type": "integer",
-                                    "description": "Total structures matching filters"
-                                },
-                                "returned": {
-                                    "type": "integer",
-                                    "description": "Number of structures returned"
-                                },
-                                "structures": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "model_identifier": {
-                                                "type": ["string", "null"],
-                                                "description": "Structure/model identifier (PDB ID or model ID)"
-                                            },
-                                            "model_category": {
-                                                "type": ["string", "null"],
-                                                "description": "Model category"
-                                            },
-                                            "provider": {
-                                                "type": ["string", "null"],
-                                                "description": "Data provider name"
-                                            },
-                                            "coverage": {
-                                                "type": ["number", "null"],
-                                                "description": "Fraction of protein covered (0-1)"
-                                            },
-                                            "resolution": {
-                                                "type": ["number", "null"],
-                                                "description": "Resolution in Angstroms (experimental only)"
-                                            },
-                                            "experimental_method": {
-                                                "type": ["string", "null"],
-                                                "description": "Experimental method (e.g., X-ray diffraction)"
-                                            },
-                                            "model_url": {
-                                                "type": ["string", "null"],
-                                                "description": "URL to download the model"
-                                            }
-                                        }
+                        "accession": {
+                            "type": "string",
+                            "description": "UniProt accession queried"
+                        },
+                        "sequence_length": {
+                            "type": ["integer", "null"],
+                            "description": "Full protein sequence length"
+                        },
+                        "total_matched": {
+                            "type": "integer",
+                            "description": "Total structures matching filters"
+                        },
+                        "returned": {
+                            "type": "integer",
+                            "description": "Number of structures returned"
+                        },
+                        "structures": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "model_identifier": {
+                                        "type": ["string", "null"],
+                                        "description": "Structure/model identifier (PDB ID or model ID)"
+                                    },
+                                    "model_category": {
+                                        "type": ["string", "null"],
+                                        "description": "Model category"
+                                    },
+                                    "provider": {
+                                        "type": ["string", "null"],
+                                        "description": "Data provider name"
+                                    },
+                                    "coverage": {
+                                        "type": ["number", "null"],
+                                        "description": "Fraction of protein covered (0-1)"
+                                    },
+                                    "resolution": {
+                                        "type": ["number", "null"],
+                                        "description": "Resolution in Angstroms (experimental only)"
+                                    },
+                                    "experimental_method": {
+                                        "type": ["string", "null"],
+                                        "description": "Experimental method (e.g., X-ray diffraction)"
+                                    },
+                                    "model_url": {
+                                        "type": ["string", "null"],
+                                        "description": "URL to download the model"
                                     }
                                 }
                             }
-                        },
-                        "metadata": {
-                            "type": "object"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
@@ -239,68 +221,59 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "accession": {
-                                    "type": "string",
-                                    "description": "UniProt accession queried"
-                                },
-                                "id": {
-                                    "type": ["string", "null"],
-                                    "description": "3D Beacons annotation record identifier"
-                                },
-                                "sequence_length": {
-                                    "type": ["integer", "null"],
-                                    "description": "Length of the annotated sequence"
-                                },
-                                "type_filter": {
-                                    "type": ["string", "null"],
-                                    "description": "Annotation type filter applied, if any"
-                                },
-                                "annotation_count": {
-                                    "type": "integer",
-                                    "description": "Number of annotation entries returned"
-                                },
-                                "annotations": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "type": {
-                                                "type": ["string", "null"],
-                                                "description": "Annotation type (DOMAIN, BINDING, ACT_SITE, etc.)"
-                                            },
-                                            "description": {
-                                                "type": ["string", "null"],
-                                                "description": "Human-readable description (may include InterPro IDs)"
-                                            },
-                                            "source_name": {
-                                                "type": ["string", "null"],
-                                                "description": "Annotation source (e.g. InterPro, UniProt)"
-                                            },
-                                            "evidence": {
-                                                "type": ["string", "null"],
-                                                "description": "Evidence level (e.g. COMPUTATIONAL/PREDICTED, EXPERIMENTAL)"
-                                            },
-                                            "residues": {
-                                                "type": ["array", "null"],
-                                                "description": "List of residue numbers covered by the annotation"
-                                            },
-                                            "regions": {
-                                                "type": ["array", "null"],
-                                                "description": "List of {start, end} region objects"
-                                            }
-                                        }
+                        "accession": {
+                            "type": "string",
+                            "description": "UniProt accession queried"
+                        },
+                        "id": {
+                            "type": ["string", "null"],
+                            "description": "3D Beacons annotation record identifier"
+                        },
+                        "sequence_length": {
+                            "type": ["integer", "null"],
+                            "description": "Length of the annotated sequence"
+                        },
+                        "type_filter": {
+                            "type": ["string", "null"],
+                            "description": "Annotation type filter applied, if any"
+                        },
+                        "annotation_count": {
+                            "type": "integer",
+                            "description": "Number of annotation entries returned"
+                        },
+                        "annotations": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": ["string", "null"],
+                                        "description": "Annotation type (DOMAIN, BINDING, ACT_SITE, etc.)"
+                                    },
+                                    "description": {
+                                        "type": ["string", "null"],
+                                        "description": "Human-readable description (may include InterPro IDs)"
+                                    },
+                                    "source_name": {
+                                        "type": ["string", "null"],
+                                        "description": "Annotation source (e.g. InterPro, UniProt)"
+                                    },
+                                    "evidence": {
+                                        "type": ["string", "null"],
+                                        "description": "Evidence level (e.g. COMPUTATIONAL/PREDICTED, EXPERIMENTAL)"
+                                    },
+                                    "residues": {
+                                        "type": ["array", "null"],
+                                        "description": "List of residue numbers covered by the annotation"
+                                    },
+                                    "regions": {
+                                        "type": ["array", "null"],
+                                        "description": "List of {start, end} region objects"
                                     }
                                 }
                             }
-                        },
-                        "metadata": {
-                            "type": "object"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",

--- a/src/tooluniverse/data/ucsc_genome_tools.json
+++ b/src/tooluniverse/data/ucsc_genome_tools.json
@@ -37,70 +37,48 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "genome": {
-                  "type": "string"
-                },
-                "search_term": {
-                  "type": "string"
-                },
-                "match_count": {
-                  "type": "integer"
-                },
-                "matches": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "track": {
-                        "type": "string"
-                      },
-                      "track_description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "position": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "transcript_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "genome": {
+              "type": "string"
+            },
+            "search_term": {
+              "type": "string"
+            },
+            "match_count": {
+              "type": "integer"
+            },
+            "matches": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "track": {
+                    "type": "string"
+                  },
+                  "track_description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "position": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "transcript_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -172,117 +150,95 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "genome": {
-                  "type": "string"
-                },
-                "name_filter": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "track_count": {
-                  "type": "integer"
-                },
-                "returned_count": {
-                  "type": "integer"
-                },
-                "tracks": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "track": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "short_label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "long_label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "parent": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "group": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "track": {
-                  "type": "string"
-                },
-                "track_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "column_count": {
-                  "type": "integer"
-                },
-                "columns": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "sqlType": {
-                        "type": "string"
-                      },
-                      "jsonType": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": "string"
-                      }
-                    }
+            "genome": {
+              "type": "string"
+            },
+            "name_filter": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "track_count": {
+              "type": "integer"
+            },
+            "returned_count": {
+              "type": "integer"
+            },
+            "tracks": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "track": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "short_label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "long_label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "parent": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "group": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
+            "track": {
+              "type": "string"
+            },
+            "track_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "column_count": {
+              "type": "integer"
+            },
+            "columns": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "sqlType": {
+                    "type": "string"
+                  },
+                  "jsonType": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -351,47 +307,25 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "genome": {
-                  "type": "string"
-                },
-                "chrom": {
-                  "type": "string"
-                },
-                "start": {
-                  "type": "integer"
-                },
-                "end": {
-                  "type": "integer"
-                },
-                "length": {
-                  "type": "integer"
-                },
-                "dna": {
-                  "type": "string"
-                }
-              }
+            "genome": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "chrom": {
+              "type": "string"
+            },
+            "start": {
+              "type": "integer"
+            },
+            "end": {
+              "type": "integer"
+            },
+            "length": {
+              "type": "integer"
+            },
+            "dna": {
+              "type": "string"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -476,59 +410,37 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "genome": {
-                  "type": "string"
-                },
-                "track": {
-                  "type": "string"
-                },
-                "track_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "chrom": {
-                  "type": "string"
-                },
-                "start": {
-                  "type": "integer"
-                },
-                "end": {
-                  "type": "integer"
-                },
-                "item_count": {
-                  "type": "integer"
-                },
-                "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  }
-                }
-              }
+            "genome": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+            "track": {
+              "type": "string"
+            },
+            "track_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "chrom": {
+              "type": "string"
+            },
+            "start": {
+              "type": "integer"
+            },
+            "end": {
+              "type": "integer"
+            },
+            "item_count": {
+              "type": "integer"
+            },
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/unibind_tools.json
+++ b/src/tooluniverse/data/unibind_tools.json
@@ -75,51 +75,39 @@
       "return_format": "JSON"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "tf_name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "total_peaks": {
-                    "type": [
-                      "string",
-                      "integer",
-                      "null"
-                    ]
-                  },
-                  "dataset_url": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "dataset_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "tf_name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "total_peaks": {
+                "type": [
+                  "string",
+                  "integer",
+                  "null"
+                ]
+              },
+              "dataset_url": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "dataset_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -183,139 +171,127 @@
       "return_format": "JSON"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
           "type": "object",
+          "required": [
+            "dataset_id",
+            "tf_name",
+            "tfbs_models"
+          ],
           "properties": {
-            "status": {
-              "const": "success"
+            "dataset_id": {
+              "type": "string"
             },
-            "data": {
-              "type": "object",
-              "required": [
-                "dataset_id",
-                "tf_name",
-                "tfbs_models"
-              ],
-              "properties": {
-                "dataset_id": {
-                  "type": "string"
-                },
-                "tf_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "cell_line": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "biological_condition": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "identifier": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "jaspar_id": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "prediction_models": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "tfbs_models": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "prediction_model": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "jaspar_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "jaspar_version": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "total_tfbs": {
-                        "type": [
-                          "string",
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "score_threshold": {
-                        "type": [
-                          "string",
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "distance_threshold": {
-                        "type": [
-                          "string",
-                          "number",
-                          "null"
-                        ]
-                      },
-                      "adj_centrimo_pvalue": {
-                        "type": [
-                          "number",
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "bed_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "fasta_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "summary_plot_url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "tf_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cell_line": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "biological_condition": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "identifier": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "jaspar_id": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "prediction_models": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "tfbs_models": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "prediction_model": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "jaspar_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "jaspar_version": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "total_tfbs": {
+                    "type": [
+                      "string",
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "score_threshold": {
+                    "type": [
+                      "string",
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "distance_threshold": {
+                    "type": [
+                      "string",
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "adj_centrimo_pvalue": {
+                    "type": [
+                      "number",
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "bed_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "fasta_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "summary_plot_url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -378,24 +354,12 @@
       "return_format": "JSON"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "required": [
-            "data"
-          ]
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/unichem_tools.json
+++ b/src/tooluniverse/data/unichem_tools.json
@@ -45,73 +45,51 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "inchi": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "inchikey": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "formula": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "source_count": {
-                  "type": "integer"
-                },
-                "sources": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "source_name": {
-                        "type": "string"
-                      },
-                      "source_long_name": {
-                        "type": "string"
-                      },
-                      "compound_id": {
-                        "type": "string"
-                      },
-                      "url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "inchi": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "inchikey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "formula": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source_count": {
+              "type": "integer"
+            },
+            "sources": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source_name": {
+                    "type": "string"
+                  },
+                  "source_long_name": {
+                    "type": "string"
+                  },
+                  "compound_id": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -147,67 +125,45 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "source_count": {
-                  "type": "integer"
-                },
-                "sources": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "source_id": {
-                        "type": "integer"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "long_name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "compound_count": {
-                        "type": [
-                          "integer",
-                          "null"
-                        ]
-                      },
-                      "last_updated": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "source_count": {
+              "type": "integer"
+            },
+            "sources": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source_id": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "long_name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "compound_count": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "last_updated": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -269,89 +225,94 @@
         {
           "type": "object",
           "properties": {
-            "data": {
+            "response": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "UniChem response status (e.g. 'Success')"
+            },
+            "searched_compound": {
               "type": "object",
               "properties": {
-                "response": {
-                  "type": ["string", "null"],
-                  "description": "UniChem response status (e.g. 'Success')"
+                "inchi": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "searched_compound": {
-                  "type": "object",
-                  "properties": {
-                    "inchi": {
-                      "type": ["string", "null"]
-                    },
-                    "inchikey": {
-                      "type": ["string", "null"]
-                    },
-                    "uci": {
-                      "type": ["integer", "null"]
-                    }
-                  }
+                "inchikey": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "total_compounds": {
-                  "type": ["integer", "null"],
-                  "description": "Total number of distinct connectivity-matched compounds"
-                },
-                "total_sources": {
-                  "type": ["integer", "null"],
-                  "description": "Total number of source-database match entries"
-                },
-                "match_count": {
-                  "type": "integer",
-                  "description": "Number of match entries returned"
-                },
-                "matches": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "source_id": {
-                        "type": ["integer", "null"]
-                      },
-                      "source_name": {
-                        "type": "string"
-                      },
-                      "source_long_name": {
-                        "type": "string"
-                      },
-                      "compound_id": {
-                        "type": "string"
-                      },
-                      "type_of_search": {
-                        "type": ["string", "null"]
-                      },
-                      "url": {
-                        "type": ["string", "null"]
-                      },
-                      "comparison": {
-                        "type": "object",
-                        "description": "Per-match boolean flags showing how this match differs from the query (charge, connectivity, formula, isotope, protonation, stereoDbond, stereoSp3, HAtoms, ...)"
-                      }
-                    }
-                  }
+                "uci": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
+            "total_compounds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Total number of distinct connectivity-matched compounds"
+            },
+            "total_sources": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Total number of source-database match entries"
+            },
+            "match_count": {
+              "type": "integer",
+              "description": "Number of match entries returned"
+            },
+            "matches": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "source_id": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "source_name": {
+                    "type": "string"
+                  },
+                  "source_long_name": {
+                    "type": "string"
+                  },
+                  "compound_id": {
+                    "type": "string"
+                  },
+                  "type_of_search": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "comparison": {
+                    "type": "object",
+                    "description": "Per-match boolean flags showing how this match differs from the query (charge, connectivity, formula, isotope, protonation, stereoDbond, stereoSp3, HAtoms, ...)"
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/uniparc_tools.json
+++ b/src/tooluniverse/data/uniparc_tools.json
@@ -10,7 +10,9 @@
                     "description": "UniParc identifier (e.g., 'UPI000002ED67' for TP53/P04637). Find UPIs via UniParc_search or from UniProt protein pages."
                 }
             },
-            "required": ["upi"]
+            "required": [
+                "upi"
+            ]
         },
         "fields": {
             "endpoint": "get_entry"
@@ -26,69 +28,114 @@
                 {
                     "type": "object",
                     "properties": {
-                        "data": {
+                        "uniparc_id": {
+                            "type": "string"
+                        },
+                        "sequence": {
                             "type": "object",
                             "properties": {
-                                "uniparc_id": {"type": "string"},
-                                "sequence": {
-                                    "type": "object",
-                                    "properties": {
-                                        "value": {"type": "string", "description": "Full amino acid sequence"},
-                                        "length": {"type": "integer"},
-                                        "mol_weight": {"type": "integer"},
-                                        "crc64": {"type": "string"},
-                                        "md5": {"type": "string"}
-                                    }
+                                "value": {
+                                    "type": "string",
+                                    "description": "Full amino acid sequence"
                                 },
-                                "cross_references": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "database": {"type": "string"},
-                                            "id": {"type": "string"},
-                                            "active": {"type": "boolean"},
-                                            "gene_name": {"type": ["string", "null"]},
-                                            "protein_name": {"type": ["string", "null"]},
-                                            "organism": {"type": ["string", "null"]},
-                                            "taxon_id": {"type": ["integer", "null"]}
-                                        }
-                                    },
-                                    "description": "Active cross-references to other databases"
+                                "length": {
+                                    "type": "integer"
                                 },
-                                "sequence_features": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "database": {"type": "string"},
-                                            "database_id": {"type": "string"},
-                                            "interpro_id": {"type": ["string", "null"]},
-                                            "interpro_name": {"type": ["string", "null"]},
-                                            "locations": {"type": "array"}
-                                        }
-                                    },
-                                    "description": "InterPro domain annotations"
+                                "mol_weight": {
+                                    "type": "integer"
+                                },
+                                "crc64": {
+                                    "type": "string"
+                                },
+                                "md5": {
+                                    "type": "string"
                                 }
                             }
                         },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "total_cross_references": {"type": "integer"},
-                                "active_cross_references": {"type": "integer"}
-                            }
+                        "cross_references": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "database": {
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "active": {
+                                        "type": "boolean"
+                                    },
+                                    "gene_name": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "protein_name": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "organism": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "taxon_id": {
+                                        "type": [
+                                            "integer",
+                                            "null"
+                                        ]
+                                    }
+                                }
+                            },
+                            "description": "Active cross-references to other databases"
+                        },
+                        "sequence_features": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "database": {
+                                        "type": "string"
+                                    },
+                                    "database_id": {
+                                        "type": "string"
+                                    },
+                                    "interpro_id": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "interpro_name": {
+                                        "type": [
+                                            "string",
+                                            "null"
+                                        ]
+                                    },
+                                    "locations": {
+                                        "type": "array"
+                                    }
+                                }
+                            },
+                            "description": "InterPro domain annotations"
                         }
-                    },
-                    "required": ["data"]
+                    }
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "error": {"type": "string"}
+                        "error": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["error"]
+                    "required": [
+                        "error"
+                    ]
                 }
             ]
         }
@@ -108,7 +155,9 @@
                     "description": "Number of results to return (default 5, max 10)."
                 }
             },
-            "required": ["query"]
+            "required": [
+                "query"
+            ]
         },
         "fields": {
             "endpoint": "search"
@@ -126,49 +175,72 @@
         "return_schema": {
             "oneOf": [
                 {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "uniparc_id": {"type": "string", "description": "Stable UPI identifier"},
-                                    "uniprot_accessions": {"type": "array", "items": {"type": "string"}},
-                                    "organisms": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "name": {"type": ["string", "null"]},
-                                                "taxon_id": {"type": ["integer", "null"]}
-                                            }
-                                        }
-                                    },
-                                    "gene_names": {"type": "array", "items": {"type": "string"}},
-                                    "oldest_created": {"type": ["string", "null"]},
-                                    "most_recent_updated": {"type": ["string", "null"]}
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "uniparc_id": {
+                                "type": "string",
+                                "description": "Stable UPI identifier"
+                            },
+                            "uniprot_accessions": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
                                 }
                             },
-                            "description": "Matching UniParc entries"
-                        },
-                        "metadata": {
-                            "type": "object",
-                            "properties": {
-                                "source": {"type": "string"},
-                                "query": {"type": "string"},
-                                "returned": {"type": "integer"}
+                            "organisms": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        },
+                                        "taxon_id": {
+                                            "type": [
+                                                "integer",
+                                                "null"
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            "gene_names": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "oldest_created": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "most_recent_updated": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
                             }
                         }
                     },
-                    "required": ["data"]
+                    "description": "Matching UniParc entries"
                 },
                 {
                     "type": "object",
                     "properties": {
-                        "error": {"type": "string"}
+                        "error": {
+                            "type": "string"
+                        }
                     },
-                    "required": ["error"]
+                    "required": [
+                        "error"
+                    ]
                 }
             ]
         }

--- a/src/tooluniverse/data/uniref_tools.json
+++ b/src/tooluniverse/data/uniref_tools.json
@@ -31,148 +31,129 @@
         {
           "type": "object",
           "properties": {
-            "data": {
+            "cluster_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "UniRef cluster ID"
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Cluster name (usually 'Cluster: protein_name')"
+            },
+            "entry_type": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Cluster type (UniRef100, UniRef90, UniRef50)"
+            },
+            "member_count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Number of sequences in the cluster"
+            },
+            "updated": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Last update date"
+            },
+            "seed_id": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Seed sequence identifier"
+            },
+            "common_taxon": {
               "type": "object",
               "properties": {
-                "cluster_id": {
+                "scientific_name": {
                   "type": [
                     "string",
                     "null"
-                  ],
-                  "description": "UniRef cluster ID"
+                  ]
                 },
-                "name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Cluster name (usually 'Cluster: protein_name')"
-                },
-                "entry_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
-                  "description": "Cluster type (UniRef100, UniRef90, UniRef50)"
-                },
-                "member_count": {
+                "taxon_id": {
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "description": "Number of sequences in the cluster"
-                },
-                "updated": {
+                  ]
+                }
+              },
+              "description": "Most specific taxon common to all members"
+            },
+            "representative_member": {
+              "type": "object",
+              "properties": {
+                "member_id": {
                   "type": [
                     "string",
                     "null"
-                  ],
-                  "description": "Last update date"
+                  ]
                 },
-                "seed_id": {
+                "member_id_type": {
                   "type": [
                     "string",
                     "null"
-                  ],
-                  "description": "Seed sequence identifier"
+                  ]
                 },
-                "common_taxon": {
-                  "type": "object",
-                  "properties": {
-                    "scientific_name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "taxon_id": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    }
-                  },
-                  "description": "Most specific taxon common to all members"
-                },
-                "representative_member": {
-                  "type": "object",
-                  "properties": {
-                    "member_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "member_id_type": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "organism_name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "organism_tax_id": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "sequence_length": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "protein_name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "accessions": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "description": "Representative (longest) member details"
-                },
-                "sequence": {
+                "organism_name": {
                   "type": [
                     "string",
                     "null"
-                  ],
-                  "description": "Representative protein sequence"
+                  ]
+                },
+                "organism_tax_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 },
                 "sequence_length": {
                   "type": [
                     "integer",
                     "null"
-                  ],
-                  "description": "Sequence length"
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
+                  ]
                 },
-                "cluster_id": {
-                  "type": "string"
+                "protein_name": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "accessions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
-              }
+              },
+              "description": "Representative (longest) member details"
+            },
+            "sequence": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Representative protein sequence"
+            },
+            "sequence_length": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Sequence length"
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -229,107 +210,82 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "cluster_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "UniRef cluster ID"
-                  },
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Cluster name"
-                  },
-                  "entry_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Cluster type"
-                  },
-                  "member_count": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Number of members"
-                  },
-                  "updated": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Last update date"
-                  },
-                  "representative_member_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Representative member ID"
-                  },
-                  "representative_organism": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Organism of representative"
-                  },
-                  "representative_protein": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Protein name of representative"
-                  },
-                  "representative_sequence_length": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
-                    "description": "Sequence length of representative"
-                  },
-                  "common_taxon": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Common taxon scientific name"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "cluster_type": {
-                  "type": "string"
-                },
-                "returned": {
-                  "type": "integer"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "cluster_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "UniRef cluster ID"
+              },
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Cluster name"
+              },
+              "entry_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Cluster type"
+              },
+              "member_count": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Number of members"
+              },
+              "updated": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Last update date"
+              },
+              "representative_member_id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Representative member ID"
+              },
+              "representative_organism": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Organism of representative"
+              },
+              "representative_protein": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Protein name of representative"
+              },
+              "representative_sequence_length": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Sequence length of representative"
+              },
+              "common_taxon": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Common taxon scientific name"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/variant_fraction_tools.json
+++ b/src/tooluniverse/data/variant_fraction_tools.json
@@ -3,6 +3,7 @@
     "type": "CodingVariantFractionTool",
     "name": "coding_variant_fraction",
     "description": "Compute the fraction of CODING variants in an Excel/CSV variant table that match a given Sequence Ontology annotation and fall below a VAF threshold. Uses the CODING-only denominator convention (synonymous_variant, missense_variant, splice_region_variant, stop_gained, stop_lost, start_lost, frameshift_variant, inframe_insertion, inframe_deletion) - intronic, UTR, intergenic, and up/downstream records are excluded. Auto-detects 'variant allele frequency'/'VAF' and 'Sequence Ontology' columns if not specified. Supports flat headers (header_rows=1) and MultiIndex headers (header_rows=2) common in cancer variant reports. Returns the fraction with coding denominator plus the 'naive' fraction (over all VAF-filtered records) for comparison.",
+    "requires_local_input": true,
     "parameter": {
       "type": "object",
       "properties": {
@@ -46,71 +47,56 @@
       ]
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "success"
+            "total_variants": {
+              "type": "integer"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_variants": {
-                  "type": "integer"
-                },
-                "vaf_filtered": {
-                  "type": "integer"
-                },
-                "coding_variants_below_vaf": {
-                  "type": "integer"
-                },
-                "matching_annotation": {
-                  "type": "integer"
-                },
-                "fraction": {
-                  "type": "number"
-                },
-                "naive_fraction": {
-                  "type": "number"
-                },
-                "vaf_column": {
-                  "type": "string"
-                },
-                "so_column": {
-                  "type": "string"
-                },
-                "vaf_threshold": {
-                  "type": "number"
-                },
-                "annotation": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "total_variants",
-                "coding_variants_below_vaf",
-                "matching_annotation",
-                "fraction"
-              ]
+            "vaf_filtered": {
+              "type": "integer"
+            },
+            "coding_variants_below_vaf": {
+              "type": "integer"
+            },
+            "matching_annotation": {
+              "type": "integer"
+            },
+            "fraction": {
+              "type": "number"
+            },
+            "naive_fraction": {
+              "type": "number"
+            },
+            "vaf_column": {
+              "type": "string"
+            },
+            "so_column": {
+              "type": "string"
+            },
+            "vaf_threshold": {
+              "type": "number"
+            },
+            "annotation": {
+              "type": "string"
             }
           },
           "required": [
-            "status",
-            "data"
+            "total_variants",
+            "coding_variants_below_vaf",
+            "matching_annotation",
+            "fraction"
           ]
         },
         {
+          "type": "object",
           "properties": {
-            "status": {
-              "const": "error"
-            },
             "error": {
               "type": "string"
             }
           },
           "required": [
-            "status",
             "error"
           ]
         }

--- a/src/tooluniverse/data/vcf_stats_tools.json
+++ b/src/tooluniverse/data/vcf_stats_tools.json
@@ -17,10 +17,9 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
-        {"properties": {"status": {"const": "success"}, "data": {"type": "object"}}, "required": ["data"]},
-        {"properties": {"status": {"const": "error"}, "error": {"type": "string"}}, "required": ["error"]}
+        {"type": "object"},
+        {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
       ]
     },
     "test_examples": [
@@ -45,10 +44,9 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
-        {"properties": {"status": {"const": "success"}, "data": {"type": "object"}}, "required": ["data"]},
-        {"properties": {"status": {"const": "error"}, "error": {"type": "string"}}, "required": ["error"]}
+        {"type": "object"},
+        {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
       ]
     },
     "test_examples": [
@@ -71,10 +69,9 @@
       }
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
-        {"properties": {"status": {"const": "success"}, "data": {"type": "object"}}, "required": ["data"]},
-        {"properties": {"status": {"const": "error"}, "error": {"type": "string"}}, "required": ["error"]}
+        {"type": "object"},
+        {"type": "object", "properties": {"error": {"type": "string"}}, "required": ["error"]}
       ]
     },
     "test_examples": [

--- a/src/tooluniverse/data/veupathdb_tools.json
+++ b/src/tooluniverse/data/veupathdb_tools.json
@@ -239,85 +239,48 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "type": "string"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "primary_key": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "source_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "product": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "organism": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "location_text": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "project": {
-                  "type": "string"
-                },
-                "organism": {
-                  "type": "string"
-                },
-                "total_count": {
-                  "type": [
-                    "integer",
-                    "null"
-                  ]
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "operation": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "primary_key": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "product": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "organism": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "location_text": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -397,83 +360,55 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
+            "primary_key": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "primary_key": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "source_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "product": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "organism": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "gene_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "location_text": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "chromosome": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "transcript_count": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
+            "source_id": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "project": {
-                  "type": "string"
-                },
-                "gene_id": {
-                  "type": "string"
-                },
-                "operation": {
-                  "type": "string"
-                }
-              }
+            "product": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "organism": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "gene_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "location_text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "chromosome": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "transcript_count": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/wikipathways_ext_tools.json
+++ b/src/tooluniverse/data/wikipathways_ext_tools.json
@@ -1,276 +1,266 @@
 [
-    {
-        "name": "WikiPathways_get_pathway_genes",
-        "description": "Get the genes involved in a WikiPathways pathway. `gene_count` counts distinct gene products; `genes` lists every symbol label WikiPathways records for them, which is larger because one gene product carries several aliases (AKT, AKT1, Akt1 are one node) and occasionally an unrelated symbol -- use `gene_products` for node-level identifiers and their exact labels. By default every gene product is returned regardless of which database annotated it; set `code` only when you need genes cross-referenced to one identifier system, and note most pathways are annotated from Entrez Gene or Ensembl rather than HGNC. Useful for extracting gene sets from curated pathways for enrichment analysis or network building. Example: WP254 (Apoptosis) has 87 gene products (139 labels) including AKT1, APAF1, BAD, BAK1, BAX, BCL2, BCL2L1, BID, CASP3, CASP8, CASP9, CFLAR, CYCS, DIABLO, FADD, FAS, NFKB1, TP53, TRAF1, XIAP.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "pathway_id": {
-                    "type": "string",
-                    "description": "WikiPathways pathway identifier. Examples: 'WP254' (Apoptosis, 87 gene products), 'WP179' (Cell cycle), 'WP4216' (Chromosomal and microsatellite instability), 'WP1584' (Type II diabetes mellitus)."
-                },
-                "code": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Optional filter restricting results to gene products annotated from one identifier system: 'H' (HGNC), 'En' (Ensembl), 'S' (UniProt), 'L' (Entrez Gene), 'Ce' (ChEBI, metabolites). Omit to return every gene product in the pathway. Most pathways are annotated from Entrez Gene or Ensembl and carry no HGNC-sourced entries, so filtering can legitimately return 0."
-                }
-            },
-            "required": [
-                "pathway_id"
-            ]
+  {
+    "name": "WikiPathways_get_pathway_genes",
+    "description": "Get the genes involved in a WikiPathways pathway. `gene_count` counts distinct gene products; `genes` lists every symbol label WikiPathways records for them, which is larger because one gene product carries several aliases (AKT, AKT1, Akt1 are one node) and occasionally an unrelated symbol -- use `gene_products` for node-level identifiers and their exact labels. By default every gene product is returned regardless of which database annotated it; set `code` only when you need genes cross-referenced to one identifier system, and note most pathways are annotated from Entrez Gene or Ensembl rather than HGNC. Useful for extracting gene sets from curated pathways for enrichment analysis or network building. Example: WP254 (Apoptosis) has 87 gene products (139 labels) including AKT1, APAF1, BAD, BAK1, BAX, BCL2, BCL2L1, BID, CASP3, CASP8, CASP9, CFLAR, CYCS, DIABLO, FADD, FAS, NFKB1, TP53, TRAF1, XIAP.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "pathway_id": {
+          "type": "string",
+          "description": "WikiPathways pathway identifier. Examples: 'WP254' (Apoptosis, 87 gene products), 'WP179' (Cell cycle), 'WP4216' (Chromosomal and microsatellite instability), 'WP1584' (Type II diabetes mellitus)."
         },
-        "fields": {
-            "endpoint": "get_pathway_genes"
-        },
-        "type": "WikiPathwaysExtTool",
-        "test_examples": [
-            {
-                "pathway_id": "WP254"
-            },
-            {
-                "pathway_id": "WP254",
-                "code": "L"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "pathway_id": {
-                                    "type": "string",
-                                    "description": "WikiPathways pathway ID"
-                                },
-                                "gene_count": {
-                                    "type": "integer",
-                                    "description": "Number of distinct gene products in the pathway"
-                                },
-                                "label_count": {
-                                    "type": "integer",
-                                    "description": "Number of distinct symbol labels across those gene products; exceeds gene_count because one gene product carries several aliases"
-                                },
-                                "identifier_type": {
-                                    "type": "string",
-                                    "description": "Identifier system results were filtered to, or 'All sources' when unfiltered"
-                                },
-                                "genes": {
-                                    "type": "array",
-                                    "description": "Every symbol label recorded for the pathway's gene products",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "gene_products": {
-                                    "type": "array",
-                                    "description": "Node-level truth: one entry per gene product with its identifier and exact labels",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "identifier": {
-                                                "type": "string"
-                                            },
-                                            "labels": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
+        "code": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Optional filter restricting results to gene products annotated from one identifier system: 'H' (HGNC), 'En' (Ensembl), 'S' (UniProt), 'L' (Entrez Gene), 'Ce' (ChEBI, metabolites). Omit to return every gene product in the pathway. Most pathways are annotated from Entrez Gene or Ensembl and carry no HGNC-sourced entries, so filtering can legitimately return 0."
         }
+      },
+      "required": [
+        "pathway_id"
+      ]
     },
-    {
-        "name": "WikiPathways_find_pathways_by_gene",
-        "description": "Find all WikiPathways pathways containing a specific gene. Takes a gene identifier (HGNC symbol, Entrez ID, or Ensembl ID) and returns all pathways in which that gene appears. Useful for understanding the biological context of a gene across curated pathway databases. Example: searching for 'TP53' returns multiple pathways including WP254 (Apoptosis), WP179 (Cell Cycle), and others. Supports multiple species.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "gene": {
-                    "type": "string",
-                    "description": "Gene identifier to search. Examples: 'TP53', 'BRCA1', 'EGFR', '7157' (Entrez), 'ENSG00000141510' (Ensembl)."
-                },
-                "species": {
-                    "type": "string",
-                    "description": "Species to filter results. Default: 'Homo sapiens'. Other options: 'Mus musculus', 'Rattus norvegicus', 'Danio rerio'.",
-                    "default": "Homo sapiens"
-                }
-            },
-            "required": [
-                "gene"
-            ]
-        },
-        "fields": {
-            "endpoint": "find_pathways_by_gene"
-        },
-        "type": "WikiPathwaysExtTool",
-        "test_examples": [
-            {
-                "gene": "TP53"
-            },
-            {
-                "gene": "BRCA1",
-                "species": "Homo sapiens"
-            }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "gene": {
-                                    "type": "string",
-                                    "description": "Gene identifier queried"
-                                },
-                                "total_pathways": {
-                                    "type": "integer",
-                                    "description": "Number of pathways containing this gene"
-                                },
-                                "pathways": {
-                                    "type": "array",
-                                    "description": "List of pathways",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {"type": "string"},
-                                            "name": {"type": "string"},
-                                            "species": {"type": "string"},
-                                            "url": {"type": ["string", "null"]}
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
-        }
+    "fields": {
+      "endpoint": "get_pathway_genes"
     },
-    {
-        "name": "WikiPathways_get_pathway_metabolites",
-        "description": "Get the metabolite/compound participants (wp:Metabolite nodes) of a WikiPathways pathway. Unlike WikiPathways_get_pathway_genes (which returns gene products only), this returns the small-molecule metabolites that are the central entities of a metabolic pathway, each with its canonical cross-reference identifier (HMDB, ChEBI, KEGG, ChemSpider, etc.), the dc:source datasource, and a representative label. Example: WP534 (Glycolysis & Gluconeogenesis, human) returns metabolites including D-Glucose (https://identifiers.org/hmdb/HMDB0000122), Aspartate (HMDB0000191), and D-Glyceraldehyde 3-phosphate (HMDB0001112). Use for metabolic-network reconstruction, metabolite-set enrichment, and mapping measured metabolites onto curated pathways.",
-        "parameter": {
-            "type": "object",
-            "properties": {
-                "pathway_id": {
-                    "type": "string",
-                    "description": "WikiPathways pathway identifier. Examples: 'WP534' (Glycolysis & Gluconeogenesis), 'WP78' (TCA cycle), 'WP143' (Fatty acid beta-oxidation), 'WP550' (Biogenic amine synthesis)."
+    "type": "WikiPathwaysExtTool",
+    "test_examples": [
+      {
+        "pathway_id": "WP254"
+      },
+      {
+        "pathway_id": "WP254",
+        "code": "L"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "pathway_id": {
+              "type": "string",
+              "description": "WikiPathways pathway ID"
+            },
+            "gene_count": {
+              "type": "integer",
+              "description": "Number of distinct gene products in the pathway"
+            },
+            "label_count": {
+              "type": "integer",
+              "description": "Number of distinct symbol labels across those gene products; exceeds gene_count because one gene product carries several aliases"
+            },
+            "identifier_type": {
+              "type": "string",
+              "description": "Identifier system results were filtered to, or 'All sources' when unfiltered"
+            },
+            "genes": {
+              "type": "array",
+              "description": "Every symbol label recorded for the pathway's gene products",
+              "items": {
+                "type": "string"
+              }
+            },
+            "gene_products": {
+              "type": "array",
+              "description": "Node-level truth: one entry per gene product with its identifier and exact labels",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "identifier": {
+                    "type": "string"
+                  },
+                  "labels": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
                 }
-            },
-            "required": [
-                "pathway_id"
-            ]
-        },
-        "fields": {
-            "endpoint": "get_pathway_metabolites"
-        },
-        "type": "WikiPathwaysExtTool",
-        "test_examples": [
-            {
-                "pathway_id": "WP534"
-            },
-            {
-                "pathway_id": "WP78"
+              }
             }
-        ],
-        "return_schema": {
-            "oneOf": [
-                {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "properties": {
-                                "pathway_id": {
-                                    "type": "string",
-                                    "description": "WikiPathways pathway ID"
-                                },
-                                "metabolite_count": {
-                                    "type": "integer",
-                                    "description": "Number of distinct metabolites in the pathway"
-                                },
-                                "metabolites": {
-                                    "type": "array",
-                                    "description": "Distinct metabolite participants",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "identifier": {
-                                                "type": "string",
-                                                "description": "Canonical metabolite identifier (e.g. identifiers.org HMDB/ChEBI/KEGG URI or bare ID)"
-                                            },
-                                            "source": {
-                                                "type": "string",
-                                                "description": "Datasource of the identifier (HMDB, ChEBI, KEGG Compound, etc.)"
-                                            },
-                                            "label": {
-                                                "type": "string",
-                                                "description": "Metabolite name/label"
-                                            },
-                                            "node": {
-                                                "type": "string",
-                                                "description": "RDF node URI for the metabolite"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "metadata": {
-                            "type": "object"
-                        }
-                    },
-                    "required": ["data"]
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["error"]
-                }
-            ]
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
         }
+      ]
     }
+  },
+  {
+    "name": "WikiPathways_find_pathways_by_gene",
+    "description": "Find all WikiPathways pathways containing a specific gene. Takes a gene identifier (HGNC symbol, Entrez ID, or Ensembl ID) and returns all pathways in which that gene appears. Useful for understanding the biological context of a gene across curated pathway databases. Example: searching for 'TP53' returns multiple pathways including WP254 (Apoptosis), WP179 (Cell Cycle), and others. Supports multiple species.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "gene": {
+          "type": "string",
+          "description": "Gene identifier to search. Examples: 'TP53', 'BRCA1', 'EGFR', '7157' (Entrez), 'ENSG00000141510' (Ensembl)."
+        },
+        "species": {
+          "type": "string",
+          "description": "Species to filter results. Default: 'Homo sapiens'. Other options: 'Mus musculus', 'Rattus norvegicus', 'Danio rerio'.",
+          "default": "Homo sapiens"
+        }
+      },
+      "required": [
+        "gene"
+      ]
+    },
+    "fields": {
+      "endpoint": "find_pathways_by_gene"
+    },
+    "type": "WikiPathwaysExtTool",
+    "test_examples": [
+      {
+        "gene": "TP53"
+      },
+      {
+        "gene": "BRCA1",
+        "species": "Homo sapiens"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "gene": {
+              "type": "string",
+              "description": "Gene identifier queried"
+            },
+            "total_pathways": {
+              "type": "integer",
+              "description": "Number of pathways containing this gene"
+            },
+            "pathways": {
+              "type": "array",
+              "description": "List of pathways",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "species": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "WikiPathways_get_pathway_metabolites",
+    "description": "Get the metabolite/compound participants (wp:Metabolite nodes) of a WikiPathways pathway. Unlike WikiPathways_get_pathway_genes (which returns gene products only), this returns the small-molecule metabolites that are the central entities of a metabolic pathway, each with its canonical cross-reference identifier (HMDB, ChEBI, KEGG, ChemSpider, etc.), the dc:source datasource, and a representative label. Example: WP534 (Glycolysis & Gluconeogenesis, human) returns metabolites including D-Glucose (https://identifiers.org/hmdb/HMDB0000122), Aspartate (HMDB0000191), and D-Glyceraldehyde 3-phosphate (HMDB0001112). Use for metabolic-network reconstruction, metabolite-set enrichment, and mapping measured metabolites onto curated pathways.",
+    "parameter": {
+      "type": "object",
+      "properties": {
+        "pathway_id": {
+          "type": "string",
+          "description": "WikiPathways pathway identifier. Examples: 'WP534' (Glycolysis & Gluconeogenesis), 'WP78' (TCA cycle), 'WP143' (Fatty acid beta-oxidation), 'WP550' (Biogenic amine synthesis)."
+        }
+      },
+      "required": [
+        "pathway_id"
+      ]
+    },
+    "fields": {
+      "endpoint": "get_pathway_metabolites"
+    },
+    "type": "WikiPathwaysExtTool",
+    "test_examples": [
+      {
+        "pathway_id": "WP534"
+      },
+      {
+        "pathway_id": "WP78"
+      }
+    ],
+    "return_schema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "pathway_id": {
+              "type": "string",
+              "description": "WikiPathways pathway ID"
+            },
+            "metabolite_count": {
+              "type": "integer",
+              "description": "Number of distinct metabolites in the pathway"
+            },
+            "metabolites": {
+              "type": "array",
+              "description": "Distinct metabolite participants",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "identifier": {
+                    "type": "string",
+                    "description": "Canonical metabolite identifier (e.g. identifiers.org HMDB/ChEBI/KEGG URI or bare ID)"
+                  },
+                  "source": {
+                    "type": "string",
+                    "description": "Datasource of the identifier (HMDB, ChEBI, KEGG Compound, etc.)"
+                  },
+                  "label": {
+                    "type": "string",
+                    "description": "Metabolite name/label"
+                  },
+                  "node": {
+                    "type": "string",
+                    "description": "RDF node URI for the metabolite"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "error"
+          ]
+        }
+      ]
+    }
+  }
 ]

--- a/src/tooluniverse/data/wormbase_tools.json
+++ b/src/tooluniverse/data/wormbase_tools.json
@@ -31,68 +31,46 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "wormbase_id": {
-                  "type": "string"
-                },
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "sequence_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "species": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "description": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "gene_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "status": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                }
-              }
+            "wormbase_id": {
+              "type": "string"
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sequence_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "species": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "gene_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -140,90 +118,68 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "wormbase_id": {
-                  "type": "string"
-                },
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "phenotype_count": {
-                  "type": "integer"
-                },
-                "phenotypes": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "phenotype_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "phenotype_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "evidence_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "not_observed_count": {
-                  "type": "integer"
-                },
-                "phenotypes_not_observed": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "phenotype_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "phenotype_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "wormbase_id": {
+              "type": "string"
+            },
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "phenotype_count": {
+              "type": "integer"
+            },
+            "phenotypes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "phenotype_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "phenotype_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "evidence_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
+            "not_observed_count": {
+              "type": "integer"
+            },
+            "phenotypes_not_observed": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "phenotype_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "phenotype_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -271,124 +227,102 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "wormbase_id": {
-                  "type": "string"
-                },
-                "gene_name": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "expressed_in_count": {
-                  "type": "integer"
-                },
-                "expressed_in": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "term_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "term_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "expressed_during": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "term_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "term_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "subcellular_localization": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "term_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "term_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "expression_clusters_count": {
-                  "type": "integer"
-                },
-                "expression_clusters": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "cluster_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "cluster_label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "wormbase_id": {
+              "type": "string"
+            },
+            "gene_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "expressed_in_count": {
+              "type": "integer"
+            },
+            "expressed_in": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "term_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
+            "expressed_during": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "term_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "subcellular_localization": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "term_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "term_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            },
+            "expression_clusters_count": {
+              "type": "integer"
+            },
+            "expression_clusters": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "cluster_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "cluster_label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -437,85 +371,63 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "wormbase_id": {
-                  "type": "string"
-                },
-                "cross_species_ortholog_count": {
-                  "type": "integer"
-                },
-                "cross_species_orthologs": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "ortholog_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "ortholog_label": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "species": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "methods": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
+            "wormbase_id": {
+              "type": "string"
+            },
+            "cross_species_ortholog_count": {
+              "type": "integer"
+            },
+            "cross_species_orthologs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "ortholog_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "ortholog_label": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "species": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "methods": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
-                  }
-                },
-                "nematode_ortholog_count": {
-                  "type": "integer"
-                },
-                "nematode_orthologs": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  }
-                },
-                "paralog_count": {
-                  "type": "integer"
-                },
-                "paralogs": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+            "nematode_ortholog_count": {
+              "type": "integer"
+            },
+            "nematode_orthologs": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "paralog_count": {
+              "type": "integer"
+            },
+            "paralogs": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -564,91 +476,69 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "wormbase_id": {
-                  "type": "string"
-                },
-                "total_interactions": {
-                  "type": "integer"
-                },
-                "physical_count": {
-                  "type": "integer"
-                },
-                "physical_interactions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "interactor_1": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "interactor_1_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "interactor_2": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "interactor_2_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "interaction_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "citation": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                },
-                "genetic_count": {
-                  "type": "integer"
-                },
-                "genetic_interactions": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
+            "wormbase_id": {
+              "type": "string"
+            },
+            "total_interactions": {
+              "type": "integer"
+            },
+            "physical_count": {
+              "type": "integer"
+            },
+            "physical_interactions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "interactor_1": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "interactor_1_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "interactor_2": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "interactor_2_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "interaction_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "citation": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
+            "genetic_count": {
+              "type": "integer"
+            },
+            "genetic_interactions": {
+              "type": "array",
+              "items": {
+                "type": "object"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -697,76 +587,54 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "wormbase_id": {
-                  "type": "string"
-                },
-                "human_gene_ids": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "disease_count": {
-                  "type": "integer"
-                },
-                "diseases": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "disease_id": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "disease_name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "model_type": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "evidence": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
+            "wormbase_id": {
+              "type": "string"
+            },
+            "human_gene_ids": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "disease_count": {
+              "type": "integer"
+            },
+            "diseases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "disease_id": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "disease_name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "model_type": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "evidence": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "source": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "string"
-                },
-                "endpoint": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/worms_tools.json
+++ b/src/tooluniverse/data/worms_tools.json
@@ -19,51 +19,38 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "required": ["status", "data"],
-          "properties": {
-            "status": {"type": "string"},
-            "count": {"type": "integer", "description": "Number of records in this response (at most `limit`)."},
-            "offset": {"type": "integer"},
-            "limit": {"type": "integer"},
-            "has_more": {"type": "boolean", "description": "True when further matching records exist beyond this page."},
-            "url": {"type": "string"},
-            "message": {"type": "string"},
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "AphiaID": {"type": "integer"},
-                  "url": {"type": "string"},
-                  "scientificname": {"type": "string"},
-                  "authority": {"type": ["string", "null"]},
-                  "status": {"type": "string"},
-                  "unacceptreason": {"type": ["string", "null"]},
-                  "taxonRankID": {"type": "integer"},
-                  "rank": {"type": "string"},
-                  "valid_AphiaID": {"type": "integer"},
-                  "valid_name": {"type": "string"},
-                  "valid_authority": {"type": ["string", "null"]},
-                  "parentNameUsageID": {"type": "integer"},
-                  "originalNameUsageID": {"type": ["integer", "null"]},
-                  "kingdom": {"type": "string"},
-                  "phylum": {"type": "string"},
-                  "class": {"type": "string"},
-                  "order": {"type": "string"},
-                  "family": {"type": ["string", "null"]},
-                  "genus": {"type": ["string", "null"]},
-                  "citation": {"type": "string"},
-                  "lsid": {"type": "string"},
-                  "isMarine": {"type": ["integer", "null"]},
-                  "isBrackish": {"type": ["integer", "null"]},
-                  "isFreshwater": {"type": ["integer", "null"]},
-                  "isTerrestrial": {"type": ["integer", "null"]},
-                  "isExtinct": {"type": ["integer", "null"]},
-                  "match_type": {"type": "string"},
-                  "modified": {"type": "string"}
-                }
-              }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "AphiaID": {"type": "integer"},
+              "url": {"type": "string"},
+              "scientificname": {"type": "string"},
+              "authority": {"type": ["string", "null"]},
+              "status": {"type": "string"},
+              "unacceptreason": {"type": ["string", "null"]},
+              "taxonRankID": {"type": "integer"},
+              "rank": {"type": "string"},
+              "valid_AphiaID": {"type": "integer"},
+              "valid_name": {"type": "string"},
+              "valid_authority": {"type": ["string", "null"]},
+              "parentNameUsageID": {"type": "integer"},
+              "originalNameUsageID": {"type": ["integer", "null"]},
+              "kingdom": {"type": "string"},
+              "phylum": {"type": "string"},
+              "class": {"type": "string"},
+              "order": {"type": "string"},
+              "family": {"type": ["string", "null"]},
+              "genus": {"type": ["string", "null"]},
+              "citation": {"type": "string"},
+              "lsid": {"type": "string"},
+              "isMarine": {"type": ["integer", "null"]},
+              "isBrackish": {"type": ["integer", "null"]},
+              "isFreshwater": {"type": ["integer", "null"]},
+              "isTerrestrial": {"type": ["integer", "null"]},
+              "isExtinct": {"type": ["integer", "null"]},
+              "match_type": {"type": "string"},
+              "modified": {"type": "string"}
             }
           }
         },
@@ -71,7 +58,6 @@
           "type": "object",
           "required": ["error"],
           "properties": {
-            "status": {"type": "string"},
             "error": {"type": "string"}
           }
         }

--- a/src/tooluniverse/data/zfin_tools.json
+++ b/src/tooluniverse/data/zfin_tools.json
@@ -31,158 +31,133 @@
         {
           "type": "object",
           "properties": {
-            "data": {
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "symbol": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "species": {
               "type": "object",
               "properties": {
-                "id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "symbol": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
                 "name": {
                   "type": [
                     "string",
                     "null"
                   ]
                 },
-                "species": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "short_name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "taxon_id": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "data_provider": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
-                },
-                "gene_synopsis": {
+                "short_name": {
                   "type": [
                     "string",
                     "null"
                   ]
                 },
-                "automated_gene_synopsis": {
+                "taxon_id": {
                   "type": [
                     "string",
                     "null"
                   ]
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "so_term": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "genomic_location": {
-                  "type": "object",
-                  "properties": {
-                    "chromosome": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "start": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "end": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "assembly": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "strand": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    }
-                  }
-                },
-                "cross_references": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "url": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_gene_id": {
-                  "type": "string"
                 },
                 "data_provider": {
                   "type": [
                     "string",
                     "null"
                   ]
+                }
+              }
+            },
+            "gene_synopsis": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "automated_gene_synopsis": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "so_term": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "genomic_location": {
+              "type": "object",
+              "properties": {
+                "chromosome": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 },
-                "source": {
-                  "type": "string"
+                "start": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "end": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "assembly": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "strand": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "cross_references": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "url": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
                 }
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -238,58 +213,30 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "gene_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "phenotype_statement": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "source": {
-                  "type": "string"
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "gene_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "phenotype_statement": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -349,100 +296,69 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "subject_gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "subject_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "subject_species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ortholog_gene_id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ortholog_symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "ortholog_species": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "is_best_score": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "is_best_score_reverse": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "methods": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "method_count": {
-                    "type": "integer"
-                  }
-                }
-              }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "stringency": {
-                  "type": "string"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "source": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "subject_gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subject_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "subject_species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ortholog_gene_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ortholog_symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "ortholog_species": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_best_score": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "is_best_score_reverse": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "methods": {
+                "type": "array",
+                "items": {
                   "type": "string"
                 }
+              },
+              "method_count": {
+                "type": "integer"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -498,108 +414,80 @@
     "return_schema": {
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "symbol": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "symbol_text": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "category": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "has_disease": {
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "has_phenotype": {
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "variants": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "name": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "type": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "location": {
-                          "type": [
-                            "object",
-                            "null"
-                          ]
-                        }
-                      }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "symbol": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "symbol_text": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "category": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "has_disease": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "has_phenotype": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "variants": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "location": {
+                      "type": [
+                        "object",
+                        "null"
+                      ]
                     }
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "total_results": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "page": {
-                  "type": "integer"
-                },
-                "source": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -650,67 +538,45 @@
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
+            "total_annotations": {
+              "type": "integer"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "total_annotations": {
-                  "type": "integer"
-                },
-                "returned": {
-                  "type": "integer"
-                },
-                "annotations": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "stage": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "location": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "data_provider": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "reference": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      }
-                    }
+            "returned": {
+              "type": "integer"
+            },
+            "annotations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "stage": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "location": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "data_provider": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "reference": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
-            },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_gene_id": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
-              }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -761,68 +627,49 @@
         {
           "type": "object",
           "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "symbol": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "species": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "alteration_type": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "gene_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "gene_symbol": {
-                  "type": [
-                    "string",
-                    "null"
-                  ]
-                },
-                "synonyms": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
+            "id": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
-            "metadata": {
-              "type": "object",
-              "properties": {
-                "query_allele_id": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
+            "symbol": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "species": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "alteration_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "gene_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "gene_symbol": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "synonyms": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/data/zooma_tools.json
+++ b/src/tooluniverse/data/zooma_tools.json
@@ -47,87 +47,75 @@
       "operation": "annotate"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "property_value": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "property_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "semantic_tags": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Ontology term IRIs (OBO/EFO PURLs) this text maps to."
-                  },
-                  "curies": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Compact CURIEs derived from the semantic-tag IRIs, e.g. 'MONDO:0004979', 'UBERON:0002371', 'EFO:0006842'."
-                  },
-                  "confidence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "HIGH, GOOD, MEDIUM, or LOW."
-                  },
-                  "source": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Annotation source name, e.g. 'zooma', 'uberon', 'efo'."
-                  },
-                  "source_type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "ONTOLOGY or DATABASE."
-                  },
-                  "evidence": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Evidence type, e.g. ZOOMA_INFERRED_FROM_CURATED, OLS_TEXT_TAGGER, OLS_EMBEDDING."
-                  },
-                  "ols_links": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "OLS API URLs for each semantic tag."
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "property_value": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "property_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "semantic_tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Ontology term IRIs (OBO/EFO PURLs) this text maps to."
+              },
+              "curies": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Compact CURIEs derived from the semantic-tag IRIs, e.g. 'MONDO:0004979', 'UBERON:0002371', 'EFO:0006842'."
+              },
+              "confidence": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "HIGH, GOOD, MEDIUM, or LOW."
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Annotation source name, e.g. 'zooma', 'uberon', 'efo'."
+              },
+              "source_type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "ONTOLOGY or DATABASE."
+              },
+              "evidence": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Evidence type, e.g. ZOOMA_INFERRED_FROM_CURATED, OLS_TEXT_TAGGER, OLS_EMBEDDING."
+              },
+              "ols_links": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "OLS API URLs for each semantic tag."
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",
@@ -180,47 +168,35 @@
       "operation": "list_datasources"
     },
     "return_schema": {
-      "type": "object",
       "oneOf": [
         {
-          "type": "object",
-          "properties": {
-            "status": {
-              "const": "success"
-            },
-            "data": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Short datasource identifier, e.g. 'uniprot', 'eva-clinvar', 'atlas'."
-                  },
-                  "type": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Datasource type: 'DATABASE' or 'ONTOLOGY'."
-                  },
-                  "uri": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "description": "Home URI of the datasource."
-                  }
-                }
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Short datasource identifier, e.g. 'uniprot', 'eva-clinvar', 'atlas'."
+              },
+              "type": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Datasource type: 'DATABASE' or 'ONTOLOGY'."
+              },
+              "uri": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Home URI of the datasource."
               }
             }
-          },
-          "required": [
-            "data"
-          ]
+          }
         },
         {
           "type": "object",

--- a/src/tooluniverse/fda_pharmacogenomic_biomarkers_tool.py
+++ b/src/tooluniverse/fda_pharmacogenomic_biomarkers_tool.py
@@ -65,12 +65,12 @@ class FDAPharmacogenomicBiomarkersTool(BaseTool):
             # Apply limit
             limited_results = filtered_results[:limit]
 
-            return {
-                "status": "success",
+            payload = {
                 "count": len(filtered_results),
                 "shown": len(limited_results),
                 "results": limited_results,
             }
+            return {"status": "success", **payload, "data": payload}
 
         except Exception as e:
             return {

--- a/src/tooluniverse/openfda_adv_tool.py
+++ b/src/tooluniverse/openfda_adv_tool.py
@@ -144,11 +144,15 @@ class FDADrugAdverseEventTool(BaseTool):
                     if term and term.upper() != reaction_filter.upper():
                         continue
 
-                # Apply mapping if available
+                # Apply mapping if available. Fall back to the raw code as a
+                # string (not the original int/etc) so an FDA code absent
+                # from our mapping (e.g. an undocumented drugcharacterization
+                # value) still satisfies the documented "term is a string"
+                # contract instead of leaking a raw int through.
                 if self.return_fields_mapping:
                     mapped_term = self.return_fields_mapping.get(
                         self.count_field, {}
-                    ).get(str(term), term)
+                    ).get(str(term), str(term))
                     mapped_results.append({"term": mapped_term, "count": count})
                 else:
                     mapped_results.append({"term": term, "count": count})

--- a/src/tooluniverse/pdbe_compound_tool.py
+++ b/src/tooluniverse/pdbe_compound_tool.py
@@ -100,7 +100,11 @@ class PDBECompoundTool(BaseTool):
 
         # Extract SMILES
         smiles = []
-        for s in compound.get("smiles", []):
+        # PDBe returns these fields as JSON null (not absent) for some
+        # compounds (e.g. HEM has cross_links: null), so `.get(key, [])`
+        # doesn't apply its default -- it returns None, and iterating that
+        # raises TypeError. `.get(key) or []` catches both cases.
+        for s in compound.get("smiles") or []:
             smiles.append(
                 {
                     "program": s.get("program"),
@@ -110,7 +114,7 @@ class PDBECompoundTool(BaseTool):
 
         # Extract cross-references
         cross_links = []
-        for cl in compound.get("cross_links", []):
+        for cl in compound.get("cross_links") or []:
             cross_links.append(
                 {
                     "resource": cl.get("resource"),
@@ -120,7 +124,7 @@ class PDBECompoundTool(BaseTool):
 
         # Extract systematic names
         sys_names = []
-        for sn in compound.get("systematic_names", []):
+        for sn in compound.get("systematic_names") or []:
             sys_names.append(
                 {
                     "program": sn.get("program"),
@@ -142,7 +146,7 @@ class PDBECompoundTool(BaseTool):
                 "smiles": smiles[:3],
                 "systematic_names": sys_names[:3],
                 "cross_references": cross_links[:15],
-                "first_observed_in": compound.get("first_observed_in", []),
+                "first_observed_in": compound.get("first_observed_in") or [],
                 "release_status": compound.get("release_status"),
                 "creation_date": compound.get("creation_date"),
             },
@@ -178,7 +182,7 @@ class PDBECompoundTool(BaseTool):
             return {"status": "error", "error": f"No data for compound '{comp_id}'."}
 
         compound = compound_list[0]
-        first_seen = compound.get("first_observed_in", [])
+        first_seen = compound.get("first_observed_in") or []
 
         # Also get compound in_pdb data from the regular PDBe API
         pdb_url = f"https://www.ebi.ac.uk/pdbe/api/pdb/compound/summary/{comp_id}"

--- a/src/tooluniverse/pdbe_kb_tool.py
+++ b/src/tooluniverse/pdbe_kb_tool.py
@@ -132,9 +132,10 @@ class PDBe_KB_Tool(BaseTool):
 
         protein_data = data[acc]
         ligands = []
-        max_ligands = 50  # Limit output size
+        all_ligand_entries = protein_data.get("data", [])
+        max_ligands = arguments.get("max_ligands") or 100
 
-        for entry in protein_data.get("data", [])[:max_ligands]:
+        for entry in all_ligand_entries[:max_ligands]:
             binding_residues = []
             for res in entry.get("residues", [])[:20]:
                 binding_residues.append(
@@ -158,14 +159,25 @@ class PDBe_KB_Tool(BaseTool):
                 }
             )
 
+        result_data = {
+            "uniprot_accession": acc,
+            "protein_length": protein_data.get("length"),
+            "ligands": ligands,
+            "total_ligands": len(all_ligand_entries),
+        }
+        if len(all_ligand_entries) > max_ligands:
+            result_data["truncated"] = True
+            result_data["truncation_note"] = (
+                f"Returning {max_ligands} of {len(all_ligand_entries)} ligands. "
+                f"Pass max_ligands={len(all_ligand_entries)} to retrieve all of them. "
+                "The API does not guarantee ordering by clinical relevance, so "
+                "a specific ligand of interest (e.g. a named drug) may be cut off "
+                "at the default limit."
+            )
+
         return {
             "status": "success",
-            "data": {
-                "uniprot_accession": acc,
-                "protein_length": protein_data.get("length"),
-                "ligands": ligands,
-                "total_ligands": len(protein_data.get("data", [])),
-            },
+            "data": result_data,
             "metadata": {
                 "source": "PDBe-KB (PDBe Knowledge Base) Graph API",
             },
@@ -190,9 +202,10 @@ class PDBe_KB_Tool(BaseTool):
 
         protein_data = data[acc]
         partners = []
-        max_partners = 30
+        all_partner_entries = protein_data.get("data", [])
+        max_partners = arguments.get("max_partners") or 60
 
-        for entry in protein_data.get("data", [])[:max_partners]:
+        for entry in all_partner_entries[:max_partners]:
             interface_residues = []
             for res in entry.get("residues", [])[:30]:
                 interface_residues.append(
@@ -211,14 +224,23 @@ class PDBe_KB_Tool(BaseTool):
                 }
             )
 
+        result_data = {
+            "uniprot_accession": acc,
+            "protein_length": protein_data.get("length"),
+            "interaction_partners": partners,
+            "total_partners": len(all_partner_entries),
+        }
+        if len(all_partner_entries) > max_partners:
+            result_data["truncated"] = True
+            result_data["truncation_note"] = (
+                f"Returning {max_partners} of {len(all_partner_entries)} interaction "
+                f"partners. Pass max_partners={len(all_partner_entries)} to retrieve "
+                "all of them."
+            )
+
         return {
             "status": "success",
-            "data": {
-                "uniprot_accession": acc,
-                "protein_length": protein_data.get("length"),
-                "interaction_partners": partners,
-                "total_partners": len(protein_data.get("data", [])),
-            },
+            "data": result_data,
             "metadata": {
                 "source": "PDBe-KB (PDBe Knowledge Base) Graph API",
             },

--- a/src/tooluniverse/pdbe_kb_tool.py
+++ b/src/tooluniverse/pdbe_kb_tool.py
@@ -133,7 +133,11 @@ class PDBe_KB_Tool(BaseTool):
         protein_data = data[acc]
         ligands = []
         all_ligand_entries = protein_data.get("data", [])
-        max_ligands = arguments.get("max_ligands") or 100
+        max_ligands = arguments.get("max_ligands")
+        # `or 100` would silently turn an explicit 0 into 100 (0 is falsy),
+        # and a negative value would slice from the end instead of erroring
+        # -- check for None explicitly and clamp instead.
+        max_ligands = 100 if max_ligands is None else max(0, max_ligands)
 
         for entry in all_ligand_entries[:max_ligands]:
             binding_residues = []
@@ -203,7 +207,11 @@ class PDBe_KB_Tool(BaseTool):
         protein_data = data[acc]
         partners = []
         all_partner_entries = protein_data.get("data", [])
-        max_partners = arguments.get("max_partners") or 60
+        max_partners = arguments.get("max_partners")
+        # `or 60` would silently turn an explicit 0 into 60 (0 is falsy),
+        # and a negative value would slice from the end instead of erroring
+        # -- check for None explicitly and clamp instead.
+        max_partners = 60 if max_partners is None else max(0, max_partners)
 
         for entry in all_partner_entries[:max_partners]:
             interface_residues = []

--- a/src/tooluniverse/pdbe_search_tool.py
+++ b/src/tooluniverse/pdbe_search_tool.py
@@ -88,9 +88,14 @@ class PDBeSearchTool(BaseTool):
 
         limit = min(arguments.get("limit", 10), 50)
 
+        # PDBe's Solr index is entity-level, not deduplicated by PDB entry --
+        # a single structure with multiple matching chains/entities can
+        # appear as several docs sharing one pdb_id. Over-fetch so dedup
+        # below can still usually fill the caller's requested `limit` with
+        # unique entries, rather than silently returning fewer.
         params = {
             "q": query,
-            "rows": limit,
+            "rows": min(limit * 3, 150),
             "fl": "pdb_id,title,resolution,experimental_method,deposition_date,number_of_entities,organism_scientific_name",
             "wt": "json",
             "sort": "resolution asc",
@@ -104,9 +109,14 @@ class PDBeSearchTool(BaseTool):
         total = solr_response.get("numFound", 0)
 
         structures = []
+        seen_pdb_ids = set()
         for doc in solr_response.get("docs", []):
+            pdb_id = doc.get("pdb_id", "")
+            if pdb_id and pdb_id in seen_pdb_ids:
+                continue
+            seen_pdb_ids.add(pdb_id)
             entry = {
-                "pdb_id": doc.get("pdb_id", ""),
+                "pdb_id": pdb_id,
                 "title": doc.get("title", ""),
                 "resolution": doc.get("resolution"),
                 "experimental_method": doc.get("experimental_method", []),
@@ -115,6 +125,8 @@ class PDBeSearchTool(BaseTool):
                 "organism": doc.get("organism_scientific_name", []),
             }
             structures.append(entry)
+            if len(structures) >= limit:
+                break
 
         return {
             "status": "success",

--- a/src/tooluniverse/pdbe_search_tool.py
+++ b/src/tooluniverse/pdbe_search_tool.py
@@ -90,42 +90,59 @@ class PDBeSearchTool(BaseTool):
 
         # PDBe's Solr index is entity-level, not deduplicated by PDB entry --
         # a single structure with multiple matching chains/entities can
-        # appear as several docs sharing one pdb_id. Over-fetch so dedup
-        # below can still usually fill the caller's requested `limit` with
-        # unique entries, rather than silently returning fewer.
-        params = {
-            "q": query,
-            "rows": min(limit * 3, 150),
-            "fl": "pdb_id,title,resolution,experimental_method,deposition_date,number_of_entities,organism_scientific_name",
-            "wt": "json",
-            "sort": "resolution asc",
-        }
-
-        response = requests.get(PDBE_SEARCH_URL, params=params, timeout=self.timeout)
-        response.raise_for_status()
-        raw = response.json()
-
-        solr_response = raw.get("response", {})
-        total = solr_response.get("numFound", 0)
-
+        # appear as many docs sharing one pdb_id. For entity-dense queries
+        # (e.g. "ribosome 70S", where one structure has dozens of matching
+        # chains) a fixed over-fetch multiplier can exhaust its rows without
+        # finding enough unique pdb_ids, especially when `sort` clusters all
+        # of one entry's docs together. Page through Solr with `start`,
+        # accumulating unique entries, until `limit` is reached or the
+        # safety cap on rows scanned is hit.
+        max_rows_scanned = max(limit * 20, 500)
+        page_size = 100
+        total = 0
         structures = []
         seen_pdb_ids = set()
-        for doc in solr_response.get("docs", []):
-            pdb_id = doc.get("pdb_id", "")
-            if pdb_id and pdb_id in seen_pdb_ids:
-                continue
-            seen_pdb_ids.add(pdb_id)
-            entry = {
-                "pdb_id": pdb_id,
-                "title": doc.get("title", ""),
-                "resolution": doc.get("resolution"),
-                "experimental_method": doc.get("experimental_method", []),
-                "deposition_date": doc.get("deposition_date"),
-                "number_of_entities": doc.get("number_of_entities"),
-                "organism": doc.get("organism_scientific_name", []),
+        start = 0
+        while len(structures) < limit and start < max_rows_scanned:
+            params = {
+                "q": query,
+                "rows": page_size,
+                "start": start,
+                "fl": "pdb_id,title,resolution,experimental_method,deposition_date,number_of_entities,organism_scientific_name",
+                "wt": "json",
+                "sort": "resolution asc",
             }
-            structures.append(entry)
-            if len(structures) >= limit:
+            response = requests.get(
+                PDBE_SEARCH_URL, params=params, timeout=self.timeout
+            )
+            response.raise_for_status()
+            raw = response.json()
+
+            solr_response = raw.get("response", {})
+            total = solr_response.get("numFound", 0)
+            docs = solr_response.get("docs", [])
+
+            for doc in docs:
+                pdb_id = doc.get("pdb_id", "")
+                if pdb_id and pdb_id in seen_pdb_ids:
+                    continue
+                seen_pdb_ids.add(pdb_id)
+                entry = {
+                    "pdb_id": pdb_id,
+                    "title": doc.get("title", ""),
+                    "resolution": doc.get("resolution"),
+                    "experimental_method": doc.get("experimental_method", []),
+                    "deposition_date": doc.get("deposition_date"),
+                    "number_of_entities": doc.get("number_of_entities"),
+                    "organism": doc.get("organism_scientific_name", []),
+                }
+                structures.append(entry)
+                if len(structures) >= limit:
+                    break
+
+            start += page_size
+            if len(docs) < page_size:
+                # Exhausted all matching docs before filling `limit`.
                 break
 
         return {
@@ -134,6 +151,11 @@ class PDBeSearchTool(BaseTool):
             "metadata": {
                 "source": "PDBe Search",
                 "total_found": total,
+                "total_found_note": (
+                    "Entity-level Solr match count, not unique PDB entries -- "
+                    "a single structure can contribute many matching chains/"
+                    "entities, so this is typically far larger than `returned`."
+                ),
                 "returned": len(structures),
                 "query": query,
                 "endpoint": "search_structures",

--- a/src/tooluniverse/pubtator_tool.py
+++ b/src/tooluniverse/pubtator_tool.py
@@ -134,7 +134,7 @@ class PubTatorTool(BaseTool):
                 ):
                     result["results"] = result["results"][:_limit]
             if isinstance(result, dict) and "status" not in result:
-                return {"status": "success", **result}
+                return {"status": "success", **result, "data": result}
             return result
         if "text" in ctype or "xml" in ctype:
             return response.text

--- a/src/tooluniverse/semantic_scholar_tool.py
+++ b/src/tooluniverse/semantic_scholar_tool.py
@@ -491,10 +491,10 @@ class SemanticScholarPDFSnippetsTool(BaseTool):
                 total_chars += len(snippet)
                 found += 1
 
-        return {
-            "status": "success",
+        payload = {
             "pdf_url": pdf_url,
             "snippets": snippets,
             "snippets_count": len(snippets),
             "truncated": total_chars >= max_total_chars,
         }
+        return {"status": "success", **payload, "data": payload}

--- a/tests/unit/test_icite_get_publications_extract_path.py
+++ b/tests/unit/test_icite_get_publications_extract_path.py
@@ -66,7 +66,10 @@ def test_unwrapped_response_satisfies_return_schema():
     }
     result = tool._process_response(_mock_response(raw_icite_body), "https://icite.od.nih.gov/api/pubs")
 
-    jsonschema.validate(instance=result, schema=config["return_schema"])
+    # cli.py validates jsonschema against result["data"] alone (never the
+    # full {status, data, metadata} envelope), so that's what return_schema
+    # describes -- a bare array of publication objects, not the envelope.
+    jsonschema.validate(instance=result["data"], schema=config["return_schema"])
 
 
 def test_without_extract_path_would_double_wrap():
@@ -82,4 +85,4 @@ def test_without_extract_path_would_double_wrap():
 
     assert result["data"] == raw_icite_body  # double-wrapped, not unwrapped
     with pytest.raises(jsonschema.ValidationError):
-        jsonschema.validate(instance=result, schema=config["return_schema"])
+        jsonschema.validate(instance=result["data"], schema=config["return_schema"])

--- a/tests/unit/test_pharmacovigilance_faers_depth.py
+++ b/tests/unit/test_pharmacovigilance_faers_depth.py
@@ -140,7 +140,7 @@ class TestDrugCharacterization(unittest.TestCase):
         self.assertEqual(terms["Interacting"], 5371)
 
     def test_unknown_code_passes_through(self):
-        """An unmapped code is returned verbatim rather than dropped."""
+        """An unmapped code is returned verbatim (as a string, per return_schema) rather than dropped."""
         tool = _make_tool(self.TOOL)
         rows = [{"term": 4, "count": 15}]  # code 4 is not in the standard map
         with patch(
@@ -148,7 +148,7 @@ class TestDrugCharacterization(unittest.TestCase):
             return_value=_patched_get(rows),
         ):
             out = tool.run({"medicinalproduct": "METFORMIN"})
-        self.assertEqual(out[0]["term"], 4)
+        self.assertEqual(out[0]["term"], "4")
         self.assertEqual(out[0]["count"], 15)
 
     def test_api_failure_returns_error_not_raise(self):

--- a/tests/unit/test_round77_null_permissive_schema_fields.py
+++ b/tests/unit/test_round77_null_permissive_schema_fields.py
@@ -4,16 +4,20 @@ return null for that field, so a genuinely-empty value failed schema
 validation even though the tool itself handled it correctly.
 
 Each of these already has a sibling field in the same schema that already
-permits null (e.g. DailyMed's previous_page/next_page, OmicsDI's organisms),
-confirming these are schema-definition gaps rather than deliberate strictness.
+permits null (e.g. OmicsDI's organisms), confirming these are
+schema-definition gaps rather than deliberate strictness.
 
 - OmicsDI_search_datasets: dataset.description / dataset.publicationDate
   (OmicsDI aggregates multiple repositories; not all of them populate these).
-- DailyMed_search_spls: metadata.previous_page_url / metadata.next_page_url
-  (already normalized to None by SearchSPLTool on the first/last page --
-  see tests/unit/test_dailymed_null_and_headers.py).
 - PDBe_get_compound_details: <compound>[].cross_links (a compound with no
   cross-references to external databases).
+
+Note: DailyMed_search_spls's return_schema no longer has a `metadata`
+sub-schema to guard -- cli.py only validates jsonschema against
+`result.get("data")`, so the tool's sibling `metadata` envelope key was
+never actually schema-checked; the old return_schema described the full
+envelope (a symptom of the double-wrapped return_schema bug fixed
+elsewhere) and has since been corrected to describe just the `data` array.
 """
 
 import json
@@ -30,13 +34,6 @@ def _dataset_item_schema():
     tool = next(t for t in tools if t["name"] == "OmicsDI_search_datasets")
     branch = tool["return_schema"]["oneOf"][0]
     return branch["properties"]["datasets"]["items"]
-
-
-def _dailymed_metadata_schema():
-    with open("src/tooluniverse/data/dailymed_tools.json") as f:
-        tools = json.load(f)
-    tool = next(t for t in tools if t["name"] == "DailyMed_search_spls")
-    return tool["return_schema"]["properties"]["metadata"]
 
 
 def _pdbe_compound_item_schema():
@@ -70,23 +67,6 @@ def test_omicsdi_dataset_still_requires_description_to_be_string_or_null():
     schema = _dataset_item_schema()
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance={"description": 12345}, schema=schema)
-
-
-def test_dailymed_metadata_allows_null_page_urls():
-    schema = _dailymed_metadata_schema()
-    jsonschema.validate(
-        instance={
-            "current_url": "https://dailymed.nlm.nih.gov/dailymed/services/v2/spls.json",
-            "next_page_url": None,
-            "total_elements": 1,
-            "total_pages": 1,
-            "current_page": 1,
-            "previous_page": None,
-            "previous_page_url": None,
-            "next_page": None,
-        },
-        schema=schema,
-    )
 
 
 def test_pdbe_compound_allows_null_cross_links():


### PR DESCRIPTION
Consolidates #454, #455, #456, #457, #459, #460, #461, #462 into a single PR. Those are being closed in favor of this one; see each for the detailed rationale/verification behind its piece if useful.

## 1. `return_schema` envelope bug (~485 tools)
`tu test` validates a tool's unwrapped `result["data"]` against `return_schema` (`cli.py`), so `return_schema` must describe the payload itself, not the `{status, data, metadata}` envelope. ~470 tools had a `oneOf`-wrapped schema requiring `data`; a second variant across 15 more files used a flat (non-`oneOf`) shape with the same mistake. Hoisted each to describe the real payload directly, following the already-correct `gwas_search_associations` pattern. No `run()` logic changed — these tools already returned correct data; this only fixes their self-test.

## 2. `scripts/test_new_tools.py`: removed an unreliable envelope-detection heuristic
The script had a heuristic trying to auto-detect envelope-shaped schemas to decide whether to validate the full result or just `data`. It produced repeated false positives (a legitimate error branch mirroring the real `{"status":"error","error":...}` shape; ENCODE's own unrelated `status` field; IDR's own legitimately-nested `data` key). Removed it — the script now always validates `result["data"]`, exactly matching `cli.py`.

## 3. Five tools returning no `data` key on success (real code bug, not schema)
`SemanticScholar_get_pdf_snippets`, `fda_pharmacogenomic_biomarkers`, `ArXiv_get_pdf_snippets`, `DailyMed_get_spl_by_setid`, `PubTator3_LiteratureSearch` built a valid payload but never wrapped it in `data` — `result["data"]` was unconditionally `None`. Fixed at the source.

## 4. RDKit nullable fields + FAERS unmapped-code stringification
`RDKit_pharmacophore_features`'s per-feature counts are intentionally `null` when `include_features` excludes that feature — schema declared them non-nullable. FAERS count-endpoint tools leaked a raw int through when an openFDA code wasn't in the 3-value documented enum map — now stringified so any unmapped code satisfies the schema's string contract.

## 5. Four tools found via a second role-play test round (real, independently-verified bugs)
- **PDBe-KB `ligand_sites`/`interface_residues`**: hardcoded truncation (50/30 items) with no transparency, silently dropping erlotinib/gefitinib for EGFR out of 245 known ligands. Added `max_ligands`/`max_partners` params + `truncated`/`truncation_note` fields.
- **`BVBRC_search_amr`**: silently accepted an unrecognized `organism` parameter and returned unfiltered cross-species data with no error. Added `additionalProperties: false`.
- **`PDBeSearch_search_structures`**: returned duplicate PDB entries (PDBe's index is entity-level). Now deduplicates by `pdb_id`.
- **`DisGeNET_search_disease`**: description falsely claimed free-text names work; it's CUI-only by design. Corrected the docs.

## Verification
- `python scripts/test_all_tools.py --parallel`: schema-invalid dropped from 101 to 0 across the full catalog (3258 tools, 5136 test examples)
- Every fix independently CLI-verified against live data before being included (not just "tests pass") — reproduction steps are in each superseded PR's description
- All 8 superseded PRs individually confirmed `MERGEABLE` before being combined here