### PR TITLE
Fix Round 14: silent parameter mismatches across ChEMBL, OpenTargets, DisGeNET, GWAS, Monarch, ClinicalTrials.gov

### DIFF
--- a/src/tooluniverse/base_tool.py
+++ b/src/tooluniverse/base_tool.py
@@ -233,6 +233,34 @@ class BaseTool:
         )
         return norm_to_key[match[0]] if match else None
 
+    @classmethod
+    def _best_property_match(
+        cls, supplied_key: str, unset_props: list
+    ) -> Optional[str]:
+        """The inverse of ``_find_misspelled_key``: given one supplied key
+        that isn't a schema property, find which *unset* property it was
+        probably meant to be. Used when there are few unknown keys but many
+        optional schema properties (a filter-heavy search endpoint), so the
+        fuzzy match runs once per supplied key instead of once per schema
+        property."""
+        if not unset_props:
+            return None
+        target = supplied_key.lower()
+        for prop in unset_props:
+            if prop.lower() == target:
+                return prop
+        target_norm = cls._normalize_key(supplied_key)
+        for prop in unset_props:
+            if cls._normalize_key(prop) == target_norm:
+                return prop
+        import difflib
+
+        norm_to_prop = {cls._normalize_key(p): p for p in unset_props}
+        match = difflib.get_close_matches(
+            target_norm, list(norm_to_prop), n=1, cutoff=0.8
+        )
+        return norm_to_prop[match[0]] if match else None
+
     def validate_parameters(self, arguments: Dict[str, Any]) -> Optional[ToolError]:
         """
         Validate parameters against tool schema.
@@ -268,6 +296,71 @@ class BaseTool:
             }
 
             jsonschema.validate(filtered_arguments, schema)
+
+            # Feature-14A-01 / Feature-14B-01: jsonschema only rejects an
+            # unknown key when it causes a *required* property to end up
+            # missing. A tool whose schema has no required properties (a
+            # common "all filters optional" search endpoint) silently drops
+            # a misnamed parameter and falls back to its unfiltered default
+            # result -- which still looks like a relevant "success"
+            # response. Confirmed live two ways:
+            #  - ChEMBL_search_drugs({"drug_name": "baricitinib"}) returned
+            #    status=success with 20 unrelated drugs (its default page)
+            #    because the schema's only search parameter is "query", not
+            #    "drug_name" -- every supplied key was unrecognized.
+            #  - OpenTargets_get_evidence_by_datasource({"efoId": ...,
+            #    "ensemblId": ..., "datasourceId": "bogus"}) silently
+            #    ignored the singular "datasourceId" (real param is plural
+            #    "datasourceIds") and returned unfiltered evidence rows,
+            #    even though efoId/ensemblId were valid and recognized.
+            # Two checks, in order of confidence:
+            #  1. A near-miss of an *unset* schema property (same fuzzy
+            #     logic as the required-property "did you mean?" hint below)
+            #     is flagged regardless of what else was supplied -- it's a
+            #     typo, not intentional extra context.
+            #  2. If nothing was recognized at all, the whole parameter set
+            #     is almost certainly wrong even without a fuzzy near-miss.
+            # A caller mixing one valid key with an unrelated extra key
+            # (no near-miss, not a total mismatch) is left alone -- lower
+            # risk of being a genuine mistake, and flagging it risks
+            # rejecting legitimate pass-through/forward-compatible callers.
+            properties = schema.get("properties", {})
+            if properties and filtered_arguments:
+                unknown = self._unknown_keys(filtered_arguments, properties)
+                if unknown:
+                    unset_props = [p for p in properties if p not in filtered_arguments]
+                    # Match each *unknown supplied key* (typically 1-2) against
+                    # the unset schema properties (can be 30+ for a
+                    # filter-heavy endpoint), rather than the reverse -- same
+                    # result, but O(unknown) fuzzy-match calls instead of
+                    # O(unset schema properties).
+                    hints = [
+                        (key, match)
+                        for key in unknown
+                        if (match := self._best_property_match(key, unset_props))
+                        is not None
+                    ]
+                    if hints:
+                        hint_text = "; ".join(
+                            f"'{k}' — did you mean '{p}'?" for k, p in hints
+                        )
+                        return ToolValidationError(
+                            f"Unrecognized parameter(s): {hint_text}",
+                            details={
+                                "unknown_parameters": unknown,
+                                "valid_parameters": sorted(properties),
+                            },
+                        )
+                    if len(unknown) == len(filtered_arguments):
+                        return ToolValidationError(
+                            f"Unrecognized parameter(s): "
+                            f"{', '.join(repr(k) for k in unknown)}. "
+                            f"This tool accepts: {', '.join(sorted(properties))}.",
+                            details={
+                                "unknown_parameters": unknown,
+                                "valid_parameters": sorted(properties),
+                            },
+                        )
             return None
         except jsonschema.ValidationError as e:
             # Create a more agent-friendly error message
@@ -320,6 +413,49 @@ class BaseTool:
                                 f" (unrecognized parameter(s): "
                                 f"{', '.join(repr(k) for k in unknown)})"
                             )
+
+            # Feature-14B-02: a "oneOf: [{required: [a]}, {required: [b]}, ...]"
+            # schema (pick exactly one of several alternative search
+            # parameters) produces a bare, unhelpful "is not valid under any
+            # of the given schemas" when none of the alternatives are
+            # present -- unlike a plain "required" failure, e.path is empty
+            # and e.message names no specific property, so the typo-hint
+            # logic above never runs. Confirmed live:
+            # gwas_get_associations_for_trait({"trait": "narcolepsy"}) (the
+            # schema's alternatives are disease_trait/efo_uri/efo_id/
+            # efo_trait, not "trait") gave only "{'trait': 'narcolepsy'} is
+            # not valid under any of the given schemas" with no hint that
+            # "trait" isn't even a real parameter, let alone which
+            # alternative it was probably meant to be. Collect the
+            # alternative-required property names from the oneOf branches
+            # and reuse the same fuzzy "did you mean?" match.
+            if e.validator == "oneOf" and isinstance(filtered_arguments, dict):
+                alt_props = []
+                for branch in e.validator_value or []:
+                    alt_props.extend(branch.get("required", []))
+                for alt_prop in dict.fromkeys(alt_props):  # de-dup, keep order
+                    if alt_prop in filtered_arguments:
+                        continue
+                    wrong_key = self._find_misspelled_key(
+                        alt_prop,
+                        filtered_arguments,
+                        properties=schema.get("properties", {}),
+                    )
+                    if wrong_key is not None:
+                        error_msg += (
+                            f" (you passed '{wrong_key}' — did you mean '{alt_prop}'?)"
+                        )
+                        break
+                else:
+                    unknown = self._unknown_keys(
+                        filtered_arguments, schema.get("properties", {})
+                    )
+                    if unknown:
+                        error_msg += (
+                            f" (unrecognized parameter(s): "
+                            f"{', '.join(repr(k) for k in unknown)}; "
+                            f"provide one of: {', '.join(alt_props)})"
+                        )
 
             return ToolValidationError(
                 error_msg,

--- a/src/tooluniverse/ctg_tool.py
+++ b/src/tooluniverse/ctg_tool.py
@@ -535,6 +535,27 @@ class ClinicalTrialsSearchTool(ClinicalTrialsTool):
             endpoint_url=formatted_endpoint_url, variables=api_params
         )
 
+        # Feature-14C-02: this tool always applies a hardcoded phase>=2
+        # filter (see default_params_not_shown above), which silently
+        # excludes every NA-phase/observational study -- the exact bucket
+        # most genetics/epidemiology trials fall into. Confirmed live:
+        # condition="orofacial cleft" returns total_count=0 here, but the
+        # same query against the raw ClinicalTrials.gov v2 API (no phase
+        # filter) surfaces real matches such as NCT03065686 ("Genetic
+        # Factors Implicated in Orofacial Cleft"), which is phase "NA".
+        # A bare total_count=0 is indistinguishable from "no matching
+        # trials exist at all", so note the filter whenever it produced
+        # zero results.
+        phase_filter_applied = "PHASE2" in str(api_params.get("filter.advanced", ""))
+        phase_filter_note = (
+            "This search excludes phase-1-only, phase-NA, and observational "
+            "studies by default (see tool description). If you expected "
+            "results (e.g. for a genetics/epidemiology trial), the true "
+            "match count on ClinicalTrials.gov may be higher than 0 -- "
+            "consider searching https://clinicaltrials.gov/ directly for "
+            "NA-phase/observational studies."
+        )
+
         # Fix-Round3-002: a well-formed query that legitimately matches zero
         # trials (empty `studies` list) is a success, not the error below --
         # `execute_RESTful_query` already returns False for genuine failures
@@ -542,15 +563,24 @@ class ClinicalTrialsSearchTool(ClinicalTrialsTool):
         # a response missing "studies" entirely) is a real error.
         # _simplify_output handles an empty list fine on its own.
         if response is not None and response and "studies" in response.keys():
+            metadata = {"source": "ClinicalTrials.gov API v2"}
+            if phase_filter_applied and not response.get("studies"):
+                metadata["note"] = phase_filter_note
             return {
                 "status": "success",
                 "data": self._simplify_output(response),
-                "metadata": {"source": "ClinicalTrials.gov API v2"},
+                "metadata": metadata,
             }
 
+        error_msg = (
+            "No studies found for the given query parameters. "
+            "Please examine your input and try different parameters."
+        )
+        if phase_filter_applied:
+            error_msg += " " + phase_filter_note
         return {
             "status": "error",
-            "error": "No studies found for the given query parameters. Please examine your input and try different parameters.",
+            "error": error_msg,
         }
 
     def _simplify_output(self, response):

--- a/src/tooluniverse/data/opentarget_tools.json
+++ b/src/tooluniverse/data/opentarget_tools.json
@@ -461,7 +461,7 @@
                 "chemblId"
             ]
         },
-        "query_schema": "\n  query drugMechanismsOfAction($chemblId: String!) {\n    drug(chemblId: $chemblId) {\n      id\n      name\n      mechanismsOfAction {\n        rows {\n          mechanismOfAction\n          actionType\n         targetName\n          targets {\n            id\n            approvedSymbol\n          }\n        }\n      }\n    }\n  }\n  ",
+        "query_schema": "\n  query drugMechanismsOfAction($chemblId: String!) {\n    drug(chemblId: $chemblId) {\n      id\n      name\n      mechanismsOfAction {\n        rows {\n          mechanismOfAction\n          actionType\n         targetName\n          targets {\n            id\n            approvedSymbol\n          }\n          references {\n            source\n            urls\n          }\n        }\n      }\n    }\n  }\n  ",
         "label": [
             "Drug",
             "MechanismsOfAction",
@@ -519,6 +519,23 @@
                                                                 },
                                                                 "approvedSymbol": {
                                                                     "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "references": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "source": {
+                                                                    "type": "string"
+                                                                },
+                                                                "urls": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
                                                                 }
                                                             }
                                                         }

--- a/src/tooluniverse/disgenet_tool.py
+++ b/src/tooluniverse/disgenet_tool.py
@@ -80,6 +80,22 @@ class DisGeNETTool(BaseTool):
             return d
         return None
 
+    @staticmethod
+    def _cui_format_error(disease: str) -> Dict[str, Any]:
+        """Feature-14C-01: shared by every '{disease}' is not a UMLS CUI'
+        error path. 'C0006142' is a fixed format example (breast cancer),
+        never a resolution of the caller's own input -- state that
+        explicitly so it can't be mistaken for a dynamically-resolved CUI."""
+        return {
+            "status": "error",
+            "error": (
+                f"'{disease}' is not a UMLS CUI. Resolve '{disease}' to its "
+                f"own CUI via umls_search_concepts -- 'C0006142' (breast "
+                f"cancer) is only a format example and unrelated to "
+                f"'{disease}'."
+            ),
+        }
+
     def _query_summary(self, kind: str, query: Dict[str, Any]):
         """Call /{gda,vda}/summary with query params. Returns (payload, warnings).
         Raises requests exceptions on HTTP error (handled by callers)."""
