### PR TITLE
Fix Round 10: Golden Gate round-trip, primer-design coverage, KEGG network genes, PyPI metadata

### DIFF
--- a/src/tooluniverse/data/dna_tools.json
+++ b/src/tooluniverse/data/dna_tools.json
@@ -986,55 +986,56 @@
         {
           "type": "object",
           "properties": {
-            "status": {
+            "enzyme": {
               "type": "string"
             },
-            "data": {
-              "type": "object",
-              "properties": {
-                "enzyme": {
-                  "type": "string"
-                },
-                "product_length": {
-                  "type": "integer",
-                  "description": "Length of the assembled circular product in bp."
-                },
-                "num_fragments_assembled": {
-                  "type": "integer"
-                },
-                "assembly_order": {
-                  "type": "array",
-                  "description": "Fragments in assembly order, each with source, length and its two overhangs."
-                },
-                "unused_fragments": {
-                  "type": "array",
-                  "description": "Site-free fragments that did not enter the circular product."
-                },
-                "product_sequence": {
-                  "type": "string"
-                }
-              }
+            "product_length": {
+              "type": "integer",
+              "description": "Length of the assembled circular product in bp."
+            },
+            "num_fragments_assembled": {
+              "type": "integer"
+            },
+            "assembly_order": {
+              "type": "array",
+              "description": "Fragments in assembly order, each with source, length and its two overhangs."
+            },
+            "unused_fragments": {
+              "type": "array",
+              "description": "Site-free fragments that did not enter the circular product."
+            },
+            "product_sequence": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "enzyme",
+            "product_length",
+            "num_fragments_assembled",
+            "assembly_order",
+            "product_sequence"
+          ]
         },
         {
           "type": "object",
           "properties": {
-            "status": {
-              "type": "string"
-            },
             "error": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "error"
+          ]
         }
       ]
     },
     "test_examples": [
       {
         "fragments": [
-          "GGTCTCAAGGTGGGGCCCCGGGGCCCCAAAACATCAGAGACCACGTACGTACGTACGTACGTACGTAC",
-          "GGTCTCACATCCCCCGGGGCCCCGGGGTTTTAGGTAGAGACCTGCATGCATGCATGCATGCATGCATG"
+          "GGTCTCAAAACATGGAGGAGCCGCAGTCAGATCCTAGCGTTGAATTCGGATCCCTTTTGAGACC",
+          "GGTCTCAAAAGGGATCCAAGCTTACGTACGTATGGAGGAGCCGCAGTCAGATATTTTGAGACC",
+          "GGTCTCAAAATCCTAGCGTTGAATTCGGATCCAAGCTTACGTACGTATGGAGCGTTTGAGACC",
+          "GGTCTCAAACGATCGATCGATCGATCGATCGGTTTTGAGACC"
         ],
         "enzyme": "BsaI",
         "circular": true

--- a/src/tooluniverse/data/kegg_network_variant_tools.json
+++ b/src/tooluniverse/data/kegg_network_variant_tools.json
@@ -41,7 +41,7 @@
   {
     "name": "KEGG_get_network",
     "type": "KEGGExtTool",
-    "description": "Get detailed KEGG network information including signaling pathway definition (e.g., EGF -> EGFR -> RAS -> RAF -> MEK -> ERK), associated disease classes, linked diseases, drug targets, and pathway elements. KEGG networks model specific molecular interaction cascades perturbed in disease. Example: N00001 returns EGF-EGFR-RAS-ERK signaling pathway linked to colorectal cancer, melanoma, breast cancer, and 7+ other cancer types.",
+    "description": "Get detailed KEGG network information including signaling pathway definition (e.g., EGF -> EGFR -> RAS -> RAF -> MEK -> ERK), associated disease classes, linked diseases, drug targets, and pathway elements. KEGG networks model specific molecular interaction cascades perturbed in disease. Example: N00001 returns EGF-EGFR-RAS-ERK signaling pathway linked to colorectal cancer, melanoma, breast cancer, and 7+ other cancer types. For N#####-style perturbed-network IDs, `genes` gives the gene symbols (with Entrez IDs and descriptions) that map the numeric IDs in `expanded`, and `pathways` cross-references the canonical KEGG PATHWAY map(s) (e.g. hsa04668) the network belongs to. For nt######-style disease/map-class network IDs, `elements` instead lists the child N##### networks that compose it (`genes`/`pathways` are empty for that ID family).",
     "parameter": {
       "type": "object",
       "properties": {
@@ -65,7 +65,30 @@
         "classes": {"type": "array", "items": {"type": "string"}},
         "diseases": {"type": "array", "items": {"type": "string"}},
         "drugs": {"type": "array", "items": {"type": "string"}},
-        "elements": {"type": "array", "items": {"type": "string"}}
+        "elements": {"type": "array", "items": {"type": "string"}},
+        "genes": {
+          "type": "array",
+          "description": "Gene symbols driving an N#####-style network, with Entrez IDs and descriptions. Empty for nt######-style (Map-class) network IDs.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "entrez_id": {"type": "string"},
+              "symbol": {"type": "string"},
+              "description": {"type": "string"}
+            }
+          }
+        },
+        "pathways": {
+          "type": "array",
+          "description": "KEGG PATHWAY map(s) this network belongs to. Empty for nt######-style (Map-class) network IDs.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "pathway_id": {"type": "string"},
+              "name": {"type": "string"}
+            }
+          }
+        }
       }
     },
     "test_examples": [

--- a/src/tooluniverse/data/wikipathways_ext_tools.json
+++ b/src/tooluniverse/data/wikipathways_ext_tools.json
@@ -6,8 +6,18 @@
       "type": "object",
       "properties": {
         "pathway_id": {
-          "type": "string",
-          "description": "WikiPathways pathway identifier. Examples: 'WP254' (Apoptosis, 87 gene products), 'WP179' (Cell cycle), 'WP4216' (Chromosomal and microsatellite instability), 'WP1584' (Type II diabetes mellitus)."
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "WikiPathways pathway identifier. Examples: 'WP254' (Apoptosis, 87 gene products), 'WP179' (Cell cycle), 'WP4216' (Chromosomal and microsatellite instability), 'WP1584' (Type II diabetes mellitus). Required unless `wpid` is given instead."
+        },
+        "wpid": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Alias for `pathway_id`, matching the parameter name used by the sibling WikiPathways_get_pathway tool. Provide either `pathway_id` or `wpid`."
         },
         "code": {
           "type": [
@@ -16,10 +26,7 @@
           ],
           "description": "Optional filter restricting results to gene products annotated from one identifier system: 'H' (HGNC), 'En' (Ensembl), 'S' (UniProt), 'L' (Entrez Gene), 'Ce' (ChEBI, metabolites). Omit to return every gene product in the pathway. Most pathways are annotated from Entrez Gene or Ensembl and carry no HGNC-sourced entries, so filtering can legitimately return 0."
         }
-      },
-      "required": [
-        "pathway_id"
-      ]
+      }
     },
     "fields": {
       "endpoint": "get_pathway_genes"
@@ -189,13 +196,20 @@
       "type": "object",
       "properties": {
         "pathway_id": {
-          "type": "string",
-          "description": "WikiPathways pathway identifier. Examples: 'WP534' (Glycolysis & Gluconeogenesis), 'WP78' (TCA cycle), 'WP143' (Fatty acid beta-oxidation), 'WP550' (Biogenic amine synthesis)."
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "WikiPathways pathway identifier. Examples: 'WP534' (Glycolysis & Gluconeogenesis), 'WP78' (TCA cycle), 'WP143' (Fatty acid beta-oxidation), 'WP550' (Biogenic amine synthesis). Required unless `wpid` is given instead."
+        },
+        "wpid": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Alias for `pathway_id`, matching the parameter name used by the sibling WikiPathways_get_pathway tool. Provide either `pathway_id` or `wpid`."
         }
-      },
-      "required": [
-        "pathway_id"
-      ]
+      }
     },
     "fields": {
       "endpoint": "get_pathway_metabolites"

--- a/src/tooluniverse/dna_tools.py
+++ b/src/tooluniverse/dna_tools.py
@@ -1879,10 +1879,31 @@ class DNATool(BaseTool):
                 "error": f"Target region ({target_end - target_start} bp) is smaller than product_size_min ({product_size_min} bp)",
             }
 
