### PR TITLE
Fix Round 4: GWAS sort/alias/dedup, IntAct empty details, OmniPath filter

### DIFF
--- a/src/tooluniverse/data/gwas_tools.json
+++ b/src/tooluniverse/data/gwas_tools.json
@@ -649,18 +649,20 @@
   {
     "type": "GWASStudyByID",
     "name": "gwas_get_study_by_id",
-    "description": "Get a specific GWAS study by its unique identifier.",
+    "description": "Get a specific GWAS study by its unique identifier. Accepts either 'study_id' or 'accession_id' (the same GCST identifier field name used by GWASAssociationsForStudy and returned on every association record) so IDs can be chained directly between gwas_* tools without renaming.",
     "parameter": {
       "type": "object",
       "properties": {
         "study_id": {
           "type": "string",
-          "description": "GWAS study identifier"
+          "description": "GWAS study identifier (GCST accession, e.g. 'GCST000392')"
+        },
+        "accession_id": {
+          "type": "string",
+          "description": "Alias for study_id -- the same GCST accession identifier, accepted so results from other gwas_* tools (which use the field name 'accession_id') can be passed straight in."
         }
       },
-      "required": [
-        "study_id"
-      ]
+      "required": []
     },
     "label": [
       "GWAS",

--- a/src/tooluniverse/data/intact_tools.json
+++ b/src/tooluniverse/data/intact_tools.json
@@ -182,12 +182,12 @@
       "return_format": "JSON"
     },
     "return_schema": {
-      "type": "array",
-      "description": "Complete interaction details"
+      "type": "object",
+      "description": "Details of the single matching interaction record"
     },
     "test_examples": [
       {
-        "interaction_id": "EBI-10000001"
+        "interaction_id": "EBI-714308-EBI-366083"
       }
     ]
   },

--- a/src/tooluniverse/data/omnipath_tools.json
+++ b/src/tooluniverse/data/omnipath_tools.json
@@ -1024,9 +1024,13 @@
               },
               "dorothea_level": {
                 "type": [
-                  "string",
+                  "array",
                   "null"
-                ]
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "description": "Confidence-level codes (A-E) this interaction is curated at; an interaction can carry more than one level."
               }
             }
           }
@@ -1046,7 +1050,6 @@
     },
     "test_examples": [
       {
-        "operation": "get_dorothea_regulon",
         "tf_gene": "TP53"
       }
     ]

--- a/src/tooluniverse/data/reactome_tools.json
+++ b/src/tooluniverse/data/reactome_tools.json
@@ -228,7 +228,7 @@
       "properties": {
         "stId": {
           "type": "string",
-          "description": "Complex Stable ID (e.g., 'R-HSA-XXXXX'). To find complex IDs, use Reactome_get_participants with a reaction ID to see complexes participating in that reaction."
+          "description": "Complex Stable ID (e.g., 'R-HSA-3209194', the TP53 Tetramer). To find complex IDs, use Reactome_get_participants with a reaction ID to see complexes participating in that reaction. Passing a Pathway or Reaction stId here will still return data (the endpoint is unified across entity types), but the response's schemaClass will not be 'Complex'."
         }
       },
       "required": ["stId"]
@@ -236,7 +236,7 @@
     "type": "ReactomeRESTTool",
     "test_examples": [
       {
-        "stId": "R-HSA-73817"
+        "stId": "R-HSA-3209194"
       }
     ],
     "return_schema": {
@@ -250,7 +250,7 @@
         "name": {"type": "array", "items": {"type": "string"}, "description": "Complex names"},
         "speciesName": {"type": "string", "description": "Species name"},
         "compartment": {"type": "array", "items": {"type": "object"}, "description": "Cellular compartments"},
-        "hasComponent": {"type": "array", "items": {"type": "object"}, "description": "Complex subunits/components"},
+        "hasComponent": {"type": "array", "items": {"type": ["object", "integer"]}, "description": "Complex subunits/components. Reactome fully expands the first occurrence of each distinct subunit but lists repeated (homomeric) copies as a bare dbId integer instead of repeating the full object."},
         "schemaClass": {"type": "string", "description": "Schema class (e.g., 'Complex')"},
         "className": {"type": "string", "description": "Class name"}
       }

--- a/src/tooluniverse/gwas_tool.py
+++ b/src/tooluniverse/gwas_tool.py
@@ -274,17 +274,18 @@ class GWASAssociationSearch(GWASRESTTool):
 
         sort = self._coerce_str(arguments.get("sort"))
         direction = self._coerce_str(arguments.get("direction"))
