### PR TITLE
Fix Round 3: GDC mutation-frequency inflation, ClinicalTrials/cBioPortal error-message fixes, PharmGKB drug filter

### DIFF
--- a/src/tooluniverse/cbioportal_tool.py
+++ b/src/tooluniverse/cbioportal_tool.py
@@ -1,5 +1,5 @@
 import requests
-from typing import Any, Dict
+from typing import Any, Callable, Dict, Optional
 from urllib.parse import quote
 from .base_tool import BaseTool
 from .tool_registry import register_tool
@@ -42,21 +42,47 @@ class CBioPortalRESTTool(BaseTool):
 
         return entrez_ids
 
-    def _get_mutation_profile_id(self, study_id: str) -> str:
-        """Get the mutation molecular profile ID for a study"""
+    def _resolve_molecular_profile_id(
+        self,
+        study_id: str,
+        matches: Callable[[Dict[str, Any]], bool],
+        guess_suffix: str,
+    ) -> Optional[str]:
+        """Look up a study's molecular-profile ID for a given alteration type.
+
+        Fix-Round3-003: previously any non-200 response (including a 404
+        for a study_id that simply doesn't exist, e.g. a plausible-looking
+        guess like 'luad_tcga_pan_can_atlas' instead of the real
+        'luad_tcga_pan_can_atlas_2018') fell through to a guessed profile
+        id, deferring the real problem to a confusing raw 404 several
+        steps later at the actual data-fetch call. A confirmed-nonexistent
+        study now returns None so the caller can give an actionable error
+        immediately. Any other outcome (study exists but lacks this
+        profile type, or a transient non-404 error) keeps the previous
+        best-effort naming-convention guess. Shared by
+        _get_mutation_profile_id and _get_cna_profile_id, which only differ
+        in which profile counts as a match and what suffix to guess.
+        """
         response = self.session.get(
             f"{self.base_url}/studies/{study_id}/molecular-profiles",
             timeout=self.timeout,
         )
+        if response.status_code == 404:
+            return None
         if response.status_code == 200:
-            profiles = response.json()
-            for profile in profiles:
-                alt_type = profile.get("molecularAlterationType")
-                if alt_type == "MUTATION_EXTENDED":
+            for profile in response.json():
+                if matches(profile):
                     return profile.get("molecularProfileId")
+        return f"{study_id}_{guess_suffix}"
 
-        # Fallback to common naming pattern
-        return f"{study_id}_mutations"
+    def _get_mutation_profile_id(self, study_id: str) -> Optional[str]:
+        """Get the mutation molecular profile ID for a study."""
+        return self._resolve_molecular_profile_id(
+            study_id,
+            lambda profile: profile.get("molecularAlterationType")
+            == "MUTATION_EXTENDED",
+            "mutations",
+        )
 
     _ALTERATION_LABELS = {
         -2: "deep_deletion",
@@ -66,21 +92,16 @@ class CBioPortalRESTTool(BaseTool):
         2: "amplification",
     }
 
-    def _get_cna_profile_id(self, study_id: str) -> str:
+    def _get_cna_profile_id(self, study_id: str) -> Optional[str]:
         """Get the discrete (GISTIC) copy-number molecular profile ID for a study."""
-        response = self.session.get(
-            f"{self.base_url}/studies/{study_id}/molecular-profiles",
-            timeout=self.timeout,
+        return self._resolve_molecular_profile_id(
+            study_id,
+            lambda profile: (
+                profile.get("molecularAlterationType") == "COPY_NUMBER_ALTERATION"
+                and profile.get("datatype") == "DISCRETE"
+            ),
+            "gistic",
         )
-        if response.status_code == 200:
-            for profile in response.json():
-                if (
-                    profile.get("molecularAlterationType") == "COPY_NUMBER_ALTERATION"
-                    and profile.get("datatype") == "DISCRETE"
-                ):
-                    return profile.get("molecularProfileId")
-        # Fallback to the common GISTIC naming pattern.
-        return f"{study_id}_gistic"
 
     def _fetch_discrete_cna(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Fetch discrete copy-number alteration (CNA) calls for a gene in a study.
@@ -106,6 +127,15 @@ class CBioPortalRESTTool(BaseTool):
         profile_id = arguments.get("molecular_profile_id") or self._get_cna_profile_id(
             study_id
         )
+        if profile_id is None:
+            return {
+                "status": "error",
+                "error": (
+                    f"Unknown cBioPortal study_id '{study_id}'. "
+                    "Use cBioPortal_get_cancer_studies to look up valid "
+                    "study IDs — study naming conventions vary."
+                ),
+            }
 
         # Resolve gene symbols -> Entrez IDs.
         entrez_ids = self._get_gene_entrez_ids(gene_list)
@@ -194,6 +224,18 @@ class CBioPortalRESTTool(BaseTool):
 
                 # Get molecular profile ID
                 profile_id = self._get_mutation_profile_id(study_id)
+                if profile_id is None:
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"Unknown cBioPortal study_id '{study_id}'. "
+                            "Use cBioPortal_get_cancer_studies to look up "
+                            "valid study IDs — study naming conventions vary "
+                            "(e.g. the LUAD Pan-Cancer Atlas study is "
+                            "'luad_tcga_pan_can_atlas_2018', not "
+                            "'luad_tcga_pan_can_atlas')."
+                        ),
+                    }
 
                 # Get gene Entrez IDs
                 entrez_ids = self._get_gene_entrez_ids(gene_list)