-        fwd_search_start = max(0, target_start - 50)
-        fwd_search_end = min(seq_len - 18, target_start + 50)
+        # Whole-sequence amplification (no target_start/target_end given) has no
+        # real edge to anchor to -- both primers are free to land anywhere near
+        # the ends, so the coverage constraint below is skipped for this case.
+        is_full_sequence = target_start == 0 and target_end == seq_len
 
-        rev_search_start = max(18, target_end - 50)
+        # The forward primer must *start* at or before target_start (else the
+        # product misses the left edge of the target), and the reverse primer
+        # must *end* at or after target_end (else it misses the right edge) --
+        # both are enforced by the coverage check below. Searching past those
+        # boundaries wastes effort on candidates that can never pass that check,
+        # and worse, can make one of them win the Tm-closeness scoring, causing
+        # a spurious "does not cover the target" failure even though a slightly
+        # worse-scoring, actually-covering primer was available in-window.
+        # Whole-sequence amplification has no such boundary to respect, so it
+        # keeps the original symmetric ±50 bp search window on both ends.
+        fwd_search_start = max(0, target_start - 50)
+        fwd_search_end = (
+            min(seq_len - 18, target_start + 50)
+            if is_full_sequence
+            else min(seq_len - 18, target_start)
+        )
+
+        rev_search_start = (
+            max(18, target_end - 50) if is_full_sequence else max(18, target_end)
+        )
         rev_search_end = min(seq_len, target_end + 50)
 
         complement_map = str.maketrans("ATGCNatgcn", "TACGNtacgn")