-        # A p_value threshold is applied CLIENT-SIDE to the fetched page (the API
-        # has no server-side p-value filter), but the API returns associations
-        # UNSORTED -- so without sorting by significance the fetched window omits
-        # the strongest loci and a strict threshold falsely returns 0 (SLE
-        # p<=1e-100 -> 0 even though hits exist at p=2e-298). When a p-value
-        # filter is requested and the caller gave no explicit sort, fetch
-        # most-significant-first so the threshold actually sees the top hits.
-        if not sort and (
-            arguments.get("p_value") is not None
-            or arguments.get("p_value_threshold") is not None
-        ):
+        # The API returns associations UNSORTED by default, so a plain
+        # discovery call with no explicit sort (e.g. just disease_trait+size)
+        # returns whichever page the API happens to store first -- which can
+        # be a low-information niche study with empty mapped_genes/locations,
+        # while the near-identical gwas_get_associations_for_trait tool
+        # defaults to sort=p_value and returns the expected top hit
+        # (Feature-4B-2). Default to most-significant-first here too, for
+        # consistency and so a p-value threshold (applied CLIENT-SIDE below,
+        # since the API has no server-side p-value filter) actually sees the
+        # top hits instead of missing them (SLE p<=1e-100 -> 0 even though
+        # hits exist at p=2e-298).
+        if not sort:
             sort = "p_value"
             if not direction:
                 direction = "asc"
