### PR TITLE
Fix Round 9: Ensembl overlap-region/sequence-type defaults, ClinVar zero-result cases, MyVariant field paths, PubChem SMILES key

### DIFF
--- a/src/tooluniverse/clinvar_tool.py
+++ b/src/tooluniverse/clinvar_tool.py
@@ -259,6 +259,7 @@ class ClinVarSearchVariants(ClinVarRESTTool):
                 gene_hyphen_variant = gene.replace("-", "")
             query_parts.append(f"{gene}[gene]")
 
+        condition_dis_index = None
         if "condition" in arguments:
             # Feature-70B-005: [disease/phenotype] is not a valid ClinVar eSearch field.
             # Use [dis] (disease/phenotype) field tag for condition searches.
@@ -266,6 +267,7 @@ class ClinVarSearchVariants(ClinVarRESTTool):
             condition = arguments["condition"].strip()
             if " " in condition and not condition.startswith('"'):
                 condition = f'"{condition}"'
+            condition_dis_index = len(query_parts)
             query_parts.append(f"{condition}[dis]")
 
         if arguments.get("rsid"):
@@ -478,6 +480,36 @@ class ClinVarSearchVariants(ClinVarRESTTool):
                     result = resolved_result
                     data = result["data"]
 
+        # Fix-R9B-1: the [dis] field only matches ClinVar's own indexed
+        # disease/phenotype name for a record, which frequently differs from
+        # the name clinicians actually use -- confirmed live that
+        # "MECP2 duplication syndrome"[dis] (arguably the most natural way to
+        # refer to this exact condition) returns 0 even though ClinVar has
+        # 101+ MECP2 records that reference that phrase in free text (under
+        # its indexed name "Xq28 duplication syndrome" instead). Retry once
+        # with the condition term unrestricted to any field ([All Fields])
+        # when the [dis]-restricted search comes back empty -- this can only
+        # add matches the strict query missed, never drop ones it found.
+        if (
+            condition_dis_index is not None
+            and int(data["esearchresult"].get("count", 0)) == 0
+        ):
+            freetext_query_parts = list(query_parts)
+            # The stored term is "<condition>[dis]" -- drop the field tag to
+            # search it unrestricted instead.
+            freetext_query_parts[condition_dis_index] = query_parts[
+                condition_dis_index
+            ][: -len("[dis]")]
+            freetext_params = dict(params, term=" AND ".join(freetext_query_parts))
+            freetext_result = self._make_request(self.endpoint, freetext_params)
+            if (
+                freetext_result.get("status") == "success"
+                and "esearchresult" in freetext_result.get("data", {})
+                and int(freetext_result["data"]["esearchresult"].get("count", 0)) > 0
+            ):
+                result = freetext_result
+                data = result["data"]
+
         esearch = data["esearchresult"]
         ids = esearch.get("idlist", [])
         count = int(esearch.get("count", 0))
@@ -516,6 +548,28 @@ class ClinVarSearchVariants(ClinVarRESTTool):
         }
         if unrecognized:
             response_data["ignored_parameters"] = unrecognized
