### PR TITLE
Fix Round 11: ClinicalTrials search, BV-BRC surveillance/AMR, WikiPathways, UniProt annotation

### DIFF
--- a/src/tooluniverse/bvbrc_tool.py
+++ b/src/tooluniverse/bvbrc_tool.py
@@ -405,7 +405,17 @@ class BVBRCTool(BaseTool):
 
         limit = min(arguments.get("limit") or 25, 100)
 
+        # Fix-11C-1: BV-BRC's surveillance collection commonly holds multiple
+        # distinct records (e.g. separate lab submissions/panels) that share
+        # identical sample_identifier/collection_date/subtype values. Without
+        # a unique identifier in the response, these genuinely distinct
+        # records looked like a duplication bug (same visible fields
+        # repeated). Including sample_accession (human-readable submission
+        # accession) and id (the record's unique key) lets callers tell
+        # distinct records apart instead of appearing to be verbatim dupes.
         select_fields = [
+            "sample_accession",
+            "id",
             "sample_identifier",
             "collection_date",
             "geographic_group",

--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -308,7 +308,34 @@ class CompoundVariantAnnotationTool(BaseTool):
                 if error:
                     sources_failed.append(f"UniProt: {error[:100]}")
                 else:
-                    annotations["uniprot"] = self._parse_uniprot(r, gene_for_gnomad)
+                    parsed = self._parse_uniprot(r, gene_for_gnomad)
+                    # Fix-11B-1: UniProt_search's entries never carry a
+                    # "function" field (confirmed live -- only accession,
+                    # id, protein_name, gene_names, organism, length), so
+                    # _parse_uniprot's function lookup silently always
+                    # returned "". Look up the real function comment with a
+                    # follow-up call keyed on the accession we just picked.
+                    accession = parsed.get("accession")
+                    if accession:
+                        try:
+                            fr = tu.run_one_function(
+                                {
+                                    "name": "UniProt_get_function_by_accession",
+                                    "arguments": {"accession": accession},
+                                }
+                            )
+                            fn_error = self._sub_call_error(fr)
+                            # run_one_function returns this tool's raw
+                            # result -- a bare list of function-comment
+                            # strings -- not wrapped in a dict.
+                            fn_list = fr if isinstance(fr, list) else None
+                            if fn_list is None and isinstance(fr, dict):
+                                fn_list = fr.get("result")
+                            if not fn_error and fn_list:
+                                parsed["function"] = str(fn_list[0])[:300]
+                        except Exception:
+                            pass  # keep parsed["function"] == "" (no data)
+                    annotations["uniprot"] = parsed
             except Exception as e:
                 sources_failed.append(f"UniProt: {str(e)[:100]}")
 

--- a/src/tooluniverse/data/bvbrc_tools.json
+++ b/src/tooluniverse/data/bvbrc_tools.json
@@ -688,6 +688,20 @@
           "items": {
             "type": "object",
             "properties": {
+              "sample_accession": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Human-readable submission accession (e.g. 'IRD_ROC000000507'). Multiple records can share the same sample_accession/sample_identifier when a sample was tested/submitted more than once -- use 'id' to distinguish them."
+              },
+              "id": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Unique BV-BRC record identifier for this surveillance entry."
+              },
               "sample_identifier": {
                 "type": [
                   "string",

--- a/src/tooluniverse/data/bvbrc_tools.json
+++ b/src/tooluniverse/data/bvbrc_tools.json
@@ -213,7 +213,7 @@
   },
   {
     "name": "BVBRC_search_amr",
-    "description": "Search for antimicrobial resistance (AMR) phenotype data in BV-BRC. Returns resistance/susceptibility data for pathogens against specific antibiotics, including MIC values, testing methods, and evidence. Essential for AMR surveillance research. Filter by 'antibiotic' (e.g. 'methicillin'), 'resistant_phenotype', and/or a specific BV-BRC 'genome_id'. There is no organism/species parameter: to scope results to one organism, first obtain its genome_id(s) (e.g. via BVBRC_search_genome_features / BVBRC_search_specialty_genes with taxon_id) and pass genome_id here.",
+    "description": "Search for ANTIBACTERIAL resistance (AMR) phenotype data in BV-BRC -- bacteria tested against antibiotics (e.g. 'methicillin', 'ciprofloxacin'), NOT antiviral drug-resistance mutations (for influenza/viral antiviral resistance, use Pathoplexus_get_mutations or literature search instead). Returns resistance/susceptibility data for pathogens against specific antibiotics, including MIC values, testing methods, and evidence. Essential for bacterial AMR surveillance research. Filter by 'antibiotic' (e.g. 'methicillin'), 'resistant_phenotype', and/or a specific BV-BRC 'genome_id'. There is no organism/species parameter: to scope results to one organism, first obtain its genome_id(s) (e.g. via BVBRC_search_genome_features / BVBRC_search_specialty_genes with taxon_id) and pass genome_id here.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/clinicaltrials_gov_tools.json
+++ b/src/tooluniverse/data/clinicaltrials_gov_tools.json
@@ -927,6 +927,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "operation": {
+          "type": "string",
+          "enum": [
+            "search"
+          ],
+          "description": "Operation (optional; defaults to 'search' for this tool).",
+          "default": "search"
+        },
         "query_cond": {
           "type": [
             "string",

--- a/src/tooluniverse/data/fda_drug_labeling_tools.json
+++ b/src/tooluniverse/data/fda_drug_labeling_tools.json
@@ -8702,7 +8702,7 @@
       "properties": {
         "mechanism_info": {
           "type": "string",
-          "description": "Information related to the desired mechanism of action."
+          "description": "Free-text mechanism-of-action keyword to search for in the drug label's 'Mechanism of Action' section (e.g., 'angiotensin', 'beta blocker', 'IL-4 receptor'). Not a diagnosis/ICD code -- this searches the label's mechanism text, not indication codes."
         },
         "indication": {
           "type": "string",
@@ -8744,8 +8744,8 @@
     ],
     "test_examples": [
       {
-        "mechanism_info": "E11.9",
-        "indication": "Hypertension",
+        "mechanism_info": "angiotensin",
+        "indication": "hypertension",
         "limit": 5,
         "skip": 0
       }

--- a/src/tooluniverse/wikipathways_tool.py
+++ b/src/tooluniverse/wikipathways_tool.py
@@ -86,6 +86,15 @@ class WikiPathwaysSearchTool:
         organism = arguments.get("organism")
         limit = int(arguments.get("limit", 20))
 
+        # Fix-11B-2: pathway titles in WikiPathways are typically unhyphenated
+        # gene/protein shorthand ("IL4 signaling"), but researchers naturally
+        # type the hyphenated form ("IL-4 signaling") -- confirmed live this
+        # returned zero results even though the pathway exists (WP395).
+        # Stripping hyphens from both sides of the CONTAINS comparison keeps
+        # the plain-substring search simple while absorbing this common
+        # notation mismatch.
+        query_norm = query.replace("-", "")
+
         organism_filter = (
             f'  FILTER(LCASE(STR(?organism)) = "{organism.lower()}")'
             if organism
@@ -98,7 +107,7 @@ SELECT DISTINCT ?pathway ?title ?organism WHERE {{
   ?pathway a wp:Pathway ;
            dc:title ?title ;
            wp:organismName ?organism .
-  FILTER(CONTAINS(LCASE(?title), "{query}"))
+  FILTER(CONTAINS(REPLACE(LCASE(?title), "-", ""), "{query_norm}"))
 {organism_filter}
 }} LIMIT {limit}
 """


### PR DESCRIPTION
## Summary

Cardiology, dermatology, and outbreak-genomics researcher persona role-play surfaced several issues; each was CLI-verified live before being queued for a fix (most persona reports turned out to be agent error or working-as-intended, and were discarded).

- **`ClinicalTrials_search_studies` was completely broken**, including its own shipped test example (`tu test ClinicalTrials_search_studies` failed with `Additional properties are not allowed ('operation' was unexpected)`). Root cause: an earlier round's fix (`Fix-R8C-2`, see `tests/unit/test_clinicaltrials_search_studies_schema.py`) added `additionalProperties: false` to reject unrecognized params, but didn't account for `_apply_operation_default` injecting `"operation"` into arguments before validation for this single-operation tool. Fixed by declaring `operation` as a proper enum schema property, matching the pattern already used elsewhere (e.g. `DNA_find_orfs`).
- **`BVBRC_search_surveillance` looked like it returned duplicate rows** for a subtype/host query. Verified directly against the live BV-BRC API: the rows are genuinely distinct records (separate lab submissions for the same sample, each with its own `id`) that only *looked* identical because no distinguishing field was in `select_fields`. Added `sample_accession`/`id` so callers can tell them apart instead of assuming a pagination bug.
- **`annotate_variant_multi_source` always returned an empty `uniprot.function`** field. `UniProt_search`'s result entries never carry a function comment (only accession/id/protein_name/gene_names/organism/length) — confirmed live. Added a follow-up `UniProt_get_function_by_accession` call keyed on the resolved accession.
- **`WikiPathways_search` returned zero results for "IL-4 signaling"** even though the pathway exists (WP395, titled "IL4 signaling"). The search is a literal substring match and pathway titles use unhyphenated gene shorthand. Normalized hyphens out of both sides of the SPARQL `CONTAINS` comparison.
- **`FDA_get_drug_names_by_mechanism_of_action`'s shipped test example was broken**: it used `"E11.9"` (an ICD-10 diagnosis code) as a mechanism-of-action search string, so it never matched. Replaced with a working example and clarified the parameter description to say it searches mechanism text, not diagnosis codes.
- **`BVBRC_search_amr`'s description didn't scope itself to antibacterial resistance**, so a researcher looking for antiviral resistance mutations got a silent empty result with no pointer to the right tool (`Pathoplexus_get_mutations`).

## Test plan

- [x] `tu test <ToolName>` passes for all 6 affected tools (previously 2 were failing: `ClinicalTrials_search_studies`, `FDA_get_drug_names_by_mechanism_of_action`)
- [x] `tu test` passes for unmodified sibling tools sharing the same code paths (`ClinicalTrials_get_study`, `ClinicalTrials_search_by_intervention`, `ClinicalTrials_search_by_sponsor`, `ClinicalTrials_get_database_stats`, `ClinicalTrials_get_field_values`) — no regression
- [x] Existing pytest suite passes, including the pre-existing `Fix-R8C-2` schema regression guard (`tests/unit/test_clinicaltrials_search_studies_schema.py`) and the `BVBRC_search_amr` description guard (`tests/unit/test_bvbrc_amr_description.py`)
- [x] `ruff check` / `ruff format --check` clean on all modified `.py` files
- [x] Live-verified `BVBRC_search_surveillance`'s "duplicate" records against the real BV-BRC API before concluding it wasn't a pagination bug