### PR TITLE
Fix Round 12: geroscience/endocrinology/hematology data-quality issues

### DIFF
--- a/src/tooluniverse/aging_cohort_tool.py
+++ b/src/tooluniverse/aging_cohort_tool.py
@@ -8,6 +8,7 @@ No external API calls -- uses an internal curated database. Cohort metadata
 changes rarely (study design, variables, and access methods are stable).
 """
 
+import math
 from typing import Dict, Any, List
 from .base_tool import BaseTool
 from .tool_registry import register_tool
@@ -1258,6 +1259,24 @@ def _token_match_count(text: str, tokens: list[str]) -> int:
     return sum(1 for tok in tokens if tok in lower)
 
 
+# Words that carry little discriminating signal for this registry: nearly
+# every cohort's text contains "study" (it's in most full_names) and
+# "biomarkers" (it's a listed variable category for most cohorts), so
+# counting them toward the match threshold makes almost any multi-word
+# query -- including nonsense ones -- match nearly the whole registry.
+_LOW_SIGNAL_TOKENS = {
+    "a", "an", "the", "of", "in", "on", "and", "or", "with", "for", "to",
+    "by", "at", "study", "studies", "data", "cohort", "cohorts", "research",
+    "biomarker", "biomarkers",
+}
+
+
+def _meaningful_tokens(tokens: list[str]) -> list[str]:
+    """Drop low-signal tokens unless doing so would empty the query."""
+    filtered = [t for t in tokens if t not in _LOW_SIGNAL_TOKENS and len(t) > 2]
+    return filtered or tokens
+
+
 def _cohort_searchable_text(c: Dict[str, Any]) -> str:
     """Build a single searchable string from all cohort fields."""
     parts = [
@@ -1299,14 +1318,21 @@ class AgingCohortSearchTool(BaseTool):
                 "retryable": False,
             }
 
-        # Tokenize query -- match at least one token, rank by coverage
+        # Tokenize query and drop low-signal tokens (e.g. "study",
+        # "biomarker") that appear in nearly every cohort's text and would
+        # otherwise make almost any query -- including a nonsense one --
+        # match most of the registry. Require a majority of the remaining
+        # tokens to hit, not just one, so relevance actually tracks the
+        # query instead of any single common word.
         tokens = query.lower().split()
+        match_tokens = _meaningful_tokens(tokens)
+        min_hits = max(1, math.ceil(len(match_tokens) * 0.6))
         scored: list[tuple[int, Dict[str, Any]]] = []
 
         for cohort in _COHORTS:
             searchable = _cohort_searchable_text(cohort)
-            hits = _token_match_count(searchable, tokens)
-            if hits == 0:
+            hits = _token_match_count(searchable, match_tokens)
+            if hits < min_hits:
                 continue
 
             # --- Optional filters ---

--- a/src/tooluniverse/compose_scripts/biomarker_discovery.py
+++ b/src/tooluniverse/compose_scripts/biomarker_discovery.py
@@ -4,6 +4,28 @@ Discover and validate biomarkers for a specific disease condition using compose 
 """
 
 
+def _extract_genes(tool_result):
+    """Pull a gene list out of an HPA_search_genes_by_query result.
+
+    call_tool() returns the tool's raw envelope (e.g.
+    {"status": "success", "data": {"genes": [...]}}), not the unwrapped
+    payload -- this previously checked for "genes" at the top level only,
+    which never matched, so every disease query silently fell through to
+    (formerly) a hardcoded fallback / (now) an honest "no genes found".
+    Check the nested location first, then the top level and bare list, for
+    resilience to either response shape.
+    """
+    if isinstance(tool_result, dict):
+        data = tool_result.get("data")
+        if isinstance(data, dict) and isinstance(data.get("genes"), list):
+            return data["genes"]
+        if isinstance(tool_result.get("genes"), list):
+            return tool_result["genes"]
+    elif isinstance(tool_result, list):
+        return tool_result
+    return []
+
+
 def compose(arguments, tooluniverse, call_tool):
     """Discover and validate biomarkers for a specific disease condition"""
 
@@ -41,16 +63,11 @@ def compose(arguments, tooluniverse, call_tool):
             hpa_result = call_tool(
                 "HPA_search_genes_by_query", {"search_query": disease_condition}
             )
