### PR TITLE
Fix Round 16: OpenAlex year-filter aliases, DisGeNET warning noise, CPIC drug names

### DIFF
--- a/src/tooluniverse/data/cpic_tools.json
+++ b/src/tooluniverse/data/cpic_tools.json
@@ -844,7 +844,7 @@
       "additionalProperties": false
     },
     "fields": {
-      "endpoint": "https://api.cpicpgx.org/v1/pair?select=genesymbol,drugid,cpiclevel,guidelineid,usedforrecommendation,clinpgxlevel,pgxtesting"
+      "endpoint": "https://api.cpicpgx.org/v1/pair?select=genesymbol,drugid,cpiclevel,guidelineid,usedforrecommendation,clinpgxlevel,pgxtesting,drug(name)"
     },
     "type": "CPICSearchPairsTool",
     "test_examples": [
@@ -894,6 +894,18 @@
                   "null",
                   "string"
                 ]
+              },
+              "drug": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "description": "The drug's generic name, embedded via CPIC's PostgREST resource-embedding join on drugid (e.g. {\"name\": \"codeine\"}) so callers don't need a separate RxNorm lookup just to identify which drug a row is about.",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }

--- a/src/tooluniverse/data/openalex_tools.json
+++ b/src/tooluniverse/data/openalex_tools.json
@@ -39,13 +39,27 @@
           "minimum": 1,
           "maximum": 200
         },
+        "num_results": {
+          "type": "integer",
+          "description": "Alias for `max_results` (OpenAlex max 200).",
+          "minimum": 1,
+          "maximum": 200
+        },
         "year_from": {
           "type": "integer",
           "description": "Start year for publication date filter (e.g., 2020). Optional parameter to limit search to papers published from this year onwards."
         },
+        "start_year": {
+          "type": "integer",
+          "description": "Alias for `year_from`."
+        },
         "year_to": {
           "type": "integer",
           "description": "End year for publication date filter (e.g., 2023). Optional parameter to limit search to papers published up to this year."
+        },
+        "end_year": {
+          "type": "integer",
+          "description": "Alias for `year_to`."
         },
         "open_access": {
           "type": "boolean",

--- a/src/tooluniverse/disgenet_tool.py
+++ b/src/tooluniverse/disgenet_tool.py
@@ -94,7 +94,21 @@ class DisGeNETTool(BaseTool):
         response.raise_for_status()
         body = response.json()
         payload = body.get("payload") or []
-        warnings = body.get("warnings") or []
+        # Fix Round 16: DisGeNET's API echoes one boilerplate "is empty /
+        # unspecified" warning for every *optional* filter param the caller
+        # didn't set -- confirmed live a plain gene lookup with no filters
+        # returned 30+ such lines (one per unset param), drowning out the
+        # one warning that's actually actionable (e.g. the academic-role
+        # source restriction). These add no signal since they just restate
+        # "you didn't set this optional filter", so drop them and keep only
+        # warnings that don't match that boilerplate shape.
+        raw_warnings = body.get("warnings") or []
+        warnings = [
+            w
+            for w in raw_warnings
+            if "is empty / unspecified" not in w
+            and "is unspecified or not a" not in w
+        ]
         return payload, warnings
 
     @staticmethod

--- a/src/tooluniverse/openalex_tool.py
+++ b/src/tooluniverse/openalex_tool.py
@@ -40,9 +40,20 @@ class OpenAlexTool(BaseTool):
                 "status": "error",
                 "error": "`search_keywords` (or `query`) parameter is required and must be non-empty.",
             }
