### PR TITLE
Fix Round 17: FAERS rate-limit handling, OpenTargets search overconfidence, GraphQL/XML tool clarity

### DIFF
--- a/src/tooluniverse/data/fda_drug_adverse_event_detail_tools.json
+++ b/src/tooluniverse/data/fda_drug_adverse_event_detail_tools.json
@@ -263,7 +263,7 @@
         },
         "reactionmeddrapt": {
           "type": "string",
-          "description": "MedDRA preferred term for the adverse reaction (required). Example: 'INFUSION RELATED REACTION', 'DYSPNOEA'."
+          "description": "MedDRA preferred term for the adverse reaction (required). Example: 'INFUSION RELATED REACTION', 'DYSPNOEA'. Must be the exact MedDRA Preferred Term FAERS uses, not a clinical description or synonym -- e.g. 'NEPHROTOXICITY' matches nothing, the real terms are 'ACUTE KIDNEY INJURY' or 'RENAL IMPAIRMENT'. A non-matching term returns an empty result (not an error), which looks identical to a genuine zero-report finding. If unsure of the exact term, call FAERS_count_reactions_by_drug_event first (with just medicinalproduct) to list the actual MedDRA terms reported for that drug."
         },
         "limit": {
           "type": "integer",

--- a/src/tooluniverse/data/idmap_tools.json
+++ b/src/tooluniverse/data/idmap_tools.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "OpenTargets_get_disease_ids_by_name",
-    "description": "Given a disease or phenotype name, find all cross-referenced external IDs (e.g., OMIM, MONDO, MeSH, ICD10, UMLS, MedDRA, NCIt, Orphanet) using Open Targets GraphQL API.",
+    "description": "Given a disease or phenotype name, find candidate diseases and their cross-referenced external IDs (e.g., OMIM, MONDO, MeSH, ICD10, UMLS, MedDRA, NCIt, Orphanet) using Open Targets GraphQL full-text search. Returns up to 5 ranked candidates, not a single guaranteed match -- OpenTargets' relevance ranking can surface an unrelated top hit for multi-word or qualified phrasing (e.g. 'localized prostate cancer' or 'high-risk prostate cancer' rank an unrelated disease/trait above 'prostate cancer' itself). Always check each hit's 'name' against the disease you intended before using its dbXRefs; prefer a plain, unqualified disease name (e.g. 'prostate cancer' rather than 'localized prostate cancer') if the top hit's name looks wrong.",
     "label": [
       "Disease",
       "Phenotype",
@@ -22,7 +22,7 @@
         "name"
       ]
     },
