### PR TITLE
Fix Round 13: ClinicalTrials.gov intervention/sponsor relevance, DisGeNET noise/alias hints, GWAS trait note, DrugBank interaction bloat

### DIFF
--- a/src/tooluniverse/ctg_tool.py
+++ b/src/tooluniverse/ctg_tool.py
@@ -24,6 +24,28 @@ def _phrase_quote_if_plain(value: str) -> str:
     return value
 
 
+def _restrict_to_area(value: str, area: str) -> str:
+    """Fix-R13B-1: CTG API v2's Essie search engine treats a bare
+    query.intr/query.spons value as a match against the whole study
+    record (brief summaries, arm descriptions, eligibility text, etc.)
+    rather than restricting to the actual intervention-name or
+    lead-sponsor-name field, so a specific query like 'vedolizumab' or
+    'Takeda' surfaces completely unrelated trials -- confirmed live: an
+    oncology trial with no vedolizumab intervention ranked in the
+    query.intr top 5 (215 unrestricted hits vs. 134 once restricted, all
+    correctly containing the drug), and a Neurocrine/Shire-sponsored
+    trial ranked in the query.spons top 5 for 'Takeda' (1977 unrestricted
+    hits vs. 1022 once restricted, all correctly Takeda-sponsored).
+    Wrapping the value in Essie's AREA[<area>] operator (and
+    phrase-quoting multi-word values, same as _phrase_quote_if_plain)
+    fixes this -- but only for a plain value with no existing Essie
+    syntax, since advanced users may already supply their own
+    AREA/boolean operators."""
+    if _ESSIE_OPERATOR_RE.search(value):
+        return value
+    return f"AREA[{area}]{_phrase_quote_if_plain(value)}"
+
+
 @register_tool("ClinicalTrialsTool")
 class ClinicalTrialsTool(RESTfulTool):
     _BASE_URL = "https://clinicaltrials.gov/api/v2"
@@ -160,6 +182,13 @@ class ClinicalTrialsTool(RESTfulTool):
             return {"status": "success", **result}
         return result
 
+    # Essie fields that get restricted via AREA[<name>] rather than a plain
+    # value match (see _restrict_to_area). Keyed by the mapped API param name.
+    _AREA_RESTRICTED_FIELDS = {
+        "query.intr": "InterventionName",
+        "query.spons": "LeadSponsorName",
+    }
+
     def _run_search(self, arguments):
         """Handle search operations (search_studies, search_by_intervention, search_by_sponsor)."""
         import requests
@@ -211,10 +240,14 @@ class ClinicalTrialsTool(RESTfulTool):
                 advanced_clauses.append(study_type_clause)
             elif key in _SEARCH_PARAM_MAP:
                 mapped_key = _SEARCH_PARAM_MAP[key]