@@ -2011,11 +2032,11 @@ class DNATool(BaseTool):
                 ),
             }
 
-        # Verify the product actually spans the requested target region.
-        # Primer search windows are centered ±50 bp around target_start/target_end, so
-        # when the target falls near a sequence boundary the best primers may sit
-        # entirely before (or after) the target, producing a valid product that misses
-        # the declared target. Detect and report instead of silently returning wrong coords.
+        # Verify the product actually spans the requested target region. This is
+        # now mostly a formality since the search windows above already exclude
+        # non-covering candidates for a real target region -- but it stays as a
+        # defensive check (e.g. a target so close to a sequence boundary that no
+        # covering primer exists at all within the ±50 bp search radius).
         #
         # Skip the coverage check when the user requested full-sequence
         # amplification (target_start == 0 and target_end == seq_len).  In that case
@@ -2023,7 +2044,6 @@ class DNATool(BaseTool):
         # be satisfied simultaneously — no primer can start before position 0 or end
         # after the last base.  Any valid primer pair covering the majority of the
         # sequence is acceptable for full-sequence amplification.
-        is_full_sequence = target_start == 0 and target_end == seq_len
         if not is_full_sequence and (
             best_fwd["start"] > target_start or best_rev["end"] < target_end
         ):
@@ -2155,7 +2175,7 @@ class DNATool(BaseTool):
                 "status": "error",
                 "error": f"Unknown enzyme: {enzyme_name}. Golden Gate uses a Type IIS enzyme (BsaI, BbsI, Esp3I/BsmBI, SapI).",
             }
-        canonical, site, _off = resolved
+        canonical, site, cut_off = resolved
 
         # Overhang length: from Biopython when available, else the curated table.
         # The previous -4 default was silently wrong for SapI (3 nt).
@@ -2191,9 +2211,37 @@ class DNATool(BaseTool):
         labels = arguments.get("labels") or []
 
         rc_site = _reverse_complement(site)
+        site_len = len(site)
 
         def _has_site(seq: str) -> bool:
             return site in seq or rc_site in seq
+
+        def _overhang_at(seq2: str, pos: int) -> str:
+            """The ov_len-bp overhang belonging to the fragment on the cut's
+            downstream side, in standard (top-strand-of-the-assembled-insert)
+            notation.
+
+            `pos` is always a top-strand bond index (see `_enzyme_cut_positions`),
+            regardless of which strand actually carried the recognition site that
+            produced it. For a forward-oriented site, the cut leaves a genuine 5'
+            overhang on the top strand immediately downstream, so the literal
+            top-strand bases at `pos` already are the overhang. For a
+            reverse-oriented site (recognition sequence on the bottom strand,
+            e.g. BsaI's GAGACC), the top-strand bond instead lands *before* the
+            overhang region, whose bases on the top strand are only the
+            complement strand's remnant — the real 5' overhang is on the bottom
+            strand at that position, so recovering it requires reverse-
+            complementing the literal read. Distinguish the two cases by checking
+            whether the forward pattern actually starts `cut_off` bases upstream
+            of `pos` (how every forward-type cut was produced); if not, this cut
+            came from the reverse-oriented match instead.
+            """
+            raw = seq2[pos : pos + ov_len]
+            fwd_start = pos - cut_off
+            is_forward_cut = (
+                fwd_start >= 0 and seq2[fwd_start : fwd_start + site_len] == site
+            )
+            return raw if is_forward_cut else _reverse_complement(raw)
 
         pieces = []
         per_input = []
@@ -2223,6 +2271,7 @@ class DNATool(BaseTool):
                 continue
 
             released = 0
+            seq2 = seq + seq
             for i, start in enumerate(cuts):
                 end = cuts[(i + 1) % len(cuts)]
                 if end > start:
@@ -2231,9 +2280,11 @@ class DNATool(BaseTool):
                     span = seq[start:] + seq[:end]
                 else:
                     continue
