### PR TITLE
Fix Round 15: Ensembl species-default, Reactome/KEGG/NCBI non-human silent failures, FAERS rate-limit masking, PubMed/translate-id docs

### DIFF
--- a/plugin/commands/translate-id.md
+++ b/plugin/commands/translate-id.md
@@ -37,7 +37,7 @@ or pick gene by default and note the assumption.
 ### 2. Pick the resolver
 
 For genes/proteins:
-- HGNC symbol → all → `tu run mygene_query_genes '{"q":"<symbol>","species":"human"}'`
+- HGNC symbol → all → `tu run MyGene_query_genes '{"query":"<symbol>","species":"human"}'`
   (returns Ensembl, UniProt, RefSeq, NCBI Gene, MGI in one call)
 - Ensembl ID → all → `tu run ensembl_lookup_gene '{"gene_id":"<id>"}'`
 - UniProt → gene/Ensembl → `tu run UniProt_search '{"query":"<accession>","limit":1}'`

--- a/src/tooluniverse/data/fda_drug_adverse_event_tools.json
+++ b/src/tooluniverse/data/fda_drug_adverse_event_tools.json
@@ -1300,7 +1300,7 @@
   {
     "type": "FDACountAdditiveReactionsTool",
     "name": "FAERS_count_additive_adverse_reactions",
-    "description": "Aggregate adverse reaction counts across specified medicinal products. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, occurcountry, serious, seriousnessdeath) are optional. Use filters sparingly to avoid overly restrictive searches that return no results. Data source: FDA Adverse Event Reporting System (FAERS).",
+    "description": "Aggregate adverse reaction counts across specified medicinal products. Note: 'medicinalproducts' is combined with OR (union) -- counts are reports mentioning ANY listed product, not reports where all of them co-occur, so results for a multi-drug list can look nearly identical to the single most-reported drug's own counts. For co-occurrence/combination-risk analysis (e.g. checking two specific drugs taken together), use FAERS_search_reports_by_drug_combination (AND) or FAERS_calculate_disproportionality instead. Only medicinalproducts is required; all other filters (patientsex, patientagegroup, occurcountry, serious, seriousnessdeath) are optional. Use filters sparingly to avoid overly restrictive searches that return no results. Data source: FDA Adverse Event Reporting System (FAERS).",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/data/pubmed_tools.json
+++ b/src/tooluniverse/data/pubmed_tools.json
@@ -11,7 +11,7 @@
       "properties": {
         "query": {
           "type": "string",
-          "description": "Search query for PubMed articles. Use keywords, author names, journal names, or MeSH terms. Examples: 'cancer immunotherapy', 'Smith J[Author]', 'Nature[Journal]', 'diabetes[MeSH]'. Use AND/OR/NOT for complex queries."
+          "description": "Search query for PubMed articles. Use keywords, author names, journal names, or MeSH terms. Examples: 'cancer immunotherapy', 'Smith J[Author]', 'Nature[Journal]', 'diabetes[MeSH]'. Use AND/OR/NOT for complex queries. Note: PubMed ANDs every space-separated keyword by default, so a long, highly specific free-text query (5+ concepts) often returns 0 results even when relevant literature exists. Prefer 2-4 key concepts, add explicit OR for synonyms, or try EuropePMC_search_articles for broader relevance-ranked full-text search if this returns 0 results."
         },
         "limit": {
           "type": "integer",

--- a/src/tooluniverse/ensembl_tool.py
+++ b/src/tooluniverse/ensembl_tool.py
@@ -50,6 +50,18 @@ class EnsemblRESTTool(BaseTool):
     def run(self, arguments: dict):
         # 0. Apply schema defaults and parameter aliases for path params
         schema_props = self.tool_config.get("parameter", {}).get("properties", {})
+        # Fix-R15C-4: remember which params the caller actually supplied
+        # (before default-injection below) so the stable-ID branch can tell
+        # "user explicitly asked for homo_sapiens" apart from "species was
+        # silently defaulted to homo_sapiens because it's a path placeholder
+        # for the /lookup/symbol/{species}/{gene_id} route". Ensembl stable
+        # IDs (ENSG.../ENSBTAG.../etc.) are already species-specific, so
+        # /lookup/id/{gene_id} needs no species filter -- but forwarding an
+        # auto-defaulted species=homo_sapiens there makes Ensembl reject any
+        # non-human stable ID with a misleading "ID not found" (confirmed
+        # live for bovine ENSBTAG00000026356: works with no species param or
+        # species=cow, HTTP 400 "not found" with species=homo_sapiens).
+        explicitly_provided = set(arguments.keys())
         arguments = dict(arguments)
         # Inject schema defaults for any missing path parameters
         for path_key in re.findall(r"\{([^{}]+)\}", self.endpoint_template):
@@ -97,7 +109,10 @@ class EnsemblRESTTool(BaseTool):
                     url = f"{ENSEMBL_BASE_URL}/lookup/id/{gene_id}"
                     # Don't use expand=1 by default to avoid timeouts
                     query_params = {}
-                    if "species" in arguments:
+                    # Only forward species if the caller explicitly passed
+                    # it -- not when it was auto-defaulted for the (unused,
+                    # for stable IDs) /lookup/symbol/{species}/... route.
+                    if "species" in arguments and "species" in explicitly_provided:
                         query_params["species"] = arguments["species"]
                     if "expand" in arguments:
                         query_params["expand"] = arguments["expand"]

--- a/src/tooluniverse/faers_analytics_tool.py
+++ b/src/tooluniverse/faers_analytics_tool.py
@@ -112,21 +112,33 @@ class FAERSAnalyticsTool(BaseTool):
                 }
 
             # Get counts for 2x2 table
+            fetch_errors: list = []
             # a = drug + event
-            a = self._get_faers_count(drug_name, adverse_event)
+            a = self._get_faers_count(drug_name, adverse_event, errors=fetch_errors)
 
             # b = drug + no event (all drug reports - drug+event)
-            b = self._get_faers_count(drug_name, None) - a
+            b = self._get_faers_count(drug_name, None, errors=fetch_errors) - a
 
             # c = no drug + event (all event reports - drug+event)
-            c = self._get_faers_count(None, adverse_event) - a
+            c = self._get_faers_count(None, adverse_event, errors=fetch_errors) - a
 
             # d = no drug + no event (total - a - b - c)
-            total = self._get_faers_total_count()
+            total = self._get_faers_total_count(errors=fetch_errors)
             d = total - a - b - c
 
             # Check for valid counts
             if a <= 0 or b <= 0 or c <= 0 or d <= 0:
+                if fetch_errors:
+                    return {
+                        "status": "error",
+                        "error": (
+                            "Could not compute disproportionality: one or more openFDA "
+                            "requests failed, so counts default to 0 rather than "
+                            "reflecting real data. Underlying error(s): "
+                            + "; ".join(dict.fromkeys(fetch_errors))
+                        ),
+                        "contingency_table": {"a": a, "b": b, "c": c, "d": d},
+                    }
                 return {
                     "status": "error",
                     "error": f"Insufficient data: a={a}, b={b}, c={c}, d={d}. Need all counts > 0 for analysis.",
@@ -567,8 +579,26 @@ class FAERSAnalyticsTool(BaseTool):
 
     # Helper methods for statistical calculations
 
-    def _get_faers_count(self, drug_name: str = None, adverse_event: str = None) -> int:
-        """Get count of FAERS reports matching criteria."""
+    def _get_faers_count(
+        self,
+        drug_name: str = None,
+        adverse_event: str = None,
+        errors: list = None,
+    ) -> int:
+        """Get count of FAERS reports matching criteria.
+
+        Fix-R15B-5: a failed fetch (e.g. openFDA's HTTP 429 rate limit) was
+        silently treated the same as a genuine zero-count result, so
+        `_calculate_disproportionality` reported "Insufficient data: a=0,
+        b=0, c=0, d=0" for well-known drug/event pairs during a rate-limit
+        window -- indistinguishable from "this combination truly has no
+        FAERS reports". Confirmed live: retrying the exact same query after
+        the rate limit cleared returned correct nonzero counts and a real
+        ROR/PRR/IC signal. `errors` (when passed) collects the failure
+        reason so the caller can surface "API request failed" instead of a
+        misleading data-availability conclusion; existing callers that don't
+        pass it keep the prior silent-zero behavior unchanged.
+        """
         try:
             query_parts = []
             if drug_name:
@@ -591,12 +621,14 @@ class FAERSAnalyticsTool(BaseTool):
             data = response.json()
             return data.get("meta", {}).get("results", {}).get("total", 0)
 
-        except Exception:
+        except Exception as e:
+            if errors is not None:
+                errors.append(str(e))
             return 0
 
-    def _get_faers_total_count(self) -> int:
+    def _get_faers_total_count(self, errors: list = None) -> int:
         """Get total number of reports in FAERS database."""
-        return self._get_faers_count(None, None)
+        return self._get_faers_count(None, None, errors=errors)
 
     def _calculate_ror_ci(self, a: int, b: int, c: int, d: int) -> Dict[str, float]:
         """Calculate 95% confidence interval for ROR."""

--- a/src/tooluniverse/kegg_ext_tool.py
+++ b/src/tooluniverse/kegg_ext_tool.py
@@ -219,6 +219,32 @@ class KEGGExtTool(BaseTool):
                     "error": f"Could not resolve gene symbol '{gene_id}' to a KEGG gene ID for organism '{organism}'. Use KEGG format 'hsa:7157' directly, or verify the gene symbol.",
                 }
             gene_id = resolved
+        else:
+            # Fix-R15C-2: a caller can plausibly pass "org:SYMBOL" (e.g.
+            # "bta:DGAT1") by analogy with the documented "hsa:7157" format,
+            # assuming the part after the colon is a gene identifier of any
+            # kind. KEGG's numeric gene IDs are org-specific and don't match
+            # symbols, so link/pathway silently returns zero rows for a
+            # symbol -- confirmed live: "bta:DGAT1" -> pathway_count 0, while
+            # the equivalent gene_symbol="DGAT1", organism="bta" resolves to
+            # "bta:282609" and returns 4 real pathways. Detect this shape
+            # (non-numeric ID part) and resolve it the same way as the
+            # bare-symbol branch above, instead of returning a silently
+            # empty "no pathways" result that looks like a real negative.
+            org_prefix, _, id_part = gene_id.partition(":")
+            if id_part and not id_part.isdigit():
+                resolved = self._resolve_gene_symbol(id_part, org_prefix)
+                if not resolved:
+                    return {
+                        "status": "error",
+                        "error": (
+                            f"'{gene_id}' looks like 'organism:SYMBOL' rather than a KEGG "
+                            f"numeric gene ID, and '{id_part}' could not be resolved to one "
+                            f"for organism '{org_prefix}'. Use KEGG format '{org_prefix}:7157' "
+                            f"directly, or pass gene_symbol='{id_part}', organism='{org_prefix}'."
+                        ),
+                    }
+                gene_id = resolved
 
         # Get pathway links for this gene
         url = f"{KEGG_BASE_URL}/link/pathway/{gene_id}"

--- a/src/tooluniverse/ncbi_datasets_tool.py
+++ b/src/tooluniverse/ncbi_datasets_tool.py
@@ -288,15 +288,41 @@ class NCBIDatasetsTool(BaseTool):
 
         reports = result.get("reports", [])
         if not reports:
+            metadata = {
+                "total_results": 0,
+                "query_symbol": symbol,
+                "query_taxon": taxon,
+                "source": "NCBI Datasets API v2",
+            }
+            # Fix-R15C-1: NCBI returns HTTP 200 (not an error) for some
+            # unresolvable taxon tokens, but includes a "messages" warning
+            # explaining why -- e.g. taxon="cattle" gets
+            # gene_warning_code=ABOVE_SPECIES_TAXON ("belongs to a taxonomy
+            # level above species") instead of the "reports" the caller
+            # expects. Previously this warning was discarded, so a plain
+            # empty-success response was indistinguishable from "this gene
+            # genuinely has no match for this taxon" (confirmed: taxon="cow"
+            # succeeds with data, taxon="bovine" errors outright, and
+            # taxon="cattle" -- silently -- returns neither). Surface the
+            # warning so the caller can tell "bad taxon token" from "real
+            # zero-match".
+            api_messages = result.get("messages") or []
+            warnings = [
+                m["warning"]["message"]
+                for m in api_messages
+                if isinstance(m, dict) and m.get("warning", {}).get("message")
+            ]
+            if warnings:
+                metadata["warning"] = (
+                    " ".join(warnings)
+                    + " Try a more specific taxon (e.g. a species common name "
+                    "like 'cow' or 'pig' rather than a broader group name, "
+                    "or an NCBI Taxonomy ID)."
+                )
             return {
                 "status": "success",
                 "data": [],
-                "metadata": {
-                    "total_results": 0,
-                    "query_symbol": symbol,
-                    "query_taxon": taxon,
-                    "source": "NCBI Datasets API v2",
-                },
+                "metadata": metadata,
             }
 
         genes = []

--- a/src/tooluniverse/reactome_tool.py
+++ b/src/tooluniverse/reactome_tool.py
@@ -176,6 +176,35 @@ class ReactomeRESTTool(BaseTool):
 
         # 5. Check HTTP status code
         if resp.status_code != 200:
+            # Fix-R15C-3: for the /data/mapping/... "list everything linked
+            # to this identifier" endpoints, Reactome signals a genuine
+            # empty result (identifier exists but has no entries of the
+            # requested kind -- e.g. a non-human ortholog with no directly
+            # curated pathways) as HTTP 404 with reason=NOT_FOUND and a
+            # "No <things> found for <id>" message, not as a real error.
+            # Confirmed live for bovine DGAT1 (Q8MK44): mapping/pathways and
+            # mapping/reactions both 404 this way, while the human ortholog
+            # (O75907) succeeds with real data via the same endpoint. Treat
+            # that specific shape as an empty list so batch/automated
+            # pipelines get a normal empty result instead of a hard
+            # exception. Scoped to /data/mapping/ only -- single-entity
+            # lookups (e.g. /data/pathway/{stId}) should keep erroring on a
+            # bad ID rather than silently returning nothing.
+            if resp.status_code == 404 and "/data/mapping/" in self.endpoint_template:
+                try:
+                    body = resp.json()
+                except ValueError:
+                    body = {}
+                if body.get("reason") == "NOT_FOUND":
+                    return {
+                        "status": "success",
+                        "data": [],
+                        "metadata": {
+                            "note": (body.get("messages") or [None])[0]
+                            or "No results found.",
+                            "source": "Reactome Content Service",
+                        },
+                    }
             return {
                 "status": "error",
                 "error": f"Reactome API returned HTTP {resp.status_code}",


### PR DESCRIPTION
## Summary

Role-play testing across new personas this round (forensic genetics, pain-management/anesthesiology pharmacogenomics, agricultural/livestock breeding genomics) surfaced several places where a tool returns a plausible-looking wrong answer instead of a clear error -- worse than crashing outright because it looks like real data.

- **src/tooluniverse/ensembl_tool.py** (high severity): `EnsemblRESTTool` auto-defaulted `species=homo_sapiens` into query params even when routing a stable-ID lookup (`/lookup/id/{gene_id}`), which doesn't need a species filter since stable IDs are already species-specific. This silently broke every non-human Ensembl gene lookup chained from a symbol resolver (confirmed with bovine DGAT1, `ENSBTAG00000026356`) with a misleading "ID not found" error. Now only forwards `species` when the caller explicitly supplied it.
- **src/tooluniverse/reactome_tool.py**: Reactome's `/data/mapping/` endpoints return HTTP 404 `NOT_FOUND` as their genuine "nothing found for this identifier" signal, which the tool treated as a hard error instead of an empty result -- breaking pathway/reaction lookups for non-human protein orthologs with no directly curated Reactome entries.
- **src/tooluniverse/kegg_ext_tool.py**: `KEGG_get_gene_pathways` silently returned an empty pathway list (indistinguishable from a real negative) when `gene_id` was passed as `"org:SYMBOL"` (e.g. `"bta:DGAT1"`) rather than KEGG's numeric ID form. Now resolves the symbol the same way the no-colon path already did.
- **src/tooluniverse/ncbi_datasets_tool.py**: `NCBIDatasets_get_gene_by_symbol` returned a silent empty success for taxon tokens NCBI itself flags as ambiguous (e.g. `"cattle"` resolves above species level), with no way to tell that apart from a genuine zero-match. Now surfaces NCBI's own warning message.
- **src/tooluniverse/faers_analytics_tool.py**: `FAERS_calculate_disproportionality`'s internal count fetcher swallowed all exceptions -- including HTTP 429 rate limits -- and returned 0, so a rate-limited window produced `"Insufficient data: a=0, b=0, c=0, d=0"` for well-known drug/event pairs instead of surfacing the real upstream failure.
- **src/tooluniverse/data/fda_drug_adverse_event_tools.json**: documented that `FAERS_count_additive_adverse_reactions` combines multiple `medicinalproducts` with OR (union), not AND (co-occurrence) -- intentional aggregation behavior, but easily misread as combination-risk counting since a sibling tool uses AND semantics for the same-shaped input.
- **src/tooluniverse/data/pubmed_tools.json**: documented that PubMed's esearch ANDs every keyword by default, so a realistic multi-concept query silently returns 0 results even when relevant literature exists (confirmed live: an 11-word query returned 0 on PubMed but multiple relevant hits on EuropePMC for the same string).
- **plugin/commands/translate-id.md**: the skill's own worked example used the wrong tool name casing (`mygene_query_genes`) and parameter name (`q`), so following its instructions literally failed immediately. Fixed to `MyGene_query_genes` / `query`.

Checked all 9 other currently-open round PRs (#478-486) for overlap before fixing anything; skipped one duplicate (DrugBank interaction-list bloat, already covered by round 13's PR #485).

## Test plan

- [x] Every fix reproduced live against the real upstream API (Ensembl, Reactome, KEGG, NCBI Datasets, openFDA, PubMed/EuropePMC), several cross-checked via raw `curl`
- [x] Shipped `test_examples` still pass for every touched tool (`tu test <tool>`)
- [x] Targeted regression suite covering Ensembl/Reactome/KEGG/NCBI-Datasets/FAERS/PubMed: 103 passed, 0 failed
- [x] Confirmed no regression on the human/default-case path for each fix (e.g. human Ensembl stable ID, human Reactome mapping, `hsa:` KEGG IDs, `taxon="human"`, non-rate-limited FAERS calls)