-                if mapped_key in ("query.cond", "query.intr") and isinstance(
+                if mapped_key == "query.cond" and isinstance(value, str):
+                    value = _phrase_quote_if_plain(value)
+                elif mapped_key in self._AREA_RESTRICTED_FIELDS and isinstance(
                     value, str
                 ):
-                    value = _phrase_quote_if_plain(value)
+                    value = _restrict_to_area(
+                        value, self._AREA_RESTRICTED_FIELDS[mapped_key]
+                    )
                 params[mapped_key] = value
 
         if advanced_clauses:

--- a/src/tooluniverse/disgenet_tool.py
+++ b/src/tooluniverse/disgenet_tool.py
@@ -27,6 +27,22 @@ DISGENET_API_URL = "https://api.disgenet.com/api/v1"
 # A disease passed as a bare UMLS CUI looks like "C0006142".
 _CUI_RE = re.compile(r"^C\d+$")
 
+# Fix-R13B-2: DisGeNET's /summary endpoints emit one "warning" per
+# *unset* optional filter param (e.g. "min_pli > The parameter value is
+# unspecified or not a double number."), regardless of whether the
+# caller ever intended to supply it. A plain gene-only query returns
+# ~30 of these alongside the one warning that's actually actionable
+# (the academic-key CURATED-sources-only note), burying it. These are
+# recognizable by their fixed "unspecified" phrasing and are dropped;
+# any other warning text (real data-quality notes) is kept.
+_UNSET_PARAM_WARNING_RE = re.compile(
+    r"is (?:empty / unspecified|unspecified or not an? [\w\s]+)\.?\s*$"
+)
+
+
+def _drop_unset_param_noise(warnings: List[str]) -> List[str]:
+    return [w for w in warnings if not _UNSET_PARAM_WARNING_RE.search(w)]
+
 
 @register_tool("DisGeNETTool")
 class DisGeNETTool(BaseTool):
@@ -94,7 +110,7 @@ class DisGeNETTool(BaseTool):
         response.raise_for_status()
         body = response.json()
         payload = body.get("payload") or []
-        warnings = body.get("warnings") or []
+        warnings = _drop_unset_param_noise(body.get("warnings") or [])
         return payload, warnings
 
     @staticmethod
@@ -222,6 +238,28 @@ class DisGeNETTool(BaseTool):
             arguments.get("min_score"),
             arguments.get("limit", self._declared_limit_default(25)),
         )
+        metadata: Dict[str, Any] = {
+            "source": "DisGeNET GDA",
+            "warnings": warnings,
+            "note": "Academic keys return CURATED sources only.",
+        }
+        # Fix-R13B-2: DisGeNET matches gene_symbol exactly, so a legacy/
+        # alias symbol (e.g. 'CARD15', the old official symbol for NOD2)
+        # silently returns an empty list with no hint that a symbol
+        # mismatch -- not a real absence of associations -- is the cause.
+        # Confirmed live: gene='CARD15' -> 0 associations, gene='NOD2' ->
+        # real Crohn/Blau-syndrome associations. We can't safely
+        # auto-resolve the alias ourselves (that needs a maintained
+        # gene-symbol synonym table we don't have), so just flag the
+        # ambiguity instead of leaving an empty result unexplained.
+        if gene and not rows and not gene.isdigit():
+            metadata["note"] += (
+                f" No associations found for gene symbol '{gene}'. DisGeNET "
+                "matches the current HGNC-approved symbol only, not older "
+                "aliases -- if this might be a legacy/alias symbol, resolve "
+                "it to its current official symbol first (e.g. via "
+                "NCBIGene_search_genes or HGNC) and retry."
+            )
         return {
             "status": "success",
             "data": {
@@ -230,11 +268,7 @@ class DisGeNETTool(BaseTool):
                 "associations": rows,
                 "count": len(rows),
             },
-            "metadata": {
-                "source": "DisGeNET GDA",
-                "warnings": warnings,
-                "note": "Academic keys return CURATED sources only.",
-            },
+            "metadata": metadata,
         }
 
     def _disease_genes(self, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/tooluniverse/gwas_tool.py
+++ b/src/tooluniverse/gwas_tool.py
@@ -152,11 +152,33 @@ class GWASRESTTool(BaseTool):
         # them was GWAS_search_associations_by_gene/gwas_get_snps_for_gene
         # (gene-based lookup), not a reworded trait string. Point to that
         # real fallback instead of a generic, non-adaptive example.
+        #
+        # Fix-R13C-1: GWAS Catalog's own trait-label search (used to
+        # resolve a plain-text disease_trait) isn't restricted to EFO --
+        # it also returns HPO/Orphanet/MONDO terms, and does no synonym
+        # expansion, so the exact current clinical term for a disease can
+        # resolve to a real-but-disconnected ontology term with zero
+        # tagged associations while an older/alternate synonym resolves
+        # to a term with real data. Confirmed live: "premature ovarian
+        # insufficiency" resolves to HP_0008209 (0 associations), but the
+        # older synonym "premature ovarian failure" resolves to
+        # MONDO_0005387 (9 real associations, e.g. PMID 21989058).
+        non_efo = not efo_id.upper().startswith("EFO")
+        ontology_hint = (
+            f" '{efo_id}' is not an EFO term (GWAS Catalog's trait search "
+            "also returns HPO/Orphanet/MONDO terms), and this ontology "
+            "does no synonym expansion, so it may resolve a current "
+            "clinical term to a real-but-disconnected entry."
+            if non_efo
+            else ""
+        )
         return (
-            f"No associations found for EFO ID '{efo_id}'. "
+            f"No associations found for EFO ID '{efo_id}'.{ontology_hint} "
             "GWAS Catalog may tag related associations under a different "
             "EFO/MONDO term, or under pleiotropic traits rather than this "
-            "specific one. If you know the gene of interest, try "
+            "specific one -- try an older/alternate clinical synonym of "
+            "the trait (e.g. an outdated but still-indexed name) if one "
+            "exists. If you know the gene of interest, try "
             "GWAS_search_associations_by_gene or gwas_get_snps_for_gene "
             "instead, which search by gene rather than by trait term."
         )

--- a/src/tooluniverse/xml_tool.py
+++ b/src/tooluniverse/xml_tool.py
@@ -4,6 +4,14 @@ from typing import List, Dict, Any, Optional, Set
 from .base_tool import BaseTool
 from .utils import download_from_hf
 from .tool_registry import register_tool
+from .logging_config import get_logger
+
+# Fix-R13B-4: dataset-load status was reported via print(), which writes
+# straight to stdout. Any caller piping a tool's raw stdout as JSON (e.g.
+# `tu run ... --raw` or a script parsing captured output) got this line
+# prepended ahead of the JSON payload and failed to parse it. Routing
+# through the logging module keeps it on stderr instead.
+logger = get_logger(__name__)
 
 
 @register_tool("XMLTool")
@@ -47,12 +55,14 @@ class XMLDatasetTool(BaseTool):
                 self.record_xpath, namespaces=self.namespaces
             )
 