@@ -439,10 +440,15 @@ class GWASStudyByID(GWASRESTTool):
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Get study by ID."""
-        if "study_id" not in arguments:
+        # Feature-4B-4: sibling tools (e.g. GWASAssociationsForStudy, and the
+        # "accession_id" field on every association record) use "accession_id"
+        # for this same GCST identifier, so accept it as an alias to avoid a
+        # natural chaining mistake when passing an ID straight from one tool
+        # to another.
+        study_id = arguments.get("study_id") or arguments.get("accession_id")
+        if not study_id:
             return {"status": "error", "error": "study_id is required"}
 
-        study_id = arguments["study_id"]
         return self._make_request(f"{self.endpoint}/{study_id}")
 
 
@@ -688,7 +694,28 @@ class GWASSNPsForGene(GWASRESTTool):
 
         data = self._make_request(self.endpoint, params)
         # v1 endpoint returns key "singleNucleotidePolymorphisms", not "snps"
-        return self._extract_embedded_data(data, "singleNucleotidePolymorphisms")
+        result = self._extract_embedded_data(data, "singleNucleotidePolymorphisms")
+
+        # Feature-4B-3: the v1 findByGene endpoint repeats identical SNP
+        # records (verified: byte-for-byte duplicate objects for the same
+        # rsId), inflating apparent SNP counts. Dedupe by rsId.
+        if result.get("status") == "success" and isinstance(result.get("data"), list):
+            seen: set = set()
+            deduped = []
+            for snp in result["data"]:
+                rs_id = snp.get("rsId") if isinstance(snp, dict) else None
+                if rs_id:
+                    if rs_id in seen:
+                        continue
+                    seen.add(rs_id)
+                deduped.append(snp)
+            if len(deduped) != len(result["data"]):
+                result.setdefault("metadata", {})["duplicates_removed"] = len(
+                    result["data"]
+                ) - len(deduped)
+            result["data"] = deduped
+
+        return result
 
 
 @register_tool("GWASAssociationsForStudy")

--- a/src/tooluniverse/intact_tool.py
+++ b/src/tooluniverse/intact_tool.py
@@ -207,6 +207,12 @@ class IntActRESTTool(BaseTool):
                 "intact_get_interactions_by_experiment": ("experiment_id", 25),
                 "intact_get_interaction_network": ("identifier", 50),
                 "intact_get_interactions_by_organism": ("taxid", 25),
+                # Feature-4C-3: this tool was missing here entirely, so it fell
+                # back from the (permanently 404ing) direct IntAct endpoint to
+                # this EBI Search fallback with no "query" param ever set --
+                # every call silently returned an empty result, including the
+                # tool's own documented example.
+                "intact_get_interaction_details": ("interaction_id", 5),
             }
 
             if tool_name == "intact_search_interactions":
@@ -261,6 +267,20 @@ class IntActRESTTool(BaseTool):
                         "hitCount": data.get("hitCount", len(entries)),
                         "interaction_ids": interaction_ids[:10],
                         "note": "Data retrieved via EBI Search API (IntAct domain). For detailed interactor info, use IntAct website.",
+                    },
+                }
+
+            # For a single interaction_id lookup, return the matching record
+            # directly rather than a one-item list (Feature-4C-3).
+            if tool_name == "intact_get_interaction_details":
+                return {
+                    "status": "success",
+                    "data": entries[0] if entries else {},
+                    "metadata": {
+                        "url": response.url,
+                        "count": len(entries),
+                        "hitCount": data.get("hitCount", len(entries)),
+                        "note": "Data retrieved via EBI Search API (IntAct domain).",
                     },
                 }
 

--- a/src/tooluniverse/omnipath_tool.py
+++ b/src/tooluniverse/omnipath_tool.py
@@ -631,7 +631,10 @@ class OmniPathTool(BaseTool):
 
         params = {
             "genesymbols": "yes",
-            "fields": "sources,references,curation_effort,type",
+            # dorothea_level must be explicitly requested or OmniPath omits it,
+            # which previously made every confidence_levels filter match nothing
+            # (Feature-4C-2).
+            "fields": "sources,references,curation_effort,type,dorothea_level",
             "datasets": "dorothea",
             "sources": tf_gene,
         }
@@ -646,11 +649,22 @@ class OmniPathTool(BaseTool):
 
         interactions = []
         for item in data:
-            dorothea_level = item.get("dorothea_level")
+            # OmniPath returns dorothea_level as a list of confidence-level codes
+            # (an interaction can be tagged at multiple levels, e.g. ["A", "D"]),
+            # not a single scalar string.
+            raw_level = item.get("dorothea_level")
+            if isinstance(raw_level, list):
+                level_set = {lvl for lvl in raw_level if lvl}
+            elif raw_level:
+                level_set = {raw_level}
+            else:
+                level_set = set()
 
             if confidence_levels:
-                levels = [level.strip() for level in confidence_levels.split(",")]
-                if dorothea_level not in levels:
+                requested = {
+                    level.strip() for level in confidence_levels.split(",") if level.strip()
+                }
+                if not level_set & requested:
                     continue
 
             interactions.append(
@@ -663,7 +677,7 @@ class OmniPathTool(BaseTool):
                     else (-1 if item.get("is_inhibition") else 0),
                     "is_stimulation": bool(item.get("is_stimulation", 0)),
                     "is_inhibition": bool(item.get("is_inhibition", 0)),
-                    "dorothea_level": dorothea_level,
+                    "dorothea_level": sorted(level_set) if level_set else None,
                     "sources": item.get("sources", []),
                     "curation_effort": item.get("curation_effort"),
                 }
@@ -673,8 +687,9 @@ class OmniPathTool(BaseTool):
 
         by_level = {}
         for i in interactions:
-            lvl = i.get("dorothea_level") or "unknown"
-            by_level.setdefault(lvl, []).append(i)
+            levels = i.get("dorothea_level") or ["unknown"]
+            for lvl in levels:
+                by_level.setdefault(lvl, []).append(i)
 
         return {
             "status": "success",


### PR DESCRIPTION
## Summary

Round 4 of the test-harness role-play cycle, covering GWAS Catalog, IntAct, and OmniPath.

- **GWASAssociationSearch**: default `sort=p_value` whenever no explicit sort is given (not just when a p-value filter is present), matching sibling tool `gwas_get_associations_for_trait` and ensuring a client-side p-value threshold actually sees the top hits (previously `disease_trait=SLE, p_value_threshold=1e-100` returned 0 hits despite real hits existing at p=2e-298).
- **GWASStudyByID**: accept `accession_id` as an alias for `study_id` -- every sibling tool and every association record uses `accession_id` for this same GCST identifier.
- **GWASSNPsForGene**: dedupe by `rsId` -- the v1 `findByGene` endpoint repeats identical SNP records (confirmed byte-for-byte duplicates), inflating apparent SNP counts.
- **intact_get_interaction_details**: this tool was missing from the EBI Search fallback's per-tool query-field config entirely, so every call -- including its own documented example -- silently returned empty. Also fixed its `return_schema` (described an array; the endpoint returns one object) and its test example (used a single-part ID that doesn't match the tool's own documented `EBI-XXXXXX-EBI-YYYYYY` format and never matched a real record).
- **OmniPath_get_dorothea_regulon**: `dorothea_level` wasn't in the requested API fields, so every `confidence_levels` filter silently matched nothing; the field is also a list of codes (an interaction can carry more than one level), not a scalar, so filtering/grouping needed set membership instead of equality.

## Verification

All CLI-verified live against the real upstream APIs (not just schema inspection):

- `gwas_search_associations` with `disease_trait=Systemic lupus erythematosus, p_value_threshold=1e-100` now returns the p=2e-298 hit instead of 0 results
- `gwas_get_study_by_id` with `accession_id=GCST000392` returns the study (previously would have errored "study_id is required")
- `gwas_get_snps_for_gene` for TP53: 22 duplicate records removed, 28 unique SNPs returned
- `intact_get_interaction_details` with a real interaction ID (`EBI-714308-EBI-366083`, fetched live from `intact_search_interactions`) now returns the actual record instead of an empty result
- `OmniPath_get_dorothea_regulon` with `confidence_levels=A` now returns matching interactions instead of an empty list
- `tu test` passes for all 6 affected tools (`gwas_search_associations`, `gwas_get_study_by_id`, `gwas_get_snps_for_gene`, `intact_get_interaction_details`, `OmniPath_get_dorothea_regulon`, `Reactome_get_complex`)