### PR TITLE
Fix Round 18: FDA label API key wiring, gene-disease aggregator gaps, Ensembl error detail

### DIFF
--- a/src/tooluniverse/compound_disease_tool.py
+++ b/src/tooluniverse/compound_disease_tool.py
@@ -11,6 +11,20 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
+def _truncate_msg(msg: str, limit: int = 240) -> str:
+    """Truncate an error message on a word boundary, never mid-word.
+
+    Sub-tool error messages are the only actionable guidance a caller gets
+    on a failed source; cutting them off mid-word at a fixed character
+    count silently drops that guidance (e.g. DisGeNET's "...resolve first
+    (e.g. umls_search_concepts)..." hint used to get cut to "umls_search_").
+    """
+    if len(msg) <= limit:
+        return msg
+    head = msg[:limit].rsplit(" ", 1)[0]
+    return head + "..."
+
+
 @register_tool("CompoundDiseaseProfileTool")
 class CompoundDiseaseProfileTool(BaseTool):
     """Gather a comprehensive disease profile from Orphanet, OMIM, DisGeNET, OpenTargets, and OLS."""
@@ -35,10 +49,12 @@ class CompoundDiseaseProfileTool(BaseTool):
             try:
                 r = tu.run_one_function({"name": tool_name, "arguments": args})
                 if isinstance(r, dict) and r.get("status") == "error":
-                    sources_failed.append(f"{source_name}: {r.get('error', '')[:100]}")
+                    sources_failed.append(
+                        f"{source_name}: {_truncate_msg(r.get('error', ''))}"
+                    )
                 return r
             except Exception as e:
-                sources_failed.append(f"{source_name}: {str(e)[:100]}")
+                sources_failed.append(f"{source_name}: {_truncate_msg(str(e))}")
                 return {"status": "error"}
 
         # 1. Orphanet

--- a/src/tooluniverse/compound_gene_disease_tool.py
+++ b/src/tooluniverse/compound_gene_disease_tool.py
@@ -10,6 +10,20 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 
+def _truncate_msg(msg: str, limit: int = 240) -> str:
+    """Truncate an error message on a word boundary, never mid-word.
+
+    Sub-tool error messages (e.g. DisGeNET's "...resolve first (e.g.
+    umls_search_concepts), then pass disease='C0152200'.") are the only
+    actionable guidance a caller gets on a failed source; cutting them off
+    mid-word at a fixed character count silently drops that guidance.
+    """
+    if len(msg) <= limit:
+        return msg
+    head = msg[:limit].rsplit(" ", 1)[0]
+    return head + "..."
+
+
 @register_tool("CompoundGeneDiseaseAssociationTool")
 class CompoundGeneDiseaseAssociationTool(BaseTool):
     """Query multiple gene-disease databases in a single call."""
@@ -42,12 +56,12 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
                 r = tu.run_one_function({"name": tool_name, "arguments": args})
                 if isinstance(r, dict) and r.get("status") == "error":
                     sources_failed.append(
-                        f"{source_name}: {r.get('error', 'unknown error')[:100]}"
+                        f"{source_name}: {_truncate_msg(r.get('error', 'unknown error'))}"
                     )
                     return r
                 return r
             except Exception as e:
-                sources_failed.append(f"{source_name}: {str(e)[:100]}")
+                sources_failed.append(f"{source_name}: {_truncate_msg(str(e))}")
                 return {"status": "error", "error": str(e)}
 
         # 1. DisGeNET
@@ -191,11 +205,11 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
             )
             if isinstance(result, dict) and result.get("status") == "error":
                 sources_failed.append(
-                    f"OpenTargets: {result.get('error', 'unknown error')[:100]}"
+                    f"OpenTargets: {_truncate_msg(result.get('error', 'unknown error'))}"
                 )
             return result
         except Exception as e:
-            sources_failed.append(f"OpenTargets: {str(e)[:100]}")
+            sources_failed.append(f"OpenTargets: {_truncate_msg(str(e))}")
             return {"status": "error", "error": str(e)}
 
     def _opentargets_disease_genes(
@@ -230,11 +244,11 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
             )
             if isinstance(result, dict) and result.get("status") == "error":
                 sources_failed.append(
-                    f"OpenTargets: {result.get('error', 'unknown error')[:100]}"
+                    f"OpenTargets: {_truncate_msg(result.get('error', 'unknown error'))}"
                 )
             return result
         except Exception as e:
