### PR TITLE
Fix Round 19: HPO phenotype-lookup pagination, FAERS comparison-signal wording

### DIFF
--- a/src/tooluniverse/data/hpo_tools.json
+++ b/src/tooluniverse/data/hpo_tools.json
@@ -273,7 +273,7 @@
   },
   {
     "name": "HPO_get_genes_by_phenotype",
-    "description": "Get the genes associated with an HPO phenotype term (genes in which variants cause this phenotype), from the JAX HPO network annotations. Returns NCBI gene IDs and symbols. Example: HP:0001250 (Seizure) is linked to genes such as RELN, SCN1A, and ~2000 others. Use to go from an observed patient phenotype to candidate disease genes for variant prioritization.",
+    "description": "Get the genes associated with an HPO phenotype term (genes in which variants cause this phenotype), from the JAX HPO network annotations. Returns NCBI gene IDs and symbols. Example: HP:0001250 (Seizure) is linked to genes such as RELN, SCN1A, and ~2000 others. Use to go from an observed patient phenotype to candidate disease genes for variant prioritization. A phenotype term can be linked to thousands of genes but 'limit' caps a single response at 500 -- check metadata.has_more in the response and pass 'offset' to page through the rest; a well-known gene for a common phenotype may not appear in the first page.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -287,6 +287,13 @@
             "null"
           ],
           "description": "Maximum number of results to return (1-500, default 50). Phenotype terms can be linked to thousands of genes."
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of results to skip before returning 'limit' results (default 0). Use with the response's metadata.has_more/metadata.total to page through phenotypes with more genes than fit in one call."
         }
       },
       "required": [
@@ -348,7 +355,7 @@
   },
   {
     "name": "HPO_get_diseases_by_phenotype",
-    "description": "Get the diseases that present with an HPO phenotype term, from the JAX HPO network annotations. Returns disease IDs (ORPHA/OMIM/DECIPHER), names, and the cross-referenced MONDO ID. Example: HP:0001250 (Seizure) is a feature of thousands of diseases. Use to build a differential diagnosis from a set of observed phenotypes.",
+    "description": "Get the diseases that present with an HPO phenotype term, from the JAX HPO network annotations. Returns disease IDs (ORPHA/OMIM/DECIPHER), names, and the cross-referenced MONDO ID. Example: HP:0001250 (Seizure) is a feature of thousands of diseases. Use to build a differential diagnosis from a set of observed phenotypes. A phenotype term can be linked to thousands of diseases but 'limit' caps a single response at 500 -- check metadata.has_more in the response and pass 'offset' to page through the rest; a well-known disease for a common phenotype may not appear in the first page.",
     "parameter": {
       "type": "object",
       "properties": {
@@ -362,6 +369,13 @@
             "null"
           ],
           "description": "Maximum number of results to return (1-500, default 50). Phenotype terms can be linked to thousands of diseases."
+        },
+        "offset": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Number of results to skip before returning 'limit' results (default 0). Use with the response's metadata.has_more/metadata.total to page through phenotypes with more diseases than fit in one call."
         }
       },
       "required": [

--- a/src/tooluniverse/faers_analytics_tool.py
+++ b/src/tooluniverse/faers_analytics_tool.py
@@ -414,15 +414,45 @@ class FAERSAnalyticsTool(BaseTool):
             ror1 = result1.get("metrics", {}).get("ROR", {}).get("value")
             ror2 = result2.get("metrics", {}).get("ROR", {}).get("value")
 
-            # Determine which drug has stronger signal
+            # Fix-19B-2: comparison text used to rank drugs purely by raw ROR
+            # magnitude ("X shows stronger signal than Y") even when NEITHER
+            # drug actually crossed this tool's own signal-detection
+            # threshold (signal_detection.signal_detected, from ROR lower CI
+            # > 1.0 and case count >= 3) -- confirmed live with
+            # nirsevimab/palivizumab + anaphylactic reaction, where both
+            # drugs had signal_detected=False (ROR < 1, i.e. no elevated-risk
+            # association) but the narrative still said one showed a
+            # "stronger signal" than the other. Ground the wording in
+            # signal_detected so "signal" language only appears when a
+            # signal was actually detected.
+            sig1 = result1.get("signal_detection", {}).get("signal_detected", False)
+            sig2 = result2.get("signal_detection", {}).get("signal_detected", False)
+
             comparison = "Inconclusive"
             if ror1 and ror2:
-                if ror1 > ror2 * 1.5:
-                    comparison = f"{drug1} shows stronger signal than {drug2}"
+                if not sig1 and not sig2:
+                    comparison = (
+                        f"Neither {drug1} nor {drug2} shows a detected safety signal "
+                        f"for {adverse_event} (ROR does not meet the signal-detection "
+                        "threshold for either drug); the higher raw ROR is not a "
+                        "meaningful difference."
+                    )
+                elif sig1 and not sig2:
+                    comparison = (
+                        f"{drug1} shows a detected safety signal for {adverse_event}; "
+                        f"{drug2} does not."
+                    )
+                elif sig2 and not sig1:
+                    comparison = (
+                        f"{drug2} shows a detected safety signal for {adverse_event}; "
+                        f"{drug1} does not."
+                    )
+                elif ror1 > ror2 * 1.5:
+                    comparison = f"Both show a detected signal; {drug1}'s is stronger than {drug2}'s"
                 elif ror2 > ror1 * 1.5:
-                    comparison = f"{drug2} shows stronger signal than {drug1}"
+                    comparison = f"Both show a detected signal; {drug2}'s is stronger than {drug1}'s"
                 else:
-                    comparison = f"{drug1} and {drug2} show similar signals"
+                    comparison = f"{drug1} and {drug2} show similar-strength detected signals"
 
             return {
                 "status": "success",

--- a/src/tooluniverse/hpo_tool.py
+++ b/src/tooluniverse/hpo_tool.py
@@ -213,7 +213,8 @@ class HPOTool(BaseTool):
         """Get genes or diseases annotated to an HPO phenotype term.
 
         Uses the JAX network-annotation endpoint, which returns the genes,
-        diseases, assays and medical actions linked to a phenotype.
+        diseases, assays and medical actions linked to a phenotype in a
+        single response (the endpoint itself has no server-side paging).
         """
         term_id = arguments.get("term_id", "")
         if not term_id:
@@ -229,6 +230,21 @@ class HPOTool(BaseTool):
             limit = 50
         limit = max(1, min(limit, 500))
 
+        # Fix-19C-1/19C-2: a phenotype term can be linked to thousands of
+        # genes/diseases (confirmed live: HP:0001263 "Global developmental
+        # delay" has 2077 genes), but `limit` is capped at 500 and this
+        # endpoint has no server-side paging -- previously the tool always
+        # sliced from position 0, so well-known genes/diseases sorted past
+        # position 500 by the API (e.g. SHANK3, MECP2 for that term) were
+        # permanently unreachable with no way to page further. The full list
+        # is already in memory from the one API call below, so paging is a
+        # free client-side slice -- no extra round-trip needed.
+        try:
+            offset = int(arguments.get("offset", 0) or 0)
+        except (TypeError, ValueError):
+            offset = 0
+        offset = max(0, offset)
+
         # The annotation endpoint lives under /api/network/, not /api/hp/.
         url = f"{HPO_ANNOTATION_URL}/{term_id}"
         response = requests.get(url, timeout=self.timeout)
@@ -238,7 +254,7 @@ class HPOTool(BaseTool):
         items = data.get(kind) or []
         total = len(items)
         trimmed = []
-        for it in items[:limit]:
+        for it in items[offset : offset + limit]:
             entry = {"id": it.get("id"), "name": it.get("name")}
             if kind == "diseases":
                 entry["mondo_id"] = it.get("mondoId")
@@ -251,7 +267,9 @@ class HPOTool(BaseTool):
                 "source": "HPO (JAX Ontology) network annotation",
                 "term_id": term_id,
                 "total": total,
+                "offset": offset,
                 "returned": len(trimmed),
+                "has_more": offset + len(trimmed) < total,
             },
         }
 