-            if hpa_result and isinstance(hpa_result, dict) and "genes" in hpa_result:
-                genes = hpa_result["genes"]
+            genes = _extract_genes(hpa_result)
+            if genes:
                 gene_search_results.extend(genes)
                 print(
                     f"✅ HPA search found {len(genes)} genes for '{disease_condition}'"
-                )
-            elif hpa_result and isinstance(hpa_result, list):
-                gene_search_results.extend(hpa_result)
-                print(
-                    f"✅ HPA search found {len(hpa_result)} genes for '{disease_condition}'"
                 )
         except Exception as e:
             print(f"⚠️ HPA search failed: {e}")
@@ -64,59 +81,31 @@ def compose(arguments, tooluniverse, call_tool):
                     hpa_result = call_tool(
                         "HPA_search_genes_by_query", {"search_query": search_term}
                     )
-                    if (
-                        hpa_result
-                        and isinstance(hpa_result, dict)
-                        and "genes" in hpa_result
-                    ):
-                        genes = hpa_result["genes"]
+                    genes = _extract_genes(hpa_result)
+                    if genes:
                         gene_search_results.extend(genes)
                         print(
                             f"✅ HPA search found {len(genes)} genes for '{search_term}'"
                         )
                         break
-                    elif hpa_result and isinstance(hpa_result, list):
-                        gene_search_results.extend(hpa_result)
-                        print(
-                            f"✅ HPA search found {len(hpa_result)} genes for '{search_term}'"
-                        )
-                        break
                 except Exception as e:
                     print(f"⚠️ HPA search failed for '{search_term}': {e}")
 
-        # Strategy 3: Use alternative search if no results
+        # NOTE: this used to silently substitute a hardcoded list of
+        # generic cancer genes (BRCA1/BRCA2/TP53/EGFR/MYC) here and print a
+        # "✅" success line whenever HPA search found nothing -- for a
+        # disease with no matches (e.g. "healthy aging", which isn't a
+        # disease HPA indexes genes against), that meant every downstream
+        # step silently analyzed unrelated cancer genes while every log
+        # line still claimed success. Report the miss honestly instead so
+        # callers can tell "no data for this query" apart from "found
+        # data."
         if not gene_search_results:
-            print("⚠️ No genes found with HPA search strategies")
-            # Create a fallback result with common cancer genes
-            fallback_genes = [
-                {
-                    "gene_name": "BRCA1",
-                    "ensembl_id": "ENSG00000012048",
-                    "description": "Breast cancer type 1 susceptibility protein",
-                },
-                {
-                    "gene_name": "BRCA2",
-                    "ensembl_id": "ENSG00000139618",
-                    "description": "Breast cancer type 2 susceptibility protein",
-                },
-                {
-                    "gene_name": "TP53",
-                    "ensembl_id": "ENSG00000141510",
-                    "description": "Tumor protein p53",
-                },
-                {
-                    "gene_name": "EGFR",
-                    "ensembl_id": "ENSG00000146648",
-                    "description": "Epidermal growth factor receptor",
-                },
-                {
-                    "gene_name": "MYC",
-                    "ensembl_id": "ENSG00000136997",
-                    "description": "MYC proto-oncogene protein",
-                },
-            ]
-            gene_search_results.extend(fallback_genes)
-            print(f"✅ Using fallback cancer genes: {len(fallback_genes)} genes")
+            print(
+                "⚠️ No genes found with HPA search strategies for "
+                f"'{disease_condition}' -- skipping expression/pathway "
+                "steps that depend on a specific gene."
+            )
 
         if gene_search_results:
             # Get details for the first gene found

--- a/src/tooluniverse/ctd_tool.py
+++ b/src/tooluniverse/ctd_tool.py
@@ -149,9 +149,11 @@ class CTDTool(BaseTool):
                     "direction)."
                 ),
                 "suggestion": (
-                    "Use OpenTargets_get_associated_diseases (live, more "
-                    "sources) or DGIdb_search_interactions for gene-disease "
-                    "associations."
+                    "Use gather_gene_disease_associations (queries DisGeNET, "
+                    "OMIM, OpenTargets, GenCC, and ClinVar in one call and "
+                    "cross-references them) or "
+                    "OpenTargets_get_diseases_phenotypes_by_target_ensembl "
+                    "for gene-disease associations."
                 ),
                 "metadata": metadata,
             }