@@ -204,10 +220,7 @@ class DisGeNETTool(BaseTool):
         if disease:
             code = self._normalize_disease(disease)
             if code is None:
-                return {
-                    "status": "error",
-                    "error": f"'{disease}' is not a UMLS CUI. Resolve the disease name to a CUI first (e.g. umls_search_concepts), then pass disease='C0152200'.",
-                }
+                return self._cui_format_error(disease)
             query["disease"] = code
         if arguments.get("source"):
             query["source"] = arguments["source"]
@@ -243,13 +256,13 @@ class DisGeNETTool(BaseTool):
         if not disease:
             return {
                 "status": "error",
-                "error": "Missing required parameter: disease (UMLS CUI, e.g. C0152200).",
+                "error": "Missing required parameter: disease (UMLS CUI, e.g. 'C0006142' for breast cancer -- an example format, not a default value).",
             }
         code = self._normalize_disease(disease)
         if code is None:
             return {
                 "status": "error",
-                "error": f"'{disease}' is not a UMLS CUI. Resolve the disease name to a CUI first (e.g. umls_search_concepts), then pass disease='C0152200'.",
+                "error": f"'{disease}' is not a UMLS CUI. Resolve '{disease}' to its own CUI via umls_search_concepts -- 'C0006142' (breast cancer) is only a format example and unrelated to '{disease}'.",
             }
 
         query: Dict[str, Any] = {"disease": code}

