### PR TITLE
Fix Round 5: CTD/metabolite RENCI-backend migration, NHANES zero-corruption, LipidMaps and Metabolomics Workbench fixes

### DIFF
--- a/src/tooluniverse/ctd_tool.py
+++ b/src/tooluniverse/ctd_tool.py
@@ -1,13 +1,27 @@
-"""CTD (Comparative Toxicogenomics Database) tool — backed by the RENCI Automat
-mirror of CTD's knowledge graph.
+"""CTD (Comparative Toxicogenomics Database) tool.
 
-CTD's native batchQuery.go now requires an altcha proof-of-work CAPTCHA, so
-direct programmatic access via that endpoint is blocked. This tool uses the
-NIH-NCATS-Translator-funded mirror at https://automat.renci.org/ctd/ instead.
-That mirror is **chemical-centric** (June-2024 snapshot, 26k nodes / 166k
-edges, biolink-categorized predicates) — it covers chemical↔gene and
-chemical↔disease cleanly, but does NOT contain CTD's gene-disease inferred
-edges. Gene→disease queries return an honest error pointing at OpenTargets.
+History of this integration, for anyone tempted to "fix" the URL again:
+
+1. CTD's native batchQuery.go now requires an altcha proof-of-work CAPTCHA,
+   so direct programmatic access via that endpoint has been blocked for a
+   long time.
+2. This tool was rewritten to use the NIH-NCATS-Translator-funded RENCI
+   Automat mirror at https://automat.renci.org/ctd/ instead.
+3. That mirror has since been decommissioned outright: its own registry
+   (https://automat.renci.org/registry) no longer lists a "ctd" backend at
+   all (confirmed live -- only cam-kp, robokopkg, translatorkg-gandalf,
+   icees-kg, ubergraph, cohd, translatorkg, ohd, and robomousekg remain).
+   Every request now 404s, not intermittently but always.
+
+Current backend: the BioThings mydisease.info API, which independently
+indexes a cached copy of CTD's chemical-disease curation under
+`ctd.chemical_related_to_disease` on each disease document. This covers the
+chemical<->disease direction only. mychem.info and mygene.info were checked
+live and carry no CTD fields at all, so there is currently no free, live
+replacement for the gene<->chemical direction; those two tools return an
+honest "permanently unavailable" error pointing at DGIdb/OpenTargets instead
+of a raw HTTP error, matching the CTD_get_gene_diseases precedent already
+established below.
 """
 
 import re
@@ -17,61 +31,56 @@ from typing import Any, Dict, List, Optional
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
-RENCI_BASE = "https://automat.renci.org/ctd"
-RENCI_HEADERS = {"Accept": "application/json", "User-Agent": "ToolUniverse CTDTool"}
-DATA_AS_OF = "2024-06"  # RENCI snapshot version
+MYDISEASE_BASE = "https://mydisease.info/v1"
+HEADERS = {"Accept": "application/json", "User-Agent": "ToolUniverse CTDTool"}
+DATA_SOURCE = "mydisease.info (BioThings) cache of CTD chemical-disease curation"
 
-_MESH_ID_RE = re.compile(r"^[CD]\d{6,9}$")  # D=descriptor, C=supplementary concept
+_MESH_ID_RE = re.compile(r"^[CD]\d{6,9}$")  # C=supplementary concept, D=descriptor
 _CAS_RN_RE = re.compile(r"^\d{1,7}-\d{2}-\d$")
-_ALL_DIGITS_RE = re.compile(r"^\d+$")
+_MONDO_RE = re.compile(r"^MONDO:\d+$", re.IGNORECASE)
 
-# Per input_type, the (pattern, CURIE prefix) pairs to try in order when the
-# bare term looks like a well-known, unambiguous ID format.
-_CURIE_RULES = {
-    "chem": ((_MESH_ID_RE, "MESH"), (_CAS_RN_RE, "CAS")),
-    "gene": ((_ALL_DIGITS_RE, "NCBIGene"),),
-    "disease": ((_MESH_ID_RE, "MESH"),),
-}
+_GENE_CHEMICAL_UNAVAILABLE = (
+    "CTD's gene<->chemical data is not available: CTD's native API is CAPTCHA-"
+    "blocked for programmatic clients, and the RENCI Automat mirror this tool "
+    "used to fall back on has been fully decommissioned (its registry no "
+    "longer lists a 'ctd' backend at all). No other free, live source of "
+    "CTD's curated gene-chemical interactions was found."
+)
+_GENE_CHEMICAL_SUGGESTION = (
+    "Use DGIdb_get_drug_gene_interactions for drug-gene interactions, or "
+    "ChEMBL/OpenTargets tools for target-compound bioactivity data."
+)
 
 
-def _candidate_curies(term: str, input_type: str) -> List[str]:
-    """Fix-R18C-2/4: CTD's own tool descriptions promise bare CAS RN, bare
-    MeSH ID, and bare NCBI Gene ID as valid input_terms formats, but the
-    RENCI mirror's equivalent_identifiers only ever store the CURIE-prefixed
-    form -- confirmed live that "D000082" (bare MeSH ID) and "80-05-7" (bare
-    CAS RN) both fail to resolve while "MESH:D000082" and "CAS:80-05-7"
-    succeed, and likewise a bare NCBI Gene ID needs "NCBIGene:" prepended.
-    When input_terms matches one of these well-known, unambiguous ID
-    formats and isn't already a CURIE, try the correctly-prefixed form
-    first; the original string is always tried too so a name/CURIE that
-    already works keeps working.
-    """
+def _term_and_prefix(term: str) -> tuple:
+    """Split a 'PREFIX:value' CURIE into (prefix, value); else (None, term)."""
     if ":" in term:
-        return [term]
-    candidates = [
-        f"{prefix}:{term}"
-        for pattern, prefix in _CURIE_RULES.get(input_type, ())
-        if pattern.match(term)
-    ]
-    candidates.append(term)
-    return candidates
+        prefix, _, value = term.partition(":")
+        return prefix.upper(), value
+    return None, term
 
 
-# Maps the existing tool configs' (input_type, report_type) to RENCI
-# (source_category, target_category). The gene→disease entry is None
-# because RENCI's CTD ingestion is chemical-centric (no gene-disease edges).
-_TYPE_MAP = {
-    ("chem", "genes_curated"): ("biolink:SmallMolecule", "biolink:Gene"),
-    ("chem", "diseases_curated"): ("biolink:SmallMolecule", "biolink:Disease"),
-    ("gene", "diseases_curated"): None,
-    ("gene", "chems_curated"): ("biolink:Gene", "biolink:SmallMolecule"),
-    ("disease", "chems_curated"): ("biolink:Disease", "biolink:SmallMolecule"),
-}
+def _chemical_match_field(term: str) -> tuple:
+    """Pick which mydisease.info nested field to match a chemical term against.
+
+    Returns (field_name, value). CTD's own chemical identifiers are MeSH IDs
+    and CAS Registry Numbers; anything else is matched by name.
+    """
+    prefix, value = _term_and_prefix(term)
+    if prefix in ("MESH", "MESH_CHEM"):
+        return "mesh_chemical_id", value
+    if prefix == "CAS":
+        return "cas_registry_number", value
+    if _MESH_ID_RE.match(term):
+        return "mesh_chemical_id", term
+    if _CAS_RN_RE.match(term):
+        return "cas_registry_number", term
+    return "chemical_name", term
 
 
 @register_tool("CTDTool")
 class CTDTool(BaseTool):
-    """Query CTD curated relationships via the RENCI Automat mirror."""
+    """Query CTD curated chemical-disease relationships via mydisease.info."""
 
     def __init__(self, tool_config: Dict[str, Any]):
         super().__init__(tool_config)
@@ -86,26 +95,26 @@ class CTDTool(BaseTool):
         except requests.exceptions.Timeout:
             return {
                 "status": "error",
-                "error": f"RENCI CTD mirror timed out after {self.timeout}s",
-                "metadata": {"backend": "RENCI Automat CTD", "data_as_of": DATA_AS_OF},
+                "error": f"mydisease.info timed out after {self.timeout}s",
+                "metadata": {"backend": DATA_SOURCE},
             }
         except requests.exceptions.ConnectionError:
             return {
                 "status": "error",
-                "error": "Failed to connect to the RENCI CTD mirror. Check network.",
-                "metadata": {"backend": "RENCI Automat CTD", "data_as_of": DATA_AS_OF},
+                "error": "Failed to connect to mydisease.info. Check network.",
+                "metadata": {"backend": DATA_SOURCE},
             }
         except requests.exceptions.HTTPError as e:
             return {
                 "status": "error",
-                "error": f"RENCI CTD mirror HTTP error: {e.response.status_code}",
-                "metadata": {"backend": "RENCI Automat CTD", "data_as_of": DATA_AS_OF},
+                "error": f"mydisease.info HTTP error: {e.response.status_code}",
+                "metadata": {"backend": DATA_SOURCE},
             }
         except Exception as e:  # noqa: BLE001
             return {
                 "status": "error",
-                "error": f"Unexpected error querying RENCI CTD mirror: {e}",
-                "metadata": {"backend": "RENCI Automat CTD", "data_as_of": DATA_AS_OF},
+                "error": f"Unexpected error querying mydisease.info: {e}",
+                "metadata": {"backend": DATA_SOURCE},
             }
 
     # -- internals -----------------------------------------------------------
@@ -125,8 +134,7 @@ class CTDTool(BaseTool):
         input_type = arguments.get("input_type", self.input_type)
         report_type = arguments.get("report_type", self.report_type)
         metadata = {
-            "backend": "RENCI Automat CTD",
-            "data_as_of": DATA_AS_OF,
+            "backend": DATA_SOURCE,
             "input_terms": input_terms,
             "input_type": input_type,
             "report_type": report_type,
@@ -136,109 +144,217 @@ class CTDTool(BaseTool):
             return {
                 "status": "error",
                 "error": (
-                    "Gene→disease relationships are not available in the RENCI CTD "
-                    "mirror (chemical-centric snapshot, no gene-disease edges)."
+                    "Gene->disease relationships are not available from CTD "
+                    "via this tool (no live curated CTD source covers this "
+                    "direction)."
                 ),
                 "suggestion": (
-                    "Use OpenTargets_get_associated_diseases (live, more sources) "
-                    "or DGIdb_search_interactions for gene-disease associations."
+                    "Use OpenTargets_get_associated_diseases (live, more "
+                    "sources) or DGIdb_search_interactions for gene-disease "
+                    "associations."
                 ),
                 "metadata": metadata,
             }
 
-        mapping = _TYPE_MAP.get((input_type, report_type))
-        if not mapping:
+        if (input_type, report_type) in (("chem", "genes_curated"), ("gene", "chems_curated")):
             return {
                 "status": "error",
-                "error": (
-                    f"Unsupported query: input_type={input_type!r}, "
-                    f"report_type={report_type!r}."
-                ),
+                "error": _GENE_CHEMICAL_UNAVAILABLE,
+                "suggestion": _GENE_CHEMICAL_SUGGESTION,
                 "metadata": metadata,
             }
-        source_cat, target_cat = mapping
 
-        canonical = None
-        for candidate in _candidate_curies(input_terms, input_type):
-            canonical = self._resolve_curie(candidate)
-            if canonical:
-                break
-        if not canonical:
+        if input_type == "chem" and report_type == "diseases_curated":
+            return self._chemical_to_diseases(input_terms, metadata)
+        if input_type == "disease" and report_type == "chems_curated":
+            return self._disease_to_chemicals(input_terms, metadata)
+
+        return {
+            "status": "error",
+            "error": f"Unsupported query: input_type={input_type!r}, report_type={report_type!r}.",
+            "metadata": metadata,
+        }
+
+    def _chemical_to_diseases(self, term: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+        field, value = _chemical_match_field(term)
+        metadata["matched_field"] = f"ctd.chemical_related_to_disease.{field}"
+        query = f'ctd.chemical_related_to_disease.{field}:"{_escape(value)}"'
+        hits = self._search(query, "mondo.label,ctd.chemical_related_to_disease")
+        if hits is None:
             return {
                 "status": "error",
-                "error": (
-                    f"'{input_terms}' was not found in the RENCI CTD mirror "
-                    f"(searched by id, equivalent_identifiers, and name)."
-                ),
+                "error": f"'{term}' was not found among CTD's curated chemical-disease associations.",
                 "metadata": metadata,
             }
-        metadata["canonical_curie"] = canonical
-        metadata["source_category"] = source_cat
-        metadata["target_category"] = target_cat
+        edges = []
+        for hit in hits:
+            disease_id = hit.get("_id")
+            disease_name = (hit.get("mondo") or {}).get("label")
+            for entry in _ctd_disease_entries(hit):
+                if not _entry_matches(entry, field, value):
+                    continue
+                edges.append(_format_chem_disease_edge(entry, disease_id, disease_name))
+        metadata["total_results"] = len(edges)
+        return {"status": "success", "data": edges, "metadata": metadata}
 
-        url = f"{RENCI_BASE}/{source_cat}/{target_cat}/{canonical}"
-        resp = requests.get(url, headers=RENCI_HEADERS, timeout=self.timeout)
-        resp.raise_for_status()
-        raw_edges = resp.json()
-        if not isinstance(raw_edges, list):
+    def _disease_to_chemicals(self, term: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+        mondo_id, disease_label = self._resolve_disease(term)
+        if not mondo_id:
             return {
                 "status": "error",
-                "error": "RENCI CTD mirror returned unexpected (non-list) payload",
+                "error": f"'{term}' could not be resolved to a disease known to CTD/MONDO.",
                 "metadata": metadata,
             }
-        formatted = [self._format_edge(e) for e in raw_edges]
-        formatted = [e for e in formatted if e]
-        metadata["total_results"] = len(formatted)
-        return {"status": "success", "data": formatted, "metadata": metadata}
-
-    def _resolve_curie(self, term: str) -> Optional[str]:
-        """Resolve an input (name or any CURIE) to the graph's canonical id.
-
-        Uses RENCI's /cypher endpoint to search by `id`, `equivalent_identifiers`,
-        or case-insensitive `name`. Returns the canonical `id` or None. Callers
-        should try candidates from `_candidate_curies()` in order -- this does
-        a single lookup and does not itself retry with a CURIE prefix.
-        """
-        return self._cypher_lookup(term)
-
-    def _cypher_lookup(self, term: str) -> Optional[str]:
-        safe = term.replace('"', "").replace("\\", "")
-        query = (
-            'MATCH (n) WHERE n.id = "' + safe + '" OR "' + safe + '" IN '
-            'n.equivalent_identifiers OR toLower(n.name) = toLower("' + safe + '") '
-            "RETURN n.id AS id LIMIT 1"
+        metadata["resolved_disease"] = {"mondo_id": mondo_id, "label": disease_label}
+        resp = requests.get(
+            f"{MYDISEASE_BASE}/disease/{mondo_id}",
+            params={"fields": "ctd.chemical_related_to_disease"},
+            headers=HEADERS,
+            timeout=self.timeout,
         )
-        resp = requests.post(
-            f"{RENCI_BASE}/cypher",
-            headers={"Content-Type": "application/json"},
-            json={"query": query},
+        resp.raise_for_status()
+        doc = resp.json()
+        entries = _ctd_disease_entries(doc)
+        edges = [_format_disease_chem_edge(e, mondo_id, disease_label) for e in entries]
+        metadata["total_results"] = len(edges)
+        return {"status": "success", "data": edges, "metadata": metadata}
+
+    def _resolve_disease(self, term: str) -> tuple:
+        """Resolve a disease name, MONDO CURIE, or MeSH ID to (mondo_id, label)."""
+        prefix, value = _term_and_prefix(term)
+        if _MONDO_RE.match(term):
+            mondo_id = term.upper()
+        elif prefix == "MESH" or _MESH_ID_RE.match(term):
+            mesh_id = value if prefix else term
+            hits = self._search(f'mondo.xrefs.mesh:"{_escape(mesh_id)}"', "mondo.label")
+            if not hits:
+                return None, None
+            return hits[0].get("_id"), (hits[0].get("mondo") or {}).get("label")
+        else:
+            # Plain free-text search over the whole mydisease.info index also
+            # matches DOID/OMIM/etc. documents that carry no `mondo` block at
+            # all (confirmed live for "asthma" -- the top two hits were DOID
+            # documents with no ctd data). Restricting the match to the
+            # `mondo.label` field keeps results anchored to MONDO documents,
+            # which is what `/v1/disease/<id>` and the ctd cross-reference
+            # both expect.
+            hits = self._search(f'mondo.label:"{_escape(term)}"', "mondo.label", size=1)
+            if not hits:
+                return None, None
+            return hits[0].get("_id"), (hits[0].get("mondo") or {}).get("label")
+
+        resp = requests.get(
+            f"{MYDISEASE_BASE}/disease/{mondo_id}",
+            params={"fields": "mondo.label"},
+            headers=HEADERS,
+            timeout=self.timeout,
+        )
+        if resp.status_code == 404:
+            return None, None
+        resp.raise_for_status()
+        doc = resp.json()
+        return mondo_id, (doc.get("mondo") or {}).get("label")
+
+    def _search(self, query: str, fields: str, size: int = 200) -> Optional[List[Dict[str, Any]]]:
+        resp = requests.get(
+            f"{MYDISEASE_BASE}/query",
+            params={"q": query, "fields": fields, "size": size},
+            headers=HEADERS,
             timeout=self.timeout,
         )
         resp.raise_for_status()
         data = resp.json()
-        try:
-            return data["results"][0]["data"][0]["row"][0]
-        except (KeyError, IndexError, TypeError):
+        hits = data.get("hits")
+        if not hits:
             return None
+        return hits
 
-    @staticmethod
-    def _format_edge(edge: Any) -> Optional[Dict[str, Any]]:
-        """RENCI returns each edge as [source_node, edge_props, target_node]."""
-        if not isinstance(edge, list) or len(edge) < 3:
-            return None
-        src, props, tgt = edge[0], edge[1], edge[2]
-        s = src if isinstance(src, dict) else {}
-        t = tgt if isinstance(tgt, dict) else {}
-        p = props if isinstance(props, dict) else {}
-        return {
-            "source_id": s.get("id"),
-            "source_name": s.get("name"),
-            "target_id": t.get("id"),
-            "target_name": t.get("name"),
-            "predicate": p.get("predicate"),
-            "qualified_predicate": p.get("qualified_predicate"),
-            "object_direction_qualifier": p.get("object_direction_qualifier"),
-            "knowledge_level": p.get("knowledge_level"),
-            "agent_type": p.get("agent_type"),
-            "primary_knowledge_source": p.get("primary_knowledge_source"),
-        }
+
+def _escape(value: str) -> str:
+    return value.replace('"', "").replace("\\", "")
+
+
+def _ctd_disease_entries(doc: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Flatten a mydisease.info document's chemical_related_to_disease entries.
+
+    BioThings occasionally merges more than one source record onto the same
+    disease document, in which case `ctd` itself is a list of sub-documents
+    instead of a single dict -- confirmed live for MONDO:0002525. Handle both
+    shapes and always return a flat list of entry dicts.
+    """
+    ctd_field = doc.get("ctd") or []
+    ctd_docs = ctd_field if isinstance(ctd_field, list) else [ctd_field]
+    entries: List[Dict[str, Any]] = []
+    for ctd_doc in ctd_docs:
+        if not isinstance(ctd_doc, dict):
+            continue
+        related = ctd_doc.get("chemical_related_to_disease") or []
+        entries.extend(related if isinstance(related, list) else [related])
+    return entries
+
+
+def _pubmed_ids(entry: Dict[str, Any]) -> Any:
+    """CTD entries usually carry one PMID but sometimes a list of several."""
+    pubmed = entry.get("pubmed")
+    if isinstance(pubmed, list):
+        return pubmed
+    return [pubmed] if pubmed else []
+
+
+def _entry_matches(entry: Dict[str, Any], field: str, value: str) -> bool:
+    entry_value = entry.get(field)
+    if entry_value is None:
+        return False
+    return str(entry_value).strip().lower() == value.strip().lower()
+
+
+_EVIDENCE_TO_PREDICATE = {
+    "marker/mechanism": "biolink:contributes_to",
+    "therapeutic": "biolink:treats",
+}
+
+
+def _format_chem_disease_edge(
+    entry: Dict[str, Any], disease_id: Optional[str], disease_name: Optional[str]
+) -> Dict[str, Any]:
+    mesh_chem = entry.get("mesh_chemical_id")
+    cas = entry.get("cas_registry_number")
+    source_id = f"MESH:{mesh_chem}" if mesh_chem else (f"CAS:{cas}" if cas else None)
+    direct_evidence = entry.get("direct_evidence")
+    return {
+        "source_id": source_id,
+        "source_name": entry.get("chemical_name"),
+        "target_id": disease_id,
+        "target_name": disease_name,
+        "predicate": None,
+        "qualified_predicate": _EVIDENCE_TO_PREDICATE.get(direct_evidence),
+        "object_direction_qualifier": None,
+        "knowledge_level": "knowledge_assertion",
+        "agent_type": "manual_agent",
+        "primary_knowledge_source": "infores:ctd",
+        "direct_evidence": direct_evidence,
+        "pubmed_ids": _pubmed_ids(entry),
+    }
+
+
+def _format_disease_chem_edge(
+    entry: Dict[str, Any], disease_id: str, disease_name: Optional[str]
+) -> Dict[str, Any]:
+    mesh_chem = entry.get("mesh_chemical_id")
+    cas = entry.get("cas_registry_number")
+    target_id = f"MESH:{mesh_chem}" if mesh_chem else (f"CAS:{cas}" if cas else None)
+    direct_evidence = entry.get("direct_evidence")
+    return {
+        "source_id": disease_id,
+        "source_name": disease_name,
+        "target_id": target_id,
+        "target_name": entry.get("chemical_name"),
+        "predicate": None,
+        "qualified_predicate": _EVIDENCE_TO_PREDICATE.get(direct_evidence),
+        "object_direction_qualifier": None,
+        "knowledge_level": "knowledge_assertion",
+        "agent_type": "manual_agent",
+        "primary_knowledge_source": "infores:ctd",
+        "direct_evidence": direct_evidence,
+        "pubmed_ids": _pubmed_ids(entry),
+    }

--- a/src/tooluniverse/data/ctd_tools.json
+++ b/src/tooluniverse/data/ctd_tools.json
@@ -1,13 +1,13 @@
 [
   {
     "name": "CTD_get_chemical_gene_interactions",
-    "description": "Get curated chemical-gene interactions from CTD (Comparative Toxicogenomics Database). Given a chemical name, returns genes it interacts with, including organism, PubMed references, and interaction types. Example: 'bisphenol A' returns thousands of gene interactions across species. Note: the result's top-level 'predicate' field is always null for this edge type -- the real interaction-type signal is in 'qualified_predicate' (e.g. 'biolink:causes') and 'object_direction_qualifier'. Backed by the RENCI Automat CTD mirror (June-2024 snapshot, biolink-categorized); CTD's native batchQuery.go is currently CAPTCHA-blocked for programmatic clients.",
+    "description": "PERMANENTLY UNAVAILABLE: this tool always returns an error. CTD's native batchQuery.go is CAPTCHA-blocked for programmatic clients, and the RENCI Automat mirror this tool used to fall back on has been fully decommissioned (its registry no longer lists a 'ctd' backend at all). No other free, live source of CTD's curated chemical-gene interactions was found. Use DGIdb_get_drug_gene_interactions or ChEMBL/OpenTargets tools for target-compound bioactivity data instead.",
     "parameter": {
       "type": "object",
       "properties": {
         "input_terms": {
           "type": "string",
-          "description": "Chemical name, CAS RN, or MeSH ID. Examples: 'bisphenol A', 'paracetamol' (the RENCI mirror's canonical name -- common synonyms like 'acetaminophen' may not resolve), 'D000082' (MeSH ID, prefix optional). CAS RN and MeSH/NCBI Gene IDs are matched by exact string against the graph's canonical name/synonym list, not fuzzy-matched, so an uncommon synonym can fail even when the substance is covered."
+          "description": "Chemical name, CAS RN, or MeSH ID. Unused -- this tool always returns an error; see the tool description."
         }
       },
       "required": [
@@ -19,14 +19,7 @@
       "report_type": "genes_curated"
     },
     "type": "CTDTool",
-    "test_examples": [
-      {
-        "input_terms": "bisphenol A"
-      },
-      {
-        "input_terms": "CHEBI:46195"
-      }
-    ],
+    "test_examples": [],
     "return_schema": {
       "oneOf": [
         {
@@ -123,13 +116,13 @@
   },
   {
     "name": "CTD_get_chemical_diseases",
-    "description": "Get curated chemical-disease associations from CTD. Given a chemical name, returns diseases it is associated with, and disease categories. Example: 'bisphenol A' returns associations with cancer, reproductive disorders, etc. Note: unlike the sibling CTD_get_chemical_gene_interactions tool, the RENCI mirror's chemical-disease edges do not carry a direct evidence type (predicate/qualified_predicate) -- those fields are consistently null here, not a query error. Backed by the RENCI Automat CTD mirror (June-2024 snapshot, biolink-categorized); CTD's native batchQuery.go is currently CAPTCHA-blocked for programmatic clients.",
+    "description": "Get curated chemical-disease associations from CTD. Given a chemical name, returns diseases it is associated with, along with the underlying evidence type (marker/mechanism vs. therapeutic) and a supporting PubMed ID. Example: 'bisphenol A' returns associations with cancer, reproductive disorders, etc. Backed by mydisease.info's cached copy of CTD's curated chemical-disease data (CTD's own native batchQuery.go is CAPTCHA-blocked for programmatic clients, and the RENCI Automat mirror this tool previously used has been fully decommissioned).",
     "parameter": {
       "type": "object",
       "properties": {
         "input_terms": {
           "type": "string",
-          "description": "Chemical name, MeSH name, synonym, CAS RN, or MeSH ID. Examples: 'arsenic', 'bisphenol A', 'C006780'."
+          "description": "Chemical name, CAS Registry Number, or CTD/MeSH chemical ID (e.g., 'C006780', 'D016729', optionally prefixed 'MESH:'). Examples: 'arsenic', 'bisphenol A', 'C006780', '80-05-7'. Matched by exact string against CTD's canonical chemical name, not fuzzy-matched, so an uncommon synonym can fail even when the substance is covered. Other identifier systems (CHEBI, PubChem CID, etc.) are not supported -- resolve to a name first."
         }
       },
       "required": [
@@ -146,7 +139,7 @@
         "input_terms": "bisphenol A"
       },
       {
-        "input_terms": "CHEBI:27563"
+        "input_terms": "C006780"
       }
     ],
     "return_schema": {
@@ -245,7 +238,7 @@
   },
   {
     "name": "CTD_get_gene_diseases",
-    "description": "Gene -> disease relationships are NOT served by the RENCI CTD mirror (chemical-centric snapshot). This tool returns a structured error and redirects callers to OpenTargets_get_associated_diseases. Use that tool instead.",
+    "description": "PERMANENTLY UNAVAILABLE: this tool always returns an error. No live, free source of CTD's curated gene-disease associations was found (CTD's native API is CAPTCHA-blocked, and the RENCI Automat mirror this tool previously fell back on has been fully decommissioned). This tool returns a structured error and redirects callers to OpenTargets_get_associated_diseases. Use that tool instead.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -366,13 +359,13 @@
   },
   {
     "name": "CTD_get_gene_chemicals",
-    "description": "Get curated gene-chemical interactions from CTD. Given a gene symbol, returns chemicals that interact with the gene product, with PubMed evidence. Example: 'TP53' returns over 2000 chemical interactions including drugs, environmental toxicants. Backed by the RENCI Automat CTD mirror (June-2024 snapshot, biolink-categorized); CTD's native batchQuery.go is currently CAPTCHA-blocked for programmatic clients.",
+    "description": "PERMANENTLY UNAVAILABLE: this tool always returns an error. CTD's native batchQuery.go is CAPTCHA-blocked for programmatic clients, and the RENCI Automat mirror this tool used to fall back on has been fully decommissioned (its registry no longer lists a 'ctd' backend at all). No other free, live source of CTD's curated gene-chemical interactions was found. Use DGIdb_get_drug_gene_interactions or ChEMBL/OpenTargets tools for target-compound bioactivity data instead.",
     "parameter": {
       "type": "object",
       "properties": {
         "input_terms": {
           "type": "string",
-          "description": "Gene symbol or NCBI Gene ID. Examples: 'CYP1A1', 'TP53', 'ESR1'."
+          "description": "Gene symbol or NCBI Gene ID. Unused -- this tool always returns an error; see the tool description."
         }
       },
       "required": [
@@ -384,14 +377,7 @@
       "report_type": "chems_curated"
     },
     "type": "CTDTool",
-    "test_examples": [
-      {
-        "input_terms": "CYP1A1"
-      },
-      {
-        "input_terms": "ESR1"
-      }
-    ],
+    "test_examples": [],
     "return_schema": {
       "oneOf": [
         {
@@ -488,13 +474,13 @@
   },
   {
     "name": "CTD_get_disease_chemicals",
-    "description": "Get curated disease-chemical associations from CTD. Given a disease name, returns chemicals associated with it, including evidence type. Example: 'breast neoplasm' returns chemicals linked to breast cancer including both therapeutic agents and toxicants. Backed by the RENCI Automat CTD mirror (June-2024 snapshot, biolink-categorized); CTD's native batchQuery.go is currently CAPTCHA-blocked for programmatic clients.",
+    "description": "Get curated disease-chemical associations from CTD. Given a disease name, MONDO CURIE, or MeSH disease ID, returns chemicals associated with it, including the underlying evidence type (marker/mechanism vs. therapeutic) and a supporting PubMed ID. Example: 'breast neoplasm' returns chemicals linked to breast cancer including both therapeutic agents and toxicants. Backed by mydisease.info's cached copy of CTD's curated chemical-disease data (CTD's own native batchQuery.go is CAPTCHA-blocked for programmatic clients, and the RENCI Automat mirror this tool previously used has been fully decommissioned).",
     "parameter": {
       "type": "object",
       "properties": {
         "input_terms": {
           "type": "string",
-          "description": "Disease name, MeSH/OMIM ID. Examples: 'breast neoplasm' (singular -- the plural 'Breast Neoplasms' does not resolve), 'asthma', 'MESH:D001249'. Matched by exact string against the graph's canonical name, not fuzzy-matched, so an uncommon phrasing can fail even when the disease is covered."
+          "description": "Disease name, MONDO CURIE (e.g. 'MONDO:0007254'), or MeSH disease ID (e.g. 'D001249', optionally prefixed 'MESH:'). Examples: 'breast neoplasm', 'asthma', 'MESH:D001249'. Free-text names are resolved via MONDO's own text search, so common synonyms generally work; exact CURIEs are more reliable for ambiguous names."
         }
       },
       "required": [
@@ -511,7 +497,7 @@
         "input_terms": "asthma"
       },
       {
-        "input_terms": "MESH:D008113"
+        "input_terms": "MESH:D001249"
       }
     ],
     "return_schema": {

--- a/src/tooluniverse/data/lipidmaps_tools.json
+++ b/src/tooluniverse/data/lipidmaps_tools.json
@@ -92,13 +92,13 @@
   },
   {
     "name": "LipidMaps_search_by_name",
-    "description": "Search for lipids by exact abbreviation in LIPID MAPS Structure Database. IMPORTANT: Only exact lipidomics abbreviations work (e.g., 'DHA', 'EPA', 'PC 16:0/18:1', 'SM 34:1'). Class names like 'ceramide' or 'sphingomyelin' will NOT match — use LipidMaps_search_by_formula for class-level searches. Returns matching lipid records with structures and classification.",
+    "description": "Search for lipids by exact abbreviation in LIPID MAPS Structure Database. IMPORTANT: Only exact lipidomics abbreviations work (e.g., 'DHA', 'EPA', 'PC 34:1' sum-composition, 'PC 16:0/18:1' acyl-chain-specific -- automatically retried against LIPID MAPS' abbrev_chains field if the sum-composition lookup finds nothing, 'SM 34:1;O2' -- sphingolipids require the ';O2' hydroxyl-count suffix, plain 'SM 34:1' does not match). Class names like 'ceramide' or 'sphingomyelin' will NOT match — use LipidMaps_search_by_formula for class-level searches. Returns matching lipid records with structures and classification.",
     "parameter": {
       "type": "object",
       "properties": {
         "input_value": {
           "type": "string",
-          "description": "Exact lipid abbreviation used in lipidomics (e.g., 'DHA', 'EPA', 'PC 16:0/18:1', 'SM 34:1'). Class names like 'ceramide' will not match — use exact abbreviations only."
+          "description": "Exact lipid abbreviation used in lipidomics (e.g., 'DHA', 'EPA', 'PC 34:1', 'PC 16:0/18:1', 'SM 34:1;O2'). Class names like 'ceramide' will not match — use exact abbreviations only. Sphingolipid sum-composition abbreviations must include the ';O2'-style hydroxyl-count suffix."
         },
         "output_item": {
           "type": "string",
@@ -122,6 +122,12 @@
       {
         "input_value": "EPA",
         "output_item": "all"
+      },
+      {
+        "input_value": "PC 16:0/18:1"
+      },
+      {
+        "input_value": "SM 34:1;O2"
       }
     ],
     "return_schema": {

--- a/src/tooluniverse/data/metabolomics_workbench_tools.json
+++ b/src/tooluniverse/data/metabolomics_workbench_tools.json
@@ -36,7 +36,7 @@
         "study_id": "ST000001"
       },
       {
-        "study_id": "ST000100",
+        "study_id": "ST000001",
         "output_item": "metabolites"
       }
     ],
@@ -58,6 +58,15 @@
           "required": [
             "error"
           ]
+        },
+        {
+          "type": "object",
+          "description": "A single study record for single-stanza output_items (summary, analysis) -- field names vary by output_item, so no fixed property list is enforced beyond 'not also carrying an error key'.",
+          "not": {
+            "required": [
+              "error"
+            ]
+          }
         }
       ]
     }

--- a/src/tooluniverse/data/nhanes_tools.json
+++ b/src/tooluniverse/data/nhanes_tools.json
@@ -130,7 +130,7 @@
         },
         "year": {
           "type": "string",
-          "description": "Optional NHANES cycle to filter (e.g., '2017-2018')"
+          "description": "Optional NHANES cycle to filter (e.g., '2017-2018'). If omitted, searches the two most recent cycles (matching nhanes_get_dataset_info's default) rather than a single fixed cycle -- a dataset renamed or dropped in one cycle can still be found via the other."
         },
         "limit": {
           "type": "integer",
@@ -152,10 +152,10 @@
           "items": {
             "type": "object",
             "properties": {
-              "name": {
+              "file_name": {
                 "type": "string"
               },
-              "year": {
+              "cycle": {
                 "type": "string"
               },
               "download_url": {
@@ -163,6 +163,13 @@
               }
             }
           }
+        },
+        "cycles_searched": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Which NHANES cycles were actually searched"
         }
       }
     },

--- a/src/tooluniverse/lipidmaps_tool.py
+++ b/src/tooluniverse/lipidmaps_tool.py
@@ -203,9 +203,37 @@ class LipidMapsTool(BaseTool):
                 + ", ".join(sorted(self._XREF_INPUT_ITEMS)),
             }
 
-        return self._make_request(
+        result = self._make_request(
             f"compound/{input_item}/{input_value}/{output_item}/json"
         )
+
+        # LMSD's `abbrev` field only stores sum-composition shorthand (e.g.
+        # 'PC 34:1'), never the acyl-chain-specific form real lipidomics
+        # workflows use ('PC 16:0/18:1') -- that regiospecific form only
+        # matches the separate `abbrev_chains` field, and even there only as
+        # 'PC 16:0_18:1' (underscore, not slash -- confirmed live that a
+        # literal or percent-encoded '/' in this path segment 404s against
+        # LIPID MAPS' router, so the substitution below is required, not
+        # cosmetic). Retry automatically so a name copy-pasted straight out
+        # of a lipidomics results table (slash form) still resolves instead
+        # of silently returning zero hits.
+        if (
+            input_item == "abbrev"
+            and not result.get("data")
+            and "/" in input_value
+        ):
+            chains_value = input_value.replace("/", "_")
+            retry = self._make_request(
+                f"compound/abbrev_chains/{chains_value}/{output_item}/json"
+            )
+            if retry.get("data"):
+                retry.setdefault("metadata", {})["resolved_via"] = (
+                    f"abbrev_chains='{chains_value}' (retried after 'abbrev' "
+                    f"lookup of the acyl-chain form '{input_value}' found nothing)"
+                )
+                return retry
+
+        return result
 
     def _query_gene(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Query lipid-related gene information from LMPD."""

--- a/src/tooluniverse/metabolite_tool.py
+++ b/src/tooluniverse/metabolite_tool.py
@@ -174,91 +174,75 @@ class MetaboliteTool(BaseTool):
         return []
 
     def _ctd_diseases(self, chemical_term: str) -> List[Dict[str, Any]]:
-        """Query CTD-via-RENCI Automat mirror for curated disease associations.
+        """Query mydisease.info's cached CTD chemical-disease curation.
 
         CTD's native batchQuery.go is altcha-CAPTCHA-blocked since early
-        2026 — see ctd_tool.py for the migration. The mirror at
-        automat.renci.org exposes the same chemical-disease edges; we
-        cypher-resolve the chemical name to a CURIE, then hit the typed
-        edge endpoint and flatten back to CTD-style rows so callers see no
-        change in shape.
+        2026, and the RENCI Automat mirror this method used as a fallback
+        has since been fully decommissioned (its registry no longer lists a
+        'ctd' backend at all -- see ctd_tool.py for the full history). This
+        queries the BioThings mydisease.info API instead, which still serves
+        CTD's chemical-disease edges under `ctd.chemical_related_to_disease`
+        on each disease document -- see ctd_tool.py's `_chemical_to_diseases`
+        for the same approach applied to the standalone CTD_* tools.
         """
-        # 1) Resolve the free-text chemical term to a graph CURIE
         safe = chemical_term.replace('"', "").replace("\\", "")
-        cypher = (
-            'MATCH (n) WHERE n.id = "' + safe + '" OR "' + safe + '" IN '
-            'n.equivalent_identifiers OR toLower(n.name) = toLower("' + safe + '") '
-            "RETURN n.id AS id LIMIT 1"
-        )
-        try:
-            r = requests.post(
-                "https://automat.renci.org/ctd/cypher",
-                headers={"Content-Type": "application/json"},
-                json={"query": cypher},
-                timeout=self.timeout,
-            )
-            r.raise_for_status()
-        except requests.RequestException as exc:
-            raise CTDBackendUnavailable(
-                f"CTD mirror (automat.renci.org/ctd) is unavailable: {exc}"
-            ) from exc
-        try:
-            payload = r.json()
-            curie = payload["results"][0]["data"][0]["row"][0]
-        except (KeyError, IndexError, TypeError, ValueError):
-            # Query succeeded but this term is not a node in the graph.
-            return []
-
-        # 2) Fetch the SmallMolecule → Disease edges
+        # `_resolve_ctd_term` tries a CAS Registry Number candidate (from
+        # PubChem synonyms) alongside plain names -- match it against the
+        # right nested field rather than always searching by name.
+        match_field = "cas_registry_number" if _CAS_RE.match(chemical_term) else "chemical_name"
         try:
             r = requests.get(
-                f"https://automat.renci.org/ctd/biolink:SmallMolecule/biolink:Disease/{curie}",
+                "https://mydisease.info/v1/query",
+                params={
+                    "q": f'ctd.chemical_related_to_disease.{match_field}:"{safe}"',
+                    "fields": "mondo.label,ctd.chemical_related_to_disease",
+                    "size": 200,
+                },
                 headers={"Accept": "application/json"},
                 timeout=self.timeout,
             )
             r.raise_for_status()
         except requests.RequestException as exc:
             raise CTDBackendUnavailable(
-                f"CTD mirror (automat.renci.org/ctd) is unavailable: {exc}"
+                f"mydisease.info is unavailable: {exc}"
             ) from exc
         try:
-            edges = r.json()
+            hits = r.json().get("hits") or []
         except ValueError:
             return []
-        if not isinstance(edges, list):
-            return []
 
-        # 3) Flatten [source, edge_props, target] back to CTD-style rows.
-        # Confirmed live (automat.renci.org/ctd chemical-disease edges):
-        # edge_props only ever carries agent_type/knowledge_level/
-        # primary_knowledge_source/publications -- there is no predicate/
-        # qualified_predicate field, so DirectEvidence (CTD's own
-        # "therapeutic"/"marker/mechanism" classification) is genuinely
-        # unavailable from this mirror, not a parsing bug. publications
-        # (PMID:xxxxx strings) IS present but was previously hardcoded to
-        # [] instead of being read.
         rows = []
-        for edge in edges:
-            if not isinstance(edge, list) or len(edge) < 3:
-                continue
-            tgt = edge[2] if isinstance(edge[2], dict) else {}
-            props = edge[1] if isinstance(edge[1], dict) else {}
-            disease_name = tgt.get("name")
-            if not disease_name:
-                continue
-            pubmed_ids = [
-                p.split(":", 1)[-1]
-                for p in props.get("publications") or []
-                if isinstance(p, str)
-            ]
-            rows.append(
-                {
-                    "DiseaseName": disease_name,
-                    "DiseaseID": tgt.get("id"),
-                    "DirectEvidence": None,
-                    "PubMedIDs": pubmed_ids,
-                }
-            )
+        for hit in hits:
+            disease_id = hit.get("_id")
+            mondo = hit.get("mondo")
+            disease_name = mondo.get("label") if isinstance(mondo, dict) else None
+            # BioThings occasionally merges more than one source record onto
+            # the same disease document, in which case `ctd` itself is a
+            # list of sub-documents instead of a single dict -- see
+            # ctd_tool.py's `_ctd_disease_entries` for the same handling.
+            ctd_field = hit.get("ctd") or []
+            ctd_docs = ctd_field if isinstance(ctd_field, list) else [ctd_field]
+            entries = []
+            for ctd_doc in ctd_docs:
+                if not isinstance(ctd_doc, dict):
+                    continue
+                related = ctd_doc.get("chemical_related_to_disease") or []
+                entries.extend(related if isinstance(related, list) else [related])
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                if str(entry.get(match_field, "")).strip().lower() != chemical_term.strip().lower():
+                    continue
+                pubmed = entry.get("pubmed")
+                pubmed_ids = pubmed if isinstance(pubmed, list) else ([pubmed] if pubmed else [])
+                rows.append(
+                    {
+                        "DiseaseName": disease_name,
+                        "DiseaseID": disease_id,
+                        "DirectEvidence": entry.get("direct_evidence"),
+                        "PubMedIDs": [str(p) for p in pubmed_ids],
+                    }
+                )
         return rows
 
     def _resolve_ctd_term(

--- a/src/tooluniverse/metabolomics_workbench_tool.py
+++ b/src/tooluniverse/metabolomics_workbench_tool.py
@@ -19,6 +19,21 @@ from .tool_registry import register_tool
 MWBENCH_BASE_URL = "https://www.metabolomicsworkbench.org/rest"
 
 
+def _add_leading_zero(value: str) -> str:
+    """Prepend the '0' Metabolomics Workbench's own API omits from deltas.
+
+    Their moverz endpoint renders a fractional delta like 0.0019 as ".0019"
+    and -0.0082 as "-.0082" -- valid enough for their own display code but
+    not standalone-parseable numeric-string syntax. Leave anything else
+    (including already-valid numbers) untouched.
+    """
+    if value.startswith("."):
+        return "0" + value
+    if value.startswith("-."):
+        return "-0" + value[1:]
+    return value
+
+
 @register_tool("MetabolomicsWorkbenchTool")
 class MetabolomicsWorkbenchTool(BaseTool):
     """
@@ -75,8 +90,16 @@ class MetabolomicsWorkbenchTool(BaseTool):
         except Exception as e:
             raise self.handle_error(e)
 
-    def _make_request(self, sub_path: str) -> Dict[str, Any]:
-        """Central method to handle API requests and response validation."""
+    def _make_request(self, sub_path: str, text_shape: str = "table") -> Dict[str, Any]:
+        """Central method to handle API requests and response validation.
+
+        `text_shape` picks how to parse a non-JSON plain-text fallback body
+        (see `_parse_tsv_text` vs `_parse_keyvalue_blocks` docstrings for the
+        two shapes Metabolomics Workbench actually sends): "table" for a
+        shared-header, many-rows response (moverz searches); "keyvalue_blocks"
+        for one-or-more blank-line-separated "field\\tvalue" stanzas (every
+        study/{summary,factors,analysis,metabolites} response).
+        """
         # Ensure /json is appended to the URL
         if not sub_path.endswith("/json"):
             url = f"{MWBENCH_BASE_URL}/{sub_path.strip('/')}/json"
@@ -94,7 +117,9 @@ class MetabolomicsWorkbenchTool(BaseTool):
                     "status": "success",
                     "data": [],
                     "message": "No results found. RefMet requires exact metabolite names "
-                    "(e.g., 'Cholic acid' not 'bile acid', 'Cer(d18:1/16:0)' not 'ceramide'). "
+                    "(e.g., 'Cholic acid' not 'bile acid', 'Cer 18:1;O2/16:0' -- RefMet's "
+                    "own space-delimited shorthand, not the 'Cer(d18:1/16:0)' isoform "
+                    "notation -- not 'ceramide'). "
                     "Try a specific compound name or use ChEBI_search for class-level terms.",
                 }
 
@@ -116,23 +141,32 @@ class MetabolomicsWorkbenchTool(BaseTool):
                         "status": "success",
                         "data": [],
                         "message": "No results found. RefMet requires exact metabolite names "
-                        "(e.g., 'Cholic acid' not 'bile acid', 'Cer(d18:1/16:0)' not 'ceramide'). "
+                        "(e.g., 'Cholic acid' not 'bile acid', 'Cer 18:1;O2/16:0' -- RefMet's "
+                        "own space-delimited shorthand, not the 'Cer(d18:1/16:0)' isoform "
+                        "notation -- not 'ceramide'). "
                         "Try a specific compound name or use ChEBI_search for class-level terms.",
                     }
 
                 return {"status": "success", "data": data}
             except ValueError:
                 # Some endpoints (confirmed live: moverz/REFMET exact-mass
-                # search, and study "metabolites" output) ignore the
-                # requested "/json" suffix and return plain tab-separated
-                # text instead. Parse that into structured rows rather
-                # than handing back one giant string with literal \t/\n
-                # characters embedded -- harder for any downstream
-                # consumer to use than the JSON every sibling endpoint
-                # returns.
-                parsed = self._parse_tsv_text(response.text)
+                # search, and every study/* output) ignore the requested
+                # "/json" suffix and return plain text instead. Parse that
+                # into structured data rather than handing back one giant
+                # string with literal \t/\n characters embedded -- harder
+                # for any downstream consumer to use than the JSON every
+                # JSON-native endpoint returns.
+                parser = (
+                    self._parse_keyvalue_blocks
+                    if text_shape == "keyvalue_blocks"
+                    else self._parse_tsv_text
+                )
+                parsed = parser(response.text)
                 if parsed is not None:
-                    return {"status": "success", "data": parsed}
+                    return {
+                        "status": "success",
+                        "data": self._normalize_numeric_fields(parsed),
+                    }
                 return {"status": "success", "data": response.text}
 
         except requests.RequestException as e:
@@ -157,6 +191,36 @@ class MetabolomicsWorkbenchTool(BaseTool):
             )
         return rows
 
+    @staticmethod
+    def _parse_keyvalue_blocks(text: str):
+        """Parse Metabolomics Workbench's study/* text format.
+
+        Unlike moverz's shared-header table, every study/{summary,factors,
+        analysis,metabolites} response is one or more blank-line-separated
+        stanzas, each just a run of "field\\tvalue" lines (confirmed live for
+        all four output_items -- there is no shared header row at all, so
+        `_parse_tsv_text`'s "first line is headers" assumption silently
+        transposed field names into data: {"study_id": "study_title",
+        "ST003897": "Postprandial ..."} instead of {"study_title":
+        "Postprandial ..."}). Returns a single flat dict for a one-stanza
+        response (summary, analysis) or a list of dicts for a multi-stanza
+        one (factors, metabolites) -- matching whether MW itself is
+        describing one record or several.
+        """
+        blocks = [b for b in text.strip().split("\n\n") if b.strip()]
+        if not blocks or "\t" not in blocks[0]:
+            return None
+        parsed_blocks = []
+        for block in blocks:
+            record = {}
+            for line in block.strip("\n").split("\n"):
+                if "\t" not in line:
+                    return None
+                key, _, value = line.partition("\t")
+                record[key] = value
+            parsed_blocks.append(record)
+        return parsed_blocks[0] if len(parsed_blocks) == 1 else parsed_blocks
+
     def _normalize_numeric_fields(self, data: Any) -> Any:
         """Convert numeric string fields to actual numbers."""
         if isinstance(data, dict):
@@ -166,6 +230,14 @@ class MetabolomicsWorkbenchTool(BaseTool):
                     data["exactmass"] = float(data["exactmass"])
                 except (ValueError, TypeError):
                     pass
+            # Metabolomics Workbench's moverz endpoint itself omits the
+            # leading zero on this field (e.g. ".0000", "-.0082"), which
+            # isn't valid standalone numeric-string syntax in most parsers.
+            # Reformat it here rather than passing the upstream quirk
+            # through unmodified.
+            for key in ("Delta", "delta"):
+                if key in data and isinstance(data[key], str):
+                    data[key] = _add_leading_zero(data[key])
             # Recursively process nested dicts
             return {k: self._normalize_numeric_fields(v) for k, v in data.items()}
         elif isinstance(data, list):
@@ -178,7 +250,9 @@ class MetabolomicsWorkbenchTool(BaseTool):
         output_item = arguments.get("output_item", "summary")
         if not study_id:
             return {"status": "error", "error": "study_id parameter is required"}
-        return self._make_request(f"study/study_id/{study_id}/{output_item}")
+        return self._make_request(
+            f"study/study_id/{study_id}/{output_item}", text_shape="keyvalue_blocks"
+        )
 
     def _query_compound(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Query compound information."""
@@ -248,6 +322,29 @@ class MetabolomicsWorkbenchTool(BaseTool):
                 "error": (
                     "At least one filter is required for METSTAT. Provide one or more of: "
                     + ", ".join(self._METSTAT_SLOTS)
+                ),
+            }
+        # A '/' in any slot -- most commonly refmet_name values like
+        # 'PC 16:0/18:1' -- 404s even when percent-encoded, because
+        # Metabolomics Workbench's router splits on a literal slash before
+        # decoding the path segment. Confirmed live: the encoded form still
+        # produces a raw upstream 404/HTML response, not a clean "no match".
+        # Reject upfront with actionable guidance instead of leaking that
+        # HTML error page to the caller.
+        bad_slots = [
+            name
+            for name, value in zip(self._METSTAT_SLOTS, slots)
+            if "/" in value
+        ]
+        if bad_slots:
+            return {
+                "status": "error",
+                "error": (
+                    f"METSTAT filter(s) {', '.join(bad_slots)} contain '/', which "
+                    "Metabolomics Workbench's REST router cannot route correctly "
+                    "even when percent-encoded. For refmet_name, use RefMet's "
+                    "sum-composition form without the acyl-chain slash (e.g. "
+                    "'PC 34:1' instead of 'PC 16:0/18:1')."
                 ),
             }
         # URL-encode each slot value (e.g. spaces) but keep the ';' separators literal.

--- a/src/tooluniverse/nhanes_tool.py
+++ b/src/tooluniverse/nhanes_tool.py
@@ -118,7 +118,14 @@ class NHANESTool(BaseTool):
         year = arguments.get("year")
         limit = arguments.get("limit", 20)
 
-        cycle_year = year.split("-")[0] if year else "2017"
+        # Omitting `year` used to silently restrict the search to a single
+        # hardcoded cycle (2017-2018), which reported a false "no results"
+        # for datasets renamed or dropped in that one cycle (e.g. searching
+        # "phenols" found nothing even though other cycles measured them).
+        # Search the two most recent cycles by default instead, matching
+        # `_get_dataset_info`'s documented "omit year -> two most recent
+        # cycles" behavior.
+        cycles = [year] if year else self._CYCLES[:2]
         components = [
             "Demographics",
             "Dietary",
@@ -127,8 +134,40 @@ class NHANESTool(BaseTool):
             "Questionnaire",
         ]
 
-        datasets = []
+        datasets: list = []
         seen_files: set = set()
+        cycles_searched: list = []
+        for cycle in cycles:
+            cycles_searched.append(cycle)
+            self._search_cycle(cycle, components, search_term, limit, datasets, seen_files)
+            if len(datasets) >= limit:
+                break
+
+        return {
+            "status": "success",
+            "data": {
+                "datasets": datasets,
+                "count": len(datasets),
+                "search_term": search_term,
+                "cycles_searched": cycles_searched,
+            },
+            "metadata": {
+                "source": "NHANES Variable List (wwwn.cdc.gov)",
+                "components_searched": components,
+            },
+        }
+
+    def _search_cycle(
+        self,
+        cycle: str,
+        components: list,
+        search_term: str,
+        limit: int,
+        datasets: list,
+        seen_files: set,
+    ) -> None:
+        """Search one NHANES cycle's variable list, appending hits in place."""
+        cycle_year = cycle.split("-")[0]
         for component in components:
             url = (
                 "https://wwwn.cdc.gov/Nchs/Nhanes/search/variablelist.aspx"
@@ -150,13 +189,11 @@ class NHANESTool(BaseTool):
                 )
                 for var_name, var_desc, file_name, file_desc in rows:
                     if search_term and not any(
-                        search_term in s.lower()
-                        for s in [var_desc, var_name, file_desc]
+                        search_term in s.lower() for s in [var_desc, var_name, file_desc]
                     ):
                         continue
                     if file_name not in seen_files:
                         seen_files.add(file_name)
-                        end_year = str(int(cycle_year) + 1)
                         datasets.append(
                             {
                                 "file_name": file_name,
@@ -164,34 +201,19 @@ class NHANESTool(BaseTool):
                                 "component": component,
                                 "matching_variable": var_name,
                                 "variable_description": var_desc,
-                                "cycle": year or f"{cycle_year}-{end_year}",
+                                "cycle": cycle,
                                 "download_url": (
                                     f"https://wwwn.cdc.gov/Nchs/Nhanes/"
-                                    f"{cycle_year}-{end_year}/"
-                                    f"DataFiles/{file_name}.XPT"
+                                    f"{cycle}/DataFiles/{file_name}.XPT"
                                 ),
                             }
                         )
                     if len(datasets) >= limit:
-                        break
+                        return
             except Exception:
                 continue
             if len(datasets) >= limit:
-                break
-
-        return {
-            "status": "success",
-            "data": {
-                "datasets": datasets,
-                "count": len(datasets),
-                "search_term": search_term,
-                "cycle": year or f"{cycle_year}-{str(int(cycle_year) + 1)}",
-            },
-            "metadata": {
-                "source": "NHANES Variable List (wwwn.cdc.gov)",
-                "components_searched": components,
-            },
-        }
+                return
 
     # Cycle suffix mapping: cycle -> letter suffix for NHANES filenames
     _CYCLE_SUFFIX = {
@@ -250,6 +272,16 @@ class NHANESTool(BaseTool):
             f"{start_year}/DataFiles/{filename}.XPT"
         )
 
+    # pandas' XPORT reader converts an all-zero 8-byte IBM float to this exact
+    # value instead of 0.0 -- its IBM-to-IEEE754 conversion (_parse_float_vec
+    # in pandas.io.sas.sas_xport) has no special case for an all-zero byte
+    # pattern, so the exponent-bias arithmetic produces a tiny denormalized
+    # double rather than true zero. Confirmed by running that exact function
+    # against an 8-zero-byte input: it returns 5.397605346934028e-79 every
+    # time, not a range of "small" values, so this can be sanitized as an
+    # exact match with no risk to genuine (always much larger) NHANES values.
+    _SAS_XPORT_ZERO_ARTIFACT = 5.397605346934028e-79
+
     def _download_xpt(self, url: str) -> pd.DataFrame:
         """Download and parse an XPT file from CDC. Returns a DataFrame."""
         resp = requests.get(url, timeout=120)
@@ -262,7 +294,8 @@ class NHANESTool(BaseTool):
         # Check for HTML error page (CDC returns 200 with HTML for missing files)
         if content[:5] == b"<!DOC" or content[:5] == b"<html":
             raise ValueError(f"File not found at {url} (CDC returned HTML error page)")
-        return pd.read_sas(io.BytesIO(content), format="xport")
+        df = pd.read_sas(io.BytesIO(content), format="xport")
+        return df.replace(self._SAS_XPORT_ZERO_ARTIFACT, 0.0)
 
     @staticmethod
     def _format_age_bounds(age_min, age_max) -> str:

--- a/tests/unit/test_confidently_wrong_answers_r6.py
+++ b/tests/unit/test_confidently_wrong_answers_r6.py
@@ -502,9 +502,11 @@ def test_metabolite_dead_ctd_backend_is_an_error_not_zero_diseases():
         }
     )
 
+    # _ctd_diseases now queries mydisease.info via requests.get (the RENCI
+    # Automat mirror it used to POST to has been fully decommissioned).
     response = MagicMock()
     response.raise_for_status.side_effect = _requests.HTTPError("404 Client Error")
-    with patch("tooluniverse.metabolite_tool.requests.post", return_value=response):
+    with patch("tooluniverse.metabolite_tool.requests.get", return_value=response):
         with pytest.raises(CTDBackendUnavailable):
             tool._ctd_diseases("cholesterol")
 
@@ -524,8 +526,10 @@ def test_metabolite_unknown_term_still_returns_empty_not_an_error():
     )
     response = MagicMock()
     response.raise_for_status.return_value = None
-    response.json.return_value = {"results": [{"data": []}]}
-    with patch("tooluniverse.metabolite_tool.requests.post", return_value=response):
+    # mydisease.info's own response shape: {"hits": [...]}, not RENCI's
+    # {"results": [{"data": [...]}]}.
+    response.json.return_value = {"hits": []}
+    with patch("tooluniverse.metabolite_tool.requests.get", return_value=response):
         assert tool._ctd_diseases("zzzz") == []
 
 

--- a/tests/unit/test_ctd_disease_predicate_caveat.py
+++ b/tests/unit/test_ctd_disease_predicate_caveat.py
@@ -1,12 +1,14 @@
-"""Regression guard for Feature-R13A-1 (docs-only): CTD_get_chemical_diseases's
-description promised "direct evidence type (therapeutic, marker/mechanism)"
-that the RENCI Automat CTD mirror never actually provides for chemical-disease
-edges -- confirmed via raw curl to automat.renci.org/ctd that the edge
-properties for a real chemical-disease pair are exactly
-{agent_type, knowledge_level, primary_knowledge_source, publications}, with no
-predicate/qualified_predicate key at all (unlike the sibling chemical-gene
-interaction edges, which do carry one). This is a genuine upstream data gap,
-not a code bug, so the fix is a description caveat rather than a code change.
+"""Regression guard: CTD_get_chemical_diseases's description must describe
+the evidence its *current* backend actually provides.
+
+Originally the RENCI Automat mirror's chemical-disease edges carried no
+predicate/qualified_predicate at all, so the description needed a caveat
+that "direct evidence type" wasn't available. That mirror has since been
+decommissioned; the tool now queries mydisease.info's cached CTD data,
+which DOES carry a real evidence type (`direct_evidence`: "marker/mechanism"
+or "therapeutic", mapped into `qualified_predicate`). The description should
+reflect this current, better backend rather than the old RENCI-specific
+caveat.
 """
 
 import json
@@ -19,9 +21,17 @@ pytestmark = pytest.mark.unit
 CONFIG_PATH = Path(__file__).parent.parent.parent / "src/tooluniverse/data/ctd_tools.json"
 
 
-def test_chemical_diseases_description_no_longer_promises_evidence_type():
+def test_chemical_diseases_description_mentions_evidence_type():
     configs = json.loads(CONFIG_PATH.read_text())
     config = next(c for c in configs if c["name"] == "CTD_get_chemical_diseases")
     description = config["description"]
-    assert "including direct evidence type" not in description
-    assert "predicate" in description.lower()
+    assert "evidence type" in description.lower()
+    assert "marker/mechanism" in description
+    assert "therapeutic" in description
+
+
+def test_chemical_diseases_description_does_not_reference_decommissioned_backend_as_current():
+    configs = json.loads(CONFIG_PATH.read_text())
+    config = next(c for c in configs if c["name"] == "CTD_get_chemical_diseases")
+    description = config["description"]
+    assert "mydisease.info" in description

--- a/tests/unit/test_ctd_id_normalization.py
+++ b/tests/unit/test_ctd_id_normalization.py
@@ -1,13 +1,12 @@
-"""Regression guard for Fix-R18C-2/4: CTD's own tool descriptions promise
-bare CAS RN, bare MeSH ID, and bare NCBI Gene ID as valid input_terms
-formats, but the RENCI Automat mirror's equivalent_identifiers only ever
-store the CURIE-prefixed form -- confirmed live that "D000082" (bare MeSH
-descriptor ID), "C006780" (bare MeSH supplementary-concept ID), "80-05-7"
-(bare CAS RN), and "7157" (bare NCBI Gene ID) all failed to resolve while
-their "MESH:"/"CAS:"/"NCBIGene:"-prefixed forms succeeded.
-_candidate_curies() now tries the correctly-prefixed form first for
-recognizable ID patterns, always falling back to the original string so a
-name or already-prefixed CURIE keeps working unchanged.
+"""Regression guard for the mydisease.info-backed CTD tool's term routing.
+
+mydisease.info indexes CTD's chemical-disease curation under distinct nested
+fields per identifier type (mesh_chemical_id, cas_registry_number,
+chemical_name) with no fuzzy cross-matching between them, so a chemical term
+must be routed to the right field before querying. `_chemical_match_field`
+picks that field from a bare term's shape (MeSH ID pattern, CAS RN pattern,
+or an explicit 'PREFIX:value' CURIE); `_term_and_prefix` does the CURIE
+splitting it relies on.
 """
 
 import sys
@@ -17,46 +16,44 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
 
-from tooluniverse.ctd_tool import _candidate_curies
+from tooluniverse.ctd_tool import _chemical_match_field, _term_and_prefix
 
 pytestmark = pytest.mark.unit
 
 
-def test_bare_mesh_descriptor_id_gets_prefixed_for_chem():
-    assert _candidate_curies("D000082", "chem") == ["MESH:D000082", "D000082"]
+def test_bare_mesh_supplementary_concept_id_matches_mesh_field():
+    assert _chemical_match_field("C006780") == ("mesh_chemical_id", "C006780")
 
 
-def test_bare_mesh_supplementary_concept_id_gets_prefixed_for_chem():
-    assert _candidate_curies("C006780", "chem") == ["MESH:C006780", "C006780"]
+def test_bare_mesh_descriptor_id_matches_mesh_field():
+    assert _chemical_match_field("D016729") == ("mesh_chemical_id", "D016729")
 
 
-def test_bare_cas_rn_gets_prefixed_for_chem():
-    assert _candidate_curies("80-05-7", "chem") == ["CAS:80-05-7", "80-05-7"]
+def test_bare_cas_rn_matches_cas_field():
+    assert _chemical_match_field("80-05-7") == ("cas_registry_number", "80-05-7")
 
 
-def test_bare_ncbi_gene_id_gets_prefixed_for_gene():
-    assert _candidate_curies("7157", "gene") == ["NCBIGene:7157", "7157"]
+def test_plain_name_matches_chemical_name_field():
+    assert _chemical_match_field("bisphenol A") == ("chemical_name", "bisphenol A")
+    assert _chemical_match_field("paracetamol") == ("chemical_name", "paracetamol")
 
 
-def test_bare_mesh_id_gets_prefixed_for_disease():
-    assert _candidate_curies("D001943", "disease") == ["MESH:D001943", "D001943"]
+def test_explicit_mesh_curie_matches_mesh_field_by_value():
+    assert _chemical_match_field("MESH:C006780") == ("mesh_chemical_id", "C006780")
 
 
-def test_already_prefixed_curie_is_passed_through_unchanged():
-    assert _candidate_curies("MESH:D000082", "chem") == ["MESH:D000082"]
-    assert _candidate_curies("CAS:80-05-7", "chem") == ["CAS:80-05-7"]
+def test_explicit_cas_curie_matches_cas_field_by_value():
+    assert _chemical_match_field("CAS:80-05-7") == ("cas_registry_number", "80-05-7")
 
 
-def test_plain_name_has_no_id_candidates_generated():
-    assert _candidate_curies("bisphenol A", "chem") == ["bisphenol A"]
-    assert _candidate_curies("paracetamol", "chem") == ["paracetamol"]
+def test_unrecognized_curie_prefix_falls_back_to_name_field():
+    # CHEBI/PubChem/etc. CURIEs aren't stored in mydisease.info's CTD cache,
+    # so they can't be routed to a specific field -- the whole term
+    # (including prefix) is matched as a literal name, which will correctly
+    # find nothing rather than silently guessing a field.
+    assert _chemical_match_field("CHEBI:27563") == ("chemical_name", "CHEBI:27563")
 
 
-def test_gene_symbol_is_not_treated_as_a_gene_id():
-    assert _candidate_curies("TP53", "gene") == ["TP53"]
-
-
-def test_all_digit_string_is_not_treated_as_gene_id_for_chem_type():
-    # A bare numeric string only means "NCBI Gene ID" when input_type is
-    # "gene" -- for chemical tools it's not auto-prefixed as anything.
-    assert _candidate_curies("7157", "chem") == ["7157"]
+def test_term_and_prefix_splits_on_first_colon():
+    assert _term_and_prefix("MESH:C006780") == ("MESH", "C006780")
+    assert _term_and_prefix("bisphenol A") == (None, "bisphenol A")

--- a/tests/unit/test_ctd_tool.py
+++ b/tests/unit/test_ctd_tool.py
@@ -1,25 +1,30 @@
-"""Unit tests for the CTD tool (RENCI Automat backend).
+"""Unit tests for the CTD tool (mydisease.info backend).
 
-The tool was migrated from CTD's native batchQuery.go (CAPTCHA-blocked in
-2026) to the NIH/NCATS-Translator-funded mirror at automat.renci.org/ctd/.
-These tests cover the new behaviour: cypher-resolution of free-text inputs
-to a graph CURIE, the typed-edge fetch, the gene→disease unsupported-path
-guard, and the envelope shape.
+The tool was originally migrated from CTD's native batchQuery.go
+(CAPTCHA-blocked) to the NIH/NCATS-Translator-funded RENCI Automat mirror,
+and has since been migrated again because that mirror was fully
+decommissioned (its registry no longer lists a 'ctd' backend at all). It now
+queries the BioThings mydisease.info API, which independently caches CTD's
+chemical-disease curation under `ctd.chemical_related_to_disease` on each
+disease document. These tests cover the current behaviour: chemical-name/
+MeSH-ID/CAS-RN resolution to the right nested field, the chemical->disease
+and disease->chemical directions, the gene<->chemical "permanently
+unavailable" guard, and the envelope shape.
 """
 
 from unittest.mock import Mock, patch
 
 import pytest
 
-from tooluniverse.ctd_tool import RENCI_HEADERS, CTDTool
+from tooluniverse.ctd_tool import CTDTool, HEADERS
 
 
-def make_ctd_tool(input_type="chem", report_type="genes_curated"):
+def make_ctd_tool(input_type="chem", report_type="diseases_curated"):
     """Create a CTD tool with a small deterministic config."""
 
     return CTDTool(
         {
-            "name": "CTD_get_chemical_gene_interactions",
+            "name": "CTD_get_chemical_diseases",
             "type": "CTDTool",
             "fields": {
                 "input_type": input_type,
@@ -29,152 +34,152 @@ def make_ctd_tool(input_type="chem", report_type="genes_curated"):
     )
 
 
-def make_cypher_response(curie):
-    """Mock the /cypher endpoint response for term resolution."""
+def make_query_response(hits):
+    """Mock a mydisease.info /query response."""
 
     response = Mock()
     response.status_code = 200
     response.raise_for_status.return_value = None
-    response.json.return_value = {
-        "results": [{"data": [{"row": [curie]}]}],
-        "errors": [],
-    }
+    response.json.return_value = {"hits": hits}
     return response
 
 
-def make_edge_response(edges):
-    """Mock the /<source>/<target>/<curie> response."""
+def make_disease_response(doc):
+    """Mock a mydisease.info /disease/<id> response."""
 
     response = Mock()
     response.status_code = 200
     response.raise_for_status.return_value = None
-    response.json.return_value = edges
+    response.json.return_value = doc
     return response
 
 
 @pytest.mark.unit
-@patch("tooluniverse.ctd_tool.requests.post")
 @patch("tooluniverse.ctd_tool.requests.get")
-def test_ctd_chemical_gene_returns_normalised_edges(mock_get, mock_post):
-    """SmallMolecule->Gene edges should flatten into the legacy CTD-style envelope."""
+def test_ctd_chemical_diseases_returns_normalised_edges(mock_get):
+    """SmallMolecule->Disease edges should flatten into the CTD-style envelope."""
 
-    mock_post.return_value = make_cypher_response("CHEBI:15365")
-    mock_get.return_value = make_edge_response(
+    mock_get.return_value = make_query_response(
         [
-            [
-                {"id": "CHEBI:15365", "name": "aspirin"},
-                {
-                    "predicate": "biolink:affects",
-                    "qualified_predicate": "biolink:causes",
-                    "object_direction_qualifier": "decreased",
-                    "knowledge_level": "knowledge_assertion",
-                    "agent_type": "manual_agent",
-                    "primary_knowledge_source": "infores:ctd",
+            {
+                "_id": "MONDO:0000495",
+                "mondo": {"label": "some disease"},
+                "ctd": {
+                    "chemical_related_to_disease": [
+                        {
+                            "chemical_name": "bisphenol A",
+                            "mesh_chemical_id": "C006780",
+                            "cas_registry_number": "80-05-7",
+                            "direct_evidence": "marker/mechanism",
+                            "pubmed": "25307304",
+                        }
+                    ]
                 },
-                {"id": "NCBIGene:7076", "name": "TIMP1"},
-            ]
+            }
         ]
     )
 
     tool = make_ctd_tool()
-    result = tool.run({"input_terms": "aspirin"})
+    result = tool.run({"input_terms": "bisphenol A"})
 
     assert result["status"] == "success"
-    assert result["data"][0]["source_id"] == "CHEBI:15365"
-    assert result["data"][0]["target_id"] == "NCBIGene:7076"
+    assert result["data"][0]["source_id"] == "MESH:C006780"
+    assert result["data"][0]["source_name"] == "bisphenol A"
+    assert result["data"][0]["target_id"] == "MONDO:0000495"
+    assert result["data"][0]["target_name"] == "some disease"
+    assert result["data"][0]["qualified_predicate"] == "biolink:contributes_to"
     assert result["data"][0]["primary_knowledge_source"] == "infores:ctd"
-    assert result["metadata"]["backend"] == "RENCI Automat CTD"
-    assert result["metadata"]["canonical_curie"] == "CHEBI:15365"
-    assert result["metadata"]["total_results"] == 1
+    assert result["metadata"]["backend"].startswith("mydisease.info")
 
 
 @pytest.mark.unit
 def test_ctd_gene_disease_returns_redirect_error():
-    """Gene->disease isn't in the RENCI snapshot; must redirect callers."""
+    """Gene->disease has no live curated CTD source; must redirect callers."""
 
     tool = make_ctd_tool(input_type="gene", report_type="diseases_curated")
     result = tool.run({"input_terms": "BRCA1"})
 
     assert result["status"] == "error"
-    assert "RENCI CTD mirror" in result["error"]
-    assert "chemical-centric" in result["error"]
     assert "OpenTargets_get_associated_diseases" in result["suggestion"]
 
 
 @pytest.mark.unit
-@patch("tooluniverse.ctd_tool.requests.post")
-@patch("tooluniverse.ctd_tool.requests.get")
-def test_ctd_bare_cas_number_falls_back_to_curie_prefix(mock_get, mock_post):
-    """Fix-R18C-2/R28-1: the graph stores CAS RNs as CURIEs ("CAS:335-67-1"),
-    not bare -- confirmed live that "335-67-1" alone doesn't match while
-    "CAS:335-67-1" does. A bare CAS RN (exactly how the tool's own
-    description tells callers to pass one) must still resolve. A CAS-shaped
-    bare term is a recognized candidate format (see _candidate_curies), so
-    the CURIE-prefixed form is tried before the bare original."""
+def test_ctd_chemical_gene_returns_permanently_unavailable_error():
+    """Gene<->chemical has no live free source since RENCI's decommissioning."""
 
-    mock_post.side_effect = [make_cypher_response("CHEBI:35549")]
-    mock_get.return_value = make_edge_response([])
+    tool = make_ctd_tool(input_type="chem", report_type="genes_curated")
+    result = tool.run({"input_terms": "bisphenol A"})
 
-    tool = make_ctd_tool()
-    result = tool.run({"input_terms": "335-67-1"})
-
-    assert result["status"] == "success"
-    assert result["metadata"]["canonical_curie"] == "CHEBI:35549"
-    assert mock_post.call_count == 1
-    assert "CAS:335-67-1" in mock_post.call_args.kwargs["json"]["query"]
+    assert result["status"] == "error"
+    assert "decommissioned" in result["error"]
+    assert "DGIdb_get_drug_gene_interactions" in result["suggestion"]
 
 
 @pytest.mark.unit
-@patch("tooluniverse.ctd_tool.requests.post")
-@patch("tooluniverse.ctd_tool.requests.get")
-def test_ctd_bare_mesh_scr_id_falls_back_to_curie_prefix(mock_get, mock_post):
-    """Same fallback for bare MeSH Supplementary Concept ids (e.g.
-    "C006780", the tool's own docstring example) -- confirmed live these
-    also only resolve with a "MESH:" prefix."""
+def test_ctd_gene_chemicals_returns_permanently_unavailable_error():
+    tool = make_ctd_tool(input_type="gene", report_type="chems_curated")
+    result = tool.run({"input_terms": "TP53"})
 
-    mock_post.side_effect = [make_cypher_response("CHEBI:33216")]
-    mock_get.return_value = make_edge_response([])
-
-    tool = make_ctd_tool()
-    result = tool.run({"input_terms": "C006780"})
-
-    assert result["status"] == "success"
-    assert result["metadata"]["canonical_curie"] == "CHEBI:33216"
-    assert mock_post.call_count == 1
-    assert "MESH:C006780" in mock_post.call_args.kwargs["json"]["query"]
+    assert result["status"] == "error"
+    assert "decommissioned" in result["error"]
 
 
 @pytest.mark.unit
-@patch("tooluniverse.ctd_tool.requests.post")
-def test_ctd_unresolvable_input_returns_error(mock_post):
-    """If cypher can't find the term, return a clear not-found error."""
+@patch("tooluniverse.ctd_tool.requests.get")
+def test_ctd_chemical_diseases_no_match_returns_error(mock_get):
+    """If the chemical isn't found in the CTD-derived index, return a clear error."""
 
-    response = Mock()
-    response.status_code = 200
-    response.raise_for_status.return_value = None
-    response.json.return_value = {"results": [{"data": []}], "errors": []}
-    mock_post.return_value = response
+    mock_get.return_value = make_query_response([])
 
     tool = make_ctd_tool()
     result = tool.run({"input_terms": "definitely-not-a-compound"})
 
     assert result["status"] == "error"
     assert "definitely-not-a-compound" in result["error"]
-    assert "not found" in result["error"]
 
 
 @pytest.mark.unit
-@patch("tooluniverse.ctd_tool.requests.post")
 @patch("tooluniverse.ctd_tool.requests.get")
-def test_ctd_request_asks_for_json(mock_get, mock_post):
-    """Edge-fetch requests should include the canonical Accept/UA headers."""
+def test_ctd_disease_chemicals_resolves_by_mondo_curie(mock_get):
+    """A bare MONDO CURIE should skip name resolution and fetch directly."""
 
-    mock_post.return_value = make_cypher_response("CHEBI:15365")
-    mock_get.return_value = make_edge_response([])
+    mock_get.side_effect = [
+        make_disease_response({"mondo": {"label": "asthma"}}),
+        make_disease_response(
+            {
+                "ctd": {
+                    "chemical_related_to_disease": [
+                        {
+                            "chemical_name": "budesonide",
+                            "mesh_chemical_id": "D001990",
+                            "direct_evidence": "therapeutic",
+                            "pubmed": "12345",
+                        }
+                    ]
+                }
+            }
+        ),
+    ]
+
+    tool = make_ctd_tool(input_type="disease", report_type="chems_curated")
+    result = tool.run({"input_terms": "MONDO:0004979"})
+
+    assert result["status"] == "success"
+    assert result["data"][0]["source_id"] == "MONDO:0004979"
+    assert result["data"][0]["target_name"] == "budesonide"
+    assert result["data"][0]["qualified_predicate"] == "biolink:treats"
+
+
+@pytest.mark.unit
+@patch("tooluniverse.ctd_tool.requests.get")
+def test_ctd_request_asks_for_json(mock_get):
+    """Requests to mydisease.info should include the canonical Accept/UA headers."""
+
+    mock_get.return_value = make_query_response([])
 
     make_ctd_tool().run({"input_terms": "aspirin"})
 
-    assert mock_get.call_args.kwargs["headers"] == RENCI_HEADERS
+    assert mock_get.call_args.kwargs["headers"] == HEADERS
 
 
 @pytest.mark.unit

--- a/tests/unit/test_metabolite_ctd_pubmed_ids.py
+++ b/tests/unit/test_metabolite_ctd_pubmed_ids.py
@@ -1,16 +1,13 @@
-"""Regression guard for Fix-R27D-1 in metabolite_tool.py's `_ctd_diseases`
-(the RENCI Automat CTD-mirror fallback used since CTD's native
-batchQuery.go became CAPTCHA-blocked).
+"""Regression guard for metabolite_tool.py's `_ctd_diseases`.
 
-Confirmed live (automat.renci.org/ctd chemical-disease edges for
-cholesterol/CHEBI:16113): edge_props only ever carries agent_type/
-knowledge_level/primary_knowledge_source/publications -- there is no
-predicate/qualified_predicate field, so `direct_evidence` is genuinely
-unavailable from this source (not a bug to "fix" further, now documented
-honestly). `publications` (PMID:xxxxx strings) IS present but was
-previously hardcoded to an empty list instead of being read, so
-`pubmed_ids` came back [] for every single result (100% of associations
-for both cholesterol and lutein in the original report).
+Originally backed by the RENCI Automat CTD mirror (used as a fallback after
+CTD's native batchQuery.go became CAPTCHA-blocked), and now backed by
+mydisease.info after that mirror was fully decommissioned (its registry no
+longer lists a 'ctd' backend at all -- see ctd_tool.py for the full
+history). mydisease.info's cached CTD data DOES carry a genuine
+`direct_evidence` field (unlike RENCI's edges, which never had one), and its
+`pubmed` field is sometimes a single string and sometimes a list of several
+PMIDs -- both shapes must be read into `PubMedIDs` without crashing.
 """
 
 from unittest.mock import MagicMock, patch
@@ -26,76 +23,143 @@ def _tool():
     return MetaboliteTool({"name": "metabolite_test", "fields": {}})
 
 
-def _cypher_resp(curie):
+def _query_resp(hits):
     r = MagicMock()
     r.raise_for_status = MagicMock()
-    r.json.return_value = {"results": [{"data": [{"row": [curie]}]}]}
-    return r
-
-
-def _edges_resp(edges):
-    r = MagicMock()
-    r.raise_for_status = MagicMock()
-    r.json.return_value = edges
+    r.json.return_value = {"hits": hits}
     return r
 
 
 class TestCtdDiseasesPubmedExtraction:
-    def test_publications_extracted_and_pmid_prefix_stripped(self):
+    def test_publications_extracted_for_matching_chemical(self):
         tool = _tool()
-        edges = [
-            [
-                {"name": "cholesterol", "id": "CHEBI:16113"},
-                {
-                    "agent_type": "manual_agent",
-                    "knowledge_level": "knowledge_assertion",
-                    "primary_knowledge_source": "infores:ctd",
-                    "publications": ["PMID:29486218", "PMID:20557099"],
+        hits = [
+            {
+                "_id": "MONDO:0013209",
+                "mondo": {"label": "metabolic dysfunction-associated steatotic liver disease"},
+                "ctd": {
+                    "chemical_related_to_disease": [
+                        {
+                            "chemical_name": "cholesterol",
+                            "mesh_chemical_id": "D002784",
+                            "direct_evidence": "marker/mechanism",
+                            "pubmed": ["29486218", "20557099"],
+                        }
+                    ]
                 },
-                {
-                    "name": "metabolic dysfunction-associated steatotic liver disease",
-                    "id": "MONDO:0013209",
-                },
-            ]
+            }
         ]
         with patch(
-            "tooluniverse.metabolite_tool.requests.post",
-            return_value=_cypher_resp("CHEBI:16113"),
-        ), patch(
             "tooluniverse.metabolite_tool.requests.get",
-            return_value=_edges_resp(edges),
+            return_value=_query_resp(hits),
         ):
             rows = tool._ctd_diseases("cholesterol")
 
         assert len(rows) == 1
         assert rows[0]["PubMedIDs"] == ["29486218", "20557099"]
-        assert rows[0]["DirectEvidence"] is None
+        assert rows[0]["DirectEvidence"] == "marker/mechanism"
+        assert rows[0]["DiseaseName"] == "metabolic dysfunction-associated steatotic liver disease"
 
-    def test_edge_with_no_publications_gets_empty_list_not_crash(self):
+    def test_single_pubmed_string_becomes_single_item_list(self):
         tool = _tool()
-        edges = [
-            [
-                {"name": "cholesterol", "id": "CHEBI:16113"},
-                {"agent_type": "manual_agent"},
-                {"name": "some disease", "id": "MONDO:0000001"},
-            ]
+        hits = [
+            {
+                "_id": "MONDO:0000001",
+                "mondo": {"label": "some disease"},
+                "ctd": {
+                    "chemical_related_to_disease": {
+                        "chemical_name": "cholesterol",
+                        "pubmed": "12345",
+                    }
+                },
+            }
         ]
         with patch(
-            "tooluniverse.metabolite_tool.requests.post",
-            return_value=_cypher_resp("CHEBI:16113"),
-        ), patch(
             "tooluniverse.metabolite_tool.requests.get",
-            return_value=_edges_resp(edges),
+            return_value=_query_resp(hits),
+        ):
+            rows = tool._ctd_diseases("cholesterol")
+
+        assert rows[0]["PubMedIDs"] == ["12345"]
+
+    def test_entry_with_no_publications_gets_empty_list_not_crash(self):
+        tool = _tool()
+        hits = [
+            {
+                "_id": "MONDO:0000001",
+                "mondo": {"label": "some disease"},
+                "ctd": {
+                    "chemical_related_to_disease": [
+                        {"chemical_name": "cholesterol", "direct_evidence": None}
+                    ]
+                },
+            }
+        ]
+        with patch(
+            "tooluniverse.metabolite_tool.requests.get",
+            return_value=_query_resp(hits),
         ):
             rows = tool._ctd_diseases("cholesterol")
 
         assert rows[0]["PubMedIDs"] == []
 
+    def test_non_matching_chemical_name_is_filtered_out(self):
+        # A hit's chemical_related_to_disease array can list many unrelated
+        # chemicals for the same disease -- only entries whose own name
+        # matches the query term should turn into rows.
+        tool = _tool()
+        hits = [
+            {
+                "_id": "MONDO:0000001",
+                "mondo": {"label": "some disease"},
+                "ctd": {
+                    "chemical_related_to_disease": [
+                        {"chemical_name": "aspirin", "pubmed": "111"},
+                        {"chemical_name": "cholesterol", "pubmed": "222"},
+                    ]
+                },
+            }
+        ]
+        with patch(
+            "tooluniverse.metabolite_tool.requests.get",
+            return_value=_query_resp(hits),
+        ):
+            rows = tool._ctd_diseases("cholesterol")
+
+        assert len(rows) == 1
+        assert rows[0]["PubMedIDs"] == ["222"]
+
+    def test_merged_ctd_list_document_is_flattened(self):
+        # BioThings occasionally merges more than one source record onto the
+        # same disease document, in which case `ctd` is a list of
+        # sub-documents instead of a single dict -- confirmed live for at
+        # least one MONDO document.
+        tool = _tool()
+        hits = [
+            {
+                "_id": "MONDO:0002525",
+                "mondo": {"label": "inherited lipid metabolism disorder"},
+                "ctd": [
+                    {
+                        "chemical_related_to_disease": [
+                            {"chemical_name": "cholesterol", "pubmed": "333"}
+                        ]
+                    }
+                ],
+            }
+        ]
+        with patch(
+            "tooluniverse.metabolite_tool.requests.get",
+            return_value=_query_resp(hits),
+        ):
+            rows = tool._ctd_diseases("cholesterol")
+
+        assert len(rows) == 1
+        assert rows[0]["PubMedIDs"] == ["333"]
+
 
 class TestGetDiseasesPubmedIdsFormat:
     def test_list_format_pubmed_ids_passed_through(self):
-        # PubMedIDs is now always a list (from _ctd_diseases), not the
-        # legacy pipe-delimited string -- both shapes must work.
         tool = _tool()
         with patch.object(
             tool,

--- a/tests/unit/test_metabolomics_workbench_tsv_parsing.py
+++ b/tests/unit/test_metabolomics_workbench_tsv_parsing.py
@@ -58,7 +58,9 @@ def test_tsv_body_parsed_into_row_dicts():
     assert result["data"][0] == {
         "Input m/z": "386.354865",
         "Matched m/z": "386.3549",
-        "Delta": ".0000",
+        # Metabolomics Workbench's own endpoint omits the leading zero
+        # (".0000"); the tool now restores it to valid numeric-string syntax.
+        "Delta": "0.0000",
         "Name": "5alpha-Cholestanone",
         "Formula": "C27H46O",
     }


### PR DESCRIPTION
## Summary

Round 5 of the test-driven quality harness, this time targeting metabolomics, proteomics/mass-spec, and environmental toxicology/exposure -- domains not covered by rounds 1-4. Three researcher personas ran real research questions against these domains; every reported finding was independently reproduced via `tu run`/`tu test` before being queued for a fix (several persona claims were discarded as false positives after not reproducing). One issue (the CTD backend outage) was found independently via direct CLI sampling of existing test_examples, ahead of the persona reports, and a persona later reproduced it too.

- **CTD tools + `Metabolite_get_diseases`/`HMDB_get_diseases`**: the RENCI Automat mirror all five of these depended on has been fully decommissioned (its own registry no longer lists a `ctd` backend). Migrated the chemical<->disease direction to `mydisease.info` (confirmed live, and it carries real evidence-type data RENCI never had); the gene<->chemical direction now returns an honest "permanently unavailable" error (no free live replacement found) instead of a misleading generic HTTP error.
- **NHANES**: `NHANES_download_and_parse` was silently corrupting every legitimate zero value in numeric columns into `5.397605346934028e-79` (a pandas XPORT-reader artifact for all-zero IBM floats, verified by reproducing it from pandas' own conversion code). `nhanes_search_datasets` silently searched only cycle 2017-2018 when `year` was omitted; now searches the two most recent cycles, matching its sibling tool.
- **LipidMaps**: `LipidMaps_search_by_name`'s own documented examples (`'PC 16:0/18:1'`, `'SM 34:1'`) returned zero results. Added an automatic retry against the `abbrev_chains` field for acyl-chain-specific names, and corrected the sphingomyelin example (needs the `;O2` hydroxyl suffix).
- **Metabolomics Workbench**: `get_study` returned a transposed, confusing shape for every output type (fixed with a dedicated stanza parser); `find_studies_by_phenotype` leaked raw upstream HTML on slash-containing filters (now rejected upfront with guidance); a misleading RefMet example in the "no results" message was corrected; `search_by_mz`/`search_by_exact_mass`'s `Delta` field is now properly zero-padded.

## Test plan

- [x] `tu test` on every changed tool (`CTD_get_chemical_diseases`, `CTD_get_disease_chemicals`, `CTD_get_chemical_gene_interactions`, `CTD_get_gene_chemicals`, `Metabolite_get_diseases`, `HMDB_get_diseases`, `NHANES_download_and_parse`, `nhanes_search_datasets`, `LipidMaps_search_by_name`, `MetabolomicsWorkbench_get_study`, `MetabolomicsWorkbench_find_studies_by_phenotype`, `MetabolomicsWorkbench_get_refmet_info`, `MetabolomicsWorkbench_search_by_mz`, `MetabolomicsWorkbench_search_by_exact_mass`) -- all pass against live APIs
- [x] Rewrote and ran the 4 pre-existing unit test files that mocked the now-removed RENCI-specific internals (`tests/unit/test_ctd_tool.py`, `test_ctd_id_normalization.py`, `test_ctd_disease_predicate_caveat.py`, `test_metabolite_ctd_pubmed_ids.py`) -- 25/25 pass
- [x] Sibling/unaffected tools in each touched file re-verified for no regressions (`LipidMaps_search_by_formula`, `LipidMaps_get_compound_by_id`, `LipidMaps_get_compound_by_xref`, `nhanes_get_dataset_info`, `MetabolomicsWorkbench_search_compound_by_name`, `_get_compound_by_pubchem_cid`, `_get_gene_protein`, `Metabolite_get_info`, `Metabolite_search`, `CTD_get_gene_diseases`)