--- a/tests/unit/test_faers_compare_drugs_signal_wording.py
+++ b/tests/unit/test_faers_compare_drugs_signal_wording.py
@@ -1,0 +1,96 @@
+"""FAERS_compare_drugs comparison-text wording (Fix-19B-2).
+
+`_compare_drugs` used to rank drugs purely by raw ROR magnitude ("X shows
+stronger signal than Y") even when neither drug actually crossed this
+tool's own signal-detection threshold (signal_detection.signal_detected).
+Confirmed live with nirsevimab/palivizumab + anaphylactic reaction: both
+drugs had signal_detected=False (ROR < 1, i.e. no elevated-risk
+association) but the narrative still claimed one showed a "stronger
+signal" -- misleading language for a clinician skimming only the text.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _tool():
+    from tooluniverse.faers_analytics_tool import FAERSAnalyticsTool
+
+    return FAERSAnalyticsTool({"name": "t", "type": "FAERSAnalyticsTool"})
+
+
+def _disproportionality_result(ror, signal_detected):
+    return {
+        "status": "success",
+        "metrics": {"ROR": {"value": ror}},
+        "signal_detection": {
+            "signal_detected": signal_detected,
+            "signal_strength": "Weak signal" if signal_detected else "No signal",
+        },
+    }
+
+
+class TestFAERSCompareDrugsSignalWording:
+    def test_neither_drug_has_a_detected_signal(self):
+        # Both RORs are < 1 (no elevated-risk association), so the
+        # comparison must not claim either drug "shows a stronger signal".
+        tool = _tool()
+        with patch.object(
+            tool,
+            "_calculate_disproportionality",
+            side_effect=[
+                _disproportionality_result(0.22, False),
+                _disproportionality_result(0.47, False),
+            ],
+        ):
+            result = tool._compare_drugs(
+                {
+                    "drug1": "nirsevimab",
+                    "drug2": "palivizumab",
+                    "adverse_event": "anaphylactic reaction",
+                }
+            )
+
+        assert result["status"] == "success"
+        comparison = result["comparison"]
+        assert "Neither" in comparison
+        assert "stronger signal" not in comparison
+
+    def test_only_one_drug_has_a_detected_signal(self):
+        tool = _tool()
+        with patch.object(
+            tool,
+            "_calculate_disproportionality",
+            side_effect=[
+                _disproportionality_result(5.0, True),
+                _disproportionality_result(0.8, False),
+            ],
+        ):
+            result = tool._compare_drugs(
+                {"drug1": "drugA", "drug2": "drugB", "adverse_event": "some event"}
+            )
+
+        comparison = result["comparison"]
+        assert "drugA shows a detected safety signal" in comparison
+        assert "drugB does not" in comparison
+
+    def test_both_drugs_have_a_detected_signal_ranks_by_magnitude(self):
+        tool = _tool()
+        with patch.object(
+            tool,
+            "_calculate_disproportionality",
+            side_effect=[
+                _disproportionality_result(8.0, True),
+                _disproportionality_result(2.0, True),
+            ],
+        ):
+            result = tool._compare_drugs(
+                {"drug1": "drugA", "drug2": "drugB", "adverse_event": "some event"}
+            )
+
+        comparison = result["comparison"]
+        assert "Both show a detected signal" in comparison
+        assert "drugA's is stronger" in comparison

--- a/tests/unit/test_hpo_phenotype_annotations.py
+++ b/tests/unit/test_hpo_phenotype_annotations.py
@@ -79,6 +79,37 @@ class TestHPOPhenotypeAnnotations(unittest.TestCase):
         self.assertEqual(result["status"], "error")
         get2.assert_not_called()
 
+    def test_offset_pages_past_the_limit_cap(self):
+        # Fix-19C-1/19C-2: a phenotype with more associations than fit in one
+        # `limit`-capped response must be reachable via `offset` -- the
+        # endpoint returns everything in one call, so paging is a client-side
+        # slice over the same fetched list, not a second network round-trip.
+        tool = _tool("get_associated_genes")
+        with patch("tooluniverse.hpo_tool.requests.get", return_value=_resp()) as get:
+            first_page = tool.run({"term_id": "HP:0001250", "limit": 2, "offset": 0})
+        with patch("tooluniverse.hpo_tool.requests.get", return_value=_resp()):
+            second_page = tool.run({"term_id": "HP:0001250", "limit": 2, "offset": 2})
+
+        self.assertEqual(get.call_count, 1)
+        self.assertEqual(len(first_page["data"]["genes"]), 2)
+        self.assertTrue(first_page["metadata"]["has_more"])
+        self.assertEqual(first_page["metadata"]["offset"], 0)
+
+        # Third gene ("LGI1") is only reachable past the first page.
+        self.assertEqual(len(second_page["data"]["genes"]), 1)
+        self.assertEqual(second_page["data"]["genes"][0]["name"], "LGI1")
+        self.assertFalse(second_page["metadata"]["has_more"])
+        self.assertEqual(second_page["metadata"]["offset"], 2)
+
+    def test_offset_defaults_to_zero_when_omitted(self):
+        # Backward compatibility: no `offset` argument behaves exactly as
+        # before this fix (starts from position 0).
+        tool = _tool("get_associated_genes")
+        with patch("tooluniverse.hpo_tool.requests.get", return_value=_resp()):
+            result = tool.run({"term_id": "HP:0001250", "limit": 2})
+        self.assertEqual(result["metadata"]["offset"], 0)
+        self.assertEqual(result["data"]["genes"][0]["name"], "RELN")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Round 19 of the test-driven improvement harness. Dispatched persona role-play across three domains not covered in prior rounds (space medicine/aerospace physiology, virology, pediatric genetics/developmental disorders), CLI-verified every reported issue, and cross-checked each against the 13 other open round PRs (#478-490) before fixing anything -- several reported issues turned out to already be covered upstream and were skipped rather than duplicated.

- **HPO_get_genes_by_phenotype / HPO_get_diseases_by_phenotype**: both tools already fetch the complete gene/disease list from the JAX network-annotation API in one call, but always sliced `items[:limit]` (limit capped at 500) with no way to page further. A common phenotype term can have thousands of associations (e.g. HP:0001263 "Global developmental delay" has 2077 genes), so well-known genes/diseases sorted past position 500 -- such as SHANK3 and MECP2 for that exact term -- were permanently unreachable, undermining the tool's stated purpose of phenotype-driven gene prioritization. Added an `offset` parameter (pure client-side slice over the already-fetched list, no extra API round-trip) and a `has_more` metadata flag.
- **FAERS_compare_drugs**: the `comparison` narrative text ranked two drugs purely by raw ROR magnitude ("X shows stronger signal than Y"), even when neither drug crossed the tool's own signal-detection threshold. Confirmed live with nirsevimab vs. palivizumab for anaphylactic reaction: both drugs had `signal_detected=False` (ROR < 1, i.e. no elevated-risk association at all) but the narrative still claimed one showed a "stronger signal" -- a clinician skimming only the sentence could be misled into thinking a real safety difference exists. Grounded the wording in `signal_detected` so "signal" language only appears when a signal was actually detected.

## Issues found but skipped (already covered by other open PRs)

- `ClinicalTrials_search_studies` "operation" parameter validation failure -- already fixed in #483 (Round 11)
- `gather_gene_disease_associations` silently dropping DisGeNET/OMIM results -- already fixed in #490 (Round 18)
- XML-tool `print()` polluting stdout (affects DrugBank interaction lookups) -- already fixed in #485 (Round 13, Fix-R13B-4)
- `ClinicalTrialsSearchTool`'s hardcoded phase>=2 filter silently excluding observational/NA-phase studies -- already surfaced via a response-metadata note in #486 (Round 14, Feature-14C-02)

One additional finding (DrugBank XML free-text search ranking an unrelated drug ahead of the queried one, due to no relevance-sorting in the shared `XMLTool._search` abstraction used by many DrugBank-family tools) was diagnosed but deferred rather than rushed, given its broad blast radius across every tool built on that shared class.

## Test plan

- [x] `tu test HPO_get_genes_by_phenotype` / `tu test HPO_get_diseases_by_phenotype` -- existing test_examples pass
- [x] CLI-verified `offset=500` on HP:0001263 returns a non-overlapping gene slice including SHANK3/MECP2, with `has_more` correctly typed
- [x] `pytest tests/unit/test_hpo_phenotype_annotations.py` -- 5/5 pass (3 existing + 2 new offset/pagination tests)
- [x] `pytest tests/unit/test_faers_compare_drugs_signal_wording.py` -- 3/3 pass (new, mocked disproportionality results covering all three wording branches)
- [x] `pytest tests/unit/test_pharmacovigilance_faers_depth.py tests/unit/test_faers_multifield_or_parens.py tests/unit/test_faers_unknown_param.py` -- 14/14 pass, no regressions
- [x] Independent `tool-validator` agent run against the HPO diff: 8/8 checks pass (schema, registration, CLI smoke, offset pagination behavior, unit tests, ruff lint)
- [x] `python3 -m json.tool src/tooluniverse/data/hpo_tools.json` -- valid JSON