-            sources_failed.append(f"OpenTargets: {str(e)[:100]}")
+            sources_failed.append(f"OpenTargets: {_truncate_msg(str(e))}")
             return {"status": "error", "error": str(e)}
 
     def _extract_genes_or_diseases(
@@ -328,6 +342,24 @@ class CompoundGeneDiseaseAssociationTool(BaseTool):
                                 items.append(
                                     {"name": str(g), "score": None, "source": source}
                                 )
+            return items
+
+        # OMIM_search: each row is {"entry": {"titles": {"preferredTitle": ...},
+        # "mimNumber": ...}} -- the identifying text is nested one level under
+        # "entry", not a top-level gene/disease field, so the generic
+        # extraction below (which only looks at top-level keys) always found
+        # nothing and silently produced zero items for every OMIM query.
+        # OMIM titles conflate gene and disorder names in one string (e.g.
+        # "VON HIPPEL-LINDAU TUMOR SUPPRESSOR; VHL"), so there's no clean
+        # gene-only/disease-only split to make here -- surface the title as-is
+        # for both query directions, same as ClinVar's disease->gene branch
+        # falls back to what the source actually gives us.
+        if isinstance(data, dict) and "entries" in data:
+            for row in (data.get("entries") or [])[:30]:
+                entry = (row or {}).get("entry") or {}
+                title = (entry.get("titles") or {}).get("preferredTitle", "")
+                if title:
+                    items.append({"name": str(title), "score": None, "source": source})
             return items
 
         # Generic list: prefer the field the caller is asking for -- gene fields

--- a/src/tooluniverse/compound_variant_tool.py
+++ b/src/tooluniverse/compound_variant_tool.py
@@ -50,6 +50,19 @@ _AA_3TO1 = {v.upper(): k for k, v in _AA_1TO3.items()}
 _MATURE_PROTEIN_OFFSET_GENES = {"HBB"}
 
 
+def _truncate_msg(msg: str, limit: int = 240) -> str:
+    """Truncate an error message on a word boundary, never mid-word.
+
+    Sub-tool error messages are the only actionable guidance a caller gets
+    on a failed source; cutting them off mid-word at a fixed character
+    count silently drops that guidance.
+    """
+    if len(msg) <= limit:
+        return msg
+    head = msg[:limit].rsplit(" ", 1)[0]
+    return head + "..."
+
+
 # ClinVar clinical-significance terms ranked most→least clinically significant.
 # Used to pick the headline classification when a query matches several ClinVar
 # variants (e.g. a multi-allelic rsid whose alleles carry different
@@ -245,13 +258,13 @@ class CompoundVariantAnnotationTool(BaseTool):
                     r, error = None, None
 
                 if error:
-                    sources_failed.append(f"ClinVar: {error[:100]}")
+                    sources_failed.append(f"ClinVar: {_truncate_msg(error)}")
                 elif parsed is not None:
                     annotations["clinvar"] = parsed
                 else:
                     annotations["clinvar"] = self._parse_clinvar(r, variant_token)
             except Exception as e:
-                sources_failed.append(f"ClinVar: {str(e)[:100]}")
+                sources_failed.append(f"ClinVar: {_truncate_msg(str(e))}")
 
         # 2. gnomAD
         if gene_for_gnomad:
@@ -264,11 +277,11 @@ class CompoundVariantAnnotationTool(BaseTool):
                 )
                 error = self._sub_call_error(r)
                 if error:
-                    sources_failed.append(f"gnomAD: {error[:100]}")
+                    sources_failed.append(f"gnomAD: {_truncate_msg(error)}")
                 else:
                     annotations["gnomad"] = self._parse_gnomad(r)
             except Exception as e:
-                sources_failed.append(f"gnomAD: {str(e)[:100]}")
+                sources_failed.append(f"gnomAD: {_truncate_msg(str(e))}")
 
         # 3. CIViC
         if gene_for_gnomad:
@@ -281,11 +294,11 @@ class CompoundVariantAnnotationTool(BaseTool):
                 )
                 error = self._sub_call_error(r)
                 if error:
-                    sources_failed.append(f"CIViC: {error[:100]}")
+                    sources_failed.append(f"CIViC: {_truncate_msg(error)}")
                 else:
                     annotations["civic"] = self._parse_civic(r, variant_token)
             except Exception as e:
-                sources_failed.append(f"CIViC: {str(e)[:100]}")
+                sources_failed.append(f"CIViC: {_truncate_msg(str(e))}")
 
         # 4. UniProt
         if gene_for_gnomad:
@@ -306,11 +319,11 @@ class CompoundVariantAnnotationTool(BaseTool):
                 )
                 error = self._sub_call_error(r)
                 if error:
-                    sources_failed.append(f"UniProt: {error[:100]}")
+                    sources_failed.append(f"UniProt: {_truncate_msg(error)}")
                 else:
                     annotations["uniprot"] = self._parse_uniprot(r, gene_for_gnomad)
             except Exception as e:
-                sources_failed.append(f"UniProt: {str(e)[:100]}")
+                sources_failed.append(f"UniProt: {_truncate_msg(str(e))}")
 
         # Build summary
         summary = self._build_summary(annotations, variant, gene_for_gnomad, rsid)