--- a/src/tooluniverse/restful_tool.py
+++ b/src/tooluniverse/restful_tool.py
@@ -67,6 +67,39 @@ class MonarchTool(RESTfulTool):
         for key in query_schema_runtime:
             if key in arguments:
                 query_schema_runtime[key] = arguments[key]
+
+        # Feature-14C-03: the /association endpoint's "subject"/"object"
+        # filters are CURIEs (e.g. "HGNC:11998"), never free-text gene/
+        # disease names -- but Monarch's API doesn't reject a bare symbol
+        # like "IRF6", it just matches nothing and returns an empty,
+        # status:success "total": 0 page that looks identical to a real
+        # "no associations for this gene" result. Confirmed live:
+        # Monarch_get_gene_diseases({"subject": "IRF6"}) silently returned
+        # total=0, while the correct CURIE HGNC:6121 returns 2 real
+        # associations. Only checked for params whose own schema
+        # description says "CURIE" (e.g. Monarch_get_gene_diseases,
+        # Monarch_get_gene_phenotypes) so tools where subject/object mean
+        # something else (e.g. free-text search) are unaffected.
+        properties = self.tool_config.get("parameter", {}).get("properties", {})
+        for curie_param in ("subject", "object"):
+            value = query_schema_runtime.get(curie_param)
+            if not isinstance(value, str) or not value.strip():
+                continue
+            description = properties.get(curie_param, {}).get("description", "")
+            if "CURIE" not in description:
+                continue
+            if ":" not in _normalize_curie(value):
+                return {
+                    "status": "error",
+                    "error": (
+                        f"'{value}' is not a CURIE for the '{curie_param}' "
+                        f"parameter. This tool requires a prefixed identifier "
+                        f"like 'HGNC:11998', not a plain gene/disease name. "
+                        f"Use Monarch_search_gene (or the relevant lookup "
+                        f"tool) to resolve '{value}' to its CURIE first."
+                    ),
+                }
+
         if "url_key" in query_schema_runtime:
             url_key_name = query_schema_runtime["url_key"]
             # Normalize an underscore ontology CURIE (HP_0000639) to the colon