+        if count == 0 and "gene" in arguments:
+            # Fix-R9B-2: a 0-count response for a `gene` filter is
+            # indistinguishable from "this gene truly has no ClinVar
+            # entries" whether the symbol was a typo (e.g. "MEPC2"), a
+            # protein/full name instead of the HGNC gene symbol (e.g.
+            # "dystrophin" instead of "DMD"), or a species mismatch --
+            # confirmed live that ClinVar's [gene] index only matches an
+            # exact current HGNC symbol and has no fuzzy/synonym fallback of
+            # its own. Automatically retrying with an unrestricted free-text
+            # search was tried and rejected: "dystrophin[All Fields]"
+            # matches 12,000+ unrelated ClinVar records that merely mention
+            # the word, which would silently swap a false-empty for a
+            # false-positive result set -- worse than reporting nothing.
+            # Surface the ambiguity instead of guessing.
+            response_data["zero_result_hint"] = (
+                f"No ClinVar records matched gene '{arguments['gene']}'. "
+                "ClinVar's gene index only recognizes the current official "
+                "HGNC symbol (e.g. 'DMD', not the protein name 'dystrophin' "
+                "or an outdated/misspelled symbol) -- verify the symbol "
+                "(e.g. via HGNC_search_genes or NCBIDatasets_get_gene) "
+                "before concluding this gene has no reported variants."
+            )
         if compound_clnsig:
             response_data["clinical_significance_note"] = (
                 "The '/' in the requested clinical_significance was treated as OR: "

--- a/src/tooluniverse/data/biothings_tools.json
+++ b/src/tooluniverse/data/biothings_tools.json
@@ -677,7 +677,7 @@
         "fields": {
           "type": "string",
           "description": "Fields to return (pre-configured for pathogenicity scores)",
-          "default": "dbnsfp.revel.score,dbnsfp.cadd.phred,dbnsfp.alphamissense.score,dbnsfp.alphamissense.pred,dbnsfp.sift.score,dbnsfp.sift.pred,dbnsfp.polyphen2_hdiv.score,dbnsfp.polyphen2_hdiv.pred,dbnsfp.metarnn.score,dbnsfp.metarnn.pred,dbnsfp.gerp_rs,dbnsfp.phylop100way_vertebrate.rankscore,dbnsfp.phastcons100way_vertebrate.rankscore,dbnsfp.vest4.score,dbnsfp.mutationtaster.pred,clinvar.rcv.clinical_significance,dbsnp.rsid"
+          "default": "dbnsfp.revel.score,cadd.phred,dbnsfp.alphamissense.score,dbnsfp.alphamissense.pred,dbnsfp.sift.score,dbnsfp.sift.pred,dbnsfp.polyphen2.hdiv.score,dbnsfp.polyphen2.hdiv.pred,dbnsfp.metarnn.score,dbnsfp.metarnn.pred,cadd.gerp.rs,dbnsfp.phylop.100way_vertebrate.rankscore,dbnsfp.phastcons.100way_vertebrate.rankscore,dbnsfp.vest4.score,dbnsfp.mutationtaster.pred,clinvar.rcv.clinical_significance,dbsnp.rsid"
         }
       },
       "required": [

--- a/src/tooluniverse/data/ensembl_tools.json
+++ b/src/tooluniverse/data/ensembl_tools.json
@@ -179,10 +179,11 @@
             "genomic",
             "cds",
             "cdna",
+            "protein",
             "peptide"
           ],
           "default": "genomic",
-          "description": "Sequence type: 'genomic' (genomic DNA), 'cds' (coding sequence), 'cdna' (cDNA), 'peptide' (protein sequence)"
+          "description": "Sequence type: 'genomic' (genomic DNA), 'cds' (coding sequence), 'cdna' (cDNA), 'protein' (protein/peptide sequence -- 'peptide' is also accepted and mapped to 'protein', the name Ensembl's own REST API actually expects)"
         },
         "species": {
           "type": "string",

--- a/src/tooluniverse/data/pubchem_tools.json
+++ b/src/tooluniverse/data/pubchem_tools.json
@@ -212,11 +212,11 @@
       "endpoint": "/compound/cid/{cid}/property/{property_list}/JSON",
       "use_pugview": false,
       "input_description": "Input is a PubChem compound ID (integer).",
-      "output_description": "Returns a JSON object with structure example:\n{\n  \"PropertyTable\": {\n    \"Properties\": [\n      {\n        \"CID\": 2244,\n        \"MolecularWeight\": 180.157,\n        \"IUPACName\": \"2-acetyloxybenzoic acid\",\n        \"CanonicalSMILES\": \"CC(=O)OC1=CC=CC=C1C(=O)O\",\n        ...\n      }\n    ]\n  }\n}\n\nWhere:\n- PropertyTable.Properties list: each element contains properties for that CID;\n- Property names determined by {property_list}, example here is [\"MolecularWeight\",\"IUPACName\",\"CanonicalSMILES\"].\nAfter calling, LLM can directly access these important molecular properties for subsequent chemical/pharmacological reasoning.",
+      "output_description": "Returns a JSON object with structure example:\n{\n  \"PropertyTable\": {\n    \"Properties\": [\n      {\n        \"CID\": 2244,\n        \"MolecularWeight\": 180.157,\n        \"IUPACName\": \"2-acetyloxybenzoic acid\",\n        \"ConnectivitySMILES\": \"CC(=O)OC1=CC=CC=C1C(=O)O\",\n        ...\n      }\n    ]\n  }\n}\n\nWhere:\n- PropertyTable.Properties list: each element contains properties for that CID;\n- Property names determined by {property_list}, example here is [\"MolecularWeight\",\"IUPACName\",\"ConnectivitySMILES\"]. Note: PubChem's PUG-REST API renamed the legacy \"CanonicalSMILES\" property to \"ConnectivitySMILES\" (and \"IsomericSMILES\" to \"SMILES\") — requesting the old names either returns data under the new key or drops the field entirely, so use the current names shown here.\nAfter calling, LLM can directly access these important molecular properties for subsequent chemical/pharmacological reasoning.",
       "property_list": [
         "MolecularWeight",
         "IUPACName",
-        "CanonicalSMILES"
+        "ConnectivitySMILES"
       ]
     },
     "type": "PubChemRESTTool",