-    "query_schema": "query getDiseaseDbXRefsByName($name: String!) {\n  search(queryString: $name, entityNames: [\"disease\"], page: { index: 0, size: 1 }) {\n    hits {\n      id\n      name\n      object {\n        ... on Disease {\n          id\n          name\n          dbXRefs\n        }\n      }\n    }\n  }\n}",
+    "query_schema": "query getDiseaseDbXRefsByName($name: String!) {\n  search(queryString: $name, entityNames: [\"disease\"], page: { index: 0, size: 5 }) {\n    hits {\n      id\n      name\n      score\n      object {\n        ... on Disease {\n          id\n          name\n          dbXRefs\n        }\n      }\n    }\n  }\n}",
     "type": "OpenTarget",
     "test_examples": [
       {
@@ -48,6 +48,10 @@
                       },
                       "name": {
                         "type": "string"
+                      },
+                      "score": {
+                        "type": "number",
+                        "description": "Open Targets' own relevance score for this candidate, in the order it was ranked. Not comparable across different queries -- use it only to judge whether the top hit clearly dominates the rest, not as an absolute confidence value."
                       },
                       "object": {
                         "type": "object",

--- a/src/tooluniverse/faers_analytics_tool.py
+++ b/src/tooluniverse/faers_analytics_tool.py
@@ -1,9 +1,11 @@
 # faers_analytics_tool.py
 
+import os
 import requests
 import math
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Optional
 from .base_tool import BaseTool
+from .http_utils import request_with_retry
 from .tool_registry import register_tool
 
 FDA_BASE_URL = "https://api.fda.gov/drug/event.json"
@@ -27,6 +29,7 @@ class FAERSAnalyticsTool(BaseTool):
         super().__init__(tool_config)
         self.parameter = tool_config.get("parameter", {})
         self.required = self.parameter.get("required", [])
+        self.api_key = os.getenv("FDA_API_KEY")
 
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Route to analytics operation."""
@@ -74,6 +77,15 @@ class FAERSAnalyticsTool(BaseTool):
 
         return self._with_data_payload(operation_result)
 
+    def _with_api_key(self, url: str) -> str:
+        """Append FDA_API_KEY (if set) to an openFDA request URL -- reduces
+        how often the anonymous tier's low rate limit is hit (see
+        _get_faers_count)."""
+        if self.api_key:
+            separator = "&" if "?" in url else "?"
+            return f"{url}{separator}api_key={self.api_key}"
+        return url
+
     def _with_data_payload(self, result: Dict[str, Any]) -> Dict[str, Any]:
         """Ensure successful operation responses include a standardized data wrapper."""
         if not isinstance(result, dict):
@@ -111,18 +123,33 @@ class FAERSAnalyticsTool(BaseTool):
                     "error": "Must provide drug_name and adverse_event",
                 }
 
-            # Get counts for 2x2 table
-            # a = drug + event
+            # Get counts for 2x2 table. Each call is Optional[int]: None means
+            # the openFDA request itself failed (e.g. rate limited), which
+            # must not be treated as a genuine zero count -- see
+            # _get_faers_count.
             a = self._get_faers_count(drug_name, adverse_event)
+            drug_total = self._get_faers_count(drug_name, None)
+            event_total = self._get_faers_count(None, adverse_event)
+            total = self._get_faers_total_count()
+
+            if None in (a, drug_total, event_total, total):
+                return {
+                    "status": "error",
+                    "error": (
+                        "One or more openFDA FAERS count queries failed "
+                        "(commonly HTTP 429 rate limiting on the anonymous "
+                        "tier), so a disproportionality analysis cannot be "
+                        "computed right now. Retry in a moment, or set the "
+                        "FDA_API_KEY environment variable to raise the rate "
+                        "limit (https://open.fda.gov/apis/authentication/)."
+                    ),
+                }
 
             # b = drug + no event (all drug reports - drug+event)
-            b = self._get_faers_count(drug_name, None) - a
-
+            b = drug_total - a
             # c = no drug + event (all event reports - drug+event)
-            c = self._get_faers_count(None, adverse_event) - a
-
+            c = event_total - a
             # d = no drug + no event (total - a - b - c)
-            total = self._get_faers_total_count()
             d = total - a - b - c
 
             # Check for valid counts
@@ -237,9 +264,9 @@ class FAERSAnalyticsTool(BaseTool):
             else:
                 base_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
 
-            url = f"{FDA_BASE_URL}?search={base_query}&count={count_field}"
+            url = self._with_api_key(f"{FDA_BASE_URL}?search={base_query}&count={count_field}")
 
-            response = requests.get(url, timeout=30)
+            response = request_with_retry(requests, "GET", url, timeout=30)
             response.raise_for_status()
 
             data = response.json()
@@ -330,17 +357,19 @@ class FAERSAnalyticsTool(BaseTool):
             search_query = base_query + seriousness_map[seriousness_type]
 
             # Get top reactions for serious events
-            url = f"{FDA_BASE_URL}?search={search_query}&count=patient.reaction.reactionmeddrapt.exact"
+            url = self._with_api_key(
+                f"{FDA_BASE_URL}?search={search_query}&count=patient.reaction.reactionmeddrapt.exact"
+            )
 
-            response = requests.get(url, timeout=30)
+            response = request_with_retry(requests, "GET", url, timeout=30)
             response.raise_for_status()
 
             data = response.json()
             results = data.get("results", [])
 
             # Get total serious event count
-            total_url = f"{FDA_BASE_URL}?search={search_query}&limit=1"
-            total_response = requests.get(total_url, timeout=30)
+            total_url = self._with_api_key(f"{FDA_BASE_URL}?search={search_query}&limit=1")
+            total_response = request_with_retry(requests, "GET", total_url, timeout=30)
             total_data = total_response.json()
             total_serious = (
                 total_data.get("meta", {}).get("results", {}).get("total", 0)
@@ -460,9 +489,9 @@ class FAERSAnalyticsTool(BaseTool):
                 search_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
 
             # Get counts by receive date (year)
-            url = f"{FDA_BASE_URL}?search={search_query}&count=receivedate"
+            url = self._with_api_key(f"{FDA_BASE_URL}?search={search_query}&count=receivedate")
 
-            response = requests.get(url, timeout=30)
+            response = request_with_retry(requests, "GET", url, timeout=30)
             response.raise_for_status()
 
             data = response.json()
@@ -530,9 +559,11 @@ class FAERSAnalyticsTool(BaseTool):
 
             # Get preferred term (PT) level reactions
             search_query = f'patient.drug.openfda.generic_name:"{drug_name}"'
-            url = f"{FDA_BASE_URL}?search={search_query}&count=patient.reaction.reactionmeddrapt.exact"
+            url = self._with_api_key(
+                f"{FDA_BASE_URL}?search={search_query}&count=patient.reaction.reactionmeddrapt.exact"
+            )
 
-            response = requests.get(url, timeout=30)
+            response = request_with_retry(requests, "GET", url, timeout=30)
             response.raise_for_status()
 
             data = response.json()
@@ -567,8 +598,15 @@ class FAERSAnalyticsTool(BaseTool):
 
     # Helper methods for statistical calculations
 
-    def _get_faers_count(self, drug_name: str = None, adverse_event: str = None) -> int:
-        """Get count of FAERS reports matching criteria."""
+    def _get_faers_count(
+        self, drug_name: str = None, adverse_event: str = None
+    ) -> Optional[int]:
+        """Get count of FAERS reports matching criteria.
+
+        Returns None (not 0) if the request fails (e.g. rate limited or a
+        network error), so a failure isn't mistaken for a genuine zero
+        count. Callers must check for None before doing arithmetic.
+        """
         try:
             query_parts = []
             if drug_name:
@@ -585,16 +623,21 @@ class FAERSAnalyticsTool(BaseTool):
                 search_query = "+AND+".join(query_parts)
                 url = f"{FDA_BASE_URL}?search={search_query}&limit=1"
 
-            response = requests.get(url, timeout=30)
+            url = self._with_api_key(url)
+
+            response = request_with_retry(requests, "GET", url, timeout=30)
+            if response.status_code == 404:
+                # openFDA returns 404 (not an empty 200) for a query with no matches.
+                return 0
             response.raise_for_status()
 
             data = response.json()
             return data.get("meta", {}).get("results", {}).get("total", 0)
 
         except Exception:
-            return 0
+            return None
 
-    def _get_faers_total_count(self) -> int:
+    def _get_faers_total_count(self) -> Optional[int]:
         """Get total number of reports in FAERS database."""
         return self._get_faers_count(None, None)
 

--- a/src/tooluniverse/graphql_tool.py
+++ b/src/tooluniverse/graphql_tool.py
@@ -131,7 +131,25 @@ class GraphQLTool(BaseTool):
         # ({"search": {}}) and is therefore not caught here.
         if not data:
             return {"status": "error", "error": self._empty_result_error(arguments)}
-        return {"status": "success", "data": data}
+        result = {"status": "success", "data": data}
+        # Fix Round 17: for a search(...)-shaped query, the same stripping
+        # collapses a genuine 0-hit result down to an opaque empty container
+        # ({"search": {}}) once its "hits": [] list is removed -- indistinguishable
+        # from a malformed/broken response without reading this source file.
+        # Confirmed live: OpenTargets_get_disease_ids_by_name with
+        # "high-risk prostate cancer" returns status=success, data={"search": {}},
+        # with no indication that this means zero matches. Only fires for queries
+        # that actually declare a "hits" field, so entity-lookup tools (which
+        # legitimately return smaller nested objects) are unaffected.
+        if "hits" in self.query_schema:
+            empty_key = next((k for k, v in data.items() if v == {}), None)
+            if empty_key:
+                result.setdefault("metadata", {})["note"] = (
+                    f"0 matches found (empty '{empty_key}' result). This is a "
+                    "genuine zero-hit search, not an error -- try a shorter or "
+                    "simpler phrasing of the search term."
+                )
+        return result
 
 
 _OT_SEARCH_QUERY = """

--- a/src/tooluniverse/xml_tool.py
+++ b/src/tooluniverse/xml_tool.py
@@ -176,6 +176,36 @@ class XMLDatasetTool(BaseTool):
             .get("default", fallback)
         )
 
