### PR TITLE
Let UCSC_get_sequence take a written locus, and echo both coordinate conventions

### DIFF
--- a/src/tooluniverse/data/ucsc_genome_tools.json
+++ b/src/tooluniverse/data/ucsc_genome_tools.json
@@ -300,7 +300,7 @@
   },
   {
     "name": "UCSC_get_sequence",
-    "description": "Get DNA sequence from the UCSC Genome Browser for a specified genomic region. Returns the nucleotide sequence for a given chromosome, start, and end position in a genome assembly. Useful for primer design, sequence analysis, and regulatory element inspection. Example: hg38, chr17, start=7668421, end=7668521 returns 100bp of TP53 sequence.",
+    "description": "Get DNA sequence from the UCSC Genome Browser for a genomic region. Pass 'region' as a written locus (e.g. 'chr14:89000000-89000100', 1-based inclusive, 101 bp) to paste coordinates verbatim, or give chrom/start/end with 'coordinate_system'. Returns the nucleotide sequence plus the resolved region in both conventions. Useful for primer design, sequence analysis and regulatory element inspection.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -314,18 +314,28 @@
         },
         "start": {
           "type": "integer",
-          "description": "0-based start position (inclusive). Example: 7668421."
+          "description": "Start position. Interpreted per 'coordinate_system' (default 0-based, inclusive). Example: 7668421."
         },
         "end": {
           "type": "integer",
-          "description": "End position (exclusive). Must be > start and span <= 100000 bp. Example: 7668521."
+          "description": "End position. Exclusive when coordinate_system is 0-based, inclusive when 1-based. Span must be <= 100000 bp. Example: 7668521."
+        },
+        "region": {
+          "type": "string",
+          "description": "Genomic region written the usual way, 1-based INCLUSIVE on both ends, e.g. 'chr14:89000000-89000100' (101 bp). This is the form shown by the UCSC browser, IGV and samtools, so you can paste a locus verbatim. PREFERRED over chrom/start/end: it removes the 0-based/1-based conversion that otherwise silently drops the first base."
+        },
+        "coordinate_system": {
+          "type": "string",
+          "enum": [
+            "0-based",
+            "1-based"
+          ],
+          "description": "Which convention chrom/start/end are given in. '0-based' (default) is half-open, matching the UCSC API: length = end - start. '1-based' is inclusive, matching a written locus: length = end - start + 1. Ignored when 'region' is supplied.",
+          "default": "0-based"
         }
       },
       "required": [
-        "genome",
-        "chrom",
-        "start",
-        "end"
+        "genome"
       ]
     },
     "fields": {
@@ -335,15 +345,20 @@
     "test_examples": [
       {
         "genome": "hg38",
+        "region": "chr14:89000000-89000100"
+      },
+      {
+        "genome": "hg38",
         "chrom": "chr17",
         "start": 7668421,
         "end": 7668521
       },
       {
         "genome": "hg38",
-        "chrom": "chrM",
-        "start": 4321,
-        "end": 5678
+        "chrom": "chr17",
+        "start": 7668422,
+        "end": 7668521,
+        "coordinate_system": "1-based"
       }
     ],
     "return_schema": {

--- a/src/tooluniverse/ucsc_genome_tool.py
+++ b/src/tooluniverse/ucsc_genome_tool.py
@@ -11,12 +11,48 @@ API: https://api.genome.ucsc.edu
 No authentication required. Rate limit: ~1 request/second recommended.
 """
 
+import re
 import requests
 from typing import Dict, Any
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 UCSC_BASE_URL = "https://api.genome.ucsc.edu"
+
+_REGION_RE = re.compile(
+    r"^\s*(?P<chrom>[\w.\-]+)\s*:\s*(?P<start>[\d,]+)\s*(?:-|\.\.)\s*(?P<end>[\d,]+)\s*$"
+)
+
+
+def _region_to_half_open(region: str) -> Dict[str, Any]:
+    """Parse a written locus into the 0-based half-open coordinates UCSC wants.
+
+    A locus written ``chr14:89000000-89000100`` — the form used by the UCSC
+    browser, IGV, ``samtools faidx`` and papers — is **1-based inclusive** and
+    spans ``end - start + 1`` bases. The REST API takes 0-based half-open
+    coordinates, so the start must be decremented. Passing the written numbers
+    through unconverted silently drops the first base and returns a sequence
+    one short: the right length to look correct and the wrong sequence.
+    """
+    match = _REGION_RE.match(region or "")
+    if not match:
+        raise ValueError(
+            f"Could not parse region '{region}'. Expected 'chrom:start-end', "
+            "e.g. 'chr14:89000000-89000100'."
+        )
+    start_1based = int(match.group("start").replace(",", ""))
+    end_1based = int(match.group("end").replace(",", ""))
+    if start_1based < 1:
+        raise ValueError(f"1-based start must be >= 1, got {start_1based}")
+    if end_1based < start_1based:
+        raise ValueError(
+            f"end ({end_1based}) must be >= start ({start_1based}) in a 1-based region"
+        )
+    return {
+        "chrom": match.group("chrom"),
+        "start": start_1based - 1,
+        "end": end_1based,
+    }
 
 
 @register_tool("UCSCGenomeTool")
@@ -243,20 +279,75 @@ class UCSCGenomeTool(BaseTool):
         }
 
     def _get_sequence(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        """Get DNA sequence for a specified genomic region."""
+        """Get DNA sequence for a specified genomic region.
+
+        Accepts either a written locus via ``region`` (1-based inclusive, the
+        form you can paste straight from a browser or paper) or explicit
+        ``chrom``/``start``/``end``. For the explicit form, ``coordinate_system``
+        states which convention the numbers are in; it defaults to the 0-based
+        half-open convention the UCSC API itself uses, so existing callers are
+        unaffected.
+        """
         genome = arguments.get("genome", "")
-        chrom = arguments.get("chrom", "")
-        start = arguments.get("start", None)
-        end = arguments.get("end", None)
+        if not genome:
+            return {"status": "error", "error": "genome parameter is required"}
 
-        if not genome or not chrom or start is None or end is None:
-            return {
-                "status": "error",
-                "error": "genome, chrom, start, and end parameters are all required",
-            }
+        region = arguments.get("region") or ""
+        coord_system = str(arguments.get("coordinate_system") or "0-based").lower()
 
-        if end <= start:
-            return {"status": "error", "error": "end must be greater than start"}
+        if region:
+            try:
+                parsed = _region_to_half_open(region)
+            except ValueError as exc:
+                return {"status": "error", "error": str(exc)}
+            chrom, start, end = parsed["chrom"], parsed["start"], parsed["end"]
+        else:
+            chrom = arguments.get("chrom", "")
+            start = arguments.get("start", None)
+            end = arguments.get("end", None)
+
+            if not chrom or start is None or end is None:
+                return {
+                    "status": "error",
+                    "error": (
+                        "Provide either 'region' (e.g. 'chr14:89000000-89000100') "
+                        "or all of 'chrom', 'start' and 'end'."
+                    ),
+                }
+
+            if coord_system in ("1-based", "1based", "1"):
+                # Written/inclusive coordinates: shift the start into half-open space.
+                if start < 1:
+                    return {
+                        "status": "error",
+                        "error": f"1-based start must be >= 1, got {start}",
+                    }
+                if end < start:
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"end ({end}) must be >= start ({start}) "
+                            "in 1-based coordinates"
+                        ),
+                    }
+                start = start - 1
+            elif coord_system in ("0-based", "0based", "0"):
+                if end <= start:
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"end ({end}) must be greater than start ({start}) "
+                            "in 0-based half-open coordinates"
+                        ),
+                    }
+            else:
+                return {
+                    "status": "error",
+                    "error": (
+                        f"Unknown coordinate_system '{coord_system}'. "
+                        "Use '1-based' (inclusive) or '0-based' (half-open)."
+                    ),
+                }
 
         if end - start > 100000:
             return {
@@ -271,11 +362,18 @@ class UCSCGenomeTool(BaseTool):
 
         dna = raw.get("dna", "")
 
+        # Echo both conventions: a convention mix-up shows up here as a region
+        # that does not match what the caller intended, instead of silently
+        # yielding a sequence shifted by one base.
+        region_1based = f"{chrom}:{start + 1}-{end}"
+
         result = {
             "genome": genome,
             "chrom": chrom,
-            "start": start,
+            "region_1based": region_1based,
+            "start_0based": start,
             "end": end,
+            "requested_length": end - start,
             "length": len(dna),
             "dna": dna,
         }
@@ -285,7 +383,11 @@ class UCSCGenomeTool(BaseTool):
             "data": result,
             "metadata": {
                 "source": "UCSC Genome Browser",
-                "query": f"{genome}:{chrom}:{start}-{end}",
+                "query": f"{genome}:{region_1based}",
+                "coordinate_note": (
+                    "region_1based is inclusive on both ends (browser/IGV style); "
+                    "start_0based/end are half-open (UCSC API style)."
+                ),
                 "endpoint": "getData/sequence",
             },
         }


### PR DESCRIPTION
## Problem

`UCSC_get_sequence` forwarded `start`/`end` straight to the UCSC REST API, which uses **0-based half-open** coordinates. A locus as written everywhere else — `chr14:89000000-89000100` in the UCSC browser, IGV, `samtools faidx`, and papers — is **1-based inclusive** and spans 101 bases.

Passing the written numbers through unconverted returns **100 bases starting one position late**.

The schema did say "0-based". But the natural action is to paste the locus, and the failure is silent: the sequence comes back the right shape, off by one base at the 5′ end.

## How it surfaced

A LAB-Bench2 DbQA2 item asks for the hg38 reference sequence at `chr14:89000000-89000100`. The returned sequence was *exactly* the expected answer with its leading base missing:

```
expected (101 nt): ATCTTGTCACTATGGTGGGG...
returned (100 nt):  TCTTGTCACTATGGTGGGG...
```

Verified against the live API:

```
start=89000000 end=89000100 -> len=100  matches expected: False
start=88999999 end=89000100 -> len=101  matches expected: True
```

## Changes

- **`region`** — a written locus (1-based inclusive, commas allowed) that can be pasted verbatim, removing the conversion step entirely.
- **`coordinate_system`** — `"0-based"` (default) or `"1-based"`, for the explicit `chrom`/`start`/`end` form, so the caller states the convention rather than converting by hand.
- **Both conventions echoed** in the response — `region_1based`, `start_0based`, `end`, `requested_length` alongside `length` — so a mix-up is visible instead of silently changing the sequence.
- **Range validation matches the convention in use**: 1-based allows `start == end` (a single base); 0-based still requires `end > start`.

## Compatibility

The default path is unchanged. `chrom`/`start`/`end` with no `coordinate_system` still means 0-based half-open and returns exactly what it did before — confirmed byte-identical in testing.

## Verification

| case | result |
|---|---|
| `region: "chr14:89000000-89000100"` | 101 nt, matches expected |
| explicit `coordinate_system: "1-based"` | 101 nt, matches expected |
| legacy 0-based path | 100 nt, byte-identical to previous behavior |
| commas (`chr14:89,000,000-89,000,100`) | 101 nt |
| malformed region / reversed range / bad `coordinate_system` / missing args | clear, specific errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Demt4qWihe1tQPJ9orTmBM