-        max_results = arguments.get("max_results", arguments.get("limit", 10))
-        year_from = arguments.get("year_from", None)
-        year_to = arguments.get("year_to", None)
+        # Fix Round 16: the schema has no `additionalProperties: false`, so a
+        # plausible-but-wrong param name (confirmed live: `num_results` and
+        # `start_year`, both natural guesses given other ToolUniverse
+        # literature tools use those exact names) was silently dropped by
+        # jsonschema and the call fell back to defaults/unfiltered results
+        # with no error -- a caller asking for "papers since 2023" got
+        # 2011/2018 papers back with no indication the year filter never
+        # applied. Accept the same common variants already covered for
+        # search_keywords/max_results above.
+        max_results = arguments.get(
+            "max_results", arguments.get("limit", arguments.get("num_results", 10))
+        )
+        year_from = arguments.get("year_from", arguments.get("start_year", None))
+        year_to = arguments.get("year_to", arguments.get("end_year", None))
         open_access = arguments.get("open_access", None)
         require_has_fulltext = bool(arguments.get("require_has_fulltext", False))
         fulltext_terms = arguments.get("fulltext_terms")


### PR DESCRIPTION
## Summary

Role-play by an ophthalmology-genetics persona and a sports-medicine/exercise-genomics persona surfaced three verified issues, each confirmed live via `tu run` before and after the fix:

- **`openalex_literature_search`** silently dropped `num_results`/`start_year`/`end_year` (plausible param names matching other ToolUniverse literature tools) because the schema has no `additionalProperties: false` — a year-filtered query silently fell back to unfiltered/default results with no error, so a caller asking for "papers since 2023" got 2011/2018 results back with no indication the filter never applied. Added these as explicit aliases (same pattern already used for `search_keywords`/`query` and `max_results`/`limit` in this tool).
- **`DisGeNET_search_gene`** (and every DisGeNET tool sharing `_query_summary`) echoed 30+ boilerplate `"is empty / unspecified"` warnings from the upstream API, one per optional filter the caller didn't set, burying the one warning that's actually actionable (e.g. the academic-key source restriction). Filtered these out at the shared helper.
- **`CPIC_search_gene_drug_pairs`** returned only RxNorm drug IDs (`"drugid": "RxNorm:38400"`) with no drug name, forcing a separate RxNorm round-trip per row — even though CPIC's own PostgREST API can embed the name via `select=...,drug(name)`, the same pattern already used by the sibling `CPIC_get_gene_drug_pairs` tool in this same file.

### Already covered by other open PRs (not duplicated here)

Several other persona-reported issues were checked against the file lists/diffs of the other 10 open sibling PRs and confirmed already fixed there:
- `ClinicalTrials_search_studies` "operation" validation failure -> PR #483
- `annotate_variant_multi_source` empty UniProt `function` field -> PR #483
- DrugBank `interacting_drugs` unbounded nested list -> PR #485
- `DisGeNET_search_disease` wrong-CUI-example error message -> PR #486
- `gwas_search_snps` silently ignoring an unrecognized `query` param -> will be covered by PR #486's systemic unknown-parameter validation once merged (traced through the logic: this specific case, where every supplied key is unrecognized, hits that PR's `len(unknown) == len(filtered_arguments)` branch)

`fda_pharmacogenomic_biomarkers` returning no tacrolimus/CYP3A5 row was checked against the live FDA source table (676 records) and confirmed to be a genuine data gap on FDA's own table, not a tool defect — not fixed.

## Test plan
- [x] `tu test openalex_literature_search` — passes
- [x] `tu test CPIC_search_gene_drug_pairs` — passes (2/2 examples)
- [x] `tu test DisGeNET_search_gene` — passes
- [x] `tu run openalex_literature_search '{"query": "retinitis pigmentosa genetics review", "num_results": 5, "start_year": 2023}'` — now correctly returns 2023+ papers (previously returned unfiltered 2011/2018 results)
- [x] `tu run DisGeNET_search_gene '{"gene":"HLA-DRB1","limit":5}'` — warnings array now contains only the actionable academic-role note, not 30+ boilerplate lines
- [x] `tu run CPIC_search_gene_drug_pairs '{"genesymbol": "CYP2D6", "limit": 5}'` — each row now includes `"drug": {"name": "..."}`