--- a/src/tooluniverse/data/kegg_disease_drug_tools.json
+++ b/src/tooluniverse/data/kegg_disease_drug_tools.json
@@ -348,7 +348,7 @@
   {
     "name": "KEGG_get_drug_targets",
     "type": "KEGGExtTool",
-    "description": "Get human gene targets linked to a KEGG drug. Returns KEGG gene IDs (hsa:XXXXX format) for known drug targets. Example: D01441 (imatinib) returns hsa:25 (ABL1), hsa:3815 (KIT), hsa:5159 (PDGFRB). Useful for drug-target interaction analysis and pharmacogenomics. Limited to human targets by default.",
+    "description": "Get human gene targets linked to a KEGG drug. Returns raw KEGG gene IDs only (hsa:XXXXX format), not gene symbols -- resolve symbols separately if you need them. Example: D01441 (imatinib) returns hsa:25 (ABL1), hsa:3815 (KIT), hsa:5156 (PDGFRA). Useful for drug-target interaction analysis and pharmacogenomics. Limited to human targets by default.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/panelapp_tools.json
+++ b/src/tooluniverse/data/panelapp_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "PanelApp_search_panels",
-    "description": "Search Genomics England PanelApp for gene panels used in clinical genetic testing. PanelApp is the authoritative source for curated gene panels used by the NHS and global genomic medicine services. Returns panel IDs, names, disease groups, status, version, and gene count statistics. Use this to find relevant gene panels for a disease area, then use PanelApp_get_panel to get the full gene list. Panels contain genes with confidence levels (green=3 for diagnostic grade, amber=2 for borderline, red=1 for limited evidence).",
+    "description": "Search Genomics England PanelApp for gene panels used in clinical genetic testing. PanelApp is the authoritative source for curated gene panels used by the NHS and global genomic medicine services. Returns panel IDs, names, disease groups, status, version, and gene count statistics. Use this to find relevant gene panels for a disease area, then use PanelApp_get_panel to get the full gene list. Panels contain genes with confidence levels (green=3 for diagnostic grade, amber=2 for borderline, red=1 for limited evidence). Matches only against panel-level metadata (name/disease group), not gene-level phenotype text, so some disease names (e.g. 'haemophilia') won't match any panel directly even though a relevant panel exists -- if a disease-name search returns nothing, try PanelApp_search_genes with the causal gene symbol instead (e.g. F8, F9 for haemophilia).",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/llm_clients.py
+++ b/src/tooluniverse/llm_clients.py
@@ -6,6 +6,25 @@ import time
 import json as _json
 
 
+def _model_family(model_id: str) -> str:
+    """Return the provider-independent model portion of a model ID."""
+    if not isinstance(model_id, str):
+        return ""
+    return model_id.rsplit("/", 1)[-1].lower()
+
+
+def is_reasoning_model(model_id: str) -> bool:
+    """True for OpenAI "reasoning" model families (o1/o3/o4/gpt-5 and their
+    variants, e.g. "o4-mini", "gpt-5-mini"). These models only support the
+    default temperature (reject any explicit value with a 400 error) and
+    take `max_completion_tokens` instead of `max_tokens`. Single source of
+    truth for both restrictions so the two checks can't drift out of sync
+    the way they previously did (temperature normalization was missing
+    "gpt-5" even though token-limit routing already had it).
+    """
+    return _model_family(model_id).startswith(("gpt-5", "o1", "o3", "o4"))
+
+
 class BaseLLMClient:
     def test_api(self) -> None:
         raise NotImplementedError
@@ -177,9 +196,12 @@ class AzureOpenAIClient(BaseLLMClient):
     def _normalize_temperature(
         self, model_id: str, temperature: Optional[float]
     ) -> Optional[float]:
-        if isinstance(model_id, str) and (
-            model_id.startswith("o3-mini") or model_id.startswith("o4-mini")
-        ):
+        # Reasoning-style models (o-series and gpt-5 family) only support
+        # the default temperature (1) and reject any explicit value with a
+        # 400 error. self._model_id defaults to "gpt-5" (see AgenticTool),
+        # so is_reasoning_model() previously missing "gpt-5" meant this
+        # fired on every default-configured Azure call.
+        if is_reasoning_model(model_id):
             if temperature is not None:
                 self.logger.warning(
                     f"Model {model_id} does not support 'temperature'; ignoring provided value."
@@ -722,15 +744,17 @@ class OpenAICompatibleClient(BaseLLMClient):
 
     @classmethod
     def _uses_max_completion_tokens(cls, model_id: str) -> bool:
-        family = cls._model_family(model_id)
-        return family.startswith(("gpt-5", "o1", "o3", "o4"))
+        return is_reasoning_model(model_id)
 
     @classmethod
     def _normalize_temperature(
         cls, model_id: str, temperature: Optional[float]
     ) -> Optional[float]:
-        family = cls._model_family(model_id)
-        if family.startswith(("o1", "o3", "o4")):
+        # Both this and _uses_max_completion_tokens above now delegate to
+        # the single module-level is_reasoning_model() classifier, so the
+        # two checks can no longer independently drift out of sync (gpt-5
+        # was previously missing from this method only).
+        if is_reasoning_model(model_id):
             return None
         return temperature
 

--- a/src/tooluniverse/omim_tool.py
+++ b/src/tooluniverse/omim_tool.py
@@ -114,16 +114,37 @@ class OMIMTool(BaseTool):
             omim_data = data.get("omim", {})
             search_response = omim_data.get("searchResponse", {})
 
+            # Search results are a lightweight index, not full records: keep
+            # only MIM number, title, entry type (prefix), and status. The
+            # full record (text sections, allelic variants, references, gene
+            # map, etc.) is available per-entry via OMIM_get_entry using the
+            # mimNumber returned here.
+            summarized_entries = []
+            for item in search_response.get("entryList", []):
+                entry = item.get("entry", {})
+                summarized_entries.append(
+                    {
+                        "mim_number": entry.get("mimNumber"),
+                        "prefix": entry.get("prefix"),
+                        "status": entry.get("status"),
+                        "preferred_title": entry.get("titles", {}).get(
+                            "preferredTitle"
+                        ),
+                        "matches": entry.get("matches"),
+                    }
+                )
+
             return {
                 "status": "success",
                 "data": {
                     "total_results": search_response.get("totalResults", 0),
                     "start": search_response.get("startIndex", 0),
-                    "entries": search_response.get("entryList", []),
+                    "entries": summarized_entries,
                 },
                 "metadata": {
                     "source": "OMIM",
                     "query": query,
+                    "note": "Use OMIM_get_entry with mim_number for full record details.",
                 },
             }
 

--- a/src/tooluniverse/panelapp_tool.py
+++ b/src/tooluniverse/panelapp_tool.py
@@ -11,6 +11,7 @@ API's fixed page_size=100) and filters client-side by substring match
 against name/disease_group/disease_sub_group.
 """
 
+import os
 from typing import Any, Dict
 
 from .base_rest_tool import BaseRESTTool
@@ -18,6 +19,41 @@ from .tool_registry import register_tool
 
 PANELS_URL = "https://panelapp.genomicsengland.co.uk/api/v1/panels/"
 _MAX_PAGES = 10  # safety cap; ~434 panels / 100 per page = 5 pages today
+
+# Thresholds for the inflection heuristic in _word_matches(). English
+# plural/adjectival suffixes (e.g. "y"->"ies", "-opathy"->"-opathies") are
+# usually 1-3 characters, so a shared prefix within 3 characters of the
+# shorter word's length is treated as the same term. _MIN_WORD_LEN and
+# _MAX_LEN_DIFF guard against short/dissimilar-length words matching by
+# coincidence (e.g. "cardiac" vs "cardiomyopathy" must NOT match).
+_MIN_WORD_LEN = 6
+_MAX_LEN_DIFF = 4
+_MAX_SUFFIX_DROP = 3
+
+
+def _word_matches(query_word: str, haystack_word: str) -> bool:
+    """True if two words are the same disease term modulo simple English
+    inflection (singular/plural, e.g. "haemoglobinopathy" vs
+    "haemoglobinopathies"). Deliberately NOT a general substring match --
+    e.g. "myopathy" is a literal substring of "cardiomyopathy" but they are
+    different, unrelated panel topics, so containment alone is too loose.
+    Only an exact match, or a shared prefix between two words of similar
+    length (inflectional suffixes differ by a couple of characters, not by
+    a whole extra word), counts as the same term.
+    """
+    if not query_word or not haystack_word:
+        return False
+    if query_word == haystack_word:
+        return True
+    if (
+        len(query_word) >= _MIN_WORD_LEN
+        and len(haystack_word) >= _MIN_WORD_LEN
+        and abs(len(query_word) - len(haystack_word)) <= _MAX_LEN_DIFF
+    ):
+        shorter = min(len(query_word), len(haystack_word))
+        common_prefix = len(os.path.commonprefix([query_word, haystack_word]))
+        return common_prefix >= shorter - _MAX_SUFFIX_DROP
+    return False
 
 
 @register_tool("PanelAppSearchTool")
@@ -43,14 +79,46 @@ class PanelAppSearchTool(BaseRESTTool):
             if not url:
                 break
 
+        # Query-derived, so computed once outside the per-panel loop below.
+        query_words = search.split()
+
         def matches(p: Dict[str, Any]) -> bool:
             haystack = " ".join(
                 str(p.get(k) or "")
                 for k in ("name", "disease_group", "disease_sub_group")
             ).lower()
-            return search in haystack
+            if search in haystack:
+                return True
+            # Plain substring matching misses simple English inflection --
+            # e.g. query "haemoglobinopathy" (singular) against panel name
+            # "...haemoglobinopathies" (plural) never matches even though a
+            # clinician typing the singular disease name expects a hit.
+            # Fall back to a per-word fuzzy-prefix match: every query word
+            # must share a long common prefix with some haystack word.
+            haystack_words = haystack.split()
+            return all(
+                any(_word_matches(qw, hw) for hw in haystack_words)
+                for qw in query_words
+            )
 
         results = [p for p in panels if matches(p)]
+        note = (
+            "PanelApp's API has no server-side search filter, so this "
+            "matches client-side against name/disease_group/"
+            "disease_sub_group across all panels."
+        )
+        if not results:
+            # This only searches panel-level metadata, which doesn't
+            # include every gene-level phenotype term (e.g. "haemophilia"
+            # doesn't appear in any panel name/disease_group text -- it's
+            # only reachable through the genes it curates, F8/F9). Point
+            # the caller at the gene-level fallback instead of a dead end.
+            note += (
+                " No panel matched this term in its name/disease_group/"
+                "disease_sub_group metadata. If you're looking for a "
+                "condition by its causal gene(s) instead, try "
+                "PanelApp_search_genes with the gene symbol."
+            )
         return {
             "status": "success",
             "data": {
@@ -62,10 +130,6 @@ class PanelAppSearchTool(BaseRESTTool):
             "metadata": {
                 "query": arguments.get("search"),
                 "total_panels_searched": len(panels),
-                "note": (
-                    "PanelApp's API has no server-side search filter, so this "
-                    "matches client-side against name/disease_group/"
-                    "disease_sub_group across all panels."
-                ),
+                "note": note,
             },
         }

--- a/tests/test_aging_cohort_tool.py
+++ b/tests/test_aging_cohort_tool.py
@@ -62,6 +62,42 @@ class TestBasicSearch:
         assert result["metadata"]["total_matched"] == 0
 
 
+class TestRelevanceFiltering:
+    """Regression guard for Fix Round 12 / Feature-12A-1: a query where only
+    one low-signal word (e.g. "biomarker", present in ~85% of the registry,
+    or "study", present in most full_names) happened to match used to
+    return nearly the entire registry -- indistinguishable from "everything
+    is relevant." Matching must actually require the query's meaningful
+    terms, not just any single common word.
+    """
+
+    def test_nonsense_query_with_common_word_returns_nothing(self, tool):
+        # Every word here is either gibberish or a near-universal term
+        # ("biomarker", "study"); none of it describes a real cohort topic.
+        result = tool.run(
+            {"query": "zzzqqxx nonexistent biomarker unicorn study"}
+        )
+        assert result["status"] == "success"
+        assert result["data"] == []
+        assert result["metadata"]["total_matched"] == 0
+
+    def test_multi_word_query_does_not_match_near_whole_registry(self, tool):
+        # A real 3-term query should surface a focused subset, not ~all
+        # cohorts (the old bug: "biomarker"/"study" alone matched 29/30).
+        result = tool.run({"query": "iron intake longitudinal"})
+        assert result["status"] == "success"
+        assert 0 < result["metadata"]["total_matched"] < len(_COHORTS) - 5
+        names = {c["name"] for c in result["data"]}
+        assert "InCHIANTI" in names  # known iron/longitudinal cohort
+
+    def test_single_meaningful_word_still_matches(self, tool):
+        # A genuine single-topic query must still work once low-signal
+        # words are excluded from the meaningful-token set.
+        result = tool.run({"query": "sarcopenia"})
+        assert result["status"] == "success"
+        assert result["metadata"]["total_matched"] >= 1
+
+
 # ---------------------------------------------------------------------------
 # Filter: country
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_biomarker_discovery_compose.py
+++ b/tests/unit/test_biomarker_discovery_compose.py
@@ -1,0 +1,132 @@
+"""Regression guard for Fix Round 12 / Feature-12A-2.
+
+BiomarkerDiscoveryWorkflow's Step 2 (HPA gene search) checked for a
+top-level "genes" key on the result of call_tool("HPA_search_genes_by_query",
+...), but call_tool() returns the tool's raw envelope
+({"status": "success", "data": {"genes": [...]}}), not the unwrapped
+payload. The check therefore never matched a real response, always fell
+through to a hardcoded fallback of unrelated cancer genes (BRCA1/BRCA2/
+TP53/EGFR/MYC) regardless of the actual disease queried, and printed a
+misleading "✅ Using fallback cancer genes" success line while doing so.
+
+This test exercises the fix directly: `_extract_genes` must correctly pull
+genes out of the real (wrapped) response shape, and the compose script must
+no longer contain the hardcoded fallback gene list at all.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_MODULE_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "tooluniverse"
+    / "compose_scripts"
+    / "biomarker_discovery.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "biomarker_discovery_under_test", _MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def module():
+    return _load_module()
+
+
+class TestExtractGenes:
+    def test_extracts_genes_from_wrapped_envelope(self, module):
+        # This is the real shape call_tool() returns for
+        # HPA_search_genes_by_query: {"status": ..., "data": {"genes": [...]}}
+        result = {
+            "status": "success",
+            "data": {"genes": [{"gene_name": "BCAS1", "ensembl_id": "ENSG1"}]},
+        }
+        genes = module._extract_genes(result)
+        assert genes == [{"gene_name": "BCAS1", "ensembl_id": "ENSG1"}]
+
+    def test_extracts_genes_from_unwrapped_dict(self, module):
+        result = {"genes": [{"gene_name": "TP53"}]}
+        assert module._extract_genes(result) == [{"gene_name": "TP53"}]
+
+    def test_extracts_genes_from_bare_list(self, module):
+        result = [{"gene_name": "EGFR"}]
+        assert module._extract_genes(result) == [{"gene_name": "EGFR"}]
+
+    def test_returns_empty_list_when_no_genes_present(self, module):
+        assert module._extract_genes({"status": "success", "data": {}}) == []
+        assert module._extract_genes(None) == []
+        assert module._extract_genes({"error": "not found"}) == []
+
+
+class TestNoHardcodedFallback:
+    def test_source_no_longer_contains_hardcoded_cancer_genes(self):
+        source = _MODULE_PATH.read_text()
+        # These gene names must not appear anywhere as a hardcoded
+        # substitute -- any mention of them should only come from real API
+        # results, never from source-level fallback data.
+        for stale_marker in (
+            "fallback cancer genes",
+            "Breast cancer type 1 susceptibility protein",
+        ):
+            assert stale_marker not in source
+
+
+class TestGeneSearchStrategy:
+    """End-to-end exercise of compose()'s Step 2 with a fake call_tool that
+    mimics the real wrapped envelope shape.
+    """
+
+    def test_finds_real_genes_via_wrapped_response(self, module):
+        calls = []
+
+        def fake_call_tool(name, args):
+            calls.append((name, args))
+            if name == "HPA_search_genes_by_query":
+                return {
+                    "status": "success",
+                    "data": {
+                        "genes": [
+                            {"gene_name": "BCAS1", "ensembl_id": "ENSG00000064787"}
+                        ]
+                    },
+                }
+            return {"status": "success", "data": {}}
+
+        result = module.compose(
+            {"disease_condition": "breast cancer", "sample_type": "tissue"},
+            tooluniverse=None,
+            call_tool=fake_call_tool,
+        )
+
+        assert result["expression_data"]["genes_found"] == 1
+        assert result["expression_data"]["all_candidates"][0]["gene_name"] == "BCAS1"
+
+    def test_no_genes_found_is_reported_honestly_not_faked(self, module):
+        def fake_call_tool(name, args):
+            if name == "HPA_search_genes_by_query":
+                return {"status": "success", "data": {"genes": []}}
+            return {"status": "success", "data": {}}
+
+        result = module.compose(
+            {"disease_condition": "healthy aging", "sample_type": "blood"},
+            tooluniverse=None,
+            call_tool=fake_call_tool,
+        )
+
+        # Must not silently contain the old fallback genes.
+        expr = result["expression_data"]
+        assert expr.get("error") == "No genes found with any search strategy"
+        candidates = expr.get("all_candidates", [])
+        gene_names = {g.get("gene_name") for g in candidates}
+        assert not gene_names & {"BRCA1", "BRCA2", "TP53", "EGFR", "MYC"}

--- a/tests/unit/test_ctd_tool.py
+++ b/tests/unit/test_ctd_tool.py
@@ -94,13 +94,20 @@ def test_ctd_chemical_diseases_returns_normalised_edges(mock_get):
 
 @pytest.mark.unit
 def test_ctd_gene_disease_returns_redirect_error():
-    """Gene->disease has no live curated CTD source; must redirect callers."""
+    """Gene->disease has no live curated CTD source; must redirect callers.
+
+    Fix Round 12 / Feature-12A-3: the redirect previously pointed to
+    "OpenTargets_get_associated_diseases", which doesn't exist as a tool
+    name (confirmed via `tu run`) -- a dead end for anyone following the
+    suggestion. It now points to gather_gene_disease_associations, a real,
+    live aggregator tool (DisGeNET/OMIM/OpenTargets/GenCC/ClinVar).
+    """
 
     tool = make_ctd_tool(input_type="gene", report_type="diseases_curated")
     result = tool.run({"input_terms": "BRCA1"})
 
     assert result["status"] == "error"
-    assert "OpenTargets_get_associated_diseases" in result["suggestion"]
+    assert "gather_gene_disease_associations" in result["suggestion"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_openai_compatible_client.py
+++ b/tests/unit/test_openai_compatible_client.py
@@ -104,6 +104,37 @@ def test_openai_compatible_default_max_tokens_from_env(monkeypatch):
     assert FakeOpenAIClient.instances[0].completions.calls[0]["max_tokens"] == 123
 
 
+def test_openai_gpt5_model_drops_unsupported_temperature(monkeypatch):
+    """Regression guard for Fix Round 12 / Feature-12A-2: "gpt-5" is the
+    default model_id (see AgenticTool), and the real API rejects any
+    non-default temperature for this family with a 400 error ("Unsupported
+    value: 'temperature' does not support 0.2 with this model"). This was
+    already handled correctly for max-token routing
+    (_uses_max_completion_tokens already lists "gpt-5"), but
+    _normalize_temperature had fallen out of sync and still sent the
+    caller's temperature straight through, crashing every default-
+    configured LLM call site (e.g. BiomarkerDiscoveryWorkflow's literature
+    step) with 0 < temperature < 1.
+    """
+    client = OpenAICompatibleClient(
+        "gpt-5",
+        logger=SimpleNamespace(warning=lambda *_: None, error=lambda *_: None),
+    )
+
+    result = client.infer(
+        messages=[{"role": "user", "content": "ping"}],
+        temperature=0.2,
+        max_tokens=None,
+        return_json=False,
+        max_retries=1,
+        retry_delay=0,
+    )
+
+    assert result == "ok"
+    call = FakeOpenAIClient.instances[0].completions.calls[0]
+    assert "temperature" not in call
+
+
 def test_openai_reasoning_model_uses_completion_tokens(monkeypatch):
     monkeypatch.setenv("OPENAI_MAX_TOKENS_BY_MODEL", '{"o4-mini": 321}')
     client = OpenAICompatibleClient(

--- a/tests/unit/test_panelapp_client_side_search.py
+++ b/tests/unit/test_panelapp_client_side_search.py
@@ -26,6 +26,21 @@ _PANELS = [
     {"id": 3, "name": "Primary ovarian insufficiency", "disease_group": "Reproductive", "disease_sub_group": ""},
 ]
 
+_BLOOD_PANELS = [
+    {
+        "id": 1397,
+        "name": "Sickle cell, thalassaemia and other haemoglobinopathies",
+        "disease_group": "Haematology",
+        "disease_sub_group": "",
+    },
+    {
+        "id": 200,
+        "name": "Congenital myopathy",
+        "disease_group": "Neurology",
+        "disease_sub_group": "",
+    },
+]
+
 
 def _tool():
     return PanelAppSearchTool({"name": "panelapp_test", "fields": {}, "parameter": {}})
@@ -80,3 +95,32 @@ class TestClientSideSearchFiltering:
         tool = _tool()
         result = tool.run({})
         assert result["status"] == "error"
+
+
+class TestSingularPluralFuzzyMatch:
+    """Regression guard for Fix Round 12 / Feature-12C-1: a clinician
+    searching the singular disease term ("haemoglobinopathy") got zero
+    results because the panel is named in the plural
+    ("...haemoglobinopathies") and plain substring matching doesn't handle
+    inflection. The fuzzy fallback must catch this without over-matching
+    unrelated terms that happen to share a substring (e.g. "myopathy" is a
+    literal substring of "cardiomyopathy" but is a different topic).
+    """
+
+    def test_singular_query_matches_plural_panel_name(self):
+        tool = _tool()
+        with patch.object(tool.session, "get", return_value=_resp(_BLOOD_PANELS)):
+            result = tool.run({"search": "haemoglobinopathy"})
+
+        assert result["data"]["count"] == 1
+        assert "haemoglobinopathies" in result["data"]["results"][0]["name"].lower()
+
+    def test_does_not_over_match_unrelated_shared_substring(self):
+        # "myopathy" is a literal substring of "cardiomyopathy", but
+        # Congenital myopathy is not a relevant hit for a cardiomyopathy
+        # search -- containment alone must not be treated as a match.
+        tool = _tool()
+        with patch.object(tool.session, "get", return_value=_resp(_BLOOD_PANELS)):
+            result = tool.run({"search": "cardiomyopathy"})
+
+        assert result["data"]["count"] == 0


### PR DESCRIPTION
## Summary

Test-harness round driven by CLI-verified role-play across three domains not previously covered: geroscience/aging biology, endocrinology/metabolic-disease genetics, and hematology (inherited blood disorders).

- **AgingCohort_search**: relevance filtering matched almost the entire registry (29/30 cohorts) whenever a query contained just one near-universal word like "biomarker" or "study" -- a nonsense query was indistinguishable from a relevant one. Now requires a majority of meaningful query tokens to match.
- **OMIM_search**: returned full OMIM records (~700KB for one query) despite its own description promising a lightweight "MIM numbers, titles, and entry types" index. Now returns just that summary.
- **PanelApp_search_panels**: a clinician searching the singular disease name ("haemoglobinopathy") got zero results because the matching panel is named in the plural. Added a scoped fuzzy-prefix fallback (verified it does NOT over-match, e.g. "myopathy" no longer false-matches "cardiomyopathy"). Also improved description/empty-result guidance for disease names not covered by panel-level metadata.
- **CTD_get_gene_diseases**: its error-redirect suggestion pointed to a tool name that doesn't exist. Now points to `gather_gene_disease_associations`, a real working aggregator.
- **KEGG_get_drug_targets**: description claimed gene-symbol output and cited a wrong example; corrected to match actual behavior.
- **BiomarkerDiscoveryWorkflow**: every default-configured LLM call crashed with a temperature-unsupported error because the default model ("gpt-5") was missing from the reasoning-model classifier used for temperature normalization, even though the sibling max-tokens check already covered it -- consolidated both into one shared classifier. Also fixed the actual root cause of "no genes found for any disease": the HPA search step checked for a top-level `"genes"` key that `call_tool()` never returns at that level (it's nested under `"data"`), so it silently fell through to a hardcoded fallback of unrelated cancer genes with a false success indicator. Now it finds real genes for real disease queries, and reports an honest miss instead of fabricating data when there truly are none.

## Test plan
- [x] Reproduced every issue via `tu run`/`tu test` before fixing
- [x] 103 tests pass across all six touched modules (`tests/unit/test_panelapp_client_side_search.py`, `tests/test_aging_cohort_tool.py`, `tests/unit/test_ctd_tool.py`, `tests/unit/test_openai_compatible_client.py`, `tests/unit/test_biomarker_discovery_compose.py`, `tests/tools/test_omim_tool.py`, `tests/unit/test_gemini_client.py`), including new regression tests for each fix
- [x] `tu test` re-run on every changed tool (`PanelApp_search_panels`, `AgingCohort_search`, `OMIM_search`, `KEGG_get_drug_targets`, `CTD_get_gene_diseases`, `BiomarkerDiscoveryWorkflow`) to confirm no schema/behavior regressions
- [x] Broader unstaged regression pass (pytest across `tests/unit`, `tests/tools`, `tests/api`, minus pre-existing environment-level collection errors from an unrelated `numpy`/`onnxruntime` binary incompatibility affecting `markitdown`-dependent guideline tests) showed no failures attributable to this change