-                # The overhang at a cut is the ov_len bases starting at the cut.
-                left_ov = (seq + seq)[start : start + ov_len]
-                right_ov = (seq + seq)[end : end + ov_len]
+                # The overhang at a cut is the ov_len bases starting at the cut,
+                # corrected to standard notation if the cut came from a
+                # reverse-oriented site match (see `_overhang_at`).
+                left_ov = _overhang_at(seq2, start)
+                right_ov = _overhang_at(seq2, end)
                 if _has_site(span):
                     continue  # re-cut in the reaction; cannot persist
                 pieces.append(

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -3,10 +3,13 @@ from graphql.language import parse
 from graphql.validation import validate
 from .base_tool import BaseTool
 from .tool_registry import register_tool
+import logging
 import re
 import requests
 import copy
 import time
+
+logger = logging.getLogger(__name__)
 
 # Upper bound on how long DiseaseTargetScoreTool will paginate through
 # OpenTargets associatedTargets before returning what it has so far. A
@@ -73,18 +76,29 @@ def execute_query(endpoint_url, query, variables=None):
         result = remove_none_and_empty_values(result)
         # Check if the response contains errors
         if "errors" in result:
-            print("Invalid Query: ", result["errors"])
+            # Log only the human-readable `message` of each GraphQL error, not
+            # the raw error objects: some APIs (e.g. OpenNeuro) include an
+            # `extensions.stacktrace` with internal server file paths, which
+            # was previously printed to stdout verbatim -- visible in every
+            # caller's output (CLI, MCP client) as an internal-implementation
+            # leak, not a useful diagnostic. `logger.debug` also keeps this out
+            # of default-level output entirely.
+            messages = [
+                e.get("message", str(e)) if isinstance(e, dict) else str(e)
+                for e in result["errors"]
+            ]
+            logger.debug("GraphQL query returned errors: %s", "; ".join(messages))
             return None
         # Feature-94A-002: always return result when data key is present,
         # even if all values are empty/null (e.g. disease not found = {"data": {}}).
         # Callers distinguish empty results from errors via status envelope.
         elif "data" not in result:
-            print("No data returned")
+            logger.debug("GraphQL response had no 'data' key")
             return None
         else:
             return result
     except requests.exceptions.JSONDecodeError:
-        print("JSONDecodeError: Could not decode the response as JSON")
+        logger.debug("Could not decode GraphQL response as JSON")
         return None
 
 

--- a/src/tooluniverse/kegg_ext_tool.py
+++ b/src/tooluniverse/kegg_ext_tool.py
@@ -1032,8 +1032,12 @@ class KEGGExtTool(BaseTool):
             "diseases": [],
             "drugs": [],
             "elements": [],
+            "genes": [],
+            "pathways": [],
         }
 
+        gene_lines: list = []
+        pathway_lines: list = []
         current_field = None
         for line in text.split("\n"):
             if line.startswith("NAME"):
@@ -1066,6 +1070,18 @@ class KEGGExtTool(BaseTool):
                 # they're merged into the one "elements" output field.
                 current_field = "ELEMENT"
                 result["elements"].append(line[12:].strip())
+            elif line.startswith("GENE"):
+                # N#####-style perturbed-network records (e.g. N00151) list
+                # the genes driving the network here as "<entrez_id>  <SYMBOL>;
+                # <description>" -- previously unhandled entirely, so the tool
+                # returned an empty gene list for exactly the records where a
+                # caller needs it most, forcing manual decoding of the numeric
+                # Entrez IDs embedded in "expanded" instead.
+                current_field = "GENE"
+                gene_lines.append(line[12:].strip())
+            elif line.startswith("PATHWAY"):
+                current_field = "PATHWAY"
+                pathway_lines.append(line[12:].strip())
             elif line.startswith("///"):
                 break
             elif line.startswith("            "):
@@ -1078,10 +1094,32 @@ class KEGGExtTool(BaseTool):
                     result["drugs"].append(content)
                 elif current_field == "ELEMENT":
                     result["elements"].append(content)
+                elif current_field == "GENE":
+                    gene_lines.append(content)
+                elif current_field == "PATHWAY":
+                    pathway_lines.append(content)
                 elif current_field == "DEFINITION":
                     result["definition"] = (result["definition"] or "") + " " + content
             else:
                 current_field = None