+    # Fix Round 17: every _search-mode tool built on this shared class takes
+    # a single param named 'query', regardless of what its own tool NAME
+    # promises (e.g. drugbank_get_pharmacology_by_drug_name_or_drugbank_id,
+    # mesh_get_subjects_by_subject_name). Confirmed live: calling that tool
+    # with 'drug_name' (the exact term in its own name) errored with
+    # "'query' is a required property" -- a natural first guess from reading
+    # the tool name fails. Accept the terms these tool names actually use as
+    # synonyms for 'query' instead of renaming the parameter across every
+    # config entry (a much larger, more disruptive change).
+    _QUERY_ALIASES = ("drug_name", "drugbank_id", "subject_name", "subject_id")
+
+    def _resolve_query_alias(self, arguments: Dict[str, Any]) -> None:
+        """Mutate arguments in place, filling in 'query' from a known alias.
+
+        Must run before schema validation (not just inside run()): jsonschema
+        rejects a missing required 'query' before run() is ever reached, so an
+        alias resolved only in run() would be dead code for every normal
+        (validated) call path.
+        """
+        if "query" in arguments or "condition" in arguments:
+            return
+        for alias in self._QUERY_ALIASES:
+            if arguments.get(alias):
+                arguments["query"] = arguments[alias]
+                break
+
+    def validate_parameters(self, arguments: Dict[str, Any]) -> Optional[Any]:
+        self._resolve_query_alias(arguments)
+        return super().validate_parameters(arguments)
+
     def run(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
         """Main entry point for the tool."""
         if not self.records:
@@ -183,6 +213,10 @@ class XMLDatasetTool(BaseTool):
                 "status": "error",
                 "error": "XML dataset not loaded or contains no records",
             }