### PR DESCRIPTION
## Summary

Role-play sessions this round covered rheumatology/autoimmune genetics, sleep medicine, and dental/oral health genetics research questions. Every reported issue was CLI-verified against live APIs before being queued.

Root cause shared by several findings: a tool whose JSON schema has no required properties (a common "all filters optional" search endpoint) lets `jsonschema.validate()` silently accept a misnamed parameter, since nothing forces a required-property check to fail. The caller gets a plausible-looking `status=success` response built from the tool's default/unfiltered query instead of an error naming the mistake.

### Verified and fixed

- **`BaseTool.validate_parameters()`** (`src/tooluniverse/base_tool.py`): now catches this class of bug for all ~2600 tools built on `BaseTool`. Two checks, added conservatively to avoid new false positives: (1) a near-miss of an unset schema property is flagged as a "did you mean?" hint regardless of what else was supplied; (2) if literally nothing supplied matches a real property, the tool's actual accepted parameter list is named. Confirmed live: `ChEMBL_search_drugs({"drug_name": "baricitinib"})` previously returned 20 unrelated drugs (its default page) because the only real parameter is `query`; `OpenTargets_get_evidence_by_datasource` silently ignored a singular `datasourceId` (real param is plural `datasourceIds`) even when mixed with otherwise-valid parameters. Also extended the existing "did you mean?" hint to `oneOf`-alternative schemas (e.g. `gwas_get_associations_for_trait`'s `disease_trait`/`efo_uri`/`efo_id`/`efo_trait`), which previously gave only a bare "not valid under any of the given schemas".
- **`restful_tool.py` (`MonarchTool`)**: `subject`/`object` parameters documented as CURIEs (e.g. `Monarch_get_gene_diseases`, `Monarch_get_gene_phenotypes`) now reject a bare gene/disease symbol instead of silently returning a `status=success, total=0` page indistinguishable from a genuine "no associations" result. Confirmed live: `Monarch_get_gene_diseases({"subject": "IRF6"})` returned `total=0`, but the correct CURIE `HGNC:6121` returns 2 real associations.
- **`disgenet_tool.py`**: `DisGeNET_search_disease`'s "not a UMLS CUI" error always suggested the identical placeholder CUI `C0152200` regardless of the input disease name, positioned right after echoing the user's own query — reading as a resolved answer rather than a generic example (and `C0152200` is Achromatopsia, unrelated to any of the diseases tested). Replaced with a consistent, explicitly-labeled example matching the tool's own description (`C0006142` for breast cancer), shared via one helper instead of three copies of the same string.
- **`opentarget_tools.json`** (`OpenTargets_get_drug_mechanisms_of_action_by_chemblId`): two evidence rows for the same drug/target/mechanism looked like exact duplicates because the query never requested the `references` field that actually distinguishes them (confirmed live for pitolisant: one row cites PubMed only, the other cites FDA + PubMed).
- **`ctg_tool.py`** (`search_clinical_trials`): the tool's hardcoded phase>=2 filter excludes NA-phase/observational studies — the bucket most genetics/epidemiology trials fall into — and a resulting `total_count=0` was indistinguishable from "no matching trials exist". Confirmed live: `condition="orofacial cleft"` returns 0 here despite real NA-phase matches (e.g. NCT03065686) existing on ClinicalTrials.gov. Added a note whenever the filter is the likely reason for a zero-result page.

