### PR TITLE
Fix Round 7: plant-genomics and microbiome data-quality issues

### DIFF
--- a/src/tooluniverse/data/mgnify_expanded_tools.json
+++ b/src/tooluniverse/data/mgnify_expanded_tools.json
@@ -229,7 +229,7 @@
   },
   {
     "name": "MGnify_get_study_detail",
-    "description": "Get detailed information about a specific MGnify metagenomics study. Returns study name, abstract, associated BioProject, centre, biomes, and counts of analyses/downloads. Complementary to MGnify_search_studies which lists studies. Example: MGYS00002008 is a Tara Oceans marine metagenomics study.",
+    "description": "Get detailed information about a specific MGnify metagenomics study. Returns study name, abstract, associated BioProject, centre, public/private status, sample count, and biomes. Complementary to MGnify_search_studies which lists studies; use MGnify_list_analyses / MGnify_list_analysis_downloads for exact analyses/downloads counts (this endpoint does not provide them). Example: MGYS00002008 is a Tara Oceans marine metagenomics study.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -281,7 +281,13 @@
                 "type": "string"
               }
             },
-            "analyses_count": {
+            "is_public": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "samples_count": {
               "type": [
                 "integer",
                 "null"

--- a/src/tooluniverse/data/usda_plants_tools.json
+++ b/src/tooluniverse/data/usda_plants_tools.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "USDA_plants_get_profile",
-        "description": "Get a USDA PLANTS Database profile for a plant by its PLANTS symbol (e.g. 'ABBA' = balsam fir): scientific name, common name, taxonomic group/rank, duration (annual/perennial), growth habits (tree/shrub/forb), native status, synonyms, and US distribution FIPS codes. Authoritative US plant taxonomy. No API key required.",
+        "description": "Get a USDA PLANTS Database profile for a plant by its PLANTS symbol (e.g. 'ABBA' = balsam fir): scientific name, common name, taxonomic group/rank, duration (annual/perennial), growth habits (tree/shrub/forb), and synonyms. 'native_statuses' gives region-level (e.g. 'L48', 'CAN') native/introduced status; fine-grained per-state/county FIPS distribution codes are not returned by this endpoint (fips_distribution is included for forward-compatibility but is null in the current USDA API response). Authoritative US plant taxonomy. No API key required.",
         "parameter": {"type": "object", "properties": {
             "symbol": {"type": "string", "description": "USDA PLANTS symbol, e.g. 'ABBA' (balsam fir), 'ACRU' (red maple), 'QUAL' (white oak)."}
         }, "required": ["symbol"]},

--- a/src/tooluniverse/mgnify_expanded_tool.py
+++ b/src/tooluniverse/mgnify_expanded_tool.py
@@ -52,9 +52,26 @@ class MGnifyExpandedTool(BaseTool):
                 "error": "Failed to connect to MGnify API. Check network connectivity.",
             }
         except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else None
+            query_id = (
+                arguments.get("study_accession")
+                or arguments.get("analysis_id")
+                or arguments.get("genome_id")
+                or arguments.get("sample_accession")
+            )
+            if status_code == 404:
+                detail = f" for '{query_id}'" if query_id else ""
+                return {
+                    "status": "error",
+                    "error": (
+                        f"MGnify API returned 404 Not Found{detail}. Check that the "
+                        "accession/ID is correct (e.g. a typo, or an ID from a "
+                        "different record type)."
+                    ),
+                }
             return {
                 "status": "error",
-                "error": f"MGnify API HTTP error: {e.response.status_code}",
+                "error": f"MGnify API HTTP error: {status_code}",
             }
         except Exception as e:
             return {
@@ -266,16 +283,24 @@ class MGnifyExpandedTool(BaseTool):
         attrs = data.get("attributes", {})
         rels = data.get("relationships", {})
 
+        # The MGnify studies/{accession} endpoint exposes "is-private" (not
+        # "is-public"), and does not include analyses/downloads counts under
+        # relationships.*.meta.count (only a "related" link with no count) --
+        # confirmed live against the API. Invert is-private into is_public,
+        # and surface samples-count (which the API does return) instead of
+        # the two counts that could never be populated from this endpoint.
+        # Use MGnify_list_analyses / MGnify_list_analysis_downloads to get
+        # exact analyses/downloads counts for a study.
+        is_private = attrs.get("is-private")
         result = {
             "study_id": data.get("id"),
             "study_name": attrs.get("study-name"),
             "study_abstract": attrs.get("study-abstract"),
             "bioproject": attrs.get("bioproject"),
             "centre_name": attrs.get("centre-name"),
-            "is_public": attrs.get("is-public"),
+            "is_public": (not is_private) if is_private is not None else None,
             "last_update": attrs.get("last-update"),
-            "analyses_count": rels.get("analyses", {}).get("meta", {}).get("count"),
-            "downloads_count": rels.get("downloads", {}).get("meta", {}).get("count"),
+            "samples_count": attrs.get("samples-count"),
             "biomes": [b.get("id") for b in rels.get("biomes", {}).get("data", [])],
         }
 

--- a/src/tooluniverse/plant_reactome_tool.py
+++ b/src/tooluniverse/plant_reactome_tool.py
@@ -11,8 +11,9 @@ API: https://plantreactome.gramene.org/ContentService/
 No authentication required. Free for all use.
 """
 
+import re
 import requests
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from .base_tool import BaseTool
 from .tool_registry import register_tool
 
@@ -53,9 +54,22 @@ class PlantReactomeTool(BaseTool):
                 "error": "Failed to connect to Plant Reactome API. Check network connectivity.",
             }
         except requests.exceptions.HTTPError as e:
+            code = e.response.status_code if e.response is not None else None
+            if code == 404:
+                # Plant Reactome's ContentService uses 404 (not an empty 200)
+                # to signal "no matches" for /search/query, and "not found"
+                # for a bad pathway_id/tax_id -- surface the query so a
+                # zero-result search doesn't look like a broken request.
+                query = arguments.get("query") or arguments.get(
+                    "pathway_id", arguments.get("tax_id", "")
+                )
+                return {
+                    "status": "error",
+                    "error": f"No Plant Reactome results found for: {query}",
+                }
             return {
                 "status": "error",
-                "error": f"Plant Reactome API HTTP error: {e.response.status_code}",
+                "error": f"Plant Reactome API HTTP error: {code}",
             }
         except Exception as e:
             return {
@@ -77,6 +91,14 @@ class PlantReactomeTool(BaseTool):
             return self._get_species_tree(arguments)
         else:
             return {"status": "error", "error": f"Unknown action: {self.action}"}
+
+    @staticmethod
+    def _strip_html(text: Optional[str]) -> Optional[str]:
+        """Remove HTML tags (e.g. the <span class="highlighting"> markup the
+        Reactome ContentService search endpoint wraps matched terms in)."""
+        if not text:
+            return text
+        return re.sub(r"<[^>]+>", "", text)
 
     def _search(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Search for plant pathways."""
@@ -107,7 +129,7 @@ class PlantReactomeTool(BaseTool):
                 results.append(
                     {
                         "stId": entry.get("stId", ""),
-                        "name": entry.get("name", ""),
+                        "name": self._strip_html(entry.get("name", "")),
                         "species": entry.get("species", [None]),
                         "exact_type": entry.get("exactType"),
                         "compartment_names": entry.get("compartmentNames"),

--- a/src/tooluniverse/usda_plants_tool.py
+++ b/src/tooluniverse/usda_plants_tool.py
@@ -444,8 +444,10 @@ class USDAPlantsProfileTool(_USDAPlantsBase):
             "data": {
                 "id": profile.get("Id"),
                 "symbol": profile.get("Symbol"),
-                "scientific_name": profile.get("ScientificNameWithoutAuthor")
-                or profile.get("ScientificName"),
+                "scientific_name": _strip_html(
+                    profile.get("ScientificNameWithoutAuthor")
+                    or profile.get("ScientificName")
+                ),
                 "common_name": profile.get("CommonName"),
                 "group": profile.get("GroupName") or profile.get("Group"),
                 "rank": profile.get("Rank"),


### PR DESCRIPTION
## Summary

Five small, independent fixes found this round via persona-driven testing across two domains not covered in prior rounds: model-organism genetics (ZFIN/WormBase/FlyBase/USDA-Plants/Plant-Reactome) and microbiome/metagenomics (MGnify). Every issue below was reproduced directly with `tu run`/`tu test` before being fixed, and every fix was re-verified the same way afterward.

- **USDA_plants_get_profile**: `scientific_name` leaked raw `<i>...</i>` HTML tags straight from the USDA API (e.g. `"<i>Abies balsamea</i> (L.) Mill."`), even though the same file already has a `_strip_html` helper that its sibling `_wetland`/`_search` methods use for the exact same field — `_profile` just never called it. Now fixed to match. Also corrected the tool description: the `PlantProfile` endpoint never actually returns per-state/county FIPS distribution codes (only a `HasDistributionData` boolean flag), so `fips_distribution` was promising data this endpoint structurally cannot provide.
- **PlantReactome_search_pathways**: pathway names leaked raw Reactome ContentService search-highlighting markup (`<span class="highlighting">Flavonoid</span>`), the identical problem the sibling `ReactomeContent_search` tool already solves with its own `_strip_html` helper — added the equivalent here. Also fixed handling of zero-match/invalid queries: this API signals "no results" via a bare HTTP 404 (confirmed live) rather than an empty 200, so a nonsense query previously surfaced as an opaque `"Plant Reactome API HTTP error: 404"`; now returns a clear "no results found for: `<query>`" message, matching the pattern the sibling human-Reactome tool already uses for its own 404s.
- **MGnify_get_study_detail**: `is_public` always came back `null` because the code read a nonexistent `is-public` JSON:API attribute — the real field is `is-private` and needs inverting (confirmed against the live API). `analyses_count`/`downloads_count` were also always `null`, since the `studies/{accession}` endpoint only ever returns relationship *links*, never a `meta.count`; replaced both with `samples_count`, which the endpoint does populate, and updated the description to point callers at `MGnify_list_analyses`/`MGnify_list_analysis_downloads` for exact counts instead of promising fields this endpoint can't fill.
- **MGnifyExpandedTool** (shared by all single-entity lookups: study/genome/analysis/sample): a 404 for a bad accession/ID surfaced as a bare `"MGnify API HTTP error: 404"` with no indication of which input was wrong. The shared error handler now echoes the queried identifier and suggests checking for a typo or a mismatched ID type — fixed once in the common `run()` handler so every endpoint benefits, not just one.

## Test plan

- [x] Every issue reproduced via `tu run`/`tu test` before fixing (see per-tool detail above)
- [x] Every fix re-verified via `tu run`/`tu test` with the original reproduction args after the change
- [x] Shipped `test_examples` still pass for all 5 affected tools (`USDA_plants_get_profile`, `PlantReactome_search_pathways`, `MGnify_get_study_detail`, `MGnify_get_genome`, and other MGnify endpoints spot-checked for the shared 404 fix)
- [x] Targeted regression suite green: `tests/unit/test_usda_plants_tool.py`, `tests/unit/test_plant_agriculture_depth.py`, `tests/unit/test_mgnify_params.py`, `tests/unit/test_epidemiology_public_health_depth.py` (26/26 passed)
- [x] Grepped `tests/` for assertions on the old (buggy) field values/behavior before removing them — none exist; the removed `analyses_count`/`downloads_count` fields and the old raw-HTML `scientific_name` were never asserted on by name, so nothing needed updating
- [x] Full `tests/` sweep (`--no-cov` for speed) shows no new failures attributable to this diff — the 9 pre-existing failures on this run are all in files this PR never touches (`test_claude_code_plugin.py` doc-sync checks, `test_ux_error_hints_r3.py` logging-capture tests, `test_http_api_thread_pool.py`), plus the same `numpy`/`numba`/`onnxruntime` ABI-mismatch collection errors already called out as pre-existing shared-environment issues in the round 6 PR

## Note

Persona testing also surfaced several lower-confidence/higher-scope findings deliberately left out of this PR to keep it focused: `FlyBase_get_gene_alleles`/`ZFIN_get_gene_alleles` returning structurally empty variant details, `WormBase_get_interactions` silently capping results at 150/category with no pagination param, raw 400/500 errors for bad gene IDs on ZFIN/WormBase/FlyBase (Alliance API backend), and the lack of a FlyBase gene-name search tool. Flagging these for a follow-up round rather than expanding this diff.