+
+        for gene_line in gene_lines:
+            entrez_id, _, rest = gene_line.partition("  ")
+            entrez_id = entrez_id.strip()
+            symbol, _, description = rest.strip().partition(";")
+            if entrez_id:
+                result["genes"].append(
+                    {
+                        "entrez_id": entrez_id,
+                        "symbol": symbol.strip(),
+                        "description": description.strip(),
+                    }
+                )
+
+        result["pathways"] = [
+            {"pathway_id": pid, "name": name}
+            for pid, name in self._parse_id_map(pathway_lines).items()
+        ]
 
         return {
             "status": "success",

--- a/src/tooluniverse/package_tool.py
+++ b/src/tooluniverse/package_tool.py
@@ -67,6 +67,53 @@ class PackageTool(BaseTool):
             # chained .get() then crashes with "'NoneType' has no attribute 'get'".
             project_urls = info.get("project_urls") or {}
 
+            # Repository URL: PyPI project_urls has no fixed key name -- projects
+            # use "Repository", "Source", "Source Code", "Code", "Homepage",
+            # or "GitHub" interchangeably (e.g. mne-python only sets "Source
+            # Code"). Try the common variants in order before giving up.
+            repository = ""
+            for key in (
+                "Repository",
+                "Source",
+                "Source Code",
+                "Code",
+                "GitHub",
+                "Development",
+                "Homepage",
+            ):
+                if project_urls.get(key):
+                    repository = project_urls[key]
+                    break
+
+            # Supported Python versions: `classifiers` is a flat list of ALL PyPI
+            # trove classifiers (license, OS, dev status, audience, ...), not
+            # just Python versions -- filtering to "Programming Language ::
+            # Python :: 3.X" entries gives the real list. Some packages (e.g.
+            # mne-python) only declare the generic "Python :: 3" classifier
+            # without per-minor-version entries; `requires_python` (e.g.
+            # ">=3.10") is the reliable fallback for those.
+            classifiers = info.get("classifiers") or []
+            python_versions = []
+            for classifier in classifiers:
+                if not classifier.startswith("Programming Language :: Python ::"):
+                    continue
+                version = classifier.rsplit("::", 1)[-1].strip()
+                if "." in version and version.replace(".", "").isdigit():
+                    python_versions.append(version)
+            if not python_versions and info.get("requires_python"):
+                python_versions = [info["requires_python"]]
+
+            # Last-updated date: `last_serial` is PyPI's internal monotonic
+            # change-counter (currently tens of millions), not a timestamp --
+            # using it as a Unix epoch decodes to bogus 1970s dates. The real
+            # upload date of the current release lives in `urls[*].upload_time_iso_8601`.
+            urls_info = pypi_data.get("urls") or []
+            last_updated = (
+                urls_info[0].get("upload_time_iso_8601", "Unknown")
+                if urls_info
+                else "Unknown"
+            )
+
             # Build response with PyPI data
             result = {
                 "package_name": info.get("name", self.package_name),
@@ -76,10 +123,8 @@ class PackageTool(BaseTool):
                 "license": info.get("license", "Not specified"),
                 "home_page": info.get("home_page", ""),
                 "documentation": project_urls.get("Documentation", ""),
-                "repository": project_urls.get(
-                    "Repository", project_urls.get("Source", "")
-                ),
-                "python_versions": info.get("classifiers", []),
+                "repository": repository,
+                "python_versions": python_versions,
                 "keywords": (
                     info.get("keywords", "").split(",") if info.get("keywords") else []
                 ),
@@ -89,7 +134,7 @@ class PackageTool(BaseTool):
                     "pip_upgrade": f"pip install --upgrade {self.package_name}",
                 },
                 "source": "pypi",
-                "last_updated": pypi_data.get("last_serial", "Unknown"),
+                "last_updated": last_updated,
             }
 
             # Merge with local enhanced information

--- a/src/tooluniverse/wikipathways_ext_tool.py
+++ b/src/tooluniverse/wikipathways_ext_tool.py
@@ -68,6 +68,18 @@ def _wpid_from_uri(uri: str) -> str:
     return tail.split("_", 1)[0]
 
 
+def _resolve_pathway_id(arguments: Dict[str, Any]) -> str:
+    """`pathway_id`, normalized, accepting `wpid` as an alias.
+
+    WikiPathways_get_pathway (the sibling tool in wikipathways_tool.py) names
+    this parameter `wpid`; accept it here too so a caller who just used that
+    tool doesn't hit a validation error switching to this one.
+    """
+    return (arguments.get("pathway_id") or arguments.get("wpid") or "").upper().replace(
+        '"', ""
+    )
+
+
 class WikiPathwaysExtTool(BaseTool):
     """WikiPathways extended endpoints via SPARQL."""
 
@@ -93,7 +105,7 @@ class WikiPathwaysExtTool(BaseTool):
             }
 
     def _get_pathway_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