@@ -366,7 +379,7 @@ class CompoundVariantAnnotationTool(BaseTool):
             )
             error = self._sub_call_error(r)
             if error:
-                sources_failed.append(f"dbSNP (rsid->gene): {error[:100]}")
+                sources_failed.append(f"dbSNP (rsid->gene): {_truncate_msg(error)}")
                 return None, None
             hgvs = str((r.get("data") or {}).get("hgvs_notation", ""))
             m = re.search(r"GENE=([A-Za-z0-9\-]+):", hgvs)
@@ -386,7 +399,7 @@ class CompoundVariantAnnotationTool(BaseTool):
             variant_tokens = _offset_protein_tokens(variant_tokens, gene)
             return gene, (variant_tokens or None)
         except Exception as e:
-            sources_failed.append(f"dbSNP (rsid->gene): {str(e)[:100]}")
+            sources_failed.append(f"dbSNP (rsid->gene): {_truncate_msg(str(e))}")
             return None, None
 
     def _parse_clinvar(self, result: Any, variant_token: str = None) -> Dict[str, Any]:

--- a/src/tooluniverse/data/cbioportal_tools.json
+++ b/src/tooluniverse/data/cbioportal_tools.json
@@ -475,7 +475,7 @@
   {
     "type": "CBioPortalRESTTool",
     "name": "cBioPortal_get_gene_info",
-    "description": "Get detailed information about a specific gene by Entrez Gene ID. Returns gene symbol, aliases, type, and chromosome location.",
+    "description": "Get basic information about a specific gene by Entrez Gene ID. Returns the HUGO gene symbol and gene type (e.g., 'protein-coding'); does not return aliases -- use HGNC_fetch_gene_by_symbol or NCBIGene_get_summary for gene aliases/chromosome location.",
     "parameter": {
       "type": "object",
       "properties": {

--- a/src/tooluniverse/ensembl_xrefs_tool.py
+++ b/src/tooluniverse/ensembl_xrefs_tool.py
@@ -56,7 +56,22 @@ class EnsemblXrefsTool(BaseTool):
                     "status": "error",
                     "error": "Ensembl ID not found. Provide a valid Ensembl stable ID.",
                 }
-            return {"status": "error", "error": f"Ensembl REST API HTTP {status}"}
+            # Fix-18B-1: swallowing the response body dropped Ensembl's own
+            # actionable message -- e.g. a bad `species` value (common for
+            # xrefs_by_symbol, which takes species as free text like "canine"
+            # instead of the required internal name "canis_lupus_familiaris")
+            # returns HTTP 400 with body {"error": "Can not find internal
+            # name for species 'canine'"}, but callers only ever saw the bare
+            # "Ensembl REST API HTTP 400". The sibling ensembl_tool.py already
+            # includes response text for this reason; do the same here.
+            detail = ""
+            if e.response is not None:
+                detail = (e.response.text or "").strip()[:200]
+            return {
+                "status": "error",
+                "error": f"Ensembl REST API HTTP {status}"
+                + (f": {detail}" if detail else ""),
+            }
         except Exception as e:
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}
 

--- a/src/tooluniverse/fda_label_tool.py
+++ b/src/tooluniverse/fda_label_tool.py
@@ -7,9 +7,11 @@ prescribing information including indications, dosing, contraindications,
 warnings, drug interactions, and pharmacology.
 
 API: https://open.fda.gov/apis/drug/label/
-No authentication required. Optional API key raises rate limits.
+No authentication required. Set the FDA_API_KEY env var to raise the
+default ~40 req/min anonymous rate limit (https://open.fda.gov/apis/authentication/).
 """
 
+import os
 import requests
 from typing import Any
 
@@ -17,6 +19,16 @@ from .base_tool import BaseTool
 from .tool_registry import register_tool
 
 FDA_LABEL_URL = "https://api.fda.gov/drug/label.json"
+
+# Placeholder values users sometimes leave in FDA_API_KEY; treat as "unset".
+_API_KEY_PLACEHOLDERS = {"none", "null", "your_fda_key_here", "your_key_here"}
+
+
+def _valid_api_key(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    v = value.strip()
+    return bool(v) and v.lower() not in _API_KEY_PLACEHOLDERS
 
 
 def _ok(data: Any, **metadata: Any) -> dict:
@@ -84,6 +96,17 @@ class FDALabelTool(BaseTool):
     def __init__(self, tool_config: dict[str, Any]):
         super().__init__(tool_config)
         self.query_type = tool_config.get("fields", {}).get("query_type", "search")
+        self.api_key = os.getenv("FDA_API_KEY")
+
+    def _params(self, **kwargs: Any) -> dict:
+        """Build request params, adding api_key when a valid FDA_API_KEY is set.
+
+        openFDA's anonymous tier is heavily rate-limited (~40 req/min); an
+        API key raises that substantially. See https://open.fda.gov/apis/authentication/
+        """
+        if _valid_api_key(self.api_key):
+            kwargs["api_key"] = self.api_key
+        return kwargs
 
     def run(self, arguments: dict[str, Any]) -> Any:
         try:
@@ -113,7 +136,7 @@ class FDALabelTool(BaseTool):
             for q in (f'{field}:"{drug_name}"', f"{field}:{drug_name}"):
                 resp = requests.get(
                     FDA_LABEL_URL,
-                    params={"search": q, "limit": limit},
+                    params=self._params(search=q, limit=limit),
                     timeout=20,
                 )
                 if resp.status_code == 404:
@@ -139,7 +162,7 @@ class FDALabelTool(BaseTool):
         q = f'indications_and_usage:"{indication}"'
         resp = requests.get(
             FDA_LABEL_URL,
-            params={"search": q, "limit": limit},
+            params=self._params(search=q, limit=limit),
             timeout=20,
         )
         labels = []
@@ -173,10 +196,10 @@ class FDALabelTool(BaseTool):
         limit = min(int(arguments.get("limit", 20)), 100)
         resp = requests.get(
             FDA_LABEL_URL,
-            params={
-                "count": "openfda.pharm_class_epc.exact",
-                "limit": limit,
-            },
+            params=self._params(
+                count="openfda.pharm_class_epc.exact",
+                limit=limit,
+            ),
             timeout=20,
         )
         resp.raise_for_status()


### PR DESCRIPTION
## Summary

Role-play rounds against allergy/clinical-immunology, veterinary medicine, and radiology/imaging-genomics personas surfaced tool-level defects that were silently degrading results rather than failing loudly. All fixes below were confirmed live via `tu run`/`tu test` before and after the change (CLI verification, per project convention).

- **`FDA_search_drug_labels` (`fda_label_tool.py`)**: `FDALabelTool` never read `FDA_API_KEY`, so it was stuck on openFDA's ~40 req/min anonymous tier and hit 429s under normal load, even though every other openFDA-backed tool in the repo already wires the key up. Now reads the env var and appends it to requests (mirroring the existing `openfda_tool.py` pattern).
- **`gather_gene_disease_associations` (`compound_gene_disease_tool.py`)**: the OMIM branch silently returned zero associations for every query -- `OMIM_search`'s payload nests the identifying title one level under `entry` (`entries[].entry.titles.preferredTitle`), and the generic top-level field extraction never found anything there. Added an OMIM-shape-aware extraction branch. Also fixed error-message truncation: a hard 100-char cut was slicing DisGeNET's actionable "resolve via umls_search_concepts" hint down to "umls_search_" mid-word; now truncates on a word boundary.
- **`gather_disease_profile` (`compound_disease_tool.py`) / `annotate_variant_multi_source` (`compound_variant_tool.py`)**: ported the same word-boundary truncation fix -- both sibling aggregator tools had the identical bug on their `sources_failed` messages.
- **`Ensembl_lookup_gene_by_symbol` (`ensembl_xrefs_tool.py`)**: `EnsemblXrefsTool` discarded the HTTP error response body on non-404 failures, so a bad `species` value (e.g. `"canine"` instead of the internal name `"canis_lupus_familiaris"`) surfaced as a bare `"HTTP 400"` instead of Ensembl's own actionable message. The sibling `ensembl_tool.py` already preserves this detail; now `ensembl_xrefs_tool.py` does too.
- **`cBioPortal_get_gene_info` (`cbioportal_tools.json`)**: description claimed the tool returns aliases and chromosome location; the live API never does for any gene tested. Corrected the description and pointed callers at the tools that actually provide that data (`HGNC_fetch_gene_by_symbol`, `NCBIGene_get_summary`).

Note: a `ClinicalTrials_search_studies` "operation" parameter-validation bug and an FDA-key-wiring issue in the sibling `openfda_tools.json` file were also found during role-play but are already fixed in unmerged sibling PRs (#483, #480 respectively) -- skipped here to avoid duplicate/conflicting fixes.

## Test plan
- [x] `tu test <ToolName>` passed for all 6 affected tools (their shipped `test_examples`) before and after
- [x] `tu run` reproduction of each original failure, confirmed fixed
- [x] Targeted regression: `pytest tests/unit/test_ensembl_xrefs_and_archive_fixes.py tests/unit/test_compound_gene_disease_clinvar_gene_names.py tests/unit/test_compound_gene_disease_opentargets_lookup.py tests/unit/test_compound_gene_disease_disease_direction.py tests/unit/test_compound_variant_tool.py tests/unit/test_clinvar_variant_name_search.py` -- all pass
- [x] `ruff check` clean on all modified files
- [x] No stray files outside the 6 intended changes (`src/tooluniverse/tools/*.py` auto-regeneration from a background run was reverted)