-            print(
-                f"Loaded XML dataset: {len(self.records)} records from root '{self.xml_root.tag}'"
+            logger.info(
+                "Loaded XML dataset: %d records from root '%s'",
+                len(self.records),
+                self.xml_root.tag,
             )
 
         except Exception as e:
-            print(f"Error loading XML dataset: {e}")
+            logger.error("Error loading XML dataset: %s", e)
             self.records = []
 
     def _get_dataset_path(self) -> Optional[str]:
@@ -61,14 +71,28 @@ class XMLDatasetTool(BaseTool):
             result = download_from_hf(self.tool_config["settings"])
             if result.get("success"):
                 return result["local_path"]
-            print(f"Failed to download dataset: {result.get('error')}")
+            logger.error("Failed to download dataset: %s", result.get("error"))
             return None
 
         if "local_dataset_path" in self.tool_config["settings"]:
             return self.tool_config["settings"]["local_dataset_path"]
 
-        print("No dataset path provided in tool configuration")
+        logger.warning("No dataset path provided in tool configuration")
         return None
+
+    # Fix-R13B-4: a record's nested list field (e.g. DrugBank's
+    # interacting_drugs) has no size bound of its own -- the tool's `limit`
+    # parameter only caps how many *top-level matched records* come back,
+    # not the length of a list field inside one record. A well-connected
+    # drug like azathioprine has ~1286 documented interactions, so a
+    # single matched record (limit=5 had no effect, since only 1 record
+    # matched "azathioprine") produced an 80k+ token payload with the
+    # clinically critical interaction undifferentiated among hundreds of
+    # others. Capping nested list fields for display (while still using
+    # the untruncated list to build searchable text, so search matching
+    # is unaffected) keeps responses usable; the true count is preserved
+    # in a sibling `<field>_total_count` key so callers know more exist.
+    _NESTED_LIST_DISPLAY_CAP = 25
 
     def _extract_record_data(self, record_element: ET.Element) -> Dict[str, Any]:
         """Extract data from a record element with caching."""
@@ -95,9 +119,8 @@ class XMLDatasetTool(BaseTool):
                     if any(entry.values()):  # Only add entries with non-empty values
                         structured_list.append(entry)
 
-                data[field_name] = structured_list
-
-                # Flatten for search
+                # Flatten for search using the full, untruncated list so
+                # matching behavior doesn't change based on the display cap.
                 for sf_name, _ in subfields.items():
                     flat_key = f"{field_name}_{sf_name}"
 
@@ -107,6 +130,13 @@ class XMLDatasetTool(BaseTool):
                     )
 
                     self.temporary_record_fields.add(flat_key)