-        pathway_id = (arguments.get("pathway_id") or "").upper().replace('"', "")
+        pathway_id = _resolve_pathway_id(arguments)
         if not pathway_id:
             return {
                 "status": "error",
@@ -178,7 +190,7 @@ SELECT DISTINCT ?gene ?gene_label WHERE {{
         the central entities (unlike get_pathway_genes which returns only gene
         products).
         """
-        pathway_id = (arguments.get("pathway_id") or "").upper().replace('"', "")
+        pathway_id = _resolve_pathway_id(arguments)
         if not pathway_id:
             return {
                 "status": "error",

--- a/tests/unit/test_dna_golden_gate_assemble.py
+++ b/tests/unit/test_dna_golden_gate_assemble.py
@@ -26,13 +26,28 @@ ASSEMBLE = {
 }
 
 
+_COMPLEMENT = str.maketrans("ACGT", "TGCA")
+
+
+def _rc(seq):
+    return seq.translate(_COMPLEMENT)[::-1]
+
+
 def _donor(ov_left, ov_right, body, backbone):
     """A circular donor with inward-facing BsaI sites flanking `body`.
 
     Cutting releases `body` (site-free, so it survives the reaction) and leaves
     the recognition sites on the backbone piece.
+
+    `ov_left`/`ov_right` are the overhang identities in the standard
+    Golden-Gate/MoClo notation used by `DNA_golden_gate_design` -- the same
+    4-letter code is shared by both mating ends of a junction. The right-hand
+    site is inward-facing (reverse-oriented, GAGACC on this strand), so BsaI
+    reads it on the bottom strand; the literal top-strand text immediately
+    before that site is therefore the *reverse complement* of `ov_right`, not
+    `ov_right` itself (mirrors `DNA_golden_gate_design`'s own construction).
     """
-    return "GGTCTC" "A" + ov_left + body + ov_right + "A" "GAGACC" + backbone
+    return "GGTCTC" "A" + ov_left + body + _rc(ov_right) + "A" "GAGACC" + backbone
 
 
 DONOR_A = _donor("AGGT", "CATC", "GGGGCCCCGGGGCCCCAAAA", "ACGTACGTACGTACGTACGTACGTAC")

--- a/tests/unit/test_graphql_tool_error_logging.py
+++ b/tests/unit/test_graphql_tool_error_logging.py
@@ -1,0 +1,63 @@
+"""`execute_query()` (shared by every GraphQLTool subclass, including
+OpenTargets and OpenNeuro) printed the raw GraphQL `errors` array straight to
+stdout on failure. Some APIs embed a full stack trace with internal server
+file paths in `extensions.stacktrace` (confirmed live via
+OpenNeuro_get_dataset with a nonexistent dataset ID, which surfaced
+'/srv/packages/openneuro-server/dist/graphql/permissions.js:92:15' etc. in
+the CLI output) -- an internal-implementation leak, not a useful diagnostic,
+and it happened even though the tool's actual returned `error` field stayed
+clean ("No data returned from API"). Fixed by logging only the sanitized
+`message` text via `logging.debug` (invisible by default) instead of
+`print()`-ing the raw error objects.
+"""
+
+import logging
+
+import pytest
+
+from tooluniverse.graphql_tool import execute_query
+
+pytestmark = pytest.mark.unit
+
+
+class _Resp:
+    ok = True
+
+    def __init__(self, body):
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+def test_graphql_errors_do_not_leak_to_stdout(monkeypatch, capsys, caplog):
+    body = {
+        "errors": [
+            {
+                "message": "Dataset ds999999 does not exist.",
+                "extensions": {
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "stacktrace": [
+                        "Error: Dataset ds999999 does not exist.",
+                        "    at checkDatasetExists "
+                        "(/srv/packages/openneuro-server/dist/graphql/permissions.js:92:15)",
+                    ],
+                },
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        "tooluniverse.graphql_tool.requests.post", lambda *a, **k: _Resp(body)
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="tooluniverse.graphql_tool"):
+        result = execute_query("https://example.org/graphql", "query { x }")
+
+    assert result is None
+    captured = capsys.readouterr()
+    # The internal server file path must not appear anywhere in stdout/stderr.
+    assert "openneuro-server" not in captured.out
+    assert "openneuro-server" not in captured.err
+    assert "stacktrace" not in captured.out
+    # The sanitized message is still available for debugging, just not printed.
+    assert any("Dataset ds999999 does not exist." in r.message for r in caplog.records)

--- a/tests/unit/test_kegg_ext_tool_fixes.py
+++ b/tests/unit/test_kegg_ext_tool_fixes.py
@@ -192,6 +192,82 @@ def test_get_network_does_not_double_prefix_already_prefixed_id():
     assert "network:network:" not in captured["url"]
 
 
+# N#####-style perturbed-network records (unlike the nt######-style Map
+# records above) carry their gene list under GENE and cross-referenced KEGG
+# pathways under PATHWAY -- previously unhandled entirely, so `elements`
+# stayed empty and the raw numeric Entrez IDs in `expanded` had no symbol
+# mapping. Confirmed live for N00151 (TNF-NFKB signaling): 16 real genes and
+# 2 real pathway cross-refs, both silently dropped.
+N_STYLE_NETWORK_FLAT_FILE = """ENTRY       N00151                      Network
+NAME        TNF-NFKB signaling pathway
+DEFINITION  TNF -> TNFRSF1A -> NFKB
+  EXPANDED  7124 -> 7132 -> 4790
+TYPE        Reference
+PATHWAY     hsa04668  TNF signaling pathway
+            hsa04064  NF-kappa B signaling pathway
+GENE        7124  TNF; tumor necrosis factor
+            7132  TNFRSF1A; TNF receptor superfamily member 1A
+            4790  NFKB1; nuclear factor kappa B subunit 1
+REFERENCE   PMID:22119011
+  AUTHORS   Verhelst K, Carpentier I, Beyaert R
+///
+"""
+
+
+def test_get_network_captures_gene_and_pathway_fields_for_n_style_ids():
+    tool = _tool("get_network")
+
+    with patch(
+        "tooluniverse.kegg_ext_tool.requests.get",
+        return_value=_resp(N_STYLE_NETWORK_FLAT_FILE),
+    ):
+        result = tool._get_network({"network_id": "N00151"})
+
+    assert result["data"]["genes"] == [
+        {
+            "entrez_id": "7124",
+            "symbol": "TNF",
+            "description": "tumor necrosis factor",
+        },
+        {
+            "entrez_id": "7132",
+            "symbol": "TNFRSF1A",
+            "description": "TNF receptor superfamily member 1A",
+        },
+        {
+            "entrez_id": "4790",
+            "symbol": "NFKB1",
+            "description": "nuclear factor kappa B subunit 1",
+        },
+    ]
+    assert result["data"]["pathways"] == [
+        {"pathway_id": "hsa04668", "name": "TNF signaling pathway"},
+        {"pathway_id": "hsa04064", "name": "NF-kappa B signaling pathway"},
+    ]
+    # A REFERENCE section (with its own indented AUTHORS/TITLE lines) must not
+    # bleed into the gene/pathway lists just because it's also indented text.
+    assert not any("PMID" in g["description"] for g in result["data"]["genes"])
+
+
+def test_get_network_element_parsing_still_works_for_nt_style_ids():
+    """The new GENE/PATHWAY branches must not regress the existing
+    MEMBER/ELEMENT handling for the other (Map-type) network ID family."""
+    tool = _tool("get_network")
+
+    with patch(
+        "tooluniverse.kegg_ext_tool.requests.get",
+        return_value=_resp(NETWORK_FLAT_FILE),
+    ):
+        result = tool._get_network({"network_id": "nt06276"})
+
+    assert result["data"]["genes"] == []
+    assert result["data"]["pathways"] == []
+    assert result["data"]["elements"] == [
+        "N00001  EGF-EGFR-RAS-ERK signaling pathway",
+        "N00002  BCR-ABL fusion kinase to RAS-ERK signaling pathway",
+    ]
+
+
 def test_brite_hierarchy_404_gives_table_type_hint():
     tool = _tool("get_brite_hierarchy")
 

--- a/tests/unit/test_package_tool_pypi_metadata.py
+++ b/tests/unit/test_package_tool_pypi_metadata.py
@@ -1,0 +1,136 @@
+"""PackageTool's `_get_pypi_info` (backing every `get_<package>_info` tool, e.g.
+`get_mne_info`, `get_nilearn_info`) derived three fields incorrectly from the raw
+PyPI JSON API response:
+
+- `last_updated` used `last_serial` (PyPI's internal monotonic change-counter,
+  currently in the tens of millions) as if it were a Unix timestamp, decoding to
+  bogus dates in 1970-1971.
+- `python_versions` returned the *entire* `classifiers` list (license, OS, dev
+  status, audience, ...) unfiltered, not just the Python version entries.
+- `repository` only checked the `Repository`/`Source` project_urls keys, missing
+  common variants like `Source Code` (e.g. mne-python) even when `documentation`
+  was found fine from the same dict.
+
+Covers the fix with mocked PyPI responses (no live pypi.org calls).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool(package_name="mne"):
+    from tooluniverse.package_tool import PackageTool
+
+    return PackageTool(
+        {
+            "name": f"get_{package_name}_info",
+            "type": "PackageTool",
+            "package_name": package_name,
+        }
+    )
+
+
+def _pypi_response(
+    classifiers=None,
+    requires_python=None,
+    project_urls=None,
+    upload_time="2026-04-20T17:16:54.447882Z",
+    last_serial=36296717,
+):
+    body = {
+        "info": {
+            "name": "mne",
+            "summary": "MEG and EEG data analysis.",
+            "version": "1.12.1",
+            "author": "MNE developers",
+            "license": "BSD-3-Clause",
+            "home_page": "",
+            "project_urls": project_urls or {},
+            "classifiers": classifiers or [],
+            "requires_python": requires_python,
+            "keywords": "",
+        },
+        "last_serial": last_serial,
+        "urls": [{"upload_time_iso_8601": upload_time}] if upload_time else [],
+    }
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = body
+    return resp
+
+
+class TestLastUpdated:
+    def test_uses_real_upload_time_not_last_serial(self):
+        tool = _make_tool()
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response()
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["last_updated"] == "2026-04-20T17:16:54.447882Z"
+        # The bogus 1970s-decoding serial number must not leak into the field.
+        assert result["last_updated"] != 36296717
+
+    def test_falls_back_to_unknown_when_no_release_urls(self):
+        tool = _make_tool()
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response(upload_time=None)
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["last_updated"] == "Unknown"
+
+
+class TestPythonVersions:
+    def test_filters_classifiers_to_python_version_entries(self):
+        tool = _make_tool("nilearn")
+        classifiers = [
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Science/Research",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3",  # generic, not a real version
+            "Topic :: Scientific/Engineering",
+        ]
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response(classifiers=classifiers)
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["python_versions"] == ["3.10", "3.11"]
+
+    def test_falls_back_to_requires_python_when_no_specific_classifiers(self):
+        """mne-python only declares the generic 'Python :: 3' classifier."""
+        tool = _make_tool()
+        classifiers = ["Programming Language :: Python :: 3"]
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response(
+                classifiers=classifiers, requires_python=">=3.10"
+            )
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["python_versions"] == [">=3.10"]
+
+
+class TestRepository:
+    def test_falls_back_to_source_code_key(self):
+        """mne-python's PyPI metadata only sets project_urls['Source Code']."""
+        tool = _make_tool()
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response(
+                project_urls={
+                    "Documentation": "https://mne.tools/",
+                    "Source Code": "https://github.com/mne-tools/mne-python/",
+                }
+            )
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["repository"] == "https://github.com/mne-tools/mne-python/"
+        assert result["documentation"] == "https://mne.tools/"
+
+    def test_prefers_repository_key_over_alternatives(self):
+        tool = _make_tool()
+        with patch("tooluniverse.package_tool.requests.get") as get:
+            get.return_value = _pypi_response(
+                project_urls={
+                    "Repository": "https://github.com/example/canonical",
+                    "Homepage": "https://example.org",
+                }
+            )
+            result = tool.run({"source": "pypi", "include_examples": False})
+        assert result["repository"] == "https://github.com/example/canonical"

--- a/tests/unit/test_wikipathways_pathway_genes.py
+++ b/tests/unit/test_wikipathways_pathway_genes.py
@@ -129,3 +129,12 @@ def test_empty_result_stays_empty():
 
 def test_missing_pathway_id_is_an_error():
     assert _make().run({})["status"] == "error"
+
+
+def test_wpid_is_accepted_as_an_alias_for_pathway_id():
+    # WikiPathways_get_pathway (the sibling tool) names this parameter `wpid`;
+    # a caller switching tools should not have to know the two use different
+    # names for the same identifier.
+    result, _ = _run({"wpid": "WP254"})
+    assert result["status"] == "success"
+    assert result["data"]["pathway_id"] == "WP254"


### PR DESCRIPTION
## Summary

Verified via CLI reproduction against issues surfaced by systems-biology (pathway/network modeling), neuroscience/psychiatric-genetics, and synthetic-biology (agricultural trait engineering) role-play sessions.

- **DNA_golden_gate_assemble**: overhangs from a reverse-oriented Type IIS recognition site were read literally off the top strand instead of reverse-complemented, so the tool could never correctly chain fragments produced by its own sibling tool `DNA_golden_gate_design` (explicitly documented as the inverse operation). Confirmed by round-tripping `DNA_golden_gate_design`'s own output through `DNA_golden_gate_assemble` and cross-checking the fix against Biopython's restriction-site cut geometry. Also fixes a `oneOf` `return_schema` ambiguity that made the tool's own `test_examples` fail (`tu test DNA_golden_gate_assemble`).
- **DNA_primer_design**: the forward/reverse primer search windows extended past the boundary they need to respect (`target_start`/`target_end`), so the single best-Tm-scoring candidate in-window could structurally be unable to cover the target, producing a spurious "does not cover the target" failure even when a covering (just slightly worse-scoring) primer existed in the same window.
- **KEGG_get_network**: `N#####`-style perturbed-network records (e.g. `N00151`, TNF-NFKB signaling) list their driving genes and source KEGG pathway map under `GENE`/`PATHWAY`, which the parser didn't recognize at all — `elements` (only meaningful for the other, `nt######`-style network family) stayed empty, silently dropping the gene list for exactly the network type callers need it most for.
- **PackageTool** (backs every `get_<package>_info` tool, e.g. `get_mne_info`, `get_nilearn_info`): `last_updated` used PyPI's internal monotonic change-counter (`last_serial`) as if it were a Unix timestamp, decoding to bogus 1970s dates; `python_versions` returned every PyPI trove classifier unfiltered (license, OS, audience, ...) instead of just Python version entries; `repository` only checked two of the several `project_urls` keys real projects use (e.g. mne-python only sets `Source Code`).
- **WikiPathways_get_pathway_genes / _get_pathway_metabolites**: now accept `wpid` as an alias for `pathway_id`, matching the parameter name used by the sibling `WikiPathways_get_pathway` tool, so switching between the two tools doesn't require renaming the same pathway identifier.
- **graphql_tool.execute_query**: GraphQL error responses were printed to stdout verbatim on failure, including upstream stack traces with internal server file paths (confirmed live via `OpenNeuro_get_dataset` on a nonexistent dataset ID, which surfaced `/srv/packages/openneuro-server/dist/graphql/permissions.js:...` in the CLI output). Now logged at debug level with just the sanitized error message.

## Test plan

- [x] `tu test` passes for every touched tool (`DNA_golden_gate_assemble`, `DNA_golden_gate_design`, `DNA_primer_design`, `DNA_gibson_design`, `WikiPathways_get_pathway_genes`, `WikiPathways_get_pathway_metabolites`, `KEGG_get_network`)
- [x] Live CLI reproduction of each original failure, confirmed fixed
- [x] Full targeted pytest run across all touched files: 116/116 pass
- [x] `tests/tools/test_return_schema_data_shapes.py`: 28/28 pass
- [x] New regression tests added: `test_graphql_tool_error_logging.py`, `test_package_tool_pypi_metadata.py`, plus additions to `test_dna_golden_gate_assemble.py`, `test_kegg_ext_tool_fixes.py`, `test_wikipathways_pathway_genes.py`
- [x] Existing `test_dna_golden_gate_assemble.py` fixture data was hand-crafted against the old (incorrect) overhang convention; updated to build biochemically-correct BsaI donor sequences and confirmed the new behavior against Biopython's own restriction-cut geometry before changing the assertions