### Reviewed but intentionally not changed this round

- `DisGeNET_search_gene`'s per-request "parameter unspecified" warning noise and the ClinicalTrials.gov intervention/sponsor `AREA[...]` restriction are already fixed on unmerged sibling PRs #485 and #483 (main hasn't absorbed them yet) — re-fixing here would only conflict on merge.
- `drugbank` `exact_match` grouping combination products under their parent drug, and Essie phrase-quoting stacking with the phase filter to collapse "non-syndromic cleft lip and palate" from 15 to 0 results, are both existing, deliberate tradeoffs from earlier rounds; changing them needs more validation than this round's time budget allows.
- Extending the `references`-field fix to two sibling OpenTargets tools (`get_known_drugs_by_drug_chemblId`, `get_associated_targets_by_drug_chemblId`) surfaced a larger, pre-existing `return_schema`/`query_schema` field mismatch in both — out of scope for this fix, flagged for a dedicated round.

## Test plan

- [x] Live CLI re-verification of every original repro case (ChEMBL_search_drugs, OpenTargets_get_evidence_by_datasource, gwas_get_associations_for_trait, Monarch_get_gene_diseases, DisGeNET_search_disease, search_clinical_trials, OpenTargets_get_drug_mechanisms_of_action_by_chemblId)
- [x] Targeted regression: 194 tests across `test_ux_error_hints_r3`, `test_parameter_validation`, additional-properties/optional-operation suites, DisGeNET, Monarch (CURIE normalization + result-id-prefix), ClinicalTrials.gov, and OpenTargets suites — all pass
- [x] `ruff check` / `ruff format --check` clean on all changed Python files
- [x] Independent tool-validator agent re-ran `tu info`/`tu run`/`tu test` smoke checks on all changed tools plus sibling Monarch tools whose params are *not* CURIE-gated (to confirm no regression) — pass