+
+                total_count = len(structured_list)
+                max_items = xpath_expr.get("max_items", self._NESTED_LIST_DISPLAY_CAP)
+                if max_items and total_count > max_items:
+                    data[f"{field_name}_total_count"] = total_count
+                    structured_list = structured_list[:max_items]
+                data[field_name] = structured_list
             else:
                 # Regular flat field extraction
                 data[field_name] = self._extract_field_value(record_element, xpath_expr)
@@ -363,16 +393,17 @@ class XMLDatasetTool(BaseTool):
         """Get the appropriate filter function for the condition."""
         filter_functions = {
             "contains": lambda data, field: value.lower() in str(data[field]).lower(),
-            "starts_with": lambda data, field: str(data[field])
-            .lower()
-            .startswith(value.lower()),
-            "ends_with": lambda data, field: str(data[field])
-            .lower()
-            .endswith(value.lower()),
+            "starts_with": lambda data, field: (
+                str(data[field]).lower().startswith(value.lower())
+            ),
+            "ends_with": lambda data, field: (
+                str(data[field]).lower().endswith(value.lower())
+            ),
             "exact": lambda data, field: str(data[field]).lower() == value.lower(),
             "not_empty": lambda data, field: str(data[field]).strip() != "",
-            "has_attribute": lambda data, field: field == "_attributes"
-            and value in data["_attributes"],
+            "has_attribute": lambda data, field: (
+                field == "_attributes" and value in data["_attributes"]
+            ),
         }
         return filter_functions.get(condition)
 

--- a/tests/unit/test_ctg_phrase_quoting.py
+++ b/tests/unit/test_ctg_phrase_quoting.py
@@ -14,6 +14,15 @@ aliases in the tool's Python code but undeclared in its JSON schema, so
 `tu info` didn't show them -- and once additionalProperties: false lands
 (a separate round-8 fix), these undocumented aliases would start being
 silently rejected as unrecognized properties.