--- a/src/tooluniverse/ctg_tool.py
+++ b/src/tooluniverse/ctg_tool.py
@@ -535,17 +535,16 @@ class ClinicalTrialsSearchTool(ClinicalTrialsTool):
             endpoint_url=formatted_endpoint_url, variables=api_params
         )
 
-        # Simplify the output if the response is valid
-        if (
-            response is not None
-            and response
-            and "studies" in response.keys()
-            and len(response["studies"]) > 0
-        ):
-            response = self._simplify_output(response)
+        # Fix-Round3-002: a well-formed query that legitimately matches zero
+        # trials (empty `studies` list) is a success, not the error below --
+        # `execute_RESTful_query` already returns False for genuine failures
+        # (HTTP error, JSON decode error, API error field), so only that (or
+        # a response missing "studies" entirely) is a real error.
+        # _simplify_output handles an empty list fine on its own.
+        if response is not None and response and "studies" in response.keys():
             return {
                 "status": "success",
-                "data": response,
+                "data": self._simplify_output(response),
                 "metadata": {"source": "ClinicalTrials.gov API v2"},
             }
 
@@ -807,7 +806,17 @@ class ClinicalTrialsDetailsTool(ClinicalTrialsTool):
                 for response in responses
             ]
 
-        if sum([len(response) > 1 for response in responses]) == 0:
+        # Fix-Round3-005: same conflation as Fix-Round3-002 (search), just in
+        # this tool's detail-lookup path -- checking whether every
+        # *simplified* response still had more than the bare NCT ID field
+        # meant "fetched fine but this field (e.g. adverse events) is
+        # legitimately empty for every trial" was indistinguishable from
+        # "none of the NCT IDs could be fetched at all". `responses` here
+        # is a 1:1 map over whatever was actually fetched (the list
+        # comprehensions above never filter), so its emptiness is the real
+        # failure signal; a request that fetched real trials but simply
+        # found no matching field data for them is a legitimate success.
+        if not responses:
             return {
                 "status": "error",
                 "error": "No relevant information found for the given NCT IDs.",

--- a/src/tooluniverse/data/pharmgkb_tools.json
+++ b/src/tooluniverse/data/pharmgkb_tools.json
@@ -461,13 +461,13 @@
   },
   {
     "name": "PharmGKB_get_drug_label_annotations",
-    "description": "Get regulatory drug-label pharmacogenomic annotations from PharmGKB/ClinPGx. By default lists FDA label annotations (id + name), capped by 'limit'. Pass source to switch agency (FDA, EMA, HCSC, PMDA). Pass label_id (e.g., 'PA166114907' for bosutinib) for one full annotation including biomarkerStatus, alternateDrugAvailable, dosingInformation, cancerGenome, and source literature. Keyless.",
+    "description": "Get regulatory drug-label pharmacogenomic annotations from PharmGKB/ClinPGx. By default lists FDA label annotations (id + name), capped by 'limit'. Pass drug_name to filter the listing to a specific drug (e.g. 'imatinib') instead of browsing unfiltered. Pass source to switch agency (FDA, EMA, HCSC, PMDA). Pass label_id (e.g., 'PA166114907' for bosutinib) for one full annotation including biomarkerStatus, alternateDrugAvailable, dosingInformation, cancerGenome, and source literature. Keyless.",
     "parameter": {
       "type": "object",
       "properties": {
         "label_id": {
           "type": "string",
-          "description": "PharmGKB Label Annotation ID (e.g., 'PA166114907' for the FDA bosutinib label). When provided, returns the full single annotation and ignores 'source'/'limit'."
+          "description": "PharmGKB Label Annotation ID (e.g., 'PA166114907' for the FDA bosutinib label). When provided, returns the full single annotation and ignores 'source'/'limit'/'drug_name'."
         },
         "source": {
           "type": "string",
@@ -479,6 +479,10 @@
             "PMDA"
           ]
         },
+        "drug_name": {
+          "type": "string",
+          "description": "Filter the listing to annotations whose name mentions this drug (case-insensitive substring match, e.g. 'imatinib'). Ignored when label_id is given."
+        },
         "limit": {
           "type": "integer",
           "description": "Maximum number of label annotations to return in listing mode (default 50, max 500)."
@@ -486,6 +490,10 @@
         "id": {
           "type": "string",
           "description": "Alias for label_id."
+        },
+        "drug": {
+          "type": "string",
+          "description": "Alias for drug_name."
         }
       },
       "required": []
@@ -501,6 +509,10 @@
       {
         "source": "FDA",
         "limit": 5
+      },
+      {
+        "source": "FDA",
+        "drug_name": "imatinib"
       }
     ],
     "return_schema": {

--- a/src/tooluniverse/gdc_tool.py
+++ b/src/tooluniverse/gdc_tool.py
@@ -708,6 +708,22 @@ class GDCMutationFreqByProjectTool:
     def __init__(self, tool_config=None):
         self.tool_config = tool_config or {}
 
+    # Fix-Round3-001: the /analysis/mutated_cases_count_by_project endpoint's
+    # bucket `doc_count` (and its identical sibling
+    # `case_summary.case_with_ssm.doc_count`) counts SSM-*occurrence* records,
+    # not distinct cases. A case with more than one sequenced sample/aliquot
+    # (or more than one distinct SSM in the gene) is counted once per
+    # occurrence record, so `doc_count` can wildly overstate the number of
+    # mutated cases. Confirmed against ground truth: for gene_symbol=KRAS in
+    # project TCGA-TGCT, the old endpoint reported mutated=255/total=263
+    # (97%), but a per-case dedup against /ssm_occurrences shows only 13
+    # distinct cases (~5%) — a ~20x inflation. We now derive the numerator
+    # ourselves by paginating raw occurrence records and counting distinct
+    # `case.case_id` values per project, instead of trusting GDC's
+    # pre-aggregated (and here, mislabeled) bucket count.
+    _MAX_OCCURRENCES = 50000  # safety cap for extremely high-mutation-burden genes
+    _PAGE_SIZE = 10000
+
     def run(self, arguments: Dict[str, Any]):
         base = self.tool_config.get("settings", {}).get(
             "base_url", "https://api.gdc.cancer.gov"
@@ -728,40 +744,64 @@ class GDCMutationFreqByProjectTool:
         except (TypeError, ValueError):
             size = 100
 
-        filters = json.dumps(
+        occ_filters = json.dumps(
             {
                 "op": "in",
                 "content": {"field": "genes.symbol", "value": [gene_symbol]},
             }
         )
-        query = {"size": 0, "filters": filters}
-        url = f"{base}/analysis/mutated_cases_count_by_project?{urlencode(query)}"
 
-        try:
-            raw = _http_get(
-                url, headers={"Accept": "application/json"}, timeout=timeout
-            )
-        except Exception as e:
-            return {
-                "status": "error",
-                "error": str(e),
-                "source": "GDC",
-                "endpoint": "mutated_cases_count_by_project",
+        cases_by_project: Dict[str, set] = {}
+        fetched = 0
+        total_available = 0
+        while True:
+            occ_query = {
+                "filters": occ_filters,
+                "fields": "case.case_id,case.project.project_id",
+                "size": self._PAGE_SIZE,
+                "from": fetched,
             }
+            occ_url = f"{base}/ssm_occurrences?{urlencode(occ_query)}"
+            try:
+                occ_raw = _http_get(
+                    occ_url, headers={"Accept": "application/json"}, timeout=timeout
+                )
+            except Exception as e:
+                return {
+                    "status": "error",
+                    "error": str(e),
+                    "source": "GDC",
+                    "endpoint": "ssm_occurrences",
+                }
 
-        buckets = (
-            raw.get("aggregations", {}).get("projects", {}).get("buckets", []) or []
-        )
+            hits = occ_raw.get("data", {}).get("hits", []) or []
+            if fetched == 0:
+                total_available = occ_raw.get("data", {}).get("pagination", {}).get(
+                    "total", len(hits)
+                )
 
-        # Fix-R4A-002: the analysis endpoint's nested `case_summary.doc_count`
-        # is NOT the project's total case count (confirmed against the raw
-        # API and cross-checked with GDC_search_cases/GDC_list_projects,
-        # e.g. it reports 2282 for TCGA-COAD when the real total is 461) —
-        # its sibling `case_summary.case_with_ssm.doc_count` is simply a
-        # duplicate of the mutated count. Fetch true per-project totals from
-        # the /projects endpoint's `summary.case_count` field instead, the
-        # same field GDC_list_projects uses.
-        project_ids = [b.get("key") for b in buckets if b.get("key")]
+            for hit in hits:
+                case = hit.get("case", {}) or {}
+                case_id = case.get("case_id")
+                project_id = (case.get("project", {}) or {}).get("project_id")
+                if not case_id or not project_id:
+                    continue
+                cases_by_project.setdefault(project_id, set()).add(case_id)
+
+            fetched += len(hits)
+            if not hits or fetched >= total_available or fetched >= self._MAX_OCCURRENCES:
+                break
+
+        truncated = fetched < total_available
+
+        # Fix-R4A-002 (still valid): the analysis endpoint's nested
+        # `case_summary.doc_count` is NOT the project's total case count
+        # (confirmed against the raw API and cross-checked with
+        # GDC_search_cases/GDC_list_projects, e.g. it reports 2282 for
+        # TCGA-COAD when the real total is 461). Fetch true per-project
+        # totals from the /projects endpoint's `summary.case_count` field
+        # instead, the same field GDC_list_projects uses.
+        project_ids = list(cases_by_project.keys())
         true_totals: Dict[str, int] = {}
         if project_ids:
             proj_filters = json.dumps(
@@ -786,17 +826,15 @@ class GDCMutationFreqByProjectTool:
                     if pid and count is not None:
                         true_totals[pid] = count
             except Exception:
-                pass  # fall back to the (less reliable) case_summary field below
+                pass  # projects with no entry in true_totals are dropped below
 
         projects = []
-        for b in buckets:
-            mutated = b.get("doc_count", 0) or 0
-            project_id = b.get("key")
-            case_summary = b.get("case_summary", {}) or {}
+        for project_id, case_ids in cases_by_project.items():
             total = true_totals.get(project_id)
-            if total is None:
-                total = case_summary.get("doc_count", 0) or 0
-            freq = round(mutated / total, 4) if total else None
+            mutated = len(case_ids)
+            if not total:
+                continue  # can't compute a meaningful frequency without a real denominator
+            freq = round(mutated / total, 4)
             projects.append(
                 {
                     "project_id": project_id,
@@ -818,10 +856,10 @@ class GDCMutationFreqByProjectTool:
         total_mutated = sum(p["mutated_case_count"] for p in projects)
         total_cases = sum(p["total_case_count"] for p in projects)
 
-        return {
+        result = {
             "status": "success",
             "source": "GDC",
-            "endpoint": "mutated_cases_count_by_project",
+            "endpoint": "ssm_occurrences",
             "data": {
                 "gene": gene_symbol,
                 "project_count": len(projects),
@@ -830,6 +868,14 @@ class GDCMutationFreqByProjectTool:
                 "projects": projects[:size],
             },
         }
+        if truncated:
+            result["data"]["note"] = (
+                f"gene has more than {self._MAX_OCCURRENCES} SSM occurrence "
+                "records; results are based on the first "
+                f"{self._MAX_OCCURRENCES} fetched and may undercount "
+                "high-mutation-burden projects."
+            )
+        return result
 
 
 @register_tool(

--- a/src/tooluniverse/pharmgkb_tool.py
+++ b/src/tooluniverse/pharmgkb_tool.py
@@ -319,6 +319,15 @@ class PharmGKBTool(BaseTool):
             limit = 50
         limit = max(1, min(limit, 500))
 
+        # Fix-Round3-004: listing mode had no way to filter by drug —
+        # a caller who wanted "the FDA label for imatinib" had to page
+        # through up to 500 unlabeled {id, name} entries by hand. The API
+        # call already returns the full, unpaginated listing (`total` was
+        # already computed from one request), so filtering client-side by
+        # a case-insensitive substring match on `name` (e.g. "Annotation of
+        # FDA Label for imatinib and ABL1, BCR") is free — no extra request.
+        drug_name = arguments.get("drug_name") or arguments.get("drug")
+
         status_code, api_response, error = self._request_json(
             f"{PHARMGKB_BASE_URL}/data/label",
             {"source": source, "view": "min"},
@@ -335,13 +344,24 @@ class PharmGKBTool(BaseTool):
         results = api_response.get("data", [])
         if not isinstance(results, list):
             results = [results]
+
+        if drug_name:
+            needle = str(drug_name).lower()
+            results = [r for r in results if needle in str(r.get("name", "")).lower()]
+
         total = len(results)
         truncated = results[:limit]
         out: Dict[str, Any] = {"status": "success", "data": truncated}
-        if total > limit:
+        if drug_name and total == 0:
             out["note"] = (
-                f"Showing {limit} of {total} {source} drug-label annotations. "
-                f"Increase 'limit' or call with label_id=<id> for full details."
+                f"No {source} drug-label annotations matched "
+                f"drug_name='{drug_name}'."
+            )
+        elif total > limit:
+            out["note"] = (
+                f"Showing {limit} of {total} {source} drug-label annotations"
+                + (f" matching drug_name='{drug_name}'" if drug_name else "")
+                + ". Increase 'limit' or call with label_id=<id> for full details."
             )
         return out
 

--- a/tests/unit/test_cancer_genomics_depth.py
+++ b/tests/unit/test_cancer_genomics_depth.py
@@ -34,28 +34,31 @@ def _gdc_tool():
     )
 
 
-_GDC_FAKE = {
-    "aggregations": {
-        "projects": {
-            "buckets": [
-                {
-                    "key": "CPTAC-3",
-                    "doc_count": 510,
-                    "case_summary": {
-                        "doc_count": 3521,
-                        "case_with_ssm": {"doc_count": 510},
-                    },
-                },
-                {
-                    "key": "TINY-PROJ",
-                    "doc_count": 6,
-                    "case_summary": {
-                        "doc_count": 10,
-                        "case_with_ssm": {"doc_count": 6},
-                    },
-                },
-            ]
-        }
+def _occurrence_hit(case_id: str, project_id: str) -> dict:
+    return {"case": {"case_id": case_id, "project": {"project_id": project_id}}}
+
+
+# Fix-Round3-001: the numerator now comes from distinct case_ids seen across
+# paginated /ssm_occurrences records (not the old, occurrence-inflated
+# /analysis/mutated_cases_count_by_project bucket doc_count -- see
+# test_gdc_mutation_frequency.py for the dedup regression guard). 510 CPTAC-3
+# cases + 6 TINY-PROJ cases, one occurrence record each.
+_OCCURRENCES_FAKE = {
+    "data": {
+        "hits": (
+            [_occurrence_hit(f"cptac3-case-{i}", "CPTAC-3") for i in range(510)]
+            + [_occurrence_hit(f"tiny-case-{i}", "TINY-PROJ") for i in range(6)]
+        ),
+        "pagination": {"total": 516},
+    }
+}
+
+_PROJECTS_FAKE = {
+    "data": {
+        "hits": [
+            {"project_id": "CPTAC-3", "summary": {"case_count": 3521}},
+            {"project_id": "TINY-PROJ", "summary": {"case_count": 10}},
+        ]
     }
 }
 
@@ -65,7 +68,7 @@ class TestGDCMutationFreqByProject(unittest.TestCase):
         """Per-project numerator/denominator are preserved and frequency computed."""
         tool = _gdc_tool()
         with patch("tooluniverse.gdc_tool._http_get") as http:
-            http.return_value = _GDC_FAKE
+            http.side_effect = [_OCCURRENCES_FAKE, _PROJECTS_FAKE]
             result = tool.run({"gene_symbol": "KRAS"})
 
         self.assertEqual(result["status"], "success")
@@ -86,7 +89,7 @@ class TestGDCMutationFreqByProject(unittest.TestCase):
         """Projects are ranked by mutation frequency, highest first."""
         tool = _gdc_tool()
         with patch("tooluniverse.gdc_tool._http_get") as http:
-            http.return_value = _GDC_FAKE
+            http.side_effect = [_OCCURRENCES_FAKE, _PROJECTS_FAKE]
             result = tool.run({"gene": "KRAS"})  # exercise the `gene` alias too
         projects = result["data"]["projects"]
         # TINY-PROJ (6/10 = 0.6) ranks above CPTAC-3 (510/3521 ~= 0.145).

--- a/tests/unit/test_cbioportal_tool.py
+++ b/tests/unit/test_cbioportal_tool.py
@@ -57,3 +57,47 @@ def test_explicit_param_overrides_default():
 
     called_url = mock_get.call_args.args[0]
     assert "pageSize=5" in called_url
+
+
+class TestMolecularProfileIdResolution:
+    """Regression guard for Fix-Round3-003: a confirmed-nonexistent
+    study_id must be reported immediately, not deferred to a confusing
+    404 several steps later at the actual mutations/CNA fetch call.
+    Covers both _get_mutation_profile_id and _get_cna_profile_id, which
+    share this behavior via _resolve_molecular_profile_id."""
+
+    def test_mutation_profile_id_returns_none_for_unknown_study(self):
+        tool = _tool()
+        resp = MagicMock()
+        resp.status_code = 404
+        with patch.object(tool.session, "get", return_value=resp):
+            assert tool._get_mutation_profile_id("not-a-real-study") is None
+
+    def test_cna_profile_id_returns_none_for_unknown_study(self):
+        tool = _tool()
+        resp = MagicMock()
+        resp.status_code = 404
+        with patch.object(tool.session, "get", return_value=resp):
+            assert tool._get_cna_profile_id("not-a-real-study") is None
+
+    def test_mutation_profile_id_found_when_study_exists(self):
+        tool = _tool()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = [
+            {"molecularAlterationType": "MUTATION_EXTENDED", "molecularProfileId": "x_mutations"},
+        ]
+        with patch.object(tool.session, "get", return_value=resp):
+            assert tool._get_mutation_profile_id("real_study") == "x_mutations"
+
+    def test_mutation_profile_id_falls_back_to_guess_when_study_has_no_profile(self):
+        """Study exists (200) but has no MUTATION_EXTENDED profile listed --
+        keep the previous best-effort naming-convention guess rather than
+        failing, since this is a different (rarer) situation than a
+        nonexistent study."""
+        tool = _tool()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = [{"molecularAlterationType": "COPY_NUMBER_ALTERATION"}]
+        with patch.object(tool.session, "get", return_value=resp):
+            assert tool._get_mutation_profile_id("real_study") == "real_study_mutations"

--- a/tests/unit/test_ctg_tool.py
+++ b/tests/unit/test_ctg_tool.py
@@ -10,7 +10,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from tooluniverse.ctg_tool import ClinicalTrialsTool
+from tooluniverse.ctg_tool import (
+    ClinicalTrialsDetailsTool,
+    ClinicalTrialsSearchTool,
+    ClinicalTrialsTool,
+)
 
 
 def make_search_tool():
@@ -20,6 +24,20 @@ def make_search_tool():
             "name": "ClinicalTrials_search_studies",
             "type": "ClinicalTrialsTool",
             "fields": {"operation": "search"},
+            "query_schema": {},
+            "parameter": {"type": "object", "properties": {}},
+        }
+    )
+
+
+def make_search_clinical_trials_tool():
+    """Construct the actual `search_clinical_trials` tool (type
+    ClinicalTrialsSearchTool), whose run() has its own zero-hit handling
+    distinct from the generic ClinicalTrialsTool used by make_search_tool()."""
+    return ClinicalTrialsSearchTool(
+        {
+            "name": "search_clinical_trials",
+            "type": "ClinicalTrialsSearchTool",
             "query_schema": {},
             "parameter": {"type": "object", "properties": {}},
         }
@@ -69,6 +87,25 @@ def test_filter_study_type_multi_value_uses_or_with_parens(mock_get):
 
 @pytest.mark.unit
 @patch("requests.get")
+def test_zero_hit_query_is_success_not_error(mock_get):
+    """Fix-Round3-002: a well-formed query that legitimately matches zero
+    trials must return status=success with an empty studies list, matching
+    ClinicalTrials_search_by_intervention's behavior for the same case --
+    not the hardcoded "no studies found" error string, which previously
+    made a genuine zero-match result indistinguishable from an API/network
+    failure and broke callers that parse JSON only on success."""
+    mock_get.return_value = make_empty_studies_response()
+
+    result = make_search_clinical_trials_tool().run(
+        {"query_cond": "asdkjqwleqwe nonsense disease"}
+    )
+
+    assert result["status"] == "success"
+    assert result["data"] == {"studies": [], "total_count": 0}
+
+
+@pytest.mark.unit
+@patch("requests.get")
 def test_filter_study_type_combines_with_filter_phase_via_and(mock_get):
     """Study-type and phase clauses must combine with AND in filter.advanced (no regression on phase handling)."""
     mock_get.return_value = make_empty_studies_response()
@@ -88,3 +125,66 @@ def test_filter_study_type_combines_with_filter_phase_via_and(mock_get):
         "AREA[Phase]PHASE3 AND AREA[StudyType]INTERVENTIONAL",
         "AREA[StudyType]INTERVENTIONAL AND AREA[Phase]PHASE3",
     )
+
+
+def make_adverse_events_tool():
+    """Construct the actual `extract_clinical_trial_adverse_events` tool
+    (type ClinicalTrialsDetailsTool)."""
+    return ClinicalTrialsDetailsTool(
+        {
+            "name": "extract_clinical_trial_adverse_events",
+            "type": "ClinicalTrialsDetailsTool",
+            "tool_url": "/studies/{nctId}",
+            "query_schema": {"adverse_event_type": "serious"},
+            "parameter": {
+                "type": "object",
+                "properties": {
+                    "nct_ids": {"type": "array"},
+                    "organ_systems": {"type": "array"},
+                    "adverse_event_type": {"type": "string"},
+                },
+            },
+        }
+    )
+
+
+@pytest.mark.unit
+@patch("requests.get")
+def test_fetched_trial_with_no_matching_field_data_is_success_not_error(mock_get):
+    """Fix-Round3-005: a real trial that was fetched successfully but simply
+    has no adverse-event data posted yet (e.g. NOT_YET_RECRUITING) must
+    return status=success with sparse data -- not the hardcoded "no
+    relevant information found" error, which previously made this
+    indistinguishable from every requested NCT ID being invalid/unreachable."""
+    response = Mock()
+    response.status_code = 200
+    response.raise_for_status.return_value = None
+    # A real, successfully-fetched study with no AdverseEventsModule posted.
+    response.json.return_value = {
+        "protocolSection": {
+            "identificationModule": {"nctId": "NCT07504601"},
+        }
+    }
+    mock_get.return_value = response
+
+    result = make_adverse_events_tool().run({"nct_ids": ["NCT07504601"]})
+
+    assert result["status"] == "success"
+    assert result["data"] == [{"NCT ID": "NCT07504601"}]
+
+
+@pytest.mark.unit
+@patch("requests.get")
+def test_no_fetchable_trials_is_error(mock_get):
+    """If every requested NCT ID fails to fetch at all (bad ID / API
+    failure), that's still a genuine error, not a success with empty
+    data. `execute_RESTful_query` signals this by returning False, which
+    it does whenever the parsed response body contains an "error" key."""
+    response = Mock()
+    response.status_code = 404
+    response.json.return_value = {"error": "study not found"}
+    mock_get.return_value = response
+
+    result = make_adverse_events_tool().run({"nct_ids": ["NCT00000000"]})
+
+    assert result["status"] == "error"

--- a/tests/unit/test_gdc_mutation_frequency.py
+++ b/tests/unit/test_gdc_mutation_frequency.py
@@ -1,12 +1,19 @@
-"""Regression guard for Fix-R4A-002: GDCMutationFreqByProjectTool denominator.
+"""Regression guards for GDCMutationFreqByProjectTool numerator/denominator.
 
-The GDC analysis endpoint's nested `case_summary.doc_count` is NOT a
-project's total case count -- confirmed against the raw API and
-cross-checked with GDC_search_cases/GDC_list_projects (e.g. it reported
-2282 for TCGA-COAD when the real total is 461, understating KRAS mutation
-frequency in colorectal cancer by ~5x: 11% instead of the real ~54%).
-The fix looks up true per-project totals via the /projects endpoint's
-`summary.case_count` field, same as GDC_list_projects already does.
+Fix-R4A-002: the GDC analysis endpoint's nested `case_summary.doc_count` is
+NOT a project's total case count -- confirmed against the raw API and
+cross-checked with GDC_search_cases/GDC_list_projects (e.g. it reported 2282
+for TCGA-COAD when the real total is 461). The fix looks up true per-project
+totals via the /projects endpoint's `summary.case_count` field, same as
+GDC_list_projects already does.
+
+Fix-Round3-001: the analysis endpoint's bucket `doc_count` (the numerator)
+counts SSM-*occurrence* records, not distinct cases, so a case with more
+than one sequenced sample/aliquot is counted once per occurrence -- for
+gene_symbol=KRAS in project TCGA-TGCT this reported mutated=255/total=263
+(97%) when only 13 cases (~5%) actually carry a KRAS mutation. The fix
+derives mutated_case_count by paginating raw `/ssm_occurrences` records and
+counting distinct `case.case_id` values per project instead.
 """
 
 from unittest.mock import patch
@@ -17,20 +24,16 @@ from tooluniverse.gdc_tool import GDCMutationFreqByProjectTool
 
 pytestmark = pytest.mark.unit
 
-_ANALYSIS_RESPONSE = {
-    "aggregations": {
-        "projects": {
-            "buckets": [
-                {
-                    "key": "TCGA-COAD",
-                    "doc_count": 250,
-                    "case_summary": {
-                        "doc_count": 2282,  # wrong: not a real case total
-                        "case_with_ssm": {"doc_count": 250},
-                    },
-                }
-            ]
-        }
+_OCCURRENCES_RESPONSE = {
+    "data": {
+        "hits": [
+            {"case": {"case_id": "case-1", "project": {"project_id": "TCGA-COAD"}}},
+            {"case": {"case_id": "case-2", "project": {"project_id": "TCGA-COAD"}}},
+            # Same case with a second distinct SSM occurrence record -- must
+            # not be double-counted as two mutated cases.
+            {"case": {"case_id": "case-2", "project": {"project_id": "TCGA-COAD"}}},
+        ],
+        "pagination": {"total": 3},
     }
 }
 
@@ -43,34 +46,38 @@ _PROJECTS_RESPONSE = {
 }
 
 
-def test_uses_projects_endpoint_case_count_not_case_summary():
+def test_numerator_is_distinct_cases_not_occurrence_records():
+    """mutated_case_count must dedupe by case_id, not count raw occurrence
+    rows (case-2 appears twice above but should only count once)."""
     tool = GDCMutationFreqByProjectTool({})
 
     with patch(
         "tooluniverse.gdc_tool._http_get",
-        side_effect=[_ANALYSIS_RESPONSE, _PROJECTS_RESPONSE],
+        side_effect=[_OCCURRENCES_RESPONSE, _PROJECTS_RESPONSE],
     ):
         result = tool.run({"gene_symbol": "KRAS"})
 
     assert result["status"] == "success"
     project = result["data"]["projects"][0]
     assert project["project_id"] == "TCGA-COAD"
-    assert project["mutated_case_count"] == 250
+    assert project["mutated_case_count"] == 2  # case-1, case-2 (deduped)
     assert project["total_case_count"] == 461
-    assert project["frequency"] == round(250 / 461, 4)
+    assert project["frequency"] == round(2 / 461, 4)
 
 
-def test_falls_back_to_case_summary_if_projects_lookup_fails():
-    """If the /projects lookup errors, still return a (less reliable)
-    result rather than failing the whole call."""
+def test_project_dropped_if_true_total_lookup_fails():
+    """If the /projects lookup errors, we have no reliable denominator for
+    that project, so it must be dropped rather than shown with a wrong or
+    fabricated total (e.g. the buggy case_summary.doc_count field, which no
+    longer exists in the /ssm_occurrences-based response at all)."""
     tool = GDCMutationFreqByProjectTool({})
 
     with patch(
         "tooluniverse.gdc_tool._http_get",
-        side_effect=[_ANALYSIS_RESPONSE, Exception("network error")],
+        side_effect=[_OCCURRENCES_RESPONSE, Exception("network error")],
     ):
         result = tool.run({"gene_symbol": "KRAS"})
 
     assert result["status"] == "success"
-    project = result["data"]["projects"][0]
-    assert project["total_case_count"] == 2282  # fallback value
+    assert result["data"]["projects"] == []
+    assert result["data"]["project_count"] == 0


### PR DESCRIPTION
## Summary

Test-harness round 3 (post PR #463): internal regression pass + 2 fresh role-play personas (clinical pharmacogenomicist, cancer genomics/molecular oncologist) exercising domains not covered by prior rounds (pharmgkb/cpic/admetai dosing guidance; civic/cbioportal/opentarget/clinical_trials tumor-board workflow). Every reported issue was CLI-verified against the live upstream API before being queued; two of the persona's lower-confidence reports (PharmGKB unsupported-parameter schema, ADMETAI dependency-version noise) turned out to already be handled gracefully or to be local-environment artifacts, not code defects, and were left alone. A `/simplify` pass (4 parallel review agents: reuse, simplification, efficiency, altitude) found and fixed two sibling instances of the same bug pattern already living in the touched files (cBioPortal's CNA profile lookup, and the ClinicalTrials NCT-detail extraction tools), plus some redundant loop-state and duplicated-fallback cleanup.

- **GDC_get_mutation_frequency_by_project**: the numerator counted SSM-occurrence records instead of distinct cases, wildly inflating mutation frequency for some project/gene pairs (confirmed: KRAS in TCGA-TGCT reported 97% when only ~5% of cases actually carry the mutation, a ~20x error). Now derives the numerator from deduped `case_id`s across paginated `/ssm_occurrences` records.
- **search_clinical_trials / extract_clinical_trial_adverse_events (and siblings)**: a query that legitimately matched zero trials returned the same hardcoded error as a genuine API failure, making the two indistinguishable and breaking callers that only parse JSON on success. Both now return a structured empty success result when real data was fetched but the query (or field) is legitimately empty.
- **cBioPortal_get_mutations / get_copy_number_alterations**: an invalid `study_id` silently fell through to a guessed molecular-profile-id and only surfaced as a confusing raw 404 several steps later. Both now report the real problem immediately and point at `cBioPortal_get_cancer_studies`.
- **PharmGKB_get_drug_label_annotations**: listing mode had no way to filter by drug name, so finding one drug's label meant paging through up to 500 entries by hand. Added an optional `drug_name` filter.

## Test plan
- [x] CLI-reproduced each issue against the live upstream API before fixing (GDC ground-truth cross-checked against raw `/ssm_occurrences` and `/cases`/`/projects` data)
- [x] Existing/updated unit tests: `test_gdc_mutation_frequency.py`, `test_cancer_genomics_depth.py`, `test_ctg_tool.py`, `test_cbioportal_tool.py` — new regression tests added for each fixed behavior
- [x] Targeted regression sweep (12 test files covering all 4 changed modules plus schema-conformance and workflow tests): 117 passed, 0 failed
- [x] Live CLI re-verification of all 6 fixed code paths post-fix
- [x] Independent `tool-validator` agent gate: 11/11 checks pass