--- a/src/tooluniverse/ensembl_compara_tool.py
+++ b/src/tooluniverse/ensembl_compara_tool.py
@@ -51,9 +51,33 @@ class EnsemblComparaTool(BaseTool):
         except requests.exceptions.ConnectionError:
             return {"status": "error", "error": "Failed to connect to Ensembl REST API"}
         except requests.exceptions.HTTPError as e:
+            # Include the response body instead of just the status code --
+            # Ensembl's 400s carry a JSON {"error": "..."} explaining what
+            # wasn't recognized (e.g. an unresolved gene symbol), and
+            # silently dropping it left a bare "HTTP error: 400" with no
+            # indication of what to fix. Matches the error-body-extraction
+            # pattern already used by ensembl_map_tool.py and
+            # ensembl_variation_ext_tool.py.
+            status = e.response.status_code if e.response is not None else "unknown"
+            body = ""
+            if e.response is not None:
+                try:
+                    body = e.response.json().get("error", "")
+                except Exception:
+                    body = e.response.text[:200]
+            gene = arguments.get("gene", "")
+            hint = (
+                f" -- gene symbol '{gene}' may not exist for the requested "
+                "species; verify it via ensembl_lookup_gene or "
+                "HGNC_search_genes."
+                if gene
+                else ""
+            )
             return {
                 "status": "error",
-                "error": f"Ensembl API HTTP error: {e.response.status_code}",
+                "error": (
+                    f"Ensembl API HTTP {status}{f': {body}' if body else ''}{hint}"
+                ),
             }
         except Exception as e:
             return {

--- a/src/tooluniverse/ensembl_tool.py
+++ b/src/tooluniverse/ensembl_tool.py
@@ -83,6 +83,19 @@ class EnsemblRESTTool(BaseTool):
             if k not in path_keys and v is not None:
                 query_params[k] = v
 
+        # Ensembl's /sequence/id endpoint calls its protein-sequence option
+        # "protein", not "peptide" -- confirmed live: type=peptide -> HTTP
+        # 400 "The type 'peptide' is not understood by this service" for
+        # every input, making protein sequence retrieval impossible via this
+        # tool. "peptide" is kept as an accepted schema value (it's the
+        # intuitive guess) and silently normalized here rather than removed,
+        # so existing callers using either name both work.
+        if (
+            "/sequence/id" in self.endpoint_template
+            and query_params.get("type") == "peptide"
+        ):
+            query_params["type"] = "protein"
+
         # 4. Special handling for certain endpoints
         # Lookup by symbol needs special routing - handle both stable IDs
         # and symbols.
@@ -110,14 +123,19 @@ class EnsemblRESTTool(BaseTool):
                     if "expand" in arguments:
                         query_params["expand"] = arguments["expand"]
 
-        # Handle overlap/region endpoint - ensure feature parameter is passed
-        if "/overlap/region" in self.endpoint_template:
-            # Feature parameter is required for overlap endpoints
-            if "feature" not in query_params and "feature" in arguments:
-                query_params["feature"] = arguments["feature"]
-            elif "feature" not in query_params:
-                # Default to variation if not specified
-                query_params["feature"] = "variation"
+        # Handle overlap/region endpoint - ensure feature parameter is passed.
+        # Different overlap/region tools mean different things by "default"
+        # (e.g. ensembl_get_structural_variants defaults to
+        # "structural_variation", ensembl_get_overlap_features defaults to
+        # "gene") — use each tool's own schema default instead of hardcoding
+        # "variation" for all of them, which silently returned SNP data from
+        # tools that promise structural variants or genes.
+        if (
+            "/overlap/region" in self.endpoint_template
+            and "feature" not in query_params
+        ):
+            schema_default = schema_props.get("feature", {}).get("default")
+            query_params["feature"] = schema_default or "variation"
 
         # 5. Make HTTP request (with small retry for transient failures)
         try:


### PR DESCRIPTION
## Summary

Persona role-play testing this round covered cheminformatics/ADMET, structural-variant/CNV genomics, and comparative-genomics/phylogenetics research questions. Every reported issue was CLI-verified against the live upstream API before being queued as a fix (roughly half of the raw persona reports turned out to be false positives -- upstream data sparsity or service outages, not ToolUniverse bugs -- and were discarded).

Fixes in this PR (all confirmed via `tu run`/`tu test` against live APIs, not mocked):

- **`ensembl_get_structural_variants` / `ensembl_get_overlap_features`** -- both share the generic `EnsemblRESTTool` `/overlap/region` handler, which hardcoded a `"variation"` fallback for the `feature` query parameter regardless of what each tool's own JSON schema declared as its default. Both tools were silently returning dbSNP point variants instead of the structural variants / genes their names and descriptions promise -- confirmed live on the tools' own shipped `test_examples`. The fallback now reads each tool's own schema default.
- **`ensembl_get_sequence`** -- rejected the only enum value that could mean "protein" (`"peptide"`) with an upstream HTTP 400, because Ensembl's REST API actually expects `type=protein`. `"peptide"` is now normalized to `"protein"`, so protein sequence retrieval works via either name.
- **`ClinVar_search_variants`** -- a `condition` search restricted to ClinVar's own indexed disease name (`[dis]`) returned 0 hits for phrasing that's arguably the most natural way to refer to a condition (e.g. "MECP2 duplication syndrome"), even though ClinVar has 100+ matching records under a different indexed name ("Xq28 duplication syndrome"). Now retries unrestricted (`[All Fields]`) once before giving up -- this can only add matches the strict query missed, never drop ones it found. Also adds a `zero_result_hint` when a `gene` filter returns 0 results, since that's otherwise indistinguishable from "this gene truly has no ClinVar entries" whether the symbol was a typo or a protein/full name instead of the HGNC symbol.
- **`MyVariant_get_pathogenicity_scores`** -- requested several dbNSFP field paths that don't match MyVariant.info's actual schema (`dbnsfp.cadd.phred` should be the top-level `cadd.phred` field; `dbnsfp.polyphen2_hdiv.score` should be `dbnsfp.polyphen2.hdiv.score`; PhyloP/PhastCons need the same dotted nesting). CADD, PolyPhen-2, GERP, PhyloP, and PhastCons scores were silently absent from every response despite being named in the tool's own description as the whole point of the tool.
- **`PubChem_get_compound_properties_by_CID`** -- requested the deprecated `"CanonicalSMILES"` property name by default; PubChem's live API now returns that data under the key `"ConnectivitySMILES"` instead, so code reading the documented key name got nothing.
- **`EnsemblCompara_get_orthologues`/`_get_paralogues`/`_get_gene_tree`** -- HTTP error handling dropped the response body, leaving a bare `"HTTP error: 400"` with no indication an unresolved gene symbol was the cause. Now extracts Ensembl's JSON error message (matching the pattern already used in `ensembl_map_tool.py`/`ensembl_variation_ext_tool.py`) plus a targeted hint.

Two persona-reported issues were investigated and found **not** to be ToolUniverse bugs: SwissADME's CYP-inhibitor/iLOGP fields return `"n/d"` because the upstream `swissadme.ch` service itself returns that (confirmed by querying the raw service directly for an unrelated compound); ADMET-AI/RDKit-dependent tools crash in this dev environment due to a NumPy 2.x binary incompatibility with the installed `admet_ai`/`rdkit` wheels, which is an environment issue, not a code defect (the tool already has a lazy-import/graceful-error wrapper around this dependency).

## Test plan

- [x] `tu test` on every changed tool passes (own shipped `test_examples`)
- [x] `pytest tests/unit/test_ensembl_*.py tests/tools/test_ensembl_tool.py tests/unit/test_clinvar_*.py tests/unit/test_phylogenetics_orthology_depth.py tests/unit/test_opentargets_efoid_bridge_and_ensembl_version.py` -- all pass, no regressions
- [x] `ruff check` / `ruff format --check` clean on all changed Python files
- [x] Verified the ClinVar/Ensembl fixes against the live APIs with the exact args the failing tools originally used