+
+        # Also resolve here so direct run() calls that skip validate_parameters
+        # (e.g. validate=False, or calling the tool class directly) still work.
+        self._resolve_query_alias(arguments)
 
         # Route to appropriate function based on arguments
         if "query" in arguments:

--- a/tests/tools/test_graphql_empty_guard.py
+++ b/tests/tools/test_graphql_empty_guard.py
@@ -55,6 +55,31 @@ class TestGraphQLEmptyGuard:
         assert result["status"] == "success"
         assert result["data"] == {"search": {}}
 
+    def test_zero_hit_search_query_gets_explanatory_note(self):
+        # Fix Round 17: a query whose schema actually declares a "hits" field
+        # (a real search(...) { hits {...} } shape, unlike the generic dummy
+        # config above) collapses to the same opaque {"search": {}} on zero
+        # hits. Confirmed live: OpenTargets_get_disease_ids_by_name with
+        # "high-risk prostate cancer" returned status=success, data=
+        # {"search": {}}, with nothing indicating that means zero matches.
+        # Attach a note so the caller isn't left guessing whether this is a
+        # real zero-hit result or something broke.
+        from tooluniverse.graphql_tool import GraphQLTool
+
+        search_cfg = dict(MINIMAL_CFG)
+        search_cfg["query_schema"] = (
+            "query($q: String!) { search(queryString: $q) { hits { id name } } }"
+        )
+        tool = GraphQLTool(search_cfg, "https://example.org/graphql")
+        with patch(
+            "tooluniverse.graphql_tool.execute_query",
+            return_value={"data": {"search": {}}},
+        ):
+            result = tool.run({"id": "anything"})
+        assert result["status"] == "success"
+        assert result["data"] == {"search": {}}
+        assert "0 matches found" in result["metadata"]["note"]
+
     def test_real_data_succeeds(self):
         tool = _base_tool()
         with patch(

--- a/tests/unit/test_faers_disproportionality_rate_limit.py
+++ b/tests/unit/test_faers_disproportionality_rate_limit.py
@@ -1,0 +1,125 @@
+"""FAERS_calculate_disproportionality: a failed openFDA count query must not
+be silently treated as a genuine zero.
+
+Regression for Fix Round 17: _get_faers_count caught every exception
+(including an HTTP 429 from openFDA's rate limit) and returned 0, which is
+indistinguishable from "no matching reports." That fake 0 then flowed into
+the 2x2 contingency-table arithmetic and could produce a mathematically
+impossible negative cell count. Confirmed live with the tool's own
+documented example (IBUPROFEN + "Gastrointestinal haemorrhage"): the
+unfiltered total-count request hit openFDA's rate limit and the tool
+reported "a=0, b=283544, c=0, d=-283544" with no indication anything had
+failed.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+DATA_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "tooluniverse"
+    / "data"
+    / "faers_analytics_tools.json"
+)
+
+
+def _make_tool():
+    from tooluniverse.faers_analytics_tool import FAERSAnalyticsTool
+
+    with open(DATA_FILE) as f:
+        tools = json.load(f)
+    config = next(
+        t for t in tools if t["name"] == "FAERS_calculate_disproportionality"
+    )
+    return FAERSAnalyticsTool(config)
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+
+            raise requests.HTTPError(f"{self.status_code} error")
+
+    def json(self):
+        return self._payload
+
+
+def test_rate_limited_total_count_returns_actionable_error_not_negative_d():
+    tool = _make_tool()
+
+    def fake_request_with_retry(session, method, url, **kwargs):
+        # The unfiltered total-count request (no `search=`) is rate limited;
+        # every filtered request succeeds -- reproduces the exact live
+        # scenario that produced a=0, b=283544, c=0, d=-283544.
+        if "limit=1" in url and "search=" not in url:
+            return _FakeResponse(429, {"error": {"code": "OVER_RATE_LIMIT"}})
+        return _FakeResponse(200, {"meta": {"results": {"total": 283544}}})
+
+    with patch(
+        "tooluniverse.faers_analytics_tool.request_with_retry",
+        side_effect=fake_request_with_retry,
+    ):
+        result = tool.run(
+            {
+                "operation": "calculate_disproportionality",
+                "drug_name": "IBUPROFEN",
+                "adverse_event": "Gastrointestinal haemorrhage",
+            }
+        )
+
+    assert result["status"] == "error"
+    # Must not silently report a fabricated (and mathematically impossible)
+    # contingency table -- the error should explain the request failed.
+    assert "contingency_table" not in result
+    assert "rate limit" in result["error"].lower() or "429" in result["error"]
+
+
+def test_all_counts_succeed_produces_sane_positive_contingency_table():
+    tool = _make_tool()
+
+    def fake_request_with_retry(session, method, url, **kwargs):
+        if "limit=1" in url and "search=" not in url:
+            return _FakeResponse(200, {"meta": {"results": {"total": 20000000}}})
+        if 'generic_name:"IBUPROFEN"' in url and "reactionmeddrapt" in url:
+            return _FakeResponse(200, {"meta": {"results": {"total": 50}}})
+        if 'generic_name:"IBUPROFEN"' in url:
+            return _FakeResponse(200, {"meta": {"results": {"total": 283544}}})
+        if "reactionmeddrapt" in url:
+            return _FakeResponse(200, {"meta": {"results": {"total": 5000}}})
+        return _FakeResponse(200, {"meta": {"results": {"total": 0}}})
+
+    with patch(
+        "tooluniverse.faers_analytics_tool.request_with_retry",
+        side_effect=fake_request_with_retry,
+    ):
+        result = tool.run(
+            {
+                "operation": "calculate_disproportionality",
+                "drug_name": "IBUPROFEN",
+                "adverse_event": "Gastrointestinal haemorrhage",
+            }
+        )
+
+    assert result["status"] == "success"
+    ct = result["data"]["contingency_table"]
+    assert all(v > 0 for v in ct.values())
+
+
+def test_api_key_appended_to_faers_requests_when_env_var_set(monkeypatch):
+    monkeypatch.setenv("FDA_API_KEY", "test-key-123")
+    tool = _make_tool()
+    assert tool.api_key == "test-key-123"
+    assert tool._with_api_key("https://api.fda.gov/drug/event.json?limit=1") == (
+        "https://api.fda.gov/drug/event.json?limit=1&api_key=test-key-123"
+    )

--- a/tests/unit/test_xml_tool_query_alias.py
+++ b/tests/unit/test_xml_tool_query_alias.py
@@ -1,0 +1,78 @@
+"""XMLTool-family tools (drugbank_*, mesh_*) all take a single search
+parameter named 'query', regardless of what the tool's own NAME promises.
+
+Regression for Fix Round 17: calling
+drugbank_get_pharmacology_by_drug_name_or_drugbank_id with 'drug_name' (the
+exact term used in the tool's own name) errored with "'query' is a required
+property" -- schema validation runs before run(), so an alias resolved only
+inside run() would never fire for a normal (validated) call. The fix
+resolves the alias inside validate_parameters() itself, mutating the shared
+arguments dict in place so the resolved 'query' is also visible to the
+subsequent run() call.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool(parameter_overrides=None):
+    from tooluniverse.xml_tool import XMLDatasetTool
+
+    config = {
+        "name": "drugbank_get_pharmacology_by_drug_name_or_drugbank_id",
+        "parameter": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "condition": {"type": "string"},
+                "value": {"type": "string"},
+            },
+            "required": ["query"],
+        },
+        "settings": {
+            # No real dataset path -- _load_dataset() catches the failure and
+            # leaves self.records == [], which is fine for validation-layer tests.
+            "record_xpath": ".//*",
+        },
+    }
+    if parameter_overrides:
+        config["parameter"].update(parameter_overrides)
+    return XMLDatasetTool(config)
+
+
+@pytest.mark.parametrize("alias", ["drug_name", "drugbank_id"])
+def test_alias_resolved_before_schema_validation(alias):
+    tool = _make_tool()
+    arguments = {alias: "buprenorphine"}
+    error = tool.validate_parameters(arguments)
+    assert error is None, f"expected no validation error, got: {error}"
+    # The alias resolution must mutate the same dict object run() will see.
+    assert arguments["query"] == "buprenorphine"
+
+
+def test_unrecognized_alias_still_errors_with_helpful_message():
+    tool = _make_tool()
+    error = tool.validate_parameters({"totally_unrelated_key": "x"})
+    assert error is not None
+    assert "query" in str(error.message if hasattr(error, "message") else error)
+
+
+def test_explicit_query_takes_precedence_over_alias():
+    tool = _make_tool()
+    arguments = {"query": "aspirin", "drug_name": "ibuprofen"}
+    error = tool.validate_parameters(arguments)
+    assert error is None
+    assert arguments["query"] == "aspirin"
+
+
+def test_condition_based_filter_call_is_unaffected():
+    # drugbank_filter_drugs_by_name's real schema requires condition+value,
+    # not query -- matches that shape rather than the search-tool default.
+    tool = _make_tool(
+        parameter_overrides={"required": ["condition", "value"]}
+    )
+    arguments = {"condition": "type", "value": "small molecule"}
+    error = tool.validate_parameters(arguments)
+    assert error is None
+    assert "query" not in arguments