+
+Fix-R13B-1: a bare query.intr/query.spons value (even phrase-quoted) is
+still matched by CTG API v2's Essie engine against the whole study
+record, not just the intervention-name/lead-sponsor-name field, so
+searching intervention="vedolizumab" surfaced an unrelated oncology
+trial with no vedolizumab intervention, and sponsor="Takeda" surfaced
+trials sponsored by Neurocrine Biosciences and Shire (confirmed live).
+Values are now wrapped in Essie's AREA[InterventionName] /
+AREA[LeadSponsorName] operators (still phrase-quoted when multi-word).
 """
 
 import json
@@ -22,7 +31,11 @@ from unittest.mock import MagicMock, patch
 import jsonschema
 import pytest
 
-from tooluniverse.ctg_tool import ClinicalTrialsTool, _phrase_quote_if_plain
+from tooluniverse.ctg_tool import (
+    ClinicalTrialsTool,
+    _phrase_quote_if_plain,
+    _restrict_to_area,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -62,6 +75,25 @@ def test_already_quoted_value_is_not_double_quoted():
     assert _phrase_quote_if_plain('"cervical cancer"') == '"cervical cancer"'
 
 
+def test_area_restricted_value_is_not_double_wrapped():
+    assert (
+        _restrict_to_area("AREA[InterventionName]nivolumab", "InterventionName")
+        == "AREA[InterventionName]nivolumab"
+    )
+
+
+def test_single_word_value_is_area_restricted_without_quotes():
+    assert _restrict_to_area("nivolumab", "InterventionName") == (
+        "AREA[InterventionName]nivolumab"
+    )
+
+
+def test_multiword_value_is_area_restricted_and_phrase_quoted():
+    assert _restrict_to_area("immunotherapy radiotherapy", "InterventionName") == (
+        'AREA[InterventionName]"immunotherapy radiotherapy"'
+    )
+
+
 def test_condition_and_intervention_are_quoted_in_live_request():
     tool = _tool()
     with patch("requests.get", return_value=_mock_response()) as mock_get:
@@ -75,7 +107,7 @@ def test_condition_and_intervention_are_quoted_in_live_request():
 
     params = mock_get.call_args.kwargs["params"]
     assert params["query.cond"] == '"cervical cancer"'
-    assert params["query.intr"] == '"immunotherapy radiotherapy"'
+    assert params["query.intr"] == 'AREA[InterventionName]"immunotherapy radiotherapy"'
 
 
 def test_sponsor_alias_maps_to_query_spons():
@@ -84,16 +116,18 @@ def test_sponsor_alias_maps_to_query_spons():
         tool.run({"sponsor": "National Cancer Institute"})
 
     params = mock_get.call_args.kwargs["params"]
-    assert params["query.spons"] == "National Cancer Institute"
+    assert params["query.spons"] == 'AREA[LeadSponsorName]"National Cancer Institute"'
 
 
 def test_schema_declares_intervention_and_sponsor():
     with open("src/tooluniverse/data/clinicaltrials_gov_tools.json") as f:
         tools = json.load(f)
-    schema = next(
-        t for t in tools if t["name"] == "ClinicalTrials_search_studies"
-    )["parameter"]
+    schema = next(t for t in tools if t["name"] == "ClinicalTrials_search_studies")[
+        "parameter"
+    ]
 
     assert "intervention" in schema["properties"]
     assert "sponsor" in schema["properties"]
-    jsonschema.validate({"condition": "hearing loss", "intervention": "gene therapy"}, schema)
+    jsonschema.validate(
+        {"condition": "hearing loss", "intervention": "gene therapy"}, schema
+    )


### PR DESCRIPTION
## Summary

Role-play sessions this round covered nephrology, gastroenterology, and reproductive-medicine/fertility-genetics research questions. Every reported issue was CLI-verified against live APIs before being queued; several reported issues turned out to be false positives (agent misreadings or expected upstream behavior) and were discarded.

### Verified and fixed

- **`ClinicalTrials_search_by_intervention` / `ClinicalTrials_search_by_sponsor`** (`src/tooluniverse/ctg_tool.py`): CTG API v2's Essie search engine matched `query.intr`/`query.spons` against the whole study record, not just the intervention-name/lead-sponsor-name field. Confirmed live: searching `intervention="vedolizumab"` surfaced an unrelated salivary-gland-carcinoma oncology trial in the top 5 (215 unrestricted hits vs. 134 once restricted to the field, all correctly containing the drug); `sponsor="Takeda"` surfaced Neurocrine Biosciences- and Shire-sponsored trials (1977 vs. 1022 once restricted). Both now wrap the value in Essie's `AREA[...]` operator, mirroring an existing fix already applied to `query.cond`.
- **`DisGeNET_search_gene`** (`src/tooluniverse/disgenet_tool.py`): the API emits one boilerplate "parameter unspecified" warning per unset optional filter (~30 for a plain gene query), burying the one actionable warning (an academic-key CURATED-sources-only note). Filtered out. Also, a legacy/alias gene symbol (e.g. `CARD15`, the old official symbol for `NOD2`) silently returned an empty association list with no indication a symbol mismatch, not an absence of data, was the cause; added an explanatory note (we can't safely auto-resolve the alias without a maintained synonym table, so we flag the ambiguity instead).
- **`gwas_get_variants_for_trait`** (`src/tooluniverse/gwas_tool.py`): confirmed live that "premature ovarian insufficiency" resolves to `HP_0008209` (an HPO term with 0 tagged associations) while the older synonym "premature ovarian failure" resolves to `MONDO_0005387` (9 real associations, e.g. PMID 21989058) — because GWAS Catalog's own trait-label search isn't restricted to EFO and does no synonym expansion. The empty-result note now explains this and suggests trying an older/alternate clinical synonym.
- **`drugbank_get_drug_interactions_by_drug_name_or_id`** and 5 sibling XMLTool-family tools (`src/tooluniverse/xml_tool.py`): a drug with many documented interactions (e.g. azathioprine, ~1286) produced an 80k+ token response regardless of the `limit` parameter, because `limit` only bounds top-level matched records, not a nested list field inside one record. Nested list fields are now capped for display (25 items) with the true count preserved in a `<field>_total_count` key; the untruncated list is still used to build searchable text so query matching is unaffected. Also moved a `print()` (dataset-load status) to the logger — it was writing straight to stdout ahead of any JSON payload, breaking naive parsing of piped/raw tool output.

### Reviewed but not changed (documented reasoning, not silently dropped)

- `find_tools` semantic search not surfacing DDI tools for a natural-language "check drug interaction" query — real discoverability gap, but fixing it well would mean touching the embedding/index pipeline, which is out of scope for a small, verifiable fix this round.
- FAERS/openFDA tool family using different drug-name parameter names (`medicinalproduct` vs `drug_name` vs `drug1`/`drug2`) — each wraps a genuinely different upstream endpoint shape; adding aliases across the family risks the "aliases that grow forever" anti-pattern without fixing the actual abstraction.
- `drugbank_get_drug_interactions_by_drug_name_or_id`'s parameter being named `query` when the tool name says "by_drug_name_or_id" — cosmetic (LOW severity), the actual error message when the wrong name is guessed already names the correct parameter.

## Test plan

- [x] `tu test` re-run on every changed tool (`ClinicalTrials_search_by_intervention`, `ClinicalTrials_search_by_sponsor`, `DisGeNET_search_gene`, `gwas_get_variants_for_trait`, and all 6 XMLTool-family drugbank tools sharing `xml_tool.py`) — all pass
- [x] Live CLI re-verification of each original repro case (vedolizumab/ustekinumab intervention search, Takeda sponsor search, CARD15/NOD2 gene lookup, premature ovarian insufficiency trait lookup, azathioprine interaction payload size + stdout cleanliness)
- [x] `pytest tests/unit/test_ctg_phrase_quoting.py tests/unit/test_ctg_tool.py tests/unit/test_ctg_phase_gate_with_status.py tests/unit/test_xml_tools_required_defaults.py tests/tools/test_disgenet_tool.py tests/unit/test_gwas_empty_result_note.py` and other gwas_* unit tests — all pass; two pre-existing tests (`test_condition_and_intervention_are_quoted_in_live_request`, `test_sponsor_alias_maps_to_query_spons`) asserted the old unrestricted-value behavior and were updated to match the new, verified-correct AREA-restricted behavior
- [x] `ruff check` / `ruff format` clean on all changed files
- [x] Full `pytest tests/` regression run — no new failures beyond a handful of pre-existing/environment-flaky ones (confirmed identical on unmodified `main`: an MCP-plugin doc-sync test, a subprocess-timeout test, and a `--refresh` flag assertion, plus two SDK-integration tests that time out at the default 60s under concurrent load but pass at 180s)