### PR DESCRIPTION
## Summary

Persona role-play across three domains not previously covered (transplant medicine/HLA-matching, urology, addiction-medicine pharmacogenomics) surfaced five CLI-verified issues, each reproduced live before being fixed:

- **FAERS_calculate_disproportionality**: silently swallowed a failed openFDA count query (commonly HTTP 429 rate limiting) and treated it as a genuine zero, producing a mathematically impossible negative contingency-table cell (`a=0, b=283544, c=0, d=-283544` on the tool's own documented example). `_get_faers_count` now returns `None` (not `0`) on request failure, and every FAERS analytics operation is wired with `FDA_API_KEY` + `request_with_retry` to reduce how often the rate limit is hit at all.
- **OpenTargets_get_disease_ids_by_name**: hardcoded search page size 1, so a single full-text-search hit was trusted blindly even when OpenTargets' own relevance ranking got it wrong (confirmed live: "localized prostate cancer" ranks *Ewing sarcoma* above prostate cancer, which doesn't appear in the top 5 at all). Now returns up to 5 ranked candidates with their relevance score, and the description tells callers to verify the `name` field before trusting `dbXRefs`.
- **GraphQLTool (shared base class)**: a search-shaped query with a genuine zero-hit result collapsed to an opaque `{"search": {}}` once its empty `hits` list was stripped by `remove_none_and_empty_values` — indistinguishable from a broken response. Now attaches an explanatory `metadata.note`, inherited by every tool built on this class.
- **XMLDatasetTool (drugbank_*/mesh_* tools, ~19 tools)**: all share one search parameter literally named `query`, regardless of what the tool's own name promises (e.g. `drugbank_get_pharmacology_by_drug_name_or_drugbank_id`). A natural first guess like `drug_name` errored with `"'query' is a required property"`. Aliases are now resolved inside `validate_parameters()` (before schema validation runs, not just inside `run()`).
- **FAERS_search_reports_by_drug_and_reaction**: the `reactionmeddrapt` parameter description now explains it requires an exact MedDRA Preferred Term and points to `FAERS_count_reactions_by_drug_event` for term discovery, since a non-matching term returns an empty result indistinguishable from a genuine zero-report finding.

A sixth finding (`gwas_search_snps` silently ignoring an unrecognized `gene` filter param) was confirmed live but not fixed here — it's already covered by the not-yet-merged systemic parameter-validation fix in PR #486, which flags any single unrecognized parameter against a tool's declared schema.

## Test plan

- [x] All 5 findings reproduced live via `tu run`/`tu test` before fixing
- [x] New regression tests: `tests/unit/test_faers_disproportionality_rate_limit.py`, `tests/unit/test_xml_tool_query_alias.py`, plus a new case in `tests/tools/test_graphql_empty_guard.py`
- [x] Existing test suites covering the changed files pass (FAERS analytics, OpenTargets/GraphQL, XML tools) — 77+ tests, 0 failures
- [x] Each fix re-verified against the original failing live call after the change
- [x] `ruff check` clean on all changed files